### PR TITLE
Add mouse lat/long indicator to viewer status bar

### DIFF
--- a/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
@@ -12,9 +12,10 @@ internal static class LatLonFormatter
 {
     /// <summary>
     /// Placeholder used when no coordinate is available (e.g. the cursor is
-    /// not over the map).
+    /// not over the map). Empty so the status bar simply shows nothing in
+    /// that state.
     /// </summary>
-    public const string Placeholder = "—";
+    public const string Placeholder = "";
 
     /// <summary>
     /// Formats a (latitude, longitude) pair in degrees-decimal-minutes form.

--- a/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Globalization;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Mariner-friendly formatting for geographic coordinates. The format is
+/// degrees-decimal-minutes (DDM), e.g. <c>"12°34.567'N  056°12.345'W"</c>,
+/// matching the convention typically used on nautical charts.
+/// </summary>
+internal static class LatLonFormatter
+{
+    /// <summary>
+    /// Placeholder used when no coordinate is available (e.g. the cursor is
+    /// not over the map).
+    /// </summary>
+    public const string Placeholder = "—";
+
+    /// <summary>
+    /// Formats a (latitude, longitude) pair in degrees-decimal-minutes form.
+    /// Latitude is rendered with two integer degree digits, longitude with
+    /// three.
+    /// </summary>
+    public static string Format(double latitude, double longitude) =>
+        $"{FormatDegMin(latitude, 'N', 'S', 2)}  {FormatDegMin(longitude, 'E', 'W', 3)}";
+
+    private static string FormatDegMin(double value, char positive, char negative, int degDigits)
+    {
+        var hemi = value >= 0 ? positive : negative;
+        var abs = Math.Abs(value);
+        var deg = (int)Math.Floor(abs);
+        var min = (abs - deg) * 60.0;
+        // Guard against floating-point rounding pushing minutes to 60.000.
+        if (min >= 60.0)
+        {
+            deg += 1;
+            min = 0.0;
+        }
+
+        var degFmt = "D" + degDigits;
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{deg.ToString(degFmt, CultureInfo.InvariantCulture)}°{min.ToString("00.000", CultureInfo.InvariantCulture)}'{hemi}");
+    }
+}

--- a/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
@@ -18,13 +18,14 @@ internal static class LatLonFormatter
 
     /// <summary>
     /// Formats a (latitude, longitude) pair in degrees-decimal-minutes form.
-    /// Latitude is rendered with two integer degree digits, longitude with
-    /// three.
+    /// Degrees are space-padded (latitude to two characters, longitude to
+    /// three) so that the readout occupies a stable width without using
+    /// leading zeros.
     /// </summary>
     public static string Format(double latitude, double longitude) =>
         $"{FormatDegMin(latitude, 'N', 'S', 2)}  {FormatDegMin(longitude, 'E', 'W', 3)}";
 
-    private static string FormatDegMin(double value, char positive, char negative, int degDigits)
+    private static string FormatDegMin(double value, char positive, char negative, int degWidth)
     {
         var hemi = value >= 0 ? positive : negative;
         var abs = Math.Abs(value);
@@ -37,9 +38,9 @@ internal static class LatLonFormatter
             min = 0.0;
         }
 
-        var degFmt = "D" + degDigits;
+        var degText = deg.ToString(CultureInfo.InvariantCulture).PadLeft(degWidth);
         return string.Create(
             CultureInfo.InvariantCulture,
-            $"{deg.ToString(degFmt, CultureInfo.InvariantCulture)}°{min.ToString("00.000", CultureInfo.InvariantCulture)}'{hemi}");
+            $"{degText}°{min.ToString("00.000", CultureInfo.InvariantCulture)}'{hemi}");
     }
 }

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -116,6 +116,7 @@
                 <TextBlock DockPanel.Dock="Right"
                            Text="{Binding MouseLatLonText}"
                            FontSize="12"
+                           FontFamily="Menlo,Consolas,Courier New,monospace"
                            Opacity="0.7"
                            VerticalAlignment="Center"
                            Margin="12,0,0,0"

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -112,10 +112,20 @@
                 Padding="8,3"
                 Height="26"
                 IsVisible="{Binding IsStatusBarVisible}">
