### PR TITLE
Add Dataset Catalog panel populated by S-128 datasets

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -37,5 +37,6 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S127.Tests/EncDotNet.S100.Datasets.S127.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S128.Tests/EncDotNet.S100.Datasets.S128.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S421.Tests/EncDotNet.S100.Datasets.S421.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
@@ -21,6 +21,9 @@ public sealed class S128DatasetProcessor : IDatasetProcessor
 
     public string ProductSpec => "S-128";
 
+    /// <summary>The parsed S-128 dataset backing this processor.</summary>
+    public S128Dataset Dataset => _dataset;
+
     public S128DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager)

--- a/src/EncDotNet.S100.Datasets.S128/S128ProductEntry.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128ProductEntry.cs
@@ -105,6 +105,22 @@ public sealed class S128ProductEntry
         }
     }
 
+    /// <summary>
+    /// The version of the referenced product specification (e.g. <c>"1.4.1"</c>),
+    /// parsed from the <c>productSpecification/version</c> complex sub-attribute.
+    /// (S-128 § 12.)
+    /// </summary>
+    public string? ProductSpecificationVersion
+    {
+        get
+        {
+            var ps = Feature.ComplexAttributes
+                .FirstOrDefault(c => c.Code.Equals("productSpecification", StringComparison.OrdinalIgnoreCase));
+            if (ps is null) return null;
+            return ps.SubAttributes.TryGetValue("version", out var v) ? v : null;
+        }
+    }
+
     /// <summary>The catalogue element classification text (S-128 § 12 <c>catalogueElementClassification</c>).</summary>
     public string? Classification =>
         Feature.Attributes.TryGetValue("catalogueElementClassification", out var v) ? v : null;

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -1,6 +1,8 @@
+using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 
 namespace EncDotNet.S100.Viewer;
 
@@ -15,11 +17,32 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            LogCrash("UnhandledException", e.ExceptionObject?.ToString() ?? "(null)");
+        System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            LogCrash("UnobservedTaskException", e.Exception?.ToString() ?? "(null)");
+            e.SetObserved();
+        };
+        Dispatcher.UIThread.UnhandledException += (_, e) =>
+        {
+            LogCrash("UIThread.UnhandledException", e.Exception?.ToString() ?? "(null)");
+            e.Handled = true;
+        };
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainWindow(StartupOptions);
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    private static void LogCrash(string label, string message)
+    {
+        var line = $"[{label}] {message}";
+        Console.Error.WriteLine(line);
+        try { System.IO.File.AppendAllText("/tmp/viewer-crash.log", $"{DateTime.Now:O} {line}\n\n"); }
+        catch { }
     }
 }

--- a/src/EncDotNet.S100.Viewer/AssemblyInfo.cs
+++ b/src/EncDotNet.S100.Viewer/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("EncDotNet.S100.Viewer.Tests")]

