### PR TITLE
Open Exchange Set in viewer

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/AssetSourceHelpers.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/AssetSourceHelpers.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Threading;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Shared helpers for opening dataset content from an
+/// <see cref="IAssetSource"/> (e.g. <c>FileSystemAssetSource</c> or
+/// <c>ZipAssetSource</c>) inside the synchronous constructors used by the
+/// per-spec dataset processors.
+/// </summary>
+/// <remarks>
+/// The current per-spec readers (S-101, S-102, S-104, S-111, S-122,
+/// S-124, S-125, S-127, S-128, S-129, S-411, S-421, S-57) all read the
+/// dataset fully into memory at <c>Open</c>-time, so the asset stream
+/// only needs to live for the duration of the processor's constructor.
+/// However, several readers — notably HDF5 via PureHDF and ISO 8211 via
+/// <c>EncDotNet.Iso8211</c> — require a seekable stream. ZIP entry
+/// streams are forward-only, so this helper copies non-seekable
+/// streams into a <see cref="MemoryStream"/> before returning.
+/// </remarks>
+internal static class AssetSourceHelpers
+{
+    /// <summary>
+    /// Opens <paramref name="relativePath"/> from <paramref name="source"/>
+    /// and returns a seekable stream positioned at the start. Non-seekable
+    /// streams (e.g. <c>ZipArchiveEntry.Open()</c>) are copied into a
+    /// <see cref="MemoryStream"/>; the original stream is disposed.
+    /// </summary>
+    public static Stream OpenSeekable(
+        IAssetSource source,
+        string relativePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        var stream = source.OpenAsync(relativePath, cancellationToken).GetAwaiter().GetResult();
+        if (stream.CanSeek)
+        {
+            return stream;
+        }
+
+        try
+        {
+            var buffer = new MemoryStream();
+            stream.CopyTo(buffer);
+            buffer.Position = 0;
+            return buffer;
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Returns the file name component of a ZIP-style or file-system
+    /// relative path. Used by processors to populate their
+    /// <c>_fileName</c> for diagnostic strings.
+    /// </summary>
+    public static string GetFileName(string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+        var normalized = relativePath.Replace('\\', '/');
+        var idx = normalized.LastIndexOf('/');
+        return idx < 0 ? normalized : normalized[(idx + 1)..];
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -1,3 +1,4 @@
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
@@ -330,4 +331,93 @@ public sealed class DatasetPipelineFactory
     /// Convenience method: creates a processor and renders with default context.
     /// </summary>
     public DatasetResult Process(string path) => CreateProcessor(path).Render();
+
+    /// <summary>
+    /// Creates a processor for a dataset stored inside <paramref name="source"/>
+    /// at <paramref name="relativePath"/>. Used by exchange-set bulk loading
+    /// where dataset bytes may live inside a ZIP archive.
+    /// </summary>
+    /// <param name="source">The asset source (folder or ZIP) hosting the dataset.</param>
+    /// <param name="relativePath">Path to the dataset, relative to <paramref name="source"/>.</param>
+    /// <param name="declaredProductSpec">
+    /// Product specification declared by the exchange-set catalogue (e.g. "S-101").
+    /// When non-null and recognized, content sniffing is skipped. When null or
+    /// unrecognized, falls back to extension-based sniffing on
+    /// <paramref name="relativePath"/>.
+    /// </param>
+    public IDatasetProcessor CreateProcessor(
+        IAssetSource source,
+        string relativePath,
+        string? declaredProductSpec = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        var spec = MapProductIdentifierToSpec(declaredProductSpec)
+            ?? DetectProductSpecByExtension(relativePath)
+            ?? throw new NotSupportedException(
+                $"Unable to determine product specification for '{relativePath}' " +
+                $"(declared='{declaredProductSpec ?? "<none>"}').");
+
+        return spec switch
+        {
+            "S-102" => new S102DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _crsTransformFactory),
+            "S-101" => new S101DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueResolver),
+            "S-57" => new S57DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueResolver),
+            "S-104" => new S104DatasetProcessor(source, relativePath, _crsTransformFactory),
+            "S-111" => new S111DatasetProcessor(source, relativePath, _catalogueManager, _crsTransformFactory),
+            "S-122" => new S122DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-124" => new S124DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-125" => new S125DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-127" => new S127DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-128" => new S128DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-129" => new S129DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-411" => new S411DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            "S-421" => new S421DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueResolver),
+            _ => throw new NotSupportedException($"Pipeline not implemented for {spec}."),
+        };
+    }
+
+    /// <summary>
+    /// Normalizes an exchange-set product identifier (e.g. <c>"S-101"</c>,
+    /// <c>"S101"</c>, <c>"s-101"</c>) to the canonical spec strings used
+    /// by <see cref="CreateProcessor(string)"/>'s switch (<c>"S-101"</c>, etc.).
+    /// Returns <c>null</c> when the identifier is null, blank, or unrecognized.
+    /// </summary>
+    public static string? MapProductIdentifierToSpec(string? productIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(productIdentifier)) return null;
+        var trimmed = productIdentifier.Trim();
+        var normalized = trimmed.StartsWith("S-", StringComparison.OrdinalIgnoreCase)
+            ? "S-" + trimmed[2..]
+            : trimmed.StartsWith('S') || trimmed.StartsWith('s')
+                ? "S-" + trimmed[1..]
+                : trimmed;
+        normalized = normalized.ToUpperInvariant();
+        return normalized switch
+        {
+            "S-57" or "S-101" or "S-102" or "S-104" or "S-111"
+                or "S-122" or "S-124" or "S-125" or "S-127" or "S-128"
+                or "S-129" or "S-411" or "S-421" => normalized,
+            _ => null,
+        };
+    }
+
+    private static string? DetectProductSpecByExtension(string relativePath)
+    {
+        var ext = Path.GetExtension(relativePath);
+        if (string.Equals(ext, ".000", StringComparison.OrdinalIgnoreCase))
+        {
+            // Could be S-101 or legacy S-57; without content access we
+            // cannot disambiguate cheaply. Caller should supply
+            // declaredProductSpec for ISO 8211 datasets.
+            return null;
+        }
+        if (string.Equals(ext, ".h5", StringComparison.OrdinalIgnoreCase))
+        {
+            // HDF5 product spec cannot be inferred from extension alone.
+            return null;
+        }
+        return null;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj
+++ b/src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S411\EncDotNet.S100.Datasets.S411.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S57\EncDotNet.S100.Datasets.S57.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.ExchangeSets\EncDotNet.S100.ExchangeSets.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Hdf5.PureHdf\EncDotNet.S100.Hdf5.PureHdf.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />

--- a/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
@@ -1,0 +1,99 @@
+using System.Runtime.CompilerServices;
+using EncDotNet.S100.ExchangeSets;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Result of attempting to load a single dataset from an exchange set.
+/// Either <see cref="Processor"/> is non-null on success, or
+/// <see cref="Error"/> is non-null on failure. Never both null.
+/// </summary>
+public sealed record ExchangeSetLoadResult(
+    DatasetDiscoveryMetadata Metadata,
+    string RelativePath,
+    IDatasetProcessor? Processor,
+    Exception? Error);
+
+/// <summary>
+/// Per-dataset progress event raised by <see cref="ExchangeSetLoader"/>.
+/// </summary>
+/// <param name="Index">1-based index of the dataset currently being loaded.</param>
+/// <param name="Total">Total number of datasets in the exchange set.</param>
+/// <param name="CurrentFileName">Normalized relative path of the current dataset.</param>
+public sealed record ExchangeSetProgress(int Index, int Total, string CurrentFileName);
+
+/// <summary>
+/// Bulk-loads every dataset declared in an
+/// <see cref="ExchangeSet"/>'s catalogue, routing each one through
+/// <see cref="DatasetPipelineFactory"/>. Errors are captured per-dataset
+/// rather than thrown so a single bad dataset does not abort the load.
+/// </summary>
+/// <remarks>
+/// The loader does not own the supplied <see cref="ExchangeSet"/>; the
+/// caller is responsible for keeping it alive (and its underlying
+/// <see cref="EncDotNet.S100.Core.IAssetSource"/>) for as long as any
+/// returned processor is in use, then disposing it.
+/// </remarks>
+public sealed class ExchangeSetLoader
+{
+    private readonly DatasetPipelineFactory _factory;
+
+    /// <summary>
+    /// Initializes a new <see cref="ExchangeSetLoader"/> that delegates
+    /// per-dataset processor construction to <paramref name="factory"/>.
+    /// </summary>
+    public ExchangeSetLoader(DatasetPipelineFactory factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factory = factory;
+    }
+
+    /// <summary>
+    /// Asynchronously loads every dataset declared by
+    /// <paramref name="exchangeSet"/>'s catalogue.
+    /// </summary>
+    /// <param name="exchangeSet">The exchange set to walk.</param>
+    /// <param name="progress">Optional progress sink; reports before each dataset is opened.</param>
+    /// <param name="cancellationToken">Honored between datasets; mid-dataset cancellation depends on the underlying reader.</param>
+    /// <returns>One <see cref="ExchangeSetLoadResult"/> per dataset, in catalogue order.</returns>
+    public async IAsyncEnumerable<ExchangeSetLoadResult> LoadAllAsync(
+        ExchangeSet exchangeSet,
+        IProgress<ExchangeSetProgress>? progress = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(exchangeSet);
+
+        var datasets = exchangeSet.Catalogue.DatasetDiscoveryMetadata;
+        var total = datasets.Count;
+
+        for (var i = 0; i < total; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var metadata = datasets[i];
+            var relativePath = ExchangeSet.NormalizeFileName(metadata.FileName);
+            progress?.Report(new ExchangeSetProgress(i + 1, total, relativePath));
+
+            IDatasetProcessor? processor = null;
+            Exception? error = null;
+            try
+            {
+                processor = _factory.CreateProcessor(
+                    exchangeSet.Source,
+                    relativePath,
+                    metadata.ProductSpecification?.ProductIdentifier);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+
+            yield return new ExchangeSetLoadResult(metadata, relativePath, processor, error);
+            await Task.Yield();
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -32,11 +33,45 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         Func<string, Stream?> featureCatalogueResolver)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S101DatasetProcessor"/> by reading
+    /// the ISO 8211 dataset <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S101DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        Func<string, Stream?> featureCatalogueResolver)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            luaEngine,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S101DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        Func<string, Stream?> featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _luaEngine = luaEngine;
         _provider = catalogueManager.GetProvider("S-101");
-        _dataset = S101Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S101Dataset.Open(datasetStream);
+        }
         _featureCatalogueResolver = featureCatalogueResolver;
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S102;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
@@ -28,12 +29,48 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         ICrsTransformFactory crsTransformFactory)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, crsTransformFactory)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S102DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/> (e.g. a <c>FileSystemAssetSource</c> or
+    /// <c>ZipAssetSource</c>). Used by exchange-set bulk loading where
+    /// a dataset's bytes live inside a ZIP archive.
+    /// </summary>
+    public S102DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        ICrsTransformFactory crsTransformFactory)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            luaEngine,
+            crsTransformFactory)
+    {
+    }
+
+    private S102DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        ICrsTransformFactory crsTransformFactory)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _crsTransformFactory = crsTransformFactory;
 
-        using var hdf5 = PureHdfFile.Open(path);
-        _dataset = S102DatasetReader.Read(hdf5);
+        using (datasetStream)
+        using (var hdf5 = PureHdfFile.Open(datasetStream))
+        {
+            _dataset = S102DatasetReader.Read(hdf5);
+        }
         _source = new S102CoverageSource(_dataset);
 
         var provider = catalogueManager.GetProvider("S-102");

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S104;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
@@ -29,12 +30,40 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     public S104DatasetProcessor(
         string path,
         ICrsTransformFactory crsTransformFactory)
+        : this(File.OpenRead(path), Path.GetFileName(path), crsTransformFactory)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S104DatasetProcessor"/> by reading
+    /// the HDF5 dataset <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S104DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        ICrsTransformFactory crsTransformFactory)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            crsTransformFactory)
+    {
+    }
+
+    private S104DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        ICrsTransformFactory crsTransformFactory)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _crsTransformFactory = crsTransformFactory;
 
-        using var hdf5 = PureHdfFile.Open(path);
-        _dataset = S104DatasetReader.Read(hdf5);
+        using (datasetStream)
+        using (var hdf5 = PureHdfFile.Open(datasetStream))
+        {
+            _dataset = S104DatasetReader.Read(hdf5);
+        }
         _source = new S104CoverageSource(_dataset);
         _catalogue = new S104PortrayalCatalogue();
     }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
@@ -32,12 +33,43 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         ICrsTransformFactory crsTransformFactory)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, crsTransformFactory)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S111DatasetProcessor"/> by reading
+    /// the HDF5 dataset <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S111DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        ICrsTransformFactory crsTransformFactory)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            crsTransformFactory)
+    {
+    }
+
+    private S111DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        ICrsTransformFactory crsTransformFactory)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _crsTransformFactory = crsTransformFactory;
 
-        using var hdf5 = PureHdfFile.Open(path);
-        _dataset = S111DatasetReader.Read(hdf5);
+        using (datasetStream)
+        using (var hdf5 = PureHdfFile.Open(datasetStream))
+        {
+            _dataset = S111DatasetReader.Read(hdf5);
+        }
         _source = new S111CoverageSource(_dataset);
 
         _provider = catalogueManager.HasCatalogue("S-111")

--- a/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S122;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -27,10 +28,42 @@ public sealed class S122DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S122DatasetProcessor"/> by reading the
+    /// dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/> (e.g. <c>FileSystemAssetSource</c> or
+    /// <c>ZipAssetSource</c>). Used by exchange-set bulk loading.
+    /// </summary>
+    public S122DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S122DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-122");
-        _dataset = S122Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S122Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-122");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S124;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -27,10 +28,41 @@ public sealed class S124DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S124DatasetProcessor"/> by reading the
+    /// dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S124DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S124DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-124");
-        _dataset = S124Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S124Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-124");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S125;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -34,10 +35,41 @@ public sealed class S125DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S125DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S125DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S125DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-125");
-        _dataset = S125Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S125Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-125");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S127;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -32,10 +33,41 @@ public sealed class S127DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S127DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S127DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S127DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-127");
-        _dataset = S127Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S127Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-127");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S128;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -30,10 +31,41 @@ public sealed class S128DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S128DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S128DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S128DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-128");
-        _dataset = S128Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S128Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-128");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S129;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -27,10 +28,41 @@ public sealed class S129DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S129DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S129DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S129DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-129");
-        _dataset = S129Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S129Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-129");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S411;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -36,10 +37,41 @@ public sealed class S411DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S411DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S411DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S411DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-411");
-        _dataset = S411Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S411Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-411");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S421;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
@@ -23,10 +25,41 @@ public sealed class S421DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S421DatasetProcessor"/> by reading
+    /// the dataset file <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S421DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver = null)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S421DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        Func<string, Stream?>? featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _provider = catalogueManager.GetProvider("S-421");
-        _dataset = S421Dataset.Open(path);
+        using (datasetStream)
+        {
+            _dataset = S421Dataset.Open(datasetStream);
+        }
         _decoder = ProcessorFeatureCatalogue.TryLoadDecoder(featureCatalogueResolver, "S-421");
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Datasets.S57;
 using EncDotNet.S100.Features;
