### PR TITLE
Add Distance & Bearing measure tool to viewer

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -80,6 +80,7 @@ public partial class App : Application
         services.AddSingleton<IRecentFilesService, RecentFilesService>();
         services.AddSingleton<PortrayalCatalogueSeeder>();
         services.AddSingleton<ScreenshotService>();
+        services.AddSingleton<EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider, MeasureOverlayAppearanceProvider>();
 
         // Phase 3 services: dataset orchestration, pick dispatch, file dialogs
         services.AddSingleton<IDatasetLoaderService, DatasetLoaderService>();

--- a/src/EncDotNet.S100.Viewer/Geodesy/MarineGeodesy.cs
+++ b/src/EncDotNet.S100.Viewer/Geodesy/MarineGeodesy.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Geodesy;
+
+/// <summary>
+/// Marine-navigation geodesy helpers used by the Measure Mode tool.
+/// </summary>
+/// <remarks>
+/// All inputs are WGS-84 latitude/longitude in degrees. Distances are
+/// returned in nautical miles. Bearings are true (relative to true north),
+/// in the closed-open range [0°, 360°).
+///
+/// <para>
+/// V1 implements rhumb-line (loxodrome) calculations only — the standard
+/// ECDIS convention for Distance/Bearing read-outs. A future
+/// great-circle helper would live alongside these methods so call sites
+/// can swap by selecting a different routine.
+/// </para>
+/// </remarks>
+internal static class MarineGeodesy
+{
+    /// <summary>Mean Earth radius in nautical miles (6371 km / 1.852).</summary>
+    private const double EarthRadiusNm = 3440.065;
+
+    /// <summary>
+    /// Maximum absolute latitude (degrees) used when evaluating rhumb-line
+    /// formulas. Clamped to avoid the singularity at the poles where the
+    /// Mercator projection (<c>ln tan(π/4 + φ/2)</c>) blows up.
+    /// </summary>
+    private const double LatitudeClampDegrees = 89.99;
+
+    /// <summary>
+    /// Computes the rhumb-line distance, in nautical miles, between two
+    /// WGS-84 points along a constant true bearing (loxodrome).
+    /// </summary>
+    public static double RhumbDistanceNm(double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg)
+    {
+        var phi1 = ClampLatRadians(lat1Deg);
+        var phi2 = ClampLatRadians(lat2Deg);
+        var dphi = phi2 - phi1;
+        var dlam = NormalizeDeltaLonRadians(DegToRad(lon2Deg - lon1Deg));
+
+        // Stretched (Mercator) latitude difference.
+        var dpsi = Math.Log(Math.Tan(Math.PI / 4.0 + phi2 / 2.0) /
+                            Math.Tan(Math.PI / 4.0 + phi1 / 2.0));
+
+        // q = dphi/dpsi normally; degenerate to cos(phi1) when latitudes match.
+        var q = Math.Abs(dpsi) > 1e-12 ? dphi / dpsi : Math.Cos(phi1);
+
+        var distRadians = Math.Sqrt(dphi * dphi + q * q * dlam * dlam);
+        return distRadians * EarthRadiusNm;
+    }
+
+    /// <summary>
+    /// Computes the rhumb-line true bearing in degrees [0°, 360°) from the
+    /// first point to the second.
+    /// </summary>
+    public static double RhumbBearingDegrees(double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg)
+    {
+        var phi1 = ClampLatRadians(lat1Deg);
+        var phi2 = ClampLatRadians(lat2Deg);
+        var dlam = NormalizeDeltaLonRadians(DegToRad(lon2Deg - lon1Deg));
+
+        var dpsi = Math.Log(Math.Tan(Math.PI / 4.0 + phi2 / 2.0) /
+                            Math.Tan(Math.PI / 4.0 + phi1 / 2.0));
+
+        var theta = Math.Atan2(dlam, dpsi);
+        var deg = RadToDeg(theta);
+        return ((deg % 360.0) + 360.0) % 360.0;
+    }
+
+    /// <summary>
+    /// Splits a sequence of waypoints into one or more sub-paths so that no
+    /// segment crosses the antimeridian (±180° longitude). Each output
+    /// sub-path uses unwrapped longitudes that are continuous across its
+    /// own segments; this lets a Mercator renderer draw the path as
+    /// straight Mercator lines without the "wrap around the world"
+    /// artifact you get when consecutive points span e.g. 179°E and
+    /// 179°W.
+    /// </summary>
+    /// <remarks>
+    /// Within a sub-path the second-and-later longitudes may exceed the
+    /// canonical [-180, 180] range — this is intentional so the renderer
+    /// can project the segment as a single straight line in Mercator
+    /// space. Each new sub-path resets to the canonical range at its
+    /// first point.
+    /// </remarks>
+    public static IReadOnlyList<IReadOnlyList<(double Lat, double Lon)>> SplitAtAntimeridian(
+        IEnumerable<(double Lat, double Lon)> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+
+        var result = new List<List<(double Lat, double Lon)>>();
+        List<(double Lat, double Lon)>? current = null;
+        double prevLon = 0.0;
+
+        foreach (var pt in points)
+        {
+            if (current is null)
+            {
+                current = new List<(double Lat, double Lon)> { pt };
+                prevLon = pt.Lon;
+                result.Add(current);
+                continue;
+            }
+
+            // If the longitude jump exceeds 180° in either direction, the
+            // shorter rhumb crossed the antimeridian — start a new sub-path.
+            var rawDelta = pt.Lon - prevLon;
+            if (rawDelta > 180.0 || rawDelta < -180.0)
+            {
+                current = new List<(double Lat, double Lon)> { pt };
+                result.Add(current);
+                prevLon = pt.Lon;
+            }
+            else
+            {
+                var unwrapped = prevLon + rawDelta;
+                current.Add((pt.Lat, unwrapped));
+                prevLon = unwrapped;
+            }
+        }
+
+        return result;
+    }
+
+    private static double DegToRad(double deg) => deg * (Math.PI / 180.0);
+    private static double RadToDeg(double rad) => rad * (180.0 / Math.PI);
+
+    private static double ClampLatRadians(double latDeg)
+    {
+        if (latDeg > LatitudeClampDegrees) latDeg = LatitudeClampDegrees;
+        else if (latDeg < -LatitudeClampDegrees) latDeg = -LatitudeClampDegrees;
+        return DegToRad(latDeg);
+    }
+
+    private static double NormalizeDeltaLonRadians(double dlamRadians)
+    {
+        // Wrap the longitude difference into (-π, π] so we always traverse
+        // the short way around the globe.
+        const double TwoPi = 2.0 * Math.PI;
+        if (dlamRadians > Math.PI) dlamRadians -= TwoPi;
+        else if (dlamRadians < -Math.PI) dlamRadians += TwoPi;
+        return dlamRadians;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -27,8 +27,14 @@
     </shadui:Window.Resources>
 
     <shadui:Window.KeyBindings>
-        <!-- Esc exits Pick Mode. -->
+        <!-- Esc exits the active map tool (pick or measure). -->
         <KeyBinding Gesture="Escape" Command="{Binding ExitPickModeCommand}" />
+        <!-- Cmd+M / Ctrl+M toggles Measure Mode. -->
+        <KeyBinding Gesture="Cmd+M" Command="{Binding ToggleMeasureModeCommand}" />
+        <KeyBinding Gesture="Ctrl+M" Command="{Binding ToggleMeasureModeCommand}" />
+        <!-- Enter / Backspace are tool actions while a tool is active. -->
+        <KeyBinding Gesture="Enter" Command="{Binding ToolCommitCommand}" />
+        <KeyBinding Gesture="Back" Command="{Binding ToolBackstepCommand}" />
     </shadui:Window.KeyBindings>
 
     <shadui:Window.Styles>
@@ -142,6 +148,14 @@
                            VerticalAlignment="Center"
                            Margin="12,0,0,0"
                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
+                <TextBlock DockPanel.Dock="Right"
+                           Text="{Binding MeasureSummary}"
+                           IsVisible="{Binding IsMeasureModeActive}"
+                           FontSize="12"
+                           FontFamily="Menlo,Consolas,Courier New,monospace"
+                           Opacity="0.85"
+                           VerticalAlignment="Center"
+                           Margin="12,0,0,0" />
                 <TextBlock Text="{Binding StatusText}"
                            FontSize="12"
                            Opacity="0.7"
@@ -372,6 +386,38 @@
                             </Style>
                         </Button.Styles>
                         <ic:FluentIcon Icon="CursorClick" IconVariant="Regular" FontSize="16" />
+                    </Button>
+                    <!--
+                      Measure Mode toggle button. Same accent-fill pattern
+                      as PickModeButton above; ruler icon distinguishes the
+                      two. Cmd/Ctrl+M is the keyboard accelerator (see the
+                      Window.KeyBindings block at the top of this file).
+                    -->
+                    <Button x:Name="MeasureModeButton"
+                            Classes="Icon MapOverlay"
+                            Classes.measureActive="{Binding IsMeasureModeActive}"
+                            Command="{Binding ToggleMeasureModeCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_MeasureMode}">
+                        <Button.Styles>
+                            <Style Selector="Button#MeasureModeButton.measureActive">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#MeasureModeButton.measureActive /template/ ContentPresenter">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                            </Style>
+                            <Style Selector="Button#MeasureModeButton.measureActive ic|FluentIcon">
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#MeasureModeButton.measureActive /template/ Border#HoverBackground">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Opacity" Value="1" />
+                            </Style>
+                        </Button.Styles>
+                        <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
                     </Button>
                     <!--
                       Zoom in / out / to-extent group. Wrapping in an inner

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -274,6 +274,7 @@ public partial class MainWindow : ShadUI.Window
     private void InitializeMapTools(MapInteractionController interactionController)
     {
         var tools = _viewModel.Tools;
+        var measureTool = new MeasureTool();
 
         var context = new MapToolContext(
             mapControl: MapControl,
@@ -283,8 +284,24 @@ public partial class MainWindow : ShadUI.Window
             refreshGraphics: () => MapControl.RefreshGraphics(),
             screenToLatLon: ScreenToLatLon);
 
-        tools.Register(new MeasureTool());
+        tools.Register(measureTool);
         tools.Initialize(context);
+
+        // Push the persisted accent colour into the measure tool and
+        // keep it in sync so users see their preferred highlight tone.
+        var initialAccent = _viewModel.Settings.AccentColor;
+        measureTool.SetAccentColor(initialAccent.R, initialAccent.G, initialAccent.B);
+        _viewModel.Settings.AccentColorChanged += c => measureTool.SetAccentColor(c.R, c.G, c.B);
+
+        // Push the active light/dark theme so the leg-label palette
+        // matches the rest of the UI; subscribe so toggling theme
+        // recolours any in-progress measurement live.
+        measureTool.SetIsDarkTheme(_viewModel.IsDarkTheme);
+        _viewModel.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(MainViewModel.IsDarkTheme))
+                measureTool.SetIsDarkTheme(_viewModel.IsDarkTheme);
+        };
 
         // Hand the same controller to the interaction controller so pointer
         // events are offered to the active tool first.

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -307,14 +307,22 @@ public partial class MainWindow : ShadUI.Window
         // events are offered to the active tool first.
         interactionController.SetToolController(tools);
 
-        // Restore the last-active tool from settings if any.
-        if (_viewModel.Settings.LastActiveToolId is { Length: > 0 } lastId)
+        // Restore the last-active tool from settings if any. Skip the
+        // measure tool — it is a transient drawing mode, not a persistent
+        // mode the user expects to find themselves in on the next launch.
+        if (_viewModel.Settings.LastActiveToolId is { Length: > 0 } lastId
+            && !string.Equals(lastId, MeasureTool.ToolId, StringComparison.Ordinal))
+        {
             tools.Activate(lastId);
+        }
 
-        // Persist the active-tool id whenever it changes.
+        // Persist the active-tool id whenever it changes, but never
+        // record the measure tool (so closing the app while measuring
+        // doesn't reopen into measure mode).
         tools.ActiveToolChanged += t =>
         {
-            _viewModel.Settings.LastActiveToolId = t?.Id;
+            if (t is null || !string.Equals(t.Id, MeasureTool.ToolId, StringComparison.Ordinal))
+                _viewModel.Settings.LastActiveToolId = t?.Id;
         };
     }
 

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -18,6 +18,7 @@ using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Tools;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui;
 using Mapsui.Layers;
@@ -184,17 +185,18 @@ public partial class MainWindow : ShadUI.Window
         // Enable trackpad pan/pinch/rotate gestures, single/double-tap pick,
         // long-press pick, mouse lat/lon readout, scale-bar/compass viewport
         // sync, and the zoom in/out overlay buttons.
