### PR TITLE
Wire MarinerSettings end-to-end and expose ECDIS knobs

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/DepthFormatting.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/DepthFormatting.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Globalization;
+
+namespace EncDotNet.S100.Pipelines;
+
+/// <summary>
+/// Locale-invariant conversion, formatting and parsing for depth values
+/// expressed in <see cref="DepthUnit"/>. Canonical storage is always metres;
+/// these helpers exist purely for user-facing presentation in the viewer
+/// (settings inputs, Pick panel, S-102 legend, status bar).
+/// </summary>
+/// <remarks>
+/// Conversion factors used:
+/// <list type="bullet">
+///   <item><description>1 m = 3.28084 ft</description></item>
+///   <item><description>1 fathom = 6 ft</description></item>
+///   <item><description>1 m = 0.546806649168854 fm (= 3.28084 / 6)</description></item>
+/// </list>
+/// </remarks>
+public static class DepthFormatting
+{
+    /// <summary>Feet per metre (international foot).</summary>
+    public const double FeetPerMetre = 3.28084;
+
+    /// <summary>Feet per fathom.</summary>
+    public const double FeetPerFathom = 6.0;
+
+    /// <summary>Fathoms per metre.</summary>
+    public const double FathomsPerMetre = FeetPerMetre / FeetPerFathom;
+
+    /// <summary>
+    /// Converts a depth value from canonical metres to the supplied display unit.
+    /// </summary>
+    public static double ToDisplay(double metres, DepthUnit unit) => unit switch
+    {
+        DepthUnit.Metres => metres,
+        DepthUnit.Feet => metres * FeetPerMetre,
+        DepthUnit.FathomsFeet => metres * FeetPerMetre, // exposed as total feet; Format splits into fm/ft
+        DepthUnit.Fathoms => metres * FathomsPerMetre,
+        _ => metres,
+    };
+
+    /// <summary>
+    /// Converts a display value back to canonical metres.
+    /// </summary>
+    /// <remarks>
+    /// For <see cref="DepthUnit.FathomsFeet"/> the input is interpreted as a
+    /// total in feet (the same convention as <see cref="ToDisplay"/>).
+    /// </remarks>
+    public static double ToMetres(double display, DepthUnit unit) => unit switch
+    {
+        DepthUnit.Metres => display,
+        DepthUnit.Feet => display / FeetPerMetre,
+        DepthUnit.FathomsFeet => display / FeetPerMetre,
+        DepthUnit.Fathoms => display / FathomsPerMetre,
+        _ => display,
+    };
+
+    /// <summary>
+    /// Returns the short abbreviation used for <paramref name="unit"/> in
+    /// formatted strings ("m", "ft", "fm", "fm/ft").
+    /// </summary>
+    public static string UnitAbbreviation(DepthUnit unit) => unit switch
+    {
+        DepthUnit.Metres => "m",
+        DepthUnit.Feet => "ft",
+        DepthUnit.FathomsFeet => "fm/ft",
+        DepthUnit.Fathoms => "fm",
+        _ => "m",
+    };
+
+    /// <summary>
+    /// Formats <paramref name="metres"/> in <paramref name="unit"/> using
+    /// invariant culture. <see cref="DepthUnit.FathomsFeet"/> renders as
+    /// "&lt;fathoms&gt;fm &lt;feet&gt;ft" (e.g. <c>"5fm 2ft"</c>).
+    /// </summary>
+    /// <param name="metres">Depth in metres.</param>
+    /// <param name="unit">Display unit.</param>
+    /// <param name="decimals">
+    /// Number of decimal places. Defaults: 1 for metres/fathoms/feet, 0 for
+    /// fathoms-and-feet (always rendered as whole feet remainder).
+    /// </param>
+    public static string Format(double metres, DepthUnit unit, int? decimals = null)
+    {
+        var inv = CultureInfo.InvariantCulture;
+
+        if (unit == DepthUnit.FathomsFeet)
+        {
+            // Convert to total feet, then split into fathoms + feet remainder.
+            // Sign-aware so values like -3.5m round-trip sensibly.
+            double totalFeet = metres * FeetPerMetre;
+            int sign = totalFeet < 0 ? -1 : 1;
+            double absFeet = Math.Abs(totalFeet);
+            int wholeFeet = (int)Math.Round(absFeet, MidpointRounding.AwayFromZero);
+            int fathoms = wholeFeet / 6;
+            int feetRem = wholeFeet % 6;
+            string prefix = sign < 0 ? "-" : "";
+            return $"{prefix}{fathoms.ToString(inv)}fm {feetRem.ToString(inv)}ft";
+        }
+
+        int d = decimals ?? 1;
+        double display = ToDisplay(metres, unit);
+        string num = display.ToString("F" + d.ToString(inv), inv);
+        return $"{num} {UnitAbbreviation(unit)}";
+    }
+
+    /// <summary>
+    /// Parses <paramref name="text"/> in <paramref name="unit"/> back to metres
+    /// using invariant culture. Returns <c>true</c> on success.
+    /// </summary>
+    /// <remarks>
+    /// Accepted forms:
+    /// <list type="bullet">
+    ///   <item><description>Bare number ("30", "30.5") — interpreted in <paramref name="unit"/>.</description></item>
+    ///   <item><description>Number with matching unit suffix ("30 m", "100ft", "5 fm").</description></item>
+    ///   <item><description>For <see cref="DepthUnit.FathomsFeet"/>: "5fm 2ft", "5 fm", "12 ft", or a bare number (treated as feet).</description></item>
+    /// </list>
+    /// </remarks>
+    public static bool TryParse(string text, DepthUnit unit, out double metres)
+    {
+        metres = 0;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var inv = CultureInfo.InvariantCulture;
+        var trimmed = text.Trim();
+
+        if (unit == DepthUnit.FathomsFeet)
+        {
+            return TryParseFathomsFeet(trimmed, inv, out metres);
+        }
+
+        // Strip a trailing unit token if the user typed one. We accept any
+        // recognised unit and convert appropriately (so "100 ft" parses
+        // correctly even when the active unit is metres — useful for paste).
+        var (value, parsedUnit) = SplitValueAndUnit(trimmed, unit);
+        if (!double.TryParse(value, NumberStyles.Float, inv, out var num))
+            return false;
+
+        metres = ToMetres(num, parsedUnit);
+        return true;
+    }
+
+    private static bool TryParseFathomsFeet(string text, IFormatProvider inv, out double metres)
+    {
+        metres = 0;
+        // Allow "5fm 2ft", "5 fm 2 ft", "5fm", "12ft", or bare number (= feet).
+        bool sawFm = false, sawFt = false;
+        double fathoms = 0, feet = 0;
+        int sign = 1;
+        var s = text;
+        if (s.StartsWith('-')) { sign = -1; s = s[1..].TrimStart(); }
+
+        // Find "fm" and "ft" occurrences (case-insensitive).
+        int fmIdx = s.IndexOf("fm", StringComparison.OrdinalIgnoreCase);
+        int ftIdx = s.IndexOf("ft", StringComparison.OrdinalIgnoreCase);
+
+        if (fmIdx >= 0)
+        {
+            var head = s[..fmIdx].Trim();
+            if (!double.TryParse(head, NumberStyles.Float, inv, out fathoms))
+                return false;
+            sawFm = true;
+            // Whatever comes after "fm" may be the feet portion.
+            var tail = s[(fmIdx + 2)..].Trim();
+            if (tail.Length > 0)
+            {
+                int tFt = tail.IndexOf("ft", StringComparison.OrdinalIgnoreCase);
+                var ftStr = tFt >= 0 ? tail[..tFt].Trim() : tail;
+                if (!double.TryParse(ftStr, NumberStyles.Float, inv, out feet))
+                    return false;
+                sawFt = true;
+            }
+        }
+        else if (ftIdx >= 0)
+        {
+            var head = s[..ftIdx].Trim();
+            if (!double.TryParse(head, NumberStyles.Float, inv, out feet))
+                return false;
+            sawFt = true;
+        }
+        else
+        {
+            // Bare number — treat as total feet (matches Format/ToDisplay convention).
+            if (!double.TryParse(s, NumberStyles.Float, inv, out feet))
+                return false;
+            sawFt = true;
+        }
+
+        if (!sawFm && !sawFt) return false;
+
+        double totalFeet = fathoms * FeetPerFathom + feet;
+        metres = sign * totalFeet / FeetPerMetre;
+        return true;
+    }
+
+    private static (string Value, DepthUnit Unit) SplitValueAndUnit(string text, DepthUnit fallback)
+    {
+        // Try to peel off a recognised trailing unit token.
+        ReadOnlySpan<(string Suffix, DepthUnit Unit)> suffixes =
+        [
+            ("metres", DepthUnit.Metres),
+            ("meter",  DepthUnit.Metres),
+            ("meters", DepthUnit.Metres),
+            ("metre",  DepthUnit.Metres),
+            ("feet",   DepthUnit.Feet),
+            ("ft",     DepthUnit.Feet),
+            ("fm",     DepthUnit.Fathoms),
+            ("m",      DepthUnit.Metres),
+        ];
+
+        foreach (var (suffix, unit) in suffixes)
+        {
+            if (text.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                var head = text[..^suffix.Length].TrimEnd();
+                return (head, unit);
+            }
+        }
+
+        return (text, fallback);
+    }
+}