-            <TextBlock Text="{Binding StatusText}"
-                       FontSize="12"
-                       Opacity="0.7"
-                       VerticalAlignment="Center" />
+            <DockPanel LastChildFill="True">
+                <TextBlock DockPanel.Dock="Right"
+                           Text="{Binding MouseLatLonText}"
+                           FontSize="12"
+                           Opacity="0.7"
+                           VerticalAlignment="Center"
+                           Margin="12,0,0,0"
+                           ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
+                <TextBlock Text="{Binding StatusText}"
+                           FontSize="12"
+                           Opacity="0.7"
+                           VerticalAlignment="Center"
+                           TextTrimming="CharacterEllipsis" />
+            </DockPanel>
         </Border>
 
         <!-- Activity bar (narrow icon strip on far left) -->

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -46,6 +46,7 @@ public partial class MainWindow : ShadUI.Window
     private string? _screenshotPath;
     private double _lastPaneWidth = 320;
     private double _lastPickPanelWidth = 360;
+    private Point? _lastMouseScreenPos;
 
     /// <summary>
     /// Threshold (milliseconds) for treating a press-and-hold as a long-press
@@ -369,6 +370,7 @@ public partial class MainWindow : ShadUI.Window
         if (MapControl.Map?.Navigator is { } scaleNav)
         {
             scaleNav.ViewportChanged += OnViewportChangedForScaleBar;
+            scaleNav.ViewportChanged += OnViewportChangedForMouseLatLon;
             UpdateScaleBar(scaleNav.Viewport);
         }
 
@@ -866,21 +868,40 @@ public partial class MainWindow : ShadUI.Window
 
     private void OnMapPointerExited(object? sender, PointerEventArgs e)
     {
+        _lastMouseScreenPos = null;
         _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+    }
+
+    private void OnViewportChangedForMouseLatLon(object? sender, EventArgs e)
+    {
+        // Pan/zoom can move the world under a stationary cursor (common with
+        // trackpad gestures), so refresh the readout whenever the viewport
+        // changes — but only if the cursor is currently over the map.
+        if (_lastMouseScreenPos is not { } pos)
+            return;
+
+        Dispatcher.UIThread.Post(() => UpdateMouseLatLonFromScreen(pos));
     }
 
     private void UpdateMouseLatLon(PointerEventArgs e)
     {
-        if (MapControl.Map?.Navigator is not { } navigator)
-        {
-            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
-            return;
-        }
-
         var position = e.GetPosition(MapControl);
         var bounds = MapControl.Bounds;
         if (position.X < 0 || position.Y < 0 ||
             position.X > bounds.Width || position.Y > bounds.Height)
+        {
+            _lastMouseScreenPos = null;
+            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            return;
+        }
+
+        _lastMouseScreenPos = position;
+        UpdateMouseLatLonFromScreen(position);
+    }
+
+    private void UpdateMouseLatLonFromScreen(Point position)
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
         {
             _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
             return;

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -26,6 +26,7 @@ using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui;
 using Mapsui.Extensions;
 using Mapsui.Layers;
+using Mapsui.Projections;
 using Mapsui.Tiling;
 
 namespace EncDotNet.S100.Viewer;
@@ -346,6 +347,7 @@ public partial class MainWindow : ShadUI.Window
         MapControl.AddHandler(PointerMovedEvent, OnMapPointerMoved, RoutingStrategies.Tunnel);
         MapControl.AddHandler(PointerReleasedEvent, OnMapPointerReleased, RoutingStrategies.Tunnel);
         MapControl.AddHandler(PointerCaptureLostEvent, OnMapPointerCaptureLost, RoutingStrategies.Tunnel);
+        MapControl.PointerExited += OnMapPointerExited;
 
         // Esc exits Pick Mode.
         AddHandler(KeyDownEvent, OnWindowKeyDown, RoutingStrategies.Tunnel);
@@ -850,6 +852,8 @@ public partial class MainWindow : ShadUI.Window
 
     private void OnMapPointerMoved(object? sender, PointerEventArgs e)
     {
+        UpdateMouseLatLon(e);
+
         if (_longPressTimer is null || _longPressOrigin is not { } origin)
             return;
 
@@ -858,6 +862,44 @@ public partial class MainWindow : ShadUI.Window
         var dy = current.Y - origin.Y;
         if ((dx * dx + dy * dy) > LongPressMoveTolerance * LongPressMoveTolerance)
             CancelLongPress();
+    }
+
+    private void OnMapPointerExited(object? sender, PointerEventArgs e)
+    {
+        _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+    }
+
+    private void UpdateMouseLatLon(PointerEventArgs e)
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
+        {
+            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            return;
+        }
+
+        var position = e.GetPosition(MapControl);
+        var bounds = MapControl.Bounds;
+        if (position.X < 0 || position.Y < 0 ||
+            position.X > bounds.Width || position.Y > bounds.Height)
+        {
+            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            return;
+        }
+
+        var world = navigator.Viewport.ScreenToWorld(position.X, position.Y);
+        var (lon, lat) = SphericalMercator.ToLonLat(world.X, world.Y);
+        if (double.IsNaN(lat) || double.IsNaN(lon) ||
+            double.IsInfinity(lat) || double.IsInfinity(lon) ||
+            lat < -90.0 || lat > 90.0)
+        {
+            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            return;
+        }
+
+        // Normalize longitude into the canonical [-180, 180] range so that
+        // panning past the antimeridian still produces sensible readings.
+        lon = ((lon + 540.0) % 360.0) - 180.0;
+        _viewModel.MouseLatLonText = LatLonFormatter.Format(lat, lon);
     }
 
     private void OnMapPointerReleased(object? sender, PointerReleasedEventArgs e)

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -56,6 +56,7 @@ internal static class Strings
     public static string Tooltip_RemoveDataset => Get(nameof(Tooltip_RemoveDataset));
     public static string Tooltip_PreviousTimeStep => Get(nameof(Tooltip_PreviousTimeStep));
     public static string Tooltip_NextTimeStep => Get(nameof(Tooltip_NextTimeStep));
