### PR TITLE
Multi-target published libraries to net8.0 and net10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.10" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
     <!-- EncDotNet -->
-    <PackageVersion Include="EncDotNet.Iso8211" Version="0.3.4" />
+    <PackageVersion Include="EncDotNet.Iso8211" Version="0.4.0" />
     <!-- Mapping / rendering -->
     <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.323" />
     <PackageVersion Include="Mapsui" Version="5.0.2" />

--- a/src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj
+++ b/src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj
@@ -1,3 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
 </Project>

--- a/src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj
+++ b/src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="EncDotNet.S100.Pipelines.Tests" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj
+++ b/src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Datasets.S104/EncDotNet.S100.Datasets.S104.csproj
+++ b/src/EncDotNet.S100.Datasets.S104/EncDotNet.S100.Datasets.S104.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Datasets.S111/EncDotNet.S100.Datasets.S111.csproj
+++ b/src/EncDotNet.S100.Datasets.S111/EncDotNet.S100.Datasets.S111.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Datasets.S124/EncDotNet.S100.Datasets.S124.csproj
+++ b/src/EncDotNet.S100.Datasets.S124/EncDotNet.S100.Datasets.S124.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />

--- a/src/EncDotNet.S100.Datasets.S129/EncDotNet.S100.Datasets.S129.csproj
+++ b/src/EncDotNet.S100.Datasets.S129/EncDotNet.S100.Datasets.S129.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />

--- a/src/EncDotNet.S100.Datasets.S421/EncDotNet.S100.Datasets.S421.csproj
+++ b/src/EncDotNet.S100.Datasets.S421/EncDotNet.S100.Datasets.S421.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />

--- a/src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj
+++ b/src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj
+++ b/src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj
@@ -1,3 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
 </Project>

--- a/src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj
+++ b/src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="PureHDF" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Portrayals/EncDotNet.S100.Portrayals.csproj
+++ b/src/EncDotNet.S100.Portrayals/EncDotNet.S100.Portrayals.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
+++ b/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mapsui" />
     <PackageReference Include="Mapsui.Nts" />

--- a/src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj
+++ b/src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="Svg.Skia" />

--- a/src/EncDotNet.S100.Scripting.MoonSharp/EncDotNet.S100.Scripting.MoonSharp.csproj
+++ b/src/EncDotNet.S100.Scripting.MoonSharp/EncDotNet.S100.Scripting.MoonSharp.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MoonSharp" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Specifications/EncDotNet.S100.Specifications.csproj
+++ b/src/EncDotNet.S100.Specifications/EncDotNet.S100.Specifications.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

Broadens the LTS reach of the published NuGet packages by adding `net8.0` alongside `net10.0` as a target framework on every library project under `src/`. Many corporate consumers cannot adopt .NET 10 yet, but .NET 8 is supported through November 2026, so shipping a net8 TFM is a cheap way to make the libraries usable to a much larger audience without holding back code that runs on net10.

The change is purely build-graph: no source edits were required because the codebase already avoids net10-only language features and APIs (no `field` keyword on packaged code, no `System.Threading.Lock`, no `params ReadOnlySpan<T>` overloads, etc.). All third-party deps already supported net8.0.

**Approach:**

- Set `<TargetFrameworks>net8.0;net10.0</TargetFrameworks>` on each of the 15 library csprojs under `src/` (Core, Features, ExchangeSets, Portrayals, Specifications, Hdf5.PureHdf, Scripting.MoonSharp, all 7 Datasets.SXxx, and both renderers). The Viewer, tests, and tools stay on net10.0 only via the unchanged `Directory.Build.props` default, so test/tool builds don't pay the multi-target tax and the Viewer continues to ship with its embedded net10 runtime.
- Bump `EncDotNet.Iso8211` from 0.3.4 to 0.4.0, which now multi-targets net8.0 + net10.0. Required so `Datasets.S101` (and `Renderers.Mapsui` transitively) can restore for net8.0.
- Update `.github/workflows/ci.yml` to install the .NET 8 SDK alongside the .NET 10 SDK in the build job. Other jobs (Viewer publish, NuGet push) don't need it.

**Verification:**

- `dotnet build EncDotNet.S100.slnx --configuration Release` produces both `bin/Release/net8.0/*.dll` and `bin/Release/net10.0/*.dll` for every library.
- `dotnet test --no-build --configuration Release` passes 230/230 tests on net10.0.
- `dotnet pack` produces nupkgs containing both `lib/net8.0/` and `lib/net10.0/` folders.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A

## Tests

- [x] Added/updated xunit tests under `tests/` — N/A, no source changes
- [x] Tests requiring real data files use `SkippableFact` — unchanged
- [x] `dotnet test --configuration Release` passes locally (230 passed, 0 failed)

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md` — not required; per-project READMEs do not call out target frameworks
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed — N/A, no behaviour change
- [x] New public APIs have XML doc comments — N/A, no API changes

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`) — version bump only (`EncDotNet.Iso8211` 0.3.4 -> 0.4.0)
- [x] `gh-advisory-database` security check run for any new dependency — N/A, same package, only TFM coverage added

## Breaking changes

None at the source/binary level. Downstream consumers continue to receive a net10-compatible binary; consumers on net8 LTS can now also restore the packages without overrides. The `EncDotNet.Iso8211` 0.4.0 bump is binary-compatible (same major.minor stream) for net10 callers.