### PR TITLE
Add a compass rose overlay to the viewer with rotation controls

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -249,6 +249,10 @@
                             Classes="Icon">
                         <ic:FluentIcon Icon="Subtract" IconVariant="Regular" FontSize="16" />
                     </Button>
+                    <views:CompassRoseView x:Name="CompassRose"
+                                           Margin="0,4,0,0"
+                                           Width="{Binding Bounds.Width, ElementName=ZoomInButton}"
+                                           Height="{Binding Bounds.Width, ElementName=ZoomInButton}" />
                 </StackPanel>
             </Grid>
         </Grid>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -518,6 +518,7 @@ public partial class MainWindow : ShadUI.Window
     private void UpdateScaleBar(Mapsui.Viewport viewport)
     {
         ScaleBar.UpdateForViewport(viewport.Resolution, viewport.CenterY);
+        CompassRose.UpdateForViewport(viewport.Rotation);
     }
 
     private void OnZoomOutClick(object? sender, RoutedEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -245,6 +245,7 @@ public partial class MainWindow : ShadUI.Window
 
         // Drive the map rotation from compass-rose drag gestures.
         CompassRose.RotationRequested += OnCompassRotationRequested;
+        CompassRose.RotationResetRequested += OnCompassRotationReset;
 
         // Apply CLI options
         _screenshotPath = options?.ScreenshotPath;
@@ -571,6 +572,16 @@ public partial class MainWindow : ShadUI.Window
         if (MapControl.Map?.Navigator is not { } navigator)
             return;
         navigator.RotateTo(rotationDegrees);
+    }
+
+    private void OnCompassRotationReset()
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
+            return;
+        // Pick the equivalent rotation closest to 0 to avoid spinning the long way.
+        var current = navigator.Viewport.Rotation;
+        var target = current > 180.0 ? 360.0 : 0.0;
+        navigator.RotateTo(target, 250);
     }
 
     private void OnMapPointerWheelChanged(object? sender, PointerWheelEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -243,6 +243,9 @@ public partial class MainWindow : ShadUI.Window
             UpdateScaleBar(scaleNav.Viewport);
         }
 
+        // Drive the map rotation from compass-rose drag gestures.
+        CompassRose.RotationRequested += OnCompassRotationRequested;
+
         // Apply CLI options
         _screenshotPath = options?.ScreenshotPath;
 
@@ -561,6 +564,13 @@ public partial class MainWindow : ShadUI.Window
         newRotation = ((newRotation % 360.0) + 360.0) % 360.0;
         navigator.RotateTo(newRotation);
         e.Handled = true;
+    }
+
+    private void OnCompassRotationRequested(double rotationDegrees)
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
+            return;
+        navigator.RotateTo(rotationDegrees);
     }
 
     private void OnMapPointerWheelChanged(object? sender, PointerWheelEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -217,6 +217,9 @@ public partial class MainWindow : ShadUI.Window
         // Enable pinch-to-zoom on the map control via trackpad magnify gesture
         MapControl.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, OnMapMagnify);
 
+        // Enable trackpad rotate gesture to rotate the map
+        MapControl.AddHandler(Gestures.PointerTouchPadGestureRotateEvent, OnMapRotateGesture);
+
         // Enable double-tap to zoom in
         MapControl.DoubleTapped += OnMapDoubleTapped;
 
@@ -539,6 +542,24 @@ public partial class MainWindow : ShadUI.Window
         var position = e.GetPosition(MapControl);
         var center = new ScreenPosition(position.X, position.Y);
         navigator.ZoomTo(newResolution, center);
+        e.Handled = true;
+    }
+
+    private void OnMapRotateGesture(object? sender, PointerDeltaEventArgs e)
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
+            return;
+
+        // macOS reports the rotation delta in degrees (counter-clockwise positive).
+        // Mapsui's viewport rotation is clockwise positive, so negate.
+        var deltaDegrees = -e.Delta.X;
+        if (deltaDegrees == 0)
+            return;
+
+        var newRotation = navigator.Viewport.Rotation + deltaDegrees;
+        // Normalize to [0, 360).
+        newRotation = ((newRotation % 360.0) + 360.0) % 360.0;
+        navigator.RotateTo(newRotation);
         e.Handled = true;
     }
 

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -590,9 +590,22 @@ public partial class MainWindow : ShadUI.Window
             return;
 
         var viewport = navigator.Viewport;