-        new MapInteractionController(_viewModel, _pickService, _loader)
-            .Attach(MapControl, ZoomInButton, ZoomOutButton, ZoomToExtentButton, ScaleBar, CompassRose);
+        var interactionController = new MapInteractionController(_viewModel, _pickService, _loader);
+        interactionController.Attach(MapControl, ZoomInButton, ZoomOutButton, ZoomToExtentButton, ScaleBar, CompassRose);
+
+        // Wire the map-tool controller to the map: tools are registered with
+        // the view-model's controller and pointer events are forwarded by
+        // the interaction controller.
+        InitializeMapTools(interactionController);
 
         // Apply the cursor that matches the current mode and keep it in sync
-        // with the view-model.
-        ApplyPickModeCursor();
-        _viewModel.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(MainViewModel.IsPickModeActive))
-                ApplyPickModeCursor();
-        };
+        // with the active tool.
+        ApplyToolCursor();
+        _viewModel.Tools.ActiveToolChanged += _ => Dispatcher.UIThread.Post(ApplyToolCursor);
 
         // Enable drag & drop of dataset files onto the map
         AddHandler(DragDrop.DropEvent, OnDrop);
@@ -254,15 +256,76 @@ public partial class MainWindow : ShadUI.Window
     }
 
     /// <summary>
-    /// Updates the map's cursor to reflect Pick Mode (cross-hair) vs. the
-    /// default panning cursor. Called once at startup and again whenever
-    /// <see cref="MainViewModel.IsPickModeActive"/> changes.
+    /// Updates the map's cursor to reflect the active map tool (Pick Mode
+    /// cross-hair, Measure Mode cross-hair, etc.). Called once at startup
+    /// and again whenever the active tool changes.
     /// </summary>
-    private void ApplyPickModeCursor()
+    private void ApplyToolCursor()
     {
-        MapControl.Cursor = _viewModel.IsPickModeActive
-            ? new Cursor(StandardCursorType.Cross)
-            : Cursor.Default;
+        MapControl.Cursor = _viewModel.Tools.ActiveTool?.Cursor ?? Cursor.Default;
+    }
+
+    /// <summary>
+    /// Registers the available <see cref="IMapTool"/>s with the view-model's
+    /// <see cref="MapToolController"/>, then initialises the controller with
+    /// a context that knows how to add overlay layers, refresh graphics, and
+    /// project pointer positions to lat/lon.
+    /// </summary>
+    private void InitializeMapTools(MapInteractionController interactionController)
+    {
+        var tools = _viewModel.Tools;
+
+        var context = new MapToolContext(
+            mapControl: MapControl,
+            addLayer: layer => MapControl.Map?.Layers.Add(layer),
+            removeLayer: layer => MapControl.Map?.Layers.Remove(layer),
+            setStatusSummary: text => Dispatcher.UIThread.Post(() => _viewModel.MeasureSummary = text),
+            refreshGraphics: () => MapControl.RefreshGraphics(),
+            screenToLatLon: ScreenToLatLon);
+
+        tools.Register(new MeasureTool());
+        tools.Initialize(context);
+
+        // Hand the same controller to the interaction controller so pointer
+        // events are offered to the active tool first.
+        interactionController.SetToolController(tools);
+
+        // Restore the last-active tool from settings if any.
+        if (_viewModel.Settings.LastActiveToolId is { Length: > 0 } lastId)
+            tools.Activate(lastId);
+
+        // Persist the active-tool id whenever it changes.
+        tools.ActiveToolChanged += t =>
+        {
+            _viewModel.Settings.LastActiveToolId = t?.Id;
+        };
+    }
+
+    /// <summary>
+    /// Converts a pointer position (in <see cref="MapControl"/> client
+    /// coordinates) to a WGS-84 lat/lon, or <c>null</c> when the pointer
+    /// projects to an invalid Mercator location. Mirrors the projection
+    /// math used by the mouse lat/lon readout in
+    /// <see cref="MapInteractionController"/>.
+    /// </summary>
+    private (double Lat, double Lon)? ScreenToLatLon(Point screen)
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
+            return null;
+
+        var world = navigator.Viewport.ScreenToWorld(screen.X, screen.Y);
+        var (lon, lat) = SphericalMercator.ToLonLat(world.X, world.Y);
+        if (double.IsNaN(lat) || double.IsNaN(lon) ||
+            double.IsInfinity(lat) || double.IsInfinity(lon) ||
+            lat < -90.0 || lat > 90.0)
+        {
+            return null;
+        }
+
+        // Normalize longitude into the canonical (-180, 180] range so paths
+        // that cross the antimeridian render with consistent endpoints.
+        lon = ((lon + 540.0) % 360.0) - 180.0;
+        return (lat, lon);
     }
 
     private async Task OpenDatasetAsync()

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -307,23 +307,11 @@ public partial class MainWindow : ShadUI.Window
         // events are offered to the active tool first.
         interactionController.SetToolController(tools);
 
-        // Restore the last-active tool from settings if any. Skip the
-        // measure tool — it is a transient drawing mode, not a persistent
-        // mode the user expects to find themselves in on the next launch.
-        if (_viewModel.Settings.LastActiveToolId is { Length: > 0 } lastId
-            && !string.Equals(lastId, MeasureTool.ToolId, StringComparison.Ordinal))
-        {
-            tools.Activate(lastId);
-        }
-
-        // Persist the active-tool id whenever it changes, but never
-        // record the measure tool (so closing the app while measuring
-        // doesn't reopen into measure mode).
-        tools.ActiveToolChanged += t =>
-        {
-            if (t is null || !string.Equals(t.Id, MeasureTool.ToolId, StringComparison.Ordinal))
-                _viewModel.Settings.LastActiveToolId = t?.Id;
-        };
+        // Tool selection is never persisted across launches — entering
+        // Pick or Measure mode must be an explicit user action each
+        // session, so the viewer always opens with no tool active.
+        // (LastActiveToolId is retained on the settings type for now to
+        // preserve the JSON shape, but neither read nor written.)
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -274,7 +274,6 @@ public partial class MainWindow : ShadUI.Window
     private void InitializeMapTools(MapInteractionController interactionController)
     {
         var tools = _viewModel.Tools;
-        var measureTool = new MeasureTool();
 
         var context = new MapToolContext(
             mapControl: MapControl,
@@ -284,34 +283,16 @@ public partial class MainWindow : ShadUI.Window
             refreshGraphics: () => MapControl.RefreshGraphics(),
             screenToLatLon: ScreenToLatLon);
 
-        tools.Register(measureTool);
+        // Tools (pick, measure) were registered by the view-model in its
+        // constructor; here we just hand them an Avalonia-aware context.
         tools.Initialize(context);
-
-        // Push the persisted accent colour into the measure tool and
-        // keep it in sync so users see their preferred highlight tone.
-        var initialAccent = _viewModel.Settings.AccentColor;
-        measureTool.SetAccentColor(initialAccent.R, initialAccent.G, initialAccent.B);
-        _viewModel.Settings.AccentColorChanged += c => measureTool.SetAccentColor(c.R, c.G, c.B);
-
-        // Push the active light/dark theme so the leg-label palette
-        // matches the rest of the UI; subscribe so toggling theme
-        // recolours any in-progress measurement live.
-        measureTool.SetIsDarkTheme(_viewModel.IsDarkTheme);
-        _viewModel.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(MainViewModel.IsDarkTheme))
-                measureTool.SetIsDarkTheme(_viewModel.IsDarkTheme);
-        };
 
         // Hand the same controller to the interaction controller so pointer
         // events are offered to the active tool first.
         interactionController.SetToolController(tools);
 
-        // Tool selection is never persisted across launches — entering
-        // Pick or Measure mode must be an explicit user action each
-        // session, so the viewer always opens with no tool active.
-        // (LastActiveToolId is retained on the settings type for now to
-        // preserve the JSON shape, but neither read nor written.)
+        // Tool selection is intentionally not persisted across launches —
+        // entering Pick or Measure mode must be an explicit user action.
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -139,4 +139,12 @@ internal static class Strings
     public static string Status_FeatureNoDetails => Get(nameof(Status_FeatureNoDetails));
     public static string Status_FeatureSummary => Get(nameof(Status_FeatureSummary));
     public static string Status_FileNoLongerExists => Get(nameof(Status_FileNoLongerExists));
+
+    // Measure Mode
+    public static string Tooltip_MeasureMode => Get(nameof(Tooltip_MeasureMode));
+    public static string Menu_MeasureMode => Get(nameof(Menu_MeasureMode));
+    public static string Status_MeasureLeg => Get(nameof(Status_MeasureLeg));
+    public static string Status_MeasureTotal => Get(nameof(Status_MeasureTotal));
+    public static string Status_MeasureNoData => Get(nameof(Status_MeasureNoData));
+    public static string Status_MeasureLegLabel => Get(nameof(Status_MeasureLegLabel));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -304,4 +304,24 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Tooltip_MouseLatLon" xml:space="preserve">
     <value>Latitude and longitude of the cursor on the map</value>
   </data>
+
+  <!-- Measure Mode -->
+  <data name="Tooltip_MeasureMode" xml:space="preserve">
+    <value>Measure distance and bearing (rhumb line)</value>
+  </data>
+  <data name="Menu_MeasureMode" xml:space="preserve">
+    <value>Measure Mode</value>
+  </data>
+  <data name="Status_MeasureLeg" xml:space="preserve">
+    <value>Leg {0}: {1:0.0} NM @ {2:000}°T</value>
+  </data>
+  <data name="Status_MeasureTotal" xml:space="preserve">
+    <value>Total: {0:0.0} NM</value>
+  </data>
+  <data name="Status_MeasureNoData" xml:space="preserve">
+    <value>Click on the map to start measuring; double-click or Enter to finish.</value>
+  </data>
+  <data name="Status_MeasureLegLabel" xml:space="preserve">
+    <value>{0:0.0} NM @ {1:000}°T</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Tools;
 using EncDotNet.S100.Viewer.ViewModels;
 using EncDotNet.S100.Viewer.Views;
 using Mapsui;
@@ -57,6 +58,25 @@ internal sealed class MapInteractionController
     private KeyModifiers _lastPressedModifiers = KeyModifiers.None;
 
     private Point? _lastMouseScreenPos;
