### PR TITLE
Add ECDIS display toolbar pill, panel, and telemetry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- EncDotNet -->
-    <PackageVersion Include="EncDotNet.Iso8211" Version="0.4.0" />
+    <PackageVersion Include="EncDotNet.Iso8211" Version="0.4.1" />
     <PackageVersion Include="EncDotNet.S57" Version="0.4.0" />
     <!-- Mapping / rendering -->
     <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.323" />

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -13,6 +13,22 @@ This library reads S-101 datasets encoded in ISO 8211 format and executes the S-
 - **`S101VectorSource`** — `IVectorSource` implementation for the vector pipeline.
 - **`DrawingInstructionParser`** — parses the semicolon-separated key:value strings emitted by the Lua portrayal pipeline into the unified `DrawingInstruction` hierarchy from `EncDotNet.S100.Core`. Honours text alignment (`TextAlignHorizontal` / `TextAlignVertical`), mm offsets (`LocalOffset`), foreground / background colour with optional transparency, line placement, and the `AugmentedPoint:GeographicCRS,…` anchor override used by SOUNDG / DepthNoBottomFound rules. Augmented line geometry (`AugmentedRay`, `ArcByRadius`, `AugmentedPath`) is recognised but not yet rendered — sector lights and all-around-light circles will log a warning.
 
