### PR TITLE
Add map scale bar overlay with configurable distance units

### DIFF
--- a/src/EncDotNet.S100.Viewer/DistanceUnit.cs
+++ b/src/EncDotNet.S100.Viewer/DistanceUnit.cs
@@ -1,43 +1,60 @@
+using System.Collections.Generic;
+
 namespace EncDotNet.S100.Viewer;
 
-/// <summary>Distance unit for the map scale bar.</summary>
+/// <summary>Distance unit system shown by the map scale bar.</summary>
 internal enum DistanceUnit
 {
-    Meters,
-    Kilometers,
+    /// <summary>Metric system: kilometers down to ~100 m, then meters.</summary>
+    Metric,
+
+    /// <summary>Statute miles down to ~1000 ft, then feet.</summary>
     Miles,
+
+    /// <summary>Nautical miles only.</summary>
     NauticalMiles,
 }
 
+/// <summary>One concrete unit (e.g. km or m) within a <see cref="DistanceUnit"/> system.</summary>
+internal readonly record struct ScaleBarUnit(double MetersPerUnit, string Abbreviation, double SwitchBelowMeters);
+
 internal static class DistanceUnitExtensions
 {
-    /// <summary>Number of meters in one of the unit.</summary>
-    public static double MetersPerUnit(this DistanceUnit unit) => unit switch
-    {
-        DistanceUnit.Meters => 1.0,
-        DistanceUnit.Kilometers => 1000.0,
-        DistanceUnit.Miles => 1609.344,
-        DistanceUnit.NauticalMiles => 1852.0,
-        _ => 1852.0,
-    };
-
-    /// <summary>Lower-case abbreviation suitable for display on the scale bar.</summary>
-    public static string Abbreviation(this DistanceUnit unit) => unit switch
-    {
-        DistanceUnit.Meters => "m",
-        DistanceUnit.Kilometers => "km",
-        DistanceUnit.Miles => "mi",
-        DistanceUnit.NauticalMiles => "nm",
-        _ => "nm",
-    };
-
     /// <summary>Human-readable display name for use in settings UIs.</summary>
     public static string DisplayName(this DistanceUnit unit) => unit switch
     {
-        DistanceUnit.Meters => "Meters (m)",
-        DistanceUnit.Kilometers => "Kilometers (km)",
-        DistanceUnit.Miles => "Miles (mi)",
+        DistanceUnit.Metric => "Metric (km, m)",
+        DistanceUnit.Miles => "Miles (mi, ft)",
         DistanceUnit.NauticalMiles => "Nautical miles (nm)",
         _ => unit.ToString(),
+    };
+
+    /// <summary>
+    /// Concrete units that the scale bar may use for the given system, ordered
+    /// from largest to smallest. Each entry's <c>SwitchBelowMeters</c> threshold
+    /// causes the bar to drop to the next entry once the total bar length falls
+    /// at or below it. The final entry's threshold is ignored.
+    /// </summary>
+    public static IReadOnlyList<ScaleBarUnit> GetUnits(this DistanceUnit unit) => unit switch
+    {
+        DistanceUnit.Metric =>
+        [
+            new(MetersPerUnit: 1000.0,            Abbreviation: "km", SwitchBelowMeters: 100.0),
+            new(MetersPerUnit: 1.0,               Abbreviation: "m",  SwitchBelowMeters: 0.0),
+        ],
+        DistanceUnit.Miles =>
+        [
+            // 1000 ft ≈ 304.8 m.
+            new(MetersPerUnit: 1609.344,          Abbreviation: "mi", SwitchBelowMeters: 304.8),
+            new(MetersPerUnit: 0.3048,            Abbreviation: "ft", SwitchBelowMeters: 0.0),
+        ],
+        DistanceUnit.NauticalMiles =>
+        [
+            new(MetersPerUnit: 1852.0,            Abbreviation: "nm", SwitchBelowMeters: 0.0),
+        ],
+        _ =>
+        [
+            new(MetersPerUnit: 1852.0,            Abbreviation: "nm", SwitchBelowMeters: 0.0),
+        ],
     };
 }

--- a/src/EncDotNet.S100.Viewer/DistanceUnit.cs
+++ b/src/EncDotNet.S100.Viewer/DistanceUnit.cs
@@ -1,0 +1,43 @@
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>Distance unit for the map scale bar.</summary>
+internal enum DistanceUnit
+{
+    Meters,
+    Kilometers,
+    Miles,
+    NauticalMiles,
+}
+
+internal static class DistanceUnitExtensions
+{
+    /// <summary>Number of meters in one of the unit.</summary>
+    public static double MetersPerUnit(this DistanceUnit unit) => unit switch
+    {
+        DistanceUnit.Meters => 1.0,
+        DistanceUnit.Kilometers => 1000.0,
+        DistanceUnit.Miles => 1609.344,
+        DistanceUnit.NauticalMiles => 1852.0,
+        _ => 1852.0,
+    };
+
+    /// <summary>Lower-case abbreviation suitable for display on the scale bar.</summary>
+    public static string Abbreviation(this DistanceUnit unit) => unit switch
+    {
+        DistanceUnit.Meters => "m",
+        DistanceUnit.Kilometers => "km",
+        DistanceUnit.Miles => "mi",
+        DistanceUnit.NauticalMiles => "nm",
+        _ => "nm",
+    };
+
+    /// <summary>Human-readable display name for use in settings UIs.</summary>
+    public static string DisplayName(this DistanceUnit unit) => unit switch
+    {
+        DistanceUnit.Meters => "Meters (m)",
+        DistanceUnit.Kilometers => "Kilometers (km)",
+        DistanceUnit.Miles => "Miles (mi)",
+        DistanceUnit.NauticalMiles => "Nautical miles (nm)",
+        _ => unit.ToString(),
+    };
+}