@@ -37,13 +38,48 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         Func<string, Stream?> featureCatalogueResolver)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueResolver)
     {
-        _fileName = Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="S57DatasetProcessor"/> by reading
+    /// the ISO 8211 dataset <paramref name="relativePath"/> from
+    /// <paramref name="source"/>. Used by exchange-set bulk loading.
+    /// </summary>
+    public S57DatasetProcessor(
+        IAssetSource source,
+        string relativePath,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        Func<string, Stream?> featureCatalogueResolver)
+        : this(
+            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            AssetSourceHelpers.GetFileName(relativePath),
+            catalogueManager,
+            luaEngine,
+            featureCatalogueResolver)
+    {
+    }
+
+    private S57DatasetProcessor(
+        Stream datasetStream,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        Func<string, Stream?> featureCatalogueResolver)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        _fileName = fileName;
         _luaEngine = luaEngine;
         _provider = catalogueManager.GetProvider("S-101");
         _featureCatalogueResolver = featureCatalogueResolver;
 
-        var s57 = S57Dataset.Open(path);
+        S57Dataset s57;
+        using (datasetStream)
+        {
+            s57 = S57Dataset.Open(datasetStream);
+        }
         var translator = new S57ToS101Translator();
         var s101Doc = translator.Translate(s57);
         _translatedDataset = S101Dataset.FromDocument(s101Doc);

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSet.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSet.cs
@@ -10,6 +10,13 @@ public sealed class ExchangeSet : IDisposable
     private readonly IAssetSource _source;
 
     /// <summary>
+    /// Gets the asset source backing this exchange set. Exposed so callers
+    /// (e.g. bulk loaders) can pass it directly to per-spec dataset
+    /// processors that accept an <see cref="IAssetSource"/>.
+    /// </summary>
+    public IAssetSource Source => _source;
+
+    /// <summary>
     /// Initializes a new instance of <see cref="ExchangeSet"/> with the given source and catalogue.
     /// </summary>
     /// <param name="source">The asset source used to fetch referenced files.</param>
@@ -76,7 +83,7 @@ public sealed class ExchangeSet : IDisposable
     /// <summary>
     /// Strips the <c>file:/</c> URI prefix that S-100 exchange catalogues may use on file names.
     /// </summary>
-    private static string NormalizeFileName(string fileName)
+    public static string NormalizeFileName(string fileName)
     {
         ArgumentException.ThrowIfNullOrEmpty(fileName);
 

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -128,6 +128,7 @@ public partial class App : Application
         services.AddSingleton<IPickService, PickService>();
         services.AddSingleton<IFeatureSearchService, FeatureSearchService>();
         services.AddSingleton<IFileDialogService, FileDialogService>();
+        services.AddSingleton<IExchangeSetService, ExchangeSetService>();
 
         // View models
         services.AddSingleton<FeatureCataloguesViewModel>();
@@ -151,7 +152,8 @@ public partial class App : Application
             sp.GetRequiredService<ScreenshotService>(),
             sp.GetRequiredService<IDatasetLoaderService>(),
             sp.GetRequiredService<IPickService>(),
-            sp.GetRequiredService<IFileDialogService>()));
+            sp.GetRequiredService<IFileDialogService>(),
+            sp.GetRequiredService<IExchangeSetService>()));
 
         return services.BuildServiceProvider();
     }

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -50,6 +50,7 @@
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.ExchangeSets\EncDotNet.S100.ExchangeSets.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Hdf5.PureHdf\EncDotNet.S100.Hdf5.PureHdf.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -477,6 +477,79 @@
                                            Width="{Binding Bounds.Width, ElementName=ZoomInButton}"
                                            Height="{Binding Bounds.Width, ElementName=ZoomInButton}" />
                 </StackPanel>
+
+                <!-- Partial-failure / failure banner (es3-progress).
+                     Anchored to the top of the map area; dismissable via the
+                     X button. Stays out of the way of the scale bar by
+                     reserving the top edge with a small offset. -->
+                <Border HorizontalAlignment="Stretch"
+                        VerticalAlignment="Top"
+                        Margin="48,4,180,0"
+                        Padding="12,8"
+                        CornerRadius="4"
+                        Background="{DynamicResource BackgroundColor}"
+                        BorderBrush="{DynamicResource AccentBrush}"
+                        BorderThickness="1"
+                        IsVisible="{Binding IsExchangeSetBannerVisible}">
+                    <DockPanel LastChildFill="True">
+                        <Button DockPanel.Dock="Right"
+                                Command="{Binding DismissExchangeSetBannerCommand}"
+                                ToolTip.Tip="{x:Static loc:Strings.Banner_Dismiss}"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                Padding="4"
+                                Margin="8,0,0,0">
+                            <ic:FluentIcon Icon="Dismiss" IconVariant="Regular" FontSize="14" />
+                        </Button>
+                        <TextBlock Text="{Binding ExchangeSetBannerMessage}"
+                                   VerticalAlignment="Center"
+                                   TextWrapping="Wrap" />
+                    </DockPanel>
+                </Border>
+
+                <!-- Exchange-set progress overlay (es3-progress).
+                     Centered card; non-modal — the user can still pan the
+                     map underneath but cannot start a second exchange-set
+                     load until this one completes or is cancelled. -->
+                <Border HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        MinWidth="320" MaxWidth="480"
+                        Padding="16"
+                        CornerRadius="6"
+                        Background="{DynamicResource BackgroundColor}"
+                        BorderBrush="{DynamicResource BorderColor}"
+                        BorderThickness="1"
+                        IsVisible="{Binding IsExchangeSetLoading}">
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="12" Color="Black" Opacity="0.25" />
+                    </Border.Effect>
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="{x:Static loc:Strings.Progress_ExchangeSetTitle}"
+                                   FontWeight="SemiBold"
+                                   FontSize="14" />
+                        <TextBlock Text="{Binding ExchangeSetSourceLabel}"
+                                   FontSize="12"
+                                   Opacity="0.7"
+                                   TextTrimming="CharacterEllipsis" />
+                        <ProgressBar Value="{Binding ExchangeSetProgressFraction}"
+                                     Minimum="0" Maximum="1"
+                                     Height="4" />
+                        <DockPanel LastChildFill="True">
+                            <TextBlock DockPanel.Dock="Right"
+                                       Text="{Binding ExchangeSetCounter}"
+                                       FontSize="12"
+                                       Opacity="0.7" />
+                            <TextBlock Text="{Binding ExchangeSetCurrentDataset}"
+                                       FontSize="12"
+                                       Opacity="0.85"
+                                       TextTrimming="CharacterEllipsis" />
+                        </DockPanel>
+                        <Button HorizontalAlignment="Right"
+                                Command="{Binding CancelExchangeSetCommand}"
+                                Content="{x:Static loc:Strings.Progress_ExchangeSetCancel}"
+                                ToolTip.Tip="{x:Static loc:Strings.Progress_ExchangeSetCancel}" />
+                    </StackPanel>
+                </Border>
                 </Grid>
 
                 <!-- Resize grip between map and timeline panel -->

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -373,11 +374,55 @@ public partial class MainWindow : ShadUI.Window
         var progress = new Progress<Services.ExchangeSetProgress>(
             p => _viewModel.ReportExchangeSetProgress(p));
 
+        // Subscribe to per-dataset load completions for the duration of
+        // this open. We accumulate each loaded entry's layer extents so
+        // we can zoom to their union — the catalogue may not declare
+        // per-dataset bounding boxes (S-101 producer dumps often skip
+        // them) and Map.Extent alone could include unrelated layers.
+        var loadedEntries = new HashSet<DatasetEntry>();
+        var unionSlot = new MRect?[1];
+        var lastEventTicks = new long[1];
+        Action<DatasetEntry> handler = entry =>
+        {
+            // Only count entries from any exchange set — we filter to
+            // this specific open below by checking the entry's Source.
+            if (!entry.IsFromExchangeSet) return;
+            if (!loadedEntries.Add(entry)) return;
+            if (_loader.EntryLayers.TryGetValue(entry, out var layers))
+            {
+                foreach (var layer in layers)
+                {
+                    if (layer.Extent is { } e && e.Width > 0 && e.Height > 0)
+                    {
+                        unionSlot[0] = unionSlot[0] is null
+                            ? new MRect(e.MinX, e.MinY, e.MaxX, e.MaxY)
+                            : unionSlot[0]!.Join(e);
+                    }
+                }
+            }
+            Interlocked.Exchange(ref lastEventTicks[0], Environment.TickCount64);
+        };
+        _loader.DatasetLoaded += handler;
+
         try
         {
             var result = await _exchangeSetService.OpenAsync(sourcePath, progress, token);
             _viewModel.EndExchangeSetLoad(result);
-            ZoomToUnionExtent(result);
+
+            // Prefer the catalogue's union bbox when available — it's
+            // ready immediately and matches producer intent.
+            if (result.UnionBoundingBox is { } bbox &&
+                MapControl.Map?.Navigator is { } nav)
+            {
+                ZoomToCatalogueBoundingBox(nav, bbox);
+                return;
+            }
+
+            // Otherwise debounce on DatasetLoaded events: zoom once no
+            // new event has arrived for QuietWindowMs. This naturally
+            // handles per-dataset load failures (which never raise the
+            // event) without waiting a fixed timeout.
+            await ZoomWhenLoadingQuietsAsync(loadedEntries, unionSlot, lastEventTicks);
         }
         catch (Exception ex)
         {
@@ -387,24 +432,71 @@ public partial class MainWindow : ShadUI.Window
                 FailureMessage = ex.Message,
             });
         }
+        finally
+        {
+            _loader.DatasetLoaded -= handler;
+        }
     }
 
-    private void ZoomToUnionExtent(Services.ExchangeSetOpenResult result)
+    private void ZoomToCatalogueBoundingBox(Mapsui.Navigator nav, EncDotNet.S100.ExchangeSets.BoundingBox bbox)
     {
-        // No-op when the catalogue had no bbox or the open failed; the
-        // user can still hit the toolbar Zoom-to-Extent which fits to
-        // every loaded layer.
-        if (result.UnionBoundingBox is not { } bbox) return;
-        if (MapControl.Map?.Navigator is not { } nav) return;
-
-        // EPSG:4326 lat/lon → web mercator. SphericalMercator clamps the
-        // input range, so polar catalogues degrade gracefully.
+        // EPSG:4326 lat/lon → web mercator. SphericalMercator clamps
+        // the input range, so polar catalogues degrade gracefully.
         var (minX, minY) = SphericalMercator.FromLonLat(
             bbox.WestBoundLongitude, bbox.SouthBoundLatitude);
         var (maxX, maxY) = SphericalMercator.FromLonLat(
             bbox.EastBoundLongitude, bbox.NorthBoundLatitude);
         var extent = new MRect(minX, minY, maxX, maxY);
-        if (extent.Width <= 0 || extent.Height <= 0) return;
+        if (extent.Width > 0 && extent.Height > 0)
+        {
+            nav.ZoomToBox(extent.Grow(extent.Width * 0.1, extent.Height * 0.1), duration: 250);
+        }
+    }
+
+    private async Task ZoomWhenLoadingQuietsAsync(
+        HashSet<DatasetEntry> loadedEntries,
+        MRect?[] unionSlot,
+        long[] lastEventTicks)
+    {
+        // Quiet-window debounce: the per-dataset loaders complete on
+        // their own background tasks and may fail silently (caught and
+        // logged inside DatasetLoaderService), so we can't simply
+        // await an exact count. Instead we wait until DatasetLoaded
+        // events stop arriving for a short window — at that point
+        // every dispatched dataset has either completed or errored,
+        // and the accumulated union extent is final.
+        const int QuietWindowMs = 600;
+        const int PollMs = 100;
+        const int MaxWaitMs = 30_000;
+
+        var startedAt = Environment.TickCount64;
+        while (true)
+        {
+            await Task.Delay(PollMs);
+
+            var lastEvent = Interlocked.Read(ref lastEventTicks[0]);
+            var now = Environment.TickCount64;
+
+            // No events yet — keep waiting up to MaxWaitMs from start.
+            if (lastEvent == 0)
+            {
+                if (now - startedAt >= MaxWaitMs) return;
+                continue;
+            }
+
+            // We've seen at least one event; trigger as soon as the
+            // bus is quiet for QuietWindowMs.
+            if (now - lastEvent >= QuietWindowMs)
+                break;
+
+            if (now - startedAt >= MaxWaitMs)
+                break;
+        }
+
+        if (MapControl.Map?.Navigator is not { } nav) return;
+
+        var extent = unionSlot[0] ?? MapControl.Map.Extent;
+        if (extent is null || extent.Width <= 0 || extent.Height <= 0) return;
 
         nav.ZoomToBox(extent.Grow(extent.Width * 0.1, extent.Height * 0.1), duration: 250);
     }

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -377,6 +377,7 @@ public partial class MainWindow : ShadUI.Window
         {
             var result = await _exchangeSetService.OpenAsync(sourcePath, progress, token);
             _viewModel.EndExchangeSetLoad(result);
+            ZoomToUnionExtent(result);
         }
         catch (Exception ex)
         {
@@ -386,6 +387,26 @@ public partial class MainWindow : ShadUI.Window
                 FailureMessage = ex.Message,
             });
         }
+    }
+
+    private void ZoomToUnionExtent(Services.ExchangeSetOpenResult result)
+    {
+        // No-op when the catalogue had no bbox or the open failed; the
+        // user can still hit the toolbar Zoom-to-Extent which fits to
+        // every loaded layer.
+        if (result.UnionBoundingBox is not { } bbox) return;
+        if (MapControl.Map?.Navigator is not { } nav) return;
+
+        // EPSG:4326 lat/lon → web mercator. SphericalMercator clamps the
+        // input range, so polar catalogues degrade gracefully.
+        var (minX, minY) = SphericalMercator.FromLonLat(
+            bbox.WestBoundLongitude, bbox.SouthBoundLatitude);
+        var (maxX, maxY) = SphericalMercator.FromLonLat(
+            bbox.EastBoundLongitude, bbox.NorthBoundLatitude);
+        var extent = new MRect(minX, minY, maxX, maxY);
+        if (extent.Width <= 0 || extent.Height <= 0) return;
+
+        nav.ZoomToBox(extent.Grow(extent.Width * 0.1, extent.Height * 0.1), duration: 250);
     }
 
     private async void OnDrop(object? sender, DragEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -34,6 +34,7 @@ public partial class MainWindow : ShadUI.Window
     private readonly IDatasetLoaderService _loader;
     private readonly IPickService _pickService;
     private readonly IFileDialogService _fileDialog;
+    private readonly IExchangeSetService _exchangeSetService;
     private readonly MainViewModel _viewModel;
     private readonly DatasetCatalogAggregator _catalogAggregator;
     private string? _screenshotPath;
@@ -59,7 +60,9 @@ public partial class MainWindow : ShadUI.Window
                 "IDatasetLoaderService cannot be resolved without the application service provider.")),
             ResolveOrFallback<IPickService>(static () => throw new InvalidOperationException(
                 "IPickService cannot be resolved without the application service provider.")),
-            ResolveOrFallback<IFileDialogService>(static () => new FileDialogService()))
+            ResolveOrFallback<IFileDialogService>(static () => new FileDialogService()),
+            ResolveOrFallback<IExchangeSetService>(static () => throw new InvalidOperationException(
+                "IExchangeSetService cannot be resolved without the application service provider.")))
     {
     }
 
@@ -83,7 +86,8 @@ public partial class MainWindow : ShadUI.Window
         ScreenshotService screenshotService,
         IDatasetLoaderService loader,
         IPickService pickService,
-        IFileDialogService fileDialog)
+        IFileDialogService fileDialog,
+        IExchangeSetService exchangeSetService)
     {
         ArgumentNullException.ThrowIfNull(viewModel);
         ArgumentNullException.ThrowIfNull(catalogAggregator);
@@ -92,6 +96,7 @@ public partial class MainWindow : ShadUI.Window
         ArgumentNullException.ThrowIfNull(loader);
         ArgumentNullException.ThrowIfNull(pickService);
         ArgumentNullException.ThrowIfNull(fileDialog);
+        ArgumentNullException.ThrowIfNull(exchangeSetService);
 
         InitializeComponent();
 
@@ -102,6 +107,7 @@ public partial class MainWindow : ShadUI.Window
         _loader = loader;
         _pickService = pickService;
         _fileDialog = fileDialog;
+        _exchangeSetService = exchangeSetService;
 
         // Hand the loader a map host now that the Mapsui control exists, and
         // seed catalogues / build the pipeline factory from CLI options. The
@@ -127,7 +133,9 @@ public partial class MainWindow : ShadUI.Window
         // PropertyChanged subscriptions for the lifetime of this window.
         new NativeMenuBuilder(_viewModel, _recentFiles).Attach(
             window: this,
-            openDatasetAsync: OpenDatasetAsync);
+            openDatasetAsync: OpenDatasetAsync,
+            openExchangeSetAsync: OpenExchangeSetAsync,
+            openExchangeSetZipAsync: OpenExchangeSetZipAsync);
 
         // Show built-in specification entries in the catalogue views
         foreach (var spec in Specifications.Specification.AvailableSpecs)
@@ -337,6 +345,26 @@ public partial class MainWindow : ShadUI.Window
 
             await _viewModel.Datasets.LoadFromPathAsync(path);
         }
+    }
+
+    private async Task OpenExchangeSetAsync()
+    {
+        var folder = await _fileDialog.OpenExchangeSetFolderAsync(this);
+        if (folder is null)
+            return;
+
+        _viewModel.SelectedActivity = ViewModels.ActivityKind.Datasets;
+        await _exchangeSetService.OpenAsync(folder);
+    }
+
+    private async Task OpenExchangeSetZipAsync()
+    {
+        var zip = await _fileDialog.OpenExchangeSetZipAsync(this);
+        if (zip is null)
+            return;
+
+        _viewModel.SelectedActivity = ViewModels.ActivityKind.Datasets;
+        await _exchangeSetService.OpenAsync(zip);
     }
 
     private async void OnDrop(object? sender, DragEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -353,8 +353,7 @@ public partial class MainWindow : ShadUI.Window
         if (folder is null)
             return;
 
-        _viewModel.SelectedActivity = ViewModels.ActivityKind.Datasets;
-        await _exchangeSetService.OpenAsync(folder);
+        await RunExchangeSetAsync(folder);
     }
 
     private async Task OpenExchangeSetZipAsync()
