### PR TITLE
Add zoom-to-extent button and refine map overlay icons

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -84,6 +84,22 @@
             <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
         </Style>
 
+        <!--
+          Map overlay buttons (Pick Mode, Zoom In/Out/Extent) sit on top
+          of the map. The default ShadUI Icon foreground uses MutedColor
+          which is hard to read against the chart canvas — bump these
+          buttons to the full ForegroundColor at rest so the icons are
+          legible. (Background is left at the ShadUI default to avoid
+          the hover-overlay shimmer that occurs when the resting fill
+          and the GhostColor hover overlay differ.)
+        -->
+        <Style Selector="Button.MapOverlay">
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}" />
+        </Style>
+        <Style Selector="Button.MapOverlay ic|FluentIcon">
+            <Setter Property="Foreground" Value="{Binding $parent[Button].Foreground}" />
+        </Style>
+
     </shadui:Window.Styles>
 
     <shadui:Window.RightWindowTitleBarContent>
@@ -304,7 +320,7 @@
                             VerticalAlignment="Top"
                             Margin="0,12,12,0">
                     <Button x:Name="PickModeButton"
-                            Classes="Icon"
+                            Classes="Icon MapOverlay"
                             Classes.pickActive="{Binding IsPickModeActive}"
                             Command="{Binding TogglePickModeCommand}"
                             ToolTip.Tip="{x:Static loc:Strings.Tooltip_PickMode}">
@@ -357,16 +373,29 @@
                         </Button.Styles>
                         <ic:FluentIcon Icon="CursorClick" IconVariant="Regular" FontSize="16" />
                     </Button>
-                    <Button x:Name="ZoomInButton"
-                            Classes="Icon"
-                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_ZoomIn}">
-                        <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="16" />
-                    </Button>
-                    <Button x:Name="ZoomOutButton"
-                            Classes="Icon"
-                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_ZoomOut}">
-                        <ic:FluentIcon Icon="Subtract" IconVariant="Regular" FontSize="16" />
-                    </Button>
+                    <!--
+                      Zoom in / out / to-extent group. Wrapping in an inner
+                      StackPanel with vertical margin gives the cluster its
+                      own visual grouping (separated from the Pick Mode
+                      button above and the compass rose below).
+                    -->
+                    <StackPanel Orientation="Vertical" Spacing="2" Margin="0,16,0,16">
+                        <Button x:Name="ZoomInButton"
+                                Classes="Icon MapOverlay"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ZoomIn}">
+                            <ic:FluentIcon Icon="ZoomIn" IconVariant="Regular" FontSize="16" />
+                        </Button>
+                        <Button x:Name="ZoomOutButton"
+                                Classes="Icon MapOverlay"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ZoomOut}">
+                            <ic:FluentIcon Icon="ZoomOut" IconVariant="Regular" FontSize="16" />
+                        </Button>
+                        <Button x:Name="ZoomToExtentButton"
+                                Classes="Icon MapOverlay"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ZoomToExtent}">
+                            <ic:FluentIcon Icon="ZoomFit" IconVariant="Regular" FontSize="16" />
+                        </Button>
+                    </StackPanel>
                     <views:CompassRoseView x:Name="CompassRose"
                                            Margin="0,4,0,0"
                                            Width="{Binding Bounds.Width, ElementName=ZoomInButton}"

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -185,7 +185,7 @@ public partial class MainWindow : ShadUI.Window
         // long-press pick, mouse lat/lon readout, scale-bar/compass viewport
         // sync, and the zoom in/out overlay buttons.
         new MapInteractionController(_viewModel, _pickService, _loader)
-            .Attach(MapControl, ZoomInButton, ZoomOutButton, ScaleBar, CompassRose);
+            .Attach(MapControl, ZoomInButton, ZoomOutButton, ZoomToExtentButton, ScaleBar, CompassRose);
 
         // Apply the cursor that matches the current mode and keep it in sync
         // with the view-model.

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -48,6 +48,7 @@ internal static class Strings
     public static string Tooltip_PickMode => Get(nameof(Tooltip_PickMode));
     public static string Tooltip_ZoomIn => Get(nameof(Tooltip_ZoomIn));
     public static string Tooltip_ZoomOut => Get(nameof(Tooltip_ZoomOut));
+    public static string Tooltip_ZoomToExtent => Get(nameof(Tooltip_ZoomToExtent));
     public static string Tooltip_ClosePickPanel => Get(nameof(Tooltip_ClosePickPanel));
     public static string Tooltip_AddFeatureCatalogue => Get(nameof(Tooltip_AddFeatureCatalogue));
     public static string Tooltip_AddPortrayalCatalogue => Get(nameof(Tooltip_AddPortrayalCatalogue));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -68,6 +68,9 @@
   <data name="Tooltip_ZoomOut" xml:space="preserve">
     <value>Zoom Out</value>
   </data>