+    public static string Tooltip_MouseLatLon => Get(nameof(Tooltip_MouseLatLon));
 
     // Buttons / actions
     public static string Button_OpenDataset => Get(nameof(Button_OpenDataset));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -296,4 +296,9 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Status_FileNoLongerExists" xml:space="preserve">
     <value>File no longer exists: {0}</value>
   </data>
+
+  <!-- Tooltips for status bar elements -->
+  <data name="Tooltip_MouseLatLon" xml:space="preserve">
+    <value>Latitude and longitude of the cursor on the map</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/ViewModels/CatalogPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/CatalogPanelViewModel.cs
@@ -126,25 +126,8 @@ internal sealed class CatalogEntryViewModel : ViewModelBase
     public string CoverageNorthEast =>
         Entry.Coverage is { } c ? FormatLatLon(c.MaxLatitude, c.MaxLongitude) : string.Empty;
 
-    /// <summary>
-    /// Formats a (lat, lon) pair in degrees-decimal-minutes form, e.g.
-    /// <c>"12°34.567'N 056°12.345'W"</c>. Mariner-friendly and matches the
-    /// convention typically used on nautical charts.
-    /// </summary>
-    private static string FormatLatLon(double latitude, double longitude)
-    {
-        return $"{FormatDegMin(latitude, 'N', 'S', 2)}  {FormatDegMin(longitude, 'E', 'W', 3)}";
-    }
-
-    private static string FormatDegMin(double value, char positive, char negative, int degDigits)
-    {
-        var hemi = value >= 0 ? positive : negative;
-        var abs = Math.Abs(value);
-        var deg = (int)Math.Floor(abs);
-        var min = (abs - deg) * 60.0;
-        var degFmt = "D" + degDigits;
-        return $"{deg.ToString(degFmt)}°{min:00.000}'{hemi}";
-    }
+    private static string FormatLatLon(double latitude, double longitude) =>
+        LatLonFormatter.Format(latitude, longitude);
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -94,6 +94,19 @@ internal sealed class MainViewModel : ViewModelBase
 
     public ICommand ToggleStatusBarCommand { get; }
 
+    private string _mouseLatLonText = LatLonFormatter.Placeholder;
+    /// <summary>
+    /// Lat/long of the mouse cursor when it is over the map, formatted in
+    /// degrees-decimal-minutes (mariner-friendly). Set to
+    /// <see cref="LatLonFormatter.Placeholder"/> when the cursor is not over
+    /// the map.
+    /// </summary>
+    public string MouseLatLonText
+    {
+        get => _mouseLatLonText;
+        set => SetProperty(ref _mouseLatLonText, value);
+    }
+
     private bool _isPickPanelEnabled;
     /// <summary>
     /// User preference for whether the pick panel is allowed to auto-open

--- a/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
@@ -9,28 +9,35 @@ public class LatLonFormatterTests
     {
         // 12.5760278° = 12° 34.5617'
         var text = LatLonFormatter.Format(12.576028, 56.205750);
-        Assert.Equal("12°34.562'N  056°12.345'E", text);
+        Assert.Equal("12°34.562'N   56°12.345'E", text);
     }
 
     [Fact]
     public void Format_SouthWest_UsesCorrectHemispheres()
     {
         var text = LatLonFormatter.Format(-12.576028, -56.205750);
-        Assert.Equal("12°34.562'S  056°12.345'W", text);
+        Assert.Equal("12°34.562'S   56°12.345'W", text);
     }
 
     [Fact]
     public void Format_Equator_RendersAsNorthAndEast()
     {
         var text = LatLonFormatter.Format(0.0, 0.0);
-        Assert.Equal("00°00.000'N  000°00.000'E", text);
+        Assert.Equal(" 0°00.000'N    0°00.000'E", text);
     }
 
     [Fact]