-        var dx = e.Delta.X * viewport.Resolution * 50;
-        var dy = e.Delta.Y * viewport.Resolution * 50;
-        navigator.CenterOn(viewport.CenterX - dx, viewport.CenterY + dy);
+
+        // Pan vector in the unrotated (screen-aligned) world frame: dragging
+        // the content right/up (Delta.X/Y > 0) moves the viewport center
+        // left/up by the same amount.
+        var dxScreen = -e.Delta.X * viewport.Resolution * 50;
+        var dyScreen = e.Delta.Y * viewport.Resolution * 50;
+
+        // Rotate the screen-space delta into world space by the viewport
+        // rotation so swipes always agree with the on-screen orientation.
+        var rad = viewport.Rotation * Math.PI / 180.0;
+        var sin = Math.Sin(rad);
+        var cos = Math.Cos(rad);
+        var dxWorld = dxScreen * cos - dyScreen * sin;
+        var dyWorld = dxScreen * sin + dyScreen * cos;
+
+        navigator.CenterOn(viewport.CenterX + dxWorld, viewport.CenterY + dyWorld);
         e.Handled = true;
     }
 

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -56,37 +56,66 @@ internal sealed class CompassRoseView : Control
         if (outerRadius <= 0)
             return;
 
-        var bgBrush = new SolidColorBrush(Color.FromArgb(220, 255, 255, 255));
-        var borderBrush = new SolidColorBrush(Color.FromArgb(96, 0, 0, 0));
+        var bgBrush = new SolidColorBrush(Color.FromArgb(140, 255, 255, 255));
+        var borderBrush = new SolidColorBrush(Color.FromArgb(64, 0, 0, 0));
         var borderPen = new Pen(borderBrush, 1);
         context.DrawEllipse(bgBrush, borderPen, new Point(cx, cy), outerRadius, outerRadius);
 
         var accent = TryFindAccentBrush() ?? Brushes.SteelBlue;
-        var tickBrush = new SolidColorBrush(Color.FromArgb(190, 30, 30, 30));
-        var cardinalBrush = new SolidColorBrush(Color.FromArgb(230, 20, 20, 20));
+        var tickBrush = new SolidColorBrush(Color.FromArgb(150, 40, 40, 40));
 
         var rotation = MapRotation;
-        var cardinalLength = Math.Max(3.0, size * 0.18);
         var minorLength = Math.Max(2.0, size * 0.10);
+        var cardinalLength = Math.Max(4.0, size * 0.22);
+        var northLength = Math.Max(5.0, size * 0.28);
 