--- a/src/EncDotNet.S100.Core/Pipelines/DepthUnit.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/DepthUnit.cs
@@ -1,0 +1,22 @@
+namespace EncDotNet.S100.Pipelines;
+
+/// <summary>
+/// Display unit used by the viewer when presenting depth values to the
+/// mariner. Canonical depth values inside the data model are always stored
+/// in metres; this enum only affects formatting/parsing of user-facing
+/// strings (S-100 Part 9 §4.2 mariner selections).
+/// </summary>
+public enum DepthUnit
+{
+    /// <summary>Metres (canonical unit, e.g. "30.5 m").</summary>
+    Metres,
+
+    /// <summary>Feet (e.g. "100 ft"). 1 m = 3.28084 ft.</summary>
+    Feet,
+
+    /// <summary>Combined fathoms and feet (e.g. "5fm 2ft"). 1 fathom = 6 ft.</summary>
+    FathomsFeet,
+
+    /// <summary>Fathoms (e.g. "5.0 fm"). 1 m = 0.546807 fathoms.</summary>
+    Fathoms,
+}

--- a/src/EncDotNet.S100.Core/Pipelines/MarinerSettings.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/MarinerSettings.cs
@@ -6,19 +6,87 @@ namespace EncDotNet.S100.Pipelines;
 /// of the current display viewport and are typically persisted across
 /// sessions per user preference.
 /// </summary>
-public sealed class MarinerSettings
+/// <remarks>
+/// All depth fields are stored in metres regardless of <see cref="DepthUnit"/>;
+/// the unit only affects how depth values are presented to the mariner in
+/// the viewer (Pick panel, legend, status bar, settings inputs). Default
+/// values for the boolean toggles match the defaults declared by the bundled
+/// S-101 portrayal catalogue (<c>portrayal_catalogue.xml</c> §<c>context</c>).
+/// </remarks>
+public sealed record MarinerSettings
 {
-    /// <summary>Safety contour depth in metres.</summary>
+    /// <summary>Safety contour depth in metres (S-101 PC parameter <c>SafetyContour</c>).</summary>
     public double SafetyContour { get; init; } = 30.0;
 
-    /// <summary>Safety depth in metres (for sounding selection).</summary>
+    /// <summary>Safety depth in metres for sounding selection (S-101 PC parameter <c>SafetyDepth</c>).</summary>
     public double SafetyDepth { get; init; } = 30.0;
 
-    /// <summary>Shallow contour depth in metres.</summary>
+    /// <summary>Shallow contour depth in metres (S-101 PC parameter <c>ShallowContour</c>).</summary>
     public double ShallowContour { get; init; } = 2.0;
 
-    /// <summary>Deep contour depth in metres.</summary>
+    /// <summary>Deep contour depth in metres (S-101 PC parameter <c>DeepContour</c>).</summary>
     public double DeepContour { get; init; } = 30.0;
+
+    /// <summary>
+    /// Display unit used by the viewer when presenting depth values to the
+    /// mariner (Pick panel, S-102 legend, status bar, settings inputs).
+    /// Canonical depth storage in this record is always metres; this only
+    /// affects formatting/parsing.
+    /// </summary>
+    public DepthUnit DepthUnit { get; init; } = DepthUnit.Metres;
+
+    /// <summary>
+    /// Whether to use the four-shade depth area scheme (S-101 PC parameter
+    /// <c>FourShades</c>). When <c>false</c> only the two-shade scheme is
+    /// used, in which case <see cref="ShallowContour"/> and
+    /// <see cref="DeepContour"/> are typically ignored by the catalogue.
+    /// </summary>
+    public bool FourShades { get; init; } = false;
+
+    /// <summary>
+    /// Whether to highlight isolated dangers in shallow water (S-101 PC
+    /// parameter <c>ShallowWaterDangers</c>).
+    /// </summary>
+    public bool ShallowWaterDangers { get; init; } = true;
+
+    /// <summary>
+    /// Whether to draw plain (un-symbolised) area boundaries (S-101 PC
+    /// parameter <c>PlainBoundaries</c>).
+    /// </summary>
+    public bool PlainBoundaries { get; init; } = true;
+
+    /// <summary>
+    /// Whether to use simplified point symbols (S-101 PC parameter
+    /// <c>SimplifiedSymbols</c>).
+    /// </summary>
+    public bool SimplifiedSymbols { get; init; } = false;
+
+    /// <summary>
+    /// Whether to draw light sectors as full lines extending to their
+    /// nominal range (S-101 PC parameter <c>FullLightLines</c>).
+    /// </summary>
+    public bool FullLightLines { get; init; } = false;
+
+    /// <summary>
+    /// Whether the chart is being drawn under a radar overlay (S-101 PC
+    /// parameter <c>RadarOverlay</c>).
+    /// </summary>
+    public bool RadarOverlay { get; init; } = false;
+
+    /// <summary>
+    /// Whether to ignore the cell scale-minimum attribute and always
+    /// portray features regardless of the user's scale (S-101 PC parameter
+    /// <c>IgnoreScaleMinimum</c>).
+    /// </summary>
+    public bool IgnoreScaleMinimum { get; init; } = false;
+
+    /// <summary>
+    /// Preferred 3-letter ISO 639-2/B language code for chart text (S-101
+    /// PC parameter <c>NationalLanguage</c>). An empty string means "use
+    /// the catalogue's declared default" — no override is sent to the
+    /// portrayal engine.
+    /// </summary>
+    public string NationalLanguage { get; init; } = "";
 
     /// <summary>Default mariner settings (safety contour 30 m, etc.).</summary>
     public static MarinerSettings Default { get; } = new();

--- a/src/EncDotNet.S100.Core/README.md
+++ b/src/EncDotNet.S100.Core/README.md
@@ -12,7 +12,7 @@ This library provides the foundational types used across the EncDotNet.S100 libr
 - **Coverage pipeline** — `ICoverageSource`, `ICoverageRenderer<T>`, `CoveragePipeline`, and supporting types (`GridGeoreferencer`, `CoverageColorScheme`, `StyledCoverageLayer`) for rendering gridded data.
 - **Vector pipeline** — `IVectorSource`, `IVectorPortrayalCatalogue`, `VectorPipeline`, and the `DrawingInstruction` hierarchy (`AreaInstruction`, `LineInstruction`, `PointInstruction`, `TextInstruction`) modelled directly on the S-100 Part 9 display list.
 - **`Part9DisplayListReader`** — parses the Part 9 display-list XML produced by XSLT-based portrayal pipelines (S-124 / S-129 / S-421) into the same unified `DrawingInstruction` hierarchy that S-101's Lua pipeline emits, so a single renderer can consume both.
-- **Shared types** — `IPortrayalCatalogue`, `ICrsTransform`, `Viewport`, `MarinerSettings`, `BoundingBox`, `RgbaColor`, `ColorPalette`.
+- **Shared types** — `IPortrayalCatalogue`, `ICrsTransform`, `Viewport`, `MarinerSettings` (S-100 Part 9 §4.2 mariner selections, including the four depth contours and S-101 portrayal toggles such as `FourShades`, `SimplifiedSymbols`, `RadarOverlay`, `NationalLanguage`), `DepthUnit` and the `DepthFormatting` helper for locale-invariant depth conversion / formatting / parsing across metres, feet, fathoms, and combined fathoms-and-feet, `BoundingBox`, `RgbaColor`, `ColorPalette`.
 
 ## Installation
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
@@ -24,6 +24,17 @@ public abstract record RenderContext
     /// user overrides — equivalent to "All" with an empty hidden set.
     /// </summary>
     public EcdisDisplaySettings? EcdisDisplay { get; init; }
+
+    /// <summary>
+    /// Mariner-configurable display preferences (S-100 Part 9 §4.2 —
+    /// safety/shallow/deep contours, S-101 boolean toggles, depth display
+    /// unit, etc.). When <c>null</c> processors fall back to
+    /// <see cref="MarinerSettings.Default"/>. Only consumed by processors
+    /// whose portrayal pipeline honours mariner selections (S-101, S-102,
+    /// S-104, S-111 today); other processors carry it transparently for
+    /// future use.
+    /// </summary>
+    public MarinerSettings? Mariner { get; init; }
 }
 
 public sealed record S101RenderContext : RenderContext;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -77,7 +77,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        var mariner = MarinerSettings.Default;