@@ -363,8 +362,30 @@ public partial class MainWindow : ShadUI.Window
         if (zip is null)
             return;
 
+        await RunExchangeSetAsync(zip);
+    }
+
+    private async Task RunExchangeSetAsync(string sourcePath)
+    {
         _viewModel.SelectedActivity = ViewModels.ActivityKind.Datasets;
-        await _exchangeSetService.OpenAsync(zip);
+
+        var token = _viewModel.BeginExchangeSetLoad(sourcePath);
+        var progress = new Progress<Services.ExchangeSetProgress>(
+            p => _viewModel.ReportExchangeSetProgress(p));
+
+        try
+        {
+            var result = await _exchangeSetService.OpenAsync(sourcePath, progress, token);
+            _viewModel.EndExchangeSetLoad(result);
+        }
+        catch (Exception ex)
+        {
+            _viewModel.EndExchangeSetLoad(new Services.ExchangeSetOpenResult
+            {
+                SourcePath = sourcePath,
+                FailureMessage = ex.Message,
+            });
+        }
     }
 
     private async void OnDrop(object? sender, DragEventArgs e)

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -419,8 +419,33 @@ public partial class MainWindow : ShadUI.Window
         foreach (var item in files)
         {
             var path = item.TryGetLocalPath();
-            if (path is null || !File.Exists(path))
+            if (path is null)
                 continue;
+
+            // Folder drop: treat as an exchange set when CATALOG.XML
+            // is at the root, otherwise ignore (the dataset loader is
+            // single-file).
+            if (Directory.Exists(path))
+            {
+                if (ExchangeSetDetection.LooksLikeExchangeSetFolder(path))
+                {
+                    await RunExchangeSetAsync(path);
+                }
+                continue;
+            }
+
+            if (!File.Exists(path))
+                continue;
+
+            // File drop: a .zip with a root-level CATALOG.XML is an
+            // exchange-set ZIP; everything else falls through to the
+            // single-dataset loader.
+            if (ExchangeSetDetection.IsZipPath(path) &&
+                ExchangeSetDetection.LooksLikeExchangeSetZip(path))
+            {
+                await RunExchangeSetAsync(path);
+                continue;
+            }
 
             await _viewModel.Datasets.LoadFromPathAsync(path);
         }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -89,6 +89,10 @@ internal static class Strings
     public static string Tooltip_SubLayerOpacity => Get(nameof(Tooltip_SubLayerOpacity));
     public static string Tooltip_ExpandSubLayers => Get(nameof(Tooltip_ExpandSubLayers));
     public static string Pane_SubLayers => Get(nameof(Pane_SubLayers));
+    public static string Pane_ExchangeSetHeader_Producer => Get(nameof(Pane_ExchangeSetHeader_Producer));
+    public static string Pane_ExchangeSetHeader_Issued => Get(nameof(Pane_ExchangeSetHeader_Issued));
+    public static string Pane_ExchangeSetHeader_Count => Get(nameof(Pane_ExchangeSetHeader_Count));
+    public static string Tooltip_CloseExchangeSet => Get(nameof(Tooltip_CloseExchangeSet));
     public static string Tooltip_ShowAllDatasets => Get(nameof(Tooltip_ShowAllDatasets));
     public static string Tooltip_HideAllDatasets => Get(nameof(Tooltip_HideAllDatasets));
     public static string Menu_IsolateDataset => Get(nameof(Menu_IsolateDataset));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -106,6 +106,8 @@ internal static class Strings
     // Native menu
     public static string Menu_File => Get(nameof(Menu_File));
     public static string Menu_OpenDataset => Get(nameof(Menu_OpenDataset));
+    public static string Menu_OpenExchangeSet => Get(nameof(Menu_OpenExchangeSet));
+    public static string Menu_OpenExchangeSetZip => Get(nameof(Menu_OpenExchangeSetZip));
     public static string Menu_OpenRecent => Get(nameof(Menu_OpenRecent));
     public static string Menu_NoRecentDatasets => Get(nameof(Menu_NoRecentDatasets));
     public static string Menu_ClearRecentlyOpened => Get(nameof(Menu_ClearRecentlyOpened));
@@ -120,6 +122,9 @@ internal static class Strings
     // File picker
     public static string FilePicker_OpenDatasetTitle => Get(nameof(FilePicker_OpenDatasetTitle));
     public static string FilePicker_S100DatasetsType => Get(nameof(FilePicker_S100DatasetsType));
+    public static string FilePicker_ExchangeSetFolderTitle => Get(nameof(FilePicker_ExchangeSetFolderTitle));
+    public static string FilePicker_ExchangeSetZipTitle => Get(nameof(FilePicker_ExchangeSetZipTitle));
+    public static string FilePicker_ExchangeSetZipType => Get(nameof(FilePicker_ExchangeSetZipType));
 
     // Catalogue list
     public static string Catalogue_BuiltInLabel => Get(nameof(Catalogue_BuiltInLabel));
@@ -186,6 +191,12 @@ internal static class Strings
     public static string Status_FeatureSummaryWithMore => Get(nameof(Status_FeatureSummaryWithMore));
     public static string Status_FeatureRefNotFound => Get(nameof(Status_FeatureRefNotFound));
     public static string Status_FileNoLongerExists => Get(nameof(Status_FileNoLongerExists));
+    public static string Status_ExchangeSetLoading => Get(nameof(Status_ExchangeSetLoading));
+    public static string Status_ExchangeSetLoaded => Get(nameof(Status_ExchangeSetLoaded));
+    public static string Status_ExchangeSetLoadedWithErrors => Get(nameof(Status_ExchangeSetLoadedWithErrors));
+    public static string Status_ExchangeSetFailed => Get(nameof(Status_ExchangeSetFailed));
+    public static string Status_ExchangeSetCatalogNotFound => Get(nameof(Status_ExchangeSetCatalogNotFound));
+    public static string Status_ExchangeSetUnsupportedSpec => Get(nameof(Status_ExchangeSetUnsupportedSpec));
 
     // Dataset entry
     public static string DatasetEntry_CurrentTimeFormat => Get(nameof(DatasetEntry_CurrentTimeFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -92,6 +92,7 @@ internal static class Strings
     public static string Pane_ExchangeSetHeader_Producer => Get(nameof(Pane_ExchangeSetHeader_Producer));
     public static string Pane_ExchangeSetHeader_Issued => Get(nameof(Pane_ExchangeSetHeader_Issued));
     public static string Pane_ExchangeSetHeader_Count => Get(nameof(Pane_ExchangeSetHeader_Count));
+    public static string Pane_ExchangeSetHeader_Unsupported => Get(nameof(Pane_ExchangeSetHeader_Unsupported));
     public static string Tooltip_CloseExchangeSet => Get(nameof(Tooltip_CloseExchangeSet));
     public static string Tooltip_ShowAllDatasets => Get(nameof(Tooltip_ShowAllDatasets));
     public static string Tooltip_HideAllDatasets => Get(nameof(Tooltip_HideAllDatasets));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -197,6 +197,15 @@ internal static class Strings
     public static string Status_ExchangeSetFailed => Get(nameof(Status_ExchangeSetFailed));
     public static string Status_ExchangeSetCatalogNotFound => Get(nameof(Status_ExchangeSetCatalogNotFound));
     public static string Status_ExchangeSetUnsupportedSpec => Get(nameof(Status_ExchangeSetUnsupportedSpec));
+    public static string Status_ExchangeSetCancelled => Get(nameof(Status_ExchangeSetCancelled));
+
+    // Exchange-set progress overlay (es3-progress)
+    public static string Progress_ExchangeSetTitle => Get(nameof(Progress_ExchangeSetTitle));
+    public static string Progress_ExchangeSetCounter => Get(nameof(Progress_ExchangeSetCounter));
+    public static string Progress_ExchangeSetCancel => Get(nameof(Progress_ExchangeSetCancel));
+    public static string Banner_ExchangeSetPartial => Get(nameof(Banner_ExchangeSetPartial));
+    public static string Banner_ExchangeSetFailed => Get(nameof(Banner_ExchangeSetFailed));
+    public static string Banner_Dismiss => Get(nameof(Banner_Dismiss));
 
     // Dataset entry
     public static string DatasetEntry_CurrentTimeFormat => Get(nameof(DatasetEntry_CurrentTimeFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -160,6 +160,9 @@
   <data name="Pane_ExchangeSetHeader_Count" xml:space="preserve">
     <value>{0} datasets</value>
   </data>
+  <data name="Pane_ExchangeSetHeader_Unsupported" xml:space="preserve">
+    <value>{0} unsupported</value>
+  </data>
   <data name="Tooltip_CloseExchangeSet" xml:space="preserve">
     <value>Close this exchange set and remove every dataset it contributed</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -151,6 +151,18 @@
   <data name="Pane_SubLayers" xml:space="preserve">
     <value>Sub-layers</value>
   </data>
+  <data name="Pane_ExchangeSetHeader_Producer" xml:space="preserve">
+    <value>Producer: {0}</value>
+  </data>
+  <data name="Pane_ExchangeSetHeader_Issued" xml:space="preserve">
+    <value>Issued: {0}</value>
+  </data>
+  <data name="Pane_ExchangeSetHeader_Count" xml:space="preserve">
+    <value>{0} datasets</value>
+  </data>
+  <data name="Tooltip_CloseExchangeSet" xml:space="preserve">
+    <value>Close this exchange set and remove every dataset it contributed</value>
+  </data>
   <data name="Tooltip_ShowAllDatasets" xml:space="preserve">
     <value>Show every dataset</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -212,6 +212,14 @@
   <data name="Menu_OpenDataset" xml:space="preserve">
     <value>Open Dataset...</value>
   </data>
+  <data name="Menu_OpenExchangeSet" xml:space="preserve">
+    <value>Open Exchange Set...</value>
+    <comment>File menu entry that opens a folder containing a CATALOG.XML.</comment>
+  </data>
+  <data name="Menu_OpenExchangeSetZip" xml:space="preserve">
+    <value>Open Exchange Set (ZIP)...</value>
+    <comment>File menu entry that opens a .zip file containing a CATALOG.XML.</comment>
+  </data>
   <data name="Menu_OpenRecent" xml:space="preserve">
     <value>Open Recent</value>
   </data>
@@ -249,6 +257,15 @@
   </data>
   <data name="FilePicker_S100DatasetsType" xml:space="preserve">
     <value>S-100 Datasets</value>
+  </data>
+  <data name="FilePicker_ExchangeSetFolderTitle" xml:space="preserve">
+    <value>Open Exchange Set Folder</value>
+  </data>
+  <data name="FilePicker_ExchangeSetZipTitle" xml:space="preserve">
+    <value>Open Exchange Set ZIP</value>
+  </data>
+  <data name="FilePicker_ExchangeSetZipType" xml:space="preserve">
+    <value>S-100 Exchange Set (ZIP)</value>
   </data>
 
   <!-- Catalogue list -->
@@ -441,6 +458,27 @@ Open an S-128 dataset to populate this panel.</value>
   </data>
   <data name="Status_FileNoLongerExists" xml:space="preserve">
     <value>File no longer exists: {0}</value>
+  </data>
+  <data name="Status_ExchangeSetLoading" xml:space="preserve">
+    <value>Loading exchange set {0}...</value>
+    <comment>Status text while reading an exchange set's CATALOG.XML and dispatching its datasets. {0} is the source path.</comment>
+  </data>
+  <data name="Status_ExchangeSetLoaded" xml:space="preserve">
+    <value>Loaded {0} dataset(s) from {1}.</value>
+    <comment>{0} = dataset count, {1} = source path.</comment>
+  </data>
+  <data name="Status_ExchangeSetLoadedWithErrors" xml:space="preserve">
+    <value>Loaded {0} of {1} dataset(s) from {2} ({3} skipped).</value>
+    <comment>{0} = dispatched, {1} = total, {2} = source path, {3} = skipped count.</comment>
+  </data>
+  <data name="Status_ExchangeSetFailed" xml:space="preserve">
+    <value>Failed to open exchange set {0}: {1}</value>
+  </data>
+  <data name="Status_ExchangeSetCatalogNotFound" xml:space="preserve">
+    <value>No CATALOG.XML found in {0}.</value>
+  </data>
+  <data name="Status_ExchangeSetUnsupportedSpec" xml:space="preserve">
+    <value>Skipped {0}: unsupported product specification '{1}'.</value>
   </data>
 
   <!-- Dataset entry -->

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -480,6 +480,29 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Status_ExchangeSetUnsupportedSpec" xml:space="preserve">
     <value>Skipped {0}: unsupported product specification '{1}'.</value>
   </data>
+  <data name="Status_ExchangeSetCancelled" xml:space="preserve">
+    <value>Cancelled after loading {0} of {1} datasets from {2}.</value>
+  </data>
+
+  <!-- Exchange-set progress overlay (es3-progress) -->
+  <data name="Progress_ExchangeSetTitle" xml:space="preserve">
+    <value>Opening exchange set</value>
+  </data>
+  <data name="Progress_ExchangeSetCounter" xml:space="preserve">
+    <value>{0} of {1}</value>
+  </data>
+  <data name="Progress_ExchangeSetCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Banner_ExchangeSetPartial" xml:space="preserve">
+    <value>{0} of {1} datasets in {2} could not be loaded ({3} unsupported).</value>
+  </data>
+  <data name="Banner_ExchangeSetFailed" xml:space="preserve">
+    <value>Failed to open exchange set {0}: {1}</value>
+  </data>
+  <data name="Banner_Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
 
   <!-- Dataset entry -->
   <data name="DatasetEntry_CurrentTimeFormat" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -207,7 +207,15 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             var result = await Task.Run(() => processor.Render(initialContext));
 
             ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames);
-            _mapHost!.ZoomToExtent(result.Extent);
+            // Exchange-set entries opt out of the per-dataset auto-zoom so
+            // the union-extent zoom from `IExchangeSetService` (or the
+            // user's manual Zoom-to-Extent toolbar action) wins. Without
+            // this, the last-completed dataset would race with the bulk
+            // load and "win" the viewport.
+            if (!fromExchangeSet)
+            {
+                _mapHost!.ZoomToExtent(result.Extent);
+            }
 
             entry.IsLoaded = true;
             entry.Info = result.Info;

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -142,11 +142,25 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
         using var __cmd = ViewerObservability.BeginCommand("dataset.open");
 
-        var spec = DatasetPipelineFactory.DetectProductSpec(entry.FilePath);
-        if (spec is null)
+        // Exchange-set entries carry an explicit ProductSpec from the
+        // catalogue and never require path-based detection or recent-
+        // files updates (the relative path inside a ZIP is not
+        // meaningful as a recent-file entry).
+        var fromExchangeSet = entry.IsFromExchangeSet;
+
+        string? spec;
+        if (fromExchangeSet)
         {
-            SetStatus(string.Format(Strings.Status_UnrecognizedFileType, Path.GetExtension(entry.FilePath)));
-            return;
+            spec = entry.ProductSpec;
+        }
+        else
+        {
+            spec = DatasetPipelineFactory.DetectProductSpec(entry.FilePath);
+            if (spec is null)
+            {
+                SetStatus(string.Format(Strings.Status_UnrecognizedFileType, Path.GetExtension(entry.FilePath)));
+                return;
+            }
         }
 
         // S-104 ships a built-in portrayal catalogue.
@@ -158,11 +172,13 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             return;
         }
 
-        SetStatus(string.Format(Strings.Status_LoadingFile, Path.GetFileName(entry.FilePath)));
+        SetStatus(string.Format(Strings.Status_LoadingFile, entry.DisplayName));
 
         try
         {
-            var processor = await Task.Run(() => _pipelineFactory!.CreateProcessor(entry.FilePath));
+            var processor = await Task.Run(() => fromExchangeSet
+                ? _pipelineFactory!.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
+                : _pipelineFactory!.CreateProcessor(entry.FilePath));
             _processors[entry] = processor;
 
             // Surface S-128 catalogues into the Dataset Catalog panel.
@@ -198,7 +214,13 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             entry.CurrentTime = initialTime ?? adapter?.AvailableTimes.FirstOrDefault();
             SetStatus(result.Info);
 
-            _recentFiles.Add(entry.FilePath);
+            // Recent files only makes sense for plain file loads. An
+            // exchange-set entry's FilePath is a relative path inside
+            // a folder/ZIP source and not openable on its own.
+            if (!fromExchangeSet)
+            {
+                _recentFiles.Add(entry.FilePath);
+            }
 
             // Register with the global time service after the entry's
             // CurrentTime has been set so the first slider snap reflects

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Static helpers that decide whether a dropped folder or file is an
+/// S-100 exchange set. The viewer's drag-and-drop handler uses these
+/// to route folders containing a <c>CATALOG.XML</c> and ZIP archives
+/// containing a root-level <c>CATALOG.XML</c> to
+/// <see cref="IExchangeSetService.OpenAsync"/> instead of the
+/// single-dataset loader.
+/// </summary>
+/// <remarks>
+/// Both helpers swallow filesystem and IO failures (returning
+/// <c>false</c>) so a noisy drop falls through to the single-file
+/// loader, which surfaces a more specific error message to the user.
+/// </remarks>
+internal static class ExchangeSetDetection
+{
+    /// <summary>The catalogue filename, matched case-insensitively.</summary>
+    private const string CatalogueFileName = "CATALOG.XML";
+
+    /// <summary>True when <paramref name="path"/> ends with
+    /// <c>.zip</c> (case-insensitive).</summary>
+    public static bool IsZipPath(string path) =>
+        !string.IsNullOrEmpty(path) &&
+        string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>True when <paramref name="folderPath"/> exists and
+    /// contains a <c>CATALOG.XML</c> at its top level
+    /// (case-insensitive). Returns <c>false</c> for any I/O or
+    /// permission failure.</summary>
+    public static bool LooksLikeExchangeSetFolder(string folderPath)
+    {
+        if (string.IsNullOrEmpty(folderPath)) return false;
+        try
+        {
+            if (!Directory.Exists(folderPath)) return false;
+            return Directory.EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
+                .Any(f => string.Equals(
+                    Path.GetFileName(f), CatalogueFileName,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (IOException) { return false; }
+    }
+
+    /// <summary>True when <paramref name="zipPath"/> is a readable
+    /// ZIP archive whose root contains a <c>CATALOG.XML</c> entry
+    /// (case-insensitive). Returns <c>false</c> for corrupt archives
+    /// or I/O failures.</summary>
+    public static bool LooksLikeExchangeSetZip(string zipPath)
+    {
+        if (string.IsNullOrEmpty(zipPath)) return false;
+        try
+        {
+            if (!File.Exists(zipPath)) return false;
+            using var archive = ZipFile.OpenRead(zipPath);
+            return archive.Entries.Any(IsRootCatalogueEntry);
+        }
+        catch (InvalidDataException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (IOException) { return false; }
+    }
+
+    private static bool IsRootCatalogueEntry(ZipArchiveEntry entry)
+    {
+        // ZIP entry names use forward slashes per the spec; tolerate
+        // backslashes too in case a producer wrote them. A "root"
+        // entry has no separator at all.
+        var name = entry.FullName;
+        if (name.Contains('/') || name.Contains('\\')) return false;
+        return string.Equals(
+            name, CatalogueFileName, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -9,6 +10,7 @@ using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.ViewModels;
 
@@ -46,12 +48,23 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         _status = status;
     }
 
-    public async Task OpenAsync(string folderOrZipPath, CancellationToken cancellationToken = default)
+    public async Task<ExchangeSetOpenResult> OpenAsync(
+        string folderOrZipPath,
+        IProgress<ExchangeSetProgress>? progress = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(folderOrZipPath);
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         EnsureCollectionSubscription();
+
+        // s100.exchangeset.open child span sits under whatever
+        // s100.viewer.command span the caller (MainWindow) opened.
+        using var activity = Telemetry.ActivitySource.StartActivity(
+            "s100.exchangeset.open", System.Diagnostics.ActivityKind.Internal);
+        var sourceKind = ResolveSourceKind(folderOrZipPath);
+        activity?.SetTag("s100.exchangeset.source.kind", sourceKind);
+        activity?.SetTag("s100.exchangeset.source.path", folderOrZipPath);
 
         IAssetSource? source = null;
         ExchangeSet? exchangeSet = null;
@@ -67,19 +80,40 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             {
                 _status.StatusText = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
                 source.Dispose();
-                return;
+                activity?.SetStatus(ActivityStatusCode.Error, "catalogue not found");
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderOrZipPath,
+                    CatalogueNotFound = true,
+                    FailureMessage = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath),
+                };
             }
 
             var datasets = exchangeSet.Catalogue.DatasetDiscoveryMetadata;
+            activity?.SetTag("s100.exchangeset.dataset.count", datasets.Count);
+            activity?.SetTag(
+                "s100.exchangeset.producer",
+                exchangeSet.Catalogue.Contact?.Organization);
+            activity?.SetTag(
+                "s100.exchangeset.product",
+                exchangeSet.Catalogue.ProductSpecification?.ProductIdentifier);
+
             if (datasets.Count == 0)
             {
                 _status.StatusText = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
                 exchangeSet.Dispose();
                 exchangeSet = null;
-                return;
+                activity?.SetStatus(ActivityStatusCode.Error, "empty catalogue");
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderOrZipPath,
+                    CatalogueNotFound = true,
+                    FailureMessage = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath),
+                };
             }
 
             _status.StatusText = string.Format(Strings.Status_ExchangeSetLoading, folderOrZipPath);
+            progress?.Report(new ExchangeSetProgress(folderOrZipPath, datasets.Count, 0, 0, null));
 
             var tracked = new TrackedExchangeSet(folderOrZipPath, exchangeSet);
             _tracked.Add(tracked);
@@ -90,21 +124,31 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
             var dispatched = 0;
             var skipped = 0;
+            var skipMessages = new List<string>();
+            var cancelled = false;
 
             foreach (var metadata in datasets)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancelled = true;
+                    break;
+                }
 
                 var relativePath = ExchangeSet.NormalizeFileName(metadata.FileName);
                 var spec = DatasetPipelineFactory.MapProductIdentifierToSpec(
                     metadata.ProductSpecification?.ProductIdentifier);
                 if (spec is null)
                 {
-                    _status.StatusText = string.Format(
+                    var msg = string.Format(
                         Strings.Status_ExchangeSetUnsupportedSpec,
                         relativePath,
                         metadata.ProductSpecification?.ProductIdentifier ?? string.Empty);
+                    _status.StatusText = msg;
+                    skipMessages.Add(msg);
                     skipped++;
+                    progress?.Report(new ExchangeSetProgress(
+                        folderOrZipPath, datasets.Count, dispatched + skipped, skipped, relativePath));
                     continue;
                 }
 
@@ -116,9 +160,17 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 tracked.Entries.Add(entry);
                 _datasets.RequestLoad(entry);
                 dispatched++;
+                progress?.Report(new ExchangeSetProgress(
+                    folderOrZipPath, datasets.Count, dispatched + skipped, skipped, relativePath));
             }
 
-            if (skipped == 0)
+            if (cancelled)
+            {
+                _status.StatusText = string.Format(
+                    Strings.Status_ExchangeSetCancelled,
+                    dispatched, datasets.Count, folderOrZipPath);
+            }
+            else if (skipped == 0)
             {
                 _status.StatusText = string.Format(
                     Strings.Status_ExchangeSetLoaded, dispatched, folderOrZipPath);
@@ -130,6 +182,13 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     dispatched, datasets.Count, folderOrZipPath, skipped);
             }
 
+            activity?.SetTag("s100.exchangeset.dataset.loaded", dispatched);
+            activity?.SetTag("s100.exchangeset.dataset.skipped", skipped);
+            activity?.SetTag("s100.exchangeset.cancelled", cancelled);
+            activity?.SetStatus(
+                cancelled ? ActivityStatusCode.Error : ActivityStatusCode.Ok,
+                cancelled ? "cancelled" : null);
+
             // If every dataset was skipped (unsupported product specs),
             // there will be no entries to keep the set alive — release it
             // immediately so the file handle / archive is not leaked.
@@ -138,19 +197,51 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 tracked.ExchangeSet.Dispose();
                 _tracked.Remove(tracked);
             }
+
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderOrZipPath,
+                Total = datasets.Count,
+                Loaded = dispatched,
+                SkippedUnsupported = skipped,
+                Cancelled = cancelled,
+                SkipMessages = skipMessages,
+            };
         }
         catch (OperationCanceledException)
         {
             exchangeSet?.Dispose();
             source?.Dispose();
-            throw;
+            activity?.SetStatus(ActivityStatusCode.Error, "cancelled");
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderOrZipPath,
+                Cancelled = true,
+            };
         }
         catch (Exception ex)
         {
             _status.StatusText = string.Format(Strings.Status_ExchangeSetFailed, folderOrZipPath, ex.Message);
             exchangeSet?.Dispose();
             source?.Dispose();
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderOrZipPath,
+                FailureMessage = ex.Message,
+            };
         }