-        for (var a = 0; a < 360; a += 10)
+        // Minor ticks every 30 degrees, skipping the cardinals (which are
+        // drawn as triangles below).
+        for (var a = 30; a < 360; a += 30)
         {
-            var isCardinal = a % 90 == 0;
-            var isNorth = a == 0;
-            var tickLen = isCardinal ? cardinalLength : minorLength;
-            var thickness = isCardinal ? 1.6 : 1.0;
-            IBrush brush = isNorth ? accent : (isCardinal ? cardinalBrush : tickBrush);
-
+            if (a % 90 == 0)
+                continue;
             var rad = (rotation + a) * Math.PI / 180.0;
             var sin = Math.Sin(rad);
             var cos = Math.Cos(rad);
             var p1 = new Point(cx + sin * outerRadius, cy - cos * outerRadius);
-            var p2 = new Point(cx + sin * (outerRadius - tickLen), cy - cos * (outerRadius - tickLen));
-            var pen = new Pen(brush, thickness)
-            {
-                LineCap = PenLineCap.Round,
-            };
+            var p2 = new Point(cx + sin * (outerRadius - minorLength), cy - cos * (outerRadius - minorLength));
+            var pen = new Pen(tickBrush, 1.0) { LineCap = PenLineCap.Round };
             context.DrawLine(pen, p1, p2);
+        }
+
+        // Cardinal ticks rendered as thin inward-pointing triangles. North is
+        // larger and rendered in the accent color.
+        for (var a = 0; a < 360; a += 90)
+        {
+            var isNorth = a == 0;
+            var tickLen = isNorth ? northLength : cardinalLength;
+            var halfBase = isNorth ? Math.Max(2.0, size * 0.07) : Math.Max(1.5, size * 0.05);
+            IBrush fill = isNorth ? accent : tickBrush;
+
+            var rad = (rotation + a) * Math.PI / 180.0;
+            var sin = Math.Sin(rad);
+            var cos = Math.Cos(rad);
+            // Tangent direction (perpendicular to the radial), used to offset
+            // the base vertices to either side of the tick line.
+            var tx = cos;
+            var ty = sin;
+
+            var tip = new Point(cx + sin * outerRadius, cy - cos * outerRadius);
+            var basePx = cx + sin * (outerRadius - tickLen);
+            var basePy = cy - cos * (outerRadius - tickLen);
+            var b1 = new Point(basePx + tx * halfBase, basePy + ty * halfBase);
+            var b2 = new Point(basePx - tx * halfBase, basePy - ty * halfBase);
+
+            var geometry = new StreamGeometry();
+            using (var ctx = geometry.Open())
+            {
+                ctx.BeginFigure(tip, isFilled: true);
+                ctx.LineTo(b1);
+                ctx.LineTo(b2);
+                ctx.EndFigure(isClosed: true);
+            }
+            context.DrawGeometry(fill, null, geometry);
         }
 
         // Center letter shows the cardinal direction nearest to screen-up.

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// Map compass-rose overlay. Draws a circular ring of tick marks with the four
+/// cardinal ticks emphasized and the north tick rendered in the accent color.
+/// The whole tick ring rotates with the map so the north tick always points to
+/// true north; the center letter shows whichever cardinal direction is most
+/// closely aligned with screen-up.
+/// </summary>
+internal sealed class CompassRoseView : Control
+{
+    /// <summary>
+    /// Map rotation in degrees clockwise (matches <c>Mapsui.Viewport.Rotation</c>).
+    /// </summary>
+    public static readonly StyledProperty<double> MapRotationProperty =
+        AvaloniaProperty.Register<CompassRoseView, double>(nameof(MapRotation));
+
+    static CompassRoseView()
+    {
+        AffectsRender<CompassRoseView>(MapRotationProperty);
+    }
+
+    public double MapRotation
+    {
+        get => GetValue(MapRotationProperty);
+        set => SetValue(MapRotationProperty, value);
+    }
+
+    /// <summary>
+    /// Updates the compass for the current map viewport rotation (degrees clockwise).
+    /// </summary>
+    public void UpdateForViewport(double mapRotationDegrees)
+    {
+        MapRotation = mapRotationDegrees;
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+
+        var width = Bounds.Width;
+        var height = Bounds.Height;
+        var size = Math.Min(width, height);
+        if (size <= 0)
+            return;
+
+        var cx = width / 2.0;
+        var cy = height / 2.0;
+        var outerRadius = size / 2.0 - 1.0;
+        if (outerRadius <= 0)
+            return;
+
+        var bgBrush = new SolidColorBrush(Color.FromArgb(220, 255, 255, 255));
+        var borderBrush = new SolidColorBrush(Color.FromArgb(96, 0, 0, 0));
+        var borderPen = new Pen(borderBrush, 1);
+        context.DrawEllipse(bgBrush, borderPen, new Point(cx, cy), outerRadius, outerRadius);
+
+        var accent = TryFindAccentBrush() ?? Brushes.SteelBlue;
+        var tickBrush = new SolidColorBrush(Color.FromArgb(190, 30, 30, 30));
+        var cardinalBrush = new SolidColorBrush(Color.FromArgb(230, 20, 20, 20));
+
+        var rotation = MapRotation;
+        var cardinalLength = Math.Max(3.0, size * 0.18);
+        var minorLength = Math.Max(2.0, size * 0.10);
+
+        for (var a = 0; a < 360; a += 10)
+        {
+            var isCardinal = a % 90 == 0;
+            var isNorth = a == 0;
+            var tickLen = isCardinal ? cardinalLength : minorLength;
+            var thickness = isCardinal ? 1.6 : 1.0;
+            IBrush brush = isNorth ? accent : (isCardinal ? cardinalBrush : tickBrush);
+
+            var rad = (rotation + a) * Math.PI / 180.0;
+            var sin = Math.Sin(rad);
+            var cos = Math.Cos(rad);
+            var p1 = new Point(cx + sin * outerRadius, cy - cos * outerRadius);
+            var p2 = new Point(cx + sin * (outerRadius - tickLen), cy - cos * (outerRadius - tickLen));
+            var pen = new Pen(brush, thickness)
+            {
+                LineCap = PenLineCap.Round,
+            };
+            context.DrawLine(pen, p1, p2);
+        }
+
+        // Center letter shows the cardinal direction nearest to screen-up.
+        // A clockwise map rotation of R puts the bearing (360 - R) at screen-up.
+        var upBearing = (((360.0 - rotation) % 360.0) + 360.0) % 360.0;
+        var letter = NearestCardinal(upBearing);
+        var typeface = new Typeface(FontFamily.Default, FontStyle.Normal, FontWeight.SemiBold);
+        var foreground = new SolidColorBrush(Color.FromRgb(26, 26, 26));
+        var fontSize = Math.Max(8.0, size * 0.40);
+        var formatted = new FormattedText(
+            letter,
+            CultureInfo.CurrentCulture,
+            FlowDirection.LeftToRight,
+            typeface,
+            fontSize,
+            foreground);
+        var origin = new Point(cx - formatted.Width / 2.0, cy - formatted.Height / 2.0);
+        context.DrawText(formatted, origin);
+    }
+
+    private IBrush? TryFindAccentBrush()
+    {
+        if (this.TryFindResource("AccentBrush", out var value) && value is IBrush brush)
+            return brush;
+        return null;
+    }
+
+    private static string NearestCardinal(double bearingDegrees)
+    {
+        // 0=N, 90=E, 180=S, 270=W. Snap to whichever is within 45 degrees.
+        var b = ((bearingDegrees % 360.0) + 360.0) % 360.0;
+        if (b < 45.0 || b >= 315.0) return "N";
+        if (b < 135.0) return "E";
+        if (b < 225.0) return "S";
+        return "W";
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -159,7 +159,13 @@ internal sealed class CompassRoseView : Control
             typeface,
             fontSize,
             palette.Foreground);
-        var origin = new Point(cx - formatted.Width / 2.0, cy - formatted.Height / 2.0);
+        // Center the visible glyph (not the full text box) on the compass.
+        // FormattedText positions by the box top-left and the cap-height sits
+        // above the baseline, so use Baseline + an approximate cap-height to
+        // center vertically without drift toward the top.
+        var capHeight = fontSize * 0.72;
+        var baselineY = cy + capHeight / 2.0;
+        var origin = new Point(cx - formatted.Width / 2.0, baselineY - formatted.Baseline);
         context.DrawText(formatted, origin);
     }
 

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Styling;
 
 namespace EncDotNet.S100.Viewer.Views;
 