--- a/src/EncDotNet.S100.Viewer/DistanceUnitNameConverter.cs
+++ b/src/EncDotNet.S100.Viewer/DistanceUnitNameConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>Converts a <see cref="DistanceUnit"/> value to its human-readable display name.</summary>
+internal sealed class DistanceUnitNameConverter : IValueConverter
+{
+    public static DistanceUnitNameConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is DistanceUnit unit ? unit.DisplayName() : value?.ToString();
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -232,6 +232,10 @@
             <!-- Map control fills remaining space, with zoom buttons overlaid -->
             <Grid Grid.Column="2" DragDrop.AllowDrop="True">
                 <mapsui:MapControl x:Name="MapControl" />
+                <views:ScaleBarView x:Name="ScaleBar"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Top"
+                                    Margin="0,12,0,0" />
                 <StackPanel Orientation="Vertical"
                             Spacing="2"
                             HorizontalAlignment="Right"

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -235,7 +235,7 @@
                 <views:ScaleBarView x:Name="ScaleBar"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Top"
-                                    Margin="0,12,0,0" />
+                                    Margin="0,4,0,0" />
                 <StackPanel Orientation="Vertical"
                             Spacing="2"
                             HorizontalAlignment="Right"

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -229,6 +229,13 @@ public partial class MainWindow : ShadUI.Window
         ZoomInButton.Click += OnZoomInClick;
         ZoomOutButton.Click += OnZoomOutClick;
 
+        // Keep the scale bar in sync with the viewport.
+        if (MapControl.Map?.Navigator is { } scaleNav)
+        {
+            scaleNav.ViewportChanged += OnViewportChangedForScaleBar;
+            UpdateScaleBar(scaleNav.Viewport);
+        }
+
         // Apply CLI options
         _screenshotPath = options?.ScreenshotPath;
 
@@ -486,6 +493,27 @@ public partial class MainWindow : ShadUI.Window
             return;
 
         navigator.ZoomTo(navigator.Viewport.Resolution / 2, 250);
+    }
+
+    private void OnViewportChangedForScaleBar(object? sender, Mapsui.ViewportChangedEventArgs e)
+    {
+        if (MapControl.Map?.Navigator is not { } nav)
+            return;
+
+        var viewport = nav.Viewport;
+        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            UpdateScaleBar(viewport);
+        }
+        else
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(() => UpdateScaleBar(viewport));
+        }
+    }
+
+    private void UpdateScaleBar(Mapsui.Viewport viewport)
+    {
+        ScaleBar.UpdateForViewport(viewport.Resolution, viewport.CenterY);
     }
 
     private void OnZoomOutClick(object? sender, RoutedEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -161,6 +161,10 @@ public partial class MainWindow : ShadUI.Window
         // Re-render all loaded datasets when symbol or text scale changes
         _viewModel.Settings.DisplayScaleChanged += () => _ = ReRenderAllDatasetsAsync();
 
+        // Apply persisted scale-bar distance unit and react to changes.
+        ScaleBar.Unit = _viewModel.Settings.DistanceUnit;
+        _viewModel.Settings.DistanceUnitChanged += unit => ScaleBar.Unit = unit;
+
         // If no pane is initially selected, start collapsed
         if (!_viewModel.IsPaneVisible)
         {

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -79,9 +79,8 @@ internal sealed class SettingsViewModel : ViewModelBase
     public static DistanceUnit[] AvailableDistanceUnits { get; } =
     [
         EncDotNet.S100.Viewer.DistanceUnit.NauticalMiles,
-        EncDotNet.S100.Viewer.DistanceUnit.Kilometers,
+        EncDotNet.S100.Viewer.DistanceUnit.Metric,
         EncDotNet.S100.Viewer.DistanceUnit.Miles,
-        EncDotNet.S100.Viewer.DistanceUnit.Meters,
     ];
 
     private DistanceUnit _distanceUnit;

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -76,6 +76,31 @@ internal sealed class SettingsViewModel : ViewModelBase
 
     public event Action? DisplayScaleChanged;
 
+    public static DistanceUnit[] AvailableDistanceUnits { get; } =
+    [
+        EncDotNet.S100.Viewer.DistanceUnit.NauticalMiles,
+        EncDotNet.S100.Viewer.DistanceUnit.Kilometers,
+        EncDotNet.S100.Viewer.DistanceUnit.Miles,
+        EncDotNet.S100.Viewer.DistanceUnit.Meters,
+    ];
+
+    private DistanceUnit _distanceUnit;
+    public DistanceUnit DistanceUnit
+    {
+        get => _distanceUnit;
+        set
+        {
+            if (SetProperty(ref _distanceUnit, value))
+            {
+                _settings.DistanceUnit = value.ToString();
+                _settings.Save();
+                DistanceUnitChanged?.Invoke(value);
+            }
+        }
+    }
+
+    public event Action<DistanceUnit>? DistanceUnitChanged;
+
     public SettingsViewModel(ViewerSettings settings)
     {
         _settings = settings;
@@ -83,5 +108,8 @@ internal sealed class SettingsViewModel : ViewModelBase
         _selectedPalette = Enum.TryParse<PaletteType>(settings.ColorProfile, ignoreCase: true, out var p) ? p : PaletteType.Day;
         _symbolScale = settings.SymbolScale;
         _textScale = settings.TextScale;
+        _distanceUnit = Enum.TryParse<DistanceUnit>(settings.DistanceUnit, ignoreCase: true, out var u)
+            ? u
+            : EncDotNet.S100.Viewer.DistanceUnit.NauticalMiles;
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -40,6 +40,9 @@ internal sealed class ViewerSettings
     /// <summary>Global text scale factor (1.0 = default). Scales all text labels.</summary>
     public double TextScale { get; set; } = 1.0;
 
+    /// <summary>Distance unit used by the map scale bar.</summary>
+    public string DistanceUnit { get; set; } = "NauticalMiles";
+
     public bool IsStatusBarVisible { get; set; } = true;
 
     public static ViewerSettings Load()

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
@@ -1,0 +1,20 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="EncDotNet.S100.Viewer.Views.ScaleBarView"
+             IsHitTestVisible="False">
+
+    <StackPanel x:Name="Root" Orientation="Vertical" Spacing="2">
+        <!-- Labels positioned absolutely above the bar -->
+        <Canvas x:Name="LabelsCanvas" Height="14" />
+
+        <!-- Segment rectangles positioned absolutely -->
+        <Canvas x:Name="BarCanvas" Height="8" />
+
+        <!-- Unit label centered below the bar -->
+        <TextBlock x:Name="UnitLabel"
+                   Text="NM"
+                   FontSize="11"
+                   HorizontalAlignment="Center"
+                   Opacity="0.85" />
+    </StackPanel>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
@@ -3,19 +3,12 @@
              x:Class="EncDotNet.S100.Viewer.Views.ScaleBarView"
              IsHitTestVisible="False">
 
-    <StackPanel x:Name="Root" Orientation="Vertical" Spacing="2"
+    <StackPanel x:Name="Root" Orientation="Vertical" Spacing="0"
                 TextElement.Foreground="#1A1A1A">
         <!-- Labels positioned absolutely above the bar -->
         <Canvas x:Name="LabelsCanvas" Height="14" />
 
         <!-- Segment rectangles positioned absolutely -->
         <Canvas x:Name="BarCanvas" Height="8" />
-
-        <!-- Unit label centered below the bar -->
-        <TextBlock x:Name="UnitLabel"
-                   Text="NM"
-                   FontSize="11"
-                   FontWeight="SemiBold"
-                   HorizontalAlignment="Center" />
     </StackPanel>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
@@ -3,7 +3,8 @@
              x:Class="EncDotNet.S100.Viewer.Views.ScaleBarView"
              IsHitTestVisible="False">
 
-    <StackPanel x:Name="Root" Orientation="Vertical" Spacing="2">
+    <StackPanel x:Name="Root" Orientation="Vertical" Spacing="2"
+                TextElement.Foreground="#1A1A1A">
         <!-- Labels positioned absolutely above the bar -->
         <Canvas x:Name="LabelsCanvas" Height="14" />
 
@@ -14,7 +15,7 @@
         <TextBlock x:Name="UnitLabel"
                    Text="NM"
                    FontSize="11"
-                   HorizontalAlignment="Center"
-                   Opacity="0.85" />
+                   FontWeight="SemiBold"
+                   HorizontalAlignment="Center" />
     </StackPanel>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml
@@ -9,6 +9,6 @@
         <Canvas x:Name="LabelsCanvas" Height="14" />
 
         <!-- Segment rectangles positioned absolutely -->
-        <Canvas x:Name="BarCanvas" Height="8" />
+        <Canvas x:Name="BarCanvas" Height="5" />
     </StackPanel>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -219,7 +219,7 @@ public partial class ScaleBarView : UserControl
     private static string FormatTickLabel(int tickIndex, double segmentLengthNm)
     {
         var value = tickIndex * segmentLengthNm;
-        return value.ToString("0.####", CultureInfo.InvariantCulture);
+        return value.ToString("0.####", CultureInfo.CurrentCulture);
     }
 
     private readonly record struct SegmentationPick(double SegmentLengthNm, int SegmentCount)

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -18,11 +18,30 @@ public partial class ScaleBarView : UserControl
 {
     private const double TargetPixelWidth = 200.0;
     private const double EarthRadiusMeters = 6378137.0;
-    private const double MetersPerNauticalMile = 1852.0;
+
+    private DistanceUnit _unit = DistanceUnit.NauticalMiles;
+    private double _lastResolution = double.NaN;
+    private double _lastCenterY = double.NaN;
 
     public ScaleBarView()
     {
         InitializeComponent();
+    }
+
+    /// <summary>Distance unit displayed by the bar. Setting this re-renders.</summary>
+    internal DistanceUnit Unit
+    {
+        get => _unit;
+        set
+        {
+            if (_unit == value)
+                return;
+            _unit = value;
+            if (!double.IsNaN(_lastResolution))
+            {
+                UpdateForViewport(_lastResolution, _lastCenterY);
+            }
+        }
     }
 
     /// <summary>
@@ -32,6 +51,9 @@ public partial class ScaleBarView : UserControl
     /// <param name="mercatorCenterY">Mercator Y coordinate of the viewport center (used to correct for latitude distortion).</param>
     public void UpdateForViewport(double mercatorResolution, double mercatorCenterY)
     {
+        _lastResolution = mercatorResolution;
+        _lastCenterY = mercatorCenterY;
+
         if (double.IsNaN(mercatorResolution) || mercatorResolution <= 0)
         {
             ClearBar();
@@ -47,14 +69,15 @@ public partial class ScaleBarView : UserControl
             return;
         }
 
-        var pick = PickSegmentation(groundMetersPerPixel, TargetPixelWidth);
+        var metersPerUnit = _unit.MetersPerUnit();
+        var pick = PickSegmentation(groundMetersPerPixel, metersPerUnit, TargetPixelWidth);
         if (pick is null)
         {
             ClearBar();
             return;
         }
 
-        BuildBar(pick.Value, groundMetersPerPixel);
+        BuildBar(pick.Value, groundMetersPerPixel, metersPerUnit, _unit.Abbreviation());
     }
 
     private void ClearBar()
@@ -65,12 +88,12 @@ public partial class ScaleBarView : UserControl
         BarCanvas.Width = 0;
     }
 
-    private void BuildBar(SegmentationPick pick, double groundMetersPerPixel)
+    private void BuildBar(SegmentationPick pick, double groundMetersPerPixel, double metersPerUnit, string unitAbbreviation)
     {
         LabelsCanvas.Children.Clear();
         BarCanvas.Children.Clear();
 
-        var segmentMeters = pick.SegmentLengthNm * MetersPerNauticalMile;
+        var segmentMeters = pick.SegmentLength * metersPerUnit;
         var segmentPx = segmentMeters / groundMetersPerPixel;
         var totalPx = segmentPx * pick.SegmentCount;
 
@@ -92,7 +115,7 @@ public partial class ScaleBarView : UserControl
         }
 
         // Labels (one at each tick: 0, 1*L, 2*L, ..., N*L)
-        const string UnitText = " NM";
+        var unitText = " " + unitAbbreviation;
         var unitWidth = 0.0;
 
         for (var i = 0; i <= pick.SegmentCount; i++)
@@ -118,7 +141,7 @@ public partial class ScaleBarView : UserControl
             {
                 var unitLabel = new TextBlock
                 {
-                    Text = UnitText,
+                    Text = unitText,
                     FontSize = 11,
                     FontWeight = FontWeight.SemiBold,
                 };
@@ -170,10 +193,10 @@ public partial class ScaleBarView : UserControl
         return text.Length * 4.0;
     }
 
-    private static SegmentationPick? PickSegmentation(double groundMetersPerPixel, double targetPx)
+    private static SegmentationPick? PickSegmentation(double groundMetersPerPixel, double metersPerUnit, double targetPx)
     {
-        var targetNm = targetPx * groundMetersPerPixel / MetersPerNauticalMile;
-        if (targetNm <= 0 || double.IsInfinity(targetNm))
+        var targetUnits = targetPx * groundMetersPerPixel / metersPerUnit;
+        if (targetUnits <= 0 || double.IsInfinity(targetUnits))
             return null;
 
         SegmentationPick? best = null;
@@ -183,8 +206,8 @@ public partial class ScaleBarView : UserControl
         {
             for (var n = 2; n <= 4; n++)
             {
-                var totalNm = candidate * n;
-                var totalPx = totalNm * MetersPerNauticalMile / groundMetersPerPixel;
+                var totalUnits = candidate * n;
+                var totalPx = totalUnits * metersPerUnit / groundMetersPerPixel;
                 // Penalise candidates that fall too far from the target width;
                 // use log-distance so over-shoot and under-shoot are weighted similarly.
                 var score = Math.Abs(Math.Log(totalPx / targetPx));
@@ -216,14 +239,14 @@ public partial class ScaleBarView : UserControl
         }
     }
 
-    private static string FormatTickLabel(int tickIndex, double segmentLengthNm)
+    private static string FormatTickLabel(int tickIndex, double segmentLength)
     {
-        var value = tickIndex * segmentLengthNm;
+        var value = tickIndex * segmentLength;
         return value.ToString("0.####", CultureInfo.CurrentCulture);
     }
 
-    private readonly record struct SegmentationPick(double SegmentLengthNm, int SegmentCount)
+    private readonly record struct SegmentationPick(double SegmentLength, int SegmentCount)
     {
-        public string FormatTick(int tickIndex) => FormatTickLabel(tickIndex, SegmentLengthNm);
+        public string FormatTick(int tickIndex) => FormatTickLabel(tickIndex, SegmentLength);
     }
 }

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -92,6 +92,9 @@ public partial class ScaleBarView : UserControl
         }
 
         // Labels (one at each tick: 0, 1*L, 2*L, ..., N*L)
+        const string UnitText = " NM";
+        var unitWidth = 0.0;
+
         for (var i = 0; i <= pick.SegmentCount; i++)
         {
             var text = pick.FormatTick(i);
@@ -108,6 +111,22 @@ public partial class ScaleBarView : UserControl
             var tickX = i * segmentPx;
             Canvas.SetLeft(label, tickX - labelWidth / 2.0);
             LabelsCanvas.Children.Add(label);
+
+            // Append the unit label after the rightmost tick value so it reads
+            // e.g. "0  1  2  3 NM".
+            if (i == pick.SegmentCount)
+            {
+                var unitLabel = new TextBlock
+                {
+                    Text = UnitText,
+                    FontSize = 11,
+                    FontWeight = FontWeight.SemiBold,
+                };
+                unitLabel.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                unitWidth = unitLabel.DesiredSize.Width;
+                Canvas.SetLeft(unitLabel, tickX + labelWidth / 2.0);
+                LabelsCanvas.Children.Add(unitLabel);
+            }
         }
 
         // Pad the canvases so the outermost labels (which extend past the bar
@@ -115,7 +134,7 @@ public partial class ScaleBarView : UserControl
         var firstLabelHalf = EstimateLabelHalfWidth(pick.FormatTick(0));
         var lastLabelHalf = EstimateLabelHalfWidth(pick.FormatTick(pick.SegmentCount));
         var leftPad = Math.Max(0, firstLabelHalf);
-        var rightPad = Math.Max(0, lastLabelHalf);
+        var rightPad = Math.Max(0, lastLabelHalf + unitWidth);
 
         // Shift everything right by leftPad so x=0 stays inside the canvas.
         foreach (var child in BarCanvas.Children)

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -99,6 +99,7 @@ public partial class ScaleBarView : UserControl
             {
                 Text = text,
                 FontSize = 11,
+                FontWeight = FontWeight.SemiBold,
                 TextAlignment = TextAlignment.Center,
             };
             // Measure to center on the tick.
@@ -163,7 +164,7 @@ public partial class ScaleBarView : UserControl
         {
             for (var n = 2; n <= 4; n++)
             {
-                var totalNm = candidate.LengthNm * n;
+                var totalNm = candidate * n;
                 var totalPx = totalNm * MetersPerNauticalMile / groundMetersPerPixel;
                 // Penalise candidates that fall too far from the target width;
                 // use log-distance so over-shoot and under-shoot are weighted similarly.
@@ -174,7 +175,7 @@ public partial class ScaleBarView : UserControl
                 if (score < bestScore)
                 {
                     bestScore = score;
-                    best = new SegmentationPick(candidate.LengthNm, n, candidate.Formatter);
+                    best = new SegmentationPick(candidate, n);
                 }
             }
         }
@@ -182,59 +183,28 @@ public partial class ScaleBarView : UserControl
         return best;
     }
 
-    private static IEnumerable<SegmentLengthCandidate> EnumerateSegmentLengths()
+    private static IEnumerable<double> EnumerateSegmentLengths()
     {
-        // Standard "1-2-2.5-5" nice numbers across many decades, plus a thirds
-        // family for the zoomed-in halves/thirds/quarters case the user asked for.
-        // 0.5 (=5e-1) and 0.25 (=2.5e-1) cover halves and quarters of 1 NM.
+        // "1-2-2.5-5" nice numbers across many decades. 0.5 (=5e-1) and
+        // 0.25 (=2.5e-1) cover halves and quarters of 1 NM at zoomed-in scales.
         for (var k = -4; k <= 6; k++)
         {
             var p = Math.Pow(10, k);
-            yield return new SegmentLengthCandidate(1.0 * p, DecimalFormatter);
-            yield return new SegmentLengthCandidate(2.0 * p, DecimalFormatter);
-            yield return new SegmentLengthCandidate(2.5 * p, DecimalFormatter);
-            yield return new SegmentLengthCandidate(5.0 * p, DecimalFormatter);
-
-            if (k >= 0)
-            {
-                // Thirds family: 1/3, 10/3, 100/3, ... NM. Only enable for
-                // p >= 1 so labels remain compact (e.g. avoid 0.0333 NM).
-                yield return new SegmentLengthCandidate(p / 3.0, MakeThirdsFormatter(p));
-            }
+            yield return 1.0 * p;
+            yield return 2.0 * p;
+            yield return 2.5 * p;
+            yield return 5.0 * p;
         }
     }
 
-    private static string DecimalFormatter(int tickIndex, double segmentLengthNm)
+    private static string FormatTickLabel(int tickIndex, double segmentLengthNm)
     {
         var value = tickIndex * segmentLengthNm;
-        // Trim trailing zeros, keep up to 4 decimals.
         return value.ToString("0.####", CultureInfo.InvariantCulture);
     }
 
-    private static Func<int, double, string> MakeThirdsFormatter(double powerOfTen)
+    private readonly record struct SegmentationPick(double SegmentLengthNm, int SegmentCount)
     {
-        // Each tick is i * (powerOfTen / 3). Express as a mixed number
-        // (whole + ⅓/⅔) when powerOfTen >= 1.
-        return (tickIndex, _) =>
-        {
-            var numerator = tickIndex * (long)Math.Round(powerOfTen);
-            var whole = numerator / 3;
-            var remainder = numerator % 3;
-            var wholeText = whole == 0 && remainder != 0 ? string.Empty : whole.ToString(CultureInfo.InvariantCulture);
-            return remainder switch
-            {
-                0 => whole.ToString(CultureInfo.InvariantCulture),
-                1 => wholeText + "\u2153", // ⅓
-                2 => wholeText + "\u2154", // ⅔
-                _ => whole.ToString(CultureInfo.InvariantCulture),
-            };
-        };
-    }
-
-    private readonly record struct SegmentLengthCandidate(double LengthNm, Func<int, double, string> Formatter);
-
-    private readonly record struct SegmentationPick(double SegmentLengthNm, int SegmentCount, Func<int, double, string> Formatter)
-    {
-        public string FormatTick(int tickIndex) => Formatter(tickIndex, SegmentLengthNm);
+        public string FormatTick(int tickIndex) => FormatTickLabel(tickIndex, SegmentLengthNm);
     }
 }

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -69,15 +69,26 @@ public partial class ScaleBarView : UserControl
             return;
         }
 