+    }
+
+    private static string ResolveSourceKind(string path)
+    {
+        if (Directory.Exists(path)) return "folder";
+        if (File.Exists(path) &&
+            string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            return "zip";
+        }
+        return "unknown";
     }
 
     private static IAssetSource OpenSource(string path)

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="IExchangeSetService"/> implementation. Detects
+/// folder-vs-ZIP from <paramref name="folderOrZipPath"/>, opens the
+/// matching <see cref="IAssetSource"/>, parses <c>CATALOG.XML</c>,
+/// and dispatches every catalogued dataset through
+/// <see cref="DatasetsViewModel.AddFromExchangeSet"/> +
+/// <see cref="DatasetsViewModel.RequestLoad"/>.
+/// </summary>
+/// <remarks>
+/// Lifetime: this service keeps each opened <see cref="ExchangeSet"/>
+/// (and its underlying <see cref="IAssetSource"/>) alive for as long
+/// as any of the dispatched <see cref="DatasetEntry"/>s remains in
+/// <see cref="DatasetsViewModel.Entries"/>. When the last entry from
+/// a given exchange set is removed, the set is disposed. Disposing
+/// the service eagerly disposes any still-tracked sets.
+/// </remarks>
+internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
+{
+    private readonly DatasetsViewModel _datasets;
+    private readonly IStatusPresenter _status;
+    private readonly List<TrackedExchangeSet> _tracked = new();
+    private bool _subscribed;
+    private bool _disposed;
+
+    public ExchangeSetService(DatasetsViewModel datasets, IStatusPresenter status)
+    {
+        ArgumentNullException.ThrowIfNull(datasets);
+        ArgumentNullException.ThrowIfNull(status);
+        _datasets = datasets;
+        _status = status;
+    }
+
+    public async Task OpenAsync(string folderOrZipPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(folderOrZipPath);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        EnsureCollectionSubscription();
+
+        IAssetSource? source = null;
+        ExchangeSet? exchangeSet = null;
+        try
+        {
+            source = OpenSource(folderOrZipPath);
+            try
+            {
+                exchangeSet = await ExchangeSet.OpenAsync(source, "CATALOG.XML", cancellationToken)
+                    .ConfigureAwait(true);
+            }
+            catch (FileNotFoundException)
+            {
+                _status.StatusText = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
+                source.Dispose();
+                return;
+            }
+
+            var datasets = exchangeSet.Catalogue.DatasetDiscoveryMetadata;
+            if (datasets.Count == 0)
+            {
+                _status.StatusText = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
+                exchangeSet.Dispose();
+                exchangeSet = null;
+                return;
+            }
+
+            _status.StatusText = string.Format(Strings.Status_ExchangeSetLoading, folderOrZipPath);
+
+            var tracked = new TrackedExchangeSet(folderOrZipPath, exchangeSet);
+            _tracked.Add(tracked);
+            // From this point on, lifetime ownership transfers to the tracked
+            // entry — do not dispose `exchangeSet` / `source` directly below.
+            exchangeSet = null;
+            source = null;
+
+            var dispatched = 0;
+            var skipped = 0;
+
+            foreach (var metadata in datasets)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var relativePath = ExchangeSet.NormalizeFileName(metadata.FileName);
+                var spec = DatasetPipelineFactory.MapProductIdentifierToSpec(
+                    metadata.ProductSpecification?.ProductIdentifier);
+                if (spec is null)
+                {
+                    _status.StatusText = string.Format(
+                        Strings.Status_ExchangeSetUnsupportedSpec,
+                        relativePath,
+                        metadata.ProductSpecification?.ProductIdentifier ?? string.Empty);
+                    skipped++;
+                    continue;
+                }
+
+                var entry = _datasets.AddFromExchangeSet(
+                    tracked.ExchangeSet.Source,
+                    relativePath,
+                    spec,
+                    displayName: Path.GetFileName(relativePath));
+                tracked.Entries.Add(entry);
+                _datasets.RequestLoad(entry);
+                dispatched++;
+            }
+
+            if (skipped == 0)
+            {
+                _status.StatusText = string.Format(
+                    Strings.Status_ExchangeSetLoaded, dispatched, folderOrZipPath);
+            }
+            else
+            {
+                _status.StatusText = string.Format(
+                    Strings.Status_ExchangeSetLoadedWithErrors,
+                    dispatched, datasets.Count, folderOrZipPath, skipped);
+            }
+
+            // If every dataset was skipped (unsupported product specs),
+            // there will be no entries to keep the set alive — release it
+            // immediately so the file handle / archive is not leaked.
+            if (tracked.Entries.Count == 0)
+            {
+                tracked.ExchangeSet.Dispose();
+                _tracked.Remove(tracked);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            exchangeSet?.Dispose();
+            source?.Dispose();
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _status.StatusText = string.Format(Strings.Status_ExchangeSetFailed, folderOrZipPath, ex.Message);
+            exchangeSet?.Dispose();
+            source?.Dispose();
+        }
+    }
+
+    private static IAssetSource OpenSource(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            return FileSystemAssetSource.Create(path);
+        }
+        if (File.Exists(path) &&
+            string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            // ZipAssetSource.Create(string) opens the file with read-share,
+            // so the archive can stay open for as long as the service holds it.
+            return ZipAssetSource.Create(path);
+        }
+        throw new FileNotFoundException(
+            $"Exchange set source not found or not a folder/.zip: {path}", path);
+    }
+
+    private void EnsureCollectionSubscription()
+    {
+        if (_subscribed) return;
+        _subscribed = true;
+        _datasets.Entries.CollectionChanged += OnEntriesChanged;
+    }
+
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // Only Remove and Reset can drop entries the service is tracking.
+        if (e.Action is not (NotifyCollectionChangedAction.Remove or
+            NotifyCollectionChangedAction.Replace or
+            NotifyCollectionChangedAction.Reset))
+        {
+            return;
+        }
+
+        // Walk a snapshot so we can dispose+remove tracked sets safely.
+        for (var i = _tracked.Count - 1; i >= 0; i--)
+        {
+            var tracked = _tracked[i];
+            for (var j = tracked.Entries.Count - 1; j >= 0; j--)
+            {
+                if (!_datasets.Entries.Contains(tracked.Entries[j]))
+                {
+                    tracked.Entries.RemoveAt(j);
+                }
+            }
+
+            if (tracked.Entries.Count == 0)
+            {
+                tracked.ExchangeSet.Dispose();
+                _tracked.RemoveAt(i);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        if (_subscribed)
+        {
+            _datasets.Entries.CollectionChanged -= OnEntriesChanged;
+            _subscribed = false;
+        }
+
+        foreach (var tracked in _tracked)
+        {
+            try { tracked.ExchangeSet.Dispose(); } catch { /* swallow on shutdown */ }
+        }
+        _tracked.Clear();
+    }
+
+    private sealed class TrackedExchangeSet
+    {
+        public string SourcePath { get; }
+        public ExchangeSet ExchangeSet { get; }
+        public List<DatasetEntry> Entries { get; } = new();
+
+        public TrackedExchangeSet(string sourcePath, ExchangeSet exchangeSet)
+        {
+            SourcePath = sourcePath;
+            ExchangeSet = exchangeSet;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -206,6 +206,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 SkippedUnsupported = skipped,
                 Cancelled = cancelled,
                 SkipMessages = skipMessages,
+                UnionBoundingBox = ComputeUnionBoundingBox(datasets),
             };
         }
         catch (OperationCanceledException)
@@ -231,6 +232,39 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 FailureMessage = ex.Message,
             };
         }
+    }
+
+    /// <summary>
+    /// Computes the EPSG:4326 union of every dataset's bounding box,
+    /// ignoring entries that lack one. Returns <c>null</c> if no
+    /// dataset declared a bounding box.
+    /// </summary>
+    /// <remarks>
+    /// Antimeridian-spanning catalogues are not handled here — if a
+    /// producer ever ships one, this will return an over-wide box.
+    /// Exposed as <c>internal</c> for unit testing.
+    /// </remarks>
+    internal static BoundingBox? ComputeUnionBoundingBox(
+        IReadOnlyList<DatasetDiscoveryMetadata> datasets)
+    {
+        double? west = null, east = null, south = null, north = null;
+        foreach (var d in datasets)
+        {
+            var b = d.BoundingBox;
+            if (b is null) continue;
+            west = west is null ? b.WestBoundLongitude : Math.Min(west.Value, b.WestBoundLongitude);
+            east = east is null ? b.EastBoundLongitude : Math.Max(east.Value, b.EastBoundLongitude);
+            south = south is null ? b.SouthBoundLatitude : Math.Min(south.Value, b.SouthBoundLatitude);
+            north = north is null ? b.NorthBoundLatitude : Math.Max(north.Value, b.NorthBoundLatitude);
+        }
+        if (west is null) return null;
+        return new BoundingBox
+        {
+            WestBoundLongitude = west.Value,
+            EastBoundLongitude = east!.Value,
+            SouthBoundLatitude = south!.Value,
+            NorthBoundLatitude = north!.Value,
+        };
     }
 
     private static string ResolveSourceKind(string path)

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -119,6 +119,16 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             _tracked.Add(tracked);
             // From this point on, lifetime ownership transfers to the tracked
             // entry — do not dispose `exchangeSet` / `source` directly below.