+
+    /// <summary>
+    /// Active map-tool registry. Pointer / double-tap events are offered to
+    /// the active tool first; if the tool marks the event handled the
+    /// existing pick / pan logic is skipped for that gesture.
+    /// </summary>
+    private MapToolController? _toolController;
+
+    /// <summary>
+    /// Called by <see cref="MainWindow"/> after construction to inject the
+    /// tool controller. Kept as a setter (rather than a constructor param)
+    /// because the controller is owned by the view-model and the
+    /// interaction-controller is built before the view-model is fully wired.
+    /// </summary>
+    public void SetToolController(MapToolController controller)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+        _toolController = controller;
+    }
 
     public MapInteractionController(
         MainViewModel viewModel,
@@ -261,6 +281,13 @@ internal sealed class MapInteractionController
 
     private void OnMapDoubleTapped(object? sender, TappedEventArgs e)
     {
+        // Active tool gets first refusal (e.g. measure-mode finalises on double-tap).
+        if (_toolController?.OnDoubleTapped(e) == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
         // In Pick Mode the double-tap zoom is suppressed so that successive
         // taps on adjacent features each register as picks rather than zooms.
         if (_viewModel.IsPickModeActive)
@@ -328,6 +355,15 @@ internal sealed class MapInteractionController
         if (_mapControl is null)
             return;
 
+        // Offer the gesture to the active tool first (e.g. measure-mode
+        // begins drag-vs-click tracking here). If the tool handles it,
+        // skip the long-press / pick wiring entirely.
+        if (_toolController?.OnPointerPressed(e) == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
         var props = e.GetCurrentPoint(_mapControl).Properties;
         if (!props.IsLeftButtonPressed)
             return;
@@ -356,6 +392,14 @@ internal sealed class MapInteractionController
     private void OnMapPointerMoved(object? sender, PointerEventArgs e)
     {
         UpdateMouseLatLon(e);
+
+        // Forward to active tool (e.g. measure-mode rubber-band update).
+        // Move events are advisory: tools may set Handled but we still want
+        // the lat/lon readout updated above.
+        if (_toolController?.OnPointerMoved(e) == true)
+        {
+            e.Handled = true;
+        }
 
         if (_longPressTimer is null || _longPressOrigin is not { } origin || _mapControl is null)
             return;
@@ -429,6 +473,10 @@ internal sealed class MapInteractionController
 
     private void OnMapPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        if (_toolController?.OnPointerReleased(e) == true)
+        {
+            e.Handled = true;
+        }
         CancelLongPress();
     }
 

--- a/src/EncDotNet.S100.Viewer/Services/MeasureOverlayAppearanceProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MeasureOverlayAppearanceProvider.cs
@@ -1,0 +1,63 @@
+using System;
+using Avalonia;
+using Avalonia.Media;
+using EncDotNet.S100.Viewer.Tools;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Bridges <see cref="SettingsViewModel.AccentColor"/> and
+/// <see cref="IThemeService.IsDarkTheme"/> into a single
+/// <see cref="IMeasureOverlayAppearanceProvider"/> so map tools can
+/// observe one source of truth instead of subscribing to several
+/// disparate notifications. Listens for both accent-colour changes and
+/// the global Avalonia <c>ActualThemeVariantChanged</c> event so the
+/// overlay updates regardless of whether the theme is toggled via the
+/// view-model command or some other code path.
+/// </summary>
+internal sealed class MeasureOverlayAppearanceProvider : IMeasureOverlayAppearanceProvider, IDisposable
+{
+    private readonly IThemeService _theme;
+    private readonly SettingsViewModel _settings;
+    private readonly Application? _application;
+    private bool _disposed;
+
+    public event EventHandler? Changed;
+
+    public MeasureOverlayAppearance Current
+    {
+        get
+        {
+            var c = _settings.AccentColor;
+            return new MeasureOverlayAppearance((c.R, c.G, c.B), _theme.IsDarkTheme);
+        }
+    }
+
+    public MeasureOverlayAppearanceProvider(IThemeService theme, SettingsViewModel settings)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+        ArgumentNullException.ThrowIfNull(settings);
+        _theme = theme;
+        _settings = settings;
+
+        _settings.AccentColorChanged += OnAccentChanged;
+
+        _application = Application.Current;
+        if (_application is not null)
+            _application.ActualThemeVariantChanged += OnThemeVariantChanged;
+    }
+
+    private void OnAccentChanged(Color _) => Changed?.Invoke(this, EventArgs.Empty);
+
+    private void OnThemeVariantChanged(object? sender, EventArgs e) => Changed?.Invoke(this, EventArgs.Empty);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _settings.AccentColorChanged -= OnAccentChanged;
+        if (_application is not null)
+            _application.ActualThemeVariantChanged -= OnThemeVariantChanged;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
@@ -77,9 +77,17 @@ internal sealed class NativeMenuBuilder
             checkedSelector: () => _viewModel.IsPickModeActive,
             gesture: new KeyGesture(Key.I));
 
+        var measureModeItem = BuildToggleItem(
+            Strings.Menu_MeasureMode,
+            initiallyChecked: _viewModel.IsMeasureModeActive,
+            execute: () => _viewModel.ToggleMeasureModeCommand.Execute(null),
+            propertyName: nameof(MainViewModel.IsMeasureModeActive),
+            checkedSelector: () => _viewModel.IsMeasureModeActive,
+            gesture: new KeyGesture(Key.M, KeyModifiers.Meta));
+
         var appearanceMenu = new NativeMenuItem(Strings.Menu_Appearance)
         {
-            Menu = new NativeMenu { sideBarItem, statusBarItem, pickPanelItem, pickModeItem },
+            Menu = new NativeMenu { sideBarItem, statusBarItem, pickPanelItem, pickModeItem, measureModeItem },
         };
 
         var viewMenu = new NativeMenuItem(Strings.Menu_View)

--- a/src/EncDotNet.S100.Viewer/Tools/IMapTool.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/IMapTool.cs
@@ -1,0 +1,92 @@
+using Avalonia.Input;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// A pluggable map tool (Pick Mode, Measure Mode, future range/bearing,
+/// parallel index, etc.). Tools own their own gesture interpretation and
+/// any overlay layers they need; the host (<see cref="MapToolController"/>
+/// + <c>MapInteractionController</c>) routes pointer/key events to the
+/// active tool and respects its <c>true</c>/<c>false</c> "handled"
+/// return value to suppress default Mapsui pan/zoom behaviour.
+/// </summary>
+internal interface IMapTool
+{
+    /// <summary>
+    /// Stable identifier for this tool, e.g. <c>"pick"</c> or
+    /// <c>"measure"</c>. Used by the controller for selection and by the UI
+    /// layer to derive view-model toggle states.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Cursor to apply while the tool is active, or <c>null</c> to inherit
+    /// the default panning cursor.
+    /// </summary>
+    Cursor? Cursor { get; }
+
+    /// <summary>
+    /// Called by the controller when this tool becomes active. The tool
+    /// captures <paramref name="context"/> for the rest of its active
+    /// lifetime; it must release any resources in <see cref="OnDeactivated"/>.
+    /// </summary>
+    void OnActivated(MapToolContext context);
+
+    /// <summary>
+    /// Called by the controller when this tool is being switched out. The
+    /// tool must remove any overlay layers and stop subscribing to map
+    /// events.
+    /// </summary>
+    void OnDeactivated();
+
+    /// <summary>
+    /// Routed pointer-pressed (tunnel phase). Return <c>true</c> to mark
+    /// the event handled and prevent Mapsui's default pan-from-press.
+    /// </summary>
+    bool OnPointerPressed(PointerPressedEventArgs e);
+
+    /// <summary>
+    /// Routed pointer-moved (tunnel phase). Return <c>true</c> to suppress
+    /// default behaviour. Most tools return <c>false</c> here so that the
+    /// mouse lat/long readout still updates.
+    /// </summary>
+    bool OnPointerMoved(PointerEventArgs e);
+
+    /// <summary>
+    /// Routed pointer-released (tunnel phase). Return <c>true</c> to
+    /// suppress default behaviour. Tools that drive on click typically
+    /// finalise the click decision here using a drag-threshold comparison
+    /// against the press position they captured in
+    /// <see cref="OnPointerPressed"/>.
+    /// </summary>
+    bool OnPointerReleased(PointerReleasedEventArgs e);
+
+    /// <summary>
+    /// Bubble-phase double-tap from Mapsui. Tools return <c>true</c> to
+    /// suppress the default zoom-on-double-tap.
+    /// </summary>
+    bool OnDoubleTapped(TappedEventArgs e);
+
+    /// <summary>
+    /// A discrete tool action triggered from a keyboard accelerator
+    /// (Enter, Backspace, Delete). The controller invokes this with the
+    /// action kind already classified so tools don't need to inspect
+    /// modifier state. Return <c>true</c> when the action was consumed.
+    /// </summary>
+    bool OnAction(MapToolAction action);
+}
+
+/// <summary>
+/// Discrete tool action triggered from a keyboard accelerator.
+/// </summary>
+internal enum MapToolAction
+{
+    /// <summary>Enter / Return — typically "finalise current input".</summary>
+    Commit,
+
+    /// <summary>Backspace — typically "remove the most recent input".</summary>
+    Backstep,
+
+    /// <summary>Delete — typically "discard the current input entirely".</summary>
+    Discard,
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MapToolContext.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MapToolContext.cs
@@ -1,0 +1,76 @@
+using System;
+using Avalonia;
+using Mapsui.Layers;
+using Mapsui.UI.Avalonia;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Services made available to <see cref="IMapTool"/> implementations while
+/// they are active. Hides the host window/view-model from tools so they
+/// remain testable and don't accumulate cross-cutting dependencies.
+/// </summary>
+internal sealed class MapToolContext
+{
+    private readonly Action<ILayer> _addLayer;
+    private readonly Action<ILayer> _removeLayer;
+    private readonly Action<string?> _setStatusSummary;
+    private readonly Action _refreshGraphics;
+    private readonly Func<Point, (double Lat, double Lon)?> _screenToLatLon;
+
+    public MapToolContext(
+        MapControl mapControl,
+        Action<ILayer> addLayer,
+        Action<ILayer> removeLayer,
+        Action<string?> setStatusSummary,
+        Action refreshGraphics,
+        Func<Point, (double Lat, double Lon)?> screenToLatLon)
+    {
+        ArgumentNullException.ThrowIfNull(mapControl);
+        ArgumentNullException.ThrowIfNull(addLayer);
+        ArgumentNullException.ThrowIfNull(removeLayer);
+        ArgumentNullException.ThrowIfNull(setStatusSummary);
+        ArgumentNullException.ThrowIfNull(refreshGraphics);
+        ArgumentNullException.ThrowIfNull(screenToLatLon);
+
+        MapControl = mapControl;
+        _addLayer = addLayer;
+        _removeLayer = removeLayer;
+        _setStatusSummary = setStatusSummary;
+        _refreshGraphics = refreshGraphics;
+        _screenToLatLon = screenToLatLon;
+    }
+
+    /// <summary>
+    /// The Mapsui control the tool is operating on. Tools should avoid
+    /// calling pan/zoom on it directly — those gestures still belong to
+    /// Mapsui — but may read viewport state for their own rendering.
+    /// </summary>
+    public MapControl MapControl { get; }
+
+    /// <summary>Adds an overlay layer to the map.</summary>
+    public void AddLayer(ILayer layer) => _addLayer(layer);
+
+    /// <summary>Removes an overlay layer from the map.</summary>
+    public void RemoveLayer(ILayer layer) => _removeLayer(layer);
+
+    /// <summary>
+    /// Sets a tool-owned summary string (e.g. measure-leg / total) on the
+    /// status bar, or <c>null</c> to clear it.
+    /// </summary>
+    public void SetStatusSummary(string? text) => _setStatusSummary(text);
+
+    /// <summary>
+    /// Asks the host to schedule a redraw of map graphics. Tools call this
+    /// after mutating their overlay layer's feature list.
+    /// </summary>
+    public void RefreshGraphics() => _refreshGraphics();
+
+    /// <summary>
+    /// Converts a pointer position (in <see cref="MapControl"/> client
+    /// coordinates) to a WGS-84 lat/lon, or <c>null</c> when the pointer
+    /// is outside the map or projects to an invalid location (e.g. above
+    /// the Mercator pole limit).
+    /// </summary>
+    public (double Lat, double Lon)? ScreenToLatLon(Point screen) => _screenToLatLon(screen);
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MapToolController.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MapToolController.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Avalonia.Input;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Owns the registry of available <see cref="IMapTool"/>s and the
+/// currently-active tool. Routes pointer / key events from the host to
+/// the active tool and notifies listeners (typically the view-model) when
+/// the active tool changes.
+/// </summary>
+internal sealed class MapToolController : INotifyPropertyChanged
+{
+    private readonly Dictionary<string, IMapTool> _tools = new(StringComparer.Ordinal);
+    private MapToolContext? _context;
+    private IMapTool? _activeTool;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Raised after the active tool changes. The argument is the new
+    /// active tool, or <c>null</c> when no tool is active. Subscribers
+    /// typically use this to update the map cursor.
+    /// </summary>
+    public event Action<IMapTool?>? ActiveToolChanged;
+
+    /// <summary>Currently active tool, or <c>null</c> when none.</summary>
+    public IMapTool? ActiveTool => _activeTool;
+
+    /// <summary>
+    /// Convenience for view-model bindings: identifier of the active tool
+    /// or <c>null</c>.
+    /// </summary>
+    public string? ActiveToolId => _activeTool?.Id;
+
+    /// <summary>
+    /// Provides the controller with the live <see cref="MapToolContext"/>
+    /// once the visual tree is built. Until this is called, tool
+    /// activation is recorded but tools are not actually invoked. After
+    /// this call, any pre-recorded active tool is fully activated.
+    /// </summary>
+    public void Initialize(MapToolContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+
+        if (_activeTool is not null)
+            _activeTool.OnActivated(context);
+    }
+
+    /// <summary>Registers a tool. Tools are typically registered once at startup.</summary>
+    public void Register(IMapTool tool)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+        _tools[tool.Id] = tool;
+    }
+
+    /// <summary>
+    /// Activates the tool with the given id, or deactivates the current
+    /// tool when <paramref name="id"/> is <c>null</c>. Activating the
+    /// already-active tool is a no-op; activating an unknown id is a
+    /// no-op.
+    /// </summary>
+    public void Activate(string? id)
+    {
+        IMapTool? next = null;
+        if (id is not null && !_tools.TryGetValue(id, out next))
+            return;
+
+        if (ReferenceEquals(next, _activeTool))
+            return;
+
+        if (_activeTool is not null && _context is not null)
+            _activeTool.OnDeactivated();
+
+        _activeTool = next;
+
+        if (_activeTool is not null && _context is not null)
+            _activeTool.OnActivated(_context);
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ActiveToolId)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ActiveTool)));
+        ActiveToolChanged?.Invoke(_activeTool);
+    }
+
+    /// <summary>Convenience: activate / deactivate a tool by id.</summary>
+    public void Toggle(string id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        Activate(string.Equals(_activeTool?.Id, id, StringComparison.Ordinal) ? null : id);
+    }
+
+    /// <summary>Returns true when the tool with the given id is currently active.</summary>
+    public bool IsActive(string id) => string.Equals(_activeTool?.Id, id, StringComparison.Ordinal);
+
+    // --- Pointer/key forwarding ---------------------------------------
+
+    public bool OnPointerPressed(PointerPressedEventArgs e) =>
+        _activeTool is { } t && t.OnPointerPressed(e);
+
+    public bool OnPointerMoved(PointerEventArgs e) =>
+        _activeTool is { } t && t.OnPointerMoved(e);
+
+    public bool OnPointerReleased(PointerReleasedEventArgs e) =>
+        _activeTool is { } t && t.OnPointerReleased(e);
+
+    public bool OnDoubleTapped(TappedEventArgs e) =>
+        _activeTool is { } t && t.OnDoubleTapped(e);
+
+    public bool OnAction(MapToolAction action) =>
+        _activeTool is { } t && t.OnAction(action);
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayAppearance.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayAppearance.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Immutable appearance bundle for the Measure Mode overlay. Aggregates
+/// every visual concern that <see cref="MeasureOverlayLayer"/> needs so
+/// the renderer's signature does not grow each time we add a new style
+/// knob (palette, contrast level, etc.).
+/// </summary>
+/// <param name="Accent">Primary accent colour as RGB bytes.</param>
+/// <param name="IsDarkTheme">True when the host application is using a dark theme variant.</param>
+public readonly record struct MeasureOverlayAppearance(
+    (byte R, byte G, byte B) Accent,
+    bool IsDarkTheme)
+{
+    /// <summary>Default appearance — application accent placeholder, light theme.</summary>
+    public static MeasureOverlayAppearance Default { get; } = new(MeasureOverlayLayer.DefaultAccent, IsDarkTheme: false);
+}
+
+/// <summary>
+/// Provides the current <see cref="MeasureOverlayAppearance"/> and
+/// notifies subscribers whenever any of its inputs change (e.g. the
+/// user picks a new accent colour or toggles light/dark theme).
+/// Implementations are expected to be application-scoped singletons.
+/// </summary>
+internal interface IMeasureOverlayAppearanceProvider
+{
+    /// <summary>Snapshot of the current appearance.</summary>
+    MeasureOverlayAppearance Current { get; }
+
+    /// <summary>Raised whenever <see cref="Current"/> would return a different value.</summary>
+    event EventHandler? Changed;
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayLayer.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Globalization;
+using EncDotNet.S100.Viewer.Geodesy;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Projections;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using MapsuiColor = Mapsui.Styles.Color;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Builds the Mapsui <see cref="MemoryLayer"/> overlay for the Measure
+/// Mode tool. Re-built from scratch on every state change — the feature
+/// count is small (a handful of waypoints + labels) so cost is
+/// negligible and the code stays declarative.
+/// </summary>
+internal static class MeasureOverlayLayer
+{
+    /// <summary>Stable layer name; reused so the host can find/remove it.</summary>
+    public const string LayerName = "Measure Overlay";
+
+    // High-contrast yellow with a black halo — chosen so the overlay stays
+    // legible against any of the Day/Dusk/Night/Bright dataset palettes.
+    private static readonly MapsuiColor LineColor = new(255, 224, 0);
+    private static readonly MapsuiColor HaloColor = new(0, 0, 0);
+    private static readonly MapsuiColor LabelBackground = new(0, 0, 0, 192);
+
+    /// <summary>Creates a fresh, empty overlay layer.</summary>
+    public static MemoryLayer Create() => new()
+    {
+        Name = LayerName,
+        Style = null,
+        Features = new List<IFeature>(),
+    };
+
+    /// <summary>
+    /// Replaces <paramref name="layer"/>'s features with a freshly built
+    /// representation of <paramref name="state"/>. Caller is responsible
+    /// for invalidating the map (e.g. via
+    /// <see cref="MapToolContext.RefreshGraphics"/>).
+    /// </summary>
+    public static void Update(MemoryLayer layer, MeasurePathState state)
+    {
+        var features = new List<IFeature>();
+
+        // Build the polyline(s) through finalised + rubber-band waypoints,
+        // splitting at the antimeridian so e.g. Tokyo→Honolulu doesn't
+        // smear across the whole world.
+        var allPoints = new List<(double Lat, double Lon)>(state.Waypoints);
+        if (state.Phase == MeasurePathState.MeasurePhase.Drawing && state.RubberBand is { } rb)
+            allPoints.Add(rb);
+
+        if (allPoints.Count >= 2)
+        {
+            var lastIsRubberBand = state.Phase == MeasurePathState.MeasurePhase.Drawing && state.RubberBand is not null;
+
+            // Solid polyline through all placed waypoints (i.e. up to but
+            // not including the rubber-band tail when one is present).
+            var solidPoints = lastIsRubberBand
+                ? allPoints.GetRange(0, allPoints.Count - 1)
+                : allPoints;
+            if (solidPoints.Count >= 2)
+                AddPolyline(features, solidPoints, dashed: false);
+
+            if (lastIsRubberBand)
+            {
+                var tailStart = allPoints[^2];
+                var tailEnd = allPoints[^1];
+                AddPolyline(features, new[] { tailStart, tailEnd }, dashed: true);
+            }
+        }
+
+        // Per-segment midpoint label.
+        foreach (var leg in state.ComputeLegs())
+        {
+            AddLegLabel(features, leg);
+        }
+
+        // Waypoint markers with index numbers.
+        for (int i = 0; i < state.Waypoints.Count; i++)
+        {
+            var (lat, lon) = state.Waypoints[i];
+            AddWaypointMarker(features, lat, lon, i + 1);
+        }
+
+        layer.Features = features;
+        layer.DataHasChanged();
+    }
+
+    private static void AddPolyline(List<IFeature> features, IReadOnlyList<(double Lat, double Lon)> points, bool dashed)
+    {
+        foreach (var subPath in MarineGeodesy.SplitAtAntimeridian(points))
+        {
+            if (subPath.Count < 2) continue;
+            var coords = new Coordinate[subPath.Count];
+            for (int i = 0; i < subPath.Count; i++)
+            {
+                var (mx, my) = SphericalMercator.FromLonLat(subPath[i].Lon, subPath[i].Lat);
+                coords[i] = new Coordinate(mx, my);
+            }
+            var line = new LineString(coords);
+
+            // Halo first so the bright line draws on top.
+            var halo = new GeometryFeature(line);
+            halo.Styles.Add(new VectorStyle
+            {
+                Line = new Pen { Color = HaloColor, Width = 5.0 },
+            });
+            features.Add(halo);
+
+            var feature = new GeometryFeature(line);
+            var pen = new Pen { Color = LineColor, Width = 3.0 };
+            if (dashed) pen.PenStyle = PenStyle.Dash;
+            feature.Styles.Add(new VectorStyle { Line = pen });
+            features.Add(feature);
+        }
+    }
+
+    private static void AddLegLabel(List<IFeature> features, MeasureLeg leg)
+    {
+        // Place the label at the midpoint in Mercator space (visually
+        // centred on the rendered segment, even when geodetic midpoint
+        // would skew toward higher latitudes).
+        var (ax, ay) = SphericalMercator.FromLonLat(leg.FromLon, leg.FromLat);
+        var (bx, by) = SphericalMercator.FromLonLat(leg.ToLon, leg.ToLat);
+        var feature = new GeometryFeature(new Point((ax + bx) / 2.0, (ay + by) / 2.0));
+
+        var text = string.Format(
+            CultureInfo.CurrentCulture,
+            EncDotNet.S100.Viewer.Resources.Strings.Status_MeasureLegLabel,
+            leg.DistanceNm,
+            leg.BearingDeg);
+
+        feature.Styles.Add(new LabelStyle
+        {
+            Text = text,
+            Font = new Font { FontFamily = "Menlo,Consolas,Courier New,monospace", Size = 12 },
+            ForeColor = new MapsuiColor(255, 255, 255),
+            BackColor = new Brush(LabelBackground),
+            Halo = new Pen { Color = HaloColor, Width = 1.0 },
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+            Offset = new Offset(0, -14),
+        });
+        features.Add(feature);
+    }
+
+    private static void AddWaypointMarker(List<IFeature> features, double lat, double lon, int index)
+    {
+        var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
+        var feature = new GeometryFeature(new Point(mx, my));
+
+        // Filled disc with halo outline for legibility.
+        feature.Styles.Add(new SymbolStyle
+        {
+            SymbolType = SymbolType.Ellipse,
+            SymbolScale = 0.55,
+            Fill = new Brush { Color = LineColor },
+            Outline = new Pen { Color = HaloColor, Width = 1.5 },
+        });
+
+        feature.Styles.Add(new LabelStyle
+        {
+            Text = index.ToString(CultureInfo.InvariantCulture),
+            Font = new Font { FontFamily = "Menlo,Consolas,Courier New,monospace", Size = 11, Bold = true },
+            ForeColor = new MapsuiColor(0, 0, 0),
+            BackColor = new Brush(MapsuiColor.Transparent),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+        });
+
+        features.Add(feature);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayLayer.cs
@@ -60,16 +60,17 @@ internal static class MeasureOverlayLayer
 
     /// <summary>
     /// Replaces <paramref name="layer"/>'s features with a freshly built
-    /// representation of <paramref name="state"/>, drawn in the supplied
-    /// <paramref name="accent"/> colour. Caller is responsible for
+    /// representation of <paramref name="state"/>, drawn using the
+    /// supplied <paramref name="appearance"/>. Caller is responsible for
     /// invalidating the map (e.g. via
     /// <see cref="MapToolContext.RefreshGraphics"/>).
     /// </summary>
-    public static void Update(MemoryLayer layer, MeasurePathState state, (byte R, byte G, byte B) accent, bool isDarkTheme)
+    public static void Update(MemoryLayer layer, MeasurePathState state, MeasureOverlayAppearance appearance)
     {
+        var accent = appearance.Accent;
         var borderColor = new MapsuiColor(accent.R, accent.G, accent.B);
         var fillColor = Lighten(accent);
-        var (labelBg, labelFg, labelHalo) = isDarkTheme
+        var (labelBg, labelFg, labelHalo) = appearance.IsDarkTheme
             // Dark theme: chip surface + light text, dark halo for outline.
             ? (new MapsuiColor(38, 38, 42, 235), new MapsuiColor(245, 245, 245), new MapsuiColor(0, 0, 0, 200))
             // Light theme: light surface + dark text, light halo so the

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureOverlayLayer.cs
@@ -22,11 +22,33 @@ internal static class MeasureOverlayLayer
     /// <summary>Stable layer name; reused so the host can find/remove it.</summary>
     public const string LayerName = "Measure Overlay";
 
-    // High-contrast yellow with a black halo — chosen so the overlay stays
-    // legible against any of the Day/Dusk/Night/Bright dataset palettes.
-    private static readonly MapsuiColor LineColor = new(255, 224, 0);
-    private static readonly MapsuiColor HaloColor = new(0, 0, 0);
-    private static readonly MapsuiColor LabelBackground = new(0, 0, 0, 192);
+    /// <summary>
+    /// Default accent (matches <c>ViewerSettings.AccentColor</c> default
+    /// of <c>#007ACC</c>). Used when no accent has been pushed to the
+    /// overlay yet.
+    /// </summary>
+    public static readonly (byte R, byte G, byte B) DefaultAccent = (0x00, 0x7A, 0xCC);
+
+    // Line is a single stroke (no border casing) drawn in the accent
+    // colour, so the path reads as one continuous shape. Transparency is
+    // applied via Style.Opacity (NOT pen colour alpha — Mapsui 5.0.2
+    // pre-multiplies the alpha into the RGB and discards it for
+    // blending, which produces a darker fully-opaque stroke).
+    // Style.Opacity works correctly on a single VectorStyle; stacking
+    // two translucent styles composites toward opaque, so we
+    // intentionally avoid a separate border casing on the line.
+    private const float LineOpacity = 0.5f;
+
+    /// <summary>
+    /// Lightens an accent toward white so the waypoint disc fill stays
+    /// visually distinct from the (full-strength accent) outline. Mix
+    /// factor 0.55 keeps enough hue to read as the same family.
+    /// </summary>
+    private static MapsuiColor Lighten((byte R, byte G, byte B) c, float mix = 0.55f)
+    {
+        byte M(byte v) => (byte)(v + (255 - v) * mix);
+        return new MapsuiColor(M(c.R), M(c.G), M(c.B));
+    }
 
     /// <summary>Creates a fresh, empty overlay layer.</summary>
     public static MemoryLayer Create() => new()
@@ -38,12 +60,21 @@ internal static class MeasureOverlayLayer
 
     /// <summary>
     /// Replaces <paramref name="layer"/>'s features with a freshly built
-    /// representation of <paramref name="state"/>. Caller is responsible
-    /// for invalidating the map (e.g. via
+    /// representation of <paramref name="state"/>, drawn in the supplied
+    /// <paramref name="accent"/> colour. Caller is responsible for
+    /// invalidating the map (e.g. via
     /// <see cref="MapToolContext.RefreshGraphics"/>).
     /// </summary>
-    public static void Update(MemoryLayer layer, MeasurePathState state)
+    public static void Update(MemoryLayer layer, MeasurePathState state, (byte R, byte G, byte B) accent, bool isDarkTheme)
     {
+        var borderColor = new MapsuiColor(accent.R, accent.G, accent.B);
+        var fillColor = Lighten(accent);
+        var (labelBg, labelFg, labelHalo) = isDarkTheme
+            // Dark theme: chip surface + light text, dark halo for outline.
+            ? (new MapsuiColor(38, 38, 42, 235), new MapsuiColor(245, 245, 245), new MapsuiColor(0, 0, 0, 200))
+            // Light theme: light surface + dark text, light halo so the
+            // text stays legible over coloured basemap features.
+            : (new MapsuiColor(248, 248, 250, 235), new MapsuiColor(20, 20, 24), new MapsuiColor(255, 255, 255, 200));
         var features = new List<IFeature>();
 
         // Build the polyline(s) through finalised + rubber-band waypoints,
@@ -63,34 +94,41 @@ internal static class MeasureOverlayLayer
                 ? allPoints.GetRange(0, allPoints.Count - 1)
                 : allPoints;
             if (solidPoints.Count >= 2)
-                AddPolyline(features, solidPoints, dashed: false);
+                AddPolyline(features, solidPoints, dashed: false, borderColor);
 
             if (lastIsRubberBand)
             {
                 var tailStart = allPoints[^2];
                 var tailEnd = allPoints[^1];
-                AddPolyline(features, new[] { tailStart, tailEnd }, dashed: true);
+                AddPolyline(features, new[] { tailStart, tailEnd }, dashed: true, borderColor);
             }
         }
 
         // Per-segment midpoint label.
         foreach (var leg in state.ComputeLegs())
         {
-            AddLegLabel(features, leg);
+            AddLegLabel(features, leg, labelBg, labelFg, labelHalo);
         }
 
         // Waypoint markers with index numbers.
         for (int i = 0; i < state.Waypoints.Count; i++)
         {
             var (lat, lon) = state.Waypoints[i];
-            AddWaypointMarker(features, lat, lon, i + 1);
+            AddWaypointMarker(features, lat, lon, i + 1, fillColor, borderColor);
+        }
+
+        // Unnumbered preview marker at the rubber-band cursor so the user
+        // always sees a circle showing where the next click will land.
+        if (state.Phase == MeasurePathState.MeasurePhase.Drawing && state.RubberBand is { } rbMarker)
+        {
+            AddWaypointDisc(features, rbMarker.Lat, rbMarker.Lon, fillColor, borderColor);
         }
 
         layer.Features = features;
         layer.DataHasChanged();
     }
 
-    private static void AddPolyline(List<IFeature> features, IReadOnlyList<(double Lat, double Lon)> points, bool dashed)
+    private static void AddPolyline(List<IFeature> features, IReadOnlyList<(double Lat, double Lon)> points, bool dashed, MapsuiColor strokeColor)
     {
         foreach (var subPath in MarineGeodesy.SplitAtAntimeridian(points))
         {
@@ -103,23 +141,21 @@ internal static class MeasureOverlayLayer
             }
             var line = new LineString(coords);
 
-            // Halo first so the bright line draws on top.
-            var halo = new GeometryFeature(line);
-            halo.Styles.Add(new VectorStyle
-            {
-                Line = new Pen { Color = HaloColor, Width = 5.0 },
-            });
-            features.Add(halo);
-
+            // Border first so the bright fill draws on top — uses a darker
+            // yellow tone so the path reads as a single stroked line.
             var feature = new GeometryFeature(line);
-            var pen = new Pen { Color = LineColor, Width = 3.0 };
+            var pen = new Pen { Color = strokeColor, Width = 5.0 };
             if (dashed) pen.PenStyle = PenStyle.Dash;
-            feature.Styles.Add(new VectorStyle { Line = pen });
+            feature.Styles.Add(new VectorStyle
+            {
+                Line = pen,
+                Opacity = LineOpacity,
+            });
             features.Add(feature);
         }
     }
 
-    private static void AddLegLabel(List<IFeature> features, MeasureLeg leg)
+    private static void AddLegLabel(List<IFeature> features, MeasureLeg leg, MapsuiColor backgroundColor, MapsuiColor foregroundColor, MapsuiColor haloColor)
     {
         // Place the label at the midpoint in Mercator space (visually
         // centred on the rendered segment, even when geodetic midpoint
@@ -138,9 +174,9 @@ internal static class MeasureOverlayLayer
         {
             Text = text,
             Font = new Font { FontFamily = "Menlo,Consolas,Courier New,monospace", Size = 12 },
-            ForeColor = new MapsuiColor(255, 255, 255),
-            BackColor = new Brush(LabelBackground),
-            Halo = new Pen { Color = HaloColor, Width = 1.0 },
+            ForeColor = foregroundColor,
+            BackColor = new Brush(backgroundColor),
+            Halo = new Pen { Color = haloColor, Width = 2.5 },
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
             VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
             Offset = new Offset(0, -14),
@@ -148,21 +184,16 @@ internal static class MeasureOverlayLayer
         features.Add(feature);
     }
 
-    private static void AddWaypointMarker(List<IFeature> features, double lat, double lon, int index)
+    /// <summary>
+    /// Adds a numbered waypoint marker (filled disc with index label).
+    /// </summary>
+    private static void AddWaypointMarker(List<IFeature> features, double lat, double lon, int index, MapsuiColor fillColor, MapsuiColor borderColor)
     {
+        AddWaypointDisc(features, lat, lon, fillColor, borderColor);
+
         var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
-        var feature = new GeometryFeature(new Point(mx, my));
-
-        // Filled disc with halo outline for legibility.
-        feature.Styles.Add(new SymbolStyle
-        {
-            SymbolType = SymbolType.Ellipse,
-            SymbolScale = 0.55,
-            Fill = new Brush { Color = LineColor },
-            Outline = new Pen { Color = HaloColor, Width = 1.5 },
-        });
-
-        feature.Styles.Add(new LabelStyle
+        var labelFeature = new GeometryFeature(new Point(mx, my));
+        labelFeature.Styles.Add(new LabelStyle
         {
             Text = index.ToString(CultureInfo.InvariantCulture),
             Font = new Font { FontFamily = "Menlo,Consolas,Courier New,monospace", Size = 11, Bold = true },
@@ -170,6 +201,21 @@ internal static class MeasureOverlayLayer
             BackColor = new Brush(MapsuiColor.Transparent),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
             VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+        });
+        features.Add(labelFeature);
+    }
+
+    private static void AddWaypointDisc(List<IFeature> features, double lat, double lon, MapsuiColor fillColor, MapsuiColor borderColor)
+    {
+        var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
+        var feature = new GeometryFeature(new Point(mx, my));
+
+        feature.Styles.Add(new SymbolStyle
+        {
+            SymbolType = SymbolType.Ellipse,
+            SymbolScale = 0.9,
+            Fill = new Brush { Color = fillColor },
+            Outline = new Pen { Color = borderColor, Width = 2.0 },
         });
 
         features.Add(feature);

--- a/src/EncDotNet.S100.Viewer/Tools/MeasurePathState.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasurePathState.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using EncDotNet.S100.Viewer.Geodesy;
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Headless state machine driving Measure Mode. Holds the ordered list
+/// of waypoints, plus a transient rubber-band coordinate that follows
+/// the cursor while the user is composing a path. UI-free and
+/// fully testable: the <see cref="MeasureTool"/> wraps it with Avalonia
+/// gesture plumbing.
+/// </summary>
+internal sealed class MeasurePathState
+{
+    private readonly List<(double Lat, double Lon)> _waypoints = new();
+    private (double Lat, double Lon)? _rubberBand;
+    private MeasurePhase _phase = MeasurePhase.Idle;
+
+    /// <summary>Lifecycle of the current measurement.</summary>
+    public enum MeasurePhase
+    {
+        /// <summary>No path. Next click starts one.</summary>
+        Idle,
+
+        /// <summary>Path under construction; rubber-band follows the cursor.</summary>
+        Drawing,
+
+        /// <summary>Path completed; visible until the user starts a new one or exits.</summary>
+        Finalised,
+    }
+
+    public MeasurePhase Phase => _phase;
+
+    /// <summary>The placed waypoints, in click order.</summary>
+    public IReadOnlyList<(double Lat, double Lon)> Waypoints => _waypoints;
+
+    /// <summary>
+    /// While <see cref="Phase"/> is <see cref="MeasurePhase.Drawing"/>,
+    /// the cursor's current world position (or <c>null</c> if the cursor
+    /// is off-map). Renderers use this to draw the dashed rubber-band
+    /// segment from the last waypoint to the cursor.
+    /// </summary>
+    public (double Lat, double Lon)? RubberBand => _rubberBand;
+
+    /// <summary>
+    /// Records a click at <paramref name="lat"/>/<paramref name="lon"/>.
+    /// Idle / Drawing append a waypoint; Finalised clears the path and
+    /// starts a new one with this waypoint.
+    /// </summary>
+    /// <returns>True when the click changed state.</returns>
+    public bool Click(double lat, double lon)
+    {
+        switch (_phase)
+        {
+            case MeasurePhase.Finalised:
+                _waypoints.Clear();
+                _rubberBand = null;
+                _waypoints.Add((lat, lon));
+                _phase = MeasurePhase.Drawing;
+                return true;
+
+            case MeasurePhase.Idle:
+                _waypoints.Add((lat, lon));
+                _phase = MeasurePhase.Drawing;
+                return true;
+
+            case MeasurePhase.Drawing:
+                _waypoints.Add((lat, lon));
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Updates the rubber-band cursor position. Pass <c>null</c> when the
+    /// cursor leaves the map. Outside of <see cref="MeasurePhase.Drawing"/>
+    /// this is a no-op so the finalised path doesn't grow a tail.
+    /// </summary>
+    public bool Hover((double Lat, double Lon)? cursor)
+    {
+        if (_phase != MeasurePhase.Drawing)
+        {
+            if (_rubberBand is null) return false;
+            _rubberBand = null;
+            return true;
+        }
+
+        if (Equals(cursor, _rubberBand))
+            return false;
+
+        _rubberBand = cursor;
+        return true;
+    }
+
+    /// <summary>
+    /// Finalises the current path. No-op unless we're drawing with at
+    /// least one waypoint. Returns true when the phase actually
+    /// transitioned to <see cref="MeasurePhase.Finalised"/>.
+    /// </summary>
+    public bool Finalise()
+    {
+        if (_phase != MeasurePhase.Drawing || _waypoints.Count == 0)
+            return false;
+
+        _phase = MeasurePhase.Finalised;
+        _rubberBand = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the most recently placed waypoint. When the last
+    /// waypoint is removed the tool drops to <see cref="MeasurePhase.Idle"/>.
+    /// In <see cref="MeasurePhase.Finalised"/> this clears the entire
+    /// path. Returns true when the state changed.
+    /// </summary>
+    public bool Backstep()
+    {
+        if (_phase == MeasurePhase.Idle || _waypoints.Count == 0)
+            return false;
+
+        if (_phase == MeasurePhase.Finalised)
+        {
+            _waypoints.Clear();
+            _rubberBand = null;
+            _phase = MeasurePhase.Idle;
+            return true;
+        }
+
+        _waypoints.RemoveAt(_waypoints.Count - 1);
+        if (_waypoints.Count == 0)
+        {
+            _rubberBand = null;
+            _phase = MeasurePhase.Idle;
+        }
+        return true;
+    }
+
+    /// <summary>Discards the entire path and returns to Idle.</summary>
+    public bool Discard()
+    {
+        if (_phase == MeasurePhase.Idle && _waypoints.Count == 0 && _rubberBand is null)
+            return false;
+        _waypoints.Clear();
+        _rubberBand = null;
+        _phase = MeasurePhase.Idle;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the rhumb distance + bearing of each placed segment
+    /// (waypoint i → waypoint i+1) plus, while drawing with a rubber-band
+    /// in scope, the in-progress pending leg from the last waypoint to
+    /// the cursor.
+    /// </summary>
+    public IReadOnlyList<MeasureLeg> ComputeLegs()
+    {
+        var result = new List<MeasureLeg>();
+        for (int i = 1; i < _waypoints.Count; i++)
+        {
+            var a = _waypoints[i - 1];
+            var b = _waypoints[i];
+            result.Add(new MeasureLeg(
+                Index: i,
+                IsRubberBand: false,
+                FromLat: a.Lat, FromLon: a.Lon,
+                ToLat: b.Lat, ToLon: b.Lon,
+                DistanceNm: MarineGeodesy.RhumbDistanceNm(a.Lat, a.Lon, b.Lat, b.Lon),
+                BearingDeg: MarineGeodesy.RhumbBearingDegrees(a.Lat, a.Lon, b.Lat, b.Lon)));
+        }
+
+        if (_phase == MeasurePhase.Drawing && _rubberBand is { } rb && _waypoints.Count > 0)
+        {
+            var a = _waypoints[^1];
+            result.Add(new MeasureLeg(
+                Index: _waypoints.Count,
+                IsRubberBand: true,
+                FromLat: a.Lat, FromLon: a.Lon,
+                ToLat: rb.Lat, ToLon: rb.Lon,
+                DistanceNm: MarineGeodesy.RhumbDistanceNm(a.Lat, a.Lon, rb.Lat, rb.Lon),
+                BearingDeg: MarineGeodesy.RhumbBearingDegrees(a.Lat, a.Lon, rb.Lat, rb.Lon)));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Total rhumb distance (NM) across all current legs, including the
+    /// pending rubber-band leg when present.
+    /// </summary>
+    public double TotalDistanceNm()
+    {
+        double total = 0.0;
+        foreach (var leg in ComputeLegs())
+            total += leg.DistanceNm;
+        return total;
+    }
+
+    /// <summary>
+    /// Renders a localised summary string for the status bar. Returns
+    /// <c>null</c> when there is nothing to show (Idle and no rubber-band).
+    /// </summary>
+    public string? FormatSummary()
+    {
+        if (_phase == MeasurePhase.Idle && _waypoints.Count == 0)
+            return Strings.Status_MeasureNoData;
+
+        var legs = ComputeLegs();
+        if (legs.Count == 0)
+        {
+            // We have a single placed waypoint and no rubber-band yet.
+            return Strings.Status_MeasureNoData;
+        }
+
+        var last = legs[^1];
+        var legText = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Status_MeasureLeg,
+            last.Index,
+            last.DistanceNm,
+            last.BearingDeg);
+        var totalText = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Status_MeasureTotal,
+            TotalDistanceNm());
+        return $"{legText}  |  {totalText}";
+    }
+}
+
+/// <summary>One segment of a measurement path.</summary>
+internal readonly record struct MeasureLeg(
+    int Index,
+    bool IsRubberBand,
+    double FromLat, double FromLon,
+    double ToLat, double ToLon,
+    double DistanceNm,
+    double BearingDeg);

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureTool.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureTool.cs
@@ -1,0 +1,170 @@
+using System;
+using Avalonia;
+using Avalonia.Input;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Distance &amp; bearing measure tool. Click adds waypoints; double-click,
+/// Enter, or right-click finalises; Backspace removes the last waypoint;
+/// Esc (handled by the controller) exits the tool.
+/// </summary>
+/// <remarks>
+/// Drag detection: a mouse-down followed by a mouse-up within
+/// <see cref="DragThresholdPx"/> is treated as a click and consumed; any
+/// larger movement falls through to Mapsui as a pan. This lets the user
+/// pan freely while in Measure Mode.
+/// </remarks>
+internal sealed class MeasureTool : IMapTool
+{
+    public const string ToolId = "measure";
+
+    /// <summary>Click vs. drag threshold (DIPs) for distinguishing pan from waypoint placement.</summary>
+    private const double DragThresholdPx = 3.0;
+
+    private readonly MeasurePathState _state = new();
+    private MapToolContext? _context;
+    private MemoryLayer? _layer;
+    private Point? _pressPosition;
+    private bool _pressIsLeftButton;
+
+    /// <summary>Exposed for tests.</summary>
+    internal MeasurePathState State => _state;
+
+    public string Id => ToolId;
+
+    private Cursor? _cursor;
+    /// <inheritdoc />
+    /// <remarks>Lazy so the type is constructable before the Avalonia
+    /// platform is initialised (e.g. in unit tests).</remarks>
+    public Cursor? Cursor => _cursor ??= new Cursor(StandardCursorType.Cross);
+
+    public void OnActivated(MapToolContext context)
+    {
+        _context = context;
+        _layer = MeasureOverlayLayer.Create();
+        context.AddLayer(_layer);
+        PushSummary();
+    }
+
+    public void OnDeactivated()
+    {
+        if (_context is not null && _layer is not null)
+            _context.RemoveLayer(_layer);
+        _layer = null;
+        _context?.SetStatusSummary(null);
+        _context = null;
+        _state.Discard();
+        _pressPosition = null;
+    }
+
+    public bool OnPointerPressed(PointerPressedEventArgs e)
+    {
+        if (_context is null) return false;
+        var props = e.GetCurrentPoint(_context.MapControl).Properties;
+
+        if (props.IsRightButtonPressed)
+        {
+            // Right-click finalises the current path.
+            if (_state.Finalise())
+            {
+                Refresh();
+                return true;
+            }
+            return true; // always consume so no context menu pops up
+        }
+
+        if (props.IsLeftButtonPressed)
+        {
+            _pressPosition = e.GetPosition(_context.MapControl);
+            _pressIsLeftButton = true;
+            // Don't consume yet — pan needs to win if the user drags.
+            return false;
+        }
+
+        return false;
+    }
+
+    public bool OnPointerMoved(PointerEventArgs e)
+    {
+        if (_context is null) return false;
+        var pos = e.GetPosition(_context.MapControl);
+        var bounds = _context.MapControl.Bounds;
+        if (pos.X < 0 || pos.Y < 0 || pos.X > bounds.Width || pos.Y > bounds.Height)
+        {
+            if (_state.Hover(null)) Refresh();
+            return false;
+        }
+
+        var world = _context.ScreenToLatLon(pos);
+        if (_state.Hover(world)) Refresh();
+        return false; // never suppress — let the lat/long readout update
+    }
+
+    public bool OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        if (_context is null || !_pressIsLeftButton || _pressPosition is not { } press)
+            return false;
+
+        _pressIsLeftButton = false;
+        var release = e.GetPosition(_context.MapControl);
+        _pressPosition = null;
+
+        var dx = release.X - press.X;
+        var dy = release.Y - press.Y;
+        if ((dx * dx + dy * dy) > DragThresholdPx * DragThresholdPx)
+            return false; // drag → let Mapsui handle the pan
+
+        var world = _context.ScreenToLatLon(release);
+        if (world is not { } w) return false;
+
+        if (_state.Click(w.Lat, w.Lon))
+            Refresh();
+        return true;
+    }
+
+    public bool OnDoubleTapped(TappedEventArgs e)
+    {
+        // Double-tap finalises the path. The first tap of the double-tap
+        // already placed a waypoint via OnPointerReleased; the second tap
+        // would have placed a duplicate — drop the duplicate and finalise
+        // instead.
+        if (_state.Phase == MeasurePathState.MeasurePhase.Drawing && _state.Waypoints.Count >= 2)
+        {
+            _state.Backstep();
+        }
+
+        if (_state.Finalise())
+        {
+            Refresh();
+        }
+        return true;
+    }
+
+    public bool OnAction(MapToolAction action)
+    {
+        bool changed = action switch
+        {
+            MapToolAction.Commit => _state.Finalise(),
+            MapToolAction.Backstep => _state.Backstep(),
+            MapToolAction.Discard => _state.Discard(),
+            _ => false,
+        };
+        if (changed) Refresh();
+        return changed;
+    }
+
+    private void Refresh()
+    {
+        if (_layer is null || _context is null) return;
+        MeasureOverlayLayer.Update(_layer, _state);
+        PushSummary();
+        _context.RefreshGraphics();
+    }
+
+    private void PushSummary()
+    {
+        _context?.SetStatusSummary(_state.FormatSummary());
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureTool.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureTool.cs
@@ -28,6 +28,28 @@ internal sealed class MeasureTool : IMapTool
     private MemoryLayer? _layer;
     private Point? _pressPosition;
     private bool _pressIsLeftButton;
+    private (byte R, byte G, byte B) _accent = MeasureOverlayLayer.DefaultAccent;
+    private bool _isDarkTheme;
+
+    /// <summary>
+    /// Updates the accent colour used to draw the overlay and refreshes
+    /// the layer if the tool is currently active.
+    /// </summary>
+    public void SetAccentColor(byte r, byte g, byte b)
+    {
+        _accent = (r, g, b);
+        if (_layer is not null) Refresh();
+    }
+
+    /// <summary>
+    /// Updates the cached light/dark theme flag (used to choose the
+    /// leg-label colour palette) and refreshes the overlay if active.
+    /// </summary>
+    public void SetIsDarkTheme(bool isDarkTheme)
+    {
+        _isDarkTheme = isDarkTheme;
+        if (_layer is not null) Refresh();
+    }
 
     /// <summary>Exposed for tests.</summary>
     internal MeasurePathState State => _state;
@@ -158,7 +180,7 @@ internal sealed class MeasureTool : IMapTool
     private void Refresh()
     {
         if (_layer is null || _context is null) return;
-        MeasureOverlayLayer.Update(_layer, _state);
+        MeasureOverlayLayer.Update(_layer, _state, _accent, _isDarkTheme);
         PushSummary();
         _context.RefreshGraphics();
     }

--- a/src/EncDotNet.S100.Viewer/Tools/MeasureTool.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MeasureTool.cs
@@ -24,31 +24,33 @@ internal sealed class MeasureTool : IMapTool
     private const double DragThresholdPx = 3.0;
 
     private readonly MeasurePathState _state = new();
+    private readonly IMeasureOverlayAppearanceProvider _appearance;
     private MapToolContext? _context;
     private MemoryLayer? _layer;
     private Point? _pressPosition;
     private bool _pressIsLeftButton;
-    private (byte R, byte G, byte B) _accent = MeasureOverlayLayer.DefaultAccent;
-    private bool _isDarkTheme;
 
     /// <summary>
-    /// Updates the accent colour used to draw the overlay and refreshes
-    /// the layer if the tool is currently active.
+    /// Creates a measure tool that draws its overlay using the appearance
+    /// supplied by <paramref name="appearance"/>. The tool subscribes to
+    /// <see cref="IMeasureOverlayAppearanceProvider.Changed"/> while
+    /// active so accent/theme updates are reflected live, and
+    /// unsubscribes on deactivation.
     /// </summary>
-    public void SetAccentColor(byte r, byte g, byte b)
+    public MeasureTool(IMeasureOverlayAppearanceProvider appearance)
     {
-        _accent = (r, g, b);
-        if (_layer is not null) Refresh();
+        ArgumentNullException.ThrowIfNull(appearance);
+        _appearance = appearance;
     }
 
-    /// <summary>
-    /// Updates the cached light/dark theme flag (used to choose the
-    /// leg-label colour palette) and refreshes the overlay if active.
-    /// </summary>
-    public void SetIsDarkTheme(bool isDarkTheme)
+    /// <summary>Test-only ctor that uses a stub appearance provider returning the default appearance.</summary>
+    internal MeasureTool() : this(new StaticAppearanceProvider(MeasureOverlayAppearance.Default)) { }
+
+    private sealed class StaticAppearanceProvider : IMeasureOverlayAppearanceProvider
     {
-        _isDarkTheme = isDarkTheme;
-        if (_layer is not null) Refresh();
+        public MeasureOverlayAppearance Current { get; }
+        public event EventHandler? Changed { add { } remove { } }
+        public StaticAppearanceProvider(MeasureOverlayAppearance value) => Current = value;
     }
 
     /// <summary>Exposed for tests.</summary>
@@ -67,11 +69,13 @@ internal sealed class MeasureTool : IMapTool
         _context = context;
         _layer = MeasureOverlayLayer.Create();
         context.AddLayer(_layer);
+        _appearance.Changed += OnAppearanceChanged;
         PushSummary();
     }
 
     public void OnDeactivated()
     {
+        _appearance.Changed -= OnAppearanceChanged;
         if (_context is not null && _layer is not null)
             _context.RemoveLayer(_layer);
         _layer = null;
@@ -79,6 +83,11 @@ internal sealed class MeasureTool : IMapTool
         _context = null;
         _state.Discard();
         _pressPosition = null;
+    }
+
+    private void OnAppearanceChanged(object? sender, EventArgs e)
+    {
+        if (_layer is not null) Refresh();
     }
 
     public bool OnPointerPressed(PointerPressedEventArgs e)
@@ -180,7 +189,7 @@ internal sealed class MeasureTool : IMapTool
     private void Refresh()
     {
         if (_layer is null || _context is null) return;
-        MeasureOverlayLayer.Update(_layer, _state, _accent, _isDarkTheme);
+        MeasureOverlayLayer.Update(_layer, _state, _appearance.Current);
         PushSummary();
         _context.RefreshGraphics();
     }

--- a/src/EncDotNet.S100.Viewer/Tools/PickTool.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/PickTool.cs
@@ -1,0 +1,43 @@
+using Avalonia.Input;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// "Cursor Pick" tool. Declarative wrapper around the pre-existing
+/// pick-mode flag; the actual pick gesture handling continues to live in
+/// <c>MapInteractionController</c> (long-press, modifier-click, single-tap
+/// in pick mode), which checks
+/// <see cref="ViewModels.MainViewModel.IsPickModeActive"/> — that flag is
+/// derived from <see cref="MapToolController.ActiveToolId"/> being
+/// <c>"pick"</c>.
+/// </summary>
+/// <remarks>
+/// All <see cref="IMapTool"/> event handlers return <c>false</c> so that
+/// the existing pick gesture pipeline in <c>MapInteractionController</c>
+/// continues to fire while this tool is active. The tool exists so that
+/// Pick Mode and Measure Mode share the same activation/deactivation
+/// machinery.
+/// </remarks>
+internal sealed class PickTool : IMapTool
+{
+    public const string ToolId = "pick";
+
+    public string Id => ToolId;
+
+    private Cursor? _cursor;
+    /// <summary>
+    /// Cross-hair cursor; lazily created so the type can be instantiated
+    /// before the Avalonia platform is up (e.g. in unit tests).
+    /// </summary>
+    public Cursor? Cursor => _cursor ??= new Cursor(StandardCursorType.Cross);
+
+    public void OnActivated(MapToolContext context) { }
+
+    public void OnDeactivated() { }
+
+    public bool OnPointerPressed(PointerPressedEventArgs e) => false;
+    public bool OnPointerMoved(PointerEventArgs e) => false;
+    public bool OnPointerReleased(PointerReleasedEventArgs e) => false;
+    public bool OnDoubleTapped(TappedEventArgs e) => false;
+    public bool OnAction(MapToolAction action) => false;
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -202,21 +202,13 @@ internal sealed class MainViewModel : ViewModelBase
     private string? _measureSummary;
 
     /// <summary>
-    /// Map-tool registry / dispatcher. The pick tool is registered eagerly
-    /// here (it's a UI-free marker tool — gesture handling lives in
-    /// <see cref="Services.MapInteractionController"/>) so view-model-level
-    /// commands and tests work without the host having to register it.
-    /// UI-bearing tools (e.g. measure) are registered by the host once the
-    /// visual tree is up.
+    /// Map-tool registry / dispatcher. Tools (pick, measure) are
+    /// registered from the constructor so view-model-level commands and
+    /// tests work without the host having to register anything.
+    /// <see cref="MapToolController.Initialize"/> is called by the view
+    /// layer once the visual tree is up.
     /// </summary>
-    public MapToolController Tools { get; } = CreateToolController();
-
-    private static MapToolController CreateToolController()
-    {
-        var c = new MapToolController();
-        c.Register(new PickTool());
-        return c;
-    }
+    public MapToolController Tools { get; } = new();
 
     private bool _isDarkTheme;
     public bool IsDarkTheme
@@ -243,7 +235,8 @@ internal sealed class MainViewModel : ViewModelBase
         SettingsViewModel settingsViewModel,
         PickReportViewModel pickReport,
         IThemeService themeService,
-        IRecentFilesService recentFiles)
+        IRecentFilesService recentFiles,
+        IMeasureOverlayAppearanceProvider measureAppearance)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(featureCatalogues);
@@ -254,11 +247,15 @@ internal sealed class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(pickReport);
         ArgumentNullException.ThrowIfNull(themeService);
         ArgumentNullException.ThrowIfNull(recentFiles);
+        ArgumentNullException.ThrowIfNull(measureAppearance);
 
         _settings = settings;
         _theme = themeService;
         _recentFiles = recentFiles;
         _isDarkTheme = themeService.IsDarkTheme;
+
+        Tools.Register(new PickTool());
+        Tools.Register(new MeasureTool(measureAppearance));
 
         FeatureCatalogues = featureCatalogues;
         PortrayalCatalogues = portrayalCatalogues;

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Tools;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -145,19 +146,77 @@ internal sealed class MainViewModel : ViewModelBase
     /// double-tap-to-zoom gesture is suppressed. This is transient state
     /// and is not persisted between sessions.
     /// </summary>
+    /// <remarks>
+    /// Backed by <see cref="Tools"/>; reflects whether
+    /// <see cref="MapToolController.ActiveToolId"/> is the pick tool's id.
+    /// Setting this property activates / deactivates the pick tool in
+    /// the controller (deactivating any other tool that was active).
+    /// </remarks>
     public bool IsPickModeActive
     {
         get => _isPickModeActive;
-        set => SetProperty(ref _isPickModeActive, value);
+        set
+        {
+            if (_isPickModeActive == value) return;
+            // Drive the change through the controller so other tools are
+            // properly deactivated; the controller's ActiveToolChanged
+            // callback below will flip our backing flag.
+            Tools.Activate(value ? PickTool.ToolId : null);
+        }
     }
 
     public ICommand TogglePickModeCommand { get; }
 
     /// <summary>
-    /// Convenience command that exits Pick Mode (no-op when already off).
+    /// Convenience command that exits the active map tool (pick or measure).
     /// Wired to the <c>Esc</c> key on the main window.
     /// </summary>
     public ICommand ExitPickModeCommand { get; }
+
+    /// <summary>
+    /// True when the Measure Mode tool is active. Mirrors
+    /// <see cref="MapToolController.ActiveToolId"/> just like
+    /// <see cref="IsPickModeActive"/>.
+    /// </summary>
+    public bool IsMeasureModeActive => Tools.IsActive(MeasureTool.ToolId);
+
+    public ICommand ToggleMeasureModeCommand { get; }
+
+    /// <summary>
+    /// Discrete tool actions wired to keyboard accelerators; current
+    /// active tool decides what (if anything) to do.
+    /// </summary>
+    public ICommand ToolCommitCommand { get; }
+    public ICommand ToolBackstepCommand { get; }
+
+    /// <summary>
+    /// Status-bar summary owned by the active tool (e.g. measure-leg /
+    /// total). <c>null</c> when no tool is active or the tool has nothing
+    /// to display.
+    /// </summary>
+    public string? MeasureSummary
+    {
+        get => _measureSummary;
+        set => SetProperty(ref _measureSummary, value);
+    }
+    private string? _measureSummary;
+
+    /// <summary>
+    /// Map-tool registry / dispatcher. The pick tool is registered eagerly
+    /// here (it's a UI-free marker tool — gesture handling lives in
+    /// <see cref="Services.MapInteractionController"/>) so view-model-level
+    /// commands and tests work without the host having to register it.
+    /// UI-bearing tools (e.g. measure) are registered by the host once the
+    /// visual tree is up.
+    /// </summary>
+    public MapToolController Tools { get; } = CreateToolController();
+
+    private static MapToolController CreateToolController()
+    {
+        var c = new MapToolController();
+        c.Register(new PickTool());
+        return c;
+    }
 
     private bool _isDarkTheme;
     public bool IsDarkTheme
@@ -252,8 +311,25 @@ internal sealed class MainViewModel : ViewModelBase
         _isPickPanelEnabled = settings.IsPickPanelVisible;
         TogglePickPanelCommand = new RelayCommand(() => IsPickPanelEnabled = !IsPickPanelEnabled);
 
-        TogglePickModeCommand = new RelayCommand(() => IsPickModeActive = !IsPickModeActive);
-        ExitPickModeCommand = new RelayCommand(() => IsPickModeActive = false);
+        TogglePickModeCommand = new RelayCommand(() => Tools.Toggle(PickTool.ToolId));
+        ExitPickModeCommand = new RelayCommand(() => Tools.Activate(null));
+        ToggleMeasureModeCommand = new RelayCommand(() => Tools.Toggle(MeasureTool.ToolId));
+        ToolCommitCommand = new RelayCommand(() => Tools.OnAction(MapToolAction.Commit));
+        ToolBackstepCommand = new RelayCommand(() => Tools.OnAction(MapToolAction.Backstep));
+
+        // Mirror the controller's active-tool changes onto the legacy
+        // IsPickModeActive flag (kept so existing XAML/cursor wiring
+        // continues to function) and the IsMeasureModeActive property.
+        Tools.ActiveToolChanged += _ =>
+        {
+            var newPick = Tools.IsActive(PickTool.ToolId);
+            if (_isPickModeActive != newPick)
+            {
+                _isPickModeActive = newPick;
+                OnPropertyChanged(nameof(IsPickModeActive));
+            }
+            OnPropertyChanged(nameof(IsMeasureModeActive));
+        };
 
         ToggleThemeCommand = new RelayCommand(() => IsDarkTheme = _theme.ToggleTheme());
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -100,25 +100,6 @@ internal sealed class SettingsViewModel : ViewModelBase
 
     public event Action<DistanceUnit>? DistanceUnitChanged;
 
-    /// <summary>
-    /// Identifier of the most-recently-active map tool (e.g. "pick" or
-    /// "measure"), or <c>null</c> when no tool was active. Persisted across
-    /// sessions so the viewer reopens in whichever tool the user left in.
-    /// Setter writes-through to <see cref="ViewerSettings.Save"/>.
-    /// </summary>
-    public string? LastActiveToolId
-    {
-        get => _settings.LastActiveToolId;
-        set
-        {
-            if (string.Equals(_settings.LastActiveToolId, value, StringComparison.Ordinal))
-                return;
-            _settings.LastActiveToolId = value;
-            _settings.Save();
-            OnPropertyChanged();
-        }
-    }
-
     public SettingsViewModel(ViewerSettings settings)
     {
         _settings = settings;

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -100,6 +100,25 @@ internal sealed class SettingsViewModel : ViewModelBase
 
     public event Action<DistanceUnit>? DistanceUnitChanged;
 
+    /// <summary>
+    /// Identifier of the most-recently-active map tool (e.g. "pick" or
+    /// "measure"), or <c>null</c> when no tool was active. Persisted across
+    /// sessions so the viewer reopens in whichever tool the user left in.
+    /// Setter writes-through to <see cref="ViewerSettings.Save"/>.
+    /// </summary>
+    public string? LastActiveToolId
+    {
+        get => _settings.LastActiveToolId;
+        set
+        {
+            if (string.Equals(_settings.LastActiveToolId, value, StringComparison.Ordinal))
+                return;
+            _settings.LastActiveToolId = value;
+            _settings.Save();
+            OnPropertyChanged();
+        }
+    }
+
     public SettingsViewModel(ViewerSettings settings)
     {
         _settings = settings;

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -43,13 +43,6 @@ internal sealed class ViewerSettings
     /// <summary>Last selected activity pane, or null if none was open.</summary>
     public string? LastSelectedActivity { get; set; }
 
-    /// <summary>
-    /// Identifier of the most-recently-active map tool (e.g. "pick",
-    /// "measure"), or <c>null</c> when no tool was active. Restored on
-    /// startup so users return to the same tool they left in.
-    /// </summary>
-    public string? LastActiveToolId { get; set; }
-
     /// <summary>Global symbol scale factor (1.0 = default). Scales all point symbols.</summary>
     public double SymbolScale { get; set; } = 1.0;
 

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -43,6 +43,13 @@ internal sealed class ViewerSettings
     /// <summary>Last selected activity pane, or null if none was open.</summary>
     public string? LastSelectedActivity { get; set; }
 
+    /// <summary>
+    /// Identifier of the most-recently-active map tool (e.g. "pick",
+    /// "measure"), or <c>null</c> when no tool was active. Restored on
+    /// startup so users return to the same tool they left in.
+    /// </summary>
+    public string? LastActiveToolId { get; set; }
+
     /// <summary>Global symbol scale factor (1.0 = default). Scales all point symbols.</summary>
     public double SymbolScale { get; set; } = 1.0;
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -76,7 +76,8 @@ public class MainViewModelOpenRecentTests : IDisposable
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             themeService: new StubThemeService(),
-            recentFiles: recent);
+            recentFiles: recent,
+            measureAppearance: new StubMeasureOverlayAppearanceProvider());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -59,7 +59,8 @@ public class MainViewModelPickModeTests
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             themeService: new StubThemeService(),
-            recentFiles: new StubRecentFilesService());
+            recentFiles: new StubRecentFilesService(),
+            measureAppearance: new StubMeasureOverlayAppearanceProvider());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/MapToolControllerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MapToolControllerTests.cs
@@ -1,0 +1,103 @@
+using Avalonia.Input;
+using EncDotNet.S100.Viewer.Tools;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class MapToolControllerTests
+{
+    private sealed class StubTool : IMapTool
+    {
+        public StubTool(string id) { Id = id; }
+        public string Id { get; }
+        public Cursor? Cursor => null;
+        public int ActivationCount { get; private set; }
+        public int DeactivationCount { get; private set; }
+        public void OnActivated(MapToolContext ctx) => ActivationCount++;
+        public void OnDeactivated() => DeactivationCount++;
+        public bool OnPointerPressed(PointerPressedEventArgs e) => false;
+        public bool OnPointerMoved(PointerEventArgs e) => false;
+        public bool OnPointerReleased(PointerReleasedEventArgs e) => false;
+        public bool OnDoubleTapped(TappedEventArgs e) => false;
+        public bool OnAction(MapToolAction action) => false;
+    }
+
+    [Fact]
+    public void Activate_UnknownId_IsNoOp()
+    {
+        var c = new MapToolController();
+        c.Activate("does-not-exist");
+        Assert.Null(c.ActiveToolId);
+    }
+
+    [Fact]
+    public void Activate_NewTool_DeactivatesPrevious()
+    {
+        var c = new MapToolController();
+        var a = new StubTool("a");
+        var b = new StubTool("b");
+        c.Register(a);
+        c.Register(b);
+
+        c.Activate("a");
+        c.Activate("b");
+
+        Assert.Equal("b", c.ActiveToolId);
+        // Without Initialize the controller doesn't fire OnActivated/Deactivated;
+        // verify only that the active id flips.
+    }
+
+    [Fact]
+    public void Toggle_FlipsActiveTool()
+    {
+        var c = new MapToolController();
+        c.Register(new StubTool("a"));
+
+        c.Toggle("a");
+        Assert.Equal("a", c.ActiveToolId);
+        c.Toggle("a");
+        Assert.Null(c.ActiveToolId);
+    }
+
+    [Fact]
+    public void IsActive_ReturnsTrueOnlyForActiveTool()
+    {
+        var c = new MapToolController();
+        c.Register(new StubTool("a"));
+        c.Register(new StubTool("b"));
+
+        c.Activate("a");
+        Assert.True(c.IsActive("a"));
+        Assert.False(c.IsActive("b"));
+    }
+
+    [Fact]
+    public void ActiveToolChanged_FiresOnActivationAndDeactivation()
+    {
+        var c = new MapToolController();
+        c.Register(new StubTool("a"));
+
+        var notifications = 0;
+        c.ActiveToolChanged += _ => notifications++;
+
+        c.Activate("a");
+        c.Activate(null);
+
+        Assert.Equal(2, notifications);
+    }
+
+    [Fact]
+    public void Activate_SameToolTwice_IsNoOp()
+    {
+        var c = new MapToolController();
+        c.Register(new StubTool("a"));
+
+        var notifications = 0;
+        c.ActiveToolChanged += _ => notifications++;
+
+        c.Activate("a");
+        c.Activate("a");
+
+        Assert.Equal(1, notifications);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/MarineGeodesyTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MarineGeodesyTests.cs
@@ -1,0 +1,97 @@
+using EncDotNet.S100.Viewer.Geodesy;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class MarineGeodesyTests
+{
+    // New York (40.7128°N, 74.0060°W) → Lisbon (38.7223°N, 9.1393°W).
+    // Reference rhumb-line distance ≈ 5550 km / 2998 NM (computed with the
+    // Movable Type Scripts rhumb formulas using mean Earth radius 6371 km
+    // = 3440.065 NM). Tolerance allows for small differences if the radius
+    // constant changes.
+    [Fact]
+    public void RhumbDistance_NewYorkToLisbon_MatchesReference()
+    {
+        var nm = MarineGeodesy.RhumbDistanceNm(40.7128, -74.0060, 38.7223, -9.1393);
+        Assert.InRange(nm, 2980.0, 3020.0);
+    }
+
+    [Fact]
+    public void RhumbBearing_NewYorkToLisbon_MatchesReference()
+    {
+        var deg = MarineGeodesy.RhumbBearingDegrees(40.7128, -74.0060, 38.7223, -9.1393);
+        // Eastward, slightly south of due-east.
+        Assert.InRange(deg, 90.0, 100.0);
+    }
+
+    [Fact]
+    public void RhumbBearing_PureEast_Returns090()
+    {
+        // Same latitude → bearing should be exactly due east.
+        var deg = MarineGeodesy.RhumbBearingDegrees(0.0, 0.0, 0.0, 1.0);
+        Assert.InRange(deg, 89.99, 90.01);
+    }
+
+    [Fact]
+    public void RhumbBearing_PureNorth_Returns000()
+    {
+        // Normalised to [0, 360); pure north is 0.
+        var deg = MarineGeodesy.RhumbBearingDegrees(0.0, 0.0, 1.0, 0.0);
+        Assert.InRange(deg, 0.0, 0.01);
+    }
+
+    [Fact]
+    public void RhumbBearing_TakesShortWayAcrossAntimeridian()
+    {
+        // 179°E → 179°W is 2° east, not 358° west.
+        var deg = MarineGeodesy.RhumbBearingDegrees(0.0, 179.0, 0.0, -179.0);
+        Assert.InRange(deg, 89.0, 91.0);
+    }
+
+    [Fact]
+    public void RhumbDistance_ZeroLengthLeg_IsZero()
+    {
+        var nm = MarineGeodesy.RhumbDistanceNm(45.0, -10.0, 45.0, -10.0);
+        Assert.Equal(0.0, nm, precision: 6);
+    }
+
+    [Fact]
+    public void RhumbDistance_HighLatitudeIsClamped_NotInfinite()
+    {
+        // Without latitude clamping the Mercator stretch blows up at ±90°
+        // and the resulting distance becomes NaN/∞. Verify the result is
+        // a finite, sensible value.
+        var nm = MarineGeodesy.RhumbDistanceNm(89.999, 0.0, 89.999, 90.0);
+        Assert.True(double.IsFinite(nm));
+        Assert.True(nm >= 0.0);
+    }
+
+    [Fact]
+    public void SplitAtAntimeridian_NoCrossing_ReturnsSinglePath()
+    {
+        var input = new[] { (0.0, 10.0), (5.0, 20.0), (10.0, 30.0) };
+        var split = MarineGeodesy.SplitAtAntimeridian(input);
+        Assert.Single(split);
+        Assert.Equal(3, split[0].Count);
+    }
+
+    [Fact]
+    public void SplitAtAntimeridian_CrossingFromEastToWest_SplitsIntoTwoSubPaths()
+    {
+        // 179°E → -179°E (i.e., 181°E) crosses the antimeridian going east.
+        // The renderer should treat this as two sub-paths.
+        var input = new[] { (0.0, 179.0), (0.0, -179.0) };
+        var split = MarineGeodesy.SplitAtAntimeridian(input);
+        Assert.Equal(2, split.Count);
+        Assert.Single(split[0]);
+        Assert.Single(split[1]);
+    }
+
+    [Fact]
+    public void SplitAtAntimeridian_EmptyInput_ReturnsEmptyList()
+    {
+        var split = MarineGeodesy.SplitAtAntimeridian(System.Array.Empty<(double, double)>());
+        Assert.Empty(split);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/MeasurePathStateTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MeasurePathStateTests.cs
@@ -1,0 +1,131 @@
+using EncDotNet.S100.Viewer.Tools;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class MeasurePathStateTests
+{
+    [Fact]
+    public void NewState_IsIdleWithNoWaypoints()
+    {
+        var s = new MeasurePathState();
+        Assert.Equal(MeasurePathState.MeasurePhase.Idle, s.Phase);
+        Assert.Empty(s.Waypoints);
+        Assert.Null(s.RubberBand);
+    }
+
+    [Fact]
+    public void Click_FromIdle_PlacesFirstWaypointAndEntersDrawing()
+    {
+        var s = new MeasurePathState();
+        var changed = s.Click(40.0, -74.0);
+        Assert.True(changed);
+        Assert.Equal(MeasurePathState.MeasurePhase.Drawing, s.Phase);
+        Assert.Single(s.Waypoints);
+    }
+
+    [Fact]
+    public void Click_FromDrawing_AppendsWaypoint()
+    {
+        var s = new MeasurePathState();
+        s.Click(40.0, -74.0);
+        s.Click(38.7, -9.1);
+        Assert.Equal(2, s.Waypoints.Count);
+        Assert.Equal(MeasurePathState.MeasurePhase.Drawing, s.Phase);
+    }
+
+    [Fact]
+    public void Finalise_FromDrawingWithWaypoints_TransitionsToFinalised()
+    {
+        var s = new MeasurePathState();
+        s.Click(40.0, -74.0);
+        s.Click(38.7, -9.1);
+        Assert.True(s.Finalise());
+        Assert.Equal(MeasurePathState.MeasurePhase.Finalised, s.Phase);
+        Assert.Null(s.RubberBand);
+    }
+
+    [Fact]
+    public void Finalise_FromIdleOrFinalised_IsNoOp()
+    {
+        var s = new MeasurePathState();
+        Assert.False(s.Finalise()); // idle, no waypoints
+
+        s.Click(0.0, 0.0);
+        s.Finalise();
+        Assert.False(s.Finalise()); // already finalised
+    }
+
+    [Fact]
+    public void Click_AfterFinalised_ClearsAndStartsNewPath()
+    {
+        var s = new MeasurePathState();
+        s.Click(0.0, 0.0);
+        s.Click(1.0, 1.0);
+        s.Finalise();
+
+        s.Click(40.0, -74.0);
+        Assert.Equal(MeasurePathState.MeasurePhase.Drawing, s.Phase);
+        Assert.Single(s.Waypoints);
+    }
+
+    [Fact]
+    public void Backstep_RemovesLastWaypoint_AndReturnsToIdleWhenEmpty()
+    {
+        var s = new MeasurePathState();
+        s.Click(0.0, 0.0);
+        s.Click(1.0, 1.0);
+
+        Assert.True(s.Backstep());
+        Assert.Single(s.Waypoints);
+        Assert.Equal(MeasurePathState.MeasurePhase.Drawing, s.Phase);
+
+        Assert.True(s.Backstep());
+        Assert.Empty(s.Waypoints);
+        Assert.Equal(MeasurePathState.MeasurePhase.Idle, s.Phase);
+    }
+
+    [Fact]
+    public void Backstep_FromFinalised_ClearsEntirePath()
+    {
+        var s = new MeasurePathState();
+        s.Click(0.0, 0.0);
+        s.Click(1.0, 1.0);
+        s.Finalise();
+
+        Assert.True(s.Backstep());
+        Assert.Empty(s.Waypoints);
+        Assert.Equal(MeasurePathState.MeasurePhase.Idle, s.Phase);
+    }
+
+    [Fact]
+    public void Hover_OnlyUpdatesInDrawingPhase()
+    {
+        var s = new MeasurePathState();
+        // Idle → no rubber band even with cursor.
+        s.Hover((10.0, 10.0));
+        Assert.Null(s.RubberBand);
+
+        s.Click(0.0, 0.0);
+        s.Hover((1.0, 1.0));
+        Assert.NotNull(s.RubberBand);
+
+        s.Finalise();
+        s.Hover((2.0, 2.0));
+        Assert.Null(s.RubberBand);
+    }
+
+    [Fact]
+    public void TotalDistance_SumsLegLengths()
+    {
+        var s = new MeasurePathState();
+        s.Click(0.0, 0.0);
+        s.Click(0.0, 1.0); // 1° east at equator ≈ 60 NM
+        s.Click(0.0, 2.0); // another 60 NM
+        s.Finalise();
+
+        var total = s.TotalDistanceNm();
+        // Two ~60 NM legs; allow some tolerance for Earth radius constants.
+        Assert.InRange(total, 119.0, 121.0);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -54,7 +54,8 @@ public class PickServiceTests
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             themeService: new StubThemeService(),
-            recentFiles: new StubRecentFilesService());
+            recentFiles: new StubRecentFilesService(),
+            measureAppearance: new StubMeasureOverlayAppearanceProvider());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/StubMeasureOverlayAppearanceProvider.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/StubMeasureOverlayAppearanceProvider.cs
@@ -1,0 +1,15 @@
+using System;
+using EncDotNet.S100.Viewer.Tools;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+internal sealed class StubMeasureOverlayAppearanceProvider : IMeasureOverlayAppearanceProvider
+{
+    public MeasureOverlayAppearance Current => MeasureOverlayAppearance.Default;
+
+    public event EventHandler? Changed
+    {
+        add { }
+        remove { }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Distance & Bearing measure tool to the Avalonia viewer so users can lay down a multi-segment path on the map, see per-leg distance/bearing labels, and read the running total in the status bar. Right-click finishes; Esc cancels. The viewer always opens with no map tool active — entering Pick or Measure mode is now an explicit user action.

The tool follows the same MVVM construction path as `PickTool`: registered in `MainViewModel`, configured via DI, and decoupled from the host window. Accent color and light/dark theme flow into the overlay through an observable `IMeasureOverlayAppearanceProvider` rather than imperative setters on the tool, so the live measurement recolours when either changes.

Visual behaviour:
- Connecting lines use the configured accent color with `VectorStyle.Opacity = 0.5` (Mapsui 5.0.2 pre-multiplies pen-color alpha into RGB and discards it, so `Opacity` is the only path that gives a true semi-transparent line).
- Waypoint discs share the accent palette with a darker border matching the line border.
- Per-leg labels use a light/dark surface + 2.5px halo that matches the application theme.
- A rubber-band preview disc tracks the cursor while picking the next waypoint.

Architecture notes:
- `MapToolController` + `IMapTool` are new abstractions in the viewer and are also used by the existing pick flow.
- `MeasureOverlayLayer.Update(layer, state, MeasureOverlayAppearance)` keeps the rendering pure — no statics, no setters, just the immutable appearance record.
- `MeasureTool` subscribes to appearance changes only while active (`OnActivated` / `OnDeactivated`) so there are no leaked event handlers.
- Tool selection is intentionally not persisted; `LastActiveToolId` was removed from `ViewerSettings` and `SettingsViewModel`.

## Spec alignment

- [x] N/A — change is purely infrastructural (viewer UX, no spec semantics)

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/` (26 new tests covering geodesy, `MeasurePathState`, the tool controller, and `MeasureTool` behaviour)
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally (81 viewer tests)

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None. `LastActiveToolId` was removed from `ViewerSettings`, but it was never actually consumed; existing settings JSON files containing the field will simply have it ignored on load.