+        var mariner = context?.Mariner ?? MarinerSettings.Default;
 
         using var fcStream = _featureCatalogueResolver("S-101")
             ?? throw new InvalidOperationException(

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -94,7 +94,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(_source, _catalogue, MarinerSettings.Default)
+        var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
             .GetAwaiter().GetResult();
         var styledLayer = (StyledCoverageLayer)layer;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -99,7 +99,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(_source, _catalogue, MarinerSettings.Default)
+        var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
             .GetAwaiter().GetResult();
         var styledLayer = (StyledCoverageLayer)layer;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -111,7 +111,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(_source, _catalogue, MarinerSettings.Default)
+        var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
             .GetAwaiter().GetResult();
         var styledLayer = (StyledCoverageLayer)layer;
 

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -277,13 +277,29 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     {
         // Known S-101 context parameters mapped from MarinerSettings.
         // PortrayalSetContextParameter expects both arguments as strings.
+        // The Lua side parses booleans from the lower-case literals
+        // "true"/"false" (per the bundled S-101 PC parameter declarations).
         var parameters = new Dictionary<string, string>
         {
             ["SafetyContour"] = mariner.SafetyContour.ToString(CultureInfo.InvariantCulture),
             ["SafetyDepth"] = mariner.SafetyDepth.ToString(CultureInfo.InvariantCulture),
             ["ShallowContour"] = mariner.ShallowContour.ToString(CultureInfo.InvariantCulture),
             ["DeepContour"] = mariner.DeepContour.ToString(CultureInfo.InvariantCulture),
+            ["FourShades"] = mariner.FourShades ? "true" : "false",
+            ["ShallowWaterDangers"] = mariner.ShallowWaterDangers ? "true" : "false",
+            ["PlainBoundaries"] = mariner.PlainBoundaries ? "true" : "false",
+            ["SimplifiedSymbols"] = mariner.SimplifiedSymbols ? "true" : "false",
+            ["FullLightLines"] = mariner.FullLightLines ? "true" : "false",
+            ["RadarOverlay"] = mariner.RadarOverlay ? "true" : "false",
+            ["IgnoreScaleMinimum"] = mariner.IgnoreScaleMinimum ? "true" : "false",
         };
+
+        // NationalLanguage is only sent when the user has explicitly chosen
+        // one — empty means "use the catalogue's declared default" (eng).
+        if (!string.IsNullOrWhiteSpace(mariner.NationalLanguage))
+        {
+            parameters["NationalLanguage"] = mariner.NationalLanguage;
+        }
 
         foreach (var (name, value) in parameters)
         {

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -176,6 +176,7 @@ public partial class App : Application
         services.AddSingleton<CatalogPanelViewModel>();
         services.AddSingleton<FeatureSearchViewModel>();
         services.AddSingleton<SettingsViewModel>();
+        services.AddSingleton<IMarinerSettingsProvider, MarinerSettingsProvider>();
         services.AddSingleton<PickReportViewModel>();
         services.AddSingleton<TimelineViewModel>();
         services.AddSingleton<DisplayToolbarViewModel>();

--- a/src/EncDotNet.S100.Viewer/DepthUnitNameConverter.cs
+++ b/src/EncDotNet.S100.Viewer/DepthUnitNameConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>Converts a <see cref="DepthUnit"/> value to its localised display name.</summary>
+internal sealed class DepthUnitNameConverter : IValueConverter
+{
+    public static DepthUnitNameConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is DepthUnit unit
+            ? unit switch
+            {
+                DepthUnit.Metres => Strings.DepthUnit_Metres,
+                DepthUnit.Feet => Strings.DepthUnit_Feet,
+                DepthUnit.FathomsFeet => Strings.DepthUnit_FathomsFeet,
+                DepthUnit.Fathoms => Strings.DepthUnit_Fathoms,
+                _ => unit.ToString(),
+            }
+            : value?.ToString();
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -206,6 +206,7 @@ internal static class Strings
     public static string Settings_NationalLanguage => Get(nameof(Settings_NationalLanguage));
     public static string Tooltip_NationalLanguage => Get(nameof(Tooltip_NationalLanguage));
     public static string Settings_NationalLanguage_Default => Get(nameof(Settings_NationalLanguage_Default));
+    public static string Language_System => Get(nameof(Language_System));
     public static string Status_MarinerSettingsApplied => Get(nameof(Status_MarinerSettingsApplied));
 
     // Distance unit display names

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -172,6 +172,42 @@ internal static class Strings
     public static string Settings_DistanceUnits => Get(nameof(Settings_DistanceUnits));
     public static string Settings_DistanceUnits_Help => Get(nameof(Settings_DistanceUnits_Help));
 
+    // Mariner settings (S-100 Part 9 §4.2)
+    public static string Settings_MarinerSection => Get(nameof(Settings_MarinerSection));
+    public static string Settings_MarinerSection_Help => Get(nameof(Settings_MarinerSection_Help));
+    public static string Settings_DepthUnit => Get(nameof(Settings_DepthUnit));
+    public static string Settings_DepthUnit_Help => Get(nameof(Settings_DepthUnit_Help));
+    public static string DepthUnit_Metres => Get(nameof(DepthUnit_Metres));
+    public static string DepthUnit_Feet => Get(nameof(DepthUnit_Feet));
+    public static string DepthUnit_FathomsFeet => Get(nameof(DepthUnit_FathomsFeet));
+    public static string DepthUnit_Fathoms => Get(nameof(DepthUnit_Fathoms));
+    public static string Settings_SafetyContour => Get(nameof(Settings_SafetyContour));
+    public static string Tooltip_SafetyContour => Get(nameof(Tooltip_SafetyContour));
+    public static string Settings_SafetyDepth => Get(nameof(Settings_SafetyDepth));
+    public static string Tooltip_SafetyDepth => Get(nameof(Tooltip_SafetyDepth));
+    public static string Settings_ShallowContour => Get(nameof(Settings_ShallowContour));
+    public static string Tooltip_ShallowContour => Get(nameof(Tooltip_ShallowContour));
+    public static string Settings_DeepContour => Get(nameof(Settings_DeepContour));
+    public static string Tooltip_DeepContour => Get(nameof(Tooltip_DeepContour));
+    public static string Settings_FourShades => Get(nameof(Settings_FourShades));
+    public static string Tooltip_FourShades => Get(nameof(Tooltip_FourShades));
+    public static string Settings_ShallowWaterDangers => Get(nameof(Settings_ShallowWaterDangers));
+    public static string Tooltip_ShallowWaterDangers => Get(nameof(Tooltip_ShallowWaterDangers));
+    public static string Settings_PlainBoundaries => Get(nameof(Settings_PlainBoundaries));
+    public static string Tooltip_PlainBoundaries => Get(nameof(Tooltip_PlainBoundaries));
+    public static string Settings_SimplifiedSymbols => Get(nameof(Settings_SimplifiedSymbols));
+    public static string Tooltip_SimplifiedSymbols => Get(nameof(Tooltip_SimplifiedSymbols));
+    public static string Settings_FullLightLines => Get(nameof(Settings_FullLightLines));
+    public static string Tooltip_FullLightLines => Get(nameof(Tooltip_FullLightLines));
+    public static string Settings_RadarOverlay => Get(nameof(Settings_RadarOverlay));
+    public static string Tooltip_RadarOverlay => Get(nameof(Tooltip_RadarOverlay));
+    public static string Settings_IgnoreScaleMinimum => Get(nameof(Settings_IgnoreScaleMinimum));
+    public static string Tooltip_IgnoreScaleMinimum => Get(nameof(Tooltip_IgnoreScaleMinimum));
+    public static string Settings_NationalLanguage => Get(nameof(Settings_NationalLanguage));
+    public static string Tooltip_NationalLanguage => Get(nameof(Tooltip_NationalLanguage));
+    public static string Settings_NationalLanguage_Default => Get(nameof(Settings_NationalLanguage_Default));
+    public static string Status_MarinerSettingsApplied => Get(nameof(Status_MarinerSettingsApplied));
+
     // Distance unit display names
     public static string DistanceUnit_Metric => Get(nameof(DistanceUnit_Metric));
     public static string DistanceUnit_Miles => Get(nameof(DistanceUnit_Miles));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -410,6 +410,110 @@ Open an S-128 dataset to populate this panel.</value>
     <value>Units used by the map scale bar.</value>
   </data>
 
+  <!-- Mariner settings (S-100 Part 9 §4.2) -->
+  <data name="Settings_MarinerSection" xml:space="preserve">
+    <value>Mariner Settings</value>
+  </data>
+  <data name="Settings_MarinerSection_Help" xml:space="preserve">
+    <value>Safety/depth preferences and S-101 portrayal toggles. Changes re-render all loaded datasets.</value>
+  </data>
+  <data name="Settings_DepthUnit" xml:space="preserve">
+    <value>Depth Unit</value>
+  </data>
+  <data name="Settings_DepthUnit_Help" xml:space="preserve">
+    <value>Display unit for depth values in the viewer (Pick panel, legends, settings inputs). Internal storage is always metres.</value>
+  </data>
+  <data name="DepthUnit_Metres" xml:space="preserve">
+    <value>Metres (m)</value>
+  </data>
+  <data name="DepthUnit_Feet" xml:space="preserve">
+    <value>Feet (ft)</value>
+  </data>
+  <data name="DepthUnit_FathomsFeet" xml:space="preserve">
+    <value>Fathoms and feet (fm/ft)</value>
+  </data>
+  <data name="DepthUnit_Fathoms" xml:space="preserve">
+    <value>Fathoms (fm)</value>
+  </data>
+  <data name="Settings_SafetyContour" xml:space="preserve">
+    <value>Safety Contour</value>
+  </data>
+  <data name="Tooltip_SafetyContour" xml:space="preserve">
+    <value>Depth boundary between safe and unsafe water for own ship (S-101 PC SafetyContour).</value>
+  </data>
+  <data name="Settings_SafetyDepth" xml:space="preserve">
+    <value>Safety Depth</value>
+  </data>
+  <data name="Tooltip_SafetyDepth" xml:space="preserve">
+    <value>Soundings shallower than this are emphasised (S-101 PC SafetyDepth).</value>
+  </data>
+  <data name="Settings_ShallowContour" xml:space="preserve">
+    <value>Shallow Contour</value>
+  </data>
+  <data name="Tooltip_ShallowContour" xml:space="preserve">
+    <value>Inner boundary of the four-shade scheme (S-101 PC ShallowContour). Must be ≤ Safety Contour.</value>
+  </data>
+  <data name="Settings_DeepContour" xml:space="preserve">
+    <value>Deep Contour</value>
+  </data>
+  <data name="Tooltip_DeepContour" xml:space="preserve">
+    <value>Outer boundary of the four-shade scheme (S-101 PC DeepContour). Must be ≥ Safety Contour.</value>
+  </data>
+  <data name="Settings_FourShades" xml:space="preserve">
+    <value>Four-shade depth scheme</value>
+  </data>
+  <data name="Tooltip_FourShades" xml:space="preserve">
+    <value>When on, depth areas use four shades using the Shallow/Safety/Deep contours; when off, only two shades are used (S-101 PC FourShades).</value>
+  </data>
+  <data name="Settings_ShallowWaterDangers" xml:space="preserve">
+    <value>Highlight shallow-water dangers</value>
+  </data>
+  <data name="Tooltip_ShallowWaterDangers" xml:space="preserve">
+    <value>Emphasise isolated dangers in shallow water (S-101 PC ShallowWaterDangers).</value>
+  </data>
+  <data name="Settings_PlainBoundaries" xml:space="preserve">
+    <value>Plain boundaries</value>
+  </data>
+  <data name="Tooltip_PlainBoundaries" xml:space="preserve">
+    <value>Draw plain (un-symbolised) area boundaries (S-101 PC PlainBoundaries).</value>
+  </data>
+  <data name="Settings_SimplifiedSymbols" xml:space="preserve">
+    <value>Simplified symbols</value>
+  </data>
+  <data name="Tooltip_SimplifiedSymbols" xml:space="preserve">
+    <value>Use simplified point symbols (S-101 PC SimplifiedSymbols).</value>
+  </data>
+  <data name="Settings_FullLightLines" xml:space="preserve">
+    <value>Full light lines</value>
+  </data>
+  <data name="Tooltip_FullLightLines" xml:space="preserve">
+    <value>Draw light sectors as full lines extending to nominal range (S-101 PC FullLightLines).</value>
+  </data>
+  <data name="Settings_RadarOverlay" xml:space="preserve">
+    <value>Radar overlay mode</value>
+  </data>
+  <data name="Tooltip_RadarOverlay" xml:space="preserve">
+    <value>Tells the catalogue the chart is being drawn under a radar overlay (S-101 PC RadarOverlay).</value>
+  </data>
+  <data name="Settings_IgnoreScaleMinimum" xml:space="preserve">
+    <value>Ignore scale minimum</value>
+  </data>
+  <data name="Tooltip_IgnoreScaleMinimum" xml:space="preserve">
+    <value>Always portray features regardless of cell scale-minimum attribute (S-101 PC IgnoreScaleMinimum).</value>
+  </data>
+  <data name="Settings_NationalLanguage" xml:space="preserve">
+    <value>National Language</value>
+  </data>
+  <data name="Tooltip_NationalLanguage" xml:space="preserve">
+    <value>Preferred 3-letter ISO 639-2/B code for chart text (S-101 PC NationalLanguage). Empty = catalogue default.</value>
+  </data>
+  <data name="Settings_NationalLanguage_Default" xml:space="preserve">
+    <value>(Catalogue default)</value>
+  </data>
+  <data name="Status_MarinerSettingsApplied" xml:space="preserve">
+    <value>Mariner settings applied.</value>
+  </data>
+
   <!-- Distance unit display names -->
   <data name="DistanceUnit_Metric" xml:space="preserve">
     <value>Metric (km, m)</value>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -510,6 +510,10 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Settings_NationalLanguage_Default" xml:space="preserve">
     <value>(Catalogue default)</value>
   </data>
+  <data name="Language_System" xml:space="preserve">
+    <value>System ({0})</value>
+    <comment>{0} is replaced with the OS UI language display name, e.g. "System (English (United States))".</comment>
+  </data>
   <data name="Status_MarinerSettingsApplied" xml:space="preserve">
     <value>Mariner settings applied.</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -34,6 +34,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly SettingsViewModel _settingsVm;
     private readonly GlobalTimeService _globalTime;
     private readonly EcdisDisplayState _ecdisDisplay;
+    private readonly IMarinerSettingsProvider _marinerSettings;
 
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayers = new();
@@ -73,7 +74,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         S128DatasetCatalogSource s128CatalogSource,
         SettingsViewModel settingsVm,
         GlobalTimeService globalTime,
-        EcdisDisplayState ecdisDisplay)
+        EcdisDisplayState ecdisDisplay,
+        IMarinerSettingsProvider marinerSettings)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
@@ -83,6 +85,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ArgumentNullException.ThrowIfNull(settingsVm);
         ArgumentNullException.ThrowIfNull(globalTime);
         ArgumentNullException.ThrowIfNull(ecdisDisplay);
+        ArgumentNullException.ThrowIfNull(marinerSettings);
 
         _settings = settings;
         _catalogueManager = catalogueManager;
@@ -92,6 +95,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _settingsVm = settingsVm;
         _globalTime = globalTime;
         _ecdisDisplay = ecdisDisplay;
+        _marinerSettings = marinerSettings;
 
         _processorsView = new ReadOnlyDictionary<DatasetEntry, IDatasetProcessor>(_processors);
         _entryLayersView = new ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>>(_entryLayers);
@@ -138,6 +142,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _settingsVm.PaletteChanged += palette => _ = ReRenderAllAsync();
         _settingsVm.DisplayScaleChanged += () => _ = ReRenderAllAsync();
         _ecdisDisplay.Changed += () => _ = ReRenderAllAsync();
+        _marinerSettings.Changed += m => _ = ReRenderAllAsync();
     }
 
     public async Task LoadAsync(DatasetEntry entry)
@@ -387,36 +392,37 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         var symbolScale = _settingsVm.SymbolScale;
         var textScale = _settingsVm.TextScale;
         var ecdis = _ecdisDisplay.Snapshot();
+        var mariner = _marinerSettings.Current;
 
         return processor switch
         {
             S104DatasetProcessor when timeStep is not null
-                => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S104DatasetProcessor
-                => new S104RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S104RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S111DatasetProcessor when timeStep is not null
-                => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S111DatasetProcessor
-                => new S111RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S111RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S101DatasetProcessor
-                => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S102DatasetProcessor
-                => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S122DatasetProcessor
-                => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S124DatasetProcessor
-                => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S125DatasetProcessor
-                => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S127DatasetProcessor
-                => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S129DatasetProcessor
-                => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S411DatasetProcessor when timeStep is not null
-                => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
             S411DatasetProcessor
-                => new S411RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
-            _ => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis },
+                => new S411RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
+            _ => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, EcdisDisplay = ecdis, Mariner = mariner },
         };
     }
 