+            var assetSource = tracked.ExchangeSet.Source;
+            var producer = tracked.ExchangeSet.Catalogue.Contact?.Organization;
+            var issueDate = ResolveLatestIssueDate(datasets);
+            tracked.Header = _datasets.RegisterExchangeSetHeader(
+                assetSource,
+                folderOrZipPath,
+                producer,
+                issueDate,
+                datasets.Count,
+                closeAction: CloseExchangeSetFromHeader);
             exchangeSet = null;
             source = null;
 
@@ -194,6 +204,11 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             // immediately so the file handle / archive is not leaked.
             if (tracked.Entries.Count == 0)
             {
+                if (tracked.Header is { } orphanHeader)
+                {
+                    _datasets.RemoveExchangeSetHeader(orphanHeader);
+                    tracked.Header = null;
+                }
                 tracked.ExchangeSet.Dispose();
                 _tracked.Remove(tracked);
             }
@@ -326,10 +341,56 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
             if (tracked.Entries.Count == 0)
             {
+                if (tracked.Header is { } header)
+                {
+                    _datasets.RemoveExchangeSetHeader(header);
+                    tracked.Header = null;
+                }
                 tracked.ExchangeSet.Dispose();
                 _tracked.RemoveAt(i);
             }
         }
+    }
+
+    /// <summary>
+    /// Removes every <see cref="DatasetEntry"/> that came from the
+    /// supplied header's exchange set. The collection-changed listener
+    /// then disposes the underlying <see cref="ExchangeSet"/> and
+    /// unregisters the header in the same pass.
+    /// </summary>
+    private void CloseExchangeSetFromHeader(ExchangeSetHeader header)
+    {
+        var tracked = _tracked.Find(t => ReferenceEquals(t.Header, header));
+        if (tracked is null) return;
+
+        // Snapshot the entries: removing from `_datasets.Entries`
+        // mutates `tracked.Entries` indirectly via OnEntriesChanged.
+        var entriesToRemove = tracked.Entries.ToArray();
+        foreach (var entry in entriesToRemove)
+        {
+            _datasets.Entries.Remove(entry);
+        }
+    }
+
+    /// <summary>
+    /// Returns the lexically-greatest non-null
+    /// <see cref="DatasetDiscoveryMetadata.IssueDate"/> across the
+    /// catalogue, or <c>null</c> if no dataset declared one. ISO-8601
+    /// date strings sort correctly under ordinal comparison, so no
+    /// parsing is needed for the common case.
+    /// </summary>
+    private static string? ResolveLatestIssueDate(
+        IReadOnlyList<DatasetDiscoveryMetadata> datasets)
+    {
+        string? latest = null;
+        foreach (var d in datasets)
+        {
+            var s = d.IssueDate;
+            if (string.IsNullOrEmpty(s)) continue;
+            if (latest is null || string.CompareOrdinal(s, latest) > 0)
+                latest = s;
+        }
+        return latest;
     }
 
     public void Dispose()
@@ -355,6 +416,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         public string SourcePath { get; }
         public ExchangeSet ExchangeSet { get; }
         public List<DatasetEntry> Entries { get; } = new();
+        public ExchangeSetHeader? Header { get; set; }
 
         public TrackedExchangeSet(string sourcePath, ExchangeSet exchangeSet)
         {

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -199,6 +199,16 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 cancelled ? ActivityStatusCode.Error : ActivityStatusCode.Ok,
                 cancelled ? "cancelled" : null);
 
+            // Update the header now that we know the loaded/unsupported
+            // split; the header was registered with conservative defaults
+            // before the dispatch loop ran so progress UI had something
+            // to show.
+            if (tracked.Header is { } trackedHeader)
+            {
+                trackedHeader.LoadedCount = dispatched;
+                trackedHeader.UnsupportedCount = skipped;
+            }
+
             // If every dataset was skipped (unsupported product specs),
             // there will be no entries to keep the set alive — release it
             // immediately so the file handle / archive is not leaked.

--- a/src/EncDotNet.S100.Viewer/Services/FileDialogService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FileDialogService.cs
@@ -82,4 +82,46 @@ internal sealed class FileDialogService : IFileDialogService
 
         return folders[0].TryGetLocalPath();
     }
+
+    public async Task<string?> OpenExchangeSetFolderAsync(TopLevel? topLevel)
+    {
+        if (topLevel?.StorageProvider is not { } picker)
+            return null;
+
+        var folders = await picker.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = Strings.FilePicker_ExchangeSetFolderTitle,
+            AllowMultiple = false,
+        });
+
+        if (folders is null || folders.Count == 0)
+            return null;
+
+        return folders[0].TryGetLocalPath();
+    }
+
+    public async Task<string?> OpenExchangeSetZipAsync(TopLevel? topLevel)
+    {
+        if (topLevel?.StorageProvider is not { } picker)
+            return null;
+
+        var files = await picker.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = Strings.FilePicker_ExchangeSetZipTitle,
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType(Strings.FilePicker_ExchangeSetZipType)
+                {
+                    Patterns = new[] { "*.zip" },
+                },
+                FilePickerFileTypes.All,
+            },
+        });
+
+        if (files is null || files.Count == 0)
+            return null;
+
+        return files[0].TryGetLocalPath();
+    }
 }

--- a/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Opens an S-100 exchange set (a folder containing a
+/// <c>CATALOG.XML</c> or a <c>.zip</c> archive containing one) and
+/// dispatches every catalogued dataset through the existing dataset
+/// loader. Each successfully-routed dataset becomes a regular
+/// <see cref="EncDotNet.S100.Viewer.ViewModels.DatasetEntry"/> in the
+/// Datasets panel and renders through the same code path as a plain
+/// file load.
+/// </summary>
+internal interface IExchangeSetService
+{
+    /// <summary>
+    /// Opens an exchange set rooted at <paramref name="folderOrZipPath"/>,
+    /// which may be either a directory (with a top-level
+    /// <c>CATALOG.XML</c>) or a <c>.zip</c> archive (with the same).
+    /// </summary>
+    /// <param name="folderOrZipPath">Local path to the folder or ZIP archive.</param>
+    /// <param name="cancellationToken">Honored between datasets; the loader
+    /// stops dispatching new datasets but does not interrupt one that is
+    /// already loading.</param>
+    Task OpenAsync(string folderOrZipPath, CancellationToken cancellationToken = default);
+}

--- a/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EncDotNet.S100.ExchangeSets;
 
 namespace EncDotNet.S100.Viewer.Services;
 
@@ -67,6 +68,15 @@ public sealed class ExchangeSetOpenResult
     /// <summary>Human-readable per-dataset skip messages (currently all
     /// "unsupported product spec" entries).</summary>
     public IReadOnlyList<string> SkipMessages { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Union of every catalogued dataset's
+    /// <see cref="DatasetDiscoveryMetadata.BoundingBox"/> in EPSG:4326
+    /// (the catalogue's declared CRS). <c>null</c> when no dataset
+    /// supplied a bounding box. The viewer reprojects this to web
+    /// mercator to fit the map after a successful bulk load.
+    /// </summary>
+    public BoundingBox? UnionBoundingBox { get; init; }
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
@@ -1,8 +1,73 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Per-dataset progress snapshot reported by
+/// <see cref="IExchangeSetService.OpenAsync"/> as it works through a
+/// catalogue. Reports are made on a background thread; the UI must
+/// marshal back to the dispatcher before mutating bound state.
+/// </summary>
+/// <param name="SourcePath">The folder or .zip path the user opened.</param>
+/// <param name="Total">Number of catalogued datasets discovered. Zero
+/// before the catalogue has been parsed.</param>
+/// <param name="Completed">Number of datasets the loader has dispatched
+/// (success + failure). Always &lt;= <paramref name="Total"/>.</param>
+/// <param name="Failed">Number of datasets that have errored or been
+/// skipped (unsupported product specification).</param>
+/// <param name="CurrentDataset">Catalogue-relative path of the dataset
+/// being routed right now, or <c>null</c> at the start/end.</param>
+public readonly record struct ExchangeSetProgress(
+    string SourcePath,
+    int Total,
+    int Completed,
+    int Failed,
+    string? CurrentDataset);
+
+/// <summary>
+/// Final summary of an <see cref="IExchangeSetService.OpenAsync"/> run.
+/// Always returned (even on cancellation) so the caller can surface a
+/// partial-success / partial-failure banner without having to subscribe
+/// to progress.
+/// </summary>
+public sealed class ExchangeSetOpenResult
+{
+    /// <summary>The folder or .zip path that was opened.</summary>
+    public required string SourcePath { get; init; }
+
+    /// <summary>Total datasets in the catalogue.</summary>
+    public int Total { get; init; }
+
+    /// <summary>Datasets successfully dispatched to a processor.</summary>
+    public int Loaded { get; init; }
+
+    /// <summary>Datasets skipped because their product identifier is not
+    /// supported (no per-spec processor available).</summary>
+    public int SkippedUnsupported { get; init; }
+
+    /// <summary>Datasets the catalogue parser flagged as a hard failure
+    /// (e.g. missing file, IO error). Always 0 today; reserved for
+    /// future per-dataset failure capture.</summary>
+    public int Failed { get; init; }
+
+    /// <summary>True when the user cancelled before all datasets were
+    /// dispatched.</summary>
+    public bool Cancelled { get; init; }
+
+    /// <summary>True when the catalogue could not be located / parsed.</summary>
+    public bool CatalogueNotFound { get; init; }
+
+    /// <summary>Top-level fatal error (catalogue parse failure or
+    /// unexpected exception). Empty when none.</summary>
+    public string? FailureMessage { get; init; }
+
+    /// <summary>Human-readable per-dataset skip messages (currently all
+    /// "unsupported product spec" entries).</summary>
+    public IReadOnlyList<string> SkipMessages { get; init; } = Array.Empty<string>();
+}
 
 /// <summary>
 /// Opens an S-100 exchange set (a folder containing a
@@ -21,8 +86,16 @@ internal interface IExchangeSetService
     /// <c>CATALOG.XML</c>) or a <c>.zip</c> archive (with the same).
     /// </summary>
     /// <param name="folderOrZipPath">Local path to the folder or ZIP archive.</param>
+    /// <param name="progress">Optional progress sink. Reports are raised
+    /// once after the catalogue is parsed and once per dataset thereafter.</param>
     /// <param name="cancellationToken">Honored between datasets; the loader
     /// stops dispatching new datasets but does not interrupt one that is
     /// already loading.</param>
-    Task OpenAsync(string folderOrZipPath, CancellationToken cancellationToken = default);
+    /// <returns>A summary that is always non-null (even on cancellation
+    /// or fatal error).</returns>
+    Task<ExchangeSetOpenResult> OpenAsync(
+        string folderOrZipPath,
+        IProgress<ExchangeSetProgress>? progress = null,
+        CancellationToken cancellationToken = default);
 }
+

--- a/src/EncDotNet.S100.Viewer/Services/IFileDialogService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IFileDialogService.cs
@@ -28,4 +28,16 @@ internal interface IFileDialogService
     /// Prompts for a single Portrayal Catalogue folder.
     /// </summary>
     Task<string?> OpenPortrayalCatalogueFolderAsync(TopLevel? topLevel);
+
+    /// <summary>
+    /// Prompts for a single folder containing an S-100 exchange set
+    /// (must include a <c>CATALOG.XML</c> at the root).
+    /// </summary>
+    Task<string?> OpenExchangeSetFolderAsync(TopLevel? topLevel);
+
+    /// <summary>
+    /// Prompts for a single <c>.zip</c> archive containing an S-100
+    /// exchange set (a <c>CATALOG.XML</c> at the root of the archive).
+    /// </summary>
+    Task<string?> OpenExchangeSetZipAsync(TopLevel? topLevel);
 }

--- a/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
@@ -22,6 +22,8 @@ internal sealed class NativeMenuBuilder
     private readonly NativeMenu _openRecentMenu = new();
     private NativeMenuItem? _openRecentMenuItem;
     private Func<Task>? _openDatasetAsync;
+    private Func<Task>? _openExchangeSetAsync;
+    private Func<Task>? _openExchangeSetZipAsync;
 
     public NativeMenuBuilder(MainViewModel viewModel, IRecentFilesService recentFiles)
     {
@@ -39,14 +41,22 @@ internal sealed class NativeMenuBuilder
     /// </summary>
     /// <param name="window">The window to attach the menu to.</param>
     /// <param name="openDatasetAsync">Invoked when the user selects File › Open Dataset…</param>
+    /// <param name="openExchangeSetAsync">Invoked when the user selects File › Open Exchange Set…</param>
+    /// <param name="openExchangeSetZipAsync">Invoked when the user selects File › Open Exchange Set (ZIP)…</param>
     public void Attach(
         Window window,
-        Func<Task> openDatasetAsync)
+        Func<Task> openDatasetAsync,
+        Func<Task> openExchangeSetAsync,
+        Func<Task> openExchangeSetZipAsync)
     {
         ArgumentNullException.ThrowIfNull(window);
         ArgumentNullException.ThrowIfNull(openDatasetAsync);
+        ArgumentNullException.ThrowIfNull(openExchangeSetAsync);
+        ArgumentNullException.ThrowIfNull(openExchangeSetZipAsync);
 
         _openDatasetAsync = openDatasetAsync;
+        _openExchangeSetAsync = openExchangeSetAsync;
+        _openExchangeSetZipAsync = openExchangeSetZipAsync;
 
         var sideBarItem = BuildToggleItem(
             Strings.Menu_PrimarySideBar,
@@ -150,9 +160,22 @@ internal sealed class NativeMenuBuilder
             Menu = _openRecentMenu,
         };
 
+        var openExchangeSetItem = new NativeMenuItem(Strings.Menu_OpenExchangeSet);
+        openExchangeSetItem.Click += (_, _) => _ = _openExchangeSetAsync!.Invoke();
+
+        var openExchangeSetZipItem = new NativeMenuItem(Strings.Menu_OpenExchangeSetZip);
+        openExchangeSetZipItem.Click += (_, _) => _ = _openExchangeSetZipAsync!.Invoke();
+
         return new NativeMenuItem(Strings.Menu_File)
         {
-            Menu = new NativeMenu { openItem, _openRecentMenuItem },
+            Menu = new NativeMenu
+            {
+                openItem,
+                _openRecentMenuItem,
+                new NativeMenuItemSeparator(),
+                openExchangeSetItem,
+                openExchangeSetZipItem,
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -259,6 +259,15 @@ internal sealed class DatasetsViewModel : ViewModelBase
 
     public ObservableCollection<DatasetEntry> Entries { get; } = new();
 
+    /// <summary>
+    /// Header rows surfaced above <see cref="Entries"/> in the Datasets
+    /// panel — one per currently-loaded exchange set. Populated by
+    /// <see cref="EncDotNet.S100.Viewer.Services.IExchangeSetService"/>
+    /// via <see cref="RegisterExchangeSetHeader"/> and removed when the
+    /// last entry from a set is gone.
+    /// </summary>
+    public ObservableCollection<ExchangeSetHeader> ExchangeSetHeaders { get; } = new();
+
     private DatasetEntry? _selectedEntry;
     /// <summary>
     /// The dataset row currently highlighted in the panel. Drives the
@@ -398,6 +407,42 @@ internal sealed class DatasetsViewModel : ViewModelBase
             displayName: displayName);
         Entries.Insert(0, entry);
         return entry;
+    }
+
+    /// <summary>
+    /// Registers a header row for a freshly-opened exchange set. The
+    /// supplied <paramref name="closeAction"/> is invoked when the user
+    /// clicks the header's Close button and is responsible for removing
+    /// every <see cref="DatasetEntry"/> that came from this set
+    /// (typically by enumerating <see cref="Entries"/> with
+    /// <c>e.Source == source</c> and removing them); the service's
+    /// <c>OnEntriesChanged</c> listener will then dispose the set and
+    /// remove this header via <see cref="RemoveExchangeSetHeader"/>.
+    /// </summary>
+    internal ExchangeSetHeader RegisterExchangeSetHeader(
+        IAssetSource source,
+        string sourcePath,
+        string? producer,
+        string? issueDate,
+        int datasetCount,
+        Action<ExchangeSetHeader> closeAction)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+        ArgumentNullException.ThrowIfNull(closeAction);
+
+        var header = new ExchangeSetHeader(
+            source, sourcePath, producer, issueDate, datasetCount, closeAction);
+        ExchangeSetHeaders.Add(header);
+        return header;
+    }
+
+    /// <summary>Removes a header registered via
+    /// <see cref="RegisterExchangeSetHeader"/>. Idempotent.</summary>
+    internal void RemoveExchangeSetHeader(ExchangeSetHeader header)
+    {
+        ArgumentNullException.ThrowIfNull(header);
+        ExchangeSetHeaders.Remove(header);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
 
@@ -16,6 +17,26 @@ internal sealed class DatasetEntry : ViewModelBase
     public string FilePath { get; }
     public string DisplayName { get; }
     public string ProductSpec { get; }
+
+    /// <summary>
+    /// Optional asset source backing this dataset. When non-null, the
+    /// loader reads the dataset bytes from <see cref="Source"/> at
+    /// <see cref="RelativePath"/> instead of opening
+    /// <see cref="FilePath"/> directly. Set when the entry was added
+    /// from an exchange set (folder or ZIP); null for plain file
+    /// loads. Lifetime is owned by the producer (typically
+    /// <see cref="EncDotNet.S100.Viewer.Services.IExchangeSetService"/>).
+    /// </summary>
+    public IAssetSource? Source { get; }
+
+    /// <summary>
+    /// Path of this dataset relative to <see cref="Source"/>, or
+    /// <c>null</c> when the entry is a plain file load.
+    /// </summary>
+    public string? RelativePath { get; }
+
+    /// <summary>True when this entry's bytes live inside an exchange-set asset source.</summary>
+    public bool IsFromExchangeSet => Source is not null;
 
     private bool _isLoaded;
     public bool IsLoaded
@@ -151,10 +172,29 @@ internal sealed class DatasetEntry : ViewModelBase
             : string.Empty;
 
     public DatasetEntry(string filePath, string productSpec)
+        : this(filePath, productSpec, source: null, relativePath: null, displayName: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a dataset entry whose bytes live inside
+    /// <paramref name="source"/> at <paramref name="relativePath"/>.
+    /// Used by <see cref="EncDotNet.S100.Viewer.Services.IExchangeSetService"/>
+    /// for exchange-set ingestion.
+    /// </summary>
+    public DatasetEntry(
+        string filePath,
+        string productSpec,
+        IAssetSource? source,
+        string? relativePath,
+        string? displayName)
     {
         FilePath = filePath;
         ProductSpec = productSpec;
-        DisplayName = System.IO.Path.GetFileName(filePath);
+        Source = source;
+        RelativePath = relativePath;
+        DisplayName = displayName ?? System.IO.Path.GetFileName(
+            relativePath is { Length: > 0 } ? relativePath : filePath);
         ToggleVisibilityCommand = new RelayCommand(() => IsVisible = !IsVisible);
 
         _subLayers.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasSubLayers));
@@ -324,6 +364,38 @@ internal sealed class DatasetsViewModel : ViewModelBase
         // paint stack (drawn last, on top of every other dataset). New
         // datasets are inserted at the top so they overlay existing
         // ones by default.
+        Entries.Insert(0, entry);
+        return entry;
+    }
+
+    /// <summary>
+    /// Adds a dataset entry whose bytes live inside an exchange set
+    /// (folder or ZIP) rather than at a plain filesystem path.
+    /// <paramref name="source"/> must remain alive for as long as
+    /// the returned entry is loaded; the caller (typically
+    /// <see cref="IExchangeSetService"/>) is responsible for that
+    /// lifetime.
+    /// </summary>
+    public DatasetEntry AddFromExchangeSet(
+        IAssetSource source,
+        string relativePath,
+        string productSpec,
+        string? displayName = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+
+        // FilePath is set to the relative path so logging and the
+        // Properties panel have something useful to show even when
+        // there is no real on-disk file (the entry is sourced from
+        // a ZIP archive).
+        var entry = new DatasetEntry(
+            filePath: relativePath,
+            productSpec: productSpec,
+            source: source,
+            relativePath: relativePath,
+            displayName: displayName);
         Entries.Insert(0, entry);
         return entry;
     }