--- a/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogAggregator.cs
+++ b/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogAggregator.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EncDotNet.S100.Viewer.Catalogs;
+
+/// <summary>
+/// Combines multiple <see cref="IDatasetCatalogSource"/> instances into a
+/// single source. Re-raises <see cref="IDatasetCatalogSource.Changed"/>
+/// whenever any registered child source changes (or when sources are added /
+/// removed).
+/// </summary>
+internal sealed class DatasetCatalogAggregator : IDatasetCatalogSource
+{
+    private readonly List<IDatasetCatalogSource> _sources = new();
+    private readonly object _lock = new();
+
+    /// <summary>Initializes a new aggregator.</summary>
+    public DatasetCatalogAggregator(string id = "aggregator", string displayName = "All catalogues")
+    {
+        Id = id;
+        DisplayName = displayName;
+    }
+
+    /// <inheritdoc/>
+    public string Id { get; }
+
+    /// <inheritdoc/>
+    public string DisplayName { get; }
+
+    /// <summary>The currently registered child sources.</summary>
+    public IReadOnlyList<IDatasetCatalogSource> Sources
+    {
+        get { lock (_lock) return _sources.ToArray(); }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<DatasetCatalogEntry> Entries
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _sources.SelectMany(s => s.Entries).ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+
+    /// <summary>Adds a child source. Raises <see cref="Changed"/>.</summary>
+    public void Add(IDatasetCatalogSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        lock (_lock)
+        {
+            if (_sources.Contains(source))
+                return;
+            _sources.Add(source);
+            source.Changed += OnChildChanged;
+        }
+
+        RaiseChanged();
+    }
+
+    /// <summary>Removes a child source. Raises <see cref="Changed"/> when the source was registered.</summary>
+    public bool Remove(IDatasetCatalogSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        bool removed;
+        lock (_lock)
+        {
+            removed = _sources.Remove(source);
+            if (removed)
+                source.Changed -= OnChildChanged;
+        }
+
+        if (removed)
+            RaiseChanged();
+        return removed;
+    }
+
+    private void OnChildChanged(object? sender, DatasetCatalogChangedEventArgs e) => RaiseChanged();
+
+    private void RaiseChanged() =>
+        Changed?.Invoke(this, new DatasetCatalogChangedEventArgs(this));
+}

--- a/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogCoverage.cs
+++ b/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogCoverage.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Viewer.Catalogs;
+
+/// <summary>
+/// Coverage geometry for a <see cref="DatasetCatalogEntry"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Coverage is expressed as a single exterior ring of (latitude, longitude)
+/// vertices in <c>EPSG:4326</c>, plus a precomputed bounding box for cheap
+/// hit-testing. The ring is intentionally simple — full multi-polygon
+/// support can be added if a future source needs it.
+/// </para>
+/// </remarks>
+internal sealed record DatasetCatalogCoverage(
+    ImmutableArray<(double Latitude, double Longitude)> Ring,
+    double MinLatitude,
+    double MinLongitude,
+    double MaxLatitude,
+    double MaxLongitude)
+{
+    /// <summary>
+    /// Builds a coverage record from a ring of (lat, lon) vertices, computing
+    /// the bounding box on the fly. Returns <see langword="null"/> when the
+    /// ring is empty.
+    /// </summary>
+    public static DatasetCatalogCoverage? FromRing(
+        ImmutableArray<(double Latitude, double Longitude)> ring)
+    {
+        if (ring.IsDefaultOrEmpty)
+            return null;
+
+        double minLat = double.MaxValue, maxLat = double.MinValue;
+        double minLon = double.MaxValue, maxLon = double.MinValue;
+        foreach (var (lat, lon) in ring)
+        {
+            if (lat < minLat) minLat = lat;
+            if (lat > maxLat) maxLat = lat;
+            if (lon < minLon) minLon = lon;
+            if (lon > maxLon) maxLon = lon;
+        }
+
+        return new DatasetCatalogCoverage(ring, minLat, minLon, maxLat, maxLon);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogEntry.cs
+++ b/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogEntry.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Viewer.Catalogs;
+
+/// <summary>
+/// A single, source-agnostic catalogue entry. Different
+/// <see cref="IDatasetCatalogSource"/> implementations (loaded S-128
+/// datasets, JSON files, online services, ...) all surface their entries as
+/// instances of this type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Fields are intentionally minimal and string-typed where the spec
+/// representations vary (edition / update numbers are textual in S-128).
+/// Source-specific extras flow through <see cref="ExtendedProperties"/>
+/// so the panel can display them generically without having to know
+/// about the originating spec.
+/// </para>
+/// </remarks>
+internal sealed record DatasetCatalogEntry
+{
+    /// <summary>
+    /// A globally unique identifier within the contributing source.
+    /// Aggregators should namespace this with <see cref="SourceId"/>.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>The id of the contributing <see cref="IDatasetCatalogSource"/>.</summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// The product specification this entry refers to, if known
+    /// (e.g. <c>"S-101"</c>, <c>"S-104"</c>, <c>"S-57"</c>).
+    /// </summary>
+    public string? ProductSpec { get; init; }
+
+    /// <summary>
+    /// The version of the referenced product specification, if known
+    /// (e.g. <c>"1.4.1"</c>).
+    /// </summary>
+    public string? ProductSpecVersion { get; init; }
+
+    /// <summary>
+    /// The product number / dataset name. Typically the short identifier
+    /// presented to the mariner (e.g. <c>"GB301820"</c> for an ENC).
+    /// </summary>
+    public string? ProductNumber { get; init; }
+
+    /// <summary>
+    /// A human-readable title for the entry. Falls back to
+    /// <see cref="ProductNumber"/> when the source has no separate title.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>The product edition number, as a free-form string.</summary>
+    public string? EditionNumber { get; init; }
+
+    /// <summary>The product update number, as a free-form string.</summary>
+    public string? UpdateNumber { get; init; }
+
+    /// <summary>The product issue date, if known.</summary>
+    public string? IssueDate { get; init; }
+
+    /// <summary>The product update / edition date, if known.</summary>
+    public string? UpdateDate { get; init; }
+
+    /// <summary>The neutral currency status of the entry.</summary>
+    public DatasetCatalogStatus Status { get; init; } = DatasetCatalogStatus.Unknown;
+
+    /// <summary>Free-form classification text supplied by the source.</summary>
+    public string? Classification { get; init; }
+
+    /// <summary>True when the source has flagged the entry as not-for-navigation.</summary>
+    public bool NotForNavigation { get; init; }
+
+    /// <summary>Coverage geometry, or <see langword="null"/> for entries that do not carry geometry.</summary>
+    public DatasetCatalogCoverage? Coverage { get; init; }
+
+    /// <summary>
+    /// Source-specific properties that do not map onto the neutral fields.
+    /// The panel may render these in a generic key/value details view.
+    /// </summary>
+    public ImmutableDictionary<string, string> ExtendedProperties { get; init; }
+        = ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogStatus.cs
+++ b/src/EncDotNet.S100.Viewer/Catalogs/DatasetCatalogStatus.cs
@@ -1,0 +1,27 @@
+namespace EncDotNet.S100.Viewer.Catalogs;
+
+/// <summary>
+/// Neutral, source-agnostic currency status for a <see cref="DatasetCatalogEntry"/>.
+/// </summary>
+/// <remarks>
+/// Each <see cref="IDatasetCatalogSource"/> is responsible for mapping its
+/// own status taxonomy onto these values (e.g. S-128's
+/// <c>S128ProductStatus</c> maps 1:1 by name).
+/// </remarks>
+internal enum DatasetCatalogStatus
+{
+    /// <summary>The status is unknown or could not be determined.</summary>
+    Unknown = 0,
+
+    /// <summary>The product is current.</summary>
+    InForce,
+
+    /// <summary>The product has been replaced by a newer edition.</summary>
+    Superseded,
+
+    /// <summary>The product has been withdrawn or cancelled.</summary>
+    Withdrawn,
+
+    /// <summary>The product is announced but not yet released.</summary>
+    Planned,
+}

--- a/src/EncDotNet.S100.Viewer/Catalogs/IDatasetCatalogSource.cs
+++ b/src/EncDotNet.S100.Viewer/Catalogs/IDatasetCatalogSource.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Catalogs;
+
+/// <summary>
+/// A pluggable supplier of <see cref="DatasetCatalogEntry"/> instances.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Dataset Catalog panel consumes one or more sources via a
+/// <see cref="DatasetCatalogAggregator"/>. Implementations include the
+/// in-process adapter over loaded S-128 datasets and may include
+/// future JSON-file or online sources.
+/// </para>
+/// <para>
+/// Sources are expected to publish a coarse <see cref="Changed"/>
+/// notification when their <see cref="Entries"/> snapshot changes; the
+/// panel re-queries the entries on each event rather than relying on
+/// item-level diffs.
+/// </para>
+/// </remarks>
+internal interface IDatasetCatalogSource
+{
+    /// <summary>A stable id for this source (used for grouping and entry namespacing).</summary>
+    string Id { get; }
+
+    /// <summary>A human-readable label for the source (shown in the panel UI).</summary>
+    string DisplayName { get; }
+
+    /// <summary>The current entries surfaced by this source.</summary>
+    IReadOnlyList<DatasetCatalogEntry> Entries { get; }
+
+    /// <summary>
+    /// Raised whenever <see cref="Entries"/> changes. Listeners should re-read
+    /// the snapshot rather than diff individual items.
+    /// </summary>
+    event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+}
+
+/// <summary>
+/// Event arguments raised by an <see cref="IDatasetCatalogSource"/> when its
+/// <see cref="IDatasetCatalogSource.Entries"/> snapshot changes.
+/// </summary>
+internal sealed class DatasetCatalogChangedEventArgs : EventArgs
+{
+    /// <summary>The source whose contents changed.</summary>
+    public IDatasetCatalogSource Source { get; }
+
+    /// <summary>Initializes a new instance.</summary>
+    public DatasetCatalogChangedEventArgs(IDatasetCatalogSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        Source = source;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Catalogs/S128DatasetCatalogSource.cs
+++ b/src/EncDotNet.S100.Viewer/Catalogs/S128DatasetCatalogSource.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.RegularExpressions;
+using EncDotNet.S100.Datasets.S128;
+
+namespace EncDotNet.S100.Viewer.Catalogs;
+
+/// <summary>
+/// An <see cref="IDatasetCatalogSource"/> backed by one or more loaded
+/// <see cref="S128Dataset"/> instances. Each <see cref="S128ProductEntry"/>
+/// is mapped onto a neutral <see cref="DatasetCatalogEntry"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Datasets are tracked by a caller-supplied <c>sourceLabel</c> (typically
+/// the dataset filename). Adding or removing a dataset raises
+/// <see cref="Changed"/>; the entries collection is replaced wholesale on
+/// each mutation.
+/// </para>
+/// </remarks>
+internal sealed class S128DatasetCatalogSource : IDatasetCatalogSource
+{
+    private readonly Dictionary<string, S128Dataset> _datasets =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    private ImmutableArray<DatasetCatalogEntry> _entries = ImmutableArray<DatasetCatalogEntry>.Empty;
+
+    /// <summary>Initializes a new source.</summary>
+    /// <param name="id">Stable id (used by the aggregator).</param>
+    /// <param name="displayName">Human-readable label shown in the panel UI.</param>
+    public S128DatasetCatalogSource(string id = "s128-loaded", string displayName = "Loaded S-128 datasets")
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        ArgumentException.ThrowIfNullOrEmpty(displayName);
+        Id = id;
+        DisplayName = displayName;
+    }
+
+    /// <inheritdoc/>
+    public string Id { get; }
+
+    /// <inheritdoc/>
+    public string DisplayName { get; }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<DatasetCatalogEntry> Entries
+    {
+        get { lock (_lock) return _entries; }
+    }
+
+    /// <inheritdoc/>
+    public event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+
+    /// <summary>
+    /// Registers (or replaces) a parsed S-128 dataset under the given label.
+    /// Raises <see cref="Changed"/>.
+    /// </summary>
+    public void AddDataset(string sourceLabel, S128Dataset dataset)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourceLabel);
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        lock (_lock)
+        {
+            _datasets[sourceLabel] = dataset;
+            _entries = Rebuild();
+        }
+
+        Changed?.Invoke(this, new DatasetCatalogChangedEventArgs(this));
+    }
+
+    /// <summary>
+    /// Removes a previously-registered dataset. Returns <see langword="true"/>
+    /// when a dataset was actually removed and raises <see cref="Changed"/>
+    /// in that case.
+    /// </summary>
+    public bool RemoveDataset(string sourceLabel)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourceLabel);
+
+        bool removed;
+        lock (_lock)
+        {
+            removed = _datasets.Remove(sourceLabel);
+            if (removed)
+                _entries = Rebuild();
+        }
+
+        if (removed)
+            Changed?.Invoke(this, new DatasetCatalogChangedEventArgs(this));
+        return removed;
+    }
+
+    /// <summary>Removes every registered dataset. Raises <see cref="Changed"/> when non-empty.</summary>
+    public void Clear()
+    {
+        bool changed;
+        lock (_lock)
+        {
+            changed = _datasets.Count > 0;
+            _datasets.Clear();
+            _entries = ImmutableArray<DatasetCatalogEntry>.Empty;
+        }
+
+        if (changed)
+            Changed?.Invoke(this, new DatasetCatalogChangedEventArgs(this));
+    }
+
+    private ImmutableArray<DatasetCatalogEntry> Rebuild()
+    {
+        if (_datasets.Count == 0)
+            return ImmutableArray<DatasetCatalogEntry>.Empty;
+
+        var builder = ImmutableArray.CreateBuilder<DatasetCatalogEntry>();
+        foreach (var (label, ds) in _datasets)
+        {
+            foreach (var entry in ds.Entries)
+            {
+                builder.Add(Map(label, entry));
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private DatasetCatalogEntry Map(string sourceLabel, S128ProductEntry entry)
+    {
+        var feature = entry.Feature;
+
+        var ext = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+        ext["sourceLabel"] = sourceLabel;
+        ext["featureType"] = entry.FeatureType;
+        if (feature.Attributes.TryGetValue("serviceStatus", out var svc))
+            ext["serviceStatus"] = svc;
+        if (feature.Attributes.TryGetValue("distributionStatus", out var dist))
+            ext["distributionStatus"] = dist;
+        if (entry.NotForNavigation)
+            ext["notForNavigation"] = "true";
+
+        return new DatasetCatalogEntry
+        {
+            Id = $"{sourceLabel}#{entry.Id}",
+            SourceId = Id,
+            ProductSpec = NormalizeSpecCode(entry.ProductSpecificationName),
+            ProductSpecVersion = entry.ProductSpecificationVersion,
+            ProductNumber = entry.ProductNumber,
+            Title = entry.ProductNumber ?? entry.Id,
+            EditionNumber = entry.EditionNumber,
+            UpdateNumber = entry.UpdateNumber,
+            IssueDate = entry.IssueDate,
+            UpdateDate = entry.UpdateDate,
+            Status = MapStatus(entry.Status),
+            Classification = entry.Classification,
+            NotForNavigation = entry.NotForNavigation,
+            Coverage = DatasetCatalogCoverage.FromRing(entry.CoverageRing),
+            ExtendedProperties = ext.ToImmutable(),
+        };
+    }
+
+    private static DatasetCatalogStatus MapStatus(S128ProductStatus status) =>
+        status switch
+        {
+            S128ProductStatus.InForce => DatasetCatalogStatus.InForce,
+            S128ProductStatus.Superseded => DatasetCatalogStatus.Superseded,
+            S128ProductStatus.Withdrawn => DatasetCatalogStatus.Withdrawn,
+            S128ProductStatus.Planned => DatasetCatalogStatus.Planned,
+            _ => DatasetCatalogStatus.Unknown,
+        };
+
+    /// <summary>
+    /// Reduces free-form product-specification names found in S-128 datasets
+    /// (e.g. <c>"S-57 Transfer Standard for Digital Hydrographic Data"</c> or
+    /// <c>"S-101"</c>) to the canonical short code (<c>"S-57"</c>,
+    /// <c>"S-101"</c>) when one can be detected at the start of the string.
+    /// Returns the input unchanged if no match is found.
+    /// </summary>
+    private static string? NormalizeSpecCode(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return raw;
+        var trimmed = raw.Trim();
+        var m = Regex.Match(trimmed, @"^S-?\d{2,4}", RegexOptions.IgnoreCase);
+        if (!m.Success) return trimmed;
+        var token = m.Value.ToUpperInvariant();
+        return token.StartsWith("S-") ? token : "S-" + token[1..];
+    }
+}

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S125\EncDotNet.S100.Datasets.S125.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S128\EncDotNet.S100.Datasets.S128.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S411\EncDotNet.S100.Datasets.S411.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -180,6 +180,23 @@
                             <ic:FluentIcon Icon="Layer" IconVariant="Regular" FontSize="22" />
                         </ToggleButton>
                     </Grid>
+
+                    <!-- Dataset Catalog -->
+                    <Grid>
+                        <Border Width="3" HorizontalAlignment="Left"
+                                Background="{DynamicResource AccentBrush}"
+                                IsVisible="{Binding IsCatalogSelected}" />
+                        <ToggleButton Classes="ActivityIcon"
+                                      IsChecked="{Binding IsCatalogSelected, Mode=OneWay}"
+                                      Command="{Binding SelectCatalogCommand}"
+                                      ToolTip.Tip="Dataset Catalog"
+                                      Height="48"
+                                      Padding="0"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center">
+                            <ic:FluentIcon Icon="Library" IconVariant="Regular" FontSize="22" />
+                        </ToggleButton>
+                    </Grid>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -216,6 +233,8 @@
                                                        IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsPortrayalCataloguesSelected}" />
                         <views:DatasetsView DataContext="{Binding Datasets}"
                                             IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsDatasetsSelected}" />
+                        <views:CatalogPanelView DataContext="{Binding CatalogPanel}"
+                                                IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsCatalogSelected}" />
                         <views:SettingsView DataContext="{Binding Settings}"
                                             IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsSettingsSelected}" />
                     </Panel>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -20,6 +20,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui;
 using Mapsui.Extensions;