+  <data name="Tooltip_ZoomToExtent" xml:space="preserve">
+    <value>Zoom to Extent</value>
+  </data>
   <data name="Tooltip_ClosePickPanel" xml:space="preserve">
     <value>Close</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
@@ -80,12 +80,14 @@ internal sealed class MapInteractionController
         MapControl mapControl,
         Button zoomInButton,
         Button zoomOutButton,
+        Button zoomToExtentButton,
         ScaleBarView scaleBar,
         CompassRoseView compassRose)
     {
         ArgumentNullException.ThrowIfNull(mapControl);
         ArgumentNullException.ThrowIfNull(zoomInButton);
         ArgumentNullException.ThrowIfNull(zoomOutButton);
+        ArgumentNullException.ThrowIfNull(zoomToExtentButton);
         ArgumentNullException.ThrowIfNull(scaleBar);
         ArgumentNullException.ThrowIfNull(compassRose);
 
@@ -112,6 +114,7 @@ internal sealed class MapInteractionController
         // Zoom in/out overlay buttons.
         zoomInButton.Click += OnZoomInClick;
         zoomOutButton.Click += OnZoomOutClick;
+        zoomToExtentButton.Click += OnZoomToExtentClick;
 
         // Compass-rose drag drives map rotation.
         compassRose.RotationRequested += OnCompassRotationRequested;
@@ -139,6 +142,26 @@ internal sealed class MapInteractionController
         if (_mapControl?.Map?.Navigator is not { } navigator)
             return;
         navigator.ZoomTo(navigator.Viewport.Resolution * 2, 250);
+    }
+
+    /// <summary>
+    /// Zooms out to the combined extent of all loaded layers (the union
+    /// reported by <see cref="Mapsui.Map.Extent"/>) so the user can see
+    /// every loaded dataset at once without repeatedly clicking
+    /// Zoom Out.
+    /// </summary>
+    private void OnZoomToExtentClick(object? sender, RoutedEventArgs e)
+    {
+        if (_mapControl?.Map is not { } map || map.Navigator is not { } navigator)
+            return;
+
+        var extent = map.Extent;
+        if (extent is null || extent.Width <= 0 || extent.Height <= 0)
+            return;
+
+        // Match DatasetLoaderService.ZoomToExtent: pad by 10% so features
+        // at the edges aren't flush against the viewport border.
+        navigator.ZoomToBox(extent.Grow(extent.Width * 0.1, extent.Height * 0.1), duration: 250);
     }
 
     private void HandleViewportChangedForScaleBar(ScaleBarView scaleBar, CompassRoseView compassRose)


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

The map overlay zoom controls were minimal: just `+` / `−` glyphs, with no quick way to zoom out to see all loaded datasets. This PR refreshes that cluster:

- Swaps the `Add` / `Subtract` icons for the magnifying-glass `ZoomIn` / `ZoomOut` FluentIcons so the buttons read at a glance as zoom controls.
- Adds a third button that zooms the navigator to the union extent of all loaded layers (Mapsui `Map.Extent`) using the `ZoomFit` icon, with the same 10% padding the dataset loader applies on first load. No-op when no datasets are loaded.
- Wraps the three zoom buttons in their own `StackPanel` with a 16px vertical margin so they read as a distinct group, separate from the Pick Mode button above and the compass rose below.
- Adds a shared `MapOverlay` button class that bumps the icon foreground from `MutedColor` to the full `ForegroundColor` at rest. The icons were hard to read against the chart canvas; this avoids touching the resting background, which would otherwise cause a hover-overlay shimmer (the same issue the existing Pick Mode active-state styles work around).

The new button is wired through `MapInteractionController.Attach`, which now takes a fourth button parameter.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a viewer UX change only; no spec semantics or pipelines are affected.

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

No tests added — the change is presentation-only on the Avalonia `MapControl` overlay (XAML icons, layout grouping, and a click handler that wraps `Navigator.ZoomToBox`). Verified manually by running the viewer and confirming the new button zooms to the combined extent.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

The viewer's README does not document individual overlay buttons, so no doc updates were needed. The new `OnZoomToExtentClick` handler has an XML doc comment describing its behaviour.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies — both `ZoomIn` / `ZoomOut` / `ZoomFit` icons already ship with the existing `FluentIcons.Avalonia.Fluent` package.

## Breaking changes

None. `MapInteractionController` is `internal` and only consumed by `MainWindow`, which is updated in the same change.