-        var metersPerUnit = _unit.MetersPerUnit();
-        var pick = PickSegmentation(groundMetersPerPixel, metersPerUnit, TargetPixelWidth);
-        if (pick is null)
+        var options = _unit.GetUnits();
+        for (var idx = 0; idx < options.Count; idx++)
         {
-            ClearBar();
-            return;
+            var option = options[idx];
+            var pick = PickSegmentation(groundMetersPerPixel, option.MetersPerUnit, TargetPixelWidth);
+            if (pick is null)
+                continue;
+
+            var totalMeters = pick.Value.SegmentLength * pick.Value.SegmentCount * option.MetersPerUnit;
+            var isLast = idx == options.Count - 1;
+            // Drop to a smaller unit (e.g. km -> m) once the bar shrinks to or
+            // below this unit's switch threshold; the smallest unit always wins.
+            if (isLast || totalMeters > option.SwitchBelowMeters)
+            {
+                BuildBar(pick.Value, groundMetersPerPixel, option.MetersPerUnit, option.Abbreviation);
+                return;
+            }
         }
 
-        BuildBar(pick.Value, groundMetersPerPixel, metersPerUnit, _unit.Abbreviation());
+        ClearBar();
     }
 
     private void ClearBar()

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// Map scale bar overlay. Renders 2-4 segments showing whole-number (or
+/// halved/thirded/quartered) nautical-mile lengths sized to the current
+/// viewport. Filled and outlined segments alternate in the accent color.
+/// </summary>
+public partial class ScaleBarView : UserControl
+{
+    private const double TargetPixelWidth = 200.0;
+    private const double EarthRadiusMeters = 6378137.0;
+    private const double MetersPerNauticalMile = 1852.0;
+
+    public ScaleBarView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    /// <summary>
+    /// Recomputes the scale bar for the current EPSG:3857 viewport.
+    /// </summary>
+    /// <param name="mercatorResolution">Map resolution in mercator meters per pixel.</param>
+    /// <param name="mercatorCenterY">Mercator Y coordinate of the viewport center (used to correct for latitude distortion).</param>
+    public void UpdateForViewport(double mercatorResolution, double mercatorCenterY)
+    {
+        if (double.IsNaN(mercatorResolution) || mercatorResolution <= 0)
+        {
+            ClearBar();
+            return;
+        }
+
+        // Convert mercator y to latitude to remove web-mercator scale distortion.
+        var latitudeRadians = Math.Atan(Math.Sinh(mercatorCenterY / EarthRadiusMeters));
+        var groundMetersPerPixel = mercatorResolution * Math.Cos(latitudeRadians);
+        if (groundMetersPerPixel <= 0)
+        {
+            ClearBar();
+            return;
+        }
+
+        var pick = PickSegmentation(groundMetersPerPixel, TargetPixelWidth);
+        if (pick is null)
+        {
+            ClearBar();
+            return;
+        }
+
+        BuildBar(pick.Value, groundMetersPerPixel);
+    }
+
+    private void ClearBar()
+    {
+        LabelsCanvas.Children.Clear();
+        BarCanvas.Children.Clear();
+        LabelsCanvas.Width = 0;
+        BarCanvas.Width = 0;
+    }
+
+    private void BuildBar(SegmentationPick pick, double groundMetersPerPixel)
+    {
+        LabelsCanvas.Children.Clear();
+        BarCanvas.Children.Clear();
+
+        var segmentMeters = pick.SegmentLengthNm * MetersPerNauticalMile;
+        var segmentPx = segmentMeters / groundMetersPerPixel;
+        var totalPx = segmentPx * pick.SegmentCount;
+
+        var accent = (IBrush?)Application.Current?.FindResource("AccentBrush") ?? Brushes.SteelBlue;
+
+        // Segments
+        for (var i = 0; i < pick.SegmentCount; i++)
+        {
+            var rect = new Rectangle
+            {
+                Width = segmentPx,
+                Height = BarCanvas.Height,
+                Stroke = accent,
+                StrokeThickness = 1,
+                Fill = (i % 2 == 0) ? accent : Brushes.Transparent,
+            };
+            Canvas.SetLeft(rect, i * segmentPx);
+            BarCanvas.Children.Add(rect);
+        }
+
+        // Labels (one at each tick: 0, 1*L, 2*L, ..., N*L)
+        for (var i = 0; i <= pick.SegmentCount; i++)
+        {
+            var text = pick.FormatTick(i);
+            var label = new TextBlock
+            {
+                Text = text,
+                FontSize = 11,
+                TextAlignment = TextAlignment.Center,
+            };
+            // Measure to center on the tick.
+            label.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            var labelWidth = label.DesiredSize.Width;
+            var tickX = i * segmentPx;
+            Canvas.SetLeft(label, tickX - labelWidth / 2.0);
+            LabelsCanvas.Children.Add(label);
+        }
+
+        // Pad the canvases so the outermost labels (which extend past the bar
+        // ends) are not clipped.
+        var firstLabelHalf = EstimateLabelHalfWidth(pick.FormatTick(0));
+        var lastLabelHalf = EstimateLabelHalfWidth(pick.FormatTick(pick.SegmentCount));
+        var leftPad = Math.Max(0, firstLabelHalf);
+        var rightPad = Math.Max(0, lastLabelHalf);
+
+        // Shift everything right by leftPad so x=0 stays inside the canvas.
+        foreach (var child in BarCanvas.Children)
+        {
+            if (child is Control c)
+            {
+                Canvas.SetLeft(c, Canvas.GetLeft(c) + leftPad);
+            }
+        }
+        foreach (var child in LabelsCanvas.Children)
+        {
+            if (child is Control c)
+            {
+                Canvas.SetLeft(c, Canvas.GetLeft(c) + leftPad);
+            }
+        }
+
+        var canvasWidth = totalPx + leftPad + rightPad;
+        BarCanvas.Width = canvasWidth;
+        LabelsCanvas.Width = canvasWidth;
+    }
+
+    private static double EstimateLabelHalfWidth(string text)
+    {
+        // Approx width per character at 11pt; sufficient for padding.
+        return text.Length * 4.0;
+    }
+
+    private static SegmentationPick? PickSegmentation(double groundMetersPerPixel, double targetPx)
+    {
+        var targetNm = targetPx * groundMetersPerPixel / MetersPerNauticalMile;
+        if (targetNm <= 0 || double.IsInfinity(targetNm))
+            return null;
+
+        SegmentationPick? best = null;
+        var bestScore = double.PositiveInfinity;
+
+        foreach (var candidate in EnumerateSegmentLengths())
+        {
+            for (var n = 2; n <= 4; n++)
+            {
+                var totalNm = candidate.LengthNm * n;
+                var totalPx = totalNm * MetersPerNauticalMile / groundMetersPerPixel;
+                // Penalise candidates that fall too far from the target width;
+                // use log-distance so over-shoot and under-shoot are weighted similarly.
+                var score = Math.Abs(Math.Log(totalPx / targetPx));
+                // Favour bars that don't grow too small to read or too wide to fit.
+                if (totalPx < 60 || totalPx > 360)
+                    score += 5;
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    best = new SegmentationPick(candidate.LengthNm, n, candidate.Formatter);
+                }
+            }
+        }
+
+        return best;
+    }
+
+    private static IEnumerable<SegmentLengthCandidate> EnumerateSegmentLengths()
+    {
+        // Standard "1-2-2.5-5" nice numbers across many decades, plus a thirds
+        // family for the zoomed-in halves/thirds/quarters case the user asked for.
+        // 0.5 (=5e-1) and 0.25 (=2.5e-1) cover halves and quarters of 1 NM.
+        for (var k = -4; k <= 6; k++)
+        {
+            var p = Math.Pow(10, k);
+            yield return new SegmentLengthCandidate(1.0 * p, DecimalFormatter);
+            yield return new SegmentLengthCandidate(2.0 * p, DecimalFormatter);
+            yield return new SegmentLengthCandidate(2.5 * p, DecimalFormatter);
+            yield return new SegmentLengthCandidate(5.0 * p, DecimalFormatter);
+
+            if (k >= 0)
+            {
+                // Thirds family: 1/3, 10/3, 100/3, ... NM. Only enable for
+                // p >= 1 so labels remain compact (e.g. avoid 0.0333 NM).
+                yield return new SegmentLengthCandidate(p / 3.0, MakeThirdsFormatter(p));
+            }
+        }
+    }
+
+    private static string DecimalFormatter(int tickIndex, double segmentLengthNm)
+    {
+        var value = tickIndex * segmentLengthNm;
+        // Trim trailing zeros, keep up to 4 decimals.
+        return value.ToString("0.####", CultureInfo.InvariantCulture);
+    }
+
+    private static Func<int, double, string> MakeThirdsFormatter(double powerOfTen)
+    {
+        // Each tick is i * (powerOfTen / 3). Express as a mixed number
+        // (whole + ⅓/⅔) when powerOfTen >= 1.
+        return (tickIndex, _) =>
+        {
+            var numerator = tickIndex * (long)Math.Round(powerOfTen);
+            var whole = numerator / 3;
+            var remainder = numerator % 3;
+            var wholeText = whole == 0 && remainder != 0 ? string.Empty : whole.ToString(CultureInfo.InvariantCulture);
+            return remainder switch
+            {
+                0 => whole.ToString(CultureInfo.InvariantCulture),
+                1 => wholeText + "\u2153", // ⅓
+                2 => wholeText + "\u2154", // ⅔
+                _ => whole.ToString(CultureInfo.InvariantCulture),
+            };
+        };
+    }
+
+    private readonly record struct SegmentLengthCandidate(double LengthNm, Func<int, double, string> Formatter);
+
+    private readonly record struct SegmentationPick(double SegmentLengthNm, int SegmentCount, Func<int, double, string> Formatter)
+    {
+        public string FormatTick(int tickIndex) => Formatter(tickIndex, SegmentLengthNm);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ScaleBarView.axaml.cs
@@ -5,7 +5,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Layout;
-using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 
 namespace EncDotNet.S100.Viewer.Views;
@@ -25,8 +24,6 @@ public partial class ScaleBarView : UserControl
     {
         InitializeComponent();
     }
-
-    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
     /// <summary>
     /// Recomputes the scale bar for the current EPSG:3857 viewport.
@@ -77,7 +74,7 @@ public partial class ScaleBarView : UserControl
         var segmentPx = segmentMeters / groundMetersPerPixel;
         var totalPx = segmentPx * pick.SegmentCount;
 
-        var accent = (IBrush?)Application.Current?.FindResource("AccentBrush") ?? Brushes.SteelBlue;
+        var accent = TryFindAccentBrush() ?? Brushes.SteelBlue;
 
         // Segments
         for (var i = 0; i < pick.SegmentCount; i++)
@@ -138,6 +135,13 @@ public partial class ScaleBarView : UserControl
         var canvasWidth = totalPx + leftPad + rightPad;
         BarCanvas.Width = canvasWidth;
         LabelsCanvas.Width = canvasWidth;
+    }
+
+    private IBrush? TryFindAccentBrush()
+    {
+        if (this.TryFindResource("AccentBrush", out var value) && value is IBrush brush)
+            return brush;
+        return null;
     }
 
     private static double EstimateLabelHalfWidth(string text)

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             xmlns:viewer="using:EncDotNet.S100.Viewer"
              x:Class="EncDotNet.S100.Viewer.Views.SettingsView"
              x:DataType="vm:SettingsViewModel">
 
