### PR TITLE
feat: add display-plane filter and text-group toolbar toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A set of .NET libraries for reading, portraying, and rendering [S-100](https://i
 
 | Application | Description |
 |---|---|
-| **EncDotNet.S100.Viewer** | Cross-platform desktop nautical chart viewer built on [Avalonia](https://avaloniaui.net/) and Mapsui. Loads S-101, S-102, S-104, S-111, S-122, S-124, S-125, S-127, S-129, S-411, S-421, and legacy S-57 datasets and renders them on an interactive map. |
+| **EncDotNet.S100.Viewer** | Cross-platform desktop nautical chart viewer built on [Avalonia](https://avaloniaui.net/) and Mapsui. Loads S-101, S-102, S-104, S-111, S-122, S-124, S-125, S-127, S-129, S-411, S-421, and legacy S-57 datasets and renders them on an interactive map. Features ECDIS display-category filtering, display-plane toggles, quick text-group toggles, and per-spec viewing-group overrides. |
 
 ### Pick / Object Information
 

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorPortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorPortrayalCatalogue.cs
@@ -35,4 +35,12 @@ public interface IVectorPortrayalCatalogue
     /// <see cref="ViewingGroupController.SetActiveModeMembership"/>.
     /// </summary>
     DisplayModeController DisplayModes { get; }
+
+    /// <summary>
+    /// Controls which S-100 Part 9 §11.6 display planes are currently
+    /// visible. The pipeline queries this controller after
+    /// viewing-group filtering to drop instructions whose plane is
+    /// hidden.
+    /// </summary>
+    DisplayPlaneController DisplayPlanes { get; }
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
@@ -13,7 +13,7 @@ namespace EncDotNet.S100.Pipelines.Vector;
 ///   <item>XSLT transformation — run applicable XSLT rules against the FeatureXML</item>
 ///   <item>Lua execution — delegate to <see cref="ILuaRuleExecutor"/> (Part 9A)</item>
 ///   <item>Drawing instruction assembly — parse XSLT output into typed objects and append Lua output</item>
-///   <item>Viewing group filtering and priority sorting</item>
+///   <item>Viewing group filtering, display plane filtering, and priority sorting</item>
 /// </list>
 /// </summary>
 public class VectorPipeline
@@ -66,9 +66,10 @@ public class VectorPipeline
                 instructions.AddRange(_luaExecutor.Execute(mariner ?? new MarinerSettings()));
             }
 
-            // Stage 6 — viewing group filter + priority sort
+            // Stage 6 — viewing group filter + display plane filter + priority sort
             var filtered = ApplyViewingGroups(instructions, catalogue.ViewingGroups);
-            var sorted = SortByPriority(filtered);
+            var planeFiltered = ApplyDisplayPlanes(filtered, catalogue.DisplayPlanes);
+            var sorted = SortByPriority(planeFiltered);
 
             PipelineMetrics.InstructionsOut.Record(sorted.Count, stageTag);
             activity?.SetTag("s100.pipeline.instructions.count", sorted.Count);
@@ -174,6 +175,23 @@ public class VectorPipeline
         {
             return false;
         }
+    }
+
+    // ── Stage 6: Display plane filtering ──────────────────────────────
+
+    /// <summary>
+    /// Removes instructions whose <see cref="DrawingInstruction.Plane"/>
+    /// is hidden by the controller (S-100 Part 9 §11.6). Runs after
+    /// viewing-group filtering so the input list is already reduced.
+    /// </summary>
+    private static IReadOnlyList<DrawingInstruction> ApplyDisplayPlanes(
+        IReadOnlyList<DrawingInstruction> instructions,
+        DisplayPlaneController displayPlanes)
+    {
+        if (displayPlanes.HiddenPlanes.Count == 0) return instructions;
+        return instructions
+            .Where(i => displayPlanes.IsVisible(i.Plane))
+            .ToList();
     }
 
     // ── Stage 6: Viewing group filtering and sort ──────────────────────

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPortrayalTypes.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPortrayalTypes.cs
@@ -188,6 +188,60 @@ public sealed class ViewingGroupController
 }
 
 /// <summary>
+/// Controls visibility of drawing instructions by display plane
+/// (S-100 Part 9 §11.6). The three canonical planes are
+/// <see cref="DisplayPlane.UnderRadar"/> and
+/// <see cref="DisplayPlane.OverRadar"/>; all planes are visible by
+/// default.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="ViewingGroupController"/> this controller has no
+/// "mode membership" layer — planes are simply on or off. The pipeline
+/// evaluates the controller after viewing-group filtering so the
+/// (typically smaller) VG-filtered list is the input.
+/// </remarks>
+public sealed class DisplayPlaneController
+{
+    private readonly HashSet<DisplayPlane> _hidden = new();
+
+    /// <summary>
+    /// Raised whenever the hidden set changes.
+    /// </summary>
+    public event Action? Changed;
+
+    /// <summary>
+    /// The set of planes that are currently hidden.
+    /// </summary>
+    public IReadOnlySet<DisplayPlane> HiddenPlanes => _hidden;
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="plane"/> is visible
+    /// (i.e. not in the hidden set).
+    /// </summary>
+    public bool IsVisible(DisplayPlane plane) => !_hidden.Contains(plane);
+
+    /// <summary>
+    /// Shows or hides <paramref name="plane"/>. Raises
+    /// <see cref="Changed"/> when the effective state changes.
+    /// </summary>
+    public void SetVisible(DisplayPlane plane, bool visible)
+    {
+        bool changed = visible ? _hidden.Remove(plane) : _hidden.Add(plane);
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Resets all planes to visible.
+    /// </summary>
+    public void ShowAll()
+    {
+        if (_hidden.Count == 0) return;
+        _hidden.Clear();
+        Changed?.Invoke();
+    }
+}
+
+/// <summary>
 /// Tracks the active S-100 Part 9 display-mode id for a vector
 /// portrayal catalogue.
 /// </summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/EcdisDisplaySettings.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/EcdisDisplaySettings.cs
@@ -55,6 +55,13 @@ public sealed record EcdisDisplaySettings
     /// </summary>
     public IReadOnlyDictionary<string, IReadOnlySet<int>> HiddenViewingGroups { get; init; }
         = new Dictionary<string, IReadOnlySet<int>>();
+
+    /// <summary>
+    /// Display planes the user has hidden via the ECDIS panel
+    /// (S-100 Part 9 §11.6). Empty by default.
+    /// </summary>
+    public IReadOnlySet<DisplayPlane> HiddenDisplayPlanes { get; init; }
+        = new HashSet<DisplayPlane>();
 }
 
 /// <summary>