@@ -36,6 +37,8 @@ public partial class MainWindow : ShadUI.Window
     private readonly MainViewModel _viewModel;
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, List<ILayer>> _entryLayers = new();
+    private readonly DatasetCatalogAggregator _catalogAggregator = new();
+    private readonly S128DatasetCatalogSource _s128CatalogSource = new();
     private readonly NativeMenu _openRecentMenu = new();
     private NativeMenuItem? _openRecentMenuItem;
     private string? _screenshotPath;
@@ -100,8 +103,13 @@ public partial class MainWindow : ShadUI.Window
                   : _settings.FeatureCataloguePaths.TryGetValue(spec, out var sp) ? File.OpenRead(sp)
                   : Specifications.Specification.TryOpenFeatureCatalogue(spec));
 
-        _viewModel = new MainViewModel(_settings, _catalogueManager);
+        _viewModel = new MainViewModel(_settings, _catalogueManager, _catalogAggregator);
         DataContext = _viewModel;
+
+        // Register catalog sources. The S-128 source receives parsed datasets
+        // as they are loaded into the viewer; future sources (online, JSON)
+        // can be registered here without changes to the panel.
+        _catalogAggregator.Add(_s128CatalogSource);
 
         // Build native menu bar
         var sideBarItem = new NativeMenuItem("Primary Side Bar")