@@ -11,7 +12,8 @@ namespace EncDotNet.S100.Viewer.Views;
 /// cardinal ticks emphasized and the north tick rendered in the accent color.
 /// The whole tick ring rotates with the map so the north tick always points to
 /// true north; the center letter shows whichever cardinal direction is most
-/// closely aligned with screen-up.
+/// closely aligned with screen-up. Background, tick, and text colors follow
+/// the active light/dark theme variant.
 /// </summary>
 internal sealed class CompassRoseView : Control
 {
@@ -24,6 +26,11 @@ internal sealed class CompassRoseView : Control
     static CompassRoseView()
     {
         AffectsRender<CompassRoseView>(MapRotationProperty);
+    }
+
+    public CompassRoseView()
+    {
+        ActualThemeVariantChanged += (_, _) => InvalidateVisual();
     }
 
     public double MapRotation
@@ -56,11 +63,9 @@ internal sealed class CompassRoseView : Control
         if (outerRadius <= 0)
             return;
 
-        var bgBrush = new SolidColorBrush(Color.FromArgb(140, 255, 255, 255));
-        context.DrawEllipse(bgBrush, null, new Point(cx, cy), outerRadius, outerRadius);
+        var palette = ResolvePalette();
 
-        var accent = TryFindAccentBrush() ?? Brushes.SteelBlue;
-        var tickBrush = new SolidColorBrush(Color.FromArgb(150, 40, 40, 40));
+        context.DrawEllipse(palette.Background, null, new Point(cx, cy), outerRadius, outerRadius);
 
         var rotation = MapRotation;
         // Inset the tick ring so ticks don't touch the compass edge.
@@ -81,7 +86,7 @@ internal sealed class CompassRoseView : Control
             var cos = Math.Cos(rad);
             var p1 = new Point(cx + sin * tickOuterRadius, cy - cos * tickOuterRadius);
             var p2 = new Point(cx + sin * (tickOuterRadius - minorLength), cy - cos * (tickOuterRadius - minorLength));
-            var pen = new Pen(tickBrush, 1.0) { LineCap = PenLineCap.Round };
+            var pen = new Pen(palette.Tick, 1.0) { LineCap = PenLineCap.Round };
             context.DrawLine(pen, p1, p2);
         }
 