@@ -137,6 +144,12 @@ public static class EcdisDisplayExtensions
         {
             foreach (var vg in hidden)
                 catalogue.ViewingGroups.SetUserOverride(vg, false);
+        }
+
+        // Push display-plane visibility (S-100 Part 9 §11.6).
+        foreach (var plane in Enum.GetValues<DisplayPlane>())
+        {
+            catalogue.DisplayPlanes.SetVisible(plane, !settings.HiddenDisplayPlanes.Contains(plane));
         }
     }
 }

--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -54,6 +54,9 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S122/S122PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S122/S122PortrayalCatalogue.cs
@@ -71,6 +71,9 @@ public sealed class S122PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S124/S124PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S124/S124PortrayalCatalogue.cs
@@ -63,6 +63,9 @@ public sealed class S124PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
@@ -64,6 +64,9 @@ public sealed class S125PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S127/S127PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S127/S127PortrayalCatalogue.cs
@@ -59,6 +59,9 @@ public sealed class S127PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     private void EnsurePalettesLoaded()
     {
         if (_palettesLoaded) return;

--- a/src/EncDotNet.S100.Datasets.S128/S128PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128PortrayalCatalogue.cs
@@ -74,6 +74,9 @@ public sealed class S128PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
@@ -63,6 +63,9 @@ public sealed class S129PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
@@ -70,6 +70,9 @@ public sealed class S411PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
@@ -62,6 +62,9 @@ public sealed class S421PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <summary>Tracks the active S-100 Part 9 §11.7 display mode.</summary>
     public DisplayModeController DisplayModes { get; } = new();
 
+    /// <summary>Controls which S-100 Part 9 §11.6 display planes are visible.</summary>
+    public DisplayPlaneController DisplayPlanes { get; } = new();
+
     // ── Palettes ───────────────────────────────────────────────────────
 
     private void EnsurePalettesLoaded()

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -144,7 +144,15 @@ public partial class App : Application
                 }
                 if (ids.Count > 0) hidden[kv.Key] = ids;
             }
-            state.Hydrate(category, hidden);
+            // Hydrate hidden display planes
+            var hiddenPlanes = new HashSet<EncDotNet.S100.Pipelines.Vector.DisplayPlane>();
+            foreach (var token in (settings.EcdisHiddenDisplayPlanes ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (Enum.TryParse<EncDotNet.S100.Pipelines.Vector.DisplayPlane>(token, ignoreCase: true, out var plane))
+                    hiddenPlanes.Add(plane);
+            }
+            state.Hydrate(category, hidden, hiddenPlanes.Count > 0 ? hiddenPlanes : null);
 
             // Persist on every change so a crash doesn't lose the user's
             // ECDIS preferences. Cheap because settings.json is small.
@@ -158,6 +166,8 @@ public partial class App : Application
                     settings.EcdisHiddenViewingGroups[kv.Key] =
                         string.Join(",", kv.Value.OrderBy(i => i));
                 }
+                settings.EcdisHiddenDisplayPlanes =
+                    string.Join(",", snap.HiddenDisplayPlanes.OrderBy(p => p));
                 try { settings.Save(); } catch { /* best-effort */ }
             };
             return state;
@@ -180,6 +190,7 @@ public partial class App : Application
         services.AddSingleton<PickReportViewModel>();
         services.AddSingleton<TimelineViewModel>();
         services.AddSingleton<DisplayToolbarViewModel>();
+        services.AddSingleton<TextGroupToolbarViewModel>();
         services.AddSingleton<EcdisDisplayPanelViewModel>();
         services.AddSingleton<MainViewModel>();
 

--- a/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
@@ -29,4 +29,9 @@ internal static class Telemetry
         Meter.CreateCounter<long>(
             "s100.viewer.viewinggroup.toggled",
             description: "Number of times a user toggled a viewing-group override.");
+
+    public static readonly Counter<long> DisplayPlaneToggled =
+        Meter.CreateCounter<long>(
+            "s100.viewer.displayplane.toggled",
+            description: "Number of times a user toggled a display-plane override.");
 }

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -514,9 +514,36 @@
                             </Flyout>
                         </Button.Flyout>
                     </Button>
+                    <!--
+                      Text group pill — compact label that opens a flyout
+                      to toggle text viewing-group layers on/off.
+                    -->
+                    <Button Classes="MapOverlay"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_TextGroupPill}"
+                            Padding="8,4"
+                            FontSize="11"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Content="{x:Static loc:Strings.Toolbar_Text}"
+                            IsEnabled="{Binding TextToolbar.IsEnabled}">
+                        <Button.Flyout>
+                            <Flyout Placement="BottomEdgeAlignedRight">
+                                <StackPanel Spacing="4" MinWidth="160">
+                                    <CheckBox Content="{x:Static loc:Strings.TextGroup_Important}"
+                                              IsChecked="{Binding TextToolbar.IsImportantVisible}"
+                                              Command="{Binding TextToolbar.ToggleImportantCommand}" />
+                                    <CheckBox Content="{x:Static loc:Strings.TextGroup_Other}"
+                                              IsChecked="{Binding TextToolbar.IsOtherVisible}"
+                                              Command="{Binding TextToolbar.ToggleOtherCommand}" />
+                                    <CheckBox Content="{x:Static loc:Strings.TextGroup_All}"
+                                              IsChecked="{Binding TextToolbar.IsAllVisible}"
+                                              Command="{Binding TextToolbar.ToggleAllCommand}" />
+                                </StackPanel>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
 
                     <!--
-                      Zoom in / out / to-extent group. Wrapping in an inner
                       StackPanel with vertical margin gives the cluster its
                       own visual grouping (separated from the Pick Mode
                       button above and the compass rose below).

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -73,8 +73,9 @@ immediately and do not re-run the dataset pipeline.
 
 ## ECDIS Display Controls
 
-The viewer exposes S-100 Part 9A display-category filtering and
-per-spec viewing-group overrides through two UI surfaces:
+The viewer exposes S-100 Part 9A display-category filtering,
+per-spec viewing-group overrides, display-plane toggles, and
+quick text-group toggles through several UI surfaces:
 
 ### Display toolbar pill
 