+## Record types
+
+`S101DocumentReader` parses the following ISO 8211 record types:
+
+| Tag | Record type | Notes |
+|-----|-------------|-------|
+| DSID | Dataset identification | Version, edition, product spec |
+| DSSI | Dataset structure info | COMF / SOMF scaling factors |
+| PRID | Point | Single 2D coordinate |
+| MRID | MultiPoint | 3D sounding arrays via C3IL field (VCID leader + YCOO/XCOO/ZCOO repeating group) |
+| CRID | Curve segment | Ordered coordinate sequences |
+| CCID | Composite curve | References to curve segments |
+| SRID | Surface | Ring-based polygon geometry |
+| FRID | Feature | Object class, attributes, spatial associations |
+| IRID | Information type | Metadata records referenced by features |
+
 ## Installation
 
 ```sh

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
@@ -244,11 +244,9 @@ internal static class S101DocumentReader
     /// sounding coordinates (S-100 Part 10a §10a-5.6).
     /// </summary>
     /// <remarks>
-    /// The C3IL field uses format <c>(b11,3b24)</c>: a 1-byte VCID leader
-    /// followed by three 4-byte signed integers (YCOO, XCOO, ZCOO) per point.
-    /// The EncDotNet.Iso8211 library does not fully split the concatenated
-    /// array descriptor (<c>VCID*YCOO!XCOO!ZCOO</c>), so coordinates are
-    /// parsed directly from the raw binary data.
+    /// The C3IL field uses concatenated array descriptor <c>VCID*YCOO!XCOO!ZCOO</c>
+    /// with format <c>(b11,3b24)</c>: a 1-byte VCID leader followed by repeating
+    /// groups of three 4-byte signed integers (YCOO, XCOO, ZCOO) per sounding point.
     /// </remarks>
     private static S101MultiPointRecord? ParseMultiPoint(Iso8211Record record, Iso8211DataDescriptiveRecord ddr)
     {
@@ -259,21 +257,18 @@ internal static class S101DocumentReader
         var mridReader = new Iso8211FieldReader(mridDef, mridField.Data);
         var rcid = mridReader.GetSubfield<uint>("RCID");
 
-        // C3IL — 3D coordinate list: 1-byte VCID + 3×4-byte signed (Y, X, Z) per point
-        const int bytesPerPoint = 1 + 4 + 4 + 4; // VCID(b11) + YCOO(b24) + XCOO(b24) + ZCOO(b24)
         var coords = ImmutableArray.CreateBuilder<(int Y, int X, int Z)>();
         var c3ilField = record.GetFieldByTag("C3IL");
         if (c3ilField is not null)
         {
-            var data = c3ilField.Data;
-            int pointCount = data.Length / bytesPerPoint;
-            for (int i = 0; i < pointCount; i++)
+            var c3ilDef = ddr.GetFieldDefinition("C3IL")!;
+            var c3ilReader = new Iso8211FieldReader(c3ilDef, c3ilField.Data);
+
+            foreach (var group in c3ilReader.GetSubfieldGroups())
             {
-                int offset = i * bytesPerPoint;
-                // Skip VCID (1 byte), then read YCOO, XCOO, ZCOO as signed 32-bit LE
-                int cy = BitConverter.ToInt32(data, offset + 1);
-                int cx = BitConverter.ToInt32(data, offset + 5);
-                int cz = BitConverter.ToInt32(data, offset + 9);
+                var cy = group.GetSubfield<int>("YCOO");
+                var cx = group.GetSubfield<int>("XCOO");
+                var cz = group.GetSubfield<int>("ZCOO");
                 coords.Add((cy, cx, cz));
             }
         }

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
@@ -38,6 +38,7 @@ internal static class S101DocumentReader
         var featureAssociationCatalogue = ImmutableDictionary.CreateBuilder<ushort, string>();
         var roleCatalogue = ImmutableDictionary.CreateBuilder<ushort, string>();
         var points = ImmutableDictionary.CreateBuilder<uint, S101PointRecord>();
+        var multiPoints = ImmutableDictionary.CreateBuilder<uint, S101MultiPointRecord>();
         var curveSegments = ImmutableDictionary.CreateBuilder<uint, S101CurveSegmentRecord>();
         var compositeCurves = ImmutableDictionary.CreateBuilder<uint, S101CompositeCurveRecord>();
         var surfaces = ImmutableDictionary.CreateBuilder<uint, S101SurfaceRecord>();
@@ -62,6 +63,12 @@ internal static class S101DocumentReader
                     var pt = ParsePoint(record, ddr);
                     if (pt is not null)
                         points[pt.RecordId] = pt;
+                    break;
+
+                case "MRID":
+                    var mpt = ParseMultiPoint(record, ddr);
+                    if (mpt is not null)
+                        multiPoints[mpt.RecordId] = mpt;
                     break;
 
                 case "CRID":
@@ -115,6 +122,7 @@ internal static class S101DocumentReader
             FeatureTypeCatalogue = featureTypeCatalogue.ToImmutable(),
             AttributeTypeCatalogue = attributeTypeCatalogue.ToImmutable(),
             Points = points.ToImmutable(),
+            MultiPoints = multiPoints.ToImmutable(),
             CurveSegments = curveSegments.ToImmutable(),
             CompositeCurves = compositeCurves.ToImmutable(),
             Surfaces = surfaces.ToImmutable(),
@@ -229,6 +237,52 @@ internal static class S101DocumentReader
         }
 
         return new S101PointRecord { RecordId = rcid, Y = y, X = x };
+    }
+
+    /// <summary>
+    /// Parses an MRID (MultiPoint Record IDentifier) record containing 3D
+    /// sounding coordinates (S-100 Part 10a §10a-5.6).
+    /// </summary>
+    /// <remarks>
+    /// The C3IL field uses format <c>(b11,3b24)</c>: a 1-byte VCID leader
+    /// followed by three 4-byte signed integers (YCOO, XCOO, ZCOO) per point.
+    /// The EncDotNet.Iso8211 library does not fully split the concatenated
+    /// array descriptor (<c>VCID*YCOO!XCOO!ZCOO</c>), so coordinates are
+    /// parsed directly from the raw binary data.
+    /// </remarks>
+    private static S101MultiPointRecord? ParseMultiPoint(Iso8211Record record, Iso8211DataDescriptiveRecord ddr)
+    {
+        var mridField = record.GetFieldByTag("MRID");
+        if (mridField is null) return null;
+
+        var mridDef = ddr.GetFieldDefinition("MRID")!;
+        var mridReader = new Iso8211FieldReader(mridDef, mridField.Data);
+        var rcid = mridReader.GetSubfield<uint>("RCID");
+
+        // C3IL — 3D coordinate list: 1-byte VCID + 3×4-byte signed (Y, X, Z) per point
+        const int bytesPerPoint = 1 + 4 + 4 + 4; // VCID(b11) + YCOO(b24) + XCOO(b24) + ZCOO(b24)
+        var coords = ImmutableArray.CreateBuilder<(int Y, int X, int Z)>();
+        var c3ilField = record.GetFieldByTag("C3IL");
+        if (c3ilField is not null)
+        {
+            var data = c3ilField.Data;
+            int pointCount = data.Length / bytesPerPoint;
+            for (int i = 0; i < pointCount; i++)
+            {
+                int offset = i * bytesPerPoint;
+                // Skip VCID (1 byte), then read YCOO, XCOO, ZCOO as signed 32-bit LE
+                int cy = BitConverter.ToInt32(data, offset + 1);
+                int cx = BitConverter.ToInt32(data, offset + 5);
+                int cz = BitConverter.ToInt32(data, offset + 9);
+                coords.Add((cy, cx, cz));
+            }
+        }
+
+        return new S101MultiPointRecord
+        {
+            RecordId = rcid,
+            Points = coords.ToImmutable(),
+        };
     }
 
     private static S101CurveSegmentRecord? ParseCurveSegment(Iso8211Record record, Iso8211DataDescriptiveRecord ddr)

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -177,6 +177,8 @@ public partial class App : Application
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<PickReportViewModel>();
         services.AddSingleton<TimelineViewModel>();
+        services.AddSingleton<DisplayToolbarViewModel>();
+        services.AddSingleton<EcdisDisplayPanelViewModel>();
         services.AddSingleton<MainViewModel>();
 
         // Main window — receives only the StartupOptions plus the small set

--- a/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
@@ -24,4 +24,9 @@ internal static class Telemetry
             "s100.viewer.command.duration",
             unit: "ms",
             description: "Wall-clock duration of a top-level viewer command.");
+
+    public static readonly Counter<long> ViewingGroupToggled =
+        Meter.CreateCounter<long>(
+            "s100.viewer.viewinggroup.toggled",
+            description: "Number of times a user toggled a viewing-group override.");
 }

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -278,6 +278,23 @@
                             <ic:FluentIcon Icon="Search" IconVariant="Regular" FontSize="22" />
                         </ToggleButton>
                     </Grid>
+
+                    <!-- ECDIS Display Controls -->
+                    <Grid>
+                        <Border Width="3" HorizontalAlignment="Left"
+                                Background="{DynamicResource AccentBrush}"
+                                IsVisible="{Binding IsEcdisDisplaySelected}" />
+                        <ToggleButton Classes="ActivityIcon"
+                                      IsChecked="{Binding IsEcdisDisplaySelected, Mode=OneWay}"
+                                      Command="{Binding SelectEcdisDisplayCommand}"
+                                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_EcdisDisplay}"
+                                      Height="48"
+                                      Padding="0"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center">
+                            <ic:FluentIcon Icon="Eye" IconVariant="Regular" FontSize="22" />
+                        </ToggleButton>
+                    </Grid>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -328,6 +345,8 @@
                                                  IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsSearchSelected}" />
                         <views:SettingsView DataContext="{Binding Settings}"
                                             IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsSettingsSelected}" />
+                        <views:EcdisDisplayPanelView DataContext="{Binding EcdisDisplayPanel}"
+                                                     IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsEcdisDisplaySelected}" />
                     </Panel>
                 </DockPanel>
             </Border>
@@ -449,6 +468,53 @@
                         </Button.Styles>
                         <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
                     </Button>
+                    <!--
+                      Display category pill — compact label that opens
+                      a flyout to switch between ECDIS display categories.
+                    -->
+                    <Button Classes="MapOverlay"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayMode}"
+                            Padding="8,4"
+                            FontSize="11"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Content="{Binding DisplayToolbar.ActiveCategoryLabel}">
+                        <Button.Flyout>
+                            <Flyout Placement="BottomEdgeAlignedRight">
+                                <StackPanel Spacing="4" MinWidth="160">
+                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_DisplayBase}"
+                                                 IsChecked="{Binding DisplayToolbar.IsDisplayBase, Mode=OneWay}"
+                                                 GroupName="DisplayCategoryFlyout">
+                                        <RadioButton.Command>
+                                            <Binding Path="DisplayToolbar.SetDisplayBaseCommand" />
+                                        </RadioButton.Command>
+                                    </RadioButton>
+                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_Standard}"
+                                                 IsChecked="{Binding DisplayToolbar.IsStandard, Mode=OneWay}"
+                                                 GroupName="DisplayCategoryFlyout">
+                                        <RadioButton.Command>
+                                            <Binding Path="DisplayToolbar.SetStandardCommand" />
+                                        </RadioButton.Command>
+                                    </RadioButton>
+                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_OtherInformation}"
+                                                 IsChecked="{Binding DisplayToolbar.IsOtherInformation, Mode=OneWay}"
+                                                 GroupName="DisplayCategoryFlyout">
+                                        <RadioButton.Command>
+                                            <Binding Path="DisplayToolbar.SetOtherInformationCommand" />
+                                        </RadioButton.Command>
+                                    </RadioButton>
+                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_All}"
+                                                 IsChecked="{Binding DisplayToolbar.IsAll, Mode=OneWay}"
+                                                 GroupName="DisplayCategoryFlyout">
+                                        <RadioButton.Command>
+                                            <Binding Path="DisplayToolbar.SetAllCommand" />
+                                        </RadioButton.Command>
+                                    </RadioButton>
+                                </StackPanel>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
+
                     <!--
                       Zoom in / out / to-extent group. Wrapping in an inner
                       StackPanel with vertical margin gives the cluster its

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -71,6 +71,35 @@ All visibility / opacity / order changes drive Mapsui's per-layer
 `Enabled`, `Opacity`, and stack position directly — they apply
 immediately and do not re-run the dataset pipeline.
 
+## ECDIS Display Controls
+
+The viewer exposes S-100 Part 9A display-category filtering and
+per-spec viewing-group overrides through two UI surfaces:
+
+### Display toolbar pill
+
+A compact pill button in the map toolbar shows the active
+**display category** (Display Base, Standard, Other Information,
+or All). Clicking the pill opens a flyout with radio buttons to
+switch categories; the change propagates through `EcdisDisplayState`
+and triggers a re-render of all vector datasets.
+
+### ECDIS panel (activity bar)
+
+A dedicated activity-bar entry opens the ECDIS Display Controls
+panel. It lists each loaded **vector** product specification
+(S-101, S-122, S-124, S-125, S-127, S-128, S-129, S-411, S-421)
+with a flat checkbox list of viewing groups sourced from the spec's
+portrayal catalogue. Unchecking a viewing group hides its features
+from the rendered output.
+
+Coverage products (S-102, S-104, S-111) have no viewing-group
+concept and are excluded from the panel.
+
+Per-spec and global "Reset overrides" buttons clear any
+user-hidden viewing groups. Override state is persisted in
+`settings.json` and restored on launch.
+
 ## Time-varying datasets and the global time slider
 
 Three product specifications carry a time dimension:

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -199,6 +199,23 @@ internal static class Strings
 
     // Measure Mode
     public static string Tooltip_MeasureMode => Get(nameof(Tooltip_MeasureMode));
+
+    // ECDIS Display Controls
+    public static string Pane_EcdisDisplay => Get(nameof(Pane_EcdisDisplay));
+    public static string Tooltip_EcdisDisplay => Get(nameof(Tooltip_EcdisDisplay));
+    public static string Toolbar_DisplayFormat => Get(nameof(Toolbar_DisplayFormat));
+    public static string Tooltip_DisplayMode => Get(nameof(Tooltip_DisplayMode));
+    public static string DisplayCategory_DisplayBase => Get(nameof(DisplayCategory_DisplayBase));
+    public static string DisplayCategory_Standard => Get(nameof(DisplayCategory_Standard));
+    public static string DisplayCategory_OtherInformation => Get(nameof(DisplayCategory_OtherInformation));
+    public static string DisplayCategory_All => Get(nameof(DisplayCategory_All));
+    public static string Button_ResetOverrides => Get(nameof(Button_ResetOverrides));
+    public static string Tooltip_ResetOverrides => Get(nameof(Tooltip_ResetOverrides));
+    public static string Button_ResetAllOverrides => Get(nameof(Button_ResetAllOverrides));
+    public static string Tooltip_ResetAllOverrides => Get(nameof(Tooltip_ResetAllOverrides));
+    public static string EcdisPanel_NoSpecs => Get(nameof(EcdisPanel_NoSpecs));
+    public static string EcdisPanel_OverrideCountFormat => Get(nameof(EcdisPanel_OverrideCountFormat));
+    public static string EcdisPanel_CategoryHeader => Get(nameof(EcdisPanel_CategoryHeader));
     public static string Menu_MeasureMode => Get(nameof(Menu_MeasureMode));
     public static string Status_MeasureLeg => Get(nameof(Status_MeasureLeg));
     public static string Status_MeasureTotal => Get(nameof(Status_MeasureTotal));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -470,6 +470,56 @@ Open an S-128 dataset to populate this panel.</value>
     <value>Latitude and longitude of the cursor on the map</value>
   </data>
 
+  <!-- ECDIS Display Controls -->
+  <data name="Pane_EcdisDisplay" xml:space="preserve">
+    <value>DISPLAY CONTROLS</value>
+  </data>
+  <data name="Tooltip_EcdisDisplay" xml:space="preserve">
+    <value>ECDIS Display Controls</value>
+  </data>
+  <data name="Toolbar_DisplayFormat" xml:space="preserve">
+    <value>Display: {0} ▾</value>
+    <comment>Toolbar pill label; {0} is the active display category name.</comment>
+  </data>
+  <data name="Tooltip_DisplayMode" xml:space="preserve">
+    <value>Change the ECDIS display category</value>
+  </data>
+  <data name="DisplayCategory_DisplayBase" xml:space="preserve">
+    <value>Display Base</value>
+  </data>
+  <data name="DisplayCategory_Standard" xml:space="preserve">
+    <value>Standard</value>
+  </data>
+  <data name="DisplayCategory_OtherInformation" xml:space="preserve">
+    <value>Other Information</value>
+  </data>
+  <data name="DisplayCategory_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="Button_ResetOverrides" xml:space="preserve">
+    <value>Reset overrides</value>
+  </data>
+  <data name="Tooltip_ResetOverrides" xml:space="preserve">
+    <value>Clear all viewing-group overrides for this spec</value>
+  </data>
+  <data name="Button_ResetAllOverrides" xml:space="preserve">
+    <value>Reset all overrides</value>
+  </data>
+  <data name="Tooltip_ResetAllOverrides" xml:space="preserve">
+    <value>Clear all viewing-group overrides across every spec</value>
+  </data>
+  <data name="EcdisPanel_NoSpecs" xml:space="preserve">
+    <value>No vector datasets loaded.
+Open an S-101, S-124, S-125, or S-421 dataset to see display controls here.</value>
+  </data>
+  <data name="EcdisPanel_OverrideCountFormat" xml:space="preserve">
+    <value>{0} overrides</value>
+    <comment>{0} is the count of user-hidden viewing groups for a spec.</comment>
+  </data>
+  <data name="EcdisPanel_CategoryHeader" xml:space="preserve">
+    <value>Display Category</value>
+  </data>
+
   <!-- Measure Mode -->
   <data name="Tooltip_MeasureMode" xml:space="preserve">
     <value>Measure distance and bearing (rhumb line)</value>

--- a/src/EncDotNet.S100.Viewer/ViewModels/ActivityKind.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ActivityKind.cs
@@ -8,4 +8,5 @@ internal enum ActivityKind
     Catalog,
     Search,
     Settings,
+    EcdisDisplay,
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/DisplayToolbarViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DisplayToolbarViewModel.cs
@@ -29,9 +29,16 @@ internal sealed class DisplayToolbarViewModel : ViewModelBase, IDisposable
         SetAllCommand = new RelayCommand(() => SetCategory(EcdisDisplayCategory.All));
     }
 
+    /// <summary>Sets the display category to Display Base.</summary>
     public ICommand SetDisplayBaseCommand { get; }
+
+    /// <summary>Sets the display category to Standard.</summary>
     public ICommand SetStandardCommand { get; }
+
+    /// <summary>Sets the display category to Other Information.</summary>
     public ICommand SetOtherInformationCommand { get; }
+
+    /// <summary>Sets the display category to All.</summary>
     public ICommand SetAllCommand { get; }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/DisplayToolbarViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DisplayToolbarViewModel.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Diagnostics;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Backs the compact display-category pill button overlaid on the map.
+/// Shows the active <see cref="EcdisDisplayCategory"/> and exposes
+/// commands to switch between the four categories.
+/// </summary>
+internal sealed class DisplayToolbarViewModel : ViewModelBase, IDisposable
+{
+    private readonly EcdisDisplayState _state;
+
+    public DisplayToolbarViewModel(EcdisDisplayState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        _state = state;
+        _state.Changed += OnStateChanged;
+
+        SetDisplayBaseCommand = new RelayCommand(() => SetCategory(EcdisDisplayCategory.DisplayBase));
+        SetStandardCommand = new RelayCommand(() => SetCategory(EcdisDisplayCategory.Standard));
+        SetOtherInformationCommand = new RelayCommand(() => SetCategory(EcdisDisplayCategory.OtherInformation));
+        SetAllCommand = new RelayCommand(() => SetCategory(EcdisDisplayCategory.All));
+    }
+
+    public ICommand SetDisplayBaseCommand { get; }
+    public ICommand SetStandardCommand { get; }
+    public ICommand SetOtherInformationCommand { get; }
+    public ICommand SetAllCommand { get; }
+
+    /// <summary>
+    /// Localized label for the toolbar pill, e.g. "Display: Standard ▾".
+    /// </summary>
+    public string ActiveCategoryLabel =>
+        string.Format(Strings.Toolbar_DisplayFormat, CategoryDisplayName(_state.Category));
+
+    /// <summary>
+    /// The active category, suitable for binding radio buttons.
+    /// </summary>
+    public EcdisDisplayCategory ActiveCategory => _state.Category;
+
+    public bool IsDisplayBase => _state.Category == EcdisDisplayCategory.DisplayBase;
+    public bool IsStandard => _state.Category == EcdisDisplayCategory.Standard;
+    public bool IsOtherInformation => _state.Category == EcdisDisplayCategory.OtherInformation;
+    public bool IsAll => _state.Category == EcdisDisplayCategory.All;
+
+    /// <summary>
+    /// Sets the display category and emits telemetry.
+    /// </summary>
+    public void SetCategory(EcdisDisplayCategory category)
+    {
+        if (_state.Category == category) return;
+
+        using var scope = ViewerObservability.BeginCommand("display.mode.changed");
+        scope.SetTag("s100.ecdis.category", category.ToString());
+        _state.SetCategory(category);
+    }
+
+    private void OnStateChanged()
+    {
+        OnPropertyChanged(nameof(ActiveCategoryLabel));
+        OnPropertyChanged(nameof(ActiveCategory));
+        OnPropertyChanged(nameof(IsDisplayBase));
+        OnPropertyChanged(nameof(IsStandard));
+        OnPropertyChanged(nameof(IsOtherInformation));
+        OnPropertyChanged(nameof(IsAll));
+    }
+
+    /// <summary>
+    /// Returns the localized display name for a category.
+    /// </summary>
+    internal static string CategoryDisplayName(EcdisDisplayCategory category) => category switch
+    {
+        EcdisDisplayCategory.DisplayBase => Strings.DisplayCategory_DisplayBase,
+        EcdisDisplayCategory.Standard => Strings.DisplayCategory_Standard,
+        EcdisDisplayCategory.OtherInformation => Strings.DisplayCategory_OtherInformation,
+        EcdisDisplayCategory.All => Strings.DisplayCategory_All,
+        _ => category.ToString(),
+    };
+
+    public void Dispose()
+    {
+        _state.Changed -= OnStateChanged;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/EcdisDisplayPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/EcdisDisplayPanelViewModel.cs
@@ -65,9 +65,16 @@ internal sealed class EcdisDisplayPanelViewModel : ViewModelBase, IDisposable
     /// <summary>Clears all overrides across every spec.</summary>
     public ICommand ResetAllOverridesCommand { get; }
 
+    /// <summary>Sets the display category to Display Base.</summary>
     public ICommand SetDisplayBaseCommand { get; }
+
+    /// <summary>Sets the display category to Standard.</summary>
     public ICommand SetStandardCommand { get; }
+
+    /// <summary>Sets the display category to Other Information.</summary>
     public ICommand SetOtherInformationCommand { get; }
+
+    /// <summary>Sets the display category to All.</summary>
     public ICommand SetAllCommand { get; }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/EcdisDisplayPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/EcdisDisplayPanelViewModel.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Backs the ECDIS Display Controls panel in the activity bar.
+/// Shows a per-spec tree of viewing-group checkboxes sourced from
+/// each loaded vector spec's portrayal catalogue.
+/// </summary>
+internal sealed class EcdisDisplayPanelViewModel : ViewModelBase, IDisposable
+{
+    private readonly EcdisDisplayState _state;
+    private readonly PortrayalCatalogueManager _catalogueManager;
+    private readonly DatasetsViewModel _datasets;
+
+    /// <summary>
+    /// Spec codes for coverage products that have no viewing-group
+    /// concept and should not appear in the ECDIS panel.
+    /// </summary>
+    private static readonly HashSet<string> CoverageSpecs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "S-102", "S-104", "S-111",
+    };
+
+    public EcdisDisplayPanelViewModel(
+        EcdisDisplayState state,
+        PortrayalCatalogueManager catalogueManager,
+        DatasetsViewModel datasets)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(catalogueManager);
+        ArgumentNullException.ThrowIfNull(datasets);
+
+        _state = state;
+        _catalogueManager = catalogueManager;
+        _datasets = datasets;
+
+        ResetAllOverridesCommand = new RelayCommand(() => _state.ClearAllOverrides());
+        SetDisplayBaseCommand = new RelayCommand(() => ActiveCategory = EcdisDisplayCategory.DisplayBase);
+        SetStandardCommand = new RelayCommand(() => ActiveCategory = EcdisDisplayCategory.Standard);
+        SetOtherInformationCommand = new RelayCommand(() => ActiveCategory = EcdisDisplayCategory.OtherInformation);
+        SetAllCommand = new RelayCommand(() => ActiveCategory = EcdisDisplayCategory.All);
+
+        _state.Changed += OnStateChanged;
+        _datasets.Entries.CollectionChanged += OnEntriesChanged;
+
+        RebuildSpecs();
+    }
+
+    /// <summary>Per-spec sections shown in the panel.</summary>
+    public ObservableCollection<EcdisSpecViewModel> Specs { get; } = new();
+
+    /// <summary>True when there are no loaded vector specs.</summary>
+    public bool IsEmpty => Specs.Count == 0;
+
+    /// <summary>Clears all overrides across every spec.</summary>
+    public ICommand ResetAllOverridesCommand { get; }
+
+    public ICommand SetDisplayBaseCommand { get; }
+    public ICommand SetStandardCommand { get; }
+    public ICommand SetOtherInformationCommand { get; }
+    public ICommand SetAllCommand { get; }
+
+    /// <summary>
+    /// The active display category, exposed for binding the category
+    /// radio group at the top of the panel.
+    /// </summary>
+    public EcdisDisplayCategory ActiveCategory
+    {
+        get => _state.Category;
+        set
+        {
+            if (_state.Category != value)
+                _state.SetCategory(value);
+        }
+    }
+
+    public bool IsDisplayBase => _state.Category == EcdisDisplayCategory.DisplayBase;
+    public bool IsStandard => _state.Category == EcdisDisplayCategory.Standard;
+    public bool IsOtherInformation => _state.Category == EcdisDisplayCategory.OtherInformation;
+    public bool IsAll => _state.Category == EcdisDisplayCategory.All;
+
+    private void OnStateChanged()
+    {
+        OnPropertyChanged(nameof(ActiveCategory));
+        OnPropertyChanged(nameof(IsDisplayBase));
+        OnPropertyChanged(nameof(IsStandard));
+        OnPropertyChanged(nameof(IsOtherInformation));
+        OnPropertyChanged(nameof(IsAll));
+        foreach (var spec in Specs)
+            spec.Refresh();
+    }
+
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RebuildSpecs();
+    }
+
+    private void RebuildSpecs()
+    {
+        // Determine which vector specs are currently loaded
+        var loadedSpecs = _datasets.Entries
+            .Select(e => e.ProductSpec)
+            .Where(s => !CoverageSpecs.Contains(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Only rebuild if the set of specs actually changed
+        var existing = Specs.Select(s => s.SpecCode).ToList();
+        if (existing.SequenceEqual(loadedSpecs, StringComparer.OrdinalIgnoreCase))
+            return;
+
+        Specs.Clear();
+        foreach (var spec in loadedSpecs)
+        {
+            if (!_catalogueManager.HasCatalogue(spec)) continue;
+            try
+            {
+                var provider = _catalogueManager.GetProvider(spec);
+                var catalogue = provider.Catalogue;
+                if (catalogue.ViewingGroups.Count > 0)
+                {
+                    Specs.Add(new EcdisSpecViewModel(_state, spec, catalogue));
+                }
+            }
+            catch
+            {
+                // If the catalogue can't be loaded, skip the spec
+            }
+        }
+
+        OnPropertyChanged(nameof(IsEmpty));
+    }
+
+    public void Dispose()
+    {
+        _state.Changed -= OnStateChanged;
+        _datasets.Entries.CollectionChanged -= OnEntriesChanged;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/EcdisSpecViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/EcdisSpecViewModel.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Represents a single product specification in the ECDIS display panel.
+/// Holds a flat list of viewing-group checkboxes and a per-spec reset command.
+/// </summary>
+internal sealed class EcdisSpecViewModel : ViewModelBase
+{
+    private readonly EcdisDisplayState _state;
+
+    public EcdisSpecViewModel(
+        EcdisDisplayState state,
+        string specCode,
+        PortrayalCatalogue catalogue)
+    {
+        _state = state;
+        SpecCode = specCode;
+
+        // Build flat VG list from the catalogue's ViewingGroups collection.
+        var items = new List<EcdisViewingGroupViewModel>();
+        foreach (var vg in catalogue.ViewingGroups)
+        {
+            if (int.TryParse(vg.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+            {
+                items.Add(new EcdisViewingGroupViewModel(state, specCode, id, vg.Description.Name));
+            }
+        }
+        ViewingGroups = items;
+
+        ResetOverridesCommand = new RelayCommand(() => _state.ClearOverridesForSpec(specCode));
+    }
+
+    /// <summary>Product spec code (e.g. "S-101").</summary>
+    public string SpecCode { get; }
+
+    /// <summary>Flat list of viewing-group checkboxes.</summary>
+    public IReadOnlyList<EcdisViewingGroupViewModel> ViewingGroups { get; }
+
+    /// <summary>Number of user-hidden viewing groups for this spec.</summary>
+    public int OverrideCount => _state.GetHidden(SpecCode).Count;
+
+    /// <summary>Formatted override count label (e.g. "3 overrides").</summary>
+    public string OverrideCountLabel =>
+        OverrideCount > 0
+            ? string.Format(Strings.EcdisPanel_OverrideCountFormat, OverrideCount)
+            : string.Empty;
+
+    /// <summary>True when at least one override is active.</summary>
+    public bool HasOverrides => OverrideCount > 0;
+
+    /// <summary>Clears all overrides for this spec.</summary>
+    public ICommand ResetOverridesCommand { get; }
+
+    /// <summary>
+    /// Refreshes the override count and every VG checkbox.
+    /// Called when the global state changes externally.
+    /// </summary>
+    internal void Refresh()
+    {
+        OnPropertyChanged(nameof(OverrideCount));
+        OnPropertyChanged(nameof(OverrideCountLabel));
+        OnPropertyChanged(nameof(HasOverrides));
+        foreach (var vg in ViewingGroups)
+            vg.Refresh();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/EcdisViewingGroupViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/EcdisViewingGroupViewModel.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Viewer.Diagnostics;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Represents a single viewing group in the ECDIS display panel.
+/// The checkbox state reflects whether the group is hidden in
+/// <see cref="EcdisDisplayState"/>.
+/// </summary>
+internal sealed class EcdisViewingGroupViewModel : ViewModelBase
+{
+    private readonly EcdisDisplayState _state;
+    private readonly string _specCode;
+
+    public EcdisViewingGroupViewModel(
+        EcdisDisplayState state,
+        string specCode,
+        int viewingGroupId,
+        string name)
+    {
+        _state = state;
+        _specCode = specCode;
+        Id = viewingGroupId;
+        Name = name;
+    }
+
+    /// <summary>Integer viewing-group id.</summary>
+    public int Id { get; }
+
+    /// <summary>Human-readable name from the portrayal catalogue.</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// True when this viewing group is visible (not in the hidden set).
+    /// Setting to false calls <see cref="EcdisDisplayState.HideViewingGroup"/>;
+    /// setting to true calls <see cref="EcdisDisplayState.ShowViewingGroup"/>.
+    /// </summary>
+    public bool IsVisible
+    {
+        get => !_state.GetHidden(_specCode).Contains(Id);
+        set
+        {
+            if (value)
+                _state.ShowViewingGroup(_specCode, Id);
+            else
+                _state.HideViewingGroup(_specCode, Id);
+
+            Telemetry.ViewingGroupToggled.Add(1,
+                new KeyValuePair<string, object?>("s100.spec", _specCode),
+                new KeyValuePair<string, object?>("s100.viewinggroup", Id));
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the <see cref="IsVisible"/> binding from the current
+    /// state (called when the global state changes externally).
+    /// </summary>
+    internal void Refresh() => OnPropertyChanged(nameof(IsVisible));
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -25,6 +25,8 @@ internal sealed class MainViewModel : ViewModelBase
     public SettingsViewModel Settings { get; }
     public PickReportViewModel PickReport { get; }
     public TimelineViewModel Timeline { get; }
+    public DisplayToolbarViewModel DisplayToolbar { get; }
+    public EcdisDisplayPanelViewModel EcdisDisplayPanel { get; }
 
     private ActivityKind? _selectedActivity;
     public ActivityKind? SelectedActivity
@@ -46,6 +48,7 @@ internal sealed class MainViewModel : ViewModelBase
                 OnPropertyChanged(nameof(IsCatalogSelected));
                 OnPropertyChanged(nameof(IsSearchSelected));
                 OnPropertyChanged(nameof(IsSettingsSelected));
+                OnPropertyChanged(nameof(IsEcdisDisplaySelected));
 
                 // Persist the last selected activity (Settings is transient, don't remember it)
                 _settings.LastSelectedActivity = value is ActivityKind.Settings ? null : value?.ToString();
@@ -64,6 +67,7 @@ internal sealed class MainViewModel : ViewModelBase
         ActivityKind.Catalog => Strings.Pane_Catalog,
         ActivityKind.Search => Strings.Pane_Search,
         ActivityKind.Settings => Strings.Pane_Settings,
+        ActivityKind.EcdisDisplay => Strings.Pane_EcdisDisplay,
         _ => string.Empty,
     };
 
@@ -73,6 +77,7 @@ internal sealed class MainViewModel : ViewModelBase
     public bool IsCatalogSelected => _selectedActivity == ActivityKind.Catalog;
     public bool IsSearchSelected => _selectedActivity == ActivityKind.Search;
     public bool IsSettingsSelected => _selectedActivity == ActivityKind.Settings;
+    public bool IsEcdisDisplaySelected => _selectedActivity == ActivityKind.EcdisDisplay;
 
     public ICommand SelectFeatureCataloguesCommand { get; }
     public ICommand SelectPortrayalCataloguesCommand { get; }
@@ -80,6 +85,7 @@ internal sealed class MainViewModel : ViewModelBase
     public ICommand SelectCatalogCommand { get; }
     public ICommand SelectSearchCommand { get; }
     public ICommand SelectSettingsCommand { get; }
+    public ICommand SelectEcdisDisplayCommand { get; }
     public ICommand TogglePrimarySideBarCommand { get; }
 
     private string? _statusText;
@@ -272,6 +278,8 @@ internal sealed class MainViewModel : ViewModelBase
         SettingsViewModel settingsViewModel,
         PickReportViewModel pickReport,
         TimelineViewModel timeline,
+        DisplayToolbarViewModel displayToolbar,
+        EcdisDisplayPanelViewModel ecdisDisplayPanel,
         IThemeService themeService,
         IRecentFilesService recentFiles,
         IMeasureOverlayAppearanceProvider measureAppearance,
@@ -286,6 +294,8 @@ internal sealed class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(settingsViewModel);
         ArgumentNullException.ThrowIfNull(pickReport);
         ArgumentNullException.ThrowIfNull(timeline);
+        ArgumentNullException.ThrowIfNull(displayToolbar);
+        ArgumentNullException.ThrowIfNull(ecdisDisplayPanel);
         ArgumentNullException.ThrowIfNull(themeService);
         ArgumentNullException.ThrowIfNull(recentFiles);
         ArgumentNullException.ThrowIfNull(measureAppearance);
@@ -315,6 +325,8 @@ internal sealed class MainViewModel : ViewModelBase
         Settings = settingsViewModel;
         PickReport = pickReport;
         Timeline = timeline;
+        DisplayToolbar = displayToolbar;
+        EcdisDisplayPanel = ecdisDisplayPanel;
         Timeline.CloseRequested += () => IsTimelineVisible = false;
         PickReport.PropertyChanged += (_, e) =>
         {
@@ -328,6 +340,7 @@ internal sealed class MainViewModel : ViewModelBase
         SelectCatalogCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Catalog);
         SelectSearchCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Search);
         SelectSettingsCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Settings);
+        SelectEcdisDisplayCommand = new RelayCommand(() => SelectedActivity = ActivityKind.EcdisDisplay);
 
         TogglePrimarySideBarCommand = new RelayCommand(() =>
         {
@@ -354,6 +367,7 @@ internal sealed class MainViewModel : ViewModelBase
             OnPropertyChanged(nameof(IsCatalogSelected));
             OnPropertyChanged(nameof(IsSearchSelected));
             OnPropertyChanged(nameof(IsSettingsSelected));
+            OnPropertyChanged(nameof(IsEcdisDisplaySelected));
         });
 
         _isStatusBarVisible = settings.IsStatusBarVisible;

--- a/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
@@ -1,0 +1,102 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
+             x:Class="EncDotNet.S100.Viewer.Views.EcdisDisplayPanelView"
+             x:DataType="vm:EcdisDisplayPanelViewModel">
+
+    <DockPanel>
+        <!-- Empty state message -->
+        <TextBlock DockPanel.Dock="Top"
+                   Text="{x:Static loc:Strings.EcdisPanel_NoSpecs}"
+                   IsVisible="{Binding IsEmpty}"
+                   Opacity="0.5"
+                   TextWrapping="Wrap"
+                   Margin="12,8" />
+
+        <ScrollViewer IsVisible="{Binding !IsEmpty}">
+            <StackPanel Spacing="12" Margin="12,4,12,12">
+                <!-- Display category radio group -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static loc:Strings.EcdisPanel_CategoryHeader}"
+                               FontSize="11"
+                               FontWeight="SemiBold"
+                               LetterSpacing="0.5"
+                               Opacity="0.7" />
+                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_DisplayBase}"
+                                 IsChecked="{Binding IsDisplayBase, Mode=OneWay}"
+                                 Command="{Binding SetDisplayBaseCommand}"
+                                 GroupName="DisplayCategory" />
+                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_Standard}"
+                                 IsChecked="{Binding IsStandard, Mode=OneWay}"
+                                 Command="{Binding SetStandardCommand}"
+                                 GroupName="DisplayCategory" />
+                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_OtherInformation}"
+                                 IsChecked="{Binding IsOtherInformation, Mode=OneWay}"
+                                 Command="{Binding SetOtherInformationCommand}"
+                                 GroupName="DisplayCategory" />
+                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_All}"
+                                 IsChecked="{Binding IsAll, Mode=OneWay}"
+                                 Command="{Binding SetAllCommand}"
+                                 GroupName="DisplayCategory" />
+                </StackPanel>
+
+                <!-- Global reset -->
+                <Button Content="{x:Static loc:Strings.Button_ResetAllOverrides}"
+                        Command="{Binding ResetAllOverridesCommand}"
+                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_ResetAllOverrides}"
+                        HorizontalAlignment="Left"
+                        Padding="8,4" />
+
+                <!-- Per-spec sections -->
+                <ItemsControl ItemsSource="{Binding Specs}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:EcdisSpecViewModel">
+                            <Border BorderBrush="{DynamicResource BorderColor}"
+                                    BorderThickness="0,1,0,0"
+                                    Padding="0,8,0,0"
+                                    Margin="0,4,0,0">
+                                <StackPanel Spacing="4">
+                                    <!-- Spec header -->
+                                    <DockPanel>
+                                        <Button DockPanel.Dock="Right"
+                                                Content="{x:Static loc:Strings.Button_ResetOverrides}"
+                                                Command="{Binding ResetOverridesCommand}"
+                                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ResetOverrides}"
+                                                IsVisible="{Binding HasOverrides}"
+                                                Padding="6,2"
+                                                FontSize="11" />
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock Text="{Binding SpecCode}"
+                                                       FontWeight="SemiBold"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Text="{Binding OverrideCountLabel}"
+                                                       IsVisible="{Binding HasOverrides}"
+                                                       Opacity="0.6"
+                                                       FontSize="11"
+                                                       VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </DockPanel>
+
+                                    <!-- Viewing group checkboxes -->
+                                    <ItemsControl ItemsSource="{Binding ViewingGroups}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate x:DataType="vm:EcdisViewingGroupViewModel">
+                                                <CheckBox IsChecked="{Binding IsVisible}"
+                                                          Margin="0,1">
+                                                    <TextBlock Text="{Binding Name}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                </CheckBox>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+public partial class EcdisDisplayPanelView : UserControl
+{
+    public EcdisDisplayPanelView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DisplayToolbarViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DisplayToolbarViewModelTests.cs
@@ -1,0 +1,94 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class DisplayToolbarViewModelTests
+{
+    [Fact]
+    public void ActiveCategoryLabel_DefaultsToStandard()
+    {
+        var state = new EcdisDisplayState();
+        using var vm = new DisplayToolbarViewModel(state);
+
+        Assert.Contains("Standard", vm.ActiveCategoryLabel);
+        Assert.Equal(EcdisDisplayCategory.Standard, vm.ActiveCategory);
+        Assert.True(vm.IsStandard);
+        Assert.False(vm.IsDisplayBase);
+    }
+
+    [Fact]
+    public void SetCategory_UpdatesLabelAndProperties()
+    {
+        var state = new EcdisDisplayState();
+        using var vm = new DisplayToolbarViewModel(state);
+
+        vm.SetCategory(EcdisDisplayCategory.DisplayBase);
+
+        Assert.Equal(EcdisDisplayCategory.DisplayBase, vm.ActiveCategory);
+        Assert.True(vm.IsDisplayBase);
+        Assert.False(vm.IsStandard);
+        Assert.Contains("Display Base", vm.ActiveCategoryLabel);
+    }
+
+    [Fact]
+    public void SetCategory_SameValue_DoesNotFirePropertyChanged()
+    {
+        var state = new EcdisDisplayState();
+        using var vm = new DisplayToolbarViewModel(state);
+
+        var changed = new List<string?>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        vm.SetCategory(EcdisDisplayCategory.Standard); // same as default
+
+        Assert.Empty(changed);
+    }
+
+    [Fact]
+    public void ExternalStateChange_RefreshesProperties()
+    {
+        var state = new EcdisDisplayState();
+        using var vm = new DisplayToolbarViewModel(state);
+
+        var changed = new List<string?>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        // Mutate state directly (simulating another UI path)
+        state.SetCategory(EcdisDisplayCategory.All);
+
+        Assert.Contains(nameof(vm.ActiveCategoryLabel), changed);
+        Assert.Contains(nameof(vm.ActiveCategory), changed);
+        Assert.True(vm.IsAll);
+    }
+
+    [Fact]
+    public void CategoryDisplayName_ReturnsLocalizedNames()
+    {
+        Assert.Equal(Strings.DisplayCategory_DisplayBase, DisplayToolbarViewModel.CategoryDisplayName(EcdisDisplayCategory.DisplayBase));
+        Assert.Equal(Strings.DisplayCategory_Standard, DisplayToolbarViewModel.CategoryDisplayName(EcdisDisplayCategory.Standard));
+        Assert.Equal(Strings.DisplayCategory_OtherInformation, DisplayToolbarViewModel.CategoryDisplayName(EcdisDisplayCategory.OtherInformation));
+        Assert.Equal(Strings.DisplayCategory_All, DisplayToolbarViewModel.CategoryDisplayName(EcdisDisplayCategory.All));
+    }
+
+    [Fact]
+    public void Commands_SwitchCategory()
+    {
+        var state = new EcdisDisplayState();
+        using var vm = new DisplayToolbarViewModel(state);
+
+        vm.SetDisplayBaseCommand.Execute(null);
+        Assert.Equal(EcdisDisplayCategory.DisplayBase, state.Category);
+
+        vm.SetAllCommand.Execute(null);
+        Assert.Equal(EcdisDisplayCategory.All, state.Category);
+
+        vm.SetOtherInformationCommand.Execute(null);
+        Assert.Equal(EcdisDisplayCategory.OtherInformation, state.Category);
+
+        vm.SetStandardCommand.Execute(null);
+        Assert.Equal(EcdisDisplayCategory.Standard, state.Category);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class EcdisDisplayPanelViewModelTests
+{
+    private sealed class StubDatasetLoaderService : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; } =
+            new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; } =
+            new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event System.Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event System.Action<string?>? StatusChanged { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+    }
+
+    private static PortrayalCatalogue CreateSyntheticCatalogue() => new()
+    {
+        ProductId = "S-101",
+        Version = "1.0",
+        ViewingGroups =
+        [
+            new ViewingGroup { Id = "11010", Description = new Description { Name = "Land area" } },
+            new ViewingGroup { Id = "12210", Description = new Description { Name = "Depth contour" } },
+            new ViewingGroup { Id = "21010", Description = new Description { Name = "Buoy" } },
+        ],
+        ViewingGroupLayers =
+        [
+            new ViewingGroupLayer
+            {
+                Id = "BaseLayers",
+                Description = new Description { Name = "Base Layers" },
+                ViewingGroupIds = ["11010"],
+            },
+        ],
+        DisplayModes =
+        [
+            new DisplayMode
+            {
+                Id = "DisplayBase",
+                Description = new Description { Name = "Display Base" },
+                ViewingGroupLayerIds = ["BaseLayers"],
+            },
+        ],
+    };
+
+    [Fact]
+    public void IsEmpty_WhenNoDatasets()
+    {
+        var state = new EcdisDisplayState();
+        var catalogues = new PortrayalCatalogueManager();
+        var datasets = new DatasetsViewModel(new StubDatasetLoaderService());
+
+        using var vm = new EcdisDisplayPanelViewModel(state, catalogues, datasets);
+
+        Assert.True(vm.IsEmpty);
+        Assert.Empty(vm.Specs);
+    }
+
+    [Fact]
+    public void ActiveCategory_TwoWaySyncWithState()
+    {
+        var state = new EcdisDisplayState();
+        var catalogues = new PortrayalCatalogueManager();
+        var datasets = new DatasetsViewModel(new StubDatasetLoaderService());
+
+        using var vm = new EcdisDisplayPanelViewModel(state, catalogues, datasets);
+
+        vm.ActiveCategory = EcdisDisplayCategory.All;
+        Assert.Equal(EcdisDisplayCategory.All, state.Category);
+        Assert.True(vm.IsAll);
+
+        state.SetCategory(EcdisDisplayCategory.DisplayBase);
+        Assert.Equal(EcdisDisplayCategory.DisplayBase, vm.ActiveCategory);
+        Assert.True(vm.IsDisplayBase);
+    }
+
+    [Fact]
+    public void ResetAllOverrides_ClearsState()
+    {
+        var state = new EcdisDisplayState();
+        state.HideViewingGroup("S-101", 11010);
+        state.HideViewingGroup("S-124", 22010);
+
+        var catalogues = new PortrayalCatalogueManager();
+        var datasets = new DatasetsViewModel(new StubDatasetLoaderService());
+
+        using var vm = new EcdisDisplayPanelViewModel(state, catalogues, datasets);
+
+        vm.ResetAllOverridesCommand.Execute(null);
+
+        Assert.Empty(state.GetHidden("S-101"));
+        Assert.Empty(state.GetHidden("S-124"));
+    }
+
+    [Fact]
+    public void CategoryCommands_SwitchCategory()
+    {
+        var state = new EcdisDisplayState();
+        var catalogues = new PortrayalCatalogueManager();
+        var datasets = new DatasetsViewModel(new StubDatasetLoaderService());
+
+        using var vm = new EcdisDisplayPanelViewModel(state, catalogues, datasets);
+
+        vm.SetDisplayBaseCommand.Execute(null);
+        Assert.Equal(EcdisDisplayCategory.DisplayBase, state.Category);
+
+        vm.SetAllCommand.Execute(null);
+        Assert.Equal(EcdisDisplayCategory.All, state.Category);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -78,6 +78,8 @@ public class MainViewModelOpenRecentTests : IDisposable
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
+            displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(loader)),
             themeService: new StubThemeService(),
             recentFiles: recent,
             measureAppearance: new StubMeasureOverlayAppearanceProvider());

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -61,6 +61,8 @@ public class MainViewModelPickModeTests
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
+            displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new StubDatasetLoaderService())),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider());

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -75,6 +75,8 @@ public class PickServiceTests
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
+            displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new StubLoader())),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider(),


### PR DESCRIPTION
## Summary

Follow-up to #31 (foundation PR, merged). Adds the UI controls for ECDIS display categories and per-spec viewing-group overrides.

### ed4 — Display toolbar pill
- Compact pill button on the map overlay showing the active `EcdisDisplayCategory`
- Flyout with four radio buttons (Display Base / Standard / Other Information / All)
- Wired to `EcdisDisplayState.SetCategory()`

### ed5 — ECDIS panel (activity bar)
- New `ActivityKind.EcdisDisplay` entry with Eye icon in the activity bar
- Side panel with category radio buttons and per-spec viewing-group checkboxes
- Each loaded vector spec (S-101, S-122, S-124, S-125, S-127, S-128, S-129, S-411, S-421) gets a collapsible section
- Coverage products (S-102/S-104/S-111) excluded — they have no viewing-group concept
- Per-spec "Reset" and global "Reset All Overrides" buttons

### ed7 — Telemetry
- `display.mode.changed` ActivitySource span when category changes
- `viewinggroup.toggled` Meter counter when VG is toggled

### Viewer rules compliance
- All strings in `Strings.resx` + `Strings.cs`
- All buttons have `ToolTip.Tip`
- No hardcoded UI strings

### Tests
- `DisplayToolbarViewModelTests` — 6 tests covering category binding, label updates, commands, external state sync
- `EcdisDisplayPanelViewModelTests` — 4 tests covering empty state, category two-way sync, reset, commands
- Existing test fixtures updated for new `MainViewModel` constructor parameters

All 158 viewer tests pass.