### PR TITLE
ECDIS display controls (foundation): pipeline + state + persistence

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorPortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorPortrayalCatalogue.cs
@@ -25,4 +25,14 @@ public interface IVectorPortrayalCatalogue
 
     /// <summary>Controls which viewing groups are currently visible.</summary>
     ViewingGroupController ViewingGroups { get; }
+
+    /// <summary>
+    /// Tracks the active S-100 Part 9 display-mode id for the
+    /// catalogue. When the controller's active id changes the
+    /// catalogue is responsible for resolving the corresponding
+    /// viewing-group membership and pushing it into
+    /// <see cref="ViewingGroups"/> via
+    /// <see cref="ViewingGroupController.SetActiveModeMembership"/>.
+    /// </summary>
+    DisplayModeController DisplayModes { get; }
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPortrayalTypes.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPortrayalTypes.cs
@@ -44,19 +44,214 @@ public sealed class AreaFill
 /// <summary>
 /// Controls visibility of features by viewing group assignment.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Effective visibility is the layered combination of two inputs
+/// (S-100 Part 9 §11.7, "Display modes and viewing groups"):
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     A <em>base mode membership</em> set established by the active
+///     <see cref="DisplayModeController"/>: when a non-null set is
+///     active, only viewing groups in the set are considered base-on
+///     and every other viewing group is base-off. When the membership
+///     is <c>null</c> (the default), every viewing group is base-on.
+///   </item>
+///   <item>
+///     <em>User overrides</em> applied on top of the base via
+///     <see cref="SetUserOverride"/>. An explicit override always wins
+///     over the base membership, allowing the user to toggle individual
+///     groups regardless of the active mode.
+///   </item>
+/// </list>
+/// </remarks>
 public sealed class ViewingGroupController
 {
-    private readonly Dictionary<int, bool> _visibility = new();
+    private readonly Dictionary<int, bool> _userOverrides = new();
+    private IReadOnlySet<int>? _modeMembership;
 
-    public IReadOnlyDictionary<int, bool> GroupVisibility => _visibility;
+    /// <summary>
+    /// Raised whenever effective visibility changes — either because
+    /// the active mode membership was updated, or because a user
+    /// override was set or cleared.
+    /// </summary>
+    public event Action? Changed;
 
-    public void SetVisible(int viewingGroup, bool visible)
+    /// <summary>Snapshot of the current per-group user overrides.</summary>
+    public IReadOnlyDictionary<int, bool> UserOverrides => _userOverrides;
+
+    /// <summary>
+    /// Backwards-compatible view: the effective visibility for every
+    /// viewing group that has either an active-mode membership entry
+    /// or an explicit user override. Groups that are visible solely by
+    /// the "no mode active → everything visible" default are not
+    /// enumerated.
+    /// </summary>
+    public IReadOnlyDictionary<int, bool> GroupVisibility
     {
-        _visibility[viewingGroup] = visible;
+        get
+        {
+            var view = new Dictionary<int, bool>();
+            if (_modeMembership is not null)
+            {
+                foreach (var id in _modeMembership)
+                {
+                    view[id] = true;
+                }
+            }
+            foreach (var (id, visible) in _userOverrides)
+            {
+                view[id] = visible;
+            }
+            return view;
+        }
     }
 
+    /// <summary>
+    /// Sets the user's explicit visibility override for
+    /// <paramref name="viewingGroup"/>. Equivalent to calling
+    /// <see cref="SetUserOverride(int, bool?)"/> with a non-null value.
+    /// </summary>
+    public void SetVisible(int viewingGroup, bool visible) =>
+        SetUserOverride(viewingGroup, visible);
+
+    /// <summary>
+    /// Sets, replaces, or clears the user override for
+    /// <paramref name="viewingGroup"/>. Pass <c>null</c> to clear so
+    /// that the base mode membership wins again.
+    /// </summary>
+    public void SetUserOverride(int viewingGroup, bool? visible)
+    {
+        bool changed;
+        if (visible is null)
+        {
+            changed = _userOverrides.Remove(viewingGroup);
+        }
+        else
+        {
+            changed = !_userOverrides.TryGetValue(viewingGroup, out var existing)
+                || existing != visible.Value;
+            _userOverrides[viewingGroup] = visible.Value;
+        }
+
+        if (changed)
+        {
+            Changed?.Invoke();
+        }
+    }
+
+    /// <summary>Clears every user override.</summary>
+    public void ClearUserOverrides()
+    {
+        if (_userOverrides.Count == 0) return;
+        _userOverrides.Clear();
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Replaces the active-mode viewing-group membership. Pass
+    /// <c>null</c> to clear so that every viewing group is visible by
+    /// default again. User overrides are preserved.
+    /// </summary>
+    public void SetActiveModeMembership(IReadOnlySet<int>? membership)
+    {
+        // Treat reference equality as a no-op fast path; otherwise the
+        // event always fires so listeners can re-render. Cheap content
+        // equality isn't worth it here — membership sets are typically
+        // immutable post-construction.
+        if (ReferenceEquals(_modeMembership, membership)) return;
+        _modeMembership = membership;
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// The active mode membership, or <c>null</c> when no mode is
+    /// active (in which case every viewing group is visible by
+    /// default).
+    /// </summary>
+    public IReadOnlySet<int>? ActiveModeMembership => _modeMembership;
+
+    /// <summary>
+    /// Returns the effective visibility for <paramref name="viewingGroup"/>.
+    /// User overrides win over base mode membership; with no override and
+    /// no active mode, the group is visible.
+    /// </summary>
     public bool IsVisible(int viewingGroup)
     {
-        return !_visibility.TryGetValue(viewingGroup, out var visible) || visible;
+        if (_userOverrides.TryGetValue(viewingGroup, out var overrideValue))
+        {
+            return overrideValue;
+        }
+
+        return _modeMembership is null || _modeMembership.Contains(viewingGroup);
+    }
+}
+
+/// <summary>
+/// Tracks the active S-100 Part 9 display-mode id for a vector
+/// portrayal catalogue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per S-100 Part 9 §11.7, a portrayal catalogue may declare one or
+/// more <c>&lt;displayMode&gt;</c> elements (e.g. <c>DisplayBase</c>,
+/// <c>StandardDisplay</c>, <c>OtherInformation</c> for S-101). Each
+/// mode references a set of <c>&lt;viewingGroupLayer&gt;</c> ids,
+/// and each layer references a set of integer viewing groups. The
+/// active mode determines the base on/off state of every viewing
+/// group; per-group user overrides (handled by
+/// <see cref="ViewingGroupController"/>) layer on top.
+/// </para>
+/// <para>
+/// This controller carries only the chosen mode id. The per-spec
+/// catalogue subscribes to <see cref="Changed"/> and translates the
+/// id into a concrete viewing-group set, which it pushes into its
+/// paired <see cref="ViewingGroupController"/>.
+/// </para>
+/// </remarks>
+public sealed class DisplayModeController
+{
+    /// <summary>
+    /// The id of the active display mode, or <c>null</c> when no mode
+    /// is active (interpreted as "all viewing groups visible").
+    /// </summary>
+    public string? ActiveDisplayModeId { get; private set; }
+
+    /// <summary>
+    /// The set of display-mode ids declared by the per-spec portrayal
+    /// catalogue this controller is bound to. Empty until
+    /// <see cref="SetDeclaredModeIds"/> is called (typically by
+    /// <c>DisplayModeMembership.Bind</c>). The viewer uses this to
+    /// decide which ECDIS categories make sense for a given spec.
+    /// </summary>
+    public IReadOnlySet<string> DeclaredModeIds { get; private set; }
+        = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Raised whenever <see cref="ActiveDisplayModeId"/> changes.
+    /// </summary>
+    public event Action? Changed;
+
+    /// <summary>
+    /// Sets <see cref="ActiveDisplayModeId"/>. Pass <c>null</c> to
+    /// clear (every viewing group visible by default).
+    /// </summary>
+    public void SetActive(string? displayModeId)
+    {
+        if (string.Equals(ActiveDisplayModeId, displayModeId, StringComparison.Ordinal))
+            return;
+
+        ActiveDisplayModeId = displayModeId;
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Records the catalogue-declared mode ids. Does not raise
+    /// <see cref="Changed"/>; this is metadata only.
+    /// </summary>
+    public void SetDeclaredModeIds(IReadOnlySet<string> ids)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+        DeclaredModeIds = ids;
     }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/EcdisDisplaySettings.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/EcdisDisplaySettings.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// The four ECDIS standard display categories (S-100 Part 9 §11.7,
+/// S-101 §10.4). The viewer exposes these as a cross-spec selection
+/// and <see cref="EcdisCategoryMapper"/> resolves each to a
+/// per-spec display-mode id.
+/// </summary>
+public enum EcdisDisplayCategory
+{
+    /// <summary>
+    /// "Display Base" — the minimum information required for safe
+    /// navigation that cannot be removed by the mariner.
+    /// </summary>
+    DisplayBase,
+
+    /// <summary>
+    /// "Standard Display" — the default ECDIS display.
+    /// </summary>
+    Standard,
+
+    /// <summary>
+    /// "Other Information" — Standard plus the producer-tagged
+    /// supplementary content. Subset of "All".
+    /// </summary>
+    OtherInformation,
+
+    /// <summary>
+    /// "All" — every viewing group is visible (no display-mode filter).
+    /// </summary>
+    All,
+}
+
+/// <summary>
+/// Cross-spec ECDIS display settings carried on every
+/// <see cref="RenderContext"/>. Producers (the viewer) populate this
+/// from <c>EcdisDisplayState</c>; consumers (per-spec processors)
+/// apply it to their <see cref="IVectorPortrayalCatalogue"/> via
+/// <see cref="EcdisDisplayExtensions.ApplyTo"/>.
+/// </summary>
+public sealed record EcdisDisplaySettings
+{
+    /// <summary>The active ECDIS category. Defaults to Standard.</summary>
+    public EcdisDisplayCategory Category { get; init; } = EcdisDisplayCategory.Standard;
+
+    /// <summary>
+    /// Per-spec viewing-group ids the user has explicitly hidden via
+    /// the ECDIS panel. Keys are spec codes (e.g. <c>"S-101"</c>).
+    /// Empty by default.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlySet<int>> HiddenViewingGroups { get; init; }
+        = new Dictionary<string, IReadOnlySet<int>>();
+}
+
+/// <summary>
+/// Maps a cross-spec <see cref="EcdisDisplayCategory"/> to the
+/// per-spec <c>displayMode</c> id declared in that spec's bundled
+/// portrayal catalogue. Specs that only declare a single mode
+/// (typically just <c>StandardDisplay</c>) fall back to <c>null</c>
+/// for non-Standard categories — meaning "no mode filter, render
+/// everything", matching the bundled catalogue's authoring intent.
+/// </summary>
+public static class EcdisCategoryMapper
+{
+    /// <summary>
+    /// Resolves the ECDIS category for a given spec to a
+    /// <see cref="DisplayModeController.ActiveDisplayModeId"/> value.
+    /// Returns <c>null</c> for "All" (no filter) or for specs that
+    /// don't declare per-category modes.
+    /// </summary>
+    /// <param name="productSpec">Spec code, e.g. <c>"S-101"</c>.</param>
+    /// <param name="category">Cross-spec ECDIS category.</param>
+    /// <param name="availableModeIds">
+    /// Display-mode ids declared by the spec's portrayal catalogue.
+    /// </param>
+    public static string? Map(
+        string productSpec,
+        EcdisDisplayCategory category,
+        IReadOnlySet<string> availableModeIds)
+    {
+        ArgumentNullException.ThrowIfNull(productSpec);
+        ArgumentNullException.ThrowIfNull(availableModeIds);
+
+        if (category == EcdisDisplayCategory.All)
+            return null;
+
+        // Canonical S-101 ids are well-known; other specs reuse the
+        // same names where they declare them.
+        var preferred = category switch
+        {
+            EcdisDisplayCategory.DisplayBase => "DisplayBase",
+            EcdisDisplayCategory.Standard => "StandardDisplay",
+            EcdisDisplayCategory.OtherInformation => "OtherInformation",
+            _ => null,
+        };
+
+        if (preferred is not null && availableModeIds.Contains(preferred))
+            return preferred;
+
+        // Fallback: spec only declares Standard (or fewer); render
+        // everything for non-Standard requests.
+        return null;
+    }
+}
+
+/// <summary>
+/// Extensions that apply <see cref="EcdisDisplaySettings"/> to a
+/// freshly-constructed per-spec vector portrayal catalogue. Called
+/// by every vector dataset processor immediately after it builds
+/// the catalogue and before <c>VectorPipeline</c> consumes it.
+/// </summary>
+public static class EcdisDisplayExtensions
+{
+    /// <summary>
+    /// Applies the supplied settings to <paramref name="catalogue"/>:
+    /// resolves the ECDIS category to the spec's display-mode id and
+    /// activates it; then writes per-spec hidden-VG ids as user-off
+    /// overrides. Idempotent — calling on a fresh catalogue always
+    /// produces the same effective visibility for a given settings
+    /// value.
+    /// </summary>
+    public static void ApplyTo(this EcdisDisplaySettings settings, IVectorPortrayalCatalogue catalogue)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(catalogue);
+
+        var modeId = EcdisCategoryMapper.Map(
+            catalogue.ProductSpec, settings.Category, catalogue.DisplayModes.DeclaredModeIds);
+        catalogue.DisplayModes.SetActive(modeId);
+
+        if (settings.HiddenViewingGroups.TryGetValue(catalogue.ProductSpec, out var hidden))
+        {
+            foreach (var vg in hidden)
+                catalogue.ViewingGroups.SetUserOverride(vg, false);
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
@@ -16,6 +16,14 @@ public abstract record RenderContext
 
     /// <summary>Global text scale factor (1.0 = default).</summary>
     public double TextScale { get; init; } = 1.0;
+
+    /// <summary>
+    /// Cross-spec ECDIS display settings (S-100 Part 9 §11.7
+    /// display-mode selection plus per-spec viewing-group overrides).
+    /// When <c>null</c> processors render with no mode filter and no
+    /// user overrides — equivalent to "All" with an empty hidden set.
+    /// </summary>
+    public EcdisDisplaySettings? EcdisDisplay { get; init; }
 }
 
 public sealed record S101RenderContext : RenderContext;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -56,6 +56,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         var s101Cat = new S101PortrayalCatalogue(_provider, _luaEngine);
         var paletteType = context?.Palette ?? PaletteType.Day;
         s101Cat.SwitchPalette(paletteType);
+        context?.EcdisDisplay?.ApplyTo(s101Cat);
         var palette = s101Cat.ActivePalette;
         Console.WriteLine($"[S101] Loaded {paletteType} palette with {palette.Colors.Count} colors");
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
@@ -37,6 +37,7 @@ public sealed class S122DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S122PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // 1. Run the S-100 Part 9 vector portrayal pipeline.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
@@ -37,6 +37,7 @@ public sealed class S124DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S124PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // 1. Run the S-100 Part 9 vector portrayal pipeline.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
@@ -45,6 +45,7 @@ public sealed class S125DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S125PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         var featureSource = new S125FeatureXmlSource(_dataset);

--- a/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
@@ -42,6 +42,7 @@ public sealed class S127DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S127PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         var featureSource = new S127FeatureXmlSource(_dataset);

--- a/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
@@ -40,6 +40,7 @@ public sealed class S128DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S128PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // 1. Run the S-100 Part 9 vector portrayal pipeline.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
@@ -37,6 +37,7 @@ public sealed class S129DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S129PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // 1. Run the S-100 Part 9 vector portrayal pipeline.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
@@ -67,6 +67,7 @@ public sealed class S411DatasetProcessor : IDatasetProcessor
         }
 
         var catalogue = new S411PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(palette);
 
         // 1. Run the S-100 Part 9 vector portrayal pipeline.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
@@ -33,6 +33,7 @@ public sealed class S421DatasetProcessor : IDatasetProcessor
     public DatasetResult Render(RenderContext? context = null)
     {
         var catalogue = new S421PortrayalCatalogue(_provider);
+        context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // 1. Run the S-100 Part 9 vector portrayal pipeline.

--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -31,6 +31,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
         _luaEngine = luaEngine;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     public string ProductSpec => "S-101";
@@ -50,6 +51,8 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     }
 
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S122/S122PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S122/S122PortrayalCatalogue.cs
@@ -34,6 +34,7 @@ public sealed class S122PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -66,6 +67,9 @@ public sealed class S122PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S124/S124PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S124/S124PortrayalCatalogue.cs
@@ -34,6 +34,7 @@ public sealed class S124PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -58,6 +59,9 @@ public sealed class S124PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
@@ -38,6 +38,7 @@ public sealed class S125PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -59,6 +60,9 @@ public sealed class S125PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S127/S127PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S127/S127PortrayalCatalogue.cs
@@ -33,6 +33,7 @@ public sealed class S127PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -54,6 +55,9 @@ public sealed class S127PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     private void EnsurePalettesLoaded()
     {

--- a/src/EncDotNet.S100.Datasets.S128/S128PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128PortrayalCatalogue.cs
@@ -39,6 +39,7 @@ public sealed class S128PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -69,6 +70,9 @@ public sealed class S128PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
@@ -34,6 +34,7 @@ public sealed class S129PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -58,6 +59,9 @@ public sealed class S129PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
@@ -41,6 +41,7 @@ public sealed class S411PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -65,6 +66,9 @@ public sealed class S411PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
@@ -34,6 +34,7 @@ public sealed class S421PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
@@ -57,6 +58,9 @@ public sealed class S421PortrayalCatalogue : IVectorPortrayalCatalogue
 
     /// <summary>Gets the controller for viewing group visibility.</summary>
     public ViewingGroupController ViewingGroups { get; } = new();
+
+    /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
+    public DisplayModeController DisplayModes { get; } = new();
 
     // ── Palettes ───────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Portrayals/DisplayModeMembership.cs
+++ b/src/EncDotNet.S100.Portrayals/DisplayModeMembership.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Portrayals;
+
+/// <summary>
+/// Resolves S-100 Part 9 §11.7 display-mode membership: walks
+/// <c>displayMode → viewingGroupLayer → viewingGroup</c> and returns
+/// the integer viewing-group ids that belong to a given mode.
+/// </summary>
+public static class DisplayModeMembership
+{
+    /// <summary>
+    /// Resolves the integer viewing-group ids that are visible for the
+    /// given display mode declared in <paramref name="catalogue"/>.
+    /// Layer ids referenced by the mode but absent from the catalogue
+    /// are skipped silently; viewing-group ids that don't parse as
+    /// integers are skipped silently (a non-numeric id is meaningless
+    /// to <c>DrawingInstruction.ViewingGroup</c>).
+    /// </summary>
+    /// <param name="catalogue">The parsed portrayal catalogue.</param>
+    /// <param name="displayModeId">
+    /// The id of the desired display mode (e.g. <c>"DisplayBase"</c>).
+    /// Matched case-insensitively. If the mode is not declared the
+    /// returned set is empty.
+    /// </param>
+    public static IReadOnlySet<int> Resolve(PortrayalCatalogue catalogue, string displayModeId)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+        ArgumentException.ThrowIfNullOrEmpty(displayModeId);
+
+        var mode = catalogue.DisplayModes
+            .FirstOrDefault(m => string.Equals(m.Id, displayModeId, StringComparison.OrdinalIgnoreCase));
+        if (mode is null) return new HashSet<int>();
+
+        var layerIndex = catalogue.ViewingGroupLayers
+            .ToDictionary(l => l.Id, l => l, StringComparer.OrdinalIgnoreCase);
+
+        var ids = new HashSet<int>();
+        foreach (var layerId in mode.ViewingGroupLayerIds)
+        {
+            if (!layerIndex.TryGetValue(layerId, out var layer)) continue;
+            foreach (var raw in layer.ViewingGroupIds)
+            {
+                if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                {
+                    ids.Add(id);
+                }
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Wires <paramref name="displayModes"/> to keep
+    /// <paramref name="viewingGroups"/> in sync with the active display
+    /// mode declared in <paramref name="catalogue"/>. The wiring
+    /// updates the viewing-group controller's mode membership only;
+    /// any user overrides set via
+    /// <see cref="ViewingGroupController.SetUserOverride"/> are
+    /// preserved across mode changes.
+    /// </summary>
+    /// <returns>
+    /// The handler that was attached to
+    /// <see cref="DisplayModeController.Changed"/>, in case callers
+    /// need to detach it later.
+    /// </returns>
+    public static Action Bind(
+        DisplayModeController displayModes,
+        ViewingGroupController viewingGroups,
+        PortrayalCatalogue catalogue)
+    {
+        ArgumentNullException.ThrowIfNull(displayModes);
+        ArgumentNullException.ThrowIfNull(viewingGroups);
+        ArgumentNullException.ThrowIfNull(catalogue);
+
+        var declaredIds = catalogue.DisplayModes
+            .Select(m => m.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        displayModes.SetDeclaredModeIds(declaredIds);
+
+        Action handler = () =>
+        {
+            var modeId = displayModes.ActiveDisplayModeId;
+
+            // Treat a mode that isn't declared by this catalogue as
+            // "no filter" rather than "empty membership" — picking
+            // an undeclared mode (e.g. requesting DisplayBase on a
+            // spec that only ships StandardDisplay) should fall back
+            // to rendering every viewing group, matching the
+            // catalogue authoring intent.
+            if (modeId is null || !declaredIds.Contains(modeId))
+            {
+                viewingGroups.SetActiveModeMembership(null);
+                return;
+            }
+
+            viewingGroups.SetActiveModeMembership(Resolve(catalogue, modeId));
+        };
+
+        displayModes.Changed += handler;
+        // Apply current state immediately so first-bind catalogues
+        // start in a consistent place.
+        handler();
+        return handler;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
@@ -123,6 +125,43 @@ public partial class App : Application
 
         // Phase 3 services: dataset orchestration, pick dispatch, file dialogs
         services.AddSingleton<GlobalTimeService>();
+        services.AddSingleton<EcdisDisplayState>(sp =>
+        {
+            var settings = sp.GetRequiredService<ViewerSettings>();
+            var state = new EcdisDisplayState();
+            var category = Enum.TryParse<EncDotNet.S100.Datasets.Pipelines.EcdisDisplayCategory>(
+                settings.EcdisDisplayCategory, ignoreCase: true, out var c)
+                ? c
+                : EncDotNet.S100.Datasets.Pipelines.EcdisDisplayCategory.Standard;
+            var hidden = new Dictionary<string, IReadOnlySet<int>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in settings.EcdisHiddenViewingGroups)
+            {
+                var ids = new HashSet<int>();
+                foreach (var token in (kv.Value ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    if (int.TryParse(token, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var id))
+                        ids.Add(id);
+                }
+                if (ids.Count > 0) hidden[kv.Key] = ids;
+            }
+            state.Hydrate(category, hidden);
+
+            // Persist on every change so a crash doesn't lose the user's
+            // ECDIS preferences. Cheap because settings.json is small.
+            state.Changed += () =>
+            {
+                settings.EcdisDisplayCategory = state.Category.ToString();
+                var snap = state.Snapshot();
+                settings.EcdisHiddenViewingGroups.Clear();
+                foreach (var kv in snap.HiddenViewingGroups)
+                {
+                    settings.EcdisHiddenViewingGroups[kv.Key] =
+                        string.Join(",", kv.Value.OrderBy(i => i));
+                }
+                try { settings.Save(); } catch { /* best-effort */ }
+            };
+            return state;
+        });
         services.AddSingleton<IStatusPresenter, StatusPresenter>();
         services.AddSingleton<IDatasetLoaderService, DatasetLoaderService>();
         services.AddSingleton<IPickService, PickService>();

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -33,6 +33,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly S128DatasetCatalogSource _s128CatalogSource;
     private readonly SettingsViewModel _settingsVm;
     private readonly GlobalTimeService _globalTime;
+    private readonly EcdisDisplayState _ecdisDisplay;
 
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayers = new();
@@ -71,7 +72,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         IRecentFilesService recentFiles,
         S128DatasetCatalogSource s128CatalogSource,
         SettingsViewModel settingsVm,
-        GlobalTimeService globalTime)
+        GlobalTimeService globalTime,
+        EcdisDisplayState ecdisDisplay)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
@@ -80,6 +82,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ArgumentNullException.ThrowIfNull(s128CatalogSource);
         ArgumentNullException.ThrowIfNull(settingsVm);
         ArgumentNullException.ThrowIfNull(globalTime);
+        ArgumentNullException.ThrowIfNull(ecdisDisplay);
 
         _settings = settings;
         _catalogueManager = catalogueManager;
@@ -88,6 +91,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _s128CatalogSource = s128CatalogSource;
         _settingsVm = settingsVm;
         _globalTime = globalTime;
+        _ecdisDisplay = ecdisDisplay;
 
         _processorsView = new ReadOnlyDictionary<DatasetEntry, IDatasetProcessor>(_processors);
         _entryLayersView = new ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>>(_entryLayers);
@@ -133,6 +137,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         // re-render lifecycle.
         _settingsVm.PaletteChanged += palette => _ = ReRenderAllAsync();
         _settingsVm.DisplayScaleChanged += () => _ = ReRenderAllAsync();
+        _ecdisDisplay.Changed += () => _ = ReRenderAllAsync();
     }
 
     public async Task LoadAsync(DatasetEntry entry)
@@ -351,36 +356,37 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         var palette = _settingsVm.SelectedPalette;
         var symbolScale = _settingsVm.SymbolScale;
         var textScale = _settingsVm.TextScale;
+        var ecdis = _ecdisDisplay.Snapshot();
 
         return processor switch
         {
             S104DatasetProcessor when timeStep is not null
-                => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S104DatasetProcessor
-                => new S104RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S104RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S111DatasetProcessor when timeStep is not null
-                => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S111DatasetProcessor
-                => new S111RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S111RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S101DatasetProcessor
-                => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S102DatasetProcessor
-                => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S122DatasetProcessor
-                => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S124DatasetProcessor
-                => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S125DatasetProcessor
-                => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S127DatasetProcessor
-                => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S129DatasetProcessor
-                => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S411DatasetProcessor when timeStep is not null
-                => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
             S411DatasetProcessor
-                => new S411RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            _ => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+                => new S411RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+            _ => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
         };
     }
 

--- a/src/EncDotNet.S100.Viewer/Services/EcdisDisplayState.cs
+++ b/src/EncDotNet.S100.Viewer/Services/EcdisDisplayState.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Cross-spec ECDIS display state singleton owned by the viewer.
+/// Tracks the active <see cref="EcdisDisplayCategory"/> and the
+/// per-spec set of viewing-group ids the user has explicitly hidden.
+/// Mutations raise <see cref="Changed"/>; the dataset loader
+/// subscribes and re-renders every loaded vector dataset.
+/// </summary>
+internal sealed class EcdisDisplayState
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, HashSet<int>> _hidden =
+        new(StringComparer.OrdinalIgnoreCase);
+    private EcdisDisplayCategory _category = EcdisDisplayCategory.Standard;
+
+    /// <summary>Raised after any mutation completes.</summary>
+    public event Action? Changed;
+
+    /// <summary>
+    /// The active ECDIS standard display category (defaults to Standard).
+    /// </summary>
+    public EcdisDisplayCategory Category
+    {
+        get { lock (_gate) return _category; }
+    }
+
+    /// <summary>
+    /// Sets <see cref="Category"/> and raises <see cref="Changed"/>
+    /// when the value differs from the current category.
+    /// </summary>
+    public void SetCategory(EcdisDisplayCategory category)
+    {
+        bool changed;
+        lock (_gate)
+        {
+            changed = _category != category;
+            _category = category;
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Hides the given viewing-group id for <paramref name="productSpec"/>.
+    /// </summary>
+    public void HideViewingGroup(string productSpec, int viewingGroupId)
+    {
+        ArgumentNullException.ThrowIfNull(productSpec);
+
+        bool changed;
+        lock (_gate)
+        {
+            if (!_hidden.TryGetValue(productSpec, out var set))
+            {
+                set = new HashSet<int>();
+                _hidden[productSpec] = set;
+            }
+            changed = set.Add(viewingGroupId);
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Removes any explicit hide for the given viewing-group id under
+    /// <paramref name="productSpec"/>.
+    /// </summary>
+    public void ShowViewingGroup(string productSpec, int viewingGroupId)
+    {
+        ArgumentNullException.ThrowIfNull(productSpec);
+
+        bool changed;
+        lock (_gate)
+        {
+            if (!_hidden.TryGetValue(productSpec, out var set))
+                return;
+            changed = set.Remove(viewingGroupId);
+            if (set.Count == 0) _hidden.Remove(productSpec);
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Clears every per-spec viewing-group override and raises
+    /// <see cref="Changed"/> if anything was cleared.
+    /// </summary>
+    public void ClearAllOverrides()
+    {
+        bool changed;
+        lock (_gate)
+        {
+            changed = _hidden.Count > 0;
+            _hidden.Clear();
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Clears the hidden set for a single spec and raises
+    /// <see cref="Changed"/> when something was cleared.
+    /// </summary>
+    public void ClearOverridesForSpec(string productSpec)
+    {
+        ArgumentNullException.ThrowIfNull(productSpec);
+        bool changed;
+        lock (_gate)
+        {
+            changed = _hidden.Remove(productSpec);
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Returns the hidden viewing-group ids for <paramref name="productSpec"/>
+    /// (empty when the spec has no overrides).
+    /// </summary>
+    public IReadOnlySet<int> GetHidden(string productSpec)
+    {
+        ArgumentNullException.ThrowIfNull(productSpec);
+        lock (_gate)
+        {
+            return _hidden.TryGetValue(productSpec, out var set)
+                ? new HashSet<int>(set)
+                : (IReadOnlySet<int>)new HashSet<int>();
+        }
+    }
+
+    /// <summary>
+    /// Builds an <see cref="EcdisDisplaySettings"/> snapshot suitable
+    /// for attaching to a <see cref="RenderContext"/>. The snapshot
+    /// is detached from this state, so subsequent mutations do not
+    /// affect in-flight renders.
+    /// </summary>
+    public EcdisDisplaySettings Snapshot()
+    {
+        lock (_gate)
+        {
+            var copy = _hidden.ToDictionary(
+                kv => kv.Key,
+                kv => (IReadOnlySet<int>)new HashSet<int>(kv.Value),
+                StringComparer.OrdinalIgnoreCase);
+            return new EcdisDisplaySettings
+            {
+                Category = _category,
+                HiddenViewingGroups = copy,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Replaces the entire state from a hydrated settings record
+    /// (used on viewer startup to restore the persisted category and
+    /// per-spec overrides). Raises <see cref="Changed"/> exactly
+    /// once after the swap.
+    /// </summary>
+    public void Hydrate(EcdisDisplayCategory category, IReadOnlyDictionary<string, IReadOnlySet<int>> hidden)
+    {
+        ArgumentNullException.ThrowIfNull(hidden);
+        lock (_gate)
+        {
+            _category = category;
+            _hidden.Clear();
+            foreach (var kv in hidden)
+                _hidden[kv.Key] = new HashSet<int>(kv.Value);
+        }
+        Changed?.Invoke();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -52,6 +52,21 @@ internal sealed class ViewerSettings
     /// <summary>Distance unit used by the map scale bar.</summary>
     public string DistanceUnit { get; set; } = "NauticalMiles";
 
+    /// <summary>
+    /// Active ECDIS display category — one of "DisplayBase",
+    /// "Standard", "OtherInformation", "All". Defaults to Standard
+    /// (S-100 Part 9 §11.7).
+    /// </summary>
+    public string EcdisDisplayCategory { get; set; } = "Standard";
+
+    /// <summary>
+    /// Per-spec viewing-group ids the user has explicitly hidden via
+    /// the ECDIS panel. Keys are spec codes (e.g. "S-101"); values
+    /// are comma-separated viewing-group ids. Empty by default.
+    /// </summary>
+    public Dictionary<string, string> EcdisHiddenViewingGroups { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+
     public bool IsStatusBarVisible { get; set; } = true;
 
     /// <summary>

--- a/tests/EncDotNet.S100.Pipelines.Tests/DisplayModeControllerTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DisplayModeControllerTests.cs
@@ -1,0 +1,123 @@
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class DisplayModeControllerTests
+{
+    [Fact]
+    public void SetActive_NewValue_RaisesChangedAndExposesId()
+    {
+        var c = new DisplayModeController();
+        var raised = 0;
+        c.Changed += () => raised++;
+
+        c.SetActive("DisplayBase");
+
+        Assert.Equal("DisplayBase", c.ActiveDisplayModeId);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void SetActive_RepeatedSameValue_DoesNotRaise()
+    {
+        var c = new DisplayModeController();
+        c.SetActive("Standard");
+
+        var raised = 0;
+        c.Changed += () => raised++;
+
+        c.SetActive("Standard");
+
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void SetActive_Null_ClearsAndRaises()
+    {
+        var c = new DisplayModeController();
+        c.SetActive("Standard");
+
+        var raised = 0;
+        c.Changed += () => raised++;
+
+        c.SetActive(null);
+
+        Assert.Null(c.ActiveDisplayModeId);
+        Assert.Equal(1, raised);
+    }
+}
+
+public class ViewingGroupControllerTests
+{
+    [Fact]
+    public void DefaultState_NoModeNoOverrides_AllVisible()
+    {
+        var v = new ViewingGroupController();
+        Assert.True(v.IsVisible(11010));
+        Assert.True(v.IsVisible(99999));
+    }
+
+    [Fact]
+    public void ActiveModeMembership_OnlyMembersVisible()
+    {
+        var v = new ViewingGroupController();
+        v.SetActiveModeMembership(new HashSet<int> { 1, 2, 3 });
+
+        Assert.True(v.IsVisible(2));
+        Assert.False(v.IsVisible(99));
+    }
+
+    [Fact]
+    public void UserOverride_TrumpsModeMembership()
+    {
+        var v = new ViewingGroupController();
+        v.SetActiveModeMembership(new HashSet<int> { 1 });
+
+        // User overrides 99 (not in membership) ON
+        v.SetUserOverride(99, true);
+        Assert.True(v.IsVisible(99));
+
+        // User overrides 1 (in membership) OFF
+        v.SetUserOverride(1, false);
+        Assert.False(v.IsVisible(1));
+    }
+
+    [Fact]
+    public void ClearUserOverrides_RestoresModeMembership()
+    {
+        var v = new ViewingGroupController();
+        v.SetActiveModeMembership(new HashSet<int> { 1 });
+        v.SetUserOverride(1, false);
+
+        v.ClearUserOverrides();
+
+        Assert.True(v.IsVisible(1));
+    }
+
+    [Fact]
+    public void Changed_FiresOnAllMutations()
+    {
+        var v = new ViewingGroupController();
+        var raised = 0;
+        v.Changed += () => raised++;
+
+        v.SetActiveModeMembership(new HashSet<int> { 1 });
+        v.SetUserOverride(2, true);
+        v.SetUserOverride(2, true); // no-op
+        v.SetUserOverride(2, null); // clear
+        v.ClearUserOverrides();      // already empty after clear -> no-op
+
+        Assert.Equal(3, raised);
+    }
+
+    [Fact]
+    public void SetVisible_IsAliasForUserOverride()
+    {
+        var v = new ViewingGroupController();
+        v.SetActiveModeMembership(new HashSet<int> { 1 });
+
+        v.SetVisible(1, false);
+
+        Assert.False(v.IsVisible(1));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/DisplayModeMembershipTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DisplayModeMembershipTests.cs
@@ -1,0 +1,125 @@
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Portrayals;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class DisplayModeMembershipTests
+{
+    private static PortrayalCatalogue MakeCatalogue() => new()
+    {
+        ProductId = "S-101",
+        Version = "1.2.0",
+        ViewingGroups =
+        [
+            new ViewingGroup { Id = "11010", Description = new Description { Name = "cursor" } },
+            new ViewingGroup { Id = "11020", Description = new Description { Name = "lights" } },
+            new ViewingGroup { Id = "21030", Description = new Description { Name = "buoys" } },
+        ],
+        ViewingGroupLayers =
+        [
+            new ViewingGroupLayer
+            {
+                Id = "1",
+                Description = new Description { Name = "Display Base" },
+                ViewingGroupIds = ["11010"],
+            },
+            new ViewingGroupLayer
+            {
+                Id = "3a",
+                Description = new Description { Name = "Buoys" },
+                ViewingGroupIds = ["21030", "non-numeric"],
+            },
+            new ViewingGroupLayer
+            {
+                Id = "3b",
+                Description = new Description { Name = "Lights" },
+                ViewingGroupIds = ["11020"],
+            },
+        ],
+        DisplayModes =
+        [
+            new DisplayMode
+            {
+                Id = "DisplayBase",
+                Description = new Description { Name = "Display Base" },
+                ViewingGroupLayerIds = ["1"],
+            },
+            new DisplayMode
+            {
+                Id = "StandardDisplay",
+                Description = new Description { Name = "Standard" },
+                ViewingGroupLayerIds = ["1", "3a", "3b", "missing-layer"],
+            },
+        ],
+    };
+
+    [Fact]
+    public void Resolve_DisplayBase_ReturnsBaseLayerVgs()
+    {
+        var set = DisplayModeMembership.Resolve(MakeCatalogue(), "DisplayBase");
+
+        Assert.Equal(new[] { 11010 }, set);
+    }
+
+    [Fact]
+    public void Resolve_StandardDisplay_AggregatesAllLayers_SkipsMissingAndNonNumeric()
+    {
+        var set = DisplayModeMembership.Resolve(MakeCatalogue(), "StandardDisplay");
+
+        Assert.Equal(new HashSet<int> { 11010, 11020, 21030 }, set);
+    }
+
+    [Fact]
+    public void Resolve_UnknownMode_ReturnsEmpty()
+    {
+        var set = DisplayModeMembership.Resolve(MakeCatalogue(), "DoesNotExist");
+
+        Assert.Empty(set);
+    }
+
+    [Fact]
+    public void Bind_DisplayModeChange_UpdatesViewingGroupController()
+    {
+        var catalogue = MakeCatalogue();
+        var vg = new ViewingGroupController();
+        var dm = new DisplayModeController();
+
+        DisplayModeMembership.Bind(dm, vg, catalogue);
+
+        // Initial state: no mode → all visible.
+        Assert.True(vg.IsVisible(99999));
+
+        dm.SetActive("DisplayBase");
+        Assert.True(vg.IsVisible(11010));
+        Assert.False(vg.IsVisible(11020));
+        Assert.False(vg.IsVisible(21030));
+
+        dm.SetActive("StandardDisplay");
+        Assert.True(vg.IsVisible(11010));
+        Assert.True(vg.IsVisible(11020));
+        Assert.True(vg.IsVisible(21030));
+
+        dm.SetActive(null);
+        Assert.True(vg.IsVisible(11010));
+        Assert.True(vg.IsVisible(99999));
+    }
+
+    [Fact]
+    public void Bind_PreservesUserOverridesAcrossModeChanges()
+    {
+        var catalogue = MakeCatalogue();
+        var vg = new ViewingGroupController();
+        var dm = new DisplayModeController();
+        DisplayModeMembership.Bind(dm, vg, catalogue);
+
+        dm.SetActive("DisplayBase");
+        vg.SetUserOverride(11020, true);   // force-on
+        vg.SetUserOverride(11010, false);  // force-off
+
+        dm.SetActive("StandardDisplay");
+
+        Assert.True(vg.IsVisible(11020));   // override still on
+        Assert.False(vg.IsVisible(11010));  // override still off
+        Assert.True(vg.IsVisible(21030));   // mode-driven, no override
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/EcdisCategoryMapperTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/EcdisCategoryMapperTests.cs
@@ -1,0 +1,99 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Cross-spec ECDIS category mapping (S-100 Part 9 §11.7).
+/// </summary>
+public class EcdisCategoryMapperTests
+{
+    private static IReadOnlySet<string> Modes(params string[] ids) =>
+        new HashSet<string>(ids, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void All_AlwaysMapsToNull()
+    {
+        Assert.Null(EcdisCategoryMapper.Map("S-101", EcdisDisplayCategory.All,
+            Modes("DisplayBase", "StandardDisplay", "OtherInformation")));
+        Assert.Null(EcdisCategoryMapper.Map("S-122", EcdisDisplayCategory.All, Modes("StandardDisplay")));
+    }
+
+    [Theory]
+    [InlineData(EcdisDisplayCategory.DisplayBase, "DisplayBase")]
+    [InlineData(EcdisDisplayCategory.Standard, "StandardDisplay")]
+    [InlineData(EcdisDisplayCategory.OtherInformation, "OtherInformation")]
+    public void S101_AllCategoriesResolveToCanonicalNames(EcdisDisplayCategory cat, string expected)
+    {
+        var modes = Modes("DisplayBase", "StandardDisplay", "OtherInformation");
+        Assert.Equal(expected, EcdisCategoryMapper.Map("S-101", cat, modes));
+    }
+
+    [Fact]
+    public void SpecWithOnlyStandard_DisplayBaseAndOther_FallBackToNull()
+    {
+        var modes = Modes("StandardDisplay");
+
+        Assert.Null(EcdisCategoryMapper.Map("S-122", EcdisDisplayCategory.DisplayBase, modes));
+        Assert.Null(EcdisCategoryMapper.Map("S-122", EcdisDisplayCategory.OtherInformation, modes));
+        Assert.Equal("StandardDisplay",
+            EcdisCategoryMapper.Map("S-122", EcdisDisplayCategory.Standard, modes));
+    }
+
+    [Fact]
+    public void SpecWithNoModes_AllCategoriesFallBackToNull()
+    {
+        var none = Modes();
+
+        Assert.Null(EcdisCategoryMapper.Map("S-411", EcdisDisplayCategory.DisplayBase, none));
+        Assert.Null(EcdisCategoryMapper.Map("S-411", EcdisDisplayCategory.Standard, none));
+        Assert.Null(EcdisCategoryMapper.Map("S-411", EcdisDisplayCategory.OtherInformation, none));
+        Assert.Null(EcdisCategoryMapper.Map("S-411", EcdisDisplayCategory.All, none));
+    }
+}
+
+public class EcdisDisplayExtensionsTests
+{
+    [Fact]
+    public async Task ApplyTo_ChangesActiveModeAndUserOverridesOnS101Catalogue()
+    {
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var provider = await PortrayalCatalogueProvider.OpenAsync(pcSource);
+        var catalogue = new EncDotNet.S100.Datasets.S101.S101PortrayalCatalogue(provider);
+
+        var settings = new EcdisDisplaySettings
+        {
+            Category = EcdisDisplayCategory.DisplayBase,
+            HiddenViewingGroups = new Dictionary<string, IReadOnlySet<int>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["S-101"] = new HashSet<int> { 11010 },
+            },
+        };
+
+        settings.ApplyTo(catalogue);
+
+        Assert.Equal("DisplayBase", catalogue.DisplayModes.ActiveDisplayModeId);
+        Assert.NotNull(catalogue.ViewingGroups.ActiveModeMembership);
+        // The user override wins over the mode membership.
+        Assert.False(catalogue.ViewingGroups.IsVisible(11010));
+    }
+
+    [Fact]
+    public async Task ApplyTo_AllCategory_ClearsModeFilter()
+    {
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var provider = await PortrayalCatalogueProvider.OpenAsync(pcSource);
+        var catalogue = new EncDotNet.S100.Datasets.S101.S101PortrayalCatalogue(provider);
+
+        // Pre-set to DisplayBase to prove ApplyTo can return us to "All".
+        catalogue.DisplayModes.SetActive("DisplayBase");
+        Assert.NotNull(catalogue.ViewingGroups.ActiveModeMembership);
+
+        new EcdisDisplaySettings { Category = EcdisDisplayCategory.All }.ApplyTo(catalogue);
+
+        Assert.Null(catalogue.DisplayModes.ActiveDisplayModeId);
+        Assert.Null(catalogue.ViewingGroups.ActiveModeMembership);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
@@ -269,6 +269,8 @@ public class S101PipelineTests
         public IReadOnlyList<PortrayalRule> Rules { get; }
         public ViewingGroupController ViewingGroups { get; }
 
+        public DisplayModeController DisplayModes { get; } = new();
+
         public XslCompiledTransform GetCompiledRule(string ruleName) =>
             _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PortrayalCatalogueDisplayModeTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PortrayalCatalogueDisplayModeTests.cs
@@ -1,0 +1,68 @@
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Integration test verifying that the bundled S-101 portrayal
+/// catalogue declares S-100 Part 9 §11.7 display modes with non-empty
+/// viewing-group membership and that the per-spec catalogue's
+/// <see cref="DisplayModeController"/> drives its
+/// <see cref="ViewingGroupController"/> when the active mode changes.
+/// </summary>
+public class S101PortrayalCatalogueDisplayModeTests
+{
+    [Fact]
+    public async Task DisplayBase_ResolvedMembership_NonEmpty_AndDrivesViewingGroups()
+    {
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var provider = await PortrayalCatalogueProvider.OpenAsync(pcSource);
+        var catalogue = new S101PortrayalCatalogue(provider);
+
+        // The bundled S-101 PC must declare the three ECDIS modes.
+        var modeIds = provider.Catalogue.DisplayModes.Select(m => m.Id).ToList();
+        Assert.Contains("DisplayBase", modeIds);
+        Assert.Contains("StandardDisplay", modeIds);
+        Assert.Contains("OtherInformation", modeIds);
+
+        // Switching to DisplayBase resolves to a non-empty VG set.
+        catalogue.DisplayModes.SetActive("DisplayBase");
+        var baseSet = DisplayModeMembership.Resolve(provider.Catalogue, "DisplayBase");
+        Assert.NotEmpty(baseSet);
+
+        // Catalogue's ViewingGroupController matches resolved membership.
+        Assert.Equal(baseSet, catalogue.ViewingGroups.ActiveModeMembership);
+
+        // A VG inside DisplayBase is visible; a VG that's only in
+        // StandardDisplay is hidden under DisplayBase.
+        var standardSet = DisplayModeMembership.Resolve(provider.Catalogue, "StandardDisplay");
+        var onlyInStandard = standardSet.Except(baseSet).FirstOrDefault();
+        if (onlyInStandard != 0)
+        {
+            Assert.True(catalogue.ViewingGroups.IsVisible(baseSet.First()));
+            Assert.False(catalogue.ViewingGroups.IsVisible(onlyInStandard));
+        }
+
+        // Switching back to "no mode" restores all-visible.
+        catalogue.DisplayModes.SetActive(null);
+        Assert.Null(catalogue.ViewingGroups.ActiveModeMembership);
+        Assert.True(catalogue.ViewingGroups.IsVisible(99999));
+    }
+
+    [Fact]
+    public async Task StandardDisplay_IsSupersetOf_DisplayBase()
+    {
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var provider = await PortrayalCatalogueProvider.OpenAsync(pcSource);
+
+        var baseSet = DisplayModeMembership.Resolve(provider.Catalogue, "DisplayBase");
+        var stdSet = DisplayModeMembership.Resolve(provider.Catalogue, "StandardDisplay");
+
+        Assert.NotEmpty(baseSet);
+        Assert.NotEmpty(stdSet);
+        Assert.True(baseSet.IsSubsetOf(stdSet),
+            "DisplayBase membership should be a subset of StandardDisplay (S-100 Part 9 §11.7).");
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
@@ -534,6 +534,8 @@ public class VectorPipelineTests
         public IReadOnlyList<PortrayalRule> Rules { get; }
         public ViewingGroupController ViewingGroups { get; }
 
+        public DisplayModeController DisplayModes { get; } = new();
+
         public XslCompiledTransform GetCompiledRule(string ruleName) =>
             _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
 

--- a/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayStateTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayStateTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.IO;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class EcdisDisplayStateTests
+{
+    [Fact]
+    public void DefaultsToStandardWithNoOverrides()
+    {
+        var state = new EcdisDisplayState();
+        Assert.Equal(EcdisDisplayCategory.Standard, state.Category);
+        Assert.Empty(state.GetHidden("S-101"));
+    }
+
+    [Fact]
+    public void SetCategory_RaisesChangedOnceOnRealMutation()
+    {
+        var state = new EcdisDisplayState();
+        var raised = 0;
+        state.Changed += () => raised++;
+
+        state.SetCategory(EcdisDisplayCategory.DisplayBase);
+        state.SetCategory(EcdisDisplayCategory.DisplayBase); // no-op
+
+        Assert.Equal(1, raised);
+        Assert.Equal(EcdisDisplayCategory.DisplayBase, state.Category);
+    }
+
+    [Fact]
+    public void HideThenShow_TogglesVisibilityAndRaisesChanged()
+    {
+        var state = new EcdisDisplayState();
+        var raised = 0;
+        state.Changed += () => raised++;
+
+        state.HideViewingGroup("S-101", 11010);
+        state.HideViewingGroup("S-101", 11010); // no-op duplicate
+        Assert.Contains(11010, state.GetHidden("S-101"));
+
+        state.ShowViewingGroup("S-101", 11010);
+        Assert.Empty(state.GetHidden("S-101"));
+
+        Assert.Equal(2, raised);
+    }
+
+    [Fact]
+    public void Snapshot_DetachedFromMutations()
+    {
+        var state = new EcdisDisplayState();
+        state.SetCategory(EcdisDisplayCategory.OtherInformation);
+        state.HideViewingGroup("S-101", 100);
+
+        var snap = state.Snapshot();
+
+        state.SetCategory(EcdisDisplayCategory.All);
+        state.HideViewingGroup("S-101", 200);
+
+        Assert.Equal(EcdisDisplayCategory.OtherInformation, snap.Category);
+        Assert.Equal(new HashSet<int> { 100 }, snap.HiddenViewingGroups["S-101"]);
+    }
+
+    [Fact]
+    public void ClearAllOverrides_RemovesEveryHiddenGroup()
+    {
+        var state = new EcdisDisplayState();
+        state.HideViewingGroup("S-101", 1);
+        state.HideViewingGroup("S-122", 2);
+
+        state.ClearAllOverrides();
+
+        Assert.Empty(state.GetHidden("S-101"));
+        Assert.Empty(state.GetHidden("S-122"));
+    }
+
+    [Fact]
+    public void Hydrate_RestoresStateAndRaisesChangedOnce()
+    {
+        var state = new EcdisDisplayState();
+        var raised = 0;
+        state.Changed += () => raised++;
+
+        var hidden = new Dictionary<string, IReadOnlySet<int>>
+        {
+            ["S-101"] = new HashSet<int> { 11010, 11020 },
+        };
+
+        state.Hydrate(EcdisDisplayCategory.DisplayBase, hidden);
+
+        Assert.Equal(EcdisDisplayCategory.DisplayBase, state.Category);
+        Assert.Equal(new HashSet<int> { 11010, 11020 }, state.GetHidden("S-101"));
+        Assert.Equal(1, raised);
+    }
+}
+
+public class ViewerSettingsEcdisRoundTripTests
+{
+    [Fact]
+    public void EcdisFields_RoundTripThroughLoadSave()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "ecdis-rt-" + Path.GetRandomFileName() + ".json");
+        try
+        {
+            var s1 = new ViewerSettings { SettingsFilePath = path };
+            s1.EcdisDisplayCategory = "DisplayBase";
+            s1.EcdisHiddenViewingGroups["S-101"] = "11010,11020";
+            s1.EcdisHiddenViewingGroups["S-122"] = "200";
+            s1.Save();
+
+            var s2 = ViewerSettings.Load(path);
+            Assert.Equal("DisplayBase", s2.EcdisDisplayCategory);
+            Assert.Equal("11010,11020", s2.EcdisHiddenViewingGroups["S-101"]);
+            Assert.Equal("200", s2.EcdisHiddenViewingGroups["S-122"]);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
Foundation slice of "ECDIS Display Controls — PR α". Completes the
plumbing required for the cross-spec **Display Mode** selection and
per-spec **Viewing-Group Layer** overrides described in the original
plan. UI work (toolbar pill + ECDIS panel + telemetry) lands in a
follow-up PR so this one stays reviewable.

## Summary

This change wires every per-spec vector portrayal catalogue to honour
the four S-100 Part 9 §11.7 standard display categories
(Display Base / Standard / Other Information / All) and to accept
per-spec viewing-group user overrides. The viewer carries the active
category and overrides on a singleton, persists them in
`ViewerSettings`, and re-renders all loaded datasets when either
changes. There is no UI yet — the active state defaults to Standard
and every category resolves correctly through the existing
`VectorPipeline.ApplyViewingGroups` filter.

## What's done (ed1, ed2, ed3, ed6 from the plan)

### Pipeline (`EncDotNet.S100.Core` + `EncDotNet.S100.Portrayals`)

- **`DisplayModeController`** (new) — sibling of
  `ViewingGroupController`. Holds `ActiveDisplayModeId`,
  `DeclaredModeIds`, `SetActive(string?)`, `Changed` event.
- **`ViewingGroupController`** (rewritten) — layered visibility:
  `IsVisible(g) = userOverrides[g] ?? (membership is null || membership.Contains(g))`.
  New: `SetActiveModeMembership`, `SetUserOverride`,
  `ClearUserOverrides`, `Changed` event. Pre-existing
  `SetVisible`/`GroupVisibility` kept as compat aliases.
- **`DisplayModeMembership.Resolve`** (new) — walks
  `displayMode → viewingGroupLayer → viewingGroup` to produce the
  integer VG set for a given mode id.
- **`DisplayModeMembership.Bind`** (new) — wires a
  `DisplayModeController` to a `ViewingGroupController` against a
  parsed catalogue. Treats a mode id not declared by the catalogue
  as **null membership** (= no filter) rather than empty membership,
  so cross-spec category mapping degrades gracefully on specs that
  ship only `StandardDisplay`.
- **`IVectorPortrayalCatalogue.DisplayModes`** added; every per-spec
  catalogue (S-101, S-122, S-124, S-125, S-127, S-128, S-129, S-411,
  S-421) now constructs and binds a `DisplayModeController` in its
  constructor.

### Cross-spec orchestration (`EncDotNet.S100.Datasets.Pipelines`)

- **`EcdisDisplayCategory`** enum (`DisplayBase`, `Standard`,
  `OtherInformation`, `All`).
- **`EcdisDisplaySettings`** record on `RenderContext` carries the
  active category plus per-spec hidden VG ids.
- **`EcdisCategoryMapper.Map`** — resolves cross-spec category to a
  per-spec mode id; falls back to `null` for `All` and for specs
  whose catalogue doesn't declare the requested category.
- **`EcdisDisplayExtensions.ApplyTo`** — every vector dataset
  processor calls `context?.EcdisDisplay?.ApplyTo(catalogue)`
  immediately after constructing its `S{nnn}PortrayalCatalogue` to
  set the mode and write hidden-VG overrides.

### Viewer state + persistence (`EncDotNet.S100.Viewer`)

- **`EcdisDisplayState`** (new singleton) — thread-safe; raises
  `Changed` on category/override mutations; provides `Snapshot()`
  for in-flight render isolation and `Hydrate(...)` for startup.
- **`DatasetLoaderService`** subscribes to `EcdisDisplayState.Changed`
  and re-renders all loaded datasets via the existing
  `ReRenderAllAsync()` path, mirroring the palette/scale wiring.
- **`ViewerSettings`** gains `EcdisDisplayCategory` (string) and
  `EcdisHiddenViewingGroups` (per-spec, comma-separated VG ids).
  `App.axaml.cs` hydrates `EcdisDisplayState` on startup and saves
  on every mutation.

## Tests

25 new tests, all passing. Full solution: 0 failures.

- `DisplayModeControllerTests` — state machine + `Changed` semantics.
- `ViewingGroupControllerTests` — base mode + override layering;
  `Changed` firing only on real mutations.
- `DisplayModeMembershipTests` — `Resolve` over a synthetic
  catalogue (skips non-numeric VG ids and missing layers); `Bind`
  preserves user overrides across mode changes.
- `S101PortrayalCatalogueDisplayModeTests` — integration against
  the bundled S-101 PC: `DisplayBase` resolves to a non-empty set,
  `StandardDisplay` is a strict superset (S-100 Part 9 §11.7), and
  switching modes drives the catalogue's `ViewingGroupController`.
- `EcdisCategoryMapperTests` — All maps to null; S-101 resolves
  every category; specs with only Standard fall back to null.
- `EcdisDisplayExtensionsTests` — `ApplyTo` flips the active mode
  and applies per-spec hidden-VG overrides on a real S-101 catalogue.
- `EcdisDisplayStateTests` — defaults, `Changed` fires once per real
  mutation, `Snapshot` is detached, `Hydrate` raises once.
- `ViewerSettingsEcdisRoundTripTests` — JSON round-trip of the new
  fields.

## What's deferred

Tracked in the plan; scheduled for follow-up PRs:

- **ed4** — Display toolbar pill + flyout (compact UX).
- **ed5** — Full ECDIS panel with per-spec VG layer trees,
  tri-state checkboxes, per-pane and global "Reset overrides".
- **ed7** — `display.mode.changed` and `viewinggroup.toggled`
  telemetry spans + counters.

The defaults in this PR mean shipping it has zero observable
behaviour change for existing users (Category = Standard, no
overrides). The follow-up PR adds the controls that surface this
plumbing to the user.

## Spec citations

- S-100 Edition 5.2.1 Part 9 §11.7 — display mode definition.
- S-101 §10.4 — Display Base / Standard / Other Information
  category authoring.