@@ -84,6 +85,15 @@ or All). Clicking the pill opens a flyout with radio buttons to
 switch categories; the change propagates through `EcdisDisplayState`
 and triggers a re-render of all vector datasets.
 
+### Text toolbar pill
+
+A "Text ▾" pill button next to the display pill opens a flyout
+with checkboxes for the three S-101 text viewing-group layers:
+**Important Text**, **Other Text**, and **All Other Chart Text**.
+Unchecking a group hides the corresponding viewing groups. The
+pill is disabled when no S-101 data (or another spec with text
+layers) is loaded.
+
 ### ECDIS panel (activity bar)
 
 A dedicated activity-bar entry opens the ECDIS Display Controls
@@ -92,6 +102,14 @@ panel. It lists each loaded **vector** product specification
 with a flat checkbox list of viewing groups sourced from the spec's
 portrayal catalogue. Unchecking a viewing group hides its features
 from the rendered output.
+
+#### Display planes
+
+Below the display-category radios, the panel shows checkboxes for
+the two S-100 display planes — **Under Radar** and **Over Radar**
+(S-100 Part 9 §11.6). Unchecking a plane hides all drawing
+instructions assigned to it across all loaded vector datasets.
+Plane visibility is persisted in `settings.json`.
 
 Coverage products (S-102, S-104, S-111) have no viewing-group
 concept and are excluded from the panel.

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -283,4 +283,18 @@ internal static class Strings
     public static string Status_MeasureTotal => Get(nameof(Status_MeasureTotal));
     public static string Status_MeasureNoData => Get(nameof(Status_MeasureNoData));
     public static string Status_MeasureLegLabel => Get(nameof(Status_MeasureLegLabel));
+
+    // ECDIS Display Planes
+    public static string EcdisPanel_DisplayPlanesHeader => Get(nameof(EcdisPanel_DisplayPlanesHeader));
+    public static string DisplayPlane_UnderRadar => Get(nameof(DisplayPlane_UnderRadar));
+    public static string DisplayPlane_OverRadar => Get(nameof(DisplayPlane_OverRadar));
+    public static string Tooltip_DisplayPlane_UnderRadar => Get(nameof(Tooltip_DisplayPlane_UnderRadar));
+    public static string Tooltip_DisplayPlane_OverRadar => Get(nameof(Tooltip_DisplayPlane_OverRadar));
+
+    // Text group toolbar pill
+    public static string Toolbar_Text => Get(nameof(Toolbar_Text));
+    public static string Tooltip_TextGroupPill => Get(nameof(Tooltip_TextGroupPill));
+    public static string TextGroup_Important => Get(nameof(TextGroup_Important));
+    public static string TextGroup_Other => Get(nameof(TextGroup_Other));
+    public static string TextGroup_All => Get(nameof(TextGroup_All));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -723,4 +723,38 @@ Open an S-101, S-124, S-125, or S-421 dataset to see display controls here.</val
   <data name="Status_MeasureLegLabel" xml:space="preserve">
     <value>{0:0.0} NM @ {1:000}°T</value>
   </data>
+
+  <!-- ECDIS Display Planes -->
+  <data name="EcdisPanel_DisplayPlanesHeader" xml:space="preserve">
+    <value>Display Planes</value>
+  </data>
+  <data name="DisplayPlane_UnderRadar" xml:space="preserve">
+    <value>Under Radar</value>
+  </data>
+  <data name="DisplayPlane_OverRadar" xml:space="preserve">
+    <value>Over Radar</value>
+  </data>
+  <data name="Tooltip_DisplayPlane_UnderRadar" xml:space="preserve">
+    <value>Toggle visibility of the Under Radar display plane</value>
+  </data>
+  <data name="Tooltip_DisplayPlane_OverRadar" xml:space="preserve">
+    <value>Toggle visibility of the Over Radar display plane</value>
+  </data>
+
+  <!-- Text group toolbar pill -->
+  <data name="Toolbar_Text" xml:space="preserve">
+    <value>Text ▾</value>
+  </data>
+  <data name="Tooltip_TextGroupPill" xml:space="preserve">
+    <value>Toggle text viewing groups</value>
+  </data>
+  <data name="TextGroup_Important" xml:space="preserve">
+    <value>Important Text</value>
+  </data>
+  <data name="TextGroup_Other" xml:space="preserve">
+    <value>Other Text</value>
+  </data>
+  <data name="TextGroup_All" xml:space="preserve">
+    <value>All other chart text</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/EcdisDisplayState.cs
+++ b/src/EncDotNet.S100.Viewer/Services/EcdisDisplayState.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
 
 namespace EncDotNet.S100.Viewer.Services;
 
@@ -17,6 +18,7 @@ internal sealed class EcdisDisplayState
     private readonly object _gate = new();
     private readonly Dictionary<string, HashSet<int>> _hidden =
         new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<DisplayPlane> _hiddenPlanes = new();
     private EcdisDisplayCategory _category = EcdisDisplayCategory.Standard;
 
     /// <summary>Raised after any mutation completes.</summary>
@@ -85,6 +87,43 @@ internal sealed class EcdisDisplayState
     }
 
     /// <summary>
+    /// Hides a display plane (S-100 Part 9 §11.6).
+    /// </summary>
+    public void HideDisplayPlane(DisplayPlane plane)
+    {
+        bool changed;
+        lock (_gate)
+        {
+            changed = _hiddenPlanes.Add(plane);
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Shows a previously hidden display plane.
+    /// </summary>
+    public void ShowDisplayPlane(DisplayPlane plane)
+    {
+        bool changed;
+        lock (_gate)
+        {
+            changed = _hiddenPlanes.Remove(plane);
+        }
+        if (changed) Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Returns the set of hidden display planes.
+    /// </summary>
+    public IReadOnlySet<DisplayPlane> GetHiddenDisplayPlanes()
+    {
+        lock (_gate)
+        {
+            return new HashSet<DisplayPlane>(_hiddenPlanes);
+        }
+    }
+
+    /// <summary>
     /// Clears every per-spec viewing-group override and raises
     /// <see cref="Changed"/> if anything was cleared.
     /// </summary>
@@ -147,6 +186,7 @@ internal sealed class EcdisDisplayState
             {
                 Category = _category,
                 HiddenViewingGroups = copy,
+                HiddenDisplayPlanes = new HashSet<DisplayPlane>(_hiddenPlanes),
             };
         }
     }
@@ -157,7 +197,10 @@ internal sealed class EcdisDisplayState
     /// per-spec overrides). Raises <see cref="Changed"/> exactly
     /// once after the swap.
     /// </summary>
-    public void Hydrate(EcdisDisplayCategory category, IReadOnlyDictionary<string, IReadOnlySet<int>> hidden)
+    public void Hydrate(
+        EcdisDisplayCategory category,
+        IReadOnlyDictionary<string, IReadOnlySet<int>> hidden,
+        IReadOnlySet<DisplayPlane>? hiddenPlanes = null)
     {
         ArgumentNullException.ThrowIfNull(hidden);
         lock (_gate)
@@ -166,6 +209,12 @@ internal sealed class EcdisDisplayState
             _hidden.Clear();
             foreach (var kv in hidden)
                 _hidden[kv.Key] = new HashSet<int>(kv.Value);
+            _hiddenPlanes.Clear();
+            if (hiddenPlanes is not null)
+            {
+                foreach (var p in hiddenPlanes)
+                    _hiddenPlanes.Add(p);
+            }
         }
         Changed?.Invoke();
     }