-    public void Format_LatitudePadsToTwoDegreeDigits_LongitudeToThree()
+    public void Format_DegreesArePadWithSpaces_NotZeros()
     {
         var text = LatLonFormatter.Format(1.0, 2.0);
-        Assert.Equal("01°00.000'N  002°00.000'E", text);
+        Assert.Equal(" 1°00.000'N    2°00.000'E", text);
+    }
+
+    [Fact]
+    public void Format_MaxDegreesFitWithoutPaddingSpaces()
+    {
+        var text = LatLonFormatter.Format(89.0, 179.0);
+        Assert.Equal("89°00.000'N  179°00.000'E", text);
     }
 
     [Fact]
@@ -38,7 +45,7 @@ public class LatLonFormatterTests
     {
         // 0.5° → 30.0000 minutes; ensure no trailing rounding artifact.
         var text = LatLonFormatter.Format(45.5, 90.5);
-        Assert.Equal("45°30.000'N  090°30.000'E", text);
+        Assert.Equal("45°30.000'N   90°30.000'E", text);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
@@ -1,0 +1,49 @@
+using EncDotNet.S100.Viewer;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class LatLonFormatterTests
+{
+    [Fact]
+    public void Format_NorthEast_UsesCorrectHemispheres()
+    {
+        // 12.5760278° = 12° 34.5617'
+        var text = LatLonFormatter.Format(12.576028, 56.205750);
+        Assert.Equal("12°34.562'N  056°12.345'E", text);
+    }
+
+    [Fact]
+    public void Format_SouthWest_UsesCorrectHemispheres()
+    {
+        var text = LatLonFormatter.Format(-12.576028, -56.205750);
+        Assert.Equal("12°34.562'S  056°12.345'W", text);
+    }
+
+    [Fact]
+    public void Format_Equator_RendersAsNorthAndEast()
+    {
+        var text = LatLonFormatter.Format(0.0, 0.0);
+        Assert.Equal("00°00.000'N  000°00.000'E", text);
+    }
+
+    [Fact]
+    public void Format_LatitudePadsToTwoDegreeDigits_LongitudeToThree()
+    {
+        var text = LatLonFormatter.Format(1.0, 2.0);
+        Assert.Equal("01°00.000'N  002°00.000'E", text);
+    }
+
+    [Fact]
+    public void Format_RoundsMinutesToThreeDecimals()
+    {
+        // 0.5° → 30.0000 minutes; ensure no trailing rounding artifact.
+        var text = LatLonFormatter.Format(45.5, 90.5);
+        Assert.Equal("45°30.000'N  090°30.000'E", text);
+    }
+
+    [Fact]
+    public void Placeholder_IsEmDash()
+    {
+        Assert.Equal("—", LatLonFormatter.Placeholder);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
@@ -49,8 +49,8 @@ public class LatLonFormatterTests
     }
 
     [Fact]
-    public void Placeholder_IsEmDash()
+    public void Placeholder_IsEmpty()
     {
-        Assert.Equal("—", LatLonFormatter.Placeholder);
+        Assert.Equal(string.Empty, LatLonFormatter.Placeholder);
     }
 }


### PR DESCRIPTION
Adds a right-aligned readout to the viewer's status bar that shows the lat/long of the cursor over the map in mariner-friendly degrees-decimal-minutes form.

## Behavior

- Displays e.g. `12°34.562'N   56°12.345'E` while the cursor is over the map.
- Updates live as the cursor moves **and** when the viewport changes (so trackpad pan/zoom with a stationary cursor refreshes the readout).
- Goes blank when the cursor leaves the map.

## Implementation

- New `LatLonFormatter` helper (DDM, space-padded degrees so values render without leading zeros while still occupying a stable column width). The catalog panel's coverage corners now delegate to it.
- `MainViewModel.MouseLatLonText` bound from a new monospaced `TextBlock` in the status bar.
- `MainWindow.axaml.cs` hooks `PointerMoved` / `PointerExited` on the Mapsui `MapControl` and `Navigator.ViewportChanged`. Screen → world conversion uses `Viewport.ScreenToWorld` followed by `SphericalMercator.ToLonLat`; longitude is normalized across the antimeridian.
- New `Tooltip_MouseLatLon` resx entry with matching `Strings` property.

## Tests

`LatLonFormatterTests` covers hemisphere selection, space-padding (vs leading zeros), max-degree case, minute rounding, and the empty placeholder. All 33 viewer tests pass.