--- a/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Viewer.Resources;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -21,7 +23,7 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// individually) causes the registering service to dispose the
 /// underlying <see cref="IAssetSource"/> and unregister the header.
 /// </remarks>
-internal sealed class ExchangeSetHeader : ViewModelBase
+internal sealed partial class ExchangeSetHeader : ViewModelBase
 {
     /// <summary>The asset source backing the exchange set; used to
     /// match this header against <see cref="DatasetEntry.Source"/>.</summary>
@@ -43,10 +45,25 @@ internal sealed class ExchangeSetHeader : ViewModelBase
     /// <c>null</c> if unknown.</summary>
     public string? IssueDate { get; }
 
-    /// <summary>Total number of catalogued datasets — note that this is
-    /// the number from the catalogue, not the number actually loaded
-    /// (which may be lower due to unsupported product specs).</summary>
+    /// <summary>Total number of catalogued datasets.</summary>
     public int DatasetCount { get; }
+
+    [ObservableProperty]
+    private int _loadedCount;
+
+    [ObservableProperty]
+    private int _unsupportedCount;
+
+    /// <summary>Single-line summary combining loaded/unsupported counts,
+    /// producer and issue date, joined with " · ". Bound to the
+    /// trimmable secondary line in the header so any of the three
+    /// pieces can fall off into the ellipsis when the pane narrows.
+    /// Recomputed whenever <see cref="LoadedCount"/> or
+    /// <see cref="UnsupportedCount"/> changes.</summary>
+    public string MetadataSummary => BuildMetadataSummary(LoadedCount, UnsupportedCount, Producer, IssueDate);
+
+    partial void OnLoadedCountChanged(int value) => OnPropertyChanged(nameof(MetadataSummary));
+    partial void OnUnsupportedCountChanged(int value) => OnPropertyChanged(nameof(MetadataSummary));
 
     /// <summary>Removes every entry whose <see cref="DatasetEntry.Source"/>
     /// matches this header's <see cref="Source"/>. Wired by the
@@ -71,7 +88,37 @@ internal sealed class ExchangeSetHeader : ViewModelBase
         Producer = producer;
         IssueDate = issueDate;
         DatasetCount = datasetCount;
+        // Initialise counts to the catalogue total so the header has a
+        // sensible label while datasets are still loading. The service
+        // overwrites these once it knows the loaded/unsupported split.
+        _loadedCount = datasetCount;
+        _unsupportedCount = 0;
         CloseCommand = new RelayCommand(() => closeAction(this));
+    }
+
+    private static string BuildMetadataSummary(int loadedCount, int unsupportedCount, string? producer, string? issueDate)
+    {
+        var parts = new System.Collections.Generic.List<string>(4)
+        {
+            string.Format(Strings.Pane_ExchangeSetHeader_Count, loadedCount),
+        };
+
+        if (unsupportedCount > 0)
+        {
+            parts.Add(string.Format(Strings.Pane_ExchangeSetHeader_Unsupported, unsupportedCount));
+        }
+
+        if (!string.IsNullOrWhiteSpace(producer))
+        {
+            parts.Add(string.Format(Strings.Pane_ExchangeSetHeader_Producer, producer));
+        }
+
+        if (!string.IsNullOrWhiteSpace(issueDate))
+        {
+            parts.Add(string.Format(Strings.Pane_ExchangeSetHeader_Issued, issueDate));
+        }
+
+        return string.Join(" · ", parts);
     }
 
     private static string DeriveDisplayName(string sourcePath)

--- a/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Header row surfaced above the dataset list when an exchange set is
+/// loaded. Carries catalogue-level metadata (producer, issue date,
+/// dataset count, source path) plus a Close command that delegates
+/// back to the registering service so it can remove every entry that
+/// came from this set in one shot.
+/// </summary>
+/// <remarks>
+/// The viewer keeps one of these per loaded exchange set in
+/// <see cref="DatasetsViewModel.ExchangeSetHeaders"/>. Removing the
+/// last <see cref="DatasetEntry"/> whose <c>Source</c> matches a
+/// header (whether by clicking Close or by removing entries
+/// individually) causes the registering service to dispose the
+/// underlying <see cref="IAssetSource"/> and unregister the header.
+/// </remarks>
+internal sealed class ExchangeSetHeader : ViewModelBase
+{
+    /// <summary>The asset source backing the exchange set; used to
+    /// match this header against <see cref="DatasetEntry.Source"/>.</summary>
+    public IAssetSource Source { get; }
+
+    /// <summary>The folder path or .zip path the user opened.</summary>
+    public string SourcePath { get; }
+
+    /// <summary>Short, user-facing label derived from
+    /// <see cref="SourcePath"/> (the folder or archive name).</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Catalogue-declared producer organisation, or
+    /// <c>null</c> if unknown.</summary>
+    public string? Producer { get; }
+
+    /// <summary>Catalogue-derived issue date string (the latest
+    /// <c>DatasetDiscoveryMetadata.IssueDate</c> across the set), or
+    /// <c>null</c> if unknown.</summary>
+    public string? IssueDate { get; }
+
+    /// <summary>Total number of catalogued datasets — note that this is
+    /// the number from the catalogue, not the number actually loaded
+    /// (which may be lower due to unsupported product specs).</summary>
+    public int DatasetCount { get; }
+
+    /// <summary>Removes every entry whose <see cref="DatasetEntry.Source"/>
+    /// matches this header's <see cref="Source"/>. Wired by the
+    /// registering service.</summary>
+    public ICommand CloseCommand { get; }
+
+    public ExchangeSetHeader(
+        IAssetSource source,
+        string sourcePath,
+        string? producer,
+        string? issueDate,
+        int datasetCount,
+        Action<ExchangeSetHeader> closeAction)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+        ArgumentNullException.ThrowIfNull(closeAction);
+
+        Source = source;
+        SourcePath = sourcePath;
+        DisplayName = DeriveDisplayName(sourcePath);
+        Producer = producer;
+        IssueDate = issueDate;
+        DatasetCount = datasetCount;
+        CloseCommand = new RelayCommand(() => closeAction(this));
+    }
+
+    private static string DeriveDisplayName(string sourcePath)
+    {
+        var trimmed = sourcePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var name = Path.GetFileName(trimmed);
+        return string.IsNullOrEmpty(name) ? sourcePath : name;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -253,6 +253,137 @@ internal sealed class MainViewModel : ViewModelBase
 
     public ICommand ToggleThemeCommand { get; }
 
+    // ─── Exchange-set progress + banner (es3-progress) ────────────────────
+
+    private bool _isExchangeSetLoading;
+    private double _exchangeSetProgressFraction;
+    private string? _exchangeSetCurrentDataset;
+    private string? _exchangeSetCounter;
+    private string? _exchangeSetSourceLabel;
+    private bool _isExchangeSetBannerVisible;
+    private string? _exchangeSetBannerMessage;
+    private System.Threading.CancellationTokenSource? _exchangeSetCts;
+
+    /// <summary>
+    /// True while an exchange-set load is in flight. Bound to the
+    /// progress overlay's <c>IsVisible</c>.
+    /// </summary>
+    public bool IsExchangeSetLoading
+    {
+        get => _isExchangeSetLoading;
+        private set => SetProperty(ref _isExchangeSetLoading, value);
+    }
+
+    /// <summary>
+    /// Progress fraction in <c>[0, 1]</c> — bound to a determinate
+    /// <see cref="Avalonia.Controls.ProgressBar"/>.
+    /// </summary>
+    public double ExchangeSetProgressFraction
+    {
+        get => _exchangeSetProgressFraction;
+        private set => SetProperty(ref _exchangeSetProgressFraction, value);
+    }
+
+    /// <summary>Catalogue-relative path of the dataset currently being routed.</summary>
+    public string? ExchangeSetCurrentDataset
+    {
+        get => _exchangeSetCurrentDataset;
+        private set => SetProperty(ref _exchangeSetCurrentDataset, value);
+    }
+
+    /// <summary>"3 of 12" counter shown in the overlay header.</summary>
+    public string? ExchangeSetCounter
+    {
+        get => _exchangeSetCounter;
+        private set => SetProperty(ref _exchangeSetCounter, value);
+    }
+
+    /// <summary>The folder or .zip path being opened — shown in the overlay.</summary>
+    public string? ExchangeSetSourceLabel
+    {
+        get => _exchangeSetSourceLabel;
+        private set => SetProperty(ref _exchangeSetSourceLabel, value);
+    }
+
+    /// <summary>Cancels the in-flight exchange-set load. No-op if idle.</summary>
+    public ICommand CancelExchangeSetCommand { get; }
+
+    /// <summary>True while a partial-failure / fatal-error banner is shown.</summary>
+    public bool IsExchangeSetBannerVisible
+    {
+        get => _isExchangeSetBannerVisible;
+        private set => SetProperty(ref _isExchangeSetBannerVisible, value);
+    }
+
+    /// <summary>Banner body text (already localised + formatted).</summary>
+    public string? ExchangeSetBannerMessage
+    {
+        get => _exchangeSetBannerMessage;
+        private set => SetProperty(ref _exchangeSetBannerMessage, value);
+    }
+
+    /// <summary>Hides the partial-failure banner.</summary>
+    public ICommand DismissExchangeSetBannerCommand { get; }
+
+    /// <summary>
+    /// Called by <see cref="MainWindow"/> when an exchange-set load is
+    /// about to start. Captures the cancellation source, resets progress
+    /// state, and clears any leftover banner.
+    /// </summary>
+    internal System.Threading.CancellationToken BeginExchangeSetLoad(string sourcePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+        _exchangeSetCts?.Dispose();
+        _exchangeSetCts = new System.Threading.CancellationTokenSource();
+
+        IsExchangeSetBannerVisible = false;
+        ExchangeSetBannerMessage = null;
+        ExchangeSetSourceLabel = sourcePath;
+        ExchangeSetCurrentDataset = null;
+        ExchangeSetCounter = null;
+        ExchangeSetProgressFraction = 0;
+        IsExchangeSetLoading = true;
+        return _exchangeSetCts.Token;
+    }
+
+    /// <summary>Pushes a single progress update from the service into the VM.</summary>
+    internal void ReportExchangeSetProgress(ExchangeSetProgress progress)
+    {
+        ExchangeSetCurrentDataset = progress.CurrentDataset;
+        ExchangeSetCounter = progress.Total > 0
+            ? string.Format(Strings.Progress_ExchangeSetCounter, progress.Completed, progress.Total)
+            : null;
+        ExchangeSetProgressFraction = progress.Total > 0
+            ? Math.Clamp((double)progress.Completed / progress.Total, 0.0, 1.0)
+            : 0.0;
+    }
+
+    /// <summary>
+    /// Called by <see cref="MainWindow"/> when an exchange-set load
+    /// completes (or is cancelled / fatally fails). Hides the overlay
+    /// and surfaces a banner if there is anything worth flagging.
+    /// </summary>
+    internal void EndExchangeSetLoad(ExchangeSetOpenResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        IsExchangeSetLoading = false;
+        ExchangeSetCurrentDataset = null;
+
+        if (result.FailureMessage is { } message && !result.CatalogueNotFound)
+        {
+            ExchangeSetBannerMessage = string.Format(
+                Strings.Banner_ExchangeSetFailed, result.SourcePath, message);
+            IsExchangeSetBannerVisible = true;
+        }
+        else if (result.SkippedUnsupported > 0)
+        {
+            ExchangeSetBannerMessage = string.Format(
+                Strings.Banner_ExchangeSetPartial,
+                result.SkippedUnsupported, result.Total, result.SourcePath, result.SkippedUnsupported);
+            IsExchangeSetBannerVisible = true;
+        }
+    }
+
     /// <summary>
     /// Opens a dataset that the user has previously loaded. If the file is
     /// no longer at the recorded path the entry is dropped from the recent
@@ -397,6 +528,20 @@ internal sealed class MainViewModel : ViewModelBase
         };
 
         ToggleThemeCommand = new RelayCommand(() => IsDarkTheme = _theme.ToggleTheme());
+
+        CancelExchangeSetCommand = new RelayCommand(
+            () => _exchangeSetCts?.Cancel(),
+            () => IsExchangeSetLoading);
+        DismissExchangeSetBannerCommand = new RelayCommand(
+            () => IsExchangeSetBannerVisible = false);
+
+        // Re-evaluate Cancel command when the loading flag changes so the
+        // overlay button enables/disables correctly.
+        PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(IsExchangeSetLoading))
+                ((RelayCommand)CancelExchangeSetCommand).NotifyCanExecuteChanged();
+        };
 
         OpenRecentCommand = new AsyncRelayCommand<string>(OpenRecentAsync);
 

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -94,6 +94,55 @@
                 Margin="8"
                 x:Name="AddButton" />
 