@@ -85,6 +86,27 @@
                                Margin="8,0,0,0"
                                MinWidth="36" />
                 </Grid>
+            </StackPanel>
+
+            <!-- Distance Unit -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="Distance Units"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBlock Text="Units used by the map scale bar."
+                           FontSize="11"
+                           Opacity="0.6"
+                           TextWrapping="Wrap" />
+                <ComboBox ItemsSource="{Binding AvailableDistanceUnits}"
+                          SelectedItem="{Binding DistanceUnit}"
+                          MinWidth="180"
+                          HorizontalAlignment="Left">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate DataType="viewer:DistanceUnit">
+                            <TextBlock Text="{Binding Converter={x:Static viewer:DistanceUnitNameConverter.Instance}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>


### PR DESCRIPTION
## Summary

Adds a scale bar overlay to the viewer's map so users can judge real-world distances at a glance. The bar sits top-center over the map, redraws on viewport changes, and picks 2-4 "nice" segments (1/2/2.5/5 x 10^k) targeting ~200px so the labels stay readable across zoom levels. Segments alternate between accent-filled and accent-outlined; labels use a fixed dark color so they remain legible against the unthemed map content, and tick values are formatted using the user's current locale.

A new "Distance Units" setting lets the user choose between Metric, Miles, and Nautical Miles. To keep numbers readable when zoomed in, Metric auto-switches from km to m once the bar measures <=100m, and Miles switches from mi to ft once the bar measures <=1000ft. Nautical Miles always uses nm. The unit abbreviation is rendered inline to the right of the last tick label (e.g. `0  1  2  3 nm`).

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a viewer-only UI change; no spec semantics, encodings, or feature/portrayal catalogues are touched.

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

No automated tests added — this is Avalonia UI code (overlay control + settings wiring) verified interactively by running the viewer. The segment-picking algorithm could be extracted and unit-tested in a follow-up if desired.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

The viewer project does not currently document individual UI features in its README, so no doc changes were made. Public types (`DistanceUnit`, converter) carry XML doc comments.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. The new `DistanceUnit` viewer setting defaults to `NauticalMiles`; older persisted values (`Meters`, `Kilometers`) fall through to the default via `Enum.TryParse` and are silently migrated.