--- a/src/EncDotNet.S100.Viewer/Services/IMarinerSettingsProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IMarinerSettingsProvider.cs
@@ -1,0 +1,24 @@
+using System;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Supplies the current user-configured <see cref="MarinerSettings"/>
+/// snapshot to the dataset pipeline (S-100 Part 9 §4.2). Implementations
+/// observe the source view-model and rebuild <see cref="Current"/>
+/// whenever any underlying property changes.
+/// </summary>
+internal interface IMarinerSettingsProvider
+{
+    /// <summary>The latest snapshot. Always non-null.</summary>
+    MarinerSettings Current { get; }
+
+    /// <summary>
+    /// Raised after <see cref="Current"/> has been rebuilt. Subscribers
+    /// (e.g. <c>DatasetLoaderService</c>) re-render all loaded datasets in
+    /// response. The new snapshot is supplied as an argument so
+    /// subscribers don't need to read <see cref="Current"/> separately.
+    /// </summary>
+    event Action<MarinerSettings>? Changed;
+}

--- a/src/EncDotNet.S100.Viewer/Services/MarinerSettingsProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MarinerSettingsProvider.cs
@@ -1,0 +1,34 @@
+using System;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="IMarinerSettingsProvider"/> implementation. Wraps
+/// <see cref="SettingsViewModel"/> and rebuilds <see cref="Current"/>
+/// whenever the view-model raises <c>MarinerChanged</c>.
+/// </summary>
+internal sealed class MarinerSettingsProvider : IMarinerSettingsProvider
+{
+    private readonly SettingsViewModel _settings;
+    private MarinerSettings _current;
+
+    public MarinerSettingsProvider(SettingsViewModel settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+        _current = settings.BuildMarinerSettings();
+        _settings.MarinerChanged += OnMarinerChanged;
+    }
+
+    public MarinerSettings Current => _current;
+
+    public event Action<MarinerSettings>? Changed;
+
+    private void OnMarinerChanged()
+    {
+        _current = _settings.BuildMarinerSettings();
+        Changed?.Invoke(_current);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/LanguageOption.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/LanguageOption.cs
@@ -1,0 +1,8 @@
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Combo-box item for the National Language picker. <see cref="Code"/> is the
+/// stored ISO 639-2/B value (or empty for "system"); <see cref="DisplayName"/>
+/// is the localised label shown to the user.
+/// </summary>
+internal sealed record LanguageOption(string Code, string DisplayName);

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using Avalonia.Media;
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.Resources;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -116,23 +119,46 @@ internal sealed class SettingsViewModel : ViewModelBase
         DepthUnit.Fathoms,
     ];
 
-    /// <summary>Common ISO 639-2/B language codes the user can pick. Empty = catalogue default.</summary>
-    public static string[] AvailableLanguageCodes { get; } =
-    [
-        "",
-        "eng",
-        "fra",
-        "spa",
-        "deu",
-        "ita",
-        "nor",
-        "swe",
-        "fin",
-        "rus",
-        "jpn",
-        "kor",
-        "zho",
-    ];
+    /// <summary>
+    /// Languages the user can pick. <see cref="LanguageOption.Code"/> is the
+    /// ISO 639-2/B 3-letter code stored in settings; empty string means
+    /// "follow the operating system's UI culture" (resolved at snapshot time
+    /// in <see cref="BuildMarinerSettings"/>).
+    /// </summary>
+    public static IReadOnlyList<LanguageOption> AvailableLanguages { get; } = BuildLanguageOptions();
+
+    private static IReadOnlyList<LanguageOption> BuildLanguageOptions()
+    {
+        var sysCulture = CultureInfo.CurrentUICulture;
+        var systemLabel = string.Format(
+            CultureInfo.CurrentUICulture,
+            Strings.Language_System,
+            sysCulture.DisplayName);
+
+        var list = new List<LanguageOption> { new("", systemLabel) };
+
+        // S-100 PC NationalLanguage uses ISO 639-2/B; we surface a short list
+        // of common chart languages and look up the localised display name
+        // from the OS culture catalogue so labels match the user's locale.
+        string[] codes = ["eng", "fra", "spa", "deu", "ita", "nld", "nor", "swe", "fin", "dan", "rus", "jpn", "kor", "zho", "ara"];
+        foreach (var code in codes)
+        {
+            var culture = TryFindCultureByThreeLetterCode(code);
+            var name = culture?.DisplayName ?? code;
+            list.Add(new LanguageOption(code, name));
+        }
+        return list;
+    }
+
+    private static CultureInfo? TryFindCultureByThreeLetterCode(string threeLetterIsoCode)
+    {
+        foreach (var c in CultureInfo.GetCultures(CultureTypes.NeutralCultures))
+        {
+            if (string.Equals(c.ThreeLetterISOLanguageName, threeLetterIsoCode, StringComparison.OrdinalIgnoreCase))
+                return c;
+        }
+        return null;
+    }
 
     /// <summary>
     /// Raised after any mariner-affecting property has changed and the
@@ -348,8 +374,24 @@ internal sealed class SettingsViewModel : ViewModelBase
         FullLightLines = _fullLightLines,
         RadarOverlay = _radarOverlay,
         IgnoreScaleMinimum = _ignoreScaleMinimum,
-        NationalLanguage = _nationalLanguage,
+        NationalLanguage = ResolveLanguageCode(_nationalLanguage),
     };