@@ -212,11 +220,28 @@ public partial class MainWindow : ShadUI.Window
                 {
                     RemoveEntryLayers(removed);
                     _processors.Remove(removed);
+                    _s128CatalogSource.RemoveDataset(removed.DisplayName);
                 }
             }
         };
 
         MapControl.Map?.Layers.Add(OpenStreetMap.CreateTileLayer());
+
+        // Disable Mapsui's built-in LoggingWidget — it can throw "minX > maxX" on
+        // narrow viewports during resize, and the exception is raised on the
+        // render thread where we cannot intercept it.
+        Mapsui.Widgets.InfoWidgets.LoggingWidget.ShowLoggingInMap = Mapsui.Widgets.ActiveMode.No;
+        if (MapControl.Map is { } mapForWidgets)
+        {
+            var remaining = mapForWidgets.Widgets
+                .Where(w => w is not Mapsui.Widgets.InfoWidgets.LoggingWidget)
+                .ToArray();
+            mapForWidgets.Widgets.Clear();
+            foreach (var w in remaining)
+            {
+                mapForWidgets.Widgets.Enqueue(w);
+            }
+        }
 
         // Enable pinch-to-zoom on the map control via trackpad magnify gesture
         MapControl.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, OnMapMagnify);
@@ -358,6 +383,12 @@ public partial class MainWindow : ShadUI.Window
         {
             var processor = await Task.Run(() => _pipelineFactory.CreateProcessor(entry.FilePath));
             _processors[entry] = processor;
+
+            // Surface S-128 catalogues into the Dataset Catalog panel.
+            if (processor is S128DatasetProcessor s128)
+            {
+                _s128CatalogSource.AddDataset(entry.DisplayName, s128.Dataset);
+            }
 
             var palette = _viewModel.Settings.SelectedPalette;
             var initialContext = CreateRenderContext(processor);

--- a/src/EncDotNet.S100.Viewer/ViewModels/ActivityKind.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ActivityKind.cs
@@ -5,5 +5,6 @@ internal enum ActivityKind
     FeatureCatalogues,
     PortrayalCatalogues,
     Datasets,
+    Catalog,
     Settings,
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/CatalogPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/CatalogPanelViewModel.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Media;
+using Avalonia.Threading;
+using EncDotNet.S100.Viewer.Catalogs;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// View model for a single catalogue entry in the Dataset Catalog panel.
+/// Wraps a neutral <see cref="DatasetCatalogEntry"/>.
+/// </summary>
+internal sealed class CatalogEntryViewModel : ViewModelBase
+{
+    public DatasetCatalogEntry Entry { get; }
+
+    public CatalogEntryViewModel(DatasetCatalogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        Entry = entry;
+    }
+
+    public string Title => Entry.Title ?? Entry.ProductNumber ?? Entry.Id;
+    public string? ProductNumber => Entry.ProductNumber;
+    public string? ProductSpec => Entry.ProductSpec;
+    public string? ProductSpecVersion => Entry.ProductSpecVersion;
+    public string? EditionNumber => Entry.EditionNumber;
+    public string? UpdateNumber => Entry.UpdateNumber;
+    public string? IssueDate => Entry.IssueDate;
+    public string? UpdateDate => Entry.UpdateDate;
+    public string? Classification => Entry.Classification;
+    public bool NotForNavigation => Entry.NotForNavigation;
+    public DatasetCatalogStatus Status => Entry.Status;
+
+    /// <summary>
+    /// Display text for the status badge. PascalCase enum names are split
+    /// on case boundaries and upper-cased (e.g. <c>InForce</c> →
+    /// <c>"IN FORCE"</c>) for a typical pill-style badge.
+    /// </summary>
+    public string StatusText => FormatStatus(Entry.Status);
+
+    private static string FormatStatus(DatasetCatalogStatus status)
+    {
+        var name = status.ToString();
+        var sb = new System.Text.StringBuilder(name.Length + 4);
+        for (int i = 0; i < name.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(name[i]))
+                sb.Append(' ');
+            sb.Append(char.ToUpperInvariant(name[i]));
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Solid colour brush used by the status badge.</summary>
+    public IBrush StatusBrush => new SolidColorBrush(Desaturate(GetStatusColor(Entry.Status), 0.35));
+
+    /// <summary>
+    /// Border brush for the status badge — a darker tint of
+    /// <see cref="StatusBrush"/> for definition against the panel background.
+    /// </summary>
+    public IBrush StatusBorderBrush
+    {
+        get
+        {
+            var c = Desaturate(GetStatusColor(Entry.Status), 0.35);
+            byte d(byte v) => (byte)(v * 3 / 4);
+            return new SolidColorBrush(Color.FromArgb(c.A, d(c.R), d(c.G), d(c.B)));
+        }
+    }
+
+    private static Color GetStatusColor(DatasetCatalogStatus status) => status switch
+    {
+        DatasetCatalogStatus.InForce => Color.Parse("#22c55e"),
+        DatasetCatalogStatus.Superseded => Color.Parse("#eab308"),
+        DatasetCatalogStatus.Withdrawn => Color.Parse("#ef4444"),
+        DatasetCatalogStatus.Planned => Color.Parse("#3b82f6"),
+        _ => Color.Parse("#9ca3af"),
+    };
+
+    /// <summary>
+    /// Mixes <paramref name="color"/> toward neutral gray (#808080) by the
+    /// given <paramref name="amount"/> (0 = no change, 1 = fully gray) to
+    /// produce a less saturated badge fill.
+    /// </summary>
+    private static Color Desaturate(Color color, double amount)
+    {
+        amount = Math.Clamp(amount, 0.0, 1.0);
+        const byte gray = 0x80;
+        byte mix(byte v) => (byte)(v + (gray - v) * amount);
+        return Color.FromArgb(color.A, mix(color.R), mix(color.G), mix(color.B));
+    }
+
+    public string SourceId => Entry.SourceId;
+
+    public string Subtitle
+    {
+        get
+        {
+            // Primary form: "S-104 (v1.4.1)" when we have both spec and version.
+            if (!string.IsNullOrEmpty(ProductSpec))
+            {
+                return string.IsNullOrEmpty(ProductSpecVersion)
+                    ? ProductSpec!
+                    : $"{ProductSpec} (v{ProductSpecVersion})";
+            }
+            return Entry.Id;
+        }
+    }
+
+    public IReadOnlyList<KeyValuePair<string, string>> ExtendedPropertyList =>
+        Entry.ExtendedProperties.OrderBy(p => p.Key).ToList();
+
+    public bool HasExtendedProperties => Entry.ExtendedProperties.Count > 0;
+
+    public bool HasCoverage => Entry.Coverage is not null;
+
+    /// <summary>Formatted south-west corner of the coverage bounding box.</summary>
+    public string CoverageSouthWest =>
+        Entry.Coverage is { } c ? FormatLatLon(c.MinLatitude, c.MinLongitude) : string.Empty;
+
+    /// <summary>Formatted north-east corner of the coverage bounding box.</summary>
+    public string CoverageNorthEast =>
+        Entry.Coverage is { } c ? FormatLatLon(c.MaxLatitude, c.MaxLongitude) : string.Empty;
+
+    /// <summary>
+    /// Formats a (lat, lon) pair in degrees-decimal-minutes form, e.g.
+    /// <c>"12°34.567'N 056°12.345'W"</c>. Mariner-friendly and matches the
+    /// convention typically used on nautical charts.
+    /// </summary>
+    private static string FormatLatLon(double latitude, double longitude)
+    {
+        return $"{FormatDegMin(latitude, 'N', 'S', 2)}  {FormatDegMin(longitude, 'E', 'W', 3)}";
+    }
+
+    private static string FormatDegMin(double value, char positive, char negative, int degDigits)
+    {
+        var hemi = value >= 0 ? positive : negative;
+        var abs = Math.Abs(value);
+        var deg = (int)Math.Floor(abs);
+        var min = (abs - deg) * 60.0;
+        var degFmt = "D" + degDigits;
+        return $"{deg.ToString(degFmt)}°{min:00.000}'{hemi}";
+    }
+}
+
+/// <summary>
+/// View model for the Dataset Catalog panel. Subscribes to an
+/// <see cref="IDatasetCatalogSource"/> (typically a
+/// <see cref="DatasetCatalogAggregator"/>) and reflects its entries into an
+/// observable collection on the UI thread.
+/// </summary>
+internal sealed class CatalogPanelViewModel : ViewModelBase
+{
+    private readonly IDatasetCatalogSource _source;
+
+    public ObservableCollection<CatalogEntryViewModel> Entries { get; } = new();
+
+    private CatalogEntryViewModel? _selectedEntry;
+    public CatalogEntryViewModel? SelectedEntry
+    {
+        get => _selectedEntry;
+        set
+        {
+            if (SetProperty(ref _selectedEntry, value))
+            {
+                OnPropertyChanged(nameof(HasSelection));
+            }
+        }
+    }
+
+    public bool HasSelection => _selectedEntry is not null;
+
+    public bool IsEmpty => Entries.Count == 0;
+
+    public string EmptyMessage =>
+        "No catalogues found.\nOpen an S-128 dataset to populate this panel.";
+
+    public CatalogPanelViewModel(IDatasetCatalogSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        _source = source;
+        _source.Changed += OnSourceChanged;
+        Refresh();
+    }
+
+    private void OnSourceChanged(object? sender, DatasetCatalogChangedEventArgs e)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            Refresh();
+        else
+            Dispatcher.UIThread.Post(Refresh);
+    }
+
+    private void Refresh()
+    {
+        var previousId = _selectedEntry?.Entry.Id;
+
+        Entries.Clear();
+        foreach (var entry in _source.Entries.OrderBy(e => e.SourceId).ThenBy(e => e.Title))
+        {
+            Entries.Add(new CatalogEntryViewModel(entry));
+        }
+
+        // Try to preserve selection across refresh
+        SelectedEntry = previousId is null
+            ? null
+            : Entries.FirstOrDefault(v => v.Entry.Id == previousId);
+
+        OnPropertyChanged(nameof(IsEmpty));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -3,6 +3,7 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Styling;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Catalogs;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -13,6 +14,7 @@ internal sealed class MainViewModel : ViewModelBase
     public FeatureCataloguesViewModel FeatureCatalogues { get; }
     public PortrayalCataloguesViewModel PortrayalCatalogues { get; }
     public DatasetsViewModel Datasets { get; }
+    public CatalogPanelViewModel CatalogPanel { get; }
     public SettingsViewModel Settings { get; }
 
     private ActivityKind? _selectedActivity;
@@ -32,6 +34,7 @@ internal sealed class MainViewModel : ViewModelBase
                 OnPropertyChanged(nameof(IsFeatureCataloguesSelected));
                 OnPropertyChanged(nameof(IsPortrayalCataloguesSelected));
                 OnPropertyChanged(nameof(IsDatasetsSelected));
+                OnPropertyChanged(nameof(IsCatalogSelected));
                 OnPropertyChanged(nameof(IsSettingsSelected));
 
                 // Persist the last selected activity (Settings is transient, don't remember it)
@@ -48,6 +51,7 @@ internal sealed class MainViewModel : ViewModelBase
         ActivityKind.FeatureCatalogues => "FEATURE CATALOGUES",
         ActivityKind.PortrayalCatalogues => "PORTRAYAL CATALOGUES",
         ActivityKind.Datasets => "DATASETS",
+        ActivityKind.Catalog => "DATASET CATALOG",
         ActivityKind.Settings => "SETTINGS",
         _ => string.Empty,
     };
@@ -55,11 +59,13 @@ internal sealed class MainViewModel : ViewModelBase
     public bool IsFeatureCataloguesSelected => _selectedActivity == ActivityKind.FeatureCatalogues;
     public bool IsPortrayalCataloguesSelected => _selectedActivity == ActivityKind.PortrayalCatalogues;
     public bool IsDatasetsSelected => _selectedActivity == ActivityKind.Datasets;
+    public bool IsCatalogSelected => _selectedActivity == ActivityKind.Catalog;
     public bool IsSettingsSelected => _selectedActivity == ActivityKind.Settings;
 
     public ICommand SelectFeatureCataloguesCommand { get; }
     public ICommand SelectPortrayalCataloguesCommand { get; }
     public ICommand SelectDatasetsCommand { get; }
+    public ICommand SelectCatalogCommand { get; }
     public ICommand SelectSettingsCommand { get; }
     public ICommand TogglePrimarySideBarCommand { get; }
 
@@ -95,18 +101,20 @@ internal sealed class MainViewModel : ViewModelBase
 
     public ICommand ToggleThemeCommand { get; }
 
-    public MainViewModel(ViewerSettings settings, PortrayalCatalogueManager catalogueManager)
+    public MainViewModel(ViewerSettings settings, PortrayalCatalogueManager catalogueManager, IDatasetCatalogSource catalogSource)
     {
         _settings = settings;
 
         FeatureCatalogues = new FeatureCataloguesViewModel(settings);
         PortrayalCatalogues = new PortrayalCataloguesViewModel(settings, catalogueManager);
         Datasets = new DatasetsViewModel();
+        CatalogPanel = new CatalogPanelViewModel(catalogSource);
         Settings = new SettingsViewModel(settings);
 
         SelectFeatureCataloguesCommand = new RelayCommand(() => SelectedActivity = ActivityKind.FeatureCatalogues);
         SelectPortrayalCataloguesCommand = new RelayCommand(() => SelectedActivity = ActivityKind.PortrayalCatalogues);
         SelectDatasetsCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Datasets);
+        SelectCatalogCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Catalog);
         SelectSettingsCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Settings);
 
         TogglePrimarySideBarCommand = new RelayCommand(() =>
@@ -131,6 +139,7 @@ internal sealed class MainViewModel : ViewModelBase
             OnPropertyChanged(nameof(IsFeatureCataloguesSelected));
             OnPropertyChanged(nameof(IsPortrayalCataloguesSelected));
             OnPropertyChanged(nameof(IsDatasetsSelected));
+            OnPropertyChanged(nameof(IsCatalogSelected));
             OnPropertyChanged(nameof(IsSettingsSelected));
         });
 