@@ -92,7 +97,7 @@ internal sealed class CompassRoseView : Control
             var isNorth = a == 0;
             var tickLen = isNorth ? northLength : cardinalLength;
             var halfBase = isNorth ? Math.Max(2.0, size * 0.07) : Math.Max(1.5, size * 0.05);
-            IBrush fill = isNorth ? accent : tickBrush;
+            IBrush fill = isNorth ? palette.North : palette.Tick;
 
             var rad = (rotation + a) * Math.PI / 180.0;
             var sin = Math.Sin(rad);
@@ -124,7 +129,6 @@ internal sealed class CompassRoseView : Control
         var upBearing = (((360.0 - rotation) % 360.0) + 360.0) % 360.0;
         var letter = NearestCardinal(upBearing);
         var typeface = new Typeface(FontFamily.Default, FontStyle.Normal, FontWeight.SemiBold);
-        var foreground = new SolidColorBrush(Color.FromRgb(26, 26, 26));
         var fontSize = Math.Max(8.0, size * 0.40);
         var formatted = new FormattedText(
             letter,
@@ -132,15 +136,40 @@ internal sealed class CompassRoseView : Control
             FlowDirection.LeftToRight,
             typeface,
             fontSize,
-            foreground);
+            palette.Foreground);
         var origin = new Point(cx - formatted.Width / 2.0, cy - formatted.Height / 2.0);
         context.DrawText(formatted, origin);
     }
 
+    private Palette ResolvePalette()
+    {
+        var isDark = ActualThemeVariant == ThemeVariant.Dark;
+        var north = TryFindAccentBrush() ?? Brushes.SteelBlue;
+        if (isDark)
+        {
+            return new Palette(
+                Background: new SolidColorBrush(Color.FromArgb(140, 30, 30, 30)),
+                Tick: new SolidColorBrush(Color.FromArgb(190, 230, 230, 230)),
+                Foreground: new SolidColorBrush(Color.FromArgb(240, 240, 240, 240)),
+                North: north);
+        }
+
+        return new Palette(
+            Background: new SolidColorBrush(Color.FromArgb(140, 255, 255, 255)),
+            Tick: new SolidColorBrush(Color.FromArgb(170, 40, 40, 40)),
+            Foreground: new SolidColorBrush(Color.FromArgb(230, 26, 26, 26)),
+            North: north);
+    }
+
     private IBrush? TryFindAccentBrush()
     {
-        if (this.TryFindResource("AccentBrush", out var value) && value is IBrush brush)
-            return brush;
+        if (this.TryFindResource("AccentBrush", out var value))
+        {
+            if (value is IBrush brush)
+                return brush;
+            if (value is Color color)
+                return new SolidColorBrush(color);
+        }
         return null;
     }
 
@@ -153,4 +182,6 @@ internal sealed class CompassRoseView : Control
         if (b < 225.0) return "S";
         return "W";
     }
+
+    private readonly record struct Palette(IBrush Background, IBrush Tick, IBrush Foreground, IBrush North);
 }

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Styling;
 
@@ -14,6 +15,10 @@ namespace EncDotNet.S100.Viewer.Views;
 /// true north; the center letter shows whichever cardinal direction is most
 /// closely aligned with screen-up. Background, tick, and text colors follow
 /// the active light/dark theme variant.