--- a/src/EncDotNet.S100.Viewer/ViewModels/EcdisDisplayPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/EcdisDisplayPanelViewModel.cs
@@ -7,7 +7,9 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Services;
+using DisplayPlane = EncDotNet.S100.Pipelines.Vector.DisplayPlane;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -96,6 +98,48 @@ internal sealed class EcdisDisplayPanelViewModel : ViewModelBase, IDisposable
     public bool IsOtherInformation => _state.Category == EcdisDisplayCategory.OtherInformation;
     public bool IsAll => _state.Category == EcdisDisplayCategory.All;
 
+    /// <summary>
+    /// Whether the Under Radar display plane is visible.
+    /// </summary>
+    public bool IsUnderRadarVisible
+    {
+        get => !_state.GetHiddenDisplayPlanes().Contains(DisplayPlane.UnderRadar);
+        set
+        {
+            if (value)
+                _state.ShowDisplayPlane(DisplayPlane.UnderRadar);
+            else
+                _state.HideDisplayPlane(DisplayPlane.UnderRadar);
+
+            Telemetry.DisplayPlaneToggled.Add(1,
+                new KeyValuePair<string, object?>("s100.displayplane", nameof(DisplayPlane.UnderRadar)),
+                new KeyValuePair<string, object?>("s100.visible", value));
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Whether the Over Radar display plane is visible.
+    /// </summary>
+    public bool IsOverRadarVisible
+    {
+        get => !_state.GetHiddenDisplayPlanes().Contains(DisplayPlane.OverRadar);
+        set
+        {
+            if (value)
+                _state.ShowDisplayPlane(DisplayPlane.OverRadar);
+            else
+                _state.HideDisplayPlane(DisplayPlane.OverRadar);
+
+            Telemetry.DisplayPlaneToggled.Add(1,
+                new KeyValuePair<string, object?>("s100.displayplane", nameof(DisplayPlane.OverRadar)),
+                new KeyValuePair<string, object?>("s100.visible", value));
+
+            OnPropertyChanged();
+        }
+    }
+
     private void OnStateChanged()
     {
         OnPropertyChanged(nameof(ActiveCategory));
@@ -103,6 +147,8 @@ internal sealed class EcdisDisplayPanelViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(IsStandard));
         OnPropertyChanged(nameof(IsOtherInformation));
         OnPropertyChanged(nameof(IsAll));
+        OnPropertyChanged(nameof(IsUnderRadarVisible));
+        OnPropertyChanged(nameof(IsOverRadarVisible));
         foreach (var spec in Specs)
             spec.Refresh();
     }

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -26,6 +26,7 @@ internal sealed class MainViewModel : ViewModelBase
     public PickReportViewModel PickReport { get; }
     public TimelineViewModel Timeline { get; }
     public DisplayToolbarViewModel DisplayToolbar { get; }
+    public TextGroupToolbarViewModel TextToolbar { get; }
     public EcdisDisplayPanelViewModel EcdisDisplayPanel { get; }
 
     private ActivityKind? _selectedActivity;
@@ -410,6 +411,7 @@ internal sealed class MainViewModel : ViewModelBase
         PickReportViewModel pickReport,
         TimelineViewModel timeline,
         DisplayToolbarViewModel displayToolbar,
+        TextGroupToolbarViewModel textToolbar,
         EcdisDisplayPanelViewModel ecdisDisplayPanel,
         IThemeService themeService,
         IRecentFilesService recentFiles,
@@ -426,6 +428,7 @@ internal sealed class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(pickReport);
         ArgumentNullException.ThrowIfNull(timeline);
         ArgumentNullException.ThrowIfNull(displayToolbar);
+        ArgumentNullException.ThrowIfNull(textToolbar);
         ArgumentNullException.ThrowIfNull(ecdisDisplayPanel);
         ArgumentNullException.ThrowIfNull(themeService);
         ArgumentNullException.ThrowIfNull(recentFiles);
@@ -457,6 +460,7 @@ internal sealed class MainViewModel : ViewModelBase
         PickReport = pickReport;
         Timeline = timeline;
         DisplayToolbar = displayToolbar;
+        TextToolbar = textToolbar;
         EcdisDisplayPanel = ecdisDisplayPanel;
         Timeline.CloseRequested += () => IsTimelineVisible = false;
         PickReport.PropertyChanged += (_, e) =>

--- a/src/EncDotNet.S100.Viewer/ViewModels/TextGroupMapping.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/TextGroupMapping.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Portrayals;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// The three quick text-group toggles exposed on the toolbar pill.
+/// </summary>
+internal enum TextGroup
+{
+    /// <summary>Important navigational text (e.g. S-101 VG layer "Important Text").</summary>
+    Important,
+
+    /// <summary>Non-critical text (e.g. S-101 VG layer "Other Text").</summary>
+    Other,
+
+    /// <summary>Remaining chart text not covered by the previous two groups.</summary>
+    All,
+}
+
+/// <summary>
+/// Resolves the three toolbar-level text groups to the concrete
+/// viewing-group ids declared by a spec's portrayal catalogue.
+/// The mapping uses the <see cref="ViewingGroupLayer.Description"/>
+/// name rather than hard-coding layer ids so future PC updates
+/// don't break the mapping.
+/// </summary>
+internal static class TextGroupMapping
+{
+    /// <summary>Canonical name strings used in the S-101 PC.</summary>
+    private static readonly IReadOnlyDictionary<TextGroup, string> CanonicalNames =
+        new Dictionary<TextGroup, string>
+        {
+            [TextGroup.Important] = "Important Text",
+            [TextGroup.Other] = "Other Text",
+            [TextGroup.All] = "All other chart text",
+        };
+
+    /// <summary>
+    /// Returns the viewing-group ids that belong to
+    /// <paramref name="group"/> according to the given
+    /// <paramref name="catalogue"/>. Returns an empty set when the
+    /// catalogue does not declare a matching layer (non-S-101 specs).
+    /// </summary>
+    public static IReadOnlySet<int> Resolve(TextGroup group, PortrayalCatalogue catalogue)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+
+        if (!CanonicalNames.TryGetValue(group, out var name))
+            return new HashSet<int>();
+
+        var layer = catalogue.ViewingGroupLayers
+            .FirstOrDefault(l => l.Description.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        if (layer is null)
+            return new HashSet<int>();
+
+        var ids = new HashSet<int>();
+        foreach (var vgId in layer.ViewingGroupIds)
+        {
+            if (int.TryParse(vgId, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var id))
+            {
+                ids.Add(id);
+            }
+        }
+        return ids;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the catalogue has at least one text
+    /// viewing-group layer (i.e. the toolbar pill should be active
+    /// for this spec).
+    /// </summary>
+    public static bool HasTextLayers(PortrayalCatalogue catalogue)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+        return CanonicalNames.Values.Any(name =>
+            catalogue.ViewingGroupLayers.Any(l =>
+                l.Description.Name.Equals(name, StringComparison.OrdinalIgnoreCase)));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/TextGroupToolbarViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/TextGroupToolbarViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
@@ -27,6 +28,7 @@ internal sealed class TextGroupToolbarViewModel : ViewModelBase, IDisposable
 {
     private readonly EcdisDisplayState _state;
     private readonly PortrayalCatalogueManager _catalogueManager;
+    private readonly DatasetsViewModel _datasets;
 
     /// <summary>Cached VG ids per text group for the primary spec.</summary>
     private readonly Dictionary<TextGroup, IReadOnlySet<int>> _resolvedGroups = new();
@@ -34,18 +36,24 @@ internal sealed class TextGroupToolbarViewModel : ViewModelBase, IDisposable
 
     public TextGroupToolbarViewModel(
         EcdisDisplayState state,
-        PortrayalCatalogueManager catalogueManager)
+        PortrayalCatalogueManager catalogueManager,
+        DatasetsViewModel datasets)
     {
         ArgumentNullException.ThrowIfNull(state);
         ArgumentNullException.ThrowIfNull(catalogueManager);
+        ArgumentNullException.ThrowIfNull(datasets);
 
         _state = state;
         _catalogueManager = catalogueManager;
+        _datasets = datasets;
         _state.Changed += OnStateChanged;
+        _datasets.Entries.CollectionChanged += OnEntriesChanged;
 
         ToggleImportantCommand = new RelayCommand(() => Toggle(TextGroup.Important));
         ToggleOtherCommand = new RelayCommand(() => Toggle(TextGroup.Other));
         ToggleAllCommand = new RelayCommand(() => Toggle(TextGroup.All));
+
+        RebuildFromLoadedSpecs();
     }
 
     public ICommand ToggleImportantCommand { get; }
@@ -132,6 +140,40 @@ internal sealed class TextGroupToolbarViewModel : ViewModelBase, IDisposable
 
     private void OnStateChanged() => NotifyAll();
 
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RebuildFromLoadedSpecs();
+    }
+
+    /// <summary>
+    /// Scans loaded datasets and resolves text layers for the first
+    /// vector spec that has them.
+    /// </summary>
+    private void RebuildFromLoadedSpecs()
+    {
+        // Find the first loaded vector spec that has text layers
+        string? matchedSpec = null;
+        foreach (var entry in _datasets.Entries)
+        {
+            var spec = entry.ProductSpec;
+            if (_catalogueManager.HasCatalogue(spec))
+            {
+                try
+                {
+                    var provider = _catalogueManager.GetProvider(spec);
+                    if (TextGroupMapping.HasTextLayers(provider.Catalogue))
+                    {
+                        matchedSpec = spec;
+                        break;
+                    }
+                }
+                catch { /* skip */ }
+            }
+        }
+
+        RefreshForSpec(matchedSpec);
+    }
+
     private void NotifyAll()
     {
         OnPropertyChanged(nameof(IsImportantVisible));
@@ -142,5 +184,6 @@ internal sealed class TextGroupToolbarViewModel : ViewModelBase, IDisposable
     public void Dispose()
     {
         _state.Changed -= OnStateChanged;
+        _datasets.Entries.CollectionChanged -= OnEntriesChanged;
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/TextGroupToolbarViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/TextGroupToolbarViewModel.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Diagnostics;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Backs the "Text ▾" toolbar pill. Exposes three checkboxes that
+/// toggle S-101 text viewing-group layers via the existing per-spec
+/// hidden-VG override map in <see cref="EcdisDisplayState"/>.
+/// </summary>
+/// <remarks>
+/// For specs that do not declare text viewing-group layers the
+/// toggles are disabled (greyed out). No new state types are
+/// introduced — the toggles manipulate the same
+/// <see cref="EcdisDisplayState.HideViewingGroup"/> /
+/// <see cref="EcdisDisplayState.ShowViewingGroup"/> API used by the
+/// ECDIS panel checkboxes.
+/// </remarks>
+internal sealed class TextGroupToolbarViewModel : ViewModelBase, IDisposable
+{
+    private readonly EcdisDisplayState _state;
+    private readonly PortrayalCatalogueManager _catalogueManager;
+
+    /// <summary>Cached VG ids per text group for the primary spec.</summary>
+    private readonly Dictionary<TextGroup, IReadOnlySet<int>> _resolvedGroups = new();
+    private string? _activeSpec;
+
+    public TextGroupToolbarViewModel(
+        EcdisDisplayState state,
+        PortrayalCatalogueManager catalogueManager)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(catalogueManager);
+
+        _state = state;
+        _catalogueManager = catalogueManager;
+        _state.Changed += OnStateChanged;
+
+        ToggleImportantCommand = new RelayCommand(() => Toggle(TextGroup.Important));
+        ToggleOtherCommand = new RelayCommand(() => Toggle(TextGroup.Other));
+        ToggleAllCommand = new RelayCommand(() => Toggle(TextGroup.All));
+    }
+
+    public ICommand ToggleImportantCommand { get; }
+    public ICommand ToggleOtherCommand { get; }
+    public ICommand ToggleAllCommand { get; }
+
+    /// <summary>Localized label for the toolbar pill.</summary>
+    public string Label => Strings.Toolbar_Text;
+
+    public bool IsImportantVisible => IsGroupVisible(TextGroup.Important);
+    public bool IsOtherVisible => IsGroupVisible(TextGroup.Other);
+    public bool IsAllVisible => IsGroupVisible(TextGroup.All);
+
+    /// <summary>
+    /// Whether the pill is enabled (at least one loaded spec has
+    /// text layers).
+    /// </summary>
+    public bool IsEnabled => _resolvedGroups.Count > 0;
+
+    /// <summary>
+    /// Called when the loaded dataset set changes. Rebuilds the
+    /// resolved VG mapping for the first spec that declares text
+    /// layers.
+    /// </summary>
+    public void RefreshForSpec(string? specCode)
+    {
+        _resolvedGroups.Clear();
+        _activeSpec = null;
+
+        if (specCode is not null && _catalogueManager.HasCatalogue(specCode))
+        {
+            try
+            {
+                var provider = _catalogueManager.GetProvider(specCode);
+                var catalogue = provider.Catalogue;
+                if (TextGroupMapping.HasTextLayers(catalogue))
+                {
+                    _activeSpec = specCode;
+                    foreach (var g in Enum.GetValues<TextGroup>())
+                    {
+                        _resolvedGroups[g] = TextGroupMapping.Resolve(g, catalogue);
+                    }
+                }
+            }
+            catch
+            {
+                // If the catalogue can't be loaded, disable the pill.
+            }
+        }
+
+        OnPropertyChanged(nameof(IsEnabled));
+        NotifyAll();
+    }
+
+    private bool IsGroupVisible(TextGroup group)
+    {
+        if (_activeSpec is null || !_resolvedGroups.TryGetValue(group, out var vgIds))
+            return true;
+        if (vgIds.Count == 0) return true;
+
+        var hidden = _state.GetHidden(_activeSpec);
+        // Group is visible when at least one of its VGs is not hidden.
+        return vgIds.Any(id => !hidden.Contains(id));
+    }
+
+    private void Toggle(TextGroup group)
+    {
+        if (_activeSpec is null || !_resolvedGroups.TryGetValue(group, out var vgIds))
+            return;
+
+        bool currentlyVisible = IsGroupVisible(group);
+        foreach (var id in vgIds)
+        {
+            if (currentlyVisible)
+                _state.HideViewingGroup(_activeSpec, id);
+            else
+                _state.ShowViewingGroup(_activeSpec, id);
+        }
+
+        Telemetry.ViewingGroupToggled.Add(1,
+            new KeyValuePair<string, object?>("s100.spec", _activeSpec),
+            new KeyValuePair<string, object?>("s100.textgroup", group.ToString()));
+    }
+
+    private void OnStateChanged() => NotifyAll();
+
+    private void NotifyAll()
+    {
+        OnPropertyChanged(nameof(IsImportantVisible));
+        OnPropertyChanged(nameof(IsOtherVisible));
+        OnPropertyChanged(nameof(IsAllVisible));
+    }
+
+    public void Dispose()
+    {
+        _state.Changed -= OnStateChanged;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -98,6 +98,13 @@ internal sealed class ViewerSettings
     public Dictionary<string, string> EcdisHiddenViewingGroups { get; set; }
         = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Display planes the user has hidden in the ECDIS panel.
+    /// Stored as a comma-separated list of enum names so the JSON
+    /// stays human-editable (S-100 Part 9 §11.6).
+    /// </summary>
+    public string EcdisHiddenDisplayPlanes { get; set; } = "";
+
     public bool IsStatusBarVisible { get; set; } = true;
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
@@ -42,6 +42,23 @@
                                  GroupName="DisplayCategory" />
                 </StackPanel>
 
+                <!-- Display planes (S-100 Part 9 §11.6) -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static loc:Strings.EcdisPanel_DisplayPlanesHeader}"
+                               FontSize="11"
+                               FontWeight="SemiBold"
+                               LetterSpacing="0.5"
+                               Opacity="0.7" />
+                    <CheckBox IsChecked="{Binding IsUnderRadarVisible}"
+                              ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayPlane_UnderRadar}">
+                        <TextBlock Text="{x:Static loc:Strings.DisplayPlane_UnderRadar}" />
+                    </CheckBox>
+                    <CheckBox IsChecked="{Binding IsOverRadarVisible}"
+                              ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayPlane_OverRadar}">
+                        <TextBlock Text="{x:Static loc:Strings.DisplayPlane_OverRadar}" />
+                    </CheckBox>
+                </StackPanel>
+
                 <!-- Global reset -->
                 <Button Content="{x:Static loc:Strings.Button_ResetAllOverrides}"
                         Command="{Binding ResetAllOverridesCommand}"

--- a/tests/EncDotNet.S100.Pipelines.Tests/DisplayPlaneControllerTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DisplayPlaneControllerTests.cs
@@ -1,0 +1,88 @@
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class DisplayPlaneControllerTests
+{
+    [Fact]
+    public void AllPlanesVisibleByDefault()
+    {
+        var ctrl = new DisplayPlaneController();
+        Assert.True(ctrl.IsVisible(DisplayPlane.UnderRadar));
+        Assert.True(ctrl.IsVisible(DisplayPlane.OverRadar));
+        Assert.Empty(ctrl.HiddenPlanes);
+    }
+
+    [Theory]
+    [InlineData(DisplayPlane.UnderRadar)]
+    [InlineData(DisplayPlane.OverRadar)]
+    public void SetVisible_False_HidesPlane(DisplayPlane plane)
+    {
+        var ctrl = new DisplayPlaneController();
+        ctrl.SetVisible(plane, false);
+        Assert.False(ctrl.IsVisible(plane));
+        Assert.Contains(plane, ctrl.HiddenPlanes);
+    }
+
+    [Fact]
+    public void SetVisible_True_ShowsPlane()
+    {
+        var ctrl = new DisplayPlaneController();
+        ctrl.SetVisible(DisplayPlane.OverRadar, false);
+        ctrl.SetVisible(DisplayPlane.OverRadar, true);
+        Assert.True(ctrl.IsVisible(DisplayPlane.OverRadar));
+    }
+
+    [Fact]
+    public void ShowAll_ClearsHiddenSet()
+    {
+        var ctrl = new DisplayPlaneController();
+        ctrl.SetVisible(DisplayPlane.UnderRadar, false);
+        ctrl.SetVisible(DisplayPlane.OverRadar, false);
+        ctrl.ShowAll();
+        Assert.Empty(ctrl.HiddenPlanes);
+    }
+
+    [Fact]
+    public void Changed_Fires_OnHide()
+    {
+        var ctrl = new DisplayPlaneController();
+        int fired = 0;
+        ctrl.Changed += () => fired++;
+        ctrl.SetVisible(DisplayPlane.UnderRadar, false);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void Changed_DoesNotFire_WhenNoChange()
+    {
+        var ctrl = new DisplayPlaneController();
+        ctrl.SetVisible(DisplayPlane.UnderRadar, false);
+        int fired = 0;
+        ctrl.Changed += () => fired++;
+        // Already hidden — should not fire
+        ctrl.SetVisible(DisplayPlane.UnderRadar, false);
+        Assert.Equal(0, fired);
+    }
+
+    [Fact]
+    public void ShowAll_DoesNotFire_WhenAlreadyAllVisible()
+    {
+        var ctrl = new DisplayPlaneController();
+        int fired = 0;
+        ctrl.Changed += () => fired++;
+        ctrl.ShowAll();
+        Assert.Equal(0, fired);
+    }
+
+    [Fact]
+    public void ShowAll_Fires_WhenPlanesHidden()
+    {
+        var ctrl = new DisplayPlaneController();
+        ctrl.SetVisible(DisplayPlane.OverRadar, false);
+        int fired = 0;
+        ctrl.Changed += () => fired++;
+        ctrl.ShowAll();
+        Assert.Equal(1, fired);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101DrawingInstructionParserTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101DrawingInstructionParserTests.cs
@@ -167,4 +167,43 @@ public class S101DrawingInstructionParserTests
 
         Assert.Null(pt.CoordinateOverride);
     }
+
+    [Fact]
+    public void DisplayPlane_OverRadar_ParsedCorrectly()
+    {
+        const string s = "ViewingGroup:12210;DrawingPriority:24;DisplayPlane:OverRadar;PointInstruction:BRIDGE01";
+
+        var parsed = DrawingInstructionParser.Parse("F1", s);
+
+        var pt = Assert.Single(parsed.OfType<PointInstruction>());
+        Assert.Equal(DisplayPlane.OverRadar, pt.Plane);
+    }
+
+    [Fact]
+    public void DisplayPlane_ConcatenatedInstructions_PreservePlane()
+    {
+        // Simulates table.concat of multiple AddInstructions calls — some OverRadar, some UnderRadar
+        const string s =
+            "ViewingGroup:12210;DrawingPriority:6;DisplayPlane:UnderRadar;LineInstruction:LITARE01;" +
+            "ViewingGroup:12210;DrawingPriority:24;DisplayPlane:OverRadar;PointInstruction:BRIDGE01";
+
+        var parsed = DrawingInstructionParser.Parse("F1", s);
+
+        Assert.Equal(2, parsed.Count);
+        var line = parsed.OfType<LineInstruction>().Single();
+        var point = parsed.OfType<PointInstruction>().Single();
+        Assert.Equal(DisplayPlane.UnderRadar, line.Plane);
+        Assert.Equal(DisplayPlane.OverRadar, point.Plane);
+    }
+
+    [Fact]
+    public void DisplayPlane_DefaultsToUnderRadar_WhenNotSpecified()
+    {
+        const string s = "ViewingGroup:10000;DrawingPriority:1;PointInstruction:DEFAULT";
+
+        var parsed = DrawingInstructionParser.Parse("F1", s);
+
+        var pt = Assert.Single(parsed.OfType<PointInstruction>());
+        Assert.Equal(DisplayPlane.UnderRadar, pt.Plane);
+    }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
@@ -271,6 +271,8 @@ public class S101PipelineTests
 
         public DisplayModeController DisplayModes { get; } = new();
 
+        public DisplayPlaneController DisplayPlanes { get; } = new();
+
         public XslCompiledTransform GetCompiledRule(string ruleName) =>
             _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorCatalogueCapabilityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorCatalogueCapabilityTests.cs
@@ -47,9 +47,10 @@ public class VectorCatalogueCapabilityTests
             .Select(m => m.Name)
             .ToHashSet();
 
-        // Property accessors come through as get_Rules / get_ViewingGroups.
+        // Property accessors come through as get_Rules / get_ViewingGroups / etc.
         Assert.Contains("get_Rules", ownMembers);
         Assert.Contains("get_ViewingGroups", ownMembers);
+        Assert.Contains("get_DisplayPlanes", ownMembers);
         Assert.DoesNotContain("GetSymbol", ownMembers);
         Assert.DoesNotContain("GetLineStyle", ownMembers);
         Assert.DoesNotContain("GetAreaFill", ownMembers);

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
@@ -482,6 +482,77 @@ public class VectorPipelineTests
         Assert.IsType<PointInstruction>(layer.Instructions[1]);
     }
 
+    [Fact]
+    public async Task ProcessAsync_HiddenDisplayPlane_FiltersInstructions()
+    {
+        // Two features: one on UnderRadar, one on OverRadar
+        var source = new FakeFeatureXmlSource(
+            featureTypes: ["Buoy", "DepthArea"],
+            featureXml: """
+                <Dataset>
+                  <Feature id="1" type="Buoy">
+                    <Position lat="47.6" lon="-122.3"/>
+                  </Feature>
+                  <Feature id="2" type="DepthArea">
+                    <Polygon>
+                      <Exterior>47.0 -123.0 47.1 -123.0 47.1 -122.9 47.0 -123.0</Exterior>
+                    </Polygon>
+                  </Feature>
+                </Dataset>
+                """);
+
+        var xslt = CompileXslt("""
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:template match="/">
+                <displayList>
+                  <xsl:for-each select="//Feature[@type='Buoy']">
+                    <pointInstruction>
+                      <featureReference><xsl:value-of select="@id"/></featureReference>
+                      <drawingPriority>8</drawingPriority>
+                      <viewingGroup>21010</viewingGroup>
+                      <displayPlane>OverRadar</displayPlane>
+                      <symbol reference="BOYLAT01"><rotation>0</rotation></symbol>
+                    </pointInstruction>
+                  </xsl:for-each>
+                  <xsl:for-each select="//Feature[@type='DepthArea']">
+                    <areaInstruction>
+                      <featureReference><xsl:value-of select="@id"/></featureReference>
+                      <drawingPriority>3</drawingPriority>
+                      <viewingGroup>13010</viewingGroup>
+                      <displayPlane>UnderRadar</displayPlane>
+                      <areaFillReference reference="DEPARE01"/>
+                    </areaInstruction>
+                  </xsl:for-each>
+                </displayList>
+              </xsl:template>
+            </xsl:stylesheet>
+            """);
+
+        var catalogue = new FakeVectorPortrayalCatalogue(
+        [
+            new PortrayalRule
+            {
+                Name = "MixedRule",
+                Type = PortrayalRuleType.Xslt,
+                ExecutionOrder = 1,
+                AppliesTo = ["Buoy", "DepthArea"],
+            },
+        ],
+        xsltRules: new() { ["MixedRule"] = xslt });
+
+        // Hide OverRadar — should filter out the Buoy point
+        catalogue.DisplayPlanes.SetVisible(DisplayPlane.OverRadar, false);
+
+        var pipeline = new VectorPipeline();
+        var layer = await pipeline.ProcessAsync(source, catalogue);
+
+        // Only the UnderRadar area should remain
+        Assert.Single(layer.Instructions);
+        var inst = Assert.IsType<AreaInstruction>(layer.Instructions[0]);
+        Assert.Equal("2", inst.FeatureReference);
+        Assert.Equal(DisplayPlane.UnderRadar, inst.Plane);
+    }
+
     #region Helpers
 
     private static XslCompiledTransform CompileXslt(string xslt)
@@ -535,6 +606,8 @@ public class VectorPipelineTests
         public ViewingGroupController ViewingGroups { get; }
 
         public DisplayModeController DisplayModes { get; } = new();
+
+        public DisplayPlaneController DisplayPlanes { get; } = new();
 
         public XslCompiledTransform GetCompiledRule(string ruleName) =>
             _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -69,6 +69,7 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new NoopLoader())),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -58,19 +58,20 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
     {
         var settings = new ViewerSettings { SettingsFilePath = _tempSettingsPath };
         var catalogues = new PortrayalCatalogueManager();
+        var datasets = new DatasetsViewModel(new NoopLoader());
         return new MainViewModel(
             settings,
             featureCatalogues: new FeatureCataloguesViewModel(settings),
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
-            datasets: new DatasetsViewModel(new NoopLoader()),
+            datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
-            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
-            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new NoopLoader())),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues, datasets),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider());

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -79,6 +79,7 @@ public class MainViewModelOpenRecentTests : IDisposable
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(loader)),
             themeService: new StubThemeService(),
             recentFiles: recent,

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -68,19 +68,20 @@ public class MainViewModelOpenRecentTests : IDisposable
         var catalogues = new PortrayalCatalogueManager();
         loader = new RecordingLoaderService();
         recent = new StubRecentFilesService();