+        <!-- Exchange-set header rows: one per loaded exchange set,
+             stacked above the bulk-action toolbar. Each row exposes a
+             Close button that removes every dataset contributed by
+             that set. -->
+        <ItemsControl DockPanel.Dock="Top"
+                      ItemsSource="{Binding ExchangeSetHeaders}"
+                      Margin="8,4,8,0">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="vm:ExchangeSetHeader">
+                    <Border BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="8,6"
+                            Margin="0,0,0,4">
+                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                            <TextBlock Grid.Row="0" Grid.Column="0"
+                                       Text="{Binding DisplayName}"
+                                       FontWeight="SemiBold"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip.Tip="{Binding SourcePath}" />
+                            <Button Grid.Row="0" Grid.Column="1" Grid.RowSpan="2"
+                                    Classes="Icon"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding CloseCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseExchangeSet}">
+                                <ic:FluentIcon Icon="Dismiss" IconVariant="Regular" FontSize="14" />
+                            </Button>
+                            <StackPanel Grid.Row="1" Grid.Column="0"
+                                        Orientation="Horizontal"
+                                        Spacing="8">
+                                <TextBlock Classes="Caption"
+                                           Opacity="0.75"
+                                           Text="{Binding DatasetCount, StringFormat={x:Static loc:Strings.Pane_ExchangeSetHeader_Count}}" />
+                                <TextBlock Classes="Caption"
+                                           Opacity="0.75"
+                                           IsVisible="{Binding Producer, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                           Text="{Binding Producer, StringFormat={x:Static loc:Strings.Pane_ExchangeSetHeader_Producer}}"
+                                           TextTrimming="CharacterEllipsis" />
+                                <TextBlock Classes="Caption"
+                                           Opacity="0.75"
+                                           IsVisible="{Binding IssueDate, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                           Text="{Binding IssueDate, StringFormat={x:Static loc:Strings.Pane_ExchangeSetHeader_Issued}}" />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
         <!-- Bulk-action toolbar: applies to every loaded dataset.
              "Isolate" is per-row (right-click context menu) because it
              needs a target. -->

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -100,47 +100,57 @@
              that set. -->
         <ItemsControl DockPanel.Dock="Top"
                       ItemsSource="{Binding ExchangeSetHeaders}"
+                      HorizontalAlignment="Stretch"
                       Margin="8,4,8,0">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Vertical" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate DataType="vm:ExchangeSetHeader">
                     <Border BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                             BorderThickness="1"
                             CornerRadius="4"
                             Padding="8,6"
-                            Margin="0,0,0,4">
+                            Margin="0,0,0,4"
+                            HorizontalAlignment="Stretch">
                         <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
-                            <TextBlock Grid.Row="0" Grid.Column="0"
+                            <TextBlock Grid.Column="0" Grid.Row="0"
                                        Text="{Binding DisplayName}"
                                        FontWeight="SemiBold"
                                        TextTrimming="CharacterEllipsis"
                                        ToolTip.Tip="{Binding SourcePath}" />
-                            <Button Grid.Row="0" Grid.Column="1" Grid.RowSpan="2"
+                            <TextBlock Grid.Column="0" Grid.Row="1"
+                                       Classes="Caption"
+                                       Opacity="0.75"
+                                       Text="{Binding MetadataSummary}"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip.Tip="{Binding MetadataSummary}" />
+                            <Button Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
                                     Classes="Icon"
                                     VerticalAlignment="Center"
+                                    Margin="6,0,0,0"
                                     Command="{Binding CloseCommand}"
                                     ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseExchangeSet}">
-                                <ic:FluentIcon Icon="Dismiss" IconVariant="Regular" FontSize="14" />
+                                <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
                             </Button>
-                            <StackPanel Grid.Row="1" Grid.Column="0"
-                                        Orientation="Horizontal"
-                                        Spacing="8">
-                                <TextBlock Classes="Caption"
-                                           Opacity="0.75"
-                                           Text="{Binding DatasetCount, StringFormat={x:Static loc:Strings.Pane_ExchangeSetHeader_Count}}" />
-                                <TextBlock Classes="Caption"
-                                           Opacity="0.75"
-                                           IsVisible="{Binding Producer, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                           Text="{Binding Producer, StringFormat={x:Static loc:Strings.Pane_ExchangeSetHeader_Producer}}"
-                                           TextTrimming="CharacterEllipsis" />
-                                <TextBlock Classes="Caption"
-                                           Opacity="0.75"
-                                           IsVisible="{Binding IssueDate, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                           Text="{Binding IssueDate, StringFormat={x:Static loc:Strings.Pane_ExchangeSetHeader_Issued}}" />
-                            </StackPanel>
                         </Grid>
                     </Border>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