+///
+/// The compass also acts as a rotation control: pressing inside the compass
+/// "grabs" an arm; subsequent pointer motion rotates the map so the grabbed
+/// angle stays under the pointer. Releasing the pointer ends the gesture.
 /// </summary>
 internal sealed class CompassRoseView : Control
 {
@@ -23,6 +28,10 @@ internal sealed class CompassRoseView : Control
     public static readonly StyledProperty<double> MapRotationProperty =
         AvaloniaProperty.Register<CompassRoseView, double>(nameof(MapRotation));
 
+    private bool _isDragging;
+    private double _grabPointerAngle;
+    private double _grabMapRotation;
+
     static CompassRoseView()
     {
         AffectsRender<CompassRoseView>(MapRotationProperty);
@@ -31,6 +40,7 @@ internal sealed class CompassRoseView : Control
     public CompassRoseView()
     {
         ActualThemeVariantChanged += (_, _) => InvalidateVisual();
+        Cursor = new Cursor(StandardCursorType.Hand);
     }
 
     public double MapRotation
@@ -38,6 +48,13 @@ internal sealed class CompassRoseView : Control
         get => GetValue(MapRotationProperty);
         set => SetValue(MapRotationProperty, value);
     }
+
+    /// <summary>
+    /// Raised continuously while the user is rotating via the compass. The
+    /// argument is the requested map rotation in degrees clockwise, normalized
+    /// to <c>[0, 360)</c>.
+    /// </summary>
+    public event Action<double>? RotationRequested;
 
     /// <summary>
     /// Updates the compass for the current map viewport rotation (degrees clockwise).
@@ -139,6 +156,76 @@ internal sealed class CompassRoseView : Control
             palette.Foreground);
         var origin = new Point(cx - formatted.Width / 2.0, cy - formatted.Height / 2.0);
         context.DrawText(formatted, origin);
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            return;
+        var pos = e.GetPosition(this);
+        if (!IsInsideCompass(pos))
+            return;
+
+        _isDragging = true;
+        _grabPointerAngle = AngleFromCenter(pos);
+        _grabMapRotation = MapRotation;
+        e.Pointer.Capture(this);
+        e.Handled = true;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        if (!_isDragging)
+            return;
+
+        var pos = e.GetPosition(this);
+        var angle = AngleFromCenter(pos);
+        var rotation = _grabMapRotation + (angle - _grabPointerAngle);
+        rotation = ((rotation % 360.0) + 360.0) % 360.0;
+        RotationRequested?.Invoke(rotation);
+        e.Handled = true;
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        if (!_isDragging)
+            return;
+
+        _isDragging = false;
+        e.Pointer.Capture(null);
+        e.Handled = true;
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        _isDragging = false;
+    }
+
+    private bool IsInsideCompass(Point pos)
+    {
+        var cx = Bounds.Width / 2.0;
+        var cy = Bounds.Height / 2.0;
+        var radius = Math.Min(Bounds.Width, Bounds.Height) / 2.0 - 1.0;
+        if (radius <= 0)
+            return false;
+        var dx = pos.X - cx;
+        var dy = pos.Y - cy;
+        return dx * dx + dy * dy <= radius * radius;
+    }
+
+    private double AngleFromCenter(Point pos)
+    {
+        var cx = Bounds.Width / 2.0;
+        var cy = Bounds.Height / 2.0;
+        // Screen-up is angle 0; clockwise positive (matches Mapsui rotation).
+        var dx = pos.X - cx;
+        var dy = pos.Y - cy;
+        var rad = Math.Atan2(dx, -dy);
+        return rad * 180.0 / Math.PI;
     }
 
     private Palette ResolvePalette()

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -57,6 +57,12 @@ internal sealed class CompassRoseView : Control
     public event Action<double>? RotationRequested;
 
     /// <summary>
+    /// Raised when the user double-clicks the compass to request resetting
+    /// the map to a north-up orientation.
+    /// </summary>
+    public event Action? RotationResetRequested;
+
+    /// <summary>
     /// Updates the compass for the current map viewport rotation (degrees clockwise).
     /// </summary>
     public void UpdateForViewport(double mapRotationDegrees)
@@ -166,6 +172,15 @@ internal sealed class CompassRoseView : Control
         var pos = e.GetPosition(this);
         if (!IsInsideCompass(pos))
             return;
+
+        if (e.ClickCount >= 2)
+        {
+            // Double-click resets the map to north-up. Don't enter drag mode.
+            _isDragging = false;
+            RotationResetRequested?.Invoke();
+            e.Handled = true;
+            return;
+        }
 
         _isDragging = true;
         _grabPointerAngle = AngleFromCenter(pos);

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -96,7 +96,6 @@ internal sealed class CompassRoseView : Control
         var tickOuterRadius = outerRadius - tickPadding;
         var minorLength = Math.Max(1.5, size * 0.05);
         var cardinalLength = Math.Max(3.0, size * 0.14);
-        var northLength = Math.Max(4.0, size * 0.20);
 
         // Minor ticks every 30 degrees, skipping the cardinals (which are
         // drawn as triangles below).
@@ -113,13 +112,13 @@ internal sealed class CompassRoseView : Control
             context.DrawLine(pen, p1, p2);
         }
 