+        var datasets = new DatasetsViewModel(loader);
         return new MainViewModel(
             settings,
             featureCatalogues: new FeatureCataloguesViewModel(settings),
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
-            datasets: new DatasetsViewModel(loader),
+            datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
-            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
-            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(loader)),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues, datasets),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: recent,
             measureAppearance: new StubMeasureOverlayAppearanceProvider());

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -62,6 +62,7 @@ public class MainViewModelPickModeTests
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new StubDatasetLoaderService())),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -51,19 +51,20 @@ public class MainViewModelPickModeTests
         var settings = new ViewerSettings();
         var catalogues = new PortrayalCatalogueManager();
         var catalogSource = new EmptyCatalogSource();
+        var datasets = new DatasetsViewModel(new StubDatasetLoaderService());
         return new MainViewModel(
             settings,
             featureCatalogues: new FeatureCataloguesViewModel(settings),
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
-            datasets: new DatasetsViewModel(new StubDatasetLoaderService()),
+            datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(catalogSource),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
-            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
-            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new StubDatasetLoaderService())),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues, datasets),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider());

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -65,19 +65,20 @@ public class PickServiceTests
         var settings = new ViewerSettings();
         var catalogues = new PortrayalCatalogueManager();
         statusPresenter = new StatusPresenter();
