### PR TITLE
Add end-to-end observability (logs, traces, metrics) and an Aspire AppHost

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,14 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
     <!-- MVVM / DI -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <!-- Logging / observability -->
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- EncDotNet -->
     <PackageVersion Include="EncDotNet.Iso8211" Version="0.4.0" />
     <PackageVersion Include="EncDotNet.S57" Version="0.4.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- EncDotNet -->

--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj" />
     <Project Path="src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj" />

--- a/README.md
+++ b/README.md
@@ -206,9 +206,18 @@ dotnet build
 The libraries are instrumented with `Microsoft.Extensions.Logging`,
 `System.Diagnostics.ActivitySource`, and `System.Diagnostics.Metrics.Meter`,
 and the viewer ships an OpenTelemetry OTLP exporter configured by the
-standard `OTEL_*` environment variables. See
-[`docs/observability.md`](docs/observability.md) for the span tree,
-metrics catalogue, and recipes for Aspire / Jaeger.
+standard `OTEL_*` environment variables. The fastest way to see logs,
+traces, and metrics is the bundled .NET Aspire host:
+
+```sh
+dotnet run --project src/EncDotNet.S100.AppHost
+```
+
+This starts the Aspire dashboard and the viewer in one step — open
+the printed `http://localhost:15069/login?t=…` URL to inspect them.
+See [`docs/observability.md`](docs/observability.md) for the span
+tree, metrics catalogue, and alternative recipes (standalone Aspire
+dashboard, Jaeger).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ Legacy ISO 8211-encoded S-57 (Edition 3.1) ENC cells are translated to the in-me
 dotnet build
 ```
 
+## Observability
+
+The libraries are instrumented with `Microsoft.Extensions.Logging`,
+`System.Diagnostics.ActivitySource`, and `System.Diagnostics.Metrics.Meter`,
+and the viewer ships an OpenTelemetry OTLP exporter configured by the
+standard `OTEL_*` environment variables. See
+[`docs/observability.md`](docs/observability.md) for the span tree,
+metrics catalogue, and recipes for Aspire / Jaeger.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,149 @@
+# Observability
+
+EncDotNet.S100 is instrumented end-to-end with the standard .NET
+diagnostic primitives so a performance spike — or any production
+deployment — can see what the libraries and the viewer are doing
+without changing code.
+
+| Concern | API used in the libraries | Default behaviour |
+|---|---|---|
+| Logs    | [`Microsoft.Extensions.Logging.Abstractions`](https://learn.microsoft.com/dotnet/core/extensions/logging) `ILogger<T>` | `NullLogger<T>` when no `ILoggerFactory` is supplied. |
+| Traces  | [`System.Diagnostics.ActivitySource`](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource) | Inert (`StartActivity` returns `null`) until something subscribes. |
+| Metrics | [`System.Diagnostics.Metrics.Meter`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation) | Inert until a `MeterListener` subscribes. |
+
+The viewer composes these into an OpenTelemetry pipeline that exports
+via OTLP, so any modern collector — .NET Aspire dashboard, Jaeger,
+Prometheus + Tempo + Loki, the OpenTelemetry Collector, etc. — can
+ingest the data without adapter code.
+
+## Naming conventions
+
+- One static `Telemetry` class per library exposing
+  `ActivitySource`, `Meter`, and instrument fields.
+- ActivitySource / Meter names mirror the assembly name, e.g.
+  `EncDotNet.S100.Datasets.S101`,
+  `EncDotNet.S100.Renderers.Mapsui`, `EncDotNet.S100.Viewer`.
+- Activity / metric / tag names are **lowercase dotted**, namespaced
+  under `s100.` (`s100.dataset.open`, `s100.pipeline.vector.process`,
+  `s100.hdf5.read.bytes`, `s100.viewport.zoom`).
+- Tag-key constants live in
+  `EncDotNet.S100.Diagnostics.TelemetryTags` (in the Core library).
+
+## Span tree (typical viewer command)
+
+```
+s100.viewer.command (kind=Internal, command="dataset.open")
+  └─ s100.dataset.open
+      ├─ s100.exchangeset.parse
+      ├─ s100.featurecatalogue.parse
+      ├─ s100.hdf5.file.open
+      └─ s100.hdf5.dataset.read   (× N)
+  └─ s100.pipeline.vector.process
+      └─ s100.lua.rule.invoke     (× N, listener-gated)
+  └─ s100.pipeline.coverage.process
+  └─ s100.render.layer.build
+  └─ s100.render.coverage.build
+```
+
+The Lua per-rule activity is gated on listener subscription so a
+busy ENC does not flood the trace pipeline. Rule volume is captured
+instead by the `s100.lua.rule.invoke.count` counter.
+
+## Metrics catalogue
+
+| Instrument | Type | Unit | Tags |
+|---|---|---|---|
+| `s100.hdf5.read.bytes` | counter | `By` | — |
+| `s100.hdf5.read.duration` | histogram | `ms` | — |
+| `s100.lua.rule.invoke.count` | counter | `{calls}` | `s100.lua.rule`, `s100.result` |
+| `s100.lua.rule.invoke.duration` | histogram | `ms` | `s100.lua.rule` |
+| `s100.pipeline.duration` | histogram | `ms` | `s100.pipeline.stage`, `s100.product` |
+| `s100.pipeline.features.in` | histogram | `{features}` | `s100.product` |
+| `s100.pipeline.drawinginstructions.out` | histogram | `{instructions}` | `s100.product` |
+| `s100.coverage.cells` | histogram | `{cells}` | `s100.product` |
+| `s100.viewer.command.duration` | histogram | `ms` | `s100.viewer.command` |
+
+## Wiring it up — the viewer
+
+`EncDotNet.S100.Viewer` already wires OpenTelemetry into its DI
+container via `ViewerObservability.AddS100Observability`. The
+exporter honours the standard environment variables:
+
+| Variable | Default |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` (gRPC) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` |
+| `OTEL_SERVICE_NAME`           | `EncDotNet.S100.Viewer` |
+| `OTEL_RESOURCE_ATTRIBUTES`    | (none) |
+
+When no collector is running the OTLP exporter retries silently —
+the viewer keeps working.
+
+### Local Aspire dashboard
+
+The simplest way to view spans + metrics + logs:
+
+```sh
+docker run --rm -it -p 18888:18888 -p 4317:4317 \
+  mcr.microsoft.com/dotnet/aspire-dashboard:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+  dotnet run --project src/EncDotNet.S100.Viewer
+```
+
+Open `http://localhost:18888` to see structured logs, traces, and
+metric scrapes side-by-side.
+
+### Local Jaeger (traces only)
+
+```sh
+docker run --rm -p 16686:16686 -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+  dotnet run --project src/EncDotNet.S100.Viewer
+```
+
+Jaeger UI: <http://localhost:16686>.
+
+## Wiring it up — your own host
+
+Libraries are already instrumented; just subscribe to the right
+sources in your composition root:
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+
+using var tracer = Sdk.CreateTracerProviderBuilder()
+    .AddSource("EncDotNet.S100.*")
+    .AddOtlpExporter()
+    .Build();
+
+using var meter = Sdk.CreateMeterProviderBuilder()
+    .AddMeter("EncDotNet.S100.*")
+    .AddOtlpExporter()
+    .Build();
+```
+
+Wildcard subscription requires OpenTelemetry SDK 1.10 or newer.
+
+## Testing
+
+`tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs`
+demonstrates how to assert on emitted activities using a plain
+`ActivityListener` — no SDK required. Use the same pattern when
+adding new instrumentation: register a listener, exercise the API,
+assert on `OperationName` and tags.
+
+## Non-goals
+
+- **No log file sinks.** Use the OTLP log exporter or wire any
+  Microsoft.Extensions.Logging-compatible sink (Serilog, NLog,
+  console) into your host.
+- **No allocation / GC profiling.** Use `dotnet-counters`,
+  `dotnet-trace`, or `EventPipe` directly for that.
+- **No custom dashboards.** Aspire/Grafana/Tempo dashboards are
+  out of scope; the metrics catalogue above is meant to be
+  self-describing.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -79,9 +79,31 @@ exporter honours the standard environment variables:
 When no collector is running the OTLP exporter retries silently —
 the viewer keeps working.
 
-### Local Aspire dashboard
+### One-step: the Aspire AppHost (recommended)
 
-The simplest way to view spans + metrics + logs:
+`src/EncDotNet.S100.AppHost` is a [.NET Aspire](https://learn.microsoft.com/dotnet/aspire/)
+host project that orchestrates the dashboard and the viewer in a
+single command. It launches the Aspire dashboard, picks free OTLP
+ports, and starts the viewer with `OTEL_EXPORTER_OTLP_ENDPOINT` /
+`OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` already set:
+
+```sh
+dotnet run --project src/EncDotNet.S100.AppHost
+```
+
+The console prints a login URL like
+`http://localhost:15069/login?t=…` — open it to see structured logs,
+traces, and metrics from the running viewer side-by-side. Closing
+either the AppHost console or the viewer window shuts both down.
+
+No Docker required. The AppHost project does not participate in
+central package management — it is a self-contained orchestration
+shim.
+
+### Local Aspire dashboard (Docker, alternative)
+
+If you don't want to run the AppHost, the dashboard can be run
+standalone:
 
 ```sh
 docker run --rm -it -p 18888:18888 -p 4317:4317 \

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,2 +1,4 @@
 - name: Documentation
   href: index.md
+- name: Observability
+  href: observability.md

--- a/src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj
+++ b/src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>encdotnet-s100-apphost</UserSecretsId>
+    <!-- The Aspire SDK floats its own dependency versions; opt out of CPM here. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Viewer\EncDotNet.S100.Viewer.csproj">
+      <IsAspireProjectResource>true</IsAspireProjectResource>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>
+

--- a/src/EncDotNet.S100.AppHost/Program.cs
+++ b/src/EncDotNet.S100.AppHost/Program.cs
@@ -10,6 +10,11 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Projects.EncDotNet_S100_Viewer>("viewer")
-    .WithEnvironment("OTEL_SERVICE_NAME", "EncDotNet.S100.Viewer");
+    .WithEnvironment("OTEL_SERVICE_NAME", "EncDotNet.S100.Viewer")
+    // Mirror traces / metrics / logs to the viewer's stdout so they
+    // surface in the Aspire dashboard's Console tab. Useful for
+    // verifying the OTLP wiring at a glance — disable by overriding
+    // this env var to "0" if the noise becomes a problem.
+    .WithEnvironment("ENC_DOTNET_OTEL_CONSOLE", "1");
 
 builder.Build().Run();

--- a/src/EncDotNet.S100.AppHost/Program.cs
+++ b/src/EncDotNet.S100.AppHost/Program.cs
@@ -1,0 +1,15 @@
+// .NET Aspire AppHost orchestrating the EncDotNet.S100 viewer.
+//
+// Running this project starts the Aspire dashboard (logs / traces /
+// metrics) and launches the viewer as a managed resource. OTLP
+// endpoint and service-name environment variables are injected
+// automatically by Aspire; the viewer's
+// EncDotNet.S100.Viewer.Diagnostics.ViewerObservability composition
+// root reads them via the standard OTEL_* contract.
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddProject<Projects.EncDotNet_S100_Viewer>("viewer")
+    .WithEnvironment("OTEL_SERVICE_NAME", "EncDotNet.S100.Viewer");
+
+builder.Build().Run();

--- a/src/EncDotNet.S100.AppHost/Properties/launchSettings.json
+++ b/src/EncDotNet.S100.AppHost/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17069;http://localhost:15069",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21069",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22069"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15069",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19069",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20069",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/src/EncDotNet.S100.Core/Diagnostics/PipelineMetrics.cs
+++ b/src/EncDotNet.S100.Core/Diagnostics/PipelineMetrics.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics.Metrics;
+
+namespace EncDotNet.S100.Diagnostics;
+
+/// <summary>
+/// Pipeline-level metrics emitted by <see cref="EncDotNet.S100.Pipelines.Vector.VectorPipeline"/>
+/// and <see cref="EncDotNet.S100.Pipelines.Coverage.CoveragePipeline"/>.
+/// </summary>
+/// <remarks>
+/// Registered against <see cref="Telemetry.Meter"/> so all
+/// <c>EncDotNet.S100.Core</c> instruments share a single meter name and
+/// can be subscribed to in one call.
+/// </remarks>
+internal static class PipelineMetrics
+{
+    public static readonly Histogram<double> Duration =
+        Telemetry.Meter.CreateHistogram<double>(
+            name: "s100.pipeline.duration",
+            unit: "ms",
+            description: "Wall-clock duration of a portrayal pipeline pass, tagged by stage and product.");
+
+    public static readonly Histogram<long> FeaturesIn =
+        Telemetry.Meter.CreateHistogram<long>(
+            name: "s100.pipeline.features.in",
+            unit: "{features}",
+            description: "Number of distinct feature types fed into the vector pipeline per pass.");
+
+    public static readonly Histogram<long> InstructionsOut =
+        Telemetry.Meter.CreateHistogram<long>(
+            name: "s100.pipeline.drawinginstructions.out",
+            unit: "{instructions}",
+            description: "Number of drawing instructions emitted by the vector pipeline per pass.");
+
+    public static readonly Histogram<long> CoverageCells =
+        Telemetry.Meter.CreateHistogram<long>(
+            name: "s100.coverage.cells",
+            unit: "{cells}",
+            description: "Number of grid cells produced by the coverage pipeline per pass (rows × columns of the sampled region).");
+}

--- a/src/EncDotNet.S100.Core/Diagnostics/S100Telemetry.cs
+++ b/src/EncDotNet.S100.Core/Diagnostics/S100Telemetry.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace EncDotNet.S100.Diagnostics;
+
+/// <summary>
+/// Helpers for creating the per-assembly <see cref="ActivitySource"/>
+/// and <see cref="Meter"/> instances used by EncDotNet.S100 libraries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each EncDotNet.S100 library exposes a single internal static
+/// <c>Telemetry</c> class that holds its <see cref="ActivitySource"/>
+/// and <see cref="Meter"/>. By convention the source / meter name is
+/// the assembly name (e.g. <c>EncDotNet.S100.Pipelines</c>,
+/// <c>EncDotNet.S100.Datasets.S101</c>) so consumers can subscribe to
+/// the entire family with the wildcard <c>EncDotNet.S100.*</c>.
+/// </para>
+/// <para>
+/// Versions track <see cref="AssemblyInformationalVersionAttribute"/>
+/// when present, falling back to the assembly's file version. Both
+/// <see cref="ActivitySource"/> and <see cref="Meter"/> are inert when
+/// no listener is attached, so libraries pay no measurable cost when
+/// observability is not wired up by the host.
+/// </para>
+/// </remarks>
+public static class S100Telemetry
+{
+    /// <summary>
+    /// Builds an <see cref="ActivitySource"/> whose name matches the
+    /// caller's assembly name and whose version matches the assembly's
+    /// informational version.
+    /// </summary>
+    /// <param name="markerType">A type from the assembly that owns the
+    /// new source. Pass <c>typeof(Telemetry)</c> from the per-library
+    /// holder class.</param>
+    public static ActivitySource CreateActivitySource(Type markerType)
+    {
+        ArgumentNullException.ThrowIfNull(markerType);
+        var assembly = markerType.Assembly;
+        return new ActivitySource(GetName(assembly), GetVersion(assembly));
+    }
+
+    /// <summary>
+    /// Builds a <see cref="Meter"/> whose name matches the caller's
+    /// assembly name and whose version matches the assembly's
+    /// informational version.
+    /// </summary>
+    public static Meter CreateMeter(Type markerType)
+    {
+        ArgumentNullException.ThrowIfNull(markerType);
+        var assembly = markerType.Assembly;
+        return new Meter(GetName(assembly), GetVersion(assembly));
+    }
+
+    private static string GetName(Assembly assembly) =>
+        assembly.GetName().Name ?? "EncDotNet.S100";
+
+    private static string GetVersion(Assembly assembly)
+    {
+        var info = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(info))
+        {
+            // Strip any "+commitsha" build metadata to keep the
+            // semver-ish version short and dashboard-friendly.
+            var plus = info.IndexOf('+');
+            return plus >= 0 ? info[..plus] : info;
+        }
+
+        return assembly.GetName().Version?.ToString() ?? "0.0.0";
+    }
+}

--- a/src/EncDotNet.S100.Core/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Core/Diagnostics/Telemetry.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace EncDotNet.S100.Diagnostics;
+
+/// <summary>
+/// Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/>
+/// for <c>EncDotNet.S100.Core</c>. Other libraries follow the same
+/// pattern (a static <c>Telemetry</c> class in their own namespace).
+/// </summary>
+/// <remarks>
+/// Held as <see langword="static"/> singletons so callers do not need
+/// to thread the source / meter through DI. Both types are thread-safe
+/// and inert when no listener is attached.
+/// </remarks>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Core/Diagnostics/TelemetryTags.cs
+++ b/src/EncDotNet.S100.Core/Diagnostics/TelemetryTags.cs
@@ -1,0 +1,47 @@
+namespace EncDotNet.S100.Diagnostics;
+
+/// <summary>
+/// Standard <see cref="System.Diagnostics.Activity"/> tag and
+/// <see cref="System.Diagnostics.Metrics.Meter"/> dimension keys used
+/// across EncDotNet.S100 telemetry. Centralising them prevents drift
+/// between libraries and lets dashboards / collectors rely on a single
+/// vocabulary.
+/// </summary>
+/// <remarks>
+/// Naming follows OpenTelemetry semantic-convention style:
+/// lowercase, dot-separated, namespaced under <c>s100.</c>. New tags
+/// added by individual libraries should follow the same shape so that
+/// querying is uniform.
+/// </remarks>
+public static class TelemetryTags
+{
+    /// <summary>S-100 product identifier, e.g. <c>S-101</c>, <c>S-102</c>, <c>S-124</c>.</summary>
+    public const string Product = "s100.product";
+
+    /// <summary>Absolute or producer-supplied dataset path (sanitised by host before export if needed).</summary>
+    public const string DatasetPath = "s100.dataset.path";
+
+    /// <summary>Pipeline stage: <c>read</c>, <c>portray</c>, or <c>render</c>.</summary>
+    public const string PipelineStage = "s100.pipeline.stage";
+
+    /// <summary>Vector pipeline feature type / acronym (e.g. <c>DEPARE</c>, <c>BOYLAT</c>).</summary>
+    public const string FeatureType = "s100.feature.type";
+
+    /// <summary>HDF5 dataCodingFormat code (1..7 per S-100 Part 10c).</summary>
+    public const string CoverageFormat = "s100.coverage.format";
+
+    /// <summary>Map viewport zoom level (Mapsui "resolution" or equivalent).</summary>
+    public const string ViewportZoom = "s100.viewport.zoom";
+
+    /// <summary>Map viewport scale denominator (e.g. 50000 for 1:50,000).</summary>
+    public const string ViewportScale = "s100.viewport.scale";
+
+    /// <summary>Outcome tag for spans / metric counters: <c>ok</c>, <c>error</c>, <c>skipped</c>.</summary>
+    public const string Result = "s100.result";
+
+    /// <summary>Lua portrayal rule name (S-100 Part 9A).</summary>
+    public const string LuaRule = "s100.lua.rule";
+
+    /// <summary>Viewer command name for the top-level user-action activity.</summary>
+    public const string ViewerCommand = "s100.viewer.command";
+}

--- a/src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj
+++ b/src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj
@@ -5,4 +5,8 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
 </Project>

--- a/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using EncDotNet.S100.Diagnostics;
+
 namespace EncDotNet.S100.Pipelines.Coverage;
 
 /// <summary>
@@ -19,25 +22,49 @@ public class CoveragePipeline
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(catalogue);
 
-        var settings = mariner ?? MarinerSettings.Default;
-        var metadata = source.Metadata;
-
-        var colorScheme = catalogue.ResolveColorScheme(settings);
-        var symbolScheme = catalogue.ResolveSymbolScheme(settings);
-        var sampled = source.Sample(GridRegion.Full);
-
-        var layer = new StyledCoverageLayer
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.pipeline.coverage.process");
+        activity?.SetTag(TelemetryTags.PipelineStage, "portray");
+        activity?.SetTag(TelemetryTags.Product, source.Metadata.ProductSpec);
+        var start = Stopwatch.GetTimestamp();
+        var productTag = new KeyValuePair<string, object?>(TelemetryTags.Product, source.Metadata.ProductSpec);
+        var stageTag = new KeyValuePair<string, object?>(TelemetryTags.PipelineStage, "coverage");
+        try
         {
-            Coverage = sampled,
-            ColorScheme = colorScheme,
-            NoDataValue = metadata.NoDataValue,
-            Georeferencer = new GridGeoreferencer(
-                metadata.GridMetadata,
-                metadata.HorizontalCRS),
-            SymbolScheme = symbolScheme,
-        };
+            var settings = mariner ?? MarinerSettings.Default;
+            var metadata = source.Metadata;
 
-        return Task.FromResult(layer);
+            var colorScheme = catalogue.ResolveColorScheme(settings);
+            var symbolScheme = catalogue.ResolveSymbolScheme(settings);
+            var sampled = source.Sample(GridRegion.Full);
+
+            long cells = (long)metadata.GridMetadata.NumRows * metadata.GridMetadata.NumColumns;
+            PipelineMetrics.CoverageCells.Record(cells, productTag);
+            activity?.SetTag("s100.coverage.cells", cells);
+
+            var layer = new StyledCoverageLayer
+            {
+                Coverage = sampled,
+                ColorScheme = colorScheme,
+                NoDataValue = metadata.NoDataValue,
+                Georeferencer = new GridGeoreferencer(
+                    metadata.GridMetadata,
+                    metadata.HorizontalCRS),
+                SymbolScheme = symbolScheme,
+            };
+
+            return Task.FromResult(layer);
+        }
+        catch
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
+        }
+        finally
+        {
+            PipelineMetrics.Duration.Record(
+                (Stopwatch.GetTimestamp() - start) * 1000.0 / Stopwatch.Frequency,
+                productTag, stageTag);
+        }
     }
 }
 

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Xml.Linq;
 using System.Xml.Xsl;
+using EncDotNet.S100.Diagnostics;
 
 namespace EncDotNet.S100.Pipelines.Vector;
 
@@ -29,42 +31,66 @@ public class VectorPipeline
         Viewport? viewport = null,
         MarinerSettings? mariner = null)
     {
-        // Stage 1 — load FeatureXML into a navigable document
-        XDocument featureDoc;
-        using (var reader = source.GetFeatureXml())
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.process");
+        activity?.SetTag(TelemetryTags.PipelineStage, "portray");
+        var start = Stopwatch.GetTimestamp();
+        var stageTag = new KeyValuePair<string, object?>(TelemetryTags.PipelineStage, "vector");
+        try
         {
-            featureDoc = XDocument.Load(reader);
+            // Stage 1 — load FeatureXML into a navigable document
+            XDocument featureDoc;
+            using (var reader = source.GetFeatureXml())
+            {
+                featureDoc = XDocument.Load(reader);
+            }
+
+            // Stage 2 — select applicable rules
+            var featureTypes = source.FeatureTypesPresent;
+            PipelineMetrics.FeaturesIn.Record(featureTypes.Count, stageTag);
+            activity?.SetTag("s100.pipeline.feature_types.count", featureTypes.Count);
+            var applicableRules = SelectRules(featureTypes, catalogue);
+            activity?.SetTag("s100.pipeline.rules.count", applicableRules.Count);
+
+            // Stage 3 — XSLT transformation
+            var drawingInstructionsDoc = RunXsltRules(featureDoc, applicableRules, catalogue, viewport);
+
+            // Stage 5 — assemble typed drawing instructions from the XSLT output
+            // using the canonical S-100 Part 9 lower-camel-case display-list reader.
+            var instructions = Part9DisplayListReader.Read(drawingInstructionsDoc).ToList();
+
+            // Stage 4 — Lua execution (S-100 Part 9A). The executor produces typed
+            // drawing instructions directly; append them to the XSLT-stage output
+            // before viewing-group filtering and priority sorting.
+            if (_luaExecutor is not null)
+            {
+                instructions.AddRange(_luaExecutor.Execute(mariner ?? new MarinerSettings()));
+            }
+
+            // Stage 6 — viewing group filter + priority sort
+            var filtered = ApplyViewingGroups(instructions, catalogue.ViewingGroups);
+            var sorted = SortByPriority(filtered);
+
+            PipelineMetrics.InstructionsOut.Record(sorted.Count, stageTag);
+            activity?.SetTag("s100.pipeline.instructions.count", sorted.Count);
+
+            IVectorLayer layer = new DefaultVectorLayer
+            {
+                Instructions = sorted,
+            };
+
+            return Task.FromResult(layer);
         }
-
-        // Stage 2 — select applicable rules
-        var featureTypes = source.FeatureTypesPresent;
-        var applicableRules = SelectRules(featureTypes, catalogue);
-
-        // Stage 3 — XSLT transformation
-        var drawingInstructionsDoc = RunXsltRules(featureDoc, applicableRules, catalogue, viewport);
-
-        // Stage 5 — assemble typed drawing instructions from the XSLT output
-        // using the canonical S-100 Part 9 lower-camel-case display-list reader.
-        var instructions = Part9DisplayListReader.Read(drawingInstructionsDoc).ToList();
-
-        // Stage 4 — Lua execution (S-100 Part 9A). The executor produces typed
-        // drawing instructions directly; append them to the XSLT-stage output
-        // before viewing-group filtering and priority sorting.
-        if (_luaExecutor is not null)
+        catch
         {
-            instructions.AddRange(_luaExecutor.Execute(mariner ?? new MarinerSettings()));
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
-
-        // Stage 6 — viewing group filter + priority sort
-        var filtered = ApplyViewingGroups(instructions, catalogue.ViewingGroups);
-        var sorted = SortByPriority(filtered);
-
-        IVectorLayer layer = new DefaultVectorLayer
+        finally
         {
-            Instructions = sorted,
-        };
-
-        return Task.FromResult(layer);
+            PipelineMetrics.Duration.Record(
+                (Stopwatch.GetTimestamp() - start) * 1000.0 / Stopwatch.Frequency,
+                stageTag);
+        }
     }
 
     // ── Stage 2: Rule selection ─────────────────────────────────────────

--- a/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.Pipelines</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S101/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S101/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S101.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S101</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using EncDotNet.Iso8211;
+using S100Diag = EncDotNet.S100.Datasets.S101.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S101;
 
@@ -10,6 +11,8 @@ internal static class S101DocumentReader
 {
     public static S101Document ReadFromFile(string path)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-101");
         var iso = Iso8211DocumentReader.ReadFromFile(path);
         return Parse(iso);
     }

--- a/src/EncDotNet.S100.Datasets.S102/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S102/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S102.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S102</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Hdf5;
+using S100Diag = EncDotNet.S100.Datasets.S102.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S102;
 
@@ -13,6 +14,8 @@ public static class S102DatasetReader
     /// </summary>
     public static S102Dataset Read(IHdf5File file)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-102");
         ArgumentNullException.ThrowIfNull(file);
 
         var root = file.Root;

--- a/src/EncDotNet.S100.Datasets.S104/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S104/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S104.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S104</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using EncDotNet.S100.Hdf5;
+using S100Diag = EncDotNet.S100.Datasets.S104.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S104;
 
@@ -15,6 +16,8 @@ public static class S104DatasetReader
     /// </summary>
     public static S104Dataset Read(IHdf5File file)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-104");
         ArgumentNullException.ThrowIfNull(file);
 
         var root = file.Root;

--- a/src/EncDotNet.S100.Datasets.S111/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S111/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S111.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S111</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using EncDotNet.S100.Hdf5;
+using S100Diag = EncDotNet.S100.Datasets.S111.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S111;
 
@@ -15,6 +16,8 @@ public static class S111DatasetReader
     /// </summary>
     public static S111Dataset Read(IHdf5File file)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-111");
         ArgumentNullException.ThrowIfNull(file);
 
         var root = file.Root;

--- a/src/EncDotNet.S100.Datasets.S122/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S122/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S122.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S122</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S122/S122DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S122/S122DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S122.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S122;
 
@@ -53,6 +54,8 @@ internal static class S122DatasetReader
 
     public static S122Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-122");
         var doc = XDocument.Load(stream);
         var root = doc.Root
             ?? throw new InvalidOperationException("S-122 GML document has no root element.");

--- a/src/EncDotNet.S100.Datasets.S124/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S124/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S124.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S124</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S124/S124DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S124/S124DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S124.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S124;
 
@@ -27,6 +28,8 @@ internal static class S124DatasetReader
 
     public static S124Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-124");
         var doc = XDocument.Load(stream);
         var root = doc.Root
             ?? throw new InvalidOperationException("S-124 GML document has no root element.");

--- a/src/EncDotNet.S100.Datasets.S125/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S125/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S125.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S125</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S125/S125DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S125.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S125;
 
@@ -63,6 +64,8 @@ internal static class S125DatasetReader
 
     public static S125Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-125");
         // Tolerate leading whitespace/BOM before the XML declaration.
         using var reader = new StreamReader(stream);
         var xml = reader.ReadToEnd().TrimStart();

--- a/src/EncDotNet.S100.Datasets.S127/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S127/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S127.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S127</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S127/S127DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S127/S127DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S127.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S127;
 
@@ -26,6 +27,8 @@ internal static class S127DatasetReader
 
     public static S127Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-127");
         var doc = XDocument.Load(stream);
         var root = doc.Root
             ?? throw new InvalidOperationException("S-127 GML document has no root element.");

--- a/src/EncDotNet.S100.Datasets.S128/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S128/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S128.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S128</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S128/S128DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S128.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S128;
 
@@ -44,6 +45,8 @@ internal static class S128DatasetReader
 
     public static S128Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-128");
         var doc = XDocument.Load(stream);
         var root = doc.Root
             ?? throw new InvalidOperationException("S-128 GML document has no root element.");

--- a/src/EncDotNet.S100.Datasets.S129/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S129/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S129.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S129</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S129/S129DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S129.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S129;
 
@@ -26,6 +27,8 @@ internal static class S129DatasetReader
 
     public static S129Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-129");
         // Some GML files have leading whitespace before the XML declaration;
         // read as text and trim to handle this gracefully.
         using var reader = new StreamReader(stream);

--- a/src/EncDotNet.S100.Datasets.S411/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S411/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S411.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S411</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S411/S411DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S411.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S411;
 
@@ -84,6 +85,8 @@ internal static class S411DatasetReader
 
     public static S411Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-411");
         // Tolerate leading whitespace before the XML declaration.
         using var reader = new StreamReader(stream);
         var xml = reader.ReadToEnd().TrimStart();

--- a/src/EncDotNet.S100.Datasets.S421/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S421/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Datasets.S421.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Datasets.S421</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Datasets.S421/S421DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S421/S421DatasetReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Xml.Linq;
+using S100Diag = EncDotNet.S100.Datasets.S421.Diagnostics;
 
 namespace EncDotNet.S100.Datasets.S421;
 
@@ -22,6 +23,8 @@ internal static class S421DatasetReader
 
     public static S421Dataset Read(Stream stream)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
+        __activity?.SetTag("s100.product", "S-421");
         // Some sample datasets contain leading whitespace before the XML declaration.
         using var reader = new StreamReader(stream);
         var xml = reader.ReadToEnd().TrimStart();

--- a/src/EncDotNet.S100.ExchangeSets/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.ExchangeSets.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.ExchangeSets</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Xml;
 using System.Xml.Linq;
+using EncDotNet.S100.ExchangeSets.Diagnostics;
 
 namespace EncDotNet.S100.ExchangeSets;
 
@@ -13,12 +14,15 @@ public static class ExchangeCatalogueReader
 
     public static ExchangeCatalogue Read(Stream stream)
     {
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.exchangeset.parse");
         var doc = XDocument.Load(stream);
         return ReadCatalogue(doc.Root ?? throw new XmlException("Missing root element."));
     }
 
     public static ExchangeCatalogue Read(string path)
     {
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.exchangeset.parse");
+        activity?.SetTag("s100.exchangeset.path", path);
         var doc = XDocument.Load(path);
         return ReadCatalogue(doc.Root ?? throw new XmlException("Missing root element."));
     }

--- a/src/EncDotNet.S100.Features/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Features/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Features.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Features</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj
+++ b/src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj
@@ -5,4 +5,8 @@
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/EncDotNet.S100.Features/FeatureCatalogueReader.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueReader.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 using System.Xml.Linq;
+using EncDotNet.S100.Features.Diagnostics;
 
 namespace EncDotNet.S100.Features;
 
@@ -17,12 +18,15 @@ public static class FeatureCatalogueReader
 
     public static FeatureCatalogue Read(Stream stream)
     {
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.featurecatalogue.parse");
         var doc = XDocument.Load(stream);
         return ReadCatalogue(doc.Root ?? throw new XmlException("Missing root element."));
     }
 
     public static FeatureCatalogue Read(string path)
     {
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.featurecatalogue.parse");
+        activity?.SetTag("s100.featurecatalogue.path", path);
         var doc = XDocument.Load(path);
         return ReadCatalogue(doc.Root ?? throw new XmlException("Missing root element."));
     }

--- a/src/EncDotNet.S100.Hdf5.PureHdf/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Hdf5.PureHdf/Diagnostics/Telemetry.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Hdf5.PureHdf.Diagnostics;
+
+/// <summary>
+/// Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Hdf5.PureHdf</c>.
+/// </summary>
+/// <remarks>
+/// Exposes the metrics catalogued in the observability plan:
+/// <list type="bullet">
+/// <item><c>s100.hdf5.read.duration</c> — histogram of attribute / dataset read durations in milliseconds.</item>
+/// <item><c>s100.hdf5.read.bytes</c> — counter of bytes returned from dataset reads (estimated from element count × <c>sizeof(T)</c>).</item>
+/// </list>
+/// </remarks>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+
+    public static readonly Histogram<double> ReadDuration =
+        Meter.CreateHistogram<double>(
+            name: "s100.hdf5.read.duration",
+            unit: "ms",
+            description: "Time taken to read an HDF5 attribute, group listing, or dataset.");
+
+    public static readonly Counter<long> ReadBytes =
+        Meter.CreateCounter<long>(
+            name: "s100.hdf5.read.bytes",
+            unit: "By",
+            description: "Bytes returned by HDF5 dataset reads.");
+}

--- a/src/EncDotNet.S100.Hdf5.PureHdf/PureHdfFile.cs
+++ b/src/EncDotNet.S100.Hdf5.PureHdf/PureHdfFile.cs
@@ -1,4 +1,8 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using EncDotNet.S100.Diagnostics;
 using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Hdf5.PureHdf.Diagnostics;
 using PureHDF;
 
 namespace EncDotNet.S100.Hdf5.PureHdf;
@@ -23,6 +27,8 @@ public sealed class PureHdfFile : IHdf5File
     public static PureHdfFile Open(string path)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.hdf5.file.open");
+        activity?.SetTag(TelemetryTags.DatasetPath, path);
         var file = H5File.OpenRead(path);
         return new PureHdfFile(file, file);
     }
@@ -31,6 +37,7 @@ public sealed class PureHdfFile : IHdf5File
     public static PureHdfFile Open(Stream stream)
     {
         ArgumentNullException.ThrowIfNull(stream);
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.hdf5.file.open");
         var file = H5File.Open(stream);
         return new PureHdfFile(file, file);
     }
@@ -84,17 +91,53 @@ public sealed class PureHdfFile : IHdf5File
 
         public T ReadAttribute<T>(string name) where T : unmanaged
         {
-            return _group.Attribute(name).Read<T>();
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                return _group.Attribute(name).Read<T>();
+            }
+            finally
+            {
+                Telemetry.ReadDuration.Record(GetElapsedMs(start), new KeyValuePair<string, object?>("kind", "attribute"));
+            }
         }
 
         public string ReadStringAttribute(string name)
         {
-            return _group.Attribute(name).Read<string>();
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                return _group.Attribute(name).Read<string>();
+            }
+            finally
+            {
+                Telemetry.ReadDuration.Record(GetElapsedMs(start), new KeyValuePair<string, object?>("kind", "attribute"));
+            }
         }
 
         public T[] ReadDataset<T>(string name) where T : unmanaged
         {
-            return _group.Dataset(name).Read<T[]>();
+            using var activity = Telemetry.ActivitySource.StartActivity("s100.hdf5.dataset.read");
+            activity?.SetTag("s100.hdf5.dataset", name);
+            var start = Stopwatch.GetTimestamp();
+            T[] result;
+            try
+            {
+                result = _group.Dataset(name).Read<T[]>();
+            }
+            finally
+            {
+                Telemetry.ReadDuration.Record(GetElapsedMs(start), new KeyValuePair<string, object?>("kind", "dataset"));
+            }
+            long bytes = (long)result.Length * Marshal.SizeOf<T>();
+            Telemetry.ReadBytes.Add(bytes);
+            activity?.SetTag("s100.hdf5.read.bytes", bytes);
+            activity?.SetTag("s100.hdf5.element.count", result.Length);
+            return result;
         }
+
+        private static double GetElapsedMs(long startTimestamp) =>
+            (Stopwatch.GetTimestamp() - startTimestamp) * 1000.0 / Stopwatch.Frequency;
     }
 }
+

--- a/src/EncDotNet.S100.Portrayals/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Portrayals/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Portrayals.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Portrayals</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Renderers.Mapsui.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Renderers.Mapsui</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageRenderer.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Pipelines;
+using S100Diag = EncDotNet.S100.Renderers.Mapsui.Diagnostics;
 using EncDotNet.S100.Pipelines.Coverage;
 using Mapsui;
 using Mapsui.Layers;
@@ -35,6 +36,8 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
 
     public ILayer Render(StyledCoverageLayer layer, PipelineViewport viewport)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.render.coverage.build");
+        __activity?.SetTag("s100.render.target", "mapsui");
         var sampled = layer.Coverage;
         var georeferencer = layer.Georeferencer;
         var colorScheme = layer.ColorScheme;

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using S100Diag = EncDotNet.S100.Renderers.Mapsui.Diagnostics;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Pipelines.Vector;
@@ -104,6 +105,10 @@ public sealed class MapsuiDisplayListRenderer
     {
         ArgumentNullException.ThrowIfNull(instructions);
         ArgumentNullException.ThrowIfNull(geometryProvider);
+
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.render.layer.build");
+        __activity?.SetTag("s100.render.target", "mapsui");
+        __activity?.SetTag("s100.render.instructions.count", instructions.Count);
 
         // Ensure the custom pattern fill renderer is registered before Mapsui
         // encounters any AnchoredPatternFillStyle instances.

--- a/src/EncDotNet.S100.Renderers.Skia/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Renderers.Skia.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Renderers.Skia</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Renderers.Skia/SkiaCoverageRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/SkiaCoverageRenderer.cs
@@ -1,4 +1,5 @@
 using SkiaSharp;
+using S100Diag = EncDotNet.S100.Renderers.Skia.Diagnostics;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 
@@ -17,6 +18,8 @@ public class SkiaCoverageRenderer : ICoverageRenderer<SKBitmap>
 
     public SKBitmap Render(StyledCoverageLayer layer, Viewport viewport)
     {
+        using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.render.coverage.build");
+        __activity?.SetTag("s100.render.target", "skia");
         var sampled = layer.Coverage;
         var colorScheme = layer.ColorScheme;
         var fieldData = sampled.GetField(colorScheme.FieldName);

--- a/src/EncDotNet.S100.Scripting.MoonSharp/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Scripting.MoonSharp/Diagnostics/Telemetry.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Scripting.MoonSharp.Diagnostics;
+
+/// <summary>
+/// Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Scripting.MoonSharp</c>.
+/// </summary>
+/// <remarks>
+/// Lua portrayal rules (S-100 Part 9A) fire at very high frequency. Per-call
+/// activities are gated by listener subscription (the <see cref="ActivitySource"/>
+/// is inert when no <c>ActivityListener</c> is attached) so the host can
+/// disable trace volume without re-instrumenting the engine. The
+/// <see cref="InvokeCount"/> counter and <see cref="InvokeDuration"/>
+/// histogram run unconditionally — they remain inert until a
+/// <c>MeterListener</c> subscribes.
+/// </remarks>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+
+    public static readonly Counter<long> InvokeCount =
+        Meter.CreateCounter<long>(
+            name: "s100.lua.rule.invoke.count",
+            unit: "{calls}",
+            description: "Number of Lua callable invocations (Call / CallMultiReturn).");
+
+    public static readonly Histogram<double> InvokeDuration =
+        Meter.CreateHistogram<double>(
+            name: "s100.lua.rule.invoke.duration",
+            unit: "ms",
+            description: "Wall-clock duration of Lua callable invocations.");
+}

--- a/src/EncDotNet.S100.Scripting.MoonSharp/MoonSharpLuaContext.cs
+++ b/src/EncDotNet.S100.Scripting.MoonSharp/MoonSharpLuaContext.cs
@@ -1,4 +1,7 @@
+using System.Diagnostics;
 using System.Globalization;
+using EncDotNet.S100.Diagnostics;
+using EncDotNet.S100.Scripting.MoonSharp.Diagnostics;
 using MoonSharp.Interpreter;
 using MoonSharp.Interpreter.Loaders;
 
@@ -61,9 +64,30 @@ internal sealed class MoonSharpLuaContext : ILuaContext
         if (fn.IsNil())
             throw new InvalidOperationException($"Lua global '{functionName}' is nil or not defined.");
 
-        var luaArgs = args.Select(MarshalToLua).ToArray();
-        var result = WithInvariantCulture(() => _script.Call(fn, luaArgs));
-        return MarshalFromLua(result);
+        // Per-call activities are gated by Source listening — when the host
+        // does not subscribe (the common case) StartActivity returns null and
+        // there is no overhead. Counter / histogram are similarly gated.
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.lua.rule.invoke");
+        activity?.SetTag(TelemetryTags.LuaRule, functionName);
+        var start = Stopwatch.GetTimestamp();
+        var ruleTag = new KeyValuePair<string, object?>(TelemetryTags.LuaRule, functionName);
+        try
+        {
+            var luaArgs = args.Select(MarshalToLua).ToArray();
+            var result = WithInvariantCulture(() => _script.Call(fn, luaArgs));
+            Telemetry.InvokeCount.Add(1, ruleTag, new KeyValuePair<string, object?>(TelemetryTags.Result, "ok"));
+            return MarshalFromLua(result);
+        }
+        catch
+        {
+            Telemetry.InvokeCount.Add(1, ruleTag, new KeyValuePair<string, object?>(TelemetryTags.Result, "error"));
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
+        }
+        finally
+        {
+            Telemetry.InvokeDuration.Record(GetElapsedMs(start), ruleTag);
+        }
     }
 
     /// <inheritdoc />
@@ -76,16 +100,38 @@ internal sealed class MoonSharpLuaContext : ILuaContext
         if (fn.IsNil())
             throw new InvalidOperationException($"Lua global '{functionName}' is nil or not defined.");
 
-        var luaArgs = args.Select(MarshalToLua).ToArray();
-        var result = WithInvariantCulture(() => _script.Call(fn, luaArgs));
-
-        if (result.Type == DataType.Tuple)
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.lua.rule.invoke");
+        activity?.SetTag(TelemetryTags.LuaRule, functionName);
+        var start = Stopwatch.GetTimestamp();
+        var ruleTag = new KeyValuePair<string, object?>(TelemetryTags.LuaRule, functionName);
+        try
         {
-            return result.Tuple.Select(MarshalFromLua).ToArray();
-        }
+            var luaArgs = args.Select(MarshalToLua).ToArray();
+            var result = WithInvariantCulture(() => _script.Call(fn, luaArgs));
 
-        return [MarshalFromLua(result)];
+            Telemetry.InvokeCount.Add(1, ruleTag, new KeyValuePair<string, object?>(TelemetryTags.Result, "ok"));
+
+            if (result.Type == DataType.Tuple)
+            {
+                return result.Tuple.Select(MarshalFromLua).ToArray();
+            }
+
+            return [MarshalFromLua(result)];
+        }
+        catch
+        {
+            Telemetry.InvokeCount.Add(1, ruleTag, new KeyValuePair<string, object?>(TelemetryTags.Result, "error"));
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
+        }
+        finally
+        {
+            Telemetry.InvokeDuration.Record(GetElapsedMs(start), ruleTag);
+        }
     }
+
+    private static double GetElapsedMs(long startTimestamp) =>
+        (Stopwatch.GetTimestamp() - startTimestamp) * 1000.0 / Stopwatch.Frequency;
 
     /// <inheritdoc />
     public void Dispose()

--- a/src/EncDotNet.S100.Specifications/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Specifications/Diagnostics/Telemetry.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Specifications.Diagnostics;
+
+/// <summary>Per-assembly <see cref="ActivitySource"/> and <see cref="Meter"/> for <c>EncDotNet.S100.Specifications</c>.</summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+}

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -51,6 +51,16 @@ public partial class App : Application
 
         s_services = ConfigureServices();
 
+        // The viewer uses a plain ServiceCollection (no generic IHost),
+        // so the IHostedService registered by AddOpenTelemetry() never
+        // runs — meaning the TracerProvider / MeterProvider would
+        // otherwise stay un-built and no ActivityListener / MeterListener
+        // would ever subscribe. Resolving them here forces construction
+        // and wires up the OTel pipeline before any instrumented code
+        // runs (dataset open, pipeline process, render, etc.).
+        _ = s_services.GetService(typeof(OpenTelemetry.Trace.TracerProvider));
+        _ = s_services.GetService(typeof(OpenTelemetry.Metrics.MeterProvider));
+
         // Emit a startup span + log so the viewer always shows up in
         // a connected OpenTelemetry collector even before the user
         // performs any traceable action. Any subscribed exporter

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -61,6 +61,11 @@ public partial class App : Application
         _ = s_services.GetService(typeof(OpenTelemetry.Trace.TracerProvider));
         _ = s_services.GetService(typeof(OpenTelemetry.Metrics.MeterProvider));
 
+        // Hook the logger factory into the static BeginCommand path so
+        // each viewer command also emits a structured log entry.
+        ViewerObservability.AttachLoggerFactory(
+            s_services.GetRequiredService<ILoggerFactory>());
+
         // Emit a startup span + log so the viewer always shows up in
         // a connected OpenTelemetry collector even before the user
         // performs any traceable action. Any subscribed exporter

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
@@ -9,6 +10,7 @@ using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace EncDotNet.S100.Viewer;
 
@@ -48,6 +50,24 @@ public partial class App : Application
         };
 
         s_services = ConfigureServices();
+
+        // Emit a startup span + log so the viewer always shows up in
+        // a connected OpenTelemetry collector even before the user
+        // performs any traceable action. Any subscribed exporter
+        // (e.g. the .NET Aspire dashboard launched via the AppHost
+        // project) will pick this up and confirm the OTEL_* wiring.
+        using (var startup = Telemetry.ActivitySource.StartActivity(
+                   "s100.viewer.startup", System.Diagnostics.ActivityKind.Internal))
+        {
+            startup?.SetTag("s100.viewer.version",
+                typeof(App).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+            var logger = s_services
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger("EncDotNet.S100.Viewer");
+            logger.LogInformation(
+                "EncDotNet.S100.Viewer started (version {Version}).",
+                typeof(App).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+        }
 
         // Wire the S-128 catalog source into the aggregator. Done here (and
         // not in MainWindow) so the registration is independent of the view.

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Catalogs;
+using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,6 +65,9 @@ public partial class App : Application
     private static IServiceProvider ConfigureServices()
     {
         var services = new ServiceCollection();
+
+        // OpenTelemetry tracing/metrics/logging — opt-in via OTEL_* env vars.
+        services.AddS100Observability();
 
         // Persisted user settings
         services.AddSingleton<ViewerSettings>(_ => ViewerSettings.Load());

--- a/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Diagnostics;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Viewer-level <see cref="ActivitySource"/> and <see cref="Meter"/>.
+/// Hosts the root <c>s100.viewer.command</c> spans and the
+/// <c>s100.viewer.command.duration</c> histogram so a single user
+/// action (open file, change palette, render) produces one causal
+/// trace.
+/// </summary>
+internal static class Telemetry
+{
+    public static readonly ActivitySource ActivitySource =
+        S100Telemetry.CreateActivitySource(typeof(Telemetry));
+
+    public static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(Telemetry));
+
+    public static readonly Histogram<double> CommandDuration =
+        Meter.CreateHistogram<double>(
+            "s100.viewer.command.duration",
+            unit: "ms",
+            description: "Wall-clock duration of a top-level viewer command.");
+}

--- a/src/EncDotNet.S100.Viewer/Diagnostics/ViewerObservability.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/ViewerObservability.cs
@@ -7,6 +7,7 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace EncDotNet.S100.Viewer.Diagnostics;
 
@@ -26,6 +27,21 @@ internal static class ViewerObservability
 {
     private const string ServiceName = "EncDotNet.S100.Viewer";
     private const string SourceWildcard = "EncDotNet.S100.*";
+
+    private static ILogger s_commandLogger = NullLogger.Instance;
+
+    /// <summary>
+    /// Wires an <see cref="ILoggerFactory"/> into the static
+    /// <see cref="BeginCommand"/> path so each viewer command emits a
+    /// structured "starting" / "completed" log entry alongside the
+    /// existing activity and metric. Pass the factory once from the
+    /// composition root after the service provider is built.
+    /// </summary>
+    public static void AttachLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        s_commandLogger = loggerFactory.CreateLogger("EncDotNet.S100.Viewer.Command");
+    }
 
     public static IServiceCollection AddS100Observability(this IServiceCollection services)
     {
@@ -90,13 +106,18 @@ internal static class ViewerObservability
     /// <summary>
     /// Starts a root <c>s100.viewer.command</c> activity wrapping a
     /// user action, recording <c>s100.viewer.command.duration</c> on
-    /// dispose.
+    /// dispose. Also emits a structured "starting" log entry now and
+    /// a "completed" / "failed" entry on dispose so connected log
+    /// sinks (Aspire dashboard, OTLP collectors) show user actions
+    /// without instrumenting every viewer service individually.
     /// </summary>
     public static CommandScope BeginCommand(string commandName)
     {
         var activity = Telemetry.ActivitySource.StartActivity(
             "s100.viewer.command", ActivityKind.Internal);
         activity?.SetTag("s100.viewer.command", commandName);
+        s_commandLogger.LogInformation(
+            "Viewer command starting: {Command}", commandName);
         return new CommandScope(activity, commandName);
     }
 
@@ -117,6 +138,12 @@ internal static class ViewerObservability
         {
             if (_activity is null) return;
             _activity.SetStatus(ok ? ActivityStatusCode.Ok : ActivityStatusCode.Error, description);
+            if (!ok)
+            {
+                s_commandLogger.LogWarning(
+                    "Viewer command failed: {Command} ({Description})",
+                    _commandName, description ?? "(no description)");
+            }
         }
 
         public void Dispose()
@@ -125,6 +152,9 @@ internal static class ViewerObservability
             Telemetry.CommandDuration.Record(elapsedMs,
                 new System.Collections.Generic.KeyValuePair<string, object?>(
                     "s100.viewer.command", _commandName));
+            s_commandLogger.LogInformation(
+                "Viewer command completed: {Command} in {ElapsedMs:F1}ms",
+                _commandName, elapsedMs);
             _activity?.Dispose();
         }
     }

--- a/src/EncDotNet.S100.Viewer/Diagnostics/ViewerObservability.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/ViewerObservability.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -32,6 +33,14 @@ internal static class ViewerObservability
         var serviceVersion = typeof(ViewerObservability).Assembly
             .GetName().Version?.ToString() ?? "0.0.0";
 
+        // Optional opt-in console export — invaluable when diagnosing
+        // "why don't I see anything in the dashboard?". Enabled by
+        // setting ENC_DOTNET_OTEL_CONSOLE=1 (the AppHost project sets
+        // this by default in its launch profiles).
+        var consoleExport = string.Equals(
+            Environment.GetEnvironmentVariable("ENC_DOTNET_OTEL_CONSOLE"),
+            "1", StringComparison.OrdinalIgnoreCase);
+
         services.AddLogging(builder =>
         {
             builder.AddOpenTelemetry(options =>
@@ -43,19 +52,37 @@ internal static class ViewerObservability
                 options.IncludeScopes = true;
                 options.ParseStateValues = true;
                 options.AddOtlpExporter();
+                if (consoleExport)
+                {
+                    options.AddConsoleExporter();
+                }
             });
         });
 
         services.AddOpenTelemetry()
             .ConfigureResource(r => r.AddService(serviceName: serviceName, serviceVersion: serviceVersion))
-            .WithTracing(tracing => tracing
-                .AddSource(SourceWildcard)
-                .AddSource(ServiceName)
-                .AddOtlpExporter())
-            .WithMetrics(metrics => metrics
-                .AddMeter(SourceWildcard)
-                .AddMeter(ServiceName)
-                .AddOtlpExporter());
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddSource(SourceWildcard)
+                    .AddSource(ServiceName)
+                    .AddOtlpExporter();
+                if (consoleExport)
+                {
+                    tracing.AddConsoleExporter();
+                }
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddMeter(SourceWildcard)
+                    .AddMeter(ServiceName)
+                    .AddOtlpExporter();
+                if (consoleExport)
+                {
+                    metrics.AddConsoleExporter();
+                }
+            });
 
         return services;
     }

--- a/src/EncDotNet.S100.Viewer/Diagnostics/ViewerObservability.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/ViewerObservability.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Composition-root helper that registers OpenTelemetry tracing,
+/// metrics, and logging into the viewer's <see cref="IServiceCollection"/>.
+/// </summary>
+/// <remarks>
+/// All <c>EncDotNet.S100.*</c> ActivitySources and Meters declared in
+/// the libraries are subscribed via wildcard. The OTLP exporter is
+/// configured via the standard OTEL_* environment variables
+/// (<c>OTEL_EXPORTER_OTLP_ENDPOINT</c>, <c>OTEL_SERVICE_NAME</c>,
+/// <c>OTEL_RESOURCE_ATTRIBUTES</c>); when no endpoint is reachable
+/// the exporter retries silently and the application keeps working.
+/// </remarks>
+internal static class ViewerObservability
+{
+    private const string ServiceName = "EncDotNet.S100.Viewer";
+    private const string SourceWildcard = "EncDotNet.S100.*";
+
+    public static IServiceCollection AddS100Observability(this IServiceCollection services)
+    {
+        var serviceName = Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME") ?? ServiceName;
+        var serviceVersion = typeof(ViewerObservability).Assembly
+            .GetName().Version?.ToString() ?? "0.0.0";
+
+        services.AddLogging(builder =>
+        {
+            builder.AddOpenTelemetry(options =>
+            {
+                options.SetResourceBuilder(
+                    ResourceBuilder.CreateDefault()
+                        .AddService(serviceName: serviceName, serviceVersion: serviceVersion));
+                options.IncludeFormattedMessage = true;
+                options.IncludeScopes = true;
+                options.ParseStateValues = true;
+                options.AddOtlpExporter();
+            });
+        });
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(r => r.AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+            .WithTracing(tracing => tracing
+                .AddSource(SourceWildcard)
+                .AddSource(ServiceName)
+                .AddOtlpExporter())
+            .WithMetrics(metrics => metrics
+                .AddMeter(SourceWildcard)
+                .AddMeter(ServiceName)
+                .AddOtlpExporter());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Starts a root <c>s100.viewer.command</c> activity wrapping a
+    /// user action, recording <c>s100.viewer.command.duration</c> on
+    /// dispose.
+    /// </summary>
+    public static CommandScope BeginCommand(string commandName)
+    {
+        var activity = Telemetry.ActivitySource.StartActivity(
+            "s100.viewer.command", ActivityKind.Internal);
+        activity?.SetTag("s100.viewer.command", commandName);
+        return new CommandScope(activity, commandName);
+    }
+
+    internal readonly struct CommandScope : IDisposable
+    {
+        private readonly Activity? _activity;
+        private readonly string _commandName;
+        private readonly long _startTimestamp;
+
+        internal CommandScope(Activity? activity, string commandName)
+        {
+            _activity = activity;
+            _commandName = commandName;
+            _startTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public void SetStatus(bool ok, string? description = null)
+        {
+            if (_activity is null) return;
+            _activity.SetStatus(ok ? ActivityStatusCode.Ok : ActivityStatusCode.Error, description);
+        }
+
+        public void Dispose()
+        {
+            var elapsedMs = Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds;
+            Telemetry.CommandDuration.Record(elapsedMs,
+                new System.Collections.Generic.KeyValuePair<string, object?>(
+                    "s100.viewer.command", _commandName));
+            _activity?.Dispose();
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Diagnostics">
@@ -33,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Avalonia.Themes.Fluent" />

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -12,6 +12,7 @@ using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Viewer.Catalogs;
+using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui.Layers;
@@ -139,6 +140,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ArgumentNullException.ThrowIfNull(entry);
         EnsureInitialized();
 
+        using var __cmd = ViewerObservability.BeginCommand("dataset.open");
+
         var spec = DatasetPipelineFactory.DetectProductSpec(entry.FilePath);
         if (spec is null)
         {
@@ -216,6 +219,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     public async Task ReRenderAtTimeAsync(DateTime t, CancellationToken cancellationToken)
     {
+        using var __cmd = ViewerObservability.BeginCommand("timeline.scrub");
+
         // Cancel any in-flight scrub render and start a fresh debounce
         // window. The token passed in is honoured in addition to the
         // internal debounce token so callers can cancel from outside
@@ -265,6 +270,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     public async Task ReRenderAllAsync()
     {
+        using var __cmd = ViewerObservability.BeginCommand("palette.change");
+
         var palette = _settingsVm.SelectedPalette;
         SetStatus(string.Format(Strings.Status_SwitchingPalette, palette));
 

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -1,5 +1,6 @@
 using System;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui;
@@ -28,6 +29,8 @@ internal sealed class PickService : IPickService
 
     public void HandlePick(MapInfo? mapInfo)
     {
+        using var __cmd = ViewerObservability.BeginCommand("pick");
+
         if (mapInfo?.Feature is not { } hitFeature || mapInfo.Layer is not { } hitLayer)
         {
             // Tap on empty map: clear any active pick so the panel hides.

--- a/src/EncDotNet.S100.Viewer/Services/ScreenshotService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ScreenshotService.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media.Imaging;
+using EncDotNet.S100.Viewer.Diagnostics;
 
 namespace EncDotNet.S100.Viewer.Services;
 
@@ -20,6 +21,8 @@ internal sealed class ScreenshotService
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(outputPath);
+
+        using var __cmd = ViewerObservability.BeginCommand("screenshot");
 
         try
         {

--- a/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Smoke tests for the observability instrumentation added across
+/// the libraries. We don't assert exact span trees (those depend on
+/// runtime data); we just verify that the named ActivitySources are
+/// reachable by an <see cref="ActivityListener"/> and that a happy-path
+/// call produces at least one activity with the expected name.
+/// </summary>
+public sealed class TelemetrySmokeTests
+{
+    [Fact]
+    public void FeatureCatalogueReader_emits_parse_activity()
+    {
+        var observed = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == "EncDotNet.S100.Features",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => observed.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var fcStream = Specification.TryOpenFeatureCatalogue("S-101")
+            ?? throw new System.InvalidOperationException("S-101 feature catalogue not found.");
+        _ = FeatureCatalogueReader.Read(fcStream);
+
+        Assert.Contains(observed, a => a.OperationName == "s100.featurecatalogue.parse");
+    }
+
+    [Fact]
+    public void All_libraries_register_named_activity_sources()
+    {
+        // Touch each library's Telemetry indirectly via a public type
+        // to ensure the assembly is loaded before we ask the listener.
+        _ = typeof(EncDotNet.S100.Diagnostics.S100Telemetry);
+        _ = typeof(EncDotNet.S100.Features.FeatureCatalogueReader);
+        _ = typeof(EncDotNet.S100.Specifications.Specification);
+
+        var seen = new HashSet<string>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src =>
+            {
+                if (src.Name.StartsWith("EncDotNet.S100", System.StringComparison.Ordinal))
+                {
+                    seen.Add(src.Name);
+                }
+                return false;
+            },
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // Force a parse so at least the Features ActivitySource is queried.
+        using var fcStream = Specification.TryOpenFeatureCatalogue("S-101")
+            ?? throw new System.InvalidOperationException("S-101 feature catalogue not found.");
+        _ = FeatureCatalogueReader.Read(fcStream);
+
+        Assert.Contains("EncDotNet.S100.Features", seen);
+    }
+}


### PR DESCRIPTION
## Summary

As a precursor to a performance spike we needed to actually see what the libraries and the viewer are doing. This PR instruments the codebase end-to-end with the standard .NET diagnostic primitives and adds a one-step way to watch the resulting data.

**Libraries** gain a per-assembly `Diagnostics.Telemetry` class exposing an `ActivitySource` and `Meter` named after the assembly (so consumers can subscribe to the whole family with the wildcard `EncDotNet.S100.*`). Hot paths are wrapped in `using var __activity = ...StartActivity(...)`: dataset readers (`s100.dataset.open`), pipelines (`s100.pipeline.vector.process`, `s100.pipeline.coverage.process`), HDF5 access, Lua rule invocation, and renderers (`s100.render.layer.build`, `s100.render.coverage.build`). A shared `S100Telemetry` helper in Core stamps each source/meter with its assembly version. Names are namespaced under `s100.` and tag keys live in a single `TelemetryTags` constants class.

**Viewer** composes those sources into an OpenTelemetry pipeline (traces + metrics + logs, all OTLP-exported) via a new `ViewerObservability.AddS100Observability` extension, honouring the standard `OTEL_*` environment variables. `BeginCommand` wraps each user action (`dataset.open`, `pick`, `screenshot`, `timeline.scrub`) in a root `s100.viewer.command` span, records `s100.viewer.command.duration`, and now also emits `Viewer command starting/completed in Nms` structured logs.

**Aspire AppHost** (`src/EncDotNet.S100.AppHost`) launches the dashboard and the viewer together with one command:

```sh
dotnet run --project src/EncDotNet.S100.AppHost
```

The dashboard's URL is printed to stdout. Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, and `OTEL_RESOURCE_ATTRIBUTES` automatically, so logs, traces, and metrics show up in the dashboard's tabs without any manual collector setup. An opt-in `ENC_DOTNET_OTEL_CONSOLE=1` env var (set by the AppHost) also mirrors telemetry to the viewer's stdout, which surfaces in the dashboard's Console tab and is invaluable when diagnosing wiring issues.

## Things worth a careful look

- **TracerProvider/MeterProvider must be eagerly resolved.** The viewer uses a plain `ServiceCollection` (no generic `IHost`), so the `IHostedService` registered by `AddOpenTelemetry()` never runs on its own. Without explicit `s_services.GetService(typeof(TracerProvider))` / `MeterProvider` calls in `App.OnFrameworkInitializationCompleted`, no `ActivityListener` ever subscribes and every `StartActivity` silently returns null. This was the bug behind "I see startup logs but no traces" during the smoke test.
- **AppHost csproj layout.** Uses the dual-SDK pattern (`<Project Sdk="Microsoft.NET.Sdk">` plus a child `<Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />` element). Using the Aspire SDK as the *root* SDK silently no-ops the build (0 warnings, 0 bin/obj output). The AppHost project also opts out of central package management because the Aspire SDK floats its own transitive versions.
- **Lua per-rule activity is listener-gated.** A busy ENC produces thousands of rule invocations; the activity is only started when a listener is actually subscribed. Volume is captured by the `s100.lua.rule.invoke.count` counter so the trace pipeline stays usable.
- **`http` launch profile sets `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true`.** Aspire requires HTTPS by default; the http profile opts out so it works without an HTTPS dev cert. Use the `https` profile if you have a cert configured.

## Spec alignment

- [x] N/A - change is purely infrastructural (build, CI, docs, tooling)

This PR adds diagnostics to the existing libraries and a new orchestration project; it does not change any spec-derived data structures, attribute names, or portrayal semantics.

**Spec section references cited in code/docs:**

N/A. All new code is host-side observability infrastructure.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

`tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs` asserts the activities/meters via a plain `ActivityListener` (no SDK required). The full `dotnet build EncDotNet.S100.slnx` is clean (0 errors, the 3 pre-existing test-project xunit warnings are unrelated to this PR).

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

`docs/observability.md` documents the span tree, the metrics catalogue, the AppHost recipe (recommended), and the standalone Aspire-dashboard / Jaeger Docker fallbacks. The top-level README's Observability section now points at the AppHost as the one-step path.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

New centrally-managed packages: `OpenTelemetry`, `OpenTelemetry.Exporter.OpenTelemetryProtocol`, `OpenTelemetry.Exporter.Console`, `OpenTelemetry.Extensions.Hosting` (all 1.15.3) and `Microsoft.Extensions.Logging`/`...DependencyInjection` (10.0.0). The AppHost project intentionally bypasses CPM (`ManagePackageVersionsCentrally=false`) because `Aspire.AppHost.Sdk` floats its own transitive dependency versions; it pins only `Aspire.Hosting.AppHost` 9.5.2 itself.

## Breaking changes

None. All instrumentation is additive: `ActivitySource` and `Meter` are inert when no listener is attached, so libraries pay no measurable cost when an embedding host has not wired up observability. The viewer's behaviour is unchanged for users who do not set any `OTEL_*` environment variables.