-        // Cardinal ticks rendered as thin inward-pointing triangles. North is
-        // larger and rendered in the accent color.
+        // Cardinal ticks rendered as thin inward-pointing triangles. The
+        // north tick uses the accent color but is otherwise the same size as
+        // the other cardinals.
         for (var a = 0; a < 360; a += 90)
         {
             var isNorth = a == 0;
-            var tickLen = isNorth ? northLength : cardinalLength;
-            var halfBase = isNorth ? Math.Max(2.0, size * 0.07) : Math.Max(1.5, size * 0.05);
+            var halfBase = Math.Max(1.5, size * 0.05);
             IBrush fill = isNorth ? palette.North : palette.Tick;
 
             var rad = (rotation + a) * Math.PI / 180.0;
@@ -131,8 +130,8 @@ internal sealed class CompassRoseView : Control
             var ty = sin;
 
             var tip = new Point(cx + sin * tickOuterRadius, cy - cos * tickOuterRadius);
-            var basePx = cx + sin * (tickOuterRadius - tickLen);
-            var basePy = cy - cos * (tickOuterRadius - tickLen);
+            var basePx = cx + sin * (tickOuterRadius - cardinalLength);
+            var basePy = cy - cos * (tickOuterRadius - cardinalLength);
             var b1 = new Point(basePx + tx * halfBase, basePy + ty * halfBase);
             var b2 = new Point(basePx - tx * halfBase, basePy - ty * halfBase);
 

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -57,17 +57,18 @@ internal sealed class CompassRoseView : Control
             return;
 
         var bgBrush = new SolidColorBrush(Color.FromArgb(140, 255, 255, 255));
-        var borderBrush = new SolidColorBrush(Color.FromArgb(64, 0, 0, 0));
-        var borderPen = new Pen(borderBrush, 1);
-        context.DrawEllipse(bgBrush, borderPen, new Point(cx, cy), outerRadius, outerRadius);
+        context.DrawEllipse(bgBrush, null, new Point(cx, cy), outerRadius, outerRadius);
 
         var accent = TryFindAccentBrush() ?? Brushes.SteelBlue;
         var tickBrush = new SolidColorBrush(Color.FromArgb(150, 40, 40, 40));
 
         var rotation = MapRotation;
-        var minorLength = Math.Max(2.0, size * 0.10);
-        var cardinalLength = Math.Max(4.0, size * 0.22);
-        var northLength = Math.Max(5.0, size * 0.28);
+        // Inset the tick ring so ticks don't touch the compass edge.
+        var tickPadding = Math.Max(2.0, size * 0.06);
+        var tickOuterRadius = outerRadius - tickPadding;
+        var minorLength = Math.Max(2.0, size * 0.08);
+        var cardinalLength = Math.Max(3.0, size * 0.14);
+        var northLength = Math.Max(4.0, size * 0.20);
 
         // Minor ticks every 30 degrees, skipping the cardinals (which are
         // drawn as triangles below).
@@ -78,8 +79,8 @@ internal sealed class CompassRoseView : Control
             var rad = (rotation + a) * Math.PI / 180.0;
             var sin = Math.Sin(rad);
             var cos = Math.Cos(rad);
-            var p1 = new Point(cx + sin * outerRadius, cy - cos * outerRadius);
-            var p2 = new Point(cx + sin * (outerRadius - minorLength), cy - cos * (outerRadius - minorLength));
+            var p1 = new Point(cx + sin * tickOuterRadius, cy - cos * tickOuterRadius);
+            var p2 = new Point(cx + sin * (tickOuterRadius - minorLength), cy - cos * (tickOuterRadius - minorLength));
             var pen = new Pen(tickBrush, 1.0) { LineCap = PenLineCap.Round };
             context.DrawLine(pen, p1, p2);
         }
@@ -101,9 +102,9 @@ internal sealed class CompassRoseView : Control
             var tx = cos;
             var ty = sin;
 