+        var datasets = new DatasetsViewModel(new StubLoader());
         return new MainViewModel(
             settings,
             featureCatalogues: new FeatureCataloguesViewModel(settings),
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
-            datasets: new DatasetsViewModel(new StubLoader()),
+            datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
-            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
-            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new StubLoader())),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues, datasets),
+            ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider(),

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -76,6 +76,7 @@ public class PickServiceTests
             pickReport: new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
+            textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues),
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, new DatasetsViewModel(new StubLoader())),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),


### PR DESCRIPTION
## Summary

Adds two ECDIS display-control features to the viewer:

### Display Plane Filter
- **`DisplayPlaneController`** in Core pipelines controls visibility of Under Radar / Over Radar planes (S-100 Part 9 §11.6)
- Pipeline filter stage runs after VG filter, before priority sort
- `DisplayPlanes` property added to `IVectorPortrayalCatalogue` and all 9 per-spec implementations
- Checkboxes in the ECDIS panel let users toggle planes on/off
- State persisted in `settings.json` via `EcdisHiddenDisplayPlanes`

### Text Group Toolbar Pill
- "Text ▾" pill button in the map toolbar with flyout checkboxes for S-101 text viewing-group layers:
  - Important Text (VG layer "101")
  - Other Text (VG layer "102")
  - All Other Chart Text (VG layer "102c")
- `TextGroupMapping` helper resolves friendly names to VG layer ids from the portrayal catalogue at runtime
- Pill disabled when no text layers are available (non-S-101 datasets)

### Other
- `DisplayPlaneToggled` telemetry counter
- All UI strings localized via `Strings.resx`
- 9 new tests (8 `DisplayPlaneControllerTests` + 1 pipeline integration test)
- Updated Viewer and top-level READMEs

## Testing
- All 630 existing tests pass
- New tests cover controller logic (set/get/event/no-op) and pipeline-level plane filtering