--- a/src/EncDotNet.S100.Viewer/ViewerCommand.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerCommand.cs
@@ -29,11 +29,21 @@ internal sealed class ViewerCommand : Command<ViewerCommandSettings>
     {
         App.StartupOptions = settings;
 
-        AppBuilder.Configure<App>()
-            .UsePlatformDetect()
-            .WithInterFont()
-            .LogToTrace()
-            .StartWithClassicDesktopLifetime([]);
+        try
+        {
+            AppBuilder.Configure<App>()
+                .UsePlatformDetect()
+                .WithInterFont()
+                .LogToTrace()
+                .StartWithClassicDesktopLifetime([]);
+        }
+        catch (System.Exception ex)
+        {
+            System.Console.Error.WriteLine($"[FATAL] {ex}");
+            try { System.IO.File.AppendAllText("/tmp/viewer-crash.log", $"{System.DateTime.Now:O}\n{ex}\n\n"); }
+            catch { }
+            throw;
+        }
 
         return 0;
     }

--- a/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
@@ -1,0 +1,290 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             x:Class="EncDotNet.S100.Viewer.Views.CatalogPanelView"
+             x:DataType="vm:CatalogPanelViewModel">
+
+    <UserControl.Styles>
+        <!-- Accent color on details splitter hover/drag (matches main pane splitter). -->
+        <Style Selector="GridSplitter#DetailsSplitter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="GridSplitter#DetailsSplitter:pointerover">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="GridSplitter#DetailsSplitter:pressed">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+    </UserControl.Styles>
+
+    <Panel>
+        <!-- Empty state — a completely separate tree from the populated
+             state so it cannot interact with the grid star-sizing of the
+             master/detail layout. -->
+        <Border IsVisible="{Binding IsEmpty}"
+                Padding="16"
+                VerticalAlignment="Center">
+            <StackPanel Spacing="8" HorizontalAlignment="Center">
+                <ic:FluentIcon Icon="Library"
+                               IconVariant="Regular"
+                               FontSize="32"
+                               Opacity="0.4"
+                               HorizontalAlignment="Center" />
+                <TextBlock Text="{Binding EmptyMessage}"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Opacity="0.6"
+                           FontSize="12" />
+            </StackPanel>
+        </Border>
+
+        <!-- Populated state — master/detail with resizable splitter. -->
+        <Grid IsVisible="{Binding !IsEmpty}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="2*" MinHeight="80" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+        <!-- Entry list (master). ListBox.Padding=0 and ListBoxItem.Margin=0
+             ensure the whole row width/height is hit-testable for selection;
+             visual spacing is supplied by the ListBoxItem's Padding (which
+             lives INSIDE the row's hit area). -->
+        <ListBox Grid.Row="0"
+                 x:Name="EntryList"
+                 ItemsSource="{Binding Entries}"
+                 SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                 Background="Transparent"
+                 BorderThickness="0"
+                 Padding="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <ListBox.Styles>
+                <!-- Suppress the default ShadUI ListBoxItem chrome (including the
+                     selection check icon) and use our own minimal selection look. -->
+                <Style Selector="ListBoxItem">
+                    <Setter Property="Padding" Value="8,6" />
+                    <Setter Property="Margin" Value="0" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <!-- Transparent (not null) background so the entire row hit-tests,
+                         not just the text glyph runs. -->
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Template">
+                        <ControlTemplate>
+                            <Border Name="PART_Container"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="4"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter Content="{TemplateBinding Content}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  HorizontalAlignment="Stretch"
+                                                  HorizontalContentAlignment="Stretch" />
+                            </Border>
+                        </ControlTemplate>
+                    </Setter>
+                </Style>
+                <Style Selector="ListBoxItem:pointerover /template/ Border#PART_Container">
+                    <Setter Property="Background" Value="{DynamicResource MutedBackgroundColor}" />
+                </Style>
+                <Style Selector="ListBoxItem:selected /template/ Border#PART_Container">
+                    <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                </Style>
+                <Style Selector="ListBoxItem:selected TextBlock">
+                    <Setter Property="Foreground" Value="White" />
+                </Style>
+            </ListBox.Styles>
+            <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="vm:CatalogEntryViewModel">
+                    <!-- Background=Transparent makes the entire row (including
+                         empty space between the text and the badge) hit-testable
+                         so click-to-select fires reliably regardless of where
+                         within the row the user clicks. -->
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"
+                          Background="Transparent">
+                        <StackPanel Grid.Column="0" Spacing="2">
+                            <TextBlock Text="{Binding Title}"
+                                       FontWeight="SemiBold"
+                                       FontSize="13"
+                                       TextTrimming="CharacterEllipsis" />
+                            <TextBlock Text="{Binding Subtitle}"
+                                       FontSize="11"
+                                       Opacity="0.7"
+                                       TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
+                        <Border Grid.Column="1"
+                                Background="{Binding StatusBrush}"
+                                BorderBrush="{Binding StatusBorderBrush}"
+                                BorderThickness="1.5"
+                                CornerRadius="9"
+                                Padding="10,4"
+                                VerticalAlignment="Center">
+                            <TextBlock Text="{Binding StatusText}"
+                                       FontSize="10"
+                                       FontWeight="Bold"
+                                       Foreground="White"
+                                       VerticalAlignment="Center"
+                                       TextAlignment="Center" />
+                        </Border>
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <!-- Resizable splitter between list and details. Row is sized to 6px
+             (a touch target); the visual line is a 1px Border centered in the
+             row, and the GridSplitter overlays it. The splitter background
+             switches to the accent brush on hover/drag (matches the main
+             pane splitter). The splitter must be a direct child of the
+             outer Grid so it can resize its rows. -->
+        <Border Grid.Row="1"
+                Height="1"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Center"
+                IsHitTestVisible="False"
+                Background="{DynamicResource BorderColor}" />
+        <GridSplitter Grid.Row="1"
+                      Name="DetailsSplitter"
+                      Height="6"
+                      Background="Transparent"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Center"
+                      ResizeDirection="Rows"
+                      ResizeBehavior="PreviousAndNext" />
+
+        <!-- Details panel. The header (title + status badge, or placeholder
+             when no row is selected) is "sticky" and lives outside the
+             ScrollViewer; everything else scrolls beneath it. -->
+        <Border Grid.Row="2"
+                ClipToBounds="True">
+            <DockPanel LastChildFill="True">
+
+            <!-- Sticky header -->
+            <Border DockPanel.Dock="Top" Padding="8,8,8,4">
+                <Panel>
+                    <!-- Placeholder when no row is selected -->
+                    <TextBlock IsVisible="{Binding !HasSelection}"
+                               Text="Select a catalogue entry to view its properties."
+                               Opacity="0.6"
+                               TextWrapping="Wrap"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center" />
+
+                    <!-- Title + status badge -->
+                    <Grid IsVisible="{Binding HasSelection}"
+                          ColumnDefinitions="*,Auto"
+                          ColumnSpacing="8">
+                        <TextBlock Grid.Column="0"
+                                   Text="{Binding SelectedEntry.Title}"
+                                   FontWeight="SemiBold"
+                                   FontSize="13"
+                                   TextWrapping="Wrap"
+                                   VerticalAlignment="Center" />
+                        <Border Grid.Column="1"
+                                Background="{Binding SelectedEntry.StatusBrush}"
+                                BorderBrush="{Binding SelectedEntry.StatusBorderBrush}"
+                                BorderThickness="1.5"
+                                CornerRadius="9"
+                                Padding="10,4"
+                                VerticalAlignment="Center">
+                            <TextBlock Text="{Binding SelectedEntry.StatusText}"
+                                       FontSize="10"
+                                       FontWeight="Bold"
+                                       Foreground="White"
+                                       VerticalAlignment="Center"
+                                       TextAlignment="Center" />
+                        </Border>
+                    </Grid>
+                </Panel>
+            </Border>
+
+            <!-- Scrolling rest fills the remaining DockPanel area -->
+            <ScrollViewer IsVisible="{Binding HasSelection}"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <StackPanel Spacing="12" Margin="8,4,8,8">
+
+                    <!-- "Not for navigation" warning banner. Orange fill with
+                         darker amber border and a warning glyph. -->
+                    <Border IsVisible="{Binding SelectedEntry.NotForNavigation, FallbackValue=False}"
+                            Background="#FFE4B5"
+                            BorderBrush="#B8860B"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="10,8">
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <ic:FluentIcon Icon="Warning"
+                                           IconVariant="Filled"
+                                           FontSize="20"
+                                           Foreground="#8B4513"
+                                           VerticalAlignment="Center" />
+                            <TextBlock Text="Not for navigation"
+                                       FontWeight="SemiBold"
+                                       Foreground="#8B4513"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Property grid. Default font size; per-row spacing for
+                         vertical breathing room. -->
+                    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+                          RowSpacing="6" ColumnSpacing="12">
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Spec" Opacity="0.6" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedEntry.ProductSpec}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Edition" Opacity="0.6" />
+                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedEntry.EditionNumber}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Update" Opacity="0.6" />
+                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedEntry.UpdateNumber}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Issued" Opacity="0.6" />
+                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedEntry.IssueDate}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Updated" Opacity="0.6" />
+                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedEntry.UpdateDate}" />
+                    </Grid>
+
+                    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto"
+                          RowSpacing="6" ColumnSpacing="12"
+                          IsVisible="{Binding SelectedEntry.HasCoverage, FallbackValue=False}">
+                        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Text="Coverage" Opacity="0.6" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="NE" Opacity="0.6" Margin="12,0,0,0" />
+                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedEntry.CoverageNorthEast}"
+                                   FontFamily="Consolas,Menlo,Monaco,monospace" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="SW" Opacity="0.6" Margin="12,0,0,0" />
+                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedEntry.CoverageSouthWest}"
+                                   FontFamily="Consolas,Menlo,Monaco,monospace" />
+                    </Grid>
+
+                    <!-- "Source properties" section header + property list.
+                         Was previously an Expander, but the Expander seemed
+                         to confuse the ScrollViewer's height calculation. -->
+                    <StackPanel Spacing="6"
+                                IsVisible="{Binding SelectedEntry.HasExtendedProperties, FallbackValue=False}">
+                        <TextBlock Text="Source properties"
+                                   FontWeight="SemiBold"
+                                   Opacity="0.8" />
+                        <ItemsControl ItemsSource="{Binding SelectedEntry.ExtendedPropertyList}"
+                                      Grid.IsSharedSizeScope="True">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnSpacing="12" Margin="0,3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" SharedSizeGroup="ExtPropKey" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{Binding Key}" Opacity="0.6" />
+                                        <TextBlock Grid.Column="1" Text="{Binding Value}" TextWrapping="Wrap" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+            </DockPanel>
+        </Border>
+        </Grid>
+    </Panel>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml.cs
@@ -1,0 +1,46 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+public partial class CatalogPanelView : UserControl
+{
+    public CatalogPanelView()
+    {
+        InitializeComponent();
+
+        var list = this.FindControl<ListBox>("EntryList");
+        if (list is not null)
+        {
+            list.ContainerPrepared += OnListContainerPrepared;
+        }
+    }
+
+    private void OnListContainerPrepared(object? sender, ContainerPreparedEventArgs e)
+    {
+        if (e.Container is ListBoxItem item)
+        {
+            // Attach a press handler that runs even if ListBox has handled the
+            // event. This works around an Avalonia quirk where the first click
+            // can be lost to a focus shift from another control (e.g. the map),
+            // requiring a second click to actually commit selection.
+            item.AddHandler(PointerPressedEvent, OnItemPointerPressed,
+                RoutingStrategies.Bubble, handledEventsToo: true);
+        }
+    }
+
+    private void OnItemPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is not CatalogPanelViewModel vm)
+            return;
+
+        if (sender is ListBoxItem { DataContext: CatalogEntryViewModel entry })
+        {
+            vm.SelectedEntry = entry;
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetCatalogAggregatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetCatalogAggregatorTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Viewer.Catalogs;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class DatasetCatalogAggregatorTests
+{
+    private sealed class FakeSource : IDatasetCatalogSource
+    {
+        private List<DatasetCatalogEntry> _entries = new();
+        public string Id { get; }
+        public string DisplayName { get; }
+        public IReadOnlyList<DatasetCatalogEntry> Entries => _entries;
+        public event System.EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+
+        public FakeSource(string id, params DatasetCatalogEntry[] entries)
+        {
+            Id = id;
+            DisplayName = id;
+            _entries = new List<DatasetCatalogEntry>(entries);
+        }
+
+        public void SetEntries(IEnumerable<DatasetCatalogEntry> entries)
+        {
+            _entries = new List<DatasetCatalogEntry>(entries);
+            Changed?.Invoke(this, new DatasetCatalogChangedEventArgs(this));
+        }
+    }
+
+    private static DatasetCatalogEntry Entry(string id, string sourceId) =>
+        new()
+        {
+            Id = id,
+            SourceId = sourceId,
+            Title = id,
+        };
+
+    [Fact]
+    public void Entries_IsUnion_OfChildSources()
+    {
+        var aggregator = new DatasetCatalogAggregator();
+        aggregator.Add(new FakeSource("a", Entry("a-1", "a"), Entry("a-2", "a")));
+        aggregator.Add(new FakeSource("b", Entry("b-1", "b")));
+
+        var ids = aggregator.Entries.Select(e => e.Id).ToArray();
+
+        Assert.Equal(3, ids.Length);
+        Assert.Contains("a-1", ids);
+        Assert.Contains("a-2", ids);
+        Assert.Contains("b-1", ids);
+    }
+
+    [Fact]
+    public void Add_RaisesChanged()
+    {
+        var aggregator = new DatasetCatalogAggregator();
+        var raised = 0;
+        aggregator.Changed += (_, _) => raised++;
+
+        aggregator.Add(new FakeSource("a"));
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void Remove_RaisesChanged_OnlyWhenSourceWasRegistered()
+    {
+        var aggregator = new DatasetCatalogAggregator();
+        var src = new FakeSource("a");
+        aggregator.Add(new FakeSource("kept"));
+        aggregator.Add(src);
+
+        var raised = 0;
+        aggregator.Changed += (_, _) => raised++;
+
+        Assert.True(aggregator.Remove(src));
+        Assert.Equal(1, raised);
+
+        // Removing again should be a no-op.
+        Assert.False(aggregator.Remove(src));
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void ChildChange_PropagatesAsAggregatorChange()
+    {
+        var aggregator = new DatasetCatalogAggregator();
+        var src = new FakeSource("a", Entry("a-1", "a"));
+        aggregator.Add(src);
+
+        var raised = 0;
+        aggregator.Changed += (_, _) => raised++;
+
+        src.SetEntries(new[] { Entry("a-1", "a"), Entry("a-2", "a") });
+
+        Assert.Equal(1, raised);
+        Assert.Equal(2, aggregator.Entries.Count);
+    }
+
+    [Fact]
+    public void Remove_StopsListeningToChildChanges()
+    {
+        var aggregator = new DatasetCatalogAggregator();
+        var src = new FakeSource("a");
+        aggregator.Add(src);
+        Assert.True(aggregator.Remove(src));
+
+        var raised = 0;
+        aggregator.Changed += (_, _) => raised++;
+
+        // Aggregator should no longer react to this source.
+        src.SetEntries(new[] { Entry("a-1", "a") });
+
+        Assert.Equal(0, raised);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj
+++ b/tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <!-- The viewer targets osx-arm64 for SelfContained publish; the tests
+         only consume managed types and do not need a RID-specific build. -->
+    <SelfContained>false</SelfContained>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>false</PublishSingleFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Viewer\EncDotNet.S100.Viewer.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S128\EncDotNet.S100.Datasets.S128.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\datasets\S128\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Viewer.Tests/S128DatasetCatalogSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/S128DatasetCatalogSourceTests.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using System.Linq;
+using EncDotNet.S100.Datasets.S128;
+using EncDotNet.S100.Viewer.Catalogs;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests for <see cref="S128DatasetCatalogSource"/> — verifies the mapping
+/// from <see cref="S128ProductEntry"/> onto the neutral
+/// <see cref="DatasetCatalogEntry"/> shape exposed by the panel.
+/// </summary>
+public class S128DatasetCatalogSourceTests
+{
+    private const string TestDataDir = "TestData";
+    private const string SampleFile = "S128_TDS_sample.gml";
+
+    private static S128Dataset LoadSample()
+    {
+        var path = Path.Combine(TestDataDir, SampleFile);
+        Assert.True(File.Exists(path), $"Test data file not found: {path}");
+        return S128Dataset.Open(path);
+    }
+
+    [Fact]
+    public void Empty_Source_HasNoEntries()
+    {
+        var src = new S128DatasetCatalogSource();
+        Assert.Empty(src.Entries);
+    }
+
+    [Fact]
+    public void AddDataset_PopulatesEntries_AndRaisesChanged()
+    {
+        var src = new S128DatasetCatalogSource();
+        var raised = 0;
+        src.Changed += (_, _) => raised++;
+
+        src.AddDataset("sample.gml", LoadSample());
+
+        Assert.Equal(1, raised);
+        Assert.NotEmpty(src.Entries);
+    }
+
+    [Fact]
+    public void Entries_AreNamespacedBySourceLabel()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+
+        Assert.All(src.Entries, e => Assert.StartsWith("sample.gml#", e.Id));
+        Assert.All(src.Entries, e => Assert.Equal(src.Id, e.SourceId));
+    }
+
+    [Fact]
+    public void Entries_CarryExpectedExtendedProperties()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+
+        var first = src.Entries[0];
+        Assert.True(first.ExtendedProperties.ContainsKey("sourceLabel"));
+        Assert.Equal("sample.gml", first.ExtendedProperties["sourceLabel"]);
+        Assert.True(first.ExtendedProperties.ContainsKey("featureType"));
+    }
+
+    [Fact]
+    public void RemoveDataset_RemovesEntries_AndRaisesChanged()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+        Assert.NotEmpty(src.Entries);
+
+        var raised = 0;
+        src.Changed += (_, _) => raised++;
+
+        var removed = src.RemoveDataset("sample.gml");
+
+        Assert.True(removed);
+        Assert.Empty(src.Entries);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void RemoveDataset_UnknownLabel_IsNoOp()
+    {
+        var src = new S128DatasetCatalogSource();
+        var raised = 0;
+        src.Changed += (_, _) => raised++;
+
+        Assert.False(src.RemoveDataset("nope.gml"));
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void AddDataset_TwiceWithSameLabel_DoesNotDuplicateEntries()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+        var initial = src.Entries.Count;
+
+        src.AddDataset("sample.gml", LoadSample());
+
+        Assert.Equal(initial, src.Entries.Count);
+    }
+
+    [Fact]
+    public void Status_MapsToNeutralEnum()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+
+        // Every neutral status value must be one of the declared enum members.
+        var allowed = new[]
+        {
+            DatasetCatalogStatus.Unknown,
+            DatasetCatalogStatus.InForce,
+            DatasetCatalogStatus.Superseded,
+            DatasetCatalogStatus.Withdrawn,
+            DatasetCatalogStatus.Planned,
+        };
+
+        Assert.All(src.Entries, e => Assert.Contains(e.Status, allowed));
+    }
+
+    [Fact]
+    public void Coverage_IsNullOrHasConsistentBoundingBox()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+
+        foreach (var entry in src.Entries.Where(e => e.Coverage is not null))
+        {
+            var cov = entry.Coverage!;
+            Assert.NotEmpty(cov.Ring);
+            Assert.True(cov.MinLatitude <= cov.MaxLatitude);
+            Assert.True(cov.MinLongitude <= cov.MaxLongitude);
+        }
+    }
+
+    [Fact]
+    public void Clear_RemovesAll_AndRaisesChanged_WhenNonEmpty()
+    {
+        var src = new S128DatasetCatalogSource();
+        src.AddDataset("sample.gml", LoadSample());
+
+        var raised = 0;
+        src.Changed += (_, _) => raised++;
+
+        src.Clear();
+
+        Assert.Empty(src.Entries);
+        Assert.Equal(1, raised);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

Adds a "Dataset Catalog" activity to the viewer that surfaces product-catalog metadata in a left-side panel. The first source is wired to loaded S-128 datasets, but the panel sits behind a small `IDatasetCatalogSource` abstraction so other sources (an online feed, a mocked JSON file, etc.) can be plugged in without coupling the UI to S-128.

The `DatasetCatalogAggregator` fans entries from any number of sources into a single observable list that the panel binds to. `S128DatasetCatalogSource` maps each `S128ProductEntry` into a `DatasetCatalogEntry`, normalising the product spec code and preserving status, coverage, and arbitrary extended properties. The view shows a master list of entries with a sticky details header (title + status badge), a "Not for navigation" warning banner, formatted lat/long coverage corners (DDM), and a shared-size-scope grid of source properties so name/value columns line up.

A few small UX details worth a careful look on review:

- **Click reliability on the entry list.** Avalonia's default `ListBox` padding/margins create dead bands; the view explicitly zeroes them and attaches a per-item `PointerPressed` handler in `ContainerPrepared` so clicks anywhere in a row select reliably.
- **Scrolling in the details pane.** A `ScrollViewer.Padding` was clipping the bottom of its content (a known Avalonia gotcha); the padding now lives on the inner `StackPanel.Margin`, and the empty/populated states are sibling subtrees rather than overlays so collapsed visibility doesn't perturb star-row sizing.
- **Mapsui logging widget.** Disabled at startup; on narrow viewports it can throw `minX > maxX` from the render thread on Mapsui 5.0.2.

## Spec alignment

- [ ] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This PR is viewer/UX infrastructure on top of the existing S-128 reader. No spec semantics are changed; the S-128 source only consumes already-parsed `S128ProductEntry` values.

**Spec section references cited in code/docs:** N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New `tests/EncDotNet.S100.Viewer.Tests/` project with 15 tests covering the aggregator, the S-128 source mapping, and view-model formatting (status badge text, DDM lat/long, extended-property exposure).

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

The viewer README does not currently describe individual activity panels; happy to add a Dataset Catalog section in a follow-up if that level of doc is desired.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new NuGet packages.

## Breaking changes

None.