-            var tip = new Point(cx + sin * outerRadius, cy - cos * outerRadius);
-            var basePx = cx + sin * (outerRadius - tickLen);
-            var basePy = cy - cos * (outerRadius - tickLen);
+            var tip = new Point(cx + sin * tickOuterRadius, cy - cos * tickOuterRadius);
+            var basePx = cx + sin * (tickOuterRadius - tickLen);
+            var basePy = cy - cos * (tickOuterRadius - tickLen);
             var b1 = new Point(basePx + tx * halfBase, basePy + ty * halfBase);
             var b2 = new Point(basePx - tx * halfBase, basePy - ty * halfBase);
 

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -118,7 +118,8 @@ internal sealed class CompassRoseView : Control
         for (var a = 0; a < 360; a += 90)
         {
             var isNorth = a == 0;
-            var halfBase = Math.Max(1.5, size * 0.05);
+            var halfBase = isNorth ? Math.Max(2.0, size * 0.065) : Math.Max(1.5, size * 0.05);
+            var tickLen = isNorth ? cardinalLength * 1.10 : cardinalLength;
             IBrush fill = isNorth ? palette.North : palette.Tick;
 
             var rad = (rotation + a) * Math.PI / 180.0;
@@ -130,8 +131,8 @@ internal sealed class CompassRoseView : Control
             var ty = sin;
 
             var tip = new Point(cx + sin * tickOuterRadius, cy - cos * tickOuterRadius);
-            var basePx = cx + sin * (tickOuterRadius - cardinalLength);
-            var basePy = cy - cos * (tickOuterRadius - cardinalLength);
+            var basePx = cx + sin * (tickOuterRadius - tickLen);
+            var basePy = cy - cos * (tickOuterRadius - tickLen);
             var b1 = new Point(basePx + tx * halfBase, basePy + ty * halfBase);
             var b2 = new Point(basePx - tx * halfBase, basePy - ty * halfBase);
 

--- a/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CompassRoseView.cs
@@ -92,9 +92,9 @@ internal sealed class CompassRoseView : Control
 
         var rotation = MapRotation;
         // Inset the tick ring so ticks don't touch the compass edge.
-        var tickPadding = Math.Max(2.0, size * 0.06);
+        var tickPadding = Math.Max(3.0, size * 0.10);
         var tickOuterRadius = outerRadius - tickPadding;
-        var minorLength = Math.Max(2.0, size * 0.08);
+        var minorLength = Math.Max(1.5, size * 0.05);
         var cardinalLength = Math.Max(3.0, size * 0.14);
         var northLength = Math.Max(4.0, size * 0.20);
 


### PR DESCRIPTION
## Summary

Adds a compass rose to the Avalonia viewer's map overlay so users always have a visible cue for which way is north when the map is rotated, and gives mouse-only users (no trackpad) a way to rotate the map. While wiring this up I also fixed a long-standing pan bug that was masked by always rendering north-up.

The compass sits below the existing zoom in/out buttons and matches their footprint. It draws a circular semi-transparent disc with a ring of tick marks; the four cardinal ticks are inward-pointing triangles, with the north triangle in the accent color and a touch larger/wider than the others. The center of the disc shows whichever cardinal letter is closest to screen-up. Background, tick, and text colors follow the active light/dark theme variant.

The compass doubles as a rotation control:

- Hovering shows the hand cursor.
- Press-and-drag inside the compass captures the pointer and rotates the map so the grabbed angle stays under the pointer; the user can swing the pointer well outside the compass to get a longer "arm".
- Double-click animates the map back to north-up over 250 ms (taking the shorter way around).
- For trackpad users I also wired up Avalonia's `PointerTouchPadGestureRotateEvent` so two-finger rotate gestures rotate the map directly.

## Approach

- New `CompassRoseView : Control` in `src/EncDotNet.S100.Viewer/Views/`. Pure code-behind, no XAML; renders via `DrawingContext` and exposes a `MapRotation` styled property plus `RotationRequested` / `RotationResetRequested` events.
- `MainWindow.axaml` adds the compass to the existing zoom-button `StackPanel`, sized to match `ZoomInButton.Bounds.Width`.
- `MainWindow.axaml.cs` forwards viewport rotation into the compass via the existing `ViewportChanged` handler, and forwards compass events to `Mapsui.Navigator.RotateTo`.
- Wheel/swipe pan now rotates the screen-space delta by the current viewport rotation before applying it to the viewport center, so swipes follow the on-screen orientation regardless of map rotation (previously swipes were inverted at 180 degrees).

## Spec alignment

- [ ] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [x] N/A - change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A - viewer UI only.

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

The change is purely viewer chrome (custom-drawn control + event wiring) and was validated by running the viewer locally and exercising rotation via both the trackpad gesture and the new drag/double-click controls. No automated tests added.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

The new `CompassRoseView` and its events are documented inline. No public API surface changes outside the viewer project, and the viewer has no README.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None.