+
+    private static string ResolveLanguageCode(string stored)
+    {
+        if (!string.IsNullOrWhiteSpace(stored))
+            return stored;
+
+        // Empty / null means "follow the OS UI culture". Map the current UI
+        // culture's 3-letter ISO 639-2 code into the same form S-101 expects.
+        // If the runtime can't supply a real code (e.g. invariant culture
+        // returns "ivl"), fall back to empty so the executor skips the param
+        // and the catalogue default applies.
+        var code = CultureInfo.CurrentUICulture.ThreeLetterISOLanguageName;
+        if (string.IsNullOrEmpty(code) || code == "ivl")
+            return string.Empty;
+        return code;
+    }
 
     public SettingsViewModel(ViewerSettings settings)
     {

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -100,6 +100,257 @@ internal sealed class SettingsViewModel : ViewModelBase
 
     public event Action<DistanceUnit>? DistanceUnitChanged;
 
+    // -------------------------------------------------------------------
+    // Mariner settings (S-100 Part 9 §4.2).
+    //
+    // Depth values are stored in metres internally; the *Display string
+    // properties round-trip through DepthFormatting using the active
+    // SelectedDepthUnit so the user types and sees their chosen unit.
+    // -------------------------------------------------------------------
+
+    public static DepthUnit[] AvailableDepthUnits { get; } =
+    [
+        DepthUnit.Metres,
+        DepthUnit.Feet,
+        DepthUnit.FathomsFeet,
+        DepthUnit.Fathoms,
+    ];
+
+    /// <summary>Common ISO 639-2/B language codes the user can pick. Empty = catalogue default.</summary>
+    public static string[] AvailableLanguageCodes { get; } =
+    [
+        "",
+        "eng",
+        "fra",
+        "spa",
+        "deu",
+        "ita",
+        "nor",
+        "swe",
+        "fin",
+        "rus",
+        "jpn",
+        "kor",
+        "zho",
+    ];
+
+    /// <summary>
+    /// Raised after any mariner-affecting property has changed and the
+    /// settings file has been saved. The <see cref="MarinerSettingsProvider"/>
+    /// listens for this and rebuilds its snapshot.
+    /// </summary>
+    public event Action? MarinerChanged;
+
+    private void RaiseMarinerChanged()
+    {
+        _settings.Save();
+        MarinerChanged?.Invoke();
+    }
+
+    private DepthUnit _selectedDepthUnit;
+    public DepthUnit SelectedDepthUnit
+    {
+        get => _selectedDepthUnit;
+        set
+        {
+            if (SetProperty(ref _selectedDepthUnit, value))
+            {
+                _settings.DepthUnit = value.ToString();
+                // Re-emit display strings so bound TextBoxes refresh.
+                OnPropertyChanged(nameof(SafetyContourDisplay));
+                OnPropertyChanged(nameof(SafetyDepthDisplay));
+                OnPropertyChanged(nameof(ShallowContourDisplay));
+                OnPropertyChanged(nameof(DeepContourDisplay));
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    private double _safetyContour;
+    public double SafetyContour
+    {
+        get => _safetyContour;
+        set
+        {
+            if (SetProperty(ref _safetyContour, value))
+            {
+                _settings.SafetyContour = value;
+                OnPropertyChanged(nameof(SafetyContourDisplay));
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    public string SafetyContourDisplay
+    {
+        get => DepthFormatting.Format(_safetyContour, _selectedDepthUnit);
+        set
+        {
+            if (DepthFormatting.TryParse(value ?? string.Empty, _selectedDepthUnit, out var m))
+                SafetyContour = m;
+        }
+    }
+
+    private double _safetyDepth;
+    public double SafetyDepth
+    {
+        get => _safetyDepth;
+        set
+        {
+            if (SetProperty(ref _safetyDepth, value))
+            {
+                _settings.SafetyDepth = value;
+                OnPropertyChanged(nameof(SafetyDepthDisplay));
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    public string SafetyDepthDisplay
+    {
+        get => DepthFormatting.Format(_safetyDepth, _selectedDepthUnit);
+        set
+        {
+            if (DepthFormatting.TryParse(value ?? string.Empty, _selectedDepthUnit, out var m))
+                SafetyDepth = m;
+        }
+    }
+
+    private double _shallowContour;
+    public double ShallowContour
+    {
+        get => _shallowContour;
+        set
+        {
+            if (SetProperty(ref _shallowContour, value))
+            {
+                _settings.ShallowContour = value;
+                OnPropertyChanged(nameof(ShallowContourDisplay));
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    public string ShallowContourDisplay
+    {
+        get => DepthFormatting.Format(_shallowContour, _selectedDepthUnit);
+        set
+        {
+            if (DepthFormatting.TryParse(value ?? string.Empty, _selectedDepthUnit, out var m))
+                ShallowContour = m;
+        }
+    }
+
+    private double _deepContour;
+    public double DeepContour
+    {
+        get => _deepContour;
+        set
+        {
+            if (SetProperty(ref _deepContour, value))
+            {
+                _settings.DeepContour = value;
+                OnPropertyChanged(nameof(DeepContourDisplay));
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    public string DeepContourDisplay
+    {
+        get => DepthFormatting.Format(_deepContour, _selectedDepthUnit);
+        set
+        {
+            if (DepthFormatting.TryParse(value ?? string.Empty, _selectedDepthUnit, out var m))
+                DeepContour = m;
+        }
+    }
+
+    private bool _fourShades;
+    public bool FourShades
+    {
+        get => _fourShades;
+        set { if (SetProperty(ref _fourShades, value)) { _settings.FourShades = value; RaiseMarinerChanged(); } }
+    }
+
+    private bool _shallowWaterDangers;
+    public bool ShallowWaterDangers
+    {
+        get => _shallowWaterDangers;
+        set { if (SetProperty(ref _shallowWaterDangers, value)) { _settings.ShallowWaterDangers = value; RaiseMarinerChanged(); } }
+    }
+
+    private bool _plainBoundaries;
+    public bool PlainBoundaries
+    {
+        get => _plainBoundaries;
+        set { if (SetProperty(ref _plainBoundaries, value)) { _settings.PlainBoundaries = value; RaiseMarinerChanged(); } }
+    }
+
+    private bool _simplifiedSymbols;
+    public bool SimplifiedSymbols
+    {
+        get => _simplifiedSymbols;
+        set { if (SetProperty(ref _simplifiedSymbols, value)) { _settings.SimplifiedSymbols = value; RaiseMarinerChanged(); } }
+    }
+
+    private bool _fullLightLines;
+    public bool FullLightLines
+    {
+        get => _fullLightLines;
+        set { if (SetProperty(ref _fullLightLines, value)) { _settings.FullLightLines = value; RaiseMarinerChanged(); } }
+    }
+
+    private bool _radarOverlay;
+    public bool RadarOverlay
+    {
+        get => _radarOverlay;
+        set { if (SetProperty(ref _radarOverlay, value)) { _settings.RadarOverlay = value; RaiseMarinerChanged(); } }
+    }
+
+    private bool _ignoreScaleMinimum;
+    public bool IgnoreScaleMinimum
+    {
+        get => _ignoreScaleMinimum;
+        set { if (SetProperty(ref _ignoreScaleMinimum, value)) { _settings.IgnoreScaleMinimum = value; RaiseMarinerChanged(); } }
+    }
+
+    private string _nationalLanguage = "";
+    public string NationalLanguage
+    {
+        get => _nationalLanguage;
+        set
+        {
+            var v = value ?? string.Empty;
+            if (SetProperty(ref _nationalLanguage, v))
+            {
+                _settings.NationalLanguage = v;
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds an immutable <see cref="MarinerSettings"/> snapshot from the
+    /// view-model's current values. Used by <see cref="MarinerSettingsProvider"/>.
+    /// </summary>
+    public MarinerSettings BuildMarinerSettings() => new()
+    {
+        SafetyContour = _safetyContour,
+        SafetyDepth = _safetyDepth,
+        ShallowContour = _shallowContour,
+        DeepContour = _deepContour,
+        DepthUnit = _selectedDepthUnit,
+        FourShades = _fourShades,
+        ShallowWaterDangers = _shallowWaterDangers,
+        PlainBoundaries = _plainBoundaries,
+        SimplifiedSymbols = _simplifiedSymbols,
+        FullLightLines = _fullLightLines,
+        RadarOverlay = _radarOverlay,
+        IgnoreScaleMinimum = _ignoreScaleMinimum,
+        NationalLanguage = _nationalLanguage,
+    };
+
     public SettingsViewModel(ViewerSettings settings)
     {
         _settings = settings;
@@ -110,5 +361,23 @@ internal sealed class SettingsViewModel : ViewModelBase
         _distanceUnit = Enum.TryParse<DistanceUnit>(settings.DistanceUnit, ignoreCase: true, out var u)
             ? u
             : EncDotNet.S100.Viewer.DistanceUnit.NauticalMiles;
+
+        // Mariner settings — pull from JSON, falling back to MarinerSettings.Default.
+        var def = MarinerSettings.Default;
+        _safetyContour = settings.SafetyContour ?? def.SafetyContour;
+        _safetyDepth = settings.SafetyDepth ?? def.SafetyDepth;
+        _shallowContour = settings.ShallowContour ?? def.ShallowContour;
+        _deepContour = settings.DeepContour ?? def.DeepContour;
+        _selectedDepthUnit = Enum.TryParse<DepthUnit>(settings.DepthUnit, ignoreCase: true, out var du)
+            ? du
+            : def.DepthUnit;
+        _fourShades = settings.FourShades ?? def.FourShades;
+        _shallowWaterDangers = settings.ShallowWaterDangers ?? def.ShallowWaterDangers;
+        _plainBoundaries = settings.PlainBoundaries ?? def.PlainBoundaries;
+        _simplifiedSymbols = settings.SimplifiedSymbols ?? def.SimplifiedSymbols;
+        _fullLightLines = settings.FullLightLines ?? def.FullLightLines;
+        _radarOverlay = settings.RadarOverlay ?? def.RadarOverlay;
+        _ignoreScaleMinimum = settings.IgnoreScaleMinimum ?? def.IgnoreScaleMinimum;
+        _nationalLanguage = settings.NationalLanguage ?? def.NationalLanguage;
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -59,6 +59,37 @@ internal sealed class ViewerSettings
     /// </summary>
     public string EcdisDisplayCategory { get; set; } = "Standard";
 
+    // Mariner settings (S-100 Part 9 §4.2). Depth values are stored in
+    // metres regardless of the user's chosen DepthUnit. All fields are
+    // nullable so older settings.json files keep working — defaults are
+    // applied by SettingsViewModel / MarinerSettingsProvider when null.
+
+    /// <summary>Safety contour depth in metres.</summary>
+    public double? SafetyContour { get; set; }
+
+    /// <summary>Safety depth in metres for sounding selection.</summary>
+    public double? SafetyDepth { get; set; }
+
+    /// <summary>Shallow contour depth in metres.</summary>
+    public double? ShallowContour { get; set; }
+
+    /// <summary>Deep contour depth in metres.</summary>
+    public double? DeepContour { get; set; }
+
+    /// <summary>Display unit name ("Metres", "Feet", "FathomsFeet", "Fathoms").</summary>
+    public string? DepthUnit { get; set; }
+
+    public bool? FourShades { get; set; }
+    public bool? ShallowWaterDangers { get; set; }
+    public bool? PlainBoundaries { get; set; }
+    public bool? SimplifiedSymbols { get; set; }
+    public bool? FullLightLines { get; set; }
+    public bool? RadarOverlay { get; set; }
+    public bool? IgnoreScaleMinimum { get; set; }
+
+    /// <summary>3-letter ISO 639-2/B language code; empty = catalogue default.</summary>
+    public string? NationalLanguage { get; set; }
+
     /// <summary>
     /// Per-spec viewing-group ids the user has explicitly hidden via
     /// the ECDIS panel. Keys are spec codes (e.g. "S-101"); values

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -115,6 +115,118 @@
                     </ComboBox.ItemTemplate>
                 </ComboBox>
             </StackPanel>
+
+            <!-- Mariner Settings (S-100 Part 9 §4.2) -->
+            <Separator Margin="0,8,0,0" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_MarinerSection}"
+                       FontSize="14"
+                       FontWeight="SemiBold"
+                       Opacity="0.7" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_MarinerSection_Help}"
+                       FontSize="11"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+
+            <!-- Depth Unit -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_DepthUnit}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBlock Text="{x:Static loc:Strings.Settings_DepthUnit_Help}"
+                           FontSize="11"
+                           Opacity="0.6"
+                           TextWrapping="Wrap" />
+                <ComboBox ItemsSource="{Binding AvailableDepthUnits}"
+                          SelectedItem="{Binding SelectedDepthUnit}"
+                          ToolTip.Tip="{x:Static loc:Strings.Settings_DepthUnit_Help}"
+                          MinWidth="180"
+                          HorizontalAlignment="Left">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={x:Static viewer:DepthUnitNameConverter.Instance}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+
+            <!-- Safety Contour -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_SafetyContour}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding SafetyContourDisplay, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                         ToolTip.Tip="{x:Static loc:Strings.Tooltip_SafetyContour}"
+                         MinWidth="120"
+                         HorizontalAlignment="Left" />
+            </StackPanel>
+
+            <!-- Safety Depth -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_SafetyDepth}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding SafetyDepthDisplay, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                         ToolTip.Tip="{x:Static loc:Strings.Tooltip_SafetyDepth}"
+                         MinWidth="120"
+                         HorizontalAlignment="Left" />
+            </StackPanel>
+
+            <!-- Shallow Contour -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_ShallowContour}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding ShallowContourDisplay, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                         ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShallowContour}"
+                         MinWidth="120"
+                         HorizontalAlignment="Left" />
+            </StackPanel>
+
+            <!-- Deep Contour -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_DeepContour}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding DeepContourDisplay, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                         ToolTip.Tip="{x:Static loc:Strings.Tooltip_DeepContour}"
+                         MinWidth="120"
+                         HorizontalAlignment="Left" />
+            </StackPanel>
+
+            <!-- S-101 toggles -->
+            <CheckBox Content="{x:Static loc:Strings.Settings_FourShades}"
+                      IsChecked="{Binding FourShades}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_FourShades}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_ShallowWaterDangers}"
+                      IsChecked="{Binding ShallowWaterDangers}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShallowWaterDangers}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_PlainBoundaries}"
+                      IsChecked="{Binding PlainBoundaries}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_PlainBoundaries}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_SimplifiedSymbols}"
+                      IsChecked="{Binding SimplifiedSymbols}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_SimplifiedSymbols}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_FullLightLines}"
+                      IsChecked="{Binding FullLightLines}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_FullLightLines}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_RadarOverlay}"
+                      IsChecked="{Binding RadarOverlay}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_RadarOverlay}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_IgnoreScaleMinimum}"
+                      IsChecked="{Binding IgnoreScaleMinimum}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_IgnoreScaleMinimum}" />
+
+            <!-- National Language -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_NationalLanguage}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <ComboBox ItemsSource="{Binding AvailableLanguageCodes}"
+                          SelectedItem="{Binding NationalLanguage}"
+                          ToolTip.Tip="{x:Static loc:Strings.Tooltip_NationalLanguage}"
+                          MinWidth="180"
+                          HorizontalAlignment="Left" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -6,7 +6,7 @@
              x:Class="EncDotNet.S100.Viewer.Views.SettingsView"
              x:DataType="vm:SettingsViewModel">
 
-    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                    VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="12" Spacing="16">
             <TextBlock Text="{x:Static loc:Strings.Settings_Heading}"
@@ -221,11 +221,18 @@
                 <TextBlock Text="{x:Static loc:Strings.Settings_NationalLanguage}"
                            FontSize="12"
                            FontWeight="SemiBold" />
-                <ComboBox ItemsSource="{Binding AvailableLanguageCodes}"
-                          SelectedItem="{Binding NationalLanguage}"
+                <ComboBox ItemsSource="{Binding AvailableLanguages}"
+                          SelectedValue="{Binding NationalLanguage}"
+                          SelectedValueBinding="{Binding Code}"
                           ToolTip.Tip="{x:Static loc:Strings.Tooltip_NationalLanguage}"
                           MinWidth="180"
-                          HorizontalAlignment="Left" />
+                          HorizontalAlignment="Left">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding DisplayName}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/tests/EncDotNet.S100.Pipelines.Tests/DepthFormattingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DepthFormattingTests.cs
@@ -1,0 +1,121 @@
+using System.Globalization;
+using EncDotNet.S100.Pipelines;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class DepthFormattingTests
+{
+    [Theory]
+    [InlineData(0.0, DepthUnit.Metres, 0.0)]
+    [InlineData(30.0, DepthUnit.Metres, 30.0)]
+    [InlineData(1.0, DepthUnit.Feet, 3.28084)]
+    [InlineData(1.0, DepthUnit.Fathoms, 0.546806649168854)]
+    public void ToDisplay_ConvertsFromMetres(double m, DepthUnit unit, double expected)
+    {
+        Assert.Equal(expected, DepthFormatting.ToDisplay(m, unit), 4);
+    }
+
+    [Theory]
+    [InlineData(DepthUnit.Metres)]
+    [InlineData(DepthUnit.Feet)]
+    [InlineData(DepthUnit.Fathoms)]
+    [InlineData(DepthUnit.FathomsFeet)]
+    public void RoundTrip_ToDisplayThenToMetres(DepthUnit unit)
+    {
+        const double original = 30.5;
+        double display = DepthFormatting.ToDisplay(original, unit);
+        double back = DepthFormatting.ToMetres(display, unit);
+        Assert.Equal(original, back, 6);
+    }
+
+    [Fact]
+    public void Format_FathomsFeet_SplitsIntoFathomsAndFeet()
+    {
+        // 32 ft = 5 fathoms 2 feet
+        double metres = 32.0 / DepthFormatting.FeetPerMetre;
+        var formatted = DepthFormatting.Format(metres, DepthUnit.FathomsFeet);
+        Assert.Equal("5fm 2ft", formatted);
+    }
+
+    [Fact]
+    public void Format_Metres_UsesInvariantCulture()
+    {
+        var prev = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE"); // uses comma as decimal separator
+            var formatted = DepthFormatting.Format(30.5, DepthUnit.Metres);
+            Assert.Equal("30.5 m", formatted);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prev;
+        }
+    }
+
+    [Theory]
+    [InlineData("30", DepthUnit.Metres, 30.0)]
+    [InlineData("30.5 m", DepthUnit.Metres, 30.5)]
+    [InlineData("100ft", DepthUnit.Metres, 30.4800)] // unit suffix overrides active unit
+    [InlineData("100", DepthUnit.Feet, 30.4800)]
+    [InlineData("5fm 2ft", DepthUnit.FathomsFeet, 9.7536)]
+    [InlineData("5 fm", DepthUnit.FathomsFeet, 9.144)]
+    [InlineData("12 ft", DepthUnit.FathomsFeet, 3.6576)]
+    public void TryParse_ParsesSupportedForms(string text, DepthUnit unit, double expectedMetres)
+    {
+        Assert.True(DepthFormatting.TryParse(text, unit, out var m));
+        Assert.Equal(expectedMetres, m, 3);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a number")]
+    [InlineData("abc fm")]
+    public void TryParse_ReturnsFalseOnInvalid(string text)
+    {
+        Assert.False(DepthFormatting.TryParse(text, DepthUnit.Metres, out _));
+    }
+
+    [Fact]
+    public void TryParse_NegativeFathomsFeet()
+    {
+        Assert.True(DepthFormatting.TryParse("-5fm 2ft", DepthUnit.FathomsFeet, out var m));
+        Assert.Equal(-9.7536, m, 3);
+    }
+
+    [Theory]
+    [InlineData(DepthUnit.Metres, "m")]
+    [InlineData(DepthUnit.Feet, "ft")]
+    [InlineData(DepthUnit.Fathoms, "fm")]
+    [InlineData(DepthUnit.FathomsFeet, "fm/ft")]
+    public void UnitAbbreviation_KnownUnits(DepthUnit unit, string expected)
+    {
+        Assert.Equal(expected, DepthFormatting.UnitAbbreviation(unit));
+    }
+}
+
+public class MarinerSettingsDefaultsTests
+{
+    [Fact]
+    public void Default_MatchesS101PortrayalCatalogueDefaults()
+    {
+        // Source: src/EncDotNet.S100.Specifications/content/S101/pc/portrayal_catalogue.xml
+        // Lines ~9681-9802 declare these context parameter defaults.
+        var d = MarinerSettings.Default;
+        Assert.Equal(30.0, d.SafetyContour);
+        Assert.Equal(30.0, d.SafetyDepth);
+        Assert.Equal(2.0, d.ShallowContour);
+        Assert.Equal(30.0, d.DeepContour);
+        Assert.False(d.FourShades);
+        Assert.True(d.ShallowWaterDangers);
+        Assert.True(d.PlainBoundaries);
+        Assert.False(d.SimplifiedSymbols);
+        Assert.False(d.FullLightLines);
+        Assert.False(d.RadarOverlay);
+        Assert.False(d.IgnoreScaleMinimum);
+        Assert.Equal(DepthUnit.Metres, d.DepthUnit);
+        Assert.Equal("", d.NationalLanguage);
+    }
+}


### PR DESCRIPTION
Plumbs `MarinerSettings` (S-100 Part 9 §4.2) through the viewer so users can change the four depth contours, the S-101 portrayal toggles already declared by the bundled portrayal catalogue, and the preferred chart language — and have all loaded datasets re-render immediately.

## Changes

**Core (`EncDotNet.S100.Core`)**
- `MarinerSettings` extended with `DepthUnit`, 7 portrayal toggles (`FourShades`, `ShallowWaterDangers`, `PlainBoundaries`, `SimplifiedSymbols`, `FullLightLines`, `RadarOverlay`, `IgnoreScaleMinimum`), and `NationalLanguage`. Defaults match the S-101 PC declared defaults (verified against `portrayal_catalogue.xml`).
- New `DepthUnit` enum and `DepthFormatting` static helper for locale-invariant conversion / formatting / parsing across metres, feet, fathoms, and combined fathoms-and-feet (e.g. `"5fm 2ft"`). Accepts unit suffixes on parse (so `"100 ft"` pasted into a metres field still rounds-trips).

**Pipelines**
- `RenderContext.Mariner` carries the user-configured snapshot through every pipeline.
- S-101 / S-102 / S-104 / S-111 dataset processors read `context?.Mariner ?? MarinerSettings.Default` instead of always using `Default`.
- `S101LuaRuleExecutor.SetContextParameters` forwards all new toggles + the language code to the bundled Lua portrayal catalogue (existing try/catch retained for forward compatibility).

**Viewer**
- `IMarinerSettingsProvider` singleton wraps `SettingsViewModel`; `DatasetLoaderService` subscribes to `Changed` and re-renders all loaded datasets, mirroring the existing palette / display-scale plumbing.
- `ViewerSettings` JSON persists 13 new fields (all nullable, falling back to spec defaults when missing).
- `SettingsView.axaml` adds a Mariner section: depth-unit picker, four depth-contour text inputs (round-tripped via `DepthFormatting`), 7 toggles, and a localised language combo-box. Every control has a `ToolTip.Tip`. Horizontal scroll is disabled so controls fit within the panel width.
- Language picker: `LanguageOption(Code, DisplayName)` records, with display names sourced from the OS culture catalogue ("English", "Français", …). Default entry is **"System (\<OS UI culture\>)"**; empty stored value resolves at snapshot time to `CultureInfo.CurrentUICulture.ThreeLetterISOLanguageName` (or skipped when invariant, falling back to the catalogue default `eng`).

## Tests
- 27 new tests in `EncDotNet.S100.Pipelines.Tests`:
  - `DepthFormatting` round-trips for every unit, FathomsFeet split formatting, locale-invariance under `de-DE`, parse acceptance of unit suffixes, negative values, invalid input rejection.
  - `MarinerSettings.Default` matches the S-101 portrayal-catalogue declared defaults.
- Full suite passes (no failures, no skips that weren't already skipped on `main`).

## Out of scope (deferred)
- Vessel specs / Display Category / sounding-label units / magnetic variation / position formats / tide-corrected safety contour / voyage profiles.
- Two pre-existing issues observed during testing (also reproducible on `main`): soundings rendered twice with different numbers, and `TextScale` not applying to sounding glyphs (they're sprite `PointInstruction`s, not `TextInstruction`s).
- More UX polish on the new Mariner settings layout — current form is functional but a denser grid would suit it better.

Refs: S-100 Edition 5.2.1 Part 9 §4.2 (Mariner Selections); S-101 portrayal-catalogue context-parameter declarations.