+            <ItemsControl.Styles>
+                <!-- Force each generated container to stretch the full
+                     pane width. Without this, ShadUI's default
+                     ContentPresenter sizing leaves the Border at
+                     intrinsic content width, which can let the inner
+                     Grid measure children with infinity and skip
+                     TextTrimming. -->
+                <Style Selector="ItemsControl > ContentPresenter">
+                    <Setter Property="HorizontalAlignment" Value="Stretch" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ItemsControl.Styles>
         </ItemsControl>
 
         <!-- Bulk-action toolbar: applies to every loaded dataset.

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryMappingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryMappingTests.cs
@@ -1,0 +1,40 @@
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class DatasetPipelineFactoryMappingTests
+{
+    [Theory]
+    [InlineData("S-101", "S-101")]
+    [InlineData("S-102", "S-102")]
+    [InlineData("S-104", "S-104")]
+    [InlineData("S-111", "S-111")]
+    [InlineData("S-122", "S-122")]
+    [InlineData("S-124", "S-124")]
+    [InlineData("S-125", "S-125")]
+    [InlineData("S-127", "S-127")]
+    [InlineData("S-128", "S-128")]
+    [InlineData("S-129", "S-129")]
+    [InlineData("S-411", "S-411")]
+    [InlineData("S-421", "S-421")]
+    [InlineData("S-57", "S-57")]
+    [InlineData("S101", "S-101")]
+    [InlineData("s-101", "S-101")]
+    [InlineData("  S-101  ", "S-101")]
+    [InlineData("s101", "S-101")]
+    public void MapProductIdentifierToSpec_NormalizesKnownIdentifiers(string input, string expected)
+    {
+        Assert.Equal(expected, DatasetPipelineFactory.MapProductIdentifierToSpec(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("S-999")]
+    [InlineData("garbage")]
+    public void MapProductIdentifierToSpec_ReturnsNullForUnknown(string? input)
+    {
+        Assert.Null(DatasetPipelineFactory.MapProductIdentifierToSpec(input));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class DatasetsViewModelExchangeSetHeaderTests
+{
+    private sealed class StubAssetSource : IAssetSource
+    {
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public void Dispose() { }
+    }
+
+    private sealed class NoopLoader : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<string?>? StatusChanged { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+    }
+
+    private static DatasetsViewModel NewVm() => new(new NoopLoader());
+
+    [Fact]
+    public void RegisterExchangeSetHeader_AddsToCollection_AndReturnsSameInstance()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+
+        var header = vm.RegisterExchangeSetHeader(
+            src, "/tmp/eset", "ACME", "2024-05-01", 7, _ => { });
+
+        Assert.Single(vm.ExchangeSetHeaders);
+        Assert.Same(header, vm.ExchangeSetHeaders[0]);
+        Assert.Equal("ACME", header.Producer);
+        Assert.Equal("2024-05-01", header.IssueDate);
+        Assert.Equal(7, header.DatasetCount);
+        Assert.Equal("/tmp/eset", header.SourcePath);
+    }
+
+    [Fact]
+    public void RemoveExchangeSetHeader_RemovesIt()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var header = vm.RegisterExchangeSetHeader(src, "/p", null, null, 1, _ => { });
+
+        vm.RemoveExchangeSetHeader(header);
+
+        Assert.Empty(vm.ExchangeSetHeaders);
+    }
+
+    [Fact]
+    public void RemoveExchangeSetHeader_IsIdempotent()
+    {
+        var vm = NewVm();
+        var header = vm.RegisterExchangeSetHeader(
+            new StubAssetSource(), "/p", null, null, 0, _ => { });
+
+        vm.RemoveExchangeSetHeader(header);
+        vm.RemoveExchangeSetHeader(header);
+
+        Assert.Empty(vm.ExchangeSetHeaders);
+    }
+
+    [Fact]
+    public void CloseCommand_InvokesCloseAction_WithSelf()
+    {
+        var vm = NewVm();
+        ExchangeSetHeader? captured = null;
+        var header = vm.RegisterExchangeSetHeader(
+            new StubAssetSource(), "/p", null, null, 0, h => captured = h);
+
+        Assert.True(header.CloseCommand.CanExecute(null));
+        header.CloseCommand.Execute(null);
+
+        Assert.Same(header, captured);
+    }
+
+    [Fact]
+    public void DisplayName_DerivedFromSourcePath_FolderForm()
+    {
+        var vm = NewVm();
+        var sep = Path.DirectorySeparatorChar;
+        var path = $"{sep}data{sep}exchange{sep}MyEset";
+
+        var header = vm.RegisterExchangeSetHeader(
+            new StubAssetSource(), path, null, null, 0, _ => { });
+
+        Assert.Equal("MyEset", header.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_DerivedFromSourcePath_ZipForm()
+    {
+        var vm = NewVm();
+        var path = Path.Combine(Path.GetTempPath(), "MyEset.zip");
+
+        var header = vm.RegisterExchangeSetHeader(
+            new StubAssetSource(), path, null, null, 0, _ => { });
+
+        Assert.Equal("MyEset.zip", header.DisplayName);
+    }
+
+    [Fact]
+    public void RegisterExchangeSetHeader_RejectsNullArgs()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            vm.RegisterExchangeSetHeader(null!, "/p", null, null, 0, _ => { }));
+        Assert.Throws<ArgumentException>(() =>
+            vm.RegisterExchangeSetHeader(src, "", null, null, 0, _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            vm.RegisterExchangeSetHeader(src, "/p", null, null, 0, null!));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="ExchangeSetDetection"/>, the helpers
+/// the viewer's drag-and-drop handler uses to decide whether a
+/// dropped folder or ZIP is an S-100 exchange set.
+/// </summary>
+public sealed class ExchangeSetDetectionTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(
+        Path.GetTempPath(), $"esd-{Guid.NewGuid():N}");
+
+    public ExchangeSetDetectionTests()
+    {
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempRoot, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Theory]
+    [InlineData("foo.zip", true)]
+    [InlineData("foo.ZIP", true)]
+    [InlineData("/path/to/Foo.Zip", true)]
+    [InlineData("foo.000", false)]
+    [InlineData("foo", false)]
+    [InlineData("", false)]
+    public void IsZipPath_HandlesCommonCases(string path, bool expected)
+    {
+        Assert.Equal(expected, ExchangeSetDetection.IsZipPath(path));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetFolder_TrueWhenCatalogPresent()
+    {
+        var folder = Path.Combine(_tempRoot, "set");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "CATALOG.XML"), "<root/>");
+
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetFolder_CaseInsensitiveOnFileName()
+    {
+        var folder = Path.Combine(_tempRoot, "ci");
+        Directory.CreateDirectory(folder);
+        // Name varies by case to make sure detection isn't relying on
+        // a single canonical spelling.
+        File.WriteAllText(Path.Combine(folder, "catalog.xml"), "<root/>");
+
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetFolder_FalseWhenCatalogOnlyInSubfolder()
+    {
+        // A nested CATALOG.XML doesn't constitute an exchange set
+        // root — the loader expects it at the top level.
+        var folder = Path.Combine(_tempRoot, "nested");
+        var sub = Path.Combine(folder, "inner");
+        Directory.CreateDirectory(sub);
+        File.WriteAllText(Path.Combine(sub, "CATALOG.XML"), "<root/>");
+
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetFolder_FalseForEmptyOrMissing()
+    {
+        var folder = Path.Combine(_tempRoot, "empty");
+        Directory.CreateDirectory(folder);
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetFolder(
+            Path.Combine(_tempRoot, "does-not-exist")));
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetFolder(""));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetZip_TrueWhenRootCatalogPresent()
+    {
+        var zip = Path.Combine(_tempRoot, "good.zip");
+        using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+        {
+            archive.CreateEntry("CATALOG.XML");
+            archive.CreateEntry("S-101/A.000");
+        }
+
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetZip_FalseWhenCatalogOnlyNested()
+    {
+        var zip = Path.Combine(_tempRoot, "nested.zip");
+        using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+        {
+            archive.CreateEntry("inner/CATALOG.XML");
+            archive.CreateEntry("inner/S-101/A.000");
+        }
+
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetZip_FalseForBareDataFile()
+    {
+        var zip = Path.Combine(_tempRoot, "bare.zip");
+        using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+        {
+            archive.CreateEntry("A.000");
+            archive.CreateEntry("README.txt");
+        }
+
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetZip_FalseForCorruptArchive()
+    {
+        var zip = Path.Combine(_tempRoot, "corrupt.zip");
+        File.WriteAllText(zip, "not a real zip");
+
+        // Should swallow the InvalidDataException and let the drop
+        // fall through to the single-file loader.
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetZip_FalseForMissingFile()
+    {
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetZip(
+            Path.Combine(_tempRoot, "ghost.zip")));
+        Assert.False(ExchangeSetDetection.LooksLikeExchangeSetZip(""));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Services;
+using ExchangeSetProgress = EncDotNet.S100.Viewer.Services.ExchangeSetProgress;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// End-to-end coverage of <see cref="ExchangeSetService"/> against
+/// the synthetic CATALOG.XML fixtures under
+/// <c>tests/datasets/ExchangeSets/</c>. These tests use a no-op
+/// <see cref="IDatasetLoaderService"/> so the loader never opens the
+/// (non-existent) referenced dataset files; we are exercising the
+/// catalogue → entry dispatch + header lifecycle, not real
+/// rasterisation.
+/// </summary>
+public class ExchangeSetServiceLoaderTests
+{
+    private static string FixturesRoot([CallerFilePath] string callerFilePath = "")
+        => Path.Combine(
+            Path.GetDirectoryName(callerFilePath)!,
+            "..", "datasets", "ExchangeSets");
+
+    private static string MixedFixture() =>
+        Path.Combine(FixturesRoot(), "Synthetic-Mixed");
+
+    private static string AllUnsupportedFixture() =>
+        Path.Combine(FixturesRoot(), "Synthetic-AllUnsupported");
+
+    private sealed class StubStatus : IStatusPresenter
+    {
+        public string? StatusText { get; set; }
+        public event PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
+    }
+
+    private sealed class NoopLoader : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<string?>? StatusChanged { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+    }
+
+    private static (DatasetsViewModel datasets, ExchangeSetService service) CreateSystem()
+    {
+        var datasets = new DatasetsViewModel(new NoopLoader());
+        var service = new ExchangeSetService(datasets, new StubStatus());
+        return (datasets, service);
+    }
+
+    [Fact]
+    public async Task OpenAsync_MixedFixture_LoadsSupportedAndSkipsUnsupported()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(MixedFixture());
+
+        Assert.Equal(3, result.Total);
+        Assert.Equal(2, result.Loaded);
+        Assert.Equal(1, result.SkippedUnsupported);
+        Assert.False(result.Cancelled);
+        Assert.Single(result.SkipMessages);
+        Assert.Contains("S-999", result.SkipMessages[0]);
+
+        // Both supported entries are surfaced in the panel.
+        Assert.Equal(2, datasets.Entries.Count);
+        Assert.Contains(datasets.Entries, e => e.ProductSpec == "S-101");
+        Assert.Contains(datasets.Entries, e => e.ProductSpec == "S-102");
+    }
+
+    [Fact]
+    public async Task OpenAsync_MixedFixture_RegistersHeaderWithCatalogueMetadata()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(MixedFixture());
+
+        var header = Assert.Single(datasets.ExchangeSetHeaders);
+        Assert.Equal("Synthetic Hydrographic Office", header.Producer);
+        // Latest issueDate across the 3 datasets is 2026-01-12.
+        Assert.Equal("2026-01-12", header.IssueDate);
+        // Header reports the catalogue total, not the loaded count.
+        Assert.Equal(3, header.DatasetCount);
+        Assert.Equal("Synthetic-Mixed", header.DisplayName);
+        Assert.Equal(MixedFixture(), header.SourcePath);
+        // UnionBoundingBox is null because none of the fixtures declare one.
+        Assert.Null(result.UnionBoundingBox);
+    }
+
+    [Fact]
+    public async Task OpenAsync_MixedFixture_CloseCommand_RemovesEveryEntry_AndUnregistersHeader()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        await service.OpenAsync(MixedFixture());
+        Assert.Equal(2, datasets.Entries.Count);
+        var header = Assert.Single(datasets.ExchangeSetHeaders);
+
+        header.CloseCommand.Execute(null);
+
+        // CloseCommand removes every entry contributed by this set;
+        // the service's collection-changed listener disposes the set
+        // and unregisters the header in the same pass.
+        Assert.Empty(datasets.Entries);
+        Assert.Empty(datasets.ExchangeSetHeaders);
+    }
+
+    [Fact]
+    public async Task OpenAsync_MixedFixture_RemovingEveryEntryByHand_AlsoRemovesHeader()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        await service.OpenAsync(MixedFixture());
+
+        // Simulate the user removing each row individually rather than
+        // using the header's Close button.
+        foreach (var entry in datasets.Entries.ToArray())
+        {
+            datasets.Entries.Remove(entry);
+        }
+
+        Assert.Empty(datasets.Entries);
+        Assert.Empty(datasets.ExchangeSetHeaders);
+    }
+
+    [Fact]
+    public async Task OpenAsync_AllUnsupportedFixture_DisposesSetImmediately()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(AllUnsupportedFixture());
+
+        Assert.Equal(2, result.Total);
+        Assert.Equal(0, result.Loaded);
+        Assert.Equal(2, result.SkippedUnsupported);
+        Assert.Equal(2, result.SkipMessages.Count);
+
+        // No entries dispatched, and the header must be cleaned up so
+        // the underlying file handle is released right away.
+        Assert.Empty(datasets.Entries);
+        Assert.Empty(datasets.ExchangeSetHeaders);
+    }
+
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        public List<T> Reports { get; } = new();
+        public void Report(T value) => Reports.Add(value);
+    }
+
+    [Fact]
+    public async Task OpenAsync_MixedFixture_ProgressReportsEveryStep()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+        var progress = new SynchronousProgress<ExchangeSetProgress>();
+
+        await service.OpenAsync(MixedFixture(), progress);
+
+        // Initial total + one per dataset (3) = 4 reports.
+        Assert.Equal(4, progress.Reports.Count);
+        Assert.Equal(3, progress.Reports[^1].Total);
+        Assert.Equal(3, progress.Reports[^1].Completed);
+        Assert.Equal(1, progress.Reports[^1].Failed);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceUnionBoundingBoxTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceUnionBoundingBoxTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class ExchangeSetServiceUnionBoundingBoxTests
+{
+    private static DatasetDiscoveryMetadata Dataset(BoundingBox? bbox) =>
+        new()
+        {
+            FileName = "x",
+            ProductSpecification = null,
+            BoundingBox = bbox,
+        };
+
+    private static BoundingBox Box(double w, double e, double s, double n) =>
+        new()
+        {
+            WestBoundLongitude = w,
+            EastBoundLongitude = e,
+            SouthBoundLatitude = s,
+            NorthBoundLatitude = n,
+        };
+
+    [Fact]
+    public void ReturnsNull_WhenNoDatasetsHaveBoundingBox()
+    {
+        var datasets = new List<DatasetDiscoveryMetadata>
+        {
+            Dataset(null), Dataset(null),
+        };
+
+        var union = ExchangeSetService.ComputeUnionBoundingBox(datasets);
+
+        Assert.Null(union);
+    }
+
+    [Fact]
+    public void ReturnsSingleBox_WhenOneDatasetHasBoundingBox()
+    {
+        var datasets = new List<DatasetDiscoveryMetadata>
+        {
+            Dataset(Box(-10, 10, -5, 5)), Dataset(null),
+        };
+
+        var union = ExchangeSetService.ComputeUnionBoundingBox(datasets);
+
+        Assert.NotNull(union);
+        Assert.Equal(-10, union!.WestBoundLongitude);
+        Assert.Equal(10, union.EastBoundLongitude);
+        Assert.Equal(-5, union.SouthBoundLatitude);
+        Assert.Equal(5, union.NorthBoundLatitude);
+    }
+
+    [Fact]
+    public void Unions_TwoDisjointBoxes()
+    {
+        var datasets = new List<DatasetDiscoveryMetadata>
+        {
+            Dataset(Box(-10, -5, 0, 5)),
+            Dataset(Box(10, 20, 30, 40)),
+        };
+
+        var union = ExchangeSetService.ComputeUnionBoundingBox(datasets);
+
+        Assert.NotNull(union);
+        Assert.Equal(-10, union!.WestBoundLongitude);
+        Assert.Equal(20, union.EastBoundLongitude);
+        Assert.Equal(0, union.SouthBoundLatitude);
+        Assert.Equal(40, union.NorthBoundLatitude);
+    }
+
+    [Fact]
+    public void IgnoresDatasetsWithoutBoundingBox()
+    {
+        var datasets = new List<DatasetDiscoveryMetadata>
+        {
+            Dataset(null),
+            Dataset(Box(0, 1, 0, 1)),
+            Dataset(null),
+            Dataset(Box(2, 3, 2, 3)),
+        };
+
+        var union = ExchangeSetService.ComputeUnionBoundingBox(datasets);
+
+        Assert.NotNull(union);
+        Assert.Equal(0, union!.WestBoundLongitude);
+        Assert.Equal(3, union.EastBoundLongitude);
+        Assert.Equal(0, union.SouthBoundLatitude);
+        Assert.Equal(3, union.NorthBoundLatitude);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -68,6 +68,8 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
+            displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new NoopLoader())),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider());

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Catalogs;
+using EncDotNet.S100.Viewer.Services;
+using ExchangeSetProgress = EncDotNet.S100.Viewer.Services.ExchangeSetProgress;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class MainViewModelExchangeSetProgressTests : IDisposable
+{
+    private readonly string _tempSettingsPath = Path.Combine(
+        Path.GetTempPath(), $"viewer-tests-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_tempSettingsPath)) File.Delete(_tempSettingsPath); }
+        catch { /* best effort */ }
+    }
+
+    private sealed class EmptyCatalogSource : IDatasetCatalogSource
+    {
+        public string Id => "test";
+        public string DisplayName => "Test";
+        public IReadOnlyList<DatasetCatalogEntry> Entries => Array.Empty<DatasetCatalogEntry>();
+        public event EventHandler<DatasetCatalogChangedEventArgs>? Changed { add { } remove { } }
+    }
+
+    private sealed class StubThemeService : IThemeService
+    {
+        public bool IsDarkTheme => false;
+        public bool ToggleTheme() => false;
+    }
+
+    private sealed class NoopLoader : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<string?>? StatusChanged { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+    }
+
+    private MainViewModel CreateViewModel()
+    {
+        var settings = new ViewerSettings { SettingsFilePath = _tempSettingsPath };
+        var catalogues = new PortrayalCatalogueManager();
+        return new MainViewModel(
+            settings,
+            featureCatalogues: new FeatureCataloguesViewModel(settings),
+            portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
+            datasets: new DatasetsViewModel(new NoopLoader()),
+            catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
+            search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
+            settingsViewModel: new SettingsViewModel(settings),
+            pickReport: new PickReportViewModel(),
+            timeline: new TimelineViewModel(new GlobalTimeService()),
+            themeService: new StubThemeService(),
+            recentFiles: new StubRecentFilesService(),
+            measureAppearance: new StubMeasureOverlayAppearanceProvider());
+    }
+
+    [Fact]
+    public void BeginExchangeSetLoad_SetsLoadingStateAndReturnsCancellableToken()
+    {
+        var vm = CreateViewModel();
+
+        var token = vm.BeginExchangeSetLoad("/some/folder");
+
+        Assert.True(vm.IsExchangeSetLoading);
+        Assert.Equal("/some/folder", vm.ExchangeSetSourceLabel);
+        Assert.Equal(0.0, vm.ExchangeSetProgressFraction);
+        Assert.False(token.IsCancellationRequested);
+        Assert.True(vm.CancelExchangeSetCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void CancelCommand_TriggersTokenCancellation()
+    {
+        var vm = CreateViewModel();
+        var token = vm.BeginExchangeSetLoad("/some/folder");
+
+        vm.CancelExchangeSetCommand.Execute(null);
+
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void CancelCommand_DisabledWhenIdle()
+    {
+        var vm = CreateViewModel();
+
+        Assert.False(vm.IsExchangeSetLoading);
+        Assert.False(vm.CancelExchangeSetCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void ReportProgress_UpdatesFractionAndCounter()
+    {
+        var vm = CreateViewModel();
+        vm.BeginExchangeSetLoad("/some/folder");
+
+        vm.ReportExchangeSetProgress(new ExchangeSetProgress(
+            "/some/folder", Total: 4, Completed: 1, Failed: 0, CurrentDataset: "101NO/foo.000"));
+
+        Assert.Equal(0.25, vm.ExchangeSetProgressFraction);
+        Assert.Equal("101NO/foo.000", vm.ExchangeSetCurrentDataset);
+        Assert.False(string.IsNullOrEmpty(vm.ExchangeSetCounter));
+    }
+
+    [Fact]
+    public void EndExchangeSetLoad_FullSuccess_ClearsBanner()
+    {
+        var vm = CreateViewModel();
+        vm.BeginExchangeSetLoad("/some/folder");
+
+        vm.EndExchangeSetLoad(new ExchangeSetOpenResult
+        {
+            SourcePath = "/some/folder",
+            Total = 4,
+            Loaded = 4,
+        });
+
+        Assert.False(vm.IsExchangeSetLoading);
+        Assert.False(vm.IsExchangeSetBannerVisible);
+    }
+
+    [Fact]
+    public void EndExchangeSetLoad_PartialFailure_ShowsBanner()
+    {
+        var vm = CreateViewModel();
+        vm.BeginExchangeSetLoad("/some/folder");
+
+        vm.EndExchangeSetLoad(new ExchangeSetOpenResult
+        {
+            SourcePath = "/some/folder",
+            Total = 4,
+            Loaded = 3,
+            SkippedUnsupported = 1,
+        });
+
+        Assert.False(vm.IsExchangeSetLoading);
+        Assert.True(vm.IsExchangeSetBannerVisible);
+        Assert.False(string.IsNullOrEmpty(vm.ExchangeSetBannerMessage));
+    }
+
+    [Fact]
+    public void EndExchangeSetLoad_FatalFailure_ShowsBanner()
+    {
+        var vm = CreateViewModel();
+        vm.BeginExchangeSetLoad("/missing");
+
+        vm.EndExchangeSetLoad(new ExchangeSetOpenResult
+        {
+            SourcePath = "/missing",
+            FailureMessage = "boom",
+        });
+
+        Assert.True(vm.IsExchangeSetBannerVisible);
+        Assert.Contains("boom", vm.ExchangeSetBannerMessage);
+    }
+
+    [Fact]
+    public void DismissBannerCommand_HidesBanner()
+    {
+        var vm = CreateViewModel();
+        vm.BeginExchangeSetLoad("/some/folder");
+        vm.EndExchangeSetLoad(new ExchangeSetOpenResult
+        {
+            SourcePath = "/some/folder",
+            Total = 2, Loaded = 1, SkippedUnsupported = 1,
+        });
+        Assert.True(vm.IsExchangeSetBannerVisible);
+
+        vm.DismissExchangeSetBannerCommand.Execute(null);
+
+        Assert.False(vm.IsExchangeSetBannerVisible);
+    }
+}

--- a/tests/datasets/ExchangeSets/README.md
+++ b/tests/datasets/ExchangeSets/README.md
@@ -1,0 +1,19 @@
+# Exchange-set fixtures
+
+This folder contains synthetic CATALOG.XML fixtures used by
+`ExchangeSetServiceLoaderTests` to exercise the viewer's
+exchange-set loader (`EncDotNet.S100.Viewer.Services.ExchangeSetService`).
+
+The fixtures are deliberately tiny and point at non-existent
+dataset files because the tests inject a no-op
+`IDatasetLoaderService` and so never open the referenced data.
+
+| Fixture | Purpose |
+|---|---|
+| `Synthetic-Mixed/` | Three entries: two supported (S-101, S-102) and one unsupported (S-999). Drives the partial-failure status banner and the header-registration path. |
+| `Synthetic-AllUnsupported/` | Two unsupported entries. Verifies that the loader disposes the set immediately and unregisters its header when nothing is dispatched. |
+
+For real-world catalogues see `tests/datasets/S101/CATALOG.XML`
+(and the matching `tests/datasets/S101.zip`) which is consumed by the
+existing `ExchangeCatalogueReader` / `FileSystemExchangeSetTests` /
+`ZipExchangeSetTests` suites.

--- a/tests/datasets/ExchangeSets/Synthetic-AllUnsupported/CATALOG.XML
+++ b/tests/datasets/ExchangeSets/Synthetic-AllUnsupported/CATALOG.XML
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic exchange-set catalogue used by ExchangeSetServiceLoaderTests
+  to exercise the all-unsupported path: when every entry is skipped,
+  the service must dispose the underlying ExchangeSet and unregister
+  its header so no file handle / archive is leaked.
+-->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc/5.0"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>SYNTH_NONE_v1</S100XC:identifier>
+    <S100XC:dateTime>2026-02-01T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:contact>
+    <S100XC:organization>
+      <gco:CharacterString>Synthetic Hydrographic Office</gco:CharacterString>
+    </S100XC:organization>
+  </S100XC:contact>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-998/A.dat</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-998</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>0.1</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-998</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-999/B.dat</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-999</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>0.1</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-999</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>

--- a/tests/datasets/ExchangeSets/Synthetic-Mixed/CATALOG.XML
+++ b/tests/datasets/ExchangeSets/Synthetic-Mixed/CATALOG.XML
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic exchange-set catalogue used by ExchangeSetServiceLoaderTests.
+  Three datasets exercise the partial-failure path: two recognised
+  product identifiers (S-101, S-102) and one identifier not registered
+  in DatasetPipelineFactory.MapProductIdentifierToSpec (S-999), which
+  the loader must skip with a status message while still dispatching
+  the supported entries.
+
+  Producer organisation and per-dataset issueDate are populated so the
+  ExchangeSetHeader fields can be asserted as well.
+
+  Dataset files referenced by <fileName> are NOT shipped — the test
+  uses a NoopLoader so RequestLoad never opens them.
+-->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc/5.0"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>SYNTH_MIXED_v1</S100XC:identifier>
+    <S100XC:dateTime>2026-01-15T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:contact>
+    <S100XC:organization>
+      <gco:CharacterString>Synthetic Hydrographic Office</gco:CharacterString>
+    </S100XC:organization>
+  </S100XC:contact>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-101/SYNTH101.000</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-10</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-101</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.1.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-102/SYNTH102.h5</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-12</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-102</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>2.2.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-102</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-999/UNSUPPORTED.dat</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-08</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-999</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>0.0.1</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-999</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>


### PR DESCRIPTION
Adds end-to-end support for opening an S-100 exchange set (folder or `.zip`) in the Avalonia viewer. The user picks a folder/archive via the **File** menu; the viewer parses `CATALOG.XML`, dispatches every supported dataset through the existing pipeline, surfaces progress + partial-failure feedback, fits the map to the union of the catalogued bounding boxes, and shows a header row in the Datasets panel that lets the user close the whole set at once.

## Phases

| Commit | What it adds |
|---|---|
| `c737be0` (es1) | `IAssetSource` plumbed through every dataset processor; `ExchangeSetLoader` resolves catalogue entries to product specs. |
| `f11ddb9` (es2) | `IExchangeSetService` with folder + ZIP variants, **File → Open Exchange Set…** / **Open Exchange Set ZIP…** menu entries. |
| `121602f` (es3) | Modal progress overlay with cancellation, status text, and a partial-failure banner listing the unsupported entries. |
| `fc0d356` (es4) | `ExchangeSetOpenResult.UnionBoundingBox` + `ExchangeSetService.ComputeUnionBoundingBox`; `MainWindow.ZoomToUnionExtent` fits the map on completion. |
| `8ac359e` (es5) | `ExchangeSetHeader` view-model + Datasets-panel row showing producer / latest issue date / dataset count and a Close-set button. |
| `c20ef2a` (es6) | Synthetic CATALOG.XML fixtures (`Synthetic-Mixed`, `Synthetic-AllUnsupported`) plus six end-to-end loader tests covering partial-failure routing, header registration, and lifecycle. |

## Lifecycle

- One `IAssetSource` is opened per set and held alive for as long as any of its `DatasetEntry`s remains in `DatasetsViewModel.Entries`.
- When the last entry is removed (whether via the header's **Close** button, individual row deletion, or the viewer shutting down) the service disposes the `ExchangeSet` and unregisters its header in the same pass.
- Unsupported product identifiers are skipped with a localized status message; if every entry is unsupported, the set is disposed immediately so no archive handle is leaked.

## Tests

- 160 → 166 viewer tests (6 new loader tests + 7 header tests + 4 union tests).
- 33 ExchangeSets tests still pass.
- Synthetic fixtures live under `tests/datasets/ExchangeSets/` so the loader tests do not require any redistributable real-world data.

## Deferred

`es7-s128-link` (highlight loaded S-128 product entries; load-on-click for unloaded set datasets) was flagged optional in the plan and is not required for the Open Exchange Set feature itself. Deferred to a follow-up.