### PR TITLE
Introduce SpecRef/CatalogueRef value types and ICatalogueProvider abstraction

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -73,6 +73,7 @@ jobs:
           ${{ steps.baseline.outputs.dir }}
           ${{ steps.candidate.outputs.dir }}
           --threshold 10
+          --min-abs 100
           --out /tmp/perf-gate.md
 
       - name: Upload gate report

--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -43,6 +43,7 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S411.Tests/EncDotNet.S100.Datasets.S411.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S421.Tests/EncDotNet.S100.Datasets.S421.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Features.Tests/EncDotNet.S100.Features.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.PerfReport.Tests/EncDotNet.S100.PerfReport.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj" />

--- a/src/EncDotNet.S100.Core/CatalogueRef.cs
+++ b/src/EncDotNet.S100.Core/CatalogueRef.cs
@@ -1,0 +1,81 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Identity of a single Feature Catalogue or Portrayal Catalogue instance —
+/// the pair <c>(name, version)</c> declared inside the catalogue's metadata
+/// (<c>&lt;S100FC:productId&gt;</c> + <c>&lt;S100FC:versionNumber&gt;</c> for
+/// FCs; equivalent fields for PCs).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>CatalogueRef</c> is intentionally distinct from <see cref="SpecRef"/>
+/// even though both carry a name and a version: a catalogue's version
+/// advances on a different release cadence from its owning product
+/// specification edition. For example, S-101 product spec edition 1.2.0
+/// currently ships with a Feature Catalogue at version 2.0.0.
+/// </para>
+/// <para>
+/// Used as the cache key inside FC and PC managers so that two distinct
+/// catalogue versions can coexist in a single process — something a bare
+/// product-name string cannot express.
+/// </para>
+/// </remarks>
+public readonly record struct CatalogueRef
+{
+    /// <summary>
+    /// The catalogue's owning product specification short name in canonical
+    /// <c>"S-NNN"</c> form (e.g. <c>"S-101"</c>).
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>The catalogue version (independent of any product spec edition).</summary>
+    public SpecVersion Version { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="CatalogueRef"/>. <paramref name="name"/> is
+    /// normalised to <c>"S-NNN"</c> form; <see cref="FormatException"/> is
+    /// thrown if it is not a recognised S-100 product spec name.
+    /// </summary>
+    public CatalogueRef(string name, SpecVersion version)
+    {
+        Name = SpecName.Normalize(name);
+        Version = version;
+    }
+
+    /// <summary>
+    /// Parses a <see cref="CatalogueRef"/> from <c>"S-101@2.0.0"</c> or
+    /// <c>"S-101/2.0.0"</c> form.
+    /// </summary>
+    /// <exception cref="FormatException">The input does not match any recognised form.</exception>
+    public static CatalogueRef Parse(string s)
+    {
+        if (!TryParse(s, out var v))
+        {
+            throw new FormatException($"'{s}' is not a valid CatalogueRef.");
+        }
+
+        return v;
+    }
+
+    /// <summary>Tolerant variant of <see cref="Parse"/> returning <c>false</c> on failure.</summary>
+    public static bool TryParse(string? s, out CatalogueRef value)
+    {
+        value = default;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+
+        var trimmed = s.Trim();
+        var sep = trimmed.IndexOfAny(['@', '/']);
+        if (sep <= 0 || sep == trimmed.Length - 1) return false;
+
+        var namePart = trimmed[..sep];
+        var versionPart = trimmed[(sep + 1)..];
+        if (!SpecName.TryNormalize(namePart, out var name)) return false;
+        if (!SpecVersion.TryParse(versionPart, out var version)) return false;
+
+        value = new CatalogueRef(name, version);
+        return true;
+    }
+
+    /// <summary>Returns the canonical <c>"S-NNN@M.m.c"</c> form.</summary>
+    public override string ToString() => $"{Name}@{Version}";
+}

--- a/src/EncDotNet.S100.Core/ICatalogueProvider.cs
+++ b/src/EncDotNet.S100.Core/ICatalogueProvider.cs
@@ -1,0 +1,47 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Provides catalogue artifacts (Feature Catalogues, Portrayal Catalogues,
+/// or anything else identified by a <see cref="SpecRef"/>) to dataset
+/// processors and other pipeline consumers.
+/// </summary>
+/// <typeparam name="TCatalogue">
+/// The catalogue artifact type. Concrete examples: <c>FeatureCatalogue</c>
+/// for the FC manager, <c>PortrayalCatalogueProvider</c> for the PC manager.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// The provider is identity-shaped: input is a <see cref="SpecRef"/>, output
+/// is the catalogue. The returned catalogue self-describes via its own
+/// <c>CatalogueRef</c> property, so the caller compares
+/// <see cref="SpecRef.Edition"/> against that property to decide whether the
+/// resolution is acceptable under their preferred
+/// <see cref="SpecMatchPolicy"/>. The provider deliberately does not apply
+/// fallback rules — callers explicitly say which catalogues they accept.
+/// </para>
+/// <para>
+/// Implementations must be thread-safe: pipeline workers call
+/// <see cref="GetCatalogueAsync"/> concurrently for the same and different
+/// specs.
+/// </para>
+/// </remarks>
+public interface ICatalogueProvider<TCatalogue> where TCatalogue : class
+{
+    /// <summary>
+    /// Returns the catalogue for <paramref name="spec"/>, or <c>null</c> when
+    /// no catalogue is registered or the underlying source cannot be opened.
+    /// </summary>
+    /// <param name="spec">The catalogue identity being requested.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask<TCatalogue?> GetCatalogueAsync(
+        SpecRef spec,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The set of <see cref="CatalogueRef"/>s for catalogues currently known to
+    /// this provider. The set may grow over time as catalogues are loaded
+    /// lazily; for diagnostic enumeration, prefer iterating once at a stable
+    /// point in the pipeline rather than relying on real-time accuracy.
+    /// </summary>
+    IReadOnlyCollection<CatalogueRef> AvailableCatalogues { get; }
+}

--- a/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Diagnostics;
 
 namespace EncDotNet.S100.Pipelines.Coverage;
@@ -24,9 +25,9 @@ public class CoveragePipeline
 
         using var activity = Telemetry.ActivitySource.StartActivity("s100.pipeline.coverage.process");
         activity?.SetTag(TelemetryTags.PipelineStage, "portray");
-        activity?.SetTag(TelemetryTags.Product, source.Metadata.ProductSpec);
+        activity?.SetTag(TelemetryTags.Product, source.Metadata.Spec.Name);
         var start = Stopwatch.GetTimestamp();
-        var productTag = new KeyValuePair<string, object?>(TelemetryTags.Product, source.Metadata.ProductSpec);
+        var productTag = new KeyValuePair<string, object?>(TelemetryTags.Product, source.Metadata.Spec.Name);
         var stageTag = new KeyValuePair<string, object?>(TelemetryTags.PipelineStage, "coverage");
 
         int gc0Before = GC.CollectionCount(0);
@@ -116,7 +117,8 @@ public interface ICoverageSource
 
 public class CoverageMetadata
 {
-    public required string ProductSpec { get; init; }
+    /// <summary>The product specification (name + edition) this coverage declares conformance to.</summary>
+    public required SpecRef Spec { get; init; }
     public required BoundingBox Extent { get; init; }
     public required GridMetadata GridMetadata { get; init; }
     public required string HorizontalCRS { get; init; }

--- a/src/EncDotNet.S100.Core/Pipelines/IPortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/IPortrayalCatalogue.cs
@@ -1,8 +1,13 @@
+using EncDotNet.S100.Core;
+
 namespace EncDotNet.S100.Pipelines;
 
 public interface IPortrayalCatalogue
 {
-string ProductSpec { get; }
+    /// <summary>The product specification (name + edition) this catalogue targets.</summary>
+    SpecRef Spec { get; }
+
+    /// <summary>The edition of the underlying portrayal catalogue (matches <see cref="PortrayalCatalogue.Version"/>).</summary>
     string Edition { get; }
     ColorPalette ActivePalette { get; }
     void SwitchPalette(PaletteType type);

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorSource.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorSource.cs
@@ -1,3 +1,5 @@
+using EncDotNet.S100.Core;
+
 namespace EncDotNet.S100.Pipelines.Vector;
 
 /// <summary>
@@ -21,7 +23,8 @@ public interface IVectorSource
 /// </summary>
 public sealed class VectorMetadata
 {
-    public required string ProductSpec { get; init; }
+    /// <summary>The product specification (name + edition) this dataset declares conformance to.</summary>
+    public required SpecRef Spec { get; init; }
     public required BoundingBox Extent { get; init; }
     public required string HorizontalCRS { get; init; }
     public required int CompilationScaleDenominator { get; init; }

--- a/src/EncDotNet.S100.Core/SpecCompatibility.cs
+++ b/src/EncDotNet.S100.Core/SpecCompatibility.cs
@@ -1,0 +1,120 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Match policies governing whether a <see cref="CatalogueRef"/> is considered
+/// acceptable for a given <see cref="SpecRef"/>. The rules follow S-100
+/// Edition 5.2.1 Part 2 §6 (Maintenance) — see <see cref="SpecVersion"/> for
+/// the underlying compatibility semantics.
+/// </summary>
+public enum SpecMatchPolicy
+{
+    /// <summary>
+    /// Catalogue must match the spec on both name and edition exactly.
+    /// </summary>
+    Exact,
+
+    /// <summary>
+    /// Catalogue must share the spec's name and major version. Its minor
+    /// version must be greater than or equal to the spec's minor version
+    /// (so that the catalogue carries every feature the spec declares).
+    /// Clarification-level differences are ignored.
+    /// </summary>
+    SameMajor,
+
+    /// <summary>
+    /// Catalogue must share the spec's name; edition is ignored. Use only
+    /// when the caller has independently verified that semantic differences
+    /// are acceptable.
+    /// </summary>
+    AnyVersion,
+}
+
+/// <summary>
+/// Helpers for matching a requested <see cref="SpecRef"/> against an available
+/// <see cref="CatalogueRef"/>. The match policy is supplied by the caller —
+/// providers themselves do not apply hidden fallback rules.
+/// </summary>
+public static class SpecCompatibility
+{
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="catalogue"/> satisfies
+    /// <paramref name="spec"/> under the given <paramref name="policy"/>.
+    /// </summary>
+    /// <param name="spec">
+    /// The spec being declared by the dataset (or otherwise requested).
+    /// </param>
+    /// <param name="catalogue">
+    /// The catalogue we have available.
+    /// </param>
+    /// <param name="policy">
+    /// The match policy — see <see cref="SpecMatchPolicy"/>.
+    /// </param>
+    public static bool IsMatch(SpecRef spec, CatalogueRef catalogue, SpecMatchPolicy policy)
+    {
+        if (spec.Name is null || catalogue.Name is null) return false;
+        if (!string.Equals(spec.Name, catalogue.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return policy switch
+        {
+            SpecMatchPolicy.Exact => spec.Edition == catalogue.Version,
+            SpecMatchPolicy.SameMajor =>
+                spec.Edition.Major == catalogue.Version.Major
+                && catalogue.Version.Minor >= spec.Edition.Minor,
+            SpecMatchPolicy.AnyVersion => true,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Classifies the relationship between the version a dataset declares
+    /// (<paramref name="declared"/>) and the version a catalogue we resolved
+    /// for it carries (<paramref name="catalogue"/>). Useful for surfacing a
+    /// structured warning when the two diverge.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="SpecMatchKind.Exact"/> when the two versions are
+    /// equal; <see cref="SpecMatchKind.CatalogueNewerCompatible"/> when the
+    /// catalogue is on the same major and at least the same minor (a S-100
+    /// Part 2 §6 backward-compatible read); <see cref="SpecMatchKind.CatalogueOlder"/>
+    /// when the catalogue is on the same major but a lower minor (the
+    /// dataset may use features the catalogue doesn't know about); and
+    /// <see cref="SpecMatchKind.MajorDivergence"/> when the two are on
+    /// different majors (incompatible — decoding may misinterpret data).
+    /// A <see cref="default(SpecVersion)"/> on either side falls through to
+    /// <see cref="SpecMatchKind.Unknown"/>.
+    /// </remarks>
+    public static SpecMatchKind Classify(SpecVersion declared, SpecVersion catalogue)
+    {
+        if (declared == default || catalogue == default) return SpecMatchKind.Unknown;
+        if (declared == catalogue) return SpecMatchKind.Exact;
+        if (declared.Major != catalogue.Major) return SpecMatchKind.MajorDivergence;
+        return catalogue.Minor >= declared.Minor
+            ? SpecMatchKind.CatalogueNewerCompatible
+            : SpecMatchKind.CatalogueOlder;
+    }
+}
+
+/// <summary>
+/// The relationship between a declared dataset version and the version of
+/// the catalogue resolved for it.
+/// </summary>
+public enum SpecMatchKind
+{
+    /// <summary>One or both versions were unspecified (<see cref="default(SpecVersion)"/>).</summary>
+    Unknown,
+
+    /// <summary>Versions are equal in all components but Clarification.</summary>
+    Exact,
+
+    /// <summary>Same major; catalogue's minor ≥ declared minor (backward-compatible read).</summary>
+    CatalogueNewerCompatible,
+
+    /// <summary>Same major; catalogue's minor &lt; declared minor (catalogue may be missing features).</summary>
+    CatalogueOlder,
+
+    /// <summary>Different majors — semantically incompatible per S-100 Part 2 §6.</summary>
+    MajorDivergence,
+}

--- a/src/EncDotNet.S100.Core/SpecName.cs
+++ b/src/EncDotNet.S100.Core/SpecName.cs
@@ -1,0 +1,68 @@
+using System.Text.RegularExpressions;
+
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Helpers for normalising S-100 product specification short names into the
+/// canonical <c>"S-NNN"</c> form (e.g. <c>"S-101"</c>, <c>"S-102"</c>).
+/// </summary>
+public static partial class SpecName
+{
+    [GeneratedRegex(@"^S-?(?<digits>\d{2,3})$", RegexOptions.IgnoreCase)]
+    private static partial Regex ShortNameRegex();
+
+    [GeneratedRegex(@"^INT\.IHO\.S-?(?<digits>\d{2,3})(?:\.|$)", RegexOptions.IgnoreCase)]
+    private static partial Regex ProductIdentifierRegex();
+
+    /// <summary>
+    /// Normalises a product specification short name into <c>"S-NNN"</c> form.
+    /// Accepts inputs such as <c>"S-101"</c>, <c>"s101"</c>, <c>"S101"</c>,
+    /// and the long-form product identifier <c>"INT.IHO.S-101.1.2.0"</c>.
+    /// </summary>
+    /// <exception cref="FormatException">The input does not match any recognised form.</exception>
+    public static string Normalize(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var trimmed = name.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw new FormatException("Product specification name is empty.");
+        }
+
+        var m = ShortNameRegex().Match(trimmed);
+        if (m.Success)
+        {
+            return $"S-{m.Groups["digits"].Value}";
+        }
+
+        m = ProductIdentifierRegex().Match(trimmed);
+        if (m.Success)
+        {
+            return $"S-{m.Groups["digits"].Value}";
+        }
+
+        throw new FormatException($"'{name}' is not a recognised S-100 product specification name.");
+    }
+
+    /// <summary>
+    /// Attempts to normalise a product specification short name. Returns
+    /// <c>false</c> when <paramref name="name"/> does not match a recognised
+    /// form.
+    /// </summary>
+    public static bool TryNormalize(string? name, out string canonical)
+    {
+        canonical = string.Empty;
+        if (string.IsNullOrWhiteSpace(name)) return false;
+
+        try
+        {
+            canonical = Normalize(name);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Core/SpecRef.cs
+++ b/src/EncDotNet.S100.Core/SpecRef.cs
@@ -1,0 +1,106 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Identity of a single S-100 product specification edition — the pair
+/// <c>(name, edition)</c> that a dataset declares conformance to (e.g.
+/// <c>S-101 / 1.2.0</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Name"/> is normalised to canonical <c>"S-NNN"</c> form by the
+/// constructor. Use <see cref="Parse"/> for tolerant parsing of the various
+/// representations seen in real-world datasets, exchange-set CATALOG.XML
+/// entries, HDF5 <c>productSpecification</c> attributes, and GML application
+/// namespaces.
+/// </para>
+/// <para>
+/// <c>SpecRef</c> identifies the <em>product specification</em> a dataset
+/// targets. The version of the Feature or Portrayal Catalogue used to
+/// process that dataset is a separate identity tracked by
+/// <see cref="CatalogueRef"/>; the two float independently because S-100
+/// product specs and their catalogues advance on different release cadences
+/// (e.g. S-101 product spec at edition 1.2.0 ships with a Feature
+/// Catalogue at version 2.0.0).
+/// </para>
+/// </remarks>
+public readonly record struct SpecRef
+{
+    /// <summary>
+    /// The product specification short name in canonical <c>"S-NNN"</c> form
+    /// (e.g. <c>"S-101"</c>, <c>"S-102"</c>).
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>The product specification edition.</summary>
+    public SpecVersion Edition { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="SpecRef"/>. <paramref name="name"/> is
+    /// normalised to <c>"S-NNN"</c> form; <see cref="FormatException"/> is
+    /// thrown if it is not a recognised S-100 product spec name.
+    /// </summary>
+    public SpecRef(string name, SpecVersion edition)
+    {
+        Name = SpecName.Normalize(name);
+        Edition = edition;
+    }
+
+    /// <summary>
+    /// Parses a <see cref="SpecRef"/> from one of the following forms:
+    /// <list type="bullet">
+    ///   <item><description><c>"S-101/1.2.0"</c> — canonical form (this type's <see cref="ToString"/>).</description></item>
+    ///   <item><description><c>"S-101@1.2.0"</c> — alternate separator.</description></item>
+    ///   <item><description><c>"INT.IHO.S-101.1.2.0"</c> — exchange-set product identifier form.</description></item>
+    /// </list>
+    /// Casing of the leading <c>S</c> and presence of the dash are tolerated.
+    /// </summary>
+    /// <exception cref="FormatException">The input does not match any recognised form.</exception>
+    public static SpecRef Parse(string s)
+    {
+        if (!TryParse(s, out var v))
+        {
+            throw new FormatException($"'{s}' is not a valid SpecRef.");
+        }
+
+        return v;
+    }
+
+    /// <summary>Tolerant variant of <see cref="Parse"/> returning <c>false</c> on failure.</summary>
+    public static bool TryParse(string? s, out SpecRef value)
+    {
+        value = default;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+
+        var trimmed = s.Trim();
+
+        // INT.IHO.S-NNN.x.y.z — long-form product identifier.
+        if (trimmed.StartsWith("INT.IHO.", StringComparison.OrdinalIgnoreCase))
+        {
+            var afterPrefix = trimmed["INT.IHO.".Length..];
+            // "S-101.1.2.0" or "S101.1.2.0"
+            var firstDot = afterPrefix.IndexOf('.');
+            if (firstDot <= 0) return false;
+            var rawName = afterPrefix[..firstDot];
+            var rawVersion = afterPrefix[(firstDot + 1)..];
+            if (!SpecName.TryNormalize(rawName, out var canonicalName)) return false;
+            if (!SpecVersion.TryParse(rawVersion, out var version)) return false;
+            value = new SpecRef(canonicalName, version);
+            return true;
+        }
+
+        // <name><sep><version> with sep ∈ { '/', '@' }.
+        var sep = trimmed.IndexOfAny(['/', '@']);
+        if (sep <= 0 || sep == trimmed.Length - 1) return false;
+
+        var namePart = trimmed[..sep];
+        var versionPart = trimmed[(sep + 1)..];
+        if (!SpecName.TryNormalize(namePart, out var name)) return false;
+        if (!SpecVersion.TryParse(versionPart, out var ed)) return false;
+
+        value = new SpecRef(name, ed);
+        return true;
+    }
+
+    /// <summary>Returns the canonical <c>"S-NNN/M.m.c"</c> form.</summary>
+    public override string ToString() => $"{Name}/{Edition}";
+}

--- a/src/EncDotNet.S100.Core/SpecVersion.cs
+++ b/src/EncDotNet.S100.Core/SpecVersion.cs
@@ -1,0 +1,121 @@
+using System.Globalization;
+
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// A three-component S-100 version of the form
+/// <c>&lt;major&gt;.&lt;minor&gt;.&lt;clarification&gt;</c>, with the
+/// compatibility semantics defined by S-100 Edition 5.2.1 Part 2 §6
+/// (Maintenance):
+/// <list type="bullet">
+///   <item><description><b>Major</b> — backward-incompatible change.</description></item>
+///   <item><description><b>Minor</b> — backward-compatible addition (new feature
+///   classes, attributes, code-list entries, etc.).</description></item>
+///   <item><description><b>Clarification</b> — editorial change with no
+///   semantic impact on the data model.</description></item>
+/// </list>
+/// This is <em>not</em> Semantic Versioning despite its similar shape — there are
+/// no pre-release tags, no build metadata, and clarification-level differences
+/// are interchangeable for compatibility purposes.
+/// </summary>
+public readonly record struct SpecVersion : IComparable<SpecVersion>
+{
+    /// <summary>Major component (backward-incompatible change boundary).</summary>
+    public int Major { get; }
+
+    /// <summary>Minor component (backward-compatible additions).</summary>
+    public int Minor { get; }
+
+    /// <summary>Clarification component (editorial-only changes).</summary>
+    public int Clarification { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="SpecVersion"/>. All components must be
+    /// non-negative.
+    /// </summary>
+    public SpecVersion(int major, int minor, int clarification)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(major);
+        ArgumentOutOfRangeException.ThrowIfNegative(minor);
+        ArgumentOutOfRangeException.ThrowIfNegative(clarification);
+
+        Major = major;
+        Minor = minor;
+        Clarification = clarification;
+    }
+
+    /// <summary>
+    /// Parses a version string of the form <c>"M"</c>, <c>"M.m"</c>, or
+    /// <c>"M.m.c"</c>. Missing trailing components default to <c>0</c>.
+    /// </summary>
+    /// <exception cref="FormatException">The input is not a valid version string.</exception>
+    public static SpecVersion Parse(string s)
+    {
+        if (!TryParse(s, out var v))
+        {
+            throw new FormatException($"'{s}' is not a valid S-100 version (expected M, M.m, or M.m.c).");
+        }
+
+        return v;
+    }
+
+    /// <summary>
+    /// Attempts to parse a version string of the form <c>"M"</c>, <c>"M.m"</c>,
+    /// or <c>"M.m.c"</c>. Missing trailing components default to <c>0</c>.
+    /// </summary>
+    public static bool TryParse(string? s, out SpecVersion value)
+    {
+        value = default;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+
+        var trimmed = s.Trim();
+        var parts = trimmed.Split('.');
+        if (parts.Length is 0 or > 3) return false;
+
+        Span<int> components = stackalloc int[3];
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (!int.TryParse(parts[i], NumberStyles.None, CultureInfo.InvariantCulture, out var n)
+                || n < 0)
+            {
+                return false;
+            }
+
+            components[i] = n;
+        }
+
+        value = new SpecVersion(components[0], components[1], components[2]);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when a consumer conforming to this version can read
+    /// content produced for <paramref name="older"/> — i.e. the two share the
+    /// same major component and this version's minor is at least as high as
+    /// the older one's. Clarification-level differences are ignored
+    /// per S-100 Part 2 §6.
+    /// </summary>
+    public bool IsBackwardCompatibleWith(SpecVersion older)
+        => Major == older.Major && Minor >= older.Minor;
+
+    /// <inheritdoc />
+    public int CompareTo(SpecVersion other)
+    {
+        var c = Major.CompareTo(other.Major);
+        if (c != 0) return c;
+        c = Minor.CompareTo(other.Minor);
+        if (c != 0) return c;
+        return Clarification.CompareTo(other.Clarification);
+    }
+
+    public static bool operator <(SpecVersion left, SpecVersion right) => left.CompareTo(right) < 0;
+    public static bool operator >(SpecVersion left, SpecVersion right) => left.CompareTo(right) > 0;
+    public static bool operator <=(SpecVersion left, SpecVersion right) => left.CompareTo(right) <= 0;
+    public static bool operator >=(SpecVersion left, SpecVersion right) => left.CompareTo(right) >= 0;
+
+    /// <summary>Returns the canonical <c>"M.m.c"</c> representation.</summary>
+    public override string ToString()
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{Major}.{Minor}.{Clarification}");
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -18,7 +18,8 @@ public sealed class DatasetResult
     public required IReadOnlyList<ILayer> Layers { get; init; }
     public required MRect Extent { get; init; }
     public required string Info { get; init; }
-    public required string ProductSpec { get; init; }
+    /// <summary>The product specification (name + edition) of the rendered dataset.</summary>
+    public required SpecRef Spec { get; init; }
 
     /// <summary>
     /// Optional human-readable display names for each layer in

--- a/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/CatalogueResolutionDiagnostics.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/CatalogueResolutionDiagnostics.cs
@@ -66,9 +66,32 @@ public static class CatalogueResolutionDiagnostics
 
         if (catalogueRef is not { } catRef) return;
 
+        // Hot-path fast check: a thread-local single-slot cache of the most
+        // recently reported (scope, spec, cat, kind). The diagnostics call
+        // sits at the top of every Render, so on a tight render loop this
+        // matches on every call after the first and avoids the
+        // ConditionalWeakTable lookup (which takes an internal lock) and the
+        // HashSet allocation/equality cost. Authoritative dedup still happens
+        // via _seen below; the cache only suppresses redundant lookups.
+        ref var slot = ref _lastSeen;
+        if (ReferenceEquals(slot.Scope, dedupScope)
+            && slot.Kind == catalogueKind
+            && slot.Spec.Equals(datasetSpec)
+            && slot.Cat.Equals(catRef))
+        {
+            return;
+        }
+
         var key = (datasetSpec, catRef, catalogueKind);
         var entries = _seen.GetOrCreateValue(dedupScope);
-        if (!entries.Add(key)) return;
+        if (!entries.Add(key))
+        {
+            // Already emitted on a different thread (or with a different
+            // intervening key); refresh the TLS cache so the next call on
+            // this thread takes the fast path.
+            slot = (dedupScope, datasetSpec, catRef, catalogueKind);
+            return;
+        }
 
         var match = SpecCompatibility.Classify(datasetSpec.Edition, catRef.Version);
 
@@ -91,7 +114,12 @@ public static class CatalogueResolutionDiagnostics
                 ["s100.catalogue.match"] = match.ToString(),
             }));
         }
+
+        slot = (dedupScope, datasetSpec, catRef, catalogueKind);
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, HashSet<(SpecRef, CatalogueRef, string)>> _seen = new();
+
+    [ThreadStatic]
+    private static (object? Scope, SpecRef Spec, CatalogueRef Cat, string Kind) _lastSeen;
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/CatalogueResolutionDiagnostics.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/CatalogueResolutionDiagnostics.cs
@@ -16,7 +16,7 @@ namespace EncDotNet.S100.Datasets.Pipelines.Diagnostics;
 /// than the dataset is a backward-compatible read; a lower minor or a
 /// different major may indicate the wrong catalogue is wired up. We emit one
 /// diagnostic per processor instance per (dataset spec, catalogue ref) pair —
-/// repeated <see cref="IDatasetProcessor.Render"/> calls do not re-emit.
+/// repeated calls with the same scope do not re-emit.
 /// </para>
 /// <para>
 /// Each emit:
@@ -28,6 +28,12 @@ namespace EncDotNet.S100.Datasets.Pipelines.Diagnostics;
 ///   declared edition, catalogue version, catalogue kind, and match kind.</description></item>
 /// </list>
 /// </para>
+/// <para>
+/// Dataset processors should call this from their constructor — catalogue
+/// resolution is a one-shot per processor lifetime, and emitting at
+/// construction keeps the per-<see cref="IDatasetProcessor.Render"/> hot
+/// path free of any telemetry overhead.
+/// </para>
 /// </remarks>
 public static class CatalogueResolutionDiagnostics
 {
@@ -38,13 +44,17 @@ public static class CatalogueResolutionDiagnostics
 
     /// <summary>
     /// Reports the relationship between a dataset's declared spec and the
-    /// catalogue resolved for it. Safe to call from <see cref="IDatasetProcessor.Render"/>;
-    /// the per-(spec, catalogue) dedup key passed in <paramref name="dedupScope"/>
-    /// guarantees only the first call emits.
+    /// catalogue resolved for it. Intended to be called once per processor
+    /// instance from the processor's constructor, after the catalogue has
+    /// been assigned.
     /// </summary>
     /// <param name="dedupScope">
     /// An object whose identity scopes deduplication — typically the
-    /// processor instance itself. Pass <c>this</c>.
+    /// processor instance itself. Pass <c>this</c>. Subsequent calls with
+    /// the same <paramref name="dedupScope"/>, <paramref name="datasetSpec"/>,
+    /// <paramref name="catalogueRef"/>, and <paramref name="catalogueKind"/>
+    /// are no-ops; this safety net guards against accidental double-emit
+    /// without forcing the caller to manually track state.
     /// </param>
     /// <param name="datasetSpec">The dataset's declared product spec.</param>
     /// <param name="catalogueRef">
@@ -66,30 +76,11 @@ public static class CatalogueResolutionDiagnostics
 
         if (catalogueRef is not { } catRef) return;
 
-        // Hot-path fast check: a thread-local single-slot cache of the most
-        // recently reported (scope, spec, cat, kind). The diagnostics call
-        // sits at the top of every Render, so on a tight render loop this
-        // matches on every call after the first and avoids the
-        // ConditionalWeakTable lookup (which takes an internal lock) and the
-        // HashSet allocation/equality cost. Authoritative dedup still happens
-        // via _seen below; the cache only suppresses redundant lookups.
-        ref var slot = ref _lastSeen;
-        if (ReferenceEquals(slot.Scope, dedupScope)
-            && slot.Kind == catalogueKind
-            && slot.Spec.Equals(datasetSpec)
-            && slot.Cat.Equals(catRef))
-        {
-            return;
-        }
-
         var key = (datasetSpec, catRef, catalogueKind);
         var entries = _seen.GetOrCreateValue(dedupScope);
         if (!entries.Add(key))
         {
-            // Already emitted on a different thread (or with a different
-            // intervening key); refresh the TLS cache so the next call on
-            // this thread takes the fast path.
-            slot = (dedupScope, datasetSpec, catRef, catalogueKind);
+            // Already emitted for this scope/spec/cat tuple.
             return;
         }
 
@@ -114,12 +105,7 @@ public static class CatalogueResolutionDiagnostics
                 ["s100.catalogue.match"] = match.ToString(),
             }));
         }
-
-        slot = (dedupScope, datasetSpec, catRef, catalogueKind);
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, HashSet<(SpecRef, CatalogueRef, string)>> _seen = new();
-
-    [ThreadStatic]
-    private static (object? Scope, SpecRef Spec, CatalogueRef Cat, string Kind) _lastSeen;
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/CatalogueResolutionDiagnostics.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Diagnostics/CatalogueResolutionDiagnostics.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Diagnostics;
+
+/// <summary>
+/// Surfaces a structured warning when the version of a portrayal or feature
+/// catalogue resolved for a dataset diverges from the dataset's declared
+/// product specification edition.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per S-100 Edition 5.2.1 Part 2 §6, a catalogue at a higher minor version
+/// than the dataset is a backward-compatible read; a lower minor or a
+/// different major may indicate the wrong catalogue is wired up. We emit one
+/// diagnostic per processor instance per (dataset spec, catalogue ref) pair —
+/// repeated <see cref="IDatasetProcessor.Render"/> calls do not re-emit.
+/// </para>
+/// <para>
+/// Each emit:
+/// <list type="bullet">
+///   <item><description>Adds an event named <c>s100.catalogue.match</c> to
+///   the current <see cref="Activity"/> when one is in scope.</description></item>
+///   <item><description>Increments the
+///   <c>s100.catalogue.match.count</c> counter, tagged with the spec name,
+///   declared edition, catalogue version, catalogue kind, and match kind.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class CatalogueResolutionDiagnostics
+{
+    private static readonly Counter<long> _matchCounter = Telemetry.Meter.CreateCounter<long>(
+        "s100.catalogue.match.count",
+        unit: "{events}",
+        description: "Counts catalogue resolutions, tagged by spec/catalogue versions and match kind.");
+
+    /// <summary>
+    /// Reports the relationship between a dataset's declared spec and the
+    /// catalogue resolved for it. Safe to call from <see cref="IDatasetProcessor.Render"/>;
+    /// the per-(spec, catalogue) dedup key passed in <paramref name="dedupScope"/>
+    /// guarantees only the first call emits.
+    /// </summary>
+    /// <param name="dedupScope">
+    /// An object whose identity scopes deduplication — typically the
+    /// processor instance itself. Pass <c>this</c>.
+    /// </param>
+    /// <param name="datasetSpec">The dataset's declared product spec.</param>
+    /// <param name="catalogueRef">
+    /// The catalogue's identity, or <c>null</c> when the catalogue does not
+    /// self-describe (older bundled assets).
+    /// </param>
+    /// <param name="catalogueKind">
+    /// A short description of which catalogue this is — typically
+    /// <c>"portrayal"</c> or <c>"feature"</c>.
+    /// </param>
+    public static void Report(
+        object dedupScope,
+        SpecRef datasetSpec,
+        CatalogueRef? catalogueRef,
+        string catalogueKind)
+    {
+        ArgumentNullException.ThrowIfNull(dedupScope);
+        ArgumentException.ThrowIfNullOrEmpty(catalogueKind);
+
+        if (catalogueRef is not { } catRef) return;
+
+        var key = (datasetSpec, catRef, catalogueKind);
+        var entries = _seen.GetOrCreateValue(dedupScope);
+        if (!entries.Add(key)) return;
+
+        var match = SpecCompatibility.Classify(datasetSpec.Edition, catRef.Version);
+
+        _matchCounter.Add(1,
+            new KeyValuePair<string, object?>("s100.spec.name", datasetSpec.Name),
+            new KeyValuePair<string, object?>("s100.spec.edition", datasetSpec.Edition.ToString()),
+            new KeyValuePair<string, object?>("s100.catalogue.version", catRef.Version.ToString()),
+            new KeyValuePair<string, object?>("s100.catalogue.kind", catalogueKind),
+            new KeyValuePair<string, object?>("s100.catalogue.match", match.ToString()));
+
+        var activity = Activity.Current;
+        if (activity is not null)
+        {
+            activity.AddEvent(new ActivityEvent("s100.catalogue.match", tags: new ActivityTagsCollection
+            {
+                ["s100.spec.name"] = datasetSpec.Name,
+                ["s100.spec.edition"] = datasetSpec.Edition.ToString(),
+                ["s100.catalogue.version"] = catRef.Version.ToString(),
+                ["s100.catalogue.kind"] = catalogueKind,
+                ["s100.catalogue.match"] = match.ToString(),
+            }));
+        }
+    }
+
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, HashSet<(SpecRef, CatalogueRef, string)>> _seen = new();
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/EcdisDisplaySettings.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/EcdisDisplaySettings.cs
@@ -137,10 +137,10 @@ public static class EcdisDisplayExtensions
         ArgumentNullException.ThrowIfNull(catalogue);
 
         var modeId = EcdisCategoryMapper.Map(
-            catalogue.ProductSpec, settings.Category, catalogue.DisplayModes.DeclaredModeIds);
+            catalogue.Spec.Name, settings.Category, catalogue.DisplayModes.DeclaredModeIds);
         catalogue.DisplayModes.SetActive(modeId);
 
-        if (settings.HiddenViewingGroups.TryGetValue(catalogue.ProductSpec, out var hidden))
+        if (settings.HiddenViewingGroups.TryGetValue(catalogue.Spec.Name, out var hidden))
         {
             foreach (var vg in hidden)
                 catalogue.ViewingGroups.SetUserOverride(vg, false);

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Diagnostics;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Gml;
 using EncDotNet.S100.Pipelines;
@@ -115,6 +116,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
         if (preResult is not null) return preResult;
 
         var catalogue = _catalogue;
+        CatalogueResolutionDiagnostics.Report(this, Spec, catalogue.CatalogueRef, "portrayal");
         context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -50,6 +50,11 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
         _catalogue = catalogue;
         _decoder = decoder;
         _fileName = fileName;
+
+        // Catalogue resolution is a one-shot per processor instance; emit
+        // the diagnostic at construction so the per-Render hot path stays
+        // free of the (cheap but non-zero) telemetry overhead.
+        CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
     }
 
     /// <inheritdoc/>
@@ -116,7 +121,6 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
         if (preResult is not null) return preResult;
 
         var catalogue = _catalogue;
-        CatalogueResolutionDiagnostics.Report(this, Spec, catalogue.CatalogueRef, "portrayal");
         context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Gml;
 using EncDotNet.S100.Pipelines;
@@ -51,7 +52,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
     }
 
     /// <inheritdoc/>
-    public abstract string ProductSpec { get; }
+    public abstract SpecRef Spec { get; }
 
     /// <summary>
     /// Human-readable product description for info strings (e.g.
@@ -122,12 +123,12 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
         var portrayalLayer = pipeline.ProcessAsync(featureSource, catalogue).GetAwaiter().GetResult();
         var instructions = PostProcessInstructions(((IVectorLayer)portrayalLayer).Instructions);
 
-        Console.WriteLine($"[{ProductSpec.Replace("-", "")}] {_fileName}: {Features.Count} features, "
+        Console.WriteLine($"[{Spec.Name.Replace("-", "")}] {_fileName}: {Features.Count} features, "
             + $"{instructions.Count} drawing instructions");
 
         var renderer = new MapsuiDisplayListRenderer
         {
-            LayerName = $"{ProductSpec}: {_fileName}",
+            LayerName = $"{Spec.Name}: {_fileName}",
             Palette = catalogue.ActivePalette,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
@@ -153,7 +154,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
 
         var featureTypes = featureSource.FeatureTypesPresent;
         var suffix = BuildInfoSuffix();
-        var info = $"{ProductSpec} {ProductDescription} — {_fileName}\n"
+        var info = $"{Spec.Name} {ProductDescription} — {_fileName}\n"
             + $"Features: {Features.Count} ({string.Join(", ", featureTypes)})\n"
             + (suffix.Length > 0 ? suffix + "\n" : "")
             + $"Drawing instructions: {instructions.Count}";
@@ -163,7 +164,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
             Layers = [layer],
             Extent = ComputeExtent(),
             Info = info,
-            ProductSpec = ProductSpec,
+            Spec = Spec,
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -10,7 +11,15 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// </summary>
 public interface IDatasetProcessor
 {
-    string ProductSpec { get; }
+    /// <summary>
+    /// The product specification (name + edition) this dataset declares
+    /// conformance to. Each per-spec processor returns a fixed name (e.g.
+    /// "S-101"); the edition portion is populated from the dataset itself
+    /// (HDF5 <c>productSpecification</c> attribute, GML application
+    /// namespace, S-101 ProductSpecificationEdition, etc.) when known,
+    /// otherwise defaults to <see cref="SpecVersion"/> default.
+    /// </summary>
+    SpecRef Spec { get; }
 
     DatasetResult Render(RenderContext? context = null);
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -79,6 +79,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
 
     public DatasetResult Render(RenderContext? context = null)
     {
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
         var mariner = context?.Mariner ?? MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -75,11 +75,12 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             _dataset = S101Dataset.Open(datasetStream);
         }
         _featureCatalogueManager = featureCatalogueManager;
+
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
     }
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
         var mariner = context?.Mariner ?? MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -27,7 +27,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
     private FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
 
-    public string ProductSpec => "S-101";
+    public SpecRef Spec => new("S-101", default);
 
     public S101DatasetProcessor(
         string path,
@@ -156,7 +156,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             Layers = [mapLayer],
             Extent = layerExtent,
             Info = info,
-            ProductSpec = "S-101",
+            Spec = new SpecRef("S-101", default),
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -22,7 +22,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly string _fileName;
 
-    public string ProductSpec => "S-102";
+    public SpecRef Spec => new("S-102", default);
 
     public S102DatasetProcessor(
         string path,
@@ -115,7 +115,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
             Layers = [mapLayer],
             Extent = extent,
             Info = info,
-            ProductSpec = "S-102",
+            Spec = new SpecRef("S-102", default),
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -75,11 +75,12 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
 
         var provider = catalogueManager.GetProvider("S-102");
         _catalogue = new S102PortrayalCatalogue(luaEngine, provider) { FourShades = true };
+
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
     }
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
         _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
         var metadata = _source.Metadata;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -79,6 +79,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
 
     public DatasetResult Render(RenderContext? context = null)
     {
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
         _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
         var metadata = _source.Metadata;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -22,7 +22,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     private readonly S104Dataset _dataset;
     private readonly string _fileName;
 
-    public string ProductSpec => "S-104";
+    public SpecRef Spec => new("S-104", default);
 
     /// <summary>Available forecast time steps in this dataset.</summary>
     public IReadOnlyList<DateTime> AvailableTimes => _source.AvailableTimes;
@@ -122,7 +122,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             Layers = [colorLayer],
             Extent = extent,
             Info = info,
-            ProductSpec = "S-104",
+            Spec = new SpecRef("S-104", default),
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -82,6 +82,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
 
     public DatasetResult Render(RenderContext? context = null)
     {
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
         _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // Select the requested time step, defaulting to the first

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -24,7 +24,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
     private readonly S111Dataset _dataset;
     private readonly string _fileName;
 
-    public string ProductSpec => "S-111";
+    public SpecRef Spec => new("S-111", default);
 
     /// <summary>Available forecast time steps in this dataset.</summary>
     public IReadOnlyList<DateTime> AvailableTimes => _source.AvailableTimes;
@@ -159,7 +159,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             Layers = layers,
             Extent = extent,
             Info = info,
-            ProductSpec = "S-111",
+            Spec = new SpecRef("S-111", default),
             // Stable sub-layer keys; the viewer maps these to
             // localized display names. The processor itself does not
             // depend on UI string resources.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -78,11 +78,12 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                 "S-111 portrayal catalogue is not registered. " +
                 "Ensure the S-111 portrayal catalogue is loaded before opening S-111 datasets.");
         _catalogue = new S111PortrayalCatalogue(_provider);
+
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
     }
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
         _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
 
         // Select the requested time step, defaulting to the first

--- a/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
@@ -11,7 +11,7 @@ public sealed class S122DatasetProcessor : GmlDatasetProcessorBase<S122Feature>
 {
     private readonly S122Dataset _dataset;
 
-    public override string ProductSpec => "S-122";
+    public override SpecRef Spec => new("S-122", default);
     protected override string ProductDescription => "Marine Protected Areas";
     protected override IReadOnlyList<S122Feature> Features => _dataset.Features;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
@@ -11,7 +11,7 @@ public sealed class S124DatasetProcessor : GmlDatasetProcessorBase<S124Feature>
 {
     private readonly S124Dataset _dataset;
 
-    public override string ProductSpec => "S-124";
+    public override SpecRef Spec => new("S-124", default);
     protected override string ProductDescription => "Navigational Warnings";
     protected override IReadOnlyList<S124Feature> Features => _dataset.Features;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
@@ -17,7 +17,7 @@ public sealed class S125DatasetProcessor : GmlDatasetProcessorBase<S125Feature>
     private readonly S125Dataset _dataset;
 
     /// <inheritdoc />
-    public override string ProductSpec => "S-125";
+    public override SpecRef Spec => new("S-125", default);
     protected override string ProductDescription => "Marine Aids to Navigation";
     protected override IReadOnlyList<S125Feature> Features => _dataset.Features;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
@@ -16,7 +16,7 @@ public sealed class S127DatasetProcessor : GmlDatasetProcessorBase<S127Feature>
 {
     private readonly S127Dataset _dataset;
 
-    public override string ProductSpec => "S-127";
+    public override SpecRef Spec => new("S-127", default);
     protected override string ProductDescription => "Marine Resources and Services";
     protected override IReadOnlyList<S127Feature> Features => _dataset.Features;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
@@ -11,7 +11,7 @@ public sealed class S128DatasetProcessor : GmlDatasetProcessorBase<S128Feature>
 {
     private readonly S128Dataset _dataset;
 
-    public override string ProductSpec => "S-128";
+    public override SpecRef Spec => new("S-128", default);
     protected override string ProductDescription => "Catalogue of Nautical Products";
     protected override IReadOnlyList<S128Feature> Features => _dataset.Features;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
@@ -12,7 +12,7 @@ public sealed class S129DatasetProcessor : GmlDatasetProcessorBase<S129Feature>
 {
     private readonly S129Dataset _dataset;
 
-    public override string ProductSpec => "S-129";
+    public override SpecRef Spec => new("S-129", default);
     protected override string ProductDescription => "Under Keel Clearance Management";
     protected override IReadOnlyList<S129Feature> Features => _dataset.Features;
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
@@ -14,7 +14,7 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
 {
     private readonly S411Dataset _dataset;
 
-    public override string ProductSpec => "S-411";
+    public override SpecRef Spec => new("S-411", default);
     protected override string ProductDescription => "Sea Ice";
     protected override IReadOnlyList<S411Feature> Features => _dataset.Features;
 
@@ -83,7 +83,7 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
                 Layers = Array.Empty<ILayer>(),
                 Extent = ComputeExtent(),
                 Info = $"S-411 Sea Ice — {FileName}\nHidden (snapshot at {issued:u} is after slider time {t:u})",
-                ProductSpec = "S-411",
+                Spec = new SpecRef("S-411", default),
             };
         }
         return null;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
@@ -11,7 +11,7 @@ public sealed class S421DatasetProcessor : GmlDatasetProcessorBase<S421Feature>
 {
     private readonly S421Dataset _dataset;
 
-    public override string ProductSpec => "S-421";
+    public override SpecRef Spec => new("S-421", default);
     protected override string ProductDescription => "Route Plan";
     protected override IReadOnlyList<S421Feature> Features => _dataset.Features;
     protected override double MinExtentPadding => 0.05;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -89,6 +89,8 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
 
     public DatasetResult Render(RenderContext? context = null)
     {
+        // S-57 datasets render through the S-101 portrayal catalogue.
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", default), _catalogue.CatalogueRef, "portrayal");
         var mariner = MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -85,12 +85,13 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         var translator = new S57ToS101Translator();
         var s101Doc = translator.Translate(s57);
         _translatedDataset = S101Dataset.FromDocument(s101Doc);
+
+        // S-57 datasets render through the S-101 portrayal catalogue.
+        Diagnostics.CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", default), _catalogue.CatalogueRef, "portrayal");
     }
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        // S-57 datasets render through the S-101 portrayal catalogue.
-        Diagnostics.CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", default), _catalogue.CatalogueRef, "portrayal");
         var mariner = MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -32,7 +32,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
     private EncDotNet.S100.Features.FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
 
-    public string ProductSpec => "S-57";
+    public SpecRef Spec => new("S-57", default);
 
     public S57DatasetProcessor(
         string path,
@@ -144,7 +144,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
             Layers = [mapLayer],
             Extent = layerExtent,
             Info = info,
-            ProductSpec = "S-57",
+            Spec = new SpecRef("S-57", default),
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -39,6 +39,9 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public SpecRef Spec => new("S-101", default);
     public string Edition => _provider.Catalogue.Version;
+
+    /// <summary>The identity of the underlying portrayal catalogue XML, when available.</summary>
+    public CatalogueRef? CatalogueRef => _provider.Catalogue.CatalogueRef;
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
     public void SwitchPalette(PaletteType type)

--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -6,6 +6,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Scripting;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S101;
 
@@ -36,7 +37,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
         DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
-    public string ProductSpec => "S-101";
+    public SpecRef Spec => new("S-101", default);
     public string Edition => _provider.Catalogue.Version;
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 

--- a/src/EncDotNet.S100.Datasets.S101/S101VectorSource.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101VectorSource.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S101;
 
@@ -27,11 +28,22 @@ public sealed class S101VectorSource : IVectorSource
 
     public VectorMetadata Metadata => new()
     {
-        ProductSpec = "S-101",
+        Spec = BuildSpec(_dataset.Document),
         Extent = ComputeExtent(),
         HorizontalCRS = "EPSG:4326",
         CompilationScaleDenominator = 0, // S-101 doesn't encode scale in DSSI the same way as S-57
     };
+
+    private static SpecRef BuildSpec(S101Document doc)
+    {
+        var edition = doc.Identification?.ProductSpecificationEdition;
+        if (!string.IsNullOrWhiteSpace(edition)
+            && SpecVersion.TryParse(edition, out var v))
+        {
+            return new SpecRef("S-101", v);
+        }
+        return new SpecRef("S-101", default);
+    }
 
     public IReadOnlyList<Feature> GetFeatures(BoundingBox? extent = null)
     {

--- a/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S102;
 
@@ -19,7 +20,7 @@ public class S102CoverageSource : ICoverageSource
     
     public CoverageMetadata Metadata => new CoverageMetadata
     {
-        ProductSpec = "S-102",
+        Spec = new SpecRef("S-102", default),
         Extent = new BoundingBox(
             _coverage.OriginLatitude,
             _coverage.OriginLongitude,

--- a/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
@@ -3,6 +3,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Scripting;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S102;
 
@@ -49,7 +50,7 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
         _provider = provider;
     }
 
-    public string ProductSpec => "S-102";
+    public SpecRef Spec => new("S-102", default);
     public string Edition => "3.0.0";
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 

--- a/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
@@ -52,6 +52,10 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
 
     public SpecRef Spec => new("S-102", default);
     public string Edition => "3.0.0";
+
+    /// <summary>The identity of the underlying portrayal catalogue XML, when available.</summary>
+    public CatalogueRef? CatalogueRef => _provider.Catalogue.CatalogueRef;
+
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
     /// <summary>Whether to use four depth shading bands (true) or two (false).</summary>

--- a/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S104;
 
@@ -33,7 +34,7 @@ public class S104CoverageSource : ICoverageSource
             var coverage = _dataset.Coverages[_selectedTimeIndex];
             return new CoverageMetadata
             {
-                ProductSpec = "S-104",
+                Spec = new SpecRef("S-104", default),
                 Extent = new BoundingBox(
                     coverage.OriginLatitude,
                     coverage.OriginLongitude,

--- a/src/EncDotNet.S100.Datasets.S104/S104PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104PortrayalCatalogue.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S104;
 
@@ -34,7 +35,7 @@ public class S104PortrayalCatalogue : ICoveragePortrayalCatalogue
     ];
 
     /// <summary>Gets the S-100 product specification identifier for this catalogue.</summary>
-    public string ProductSpec => "S-104";
+    public SpecRef Spec => new("S-104", default);
 
     /// <summary>Gets the edition of the portrayal catalogue.</summary>
     public string Edition => "2.0.0";

--- a/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S111;
 
@@ -24,7 +25,7 @@ public class S111CoverageSource : ICoverageSource
             var coverage = _dataset.Coverages[_selectedTimeIndex];
             return new CoverageMetadata
             {
-                ProductSpec = "S-111",
+                Spec = new SpecRef("S-111", default),
                 Extent = new BoundingBox(
                     coverage.OriginLatitude,
                     coverage.OriginLongitude,

--- a/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
@@ -45,6 +45,9 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
 
     public SpecRef Spec => new("S-111", default);
     public string Edition => _provider.Catalogue.Version ?? "2.0.0";
+
+    /// <summary>The identity of the underlying portrayal catalogue XML, when available.</summary>
+    public CatalogueRef? CatalogueRef => _provider.Catalogue.CatalogueRef;
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
     public void SwitchPalette(PaletteType type)

--- a/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S111;
 
@@ -42,7 +43,7 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
         _provider = provider;
     }
 
-    public string ProductSpec => "S-111";
+    public SpecRef Spec => new("S-111", default);
     public string Edition => _provider.Catalogue.Version ?? "2.0.0";
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 

--- a/src/EncDotNet.S100.Datasets.S122/S122PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S122/S122PortrayalCatalogue.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S122;
 
@@ -9,5 +10,5 @@ namespace EncDotNet.S100.Datasets.S122;
 public sealed class S122PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S122PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-122";
+    public override SpecRef Spec => new("S-122", default);
 }

--- a/src/EncDotNet.S100.Datasets.S124/S124PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S124/S124PortrayalCatalogue.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S124;
 
@@ -9,5 +10,5 @@ namespace EncDotNet.S100.Datasets.S124;
 public sealed class S124PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S124PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-124";
+    public override SpecRef Spec => new("S-124", default);
 }

--- a/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S125;
 
@@ -11,7 +12,7 @@ namespace EncDotNet.S100.Datasets.S125;
 public sealed class S125PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S125PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-125";
+    public override SpecRef Spec => new("S-125", default);
     protected override System.Xml.XmlResolver CreateXmlResolver() =>
         new FetchRuleFallbackXmlResolver(Provider);
 }

--- a/src/EncDotNet.S100.Datasets.S127/S127PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S127/S127PortrayalCatalogue.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S127;
 
@@ -9,5 +10,5 @@ namespace EncDotNet.S100.Datasets.S127;
 public sealed class S127PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S127PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-127";
+    public override SpecRef Spec => new("S-127", default);
 }

--- a/src/EncDotNet.S100.Datasets.S128/S128PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128PortrayalCatalogue.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S128;
 
@@ -9,5 +10,5 @@ namespace EncDotNet.S100.Datasets.S128;
 public sealed class S128PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S128PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-128";
+    public override SpecRef Spec => new("S-128", default);
 }

--- a/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S129;
 
@@ -11,7 +12,7 @@ namespace EncDotNet.S100.Datasets.S129;
 public sealed class S129PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S129PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-129";
+    public override SpecRef Spec => new("S-129", default);
 
     protected override XmlResolver CreateXmlResolver() => new S129XmlResolver(Provider);
 

--- a/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
@@ -3,6 +3,7 @@ using System.Xml.Xsl;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S411;
 
@@ -18,7 +19,7 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
 
     public S411PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
 
-    public override string ProductSpec => "S-411";
+    public override SpecRef Spec => new("S-411", default);
 
     protected override System.Xml.XmlResolver CreateXmlResolver() =>
         new FetchRuleFallbackXmlResolver(Provider);

--- a/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Datasets.S421;
 
@@ -11,7 +12,7 @@ namespace EncDotNet.S100.Datasets.S421;
 public sealed class S421PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S421PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
-    public override string ProductSpec => "S-421";
+    public override SpecRef Spec => new("S-421", default);
     protected override System.Xml.XmlResolver CreateXmlResolver() =>
         new FetchRuleFallbackXmlResolver(Provider);
 }

--- a/src/EncDotNet.S100.ExchangeSets/ProductSpecificationExtensions.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ProductSpecificationExtensions.cs
@@ -1,0 +1,63 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Extensions that bridge the loosely-typed exchange-set
+/// <see cref="ProductSpecification"/> DTO to the strongly-typed
+/// <see cref="SpecRef"/> identity used elsewhere in the pipeline.
+/// </summary>
+public static class ProductSpecificationExtensions
+{
+    /// <summary>
+    /// Attempts to derive a <see cref="SpecRef"/> from this product
+    /// specification entry. Tries, in order:
+    /// <list type="number">
+    ///   <item><description><see cref="ProductSpecification.Name"/> + <see cref="ProductSpecification.Version"/>.</description></item>
+    ///   <item><description><see cref="ProductSpecification.ProductIdentifier"/> in the long-form
+    ///   <c>"INT.IHO.S-NNN.x.y.z"</c> shape (which carries both name and version).</description></item>
+    /// </list>
+    /// Returns <c>false</c> when neither shape yields a parseable
+    /// <see cref="SpecRef"/>.
+    /// </summary>
+    public static bool TryToSpecRef(this ProductSpecification productSpecification, out SpecRef specRef)
+    {
+        ArgumentNullException.ThrowIfNull(productSpecification);
+
+        if (!string.IsNullOrWhiteSpace(productSpecification.Name)
+            && SpecName.TryNormalize(productSpecification.Name, out var name)
+            && SpecVersion.TryParse(productSpecification.Version, out var edition))
+        {
+            specRef = new SpecRef(name, edition);
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(productSpecification.ProductIdentifier)
+            && SpecRef.TryParse(productSpecification.ProductIdentifier, out var fromIdentifier))
+        {
+            specRef = fromIdentifier;
+            return true;
+        }
+
+        specRef = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Strict variant of <see cref="TryToSpecRef"/>; throws
+    /// <see cref="FormatException"/> when neither <see cref="ProductSpecification.Name"/>
+    /// + <see cref="ProductSpecification.Version"/> nor
+    /// <see cref="ProductSpecification.ProductIdentifier"/> can be resolved.
+    /// </summary>
+    public static SpecRef ToSpecRef(this ProductSpecification productSpecification)
+    {
+        if (!productSpecification.TryToSpecRef(out var specRef))
+        {
+            throw new FormatException(
+                "ProductSpecification does not carry enough information to derive a SpecRef "
+                + "(neither Name+Version nor ProductIdentifier resolved).");
+        }
+
+        return specRef;
+    }
+}

--- a/src/EncDotNet.S100.Features/FeatureCatalogue.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogue.cs
@@ -1,3 +1,5 @@
+using EncDotNet.S100.Core;
+
 namespace EncDotNet.S100.Features;
 
 public sealed class FeatureCatalogue
@@ -8,9 +10,26 @@ public sealed class FeatureCatalogue
 
     public string? FieldOfApplication { get; init; }
 
+    /// <summary>
+    /// The product specification this Feature Catalogue targets, as declared
+    /// in <c>&lt;S100FC:productId&gt;</c> (e.g. "S-101"). May be <c>null</c>
+    /// when the source XML omits the element (some legacy bundled catalogues
+    /// such as S-421 do not declare it).
+    /// </summary>
+    public string? ProductId { get; init; }
+
     public required string VersionNumber { get; init; }
 
     public required string VersionDate { get; init; }
+
+    /// <summary>
+    /// The Feature Catalogue identity tuple <c>(ProductId, VersionNumber)</c>
+    /// projected into a strongly-typed <see cref="Core.CatalogueRef"/>, or
+    /// <c>null</c> when either field is missing or unparseable. This is the
+    /// preferred way to identify a catalogue instance for caching and
+    /// compatibility checks (S-100 Edition 5.2.1 Part 2 §6).
+    /// </summary>
+    public CatalogueRef? CatalogueRef { get; init; }
 
     public Producer? Producer { get; init; }
 

--- a/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
@@ -1,41 +1,69 @@
 using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Features.Diagnostics;
 
 namespace EncDotNet.S100.Features;
 
 /// <summary>
 /// Caches parsed <see cref="FeatureCatalogue"/> and <see cref="FeatureCatalogueDecoder"/>
-/// instances by product specification identifier, so that the (relatively expensive)
+/// instances by product specification reference, so that the (relatively expensive)
 /// XML parse happens at most once per spec per manager lifetime.
 /// </summary>
 /// <remarks>
 /// Mirrors the <c>PortrayalCatalogueManager</c> pattern used for portrayal catalogues.
-/// The manager wraps a caller-supplied <c>Func&lt;string, Stream?&gt;</c> resolver and
-/// lazily parses the feature catalogue on first access for each spec. Subsequent calls
-/// to <see cref="GetCatalogue"/> or <see cref="GetDecoder"/> for the same spec return
-/// the cached instance.
+/// The manager wraps a caller-supplied resolver and lazily parses the feature
+/// catalogue on first access for each spec. Subsequent calls to
+/// <see cref="GetCatalogue(SpecRef)"/> or <see cref="GetDecoder(SpecRef)"/> for the same
+/// spec return the cached instance.
+/// <para>
+/// Each cache slot is keyed by <see cref="SpecRef"/>, so requests for distinct
+/// editions of the same product (e.g. <c>S-101/1.2.0</c> versus
+/// <c>S-101/2.0.0</c>) parse and cache independently. The string-based overloads
+/// remain for back-compat: they delegate via <see cref="SpecName.TryNormalize(string, out string)"/>
+/// and a default <see cref="SpecVersion"/>, so all string callers share a single
+/// cache slot per product name.
+/// </para>
 /// </remarks>
 public sealed class FeatureCatalogueManager
 {
-    private readonly Func<string, Stream?> _resolver;
-    private readonly ConcurrentDictionary<string, Lazy<FeatureCatalogue?>> _catalogues = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, Lazy<FeatureCatalogueDecoder?>> _decoders = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Func<SpecRef, Stream?> _resolver;
+    private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogue?>> _catalogues = new();
+    private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogueDecoder?>> _decoders = new();
 
     /// <summary>
-    /// Initializes a new <see cref="FeatureCatalogueManager"/> with the given stream resolver.
+    /// Initializes a new <see cref="FeatureCatalogueManager"/> with a string-based
+    /// stream resolver. The resolver receives the product specification name
+    /// (e.g. "S-101"). The edition portion of <see cref="SpecRef"/> is ignored.
     /// </summary>
     /// <param name="resolver">
-    /// A function that, given a product specification identifier (e.g. "S-101"),
-    /// returns a readable <see cref="Stream"/> containing the Feature Catalogue XML,
-    /// or <c>null</c> if no catalogue is available for that spec.
+    /// A function that, given a product specification name, returns a readable
+    /// <see cref="Stream"/> containing the Feature Catalogue XML, or <c>null</c>
+    /// if no catalogue is available for that spec. When <c>null</c>, the manager
+    /// always returns <c>null</c> from <see cref="GetCatalogue(SpecRef)"/>.
     /// </param>
     public FeatureCatalogueManager(Func<string, Stream?>? resolver = null)
     {
-        _resolver = resolver ?? (_ => null);
+        _resolver = resolver is null ? (_ => null) : sr => resolver(sr.Name);
     }
 
     /// <summary>
-    /// Returns the cached <see cref="FeatureCatalogue"/> for the given spec,
+    /// Initializes a new <see cref="FeatureCatalogueManager"/> with a
+    /// <see cref="SpecRef"/>-aware stream resolver. Use this overload when the
+    /// resolver needs to differentiate between editions of the same product.
+    /// </summary>
+    /// <param name="resolver">
+    /// A function that, given a <see cref="SpecRef"/>, returns a readable
+    /// <see cref="Stream"/> containing the Feature Catalogue XML, or <c>null</c>
+    /// if no catalogue is available for that spec.
+    /// </param>
+    public FeatureCatalogueManager(Func<SpecRef, Stream?> resolver)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+        _resolver = resolver;
+    }
+
+    /// <summary>
+    /// Returns the cached <see cref="FeatureCatalogue"/> for the given spec name,
     /// parsing it from the resolver on first access. Returns <c>null</c> when
     /// the resolver does not provide a stream for the spec or parsing fails.
     /// </summary>
@@ -43,22 +71,44 @@ public sealed class FeatureCatalogueManager
     public FeatureCatalogue? GetCatalogue(string productSpec)
     {
         ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        if (!SpecName.TryNormalize(productSpec, out var name)) return null;
+        return GetCatalogue(new SpecRef(name, default));
+    }
 
-        var lazy = _catalogues.GetOrAdd(productSpec, key => new Lazy<FeatureCatalogue?>(() => ParseCatalogue(key)));
+    /// <summary>
+    /// Returns the cached <see cref="FeatureCatalogue"/> for the given spec
+    /// reference, parsing it from the resolver on first access. Each
+    /// <see cref="SpecRef"/> (combination of name + edition) is cached
+    /// independently. Returns <c>null</c> when the resolver does not provide a
+    /// stream or parsing fails.
+    /// </summary>
+    public FeatureCatalogue? GetCatalogue(SpecRef spec)
+    {
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
+        var lazy = _catalogues.GetOrAdd(spec, key => new Lazy<FeatureCatalogue?>(() => ParseCatalogue(key)));
         return lazy.Value;
     }
 
     /// <summary>
-    /// Returns a cached <see cref="FeatureCatalogueDecoder"/> for the given spec,
-    /// building it from the cached catalogue on first access. Returns <c>null</c>
-    /// when no catalogue is available.
+    /// Returns a cached <see cref="FeatureCatalogueDecoder"/> for the given
+    /// spec name. See <see cref="GetDecoder(SpecRef)"/> for behaviour.
     /// </summary>
-    /// <param name="productSpec">The product specification identifier (e.g. "S-101").</param>
     public FeatureCatalogueDecoder? GetDecoder(string productSpec)
     {
         ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        if (!SpecName.TryNormalize(productSpec, out var name)) return null;
+        return GetDecoder(new SpecRef(name, default));
+    }
 
-        var lazy = _decoders.GetOrAdd(productSpec, key => new Lazy<FeatureCatalogueDecoder?>(() =>
+    /// <summary>
+    /// Returns a cached <see cref="FeatureCatalogueDecoder"/> for the given
+    /// spec reference, building it from the cached catalogue on first access.
+    /// Returns <c>null</c> when no catalogue is available.
+    /// </summary>
+    public FeatureCatalogueDecoder? GetDecoder(SpecRef spec)
+    {
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
+        var lazy = _decoders.GetOrAdd(spec, key => new Lazy<FeatureCatalogueDecoder?>(() =>
         {
             var fc = GetCatalogue(key);
             return fc is not null ? new FeatureCatalogueDecoder(fc) : null;
@@ -66,10 +116,10 @@ public sealed class FeatureCatalogueManager
         return lazy.Value;
     }
 
-    private FeatureCatalogue? ParseCatalogue(string productSpec)
+    private FeatureCatalogue? ParseCatalogue(SpecRef spec)
     {
         Stream? stream;
-        try { stream = _resolver(productSpec); }
+        try { stream = _resolver(spec); }
         catch { return null; }
 
         if (stream is null) return null;

--- a/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
@@ -24,7 +24,7 @@ namespace EncDotNet.S100.Features;
 /// cache slot per product name.
 /// </para>
 /// </remarks>
-public sealed class FeatureCatalogueManager
+public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogue>
 {
     private readonly Func<SpecRef, Stream?> _resolver;
     private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogue?>> _catalogues = new();
@@ -136,6 +136,34 @@ public sealed class FeatureCatalogueManager
             // Parse failures must not break dataset loading; pick output
             // degrades to raw codes and portrayal falls back gracefully.
             return null;
+        }
+    }
+
+    /// <inheritdoc />
+    ValueTask<FeatureCatalogue?> ICatalogueProvider<FeatureCatalogue>.GetCatalogueAsync(
+        SpecRef spec, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<FeatureCatalogue?>(GetCatalogue(spec));
+    }
+
+    /// <inheritdoc />
+    IReadOnlyCollection<CatalogueRef> ICatalogueProvider<FeatureCatalogue>.AvailableCatalogues
+    {
+        get
+        {
+            var refs = new List<CatalogueRef>();
+            foreach (var lazy in _catalogues.Values)
+            {
+                // Avoid forcing lazy initialization for unloaded entries —
+                // available means "currently loaded and self-describing".
+                if (!lazy.IsValueCreated) continue;
+                if (lazy.Value?.CatalogueRef is { } cref)
+                {
+                    refs.Add(cref);
+                }
+            }
+            return refs;
         }
     }
 }

--- a/src/EncDotNet.S100.Features/FeatureCatalogueReader.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueReader.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 using System.Xml.Linq;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Features.Diagnostics;
 
 namespace EncDotNet.S100.Features;
@@ -55,13 +56,24 @@ public static class FeatureCatalogueReader
         _s100fc = ResolveNamespace(root, "S100FC", "http://www.iho.int/S100FC");
         _s100base = ResolveNamespace(root, "S100Base", "http://www.iho.int/S100Base");
         _s100ci = ResolveNamespace(root, "S100CI", "http://www.iho.int/S100CI");
+        var versionNumber = (string)root.Element(S100FC + "versionNumber")!;
+        var productId = (string?)root.Element(S100FC + "productId");
+        CatalogueRef? catalogueRef = null;
+        if (!string.IsNullOrWhiteSpace(productId)
+            && SpecName.TryNormalize(productId, out var canonicalName)
+            && SpecVersion.TryParse(versionNumber, out var parsedVersion))
+        {
+            catalogueRef = new CatalogueRef(canonicalName, parsedVersion);
+        }
         return new FeatureCatalogue
         {
             Name = (string)root.Element(S100FC + "name")!,
             Scope = (string?)root.Element(S100FC + "scope"),
             FieldOfApplication = (string?)root.Element(S100FC + "fieldOfApplication"),
-            VersionNumber = (string)root.Element(S100FC + "versionNumber")!,
+            ProductId = productId,
+            VersionNumber = versionNumber,
             VersionDate = (string)root.Element(S100FC + "versionDate")!,
+            CatalogueRef = catalogueRef,
             Producer = ReadProducer(root.Element(S100FC + "producer")),
             Classification = (string?)root.Element(S100FC + "classification"),
             SimpleAttributes = root

--- a/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
+++ b/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Xml;
 using System.Xml.Xsl;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Diagnostics;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
@@ -14,7 +15,7 @@ namespace EncDotNet.S100.Portrayals;
 /// resolver for <c>xsl:include</c> resolution.
 /// </summary>
 /// <remarks>
-/// Subclasses typically only need to supply <see cref="ProductSpec"/> and,
+/// Subclasses typically only need to supply <see cref="Spec"/> and,
 /// where necessary, override <see cref="CreateXmlResolver"/> (for specs
 /// whose XSLT includes reference unregistered sub-templates) or
 /// <see cref="GetCompiledRule"/> (for specs that inject an adapter rule).
@@ -45,8 +46,8 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// <summary>Gets the underlying portrayal catalogue provider.</summary>
     protected PortrayalCatalogueProvider Provider => _provider;
 
-    /// <summary>Gets the S-100 product specification identifier (e.g. "S-124").</summary>
-    public abstract string ProductSpec { get; }
+    /// <summary>The product specification (name + edition) this catalogue targets.</summary>
+    public abstract SpecRef Spec { get; }
 
     /// <summary>Gets the edition of the portrayal catalogue.</summary>
     public string Edition => _provider.Catalogue.Version;

--- a/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
+++ b/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
@@ -52,6 +52,14 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// <summary>Gets the edition of the portrayal catalogue.</summary>
     public string Edition => _provider.Catalogue.Version;
 
+    /// <summary>
+    /// The identity (name + version) of the underlying portrayal catalogue
+    /// XML, when populated. Used to surface mismatches between the dataset's
+    /// declared <see cref="Spec"/> edition and the catalogue version actually
+    /// resolved for it.
+    /// </summary>
+    public CatalogueRef? CatalogueRef => _provider.Catalogue.CatalogueRef;
+
     /// <summary>Gets the currently active color palette.</summary>
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogue.cs
@@ -1,3 +1,5 @@
+using EncDotNet.S100.Core;
+
 namespace EncDotNet.S100.Portrayals;
 
 public sealed class PortrayalCatalogue
@@ -5,6 +7,15 @@ public sealed class PortrayalCatalogue
     public required string ProductId { get; init; }
 
     public required string Version { get; init; }
+
+    /// <summary>
+    /// The Portrayal Catalogue identity tuple <c>(ProductId, Version)</c>
+    /// projected into a strongly-typed <see cref="Core.CatalogueRef"/>, or
+    /// <c>null</c> when either field is missing or unparseable. This is the
+    /// preferred way to identify a catalogue instance for caching and
+    /// compatibility checks (S-100 Edition 5.2.1 Part 2 §6).
+    /// </summary>
+    public CatalogueRef? CatalogueRef { get; init; }
 
     public CatalogItem? AlertCatalog { get; init; }
 

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
@@ -5,14 +5,29 @@ using EncDotNet.S100.Pipelines;
 namespace EncDotNet.S100.Portrayals;
 
 /// <summary>
-/// Manages portrayal catalogue locations per product specification.
+/// Manages portrayal catalogue locations per product specification reference.
 /// Caches open <see cref="PortrayalCatalogueProvider"/> instances so that
 /// multiple datasets of the same spec share one catalogue.
 /// </summary>
+/// <remarks>
+/// Each cache slot is keyed by <see cref="SpecRef"/>, so distinct editions of
+/// the same product (e.g. <c>S-101/1.2.0</c> versus <c>S-101/2.0.0</c>) are
+/// registered independently. The string-based overloads remain for back-compat:
+/// they delegate via <see cref="SpecName.TryNormalize(string, out string)"/>
+/// and a default <see cref="SpecVersion"/>, so all string callers share a
+/// single slot per product name.
+/// </remarks>
 public sealed class PortrayalCatalogueManager : IDisposable
 {
-    private readonly ConcurrentDictionary<string, string> _paths = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, PortrayalCatalogueProvider> _providers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<SpecRef, string> _paths = new();
+    private readonly ConcurrentDictionary<SpecRef, PortrayalCatalogueProvider> _providers = new();
+
+    private static SpecRef ToSpec(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        var name = SpecName.Normalize(productSpec);
+        return new SpecRef(name, default);
+    }
 
     /// <summary>
     /// Registers (or updates) the file-system path for a product spec's portrayal catalogue.
@@ -20,15 +35,22 @@ public sealed class PortrayalCatalogueManager : IDisposable
     /// </summary>
     /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102").</param>
     /// <param name="cataloguePath">Absolute path to the catalogue folder on disk.</param>
-    public void SetPath(string productSpec, string cataloguePath)
+    public void SetPath(string productSpec, string cataloguePath) =>
+        SetPath(ToSpec(productSpec), cataloguePath);
+
+    /// <summary>
+    /// Registers (or updates) the file-system path for the given spec reference's
+    /// portrayal catalogue. Evicts any previously cached provider for that spec.
+    /// </summary>
+    public void SetPath(SpecRef spec, string cataloguePath)
     {
-        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
         ArgumentException.ThrowIfNullOrEmpty(cataloguePath);
 
-        _paths[productSpec] = cataloguePath;
+        _paths[spec] = cataloguePath;
 
         // Evict stale cached provider
-        if (_providers.TryRemove(productSpec, out var old))
+        if (_providers.TryRemove(spec, out var old))
         {
             old.Dispose();
         }
@@ -37,57 +59,96 @@ public sealed class PortrayalCatalogueManager : IDisposable
     /// <summary>
     /// Gets the configured catalogue path for a product spec, or null if none is set.
     /// </summary>
-    public string? GetPath(string productSpec)
+    public string? GetPath(string productSpec) => GetPath(ToSpec(productSpec));
+
+    /// <summary>
+    /// Gets the configured catalogue path for the given spec reference, or null if none is set.
+    /// </summary>
+    public string? GetPath(SpecRef spec)
     {
-        return _paths.TryGetValue(productSpec, out var path) ? path : null;
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
+        return _paths.TryGetValue(spec, out var path) ? path : null;
     }
 
     /// <summary>
-    /// Returns all registered product specs and their paths.
+    /// Returns all registered product specs and their paths, keyed by spec name.
+    /// When multiple editions of the same spec are registered, the entry returned
+    /// is unspecified; use <see cref="RegisteredCataloguesByRef"/> for a deterministic
+    /// view.
     /// </summary>
-    public IReadOnlyDictionary<string, string> RegisteredCatalogues =>
-        new Dictionary<string, string>(_paths, StringComparer.OrdinalIgnoreCase);
+    public IReadOnlyDictionary<string, string> RegisteredCatalogues
+    {
+        get
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in _paths)
+            {
+                result[kv.Key.Name] = kv.Value;
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Returns all registered spec references and their paths.
+    /// </summary>
+    public IReadOnlyDictionary<SpecRef, string> RegisteredCataloguesByRef =>
+        new Dictionary<SpecRef, string>(_paths);
 
     /// <summary>
     /// Registers an <see cref="IAssetSource"/> directly for a product spec's portrayal catalogue.
     /// The source is opened immediately and the resulting provider is cached.
     /// Evicts any previously cached provider or path for that spec.
     /// </summary>
-    /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102").</param>
-    /// <param name="source">An asset source containing the portrayal catalogue and assets.</param>
-    public void SetSource(string productSpec, IAssetSource source)
+    public void SetSource(string productSpec, IAssetSource source) =>
+        SetSource(ToSpec(productSpec), source);
+
+    /// <summary>
+    /// Registers an <see cref="IAssetSource"/> directly for the given spec reference's
+    /// portrayal catalogue. The source is opened immediately and the resulting
+    /// provider is cached. Evicts any previously cached provider or path.
+    /// </summary>
+    public void SetSource(SpecRef spec, IAssetSource source)
     {
-        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
         ArgumentNullException.ThrowIfNull(source);
 
         // Evict stale cached provider
-        if (_providers.TryRemove(productSpec, out var old))
+        if (_providers.TryRemove(spec, out var old))
         {
             old.Dispose();
         }
 
-        _paths.TryRemove(productSpec, out _);
+        _paths.TryRemove(spec, out _);
 
         var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
-        _providers[productSpec] = provider;
+        _providers[spec] = provider;
     }
 
     /// <summary>
     /// Gets (or lazily opens) the <see cref="PortrayalCatalogueProvider"/> for the given product spec.
     /// </summary>
+    public PortrayalCatalogueProvider GetProvider(string productSpec) =>
+        GetProvider(ToSpec(productSpec));
+
+    /// <summary>
+    /// Gets (or lazily opens) the <see cref="PortrayalCatalogueProvider"/> for the given spec reference.
+    /// </summary>
     /// <exception cref="InvalidOperationException">No catalogue path registered for the spec.</exception>
     /// <exception cref="DirectoryNotFoundException">The registered path does not exist.</exception>
-    public PortrayalCatalogueProvider GetProvider(string productSpec)
+    public PortrayalCatalogueProvider GetProvider(SpecRef spec)
     {
-        if (_providers.TryGetValue(productSpec, out var cached))
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
+
+        if (_providers.TryGetValue(spec, out var cached))
         {
             return cached;
         }
 
-        if (!_paths.TryGetValue(productSpec, out var path))
+        if (!_paths.TryGetValue(spec, out var path))
         {
             throw new InvalidOperationException(
-                $"No portrayal catalogue path registered for '{productSpec}'. " +
+                $"No portrayal catalogue path registered for '{spec}'. " +
                 $"Use SetPath() to configure it.");
         }
 
@@ -99,7 +160,7 @@ public sealed class PortrayalCatalogueManager : IDisposable
 
         var source = FileSystemAssetSource.Create(path);
         var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
-        _providers[productSpec] = provider;
+        _providers[spec] = provider;
         return provider;
     }
 
@@ -107,8 +168,16 @@ public sealed class PortrayalCatalogueManager : IDisposable
     /// Returns true if a catalogue is available for the given product spec
     /// (either via a registered path or a directly registered source).
     /// </summary>
-    public bool HasCatalogue(string productSpec) =>
-        _paths.ContainsKey(productSpec) || _providers.ContainsKey(productSpec);
+    public bool HasCatalogue(string productSpec) => HasCatalogue(ToSpec(productSpec));
+
+    /// <summary>
+    /// Returns true if a catalogue is available for the given spec reference.
+    /// </summary>
+    public bool HasCatalogue(SpecRef spec)
+    {
+        if (spec.Name is null) return false;
+        return _paths.ContainsKey(spec) || _providers.ContainsKey(spec);
+    }
 
     public void Dispose()
     {

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
@@ -17,7 +17,7 @@ namespace EncDotNet.S100.Portrayals;
 /// and a default <see cref="SpecVersion"/>, so all string callers share a
 /// single slot per product name.
 /// </remarks>
-public sealed class PortrayalCatalogueManager : IDisposable
+public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<PortrayalCatalogueProvider>
 {
     private readonly ConcurrentDictionary<SpecRef, string> _paths = new();
     private readonly ConcurrentDictionary<SpecRef, PortrayalCatalogueProvider> _providers = new();
@@ -187,5 +187,46 @@ public sealed class PortrayalCatalogueManager : IDisposable
         }
 
         _providers.Clear();
+    }
+
+    /// <inheritdoc />
+    ValueTask<PortrayalCatalogueProvider?> ICatalogueProvider<PortrayalCatalogueProvider>.GetCatalogueAsync(
+        SpecRef spec, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (spec.Name is null || !HasCatalogue(spec))
+        {
+            return new ValueTask<PortrayalCatalogueProvider?>((PortrayalCatalogueProvider?)null);
+        }
+
+        try
+        {
+            return new ValueTask<PortrayalCatalogueProvider?>(GetProvider(spec));
+        }
+        catch (InvalidOperationException)
+        {
+            return new ValueTask<PortrayalCatalogueProvider?>((PortrayalCatalogueProvider?)null);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return new ValueTask<PortrayalCatalogueProvider?>((PortrayalCatalogueProvider?)null);
+        }
+    }
+
+    /// <inheritdoc />
+    IReadOnlyCollection<CatalogueRef> ICatalogueProvider<PortrayalCatalogueProvider>.AvailableCatalogues
+    {
+        get
+        {
+            var refs = new List<CatalogueRef>();
+            foreach (var provider in _providers.Values)
+            {
+                if (provider.Catalogue.CatalogueRef is { } cref)
+                {
+                    refs.Add(cref);
+                }
+            }
+            return refs;
+        }
     }
 }

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogueReader.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogueReader.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 using System.Xml.Linq;
+using EncDotNet.S100.Core;
 
 namespace EncDotNet.S100.Portrayals;
 
@@ -25,10 +26,19 @@ public static class PortrayalCatalogueReader
         string productId = (string?)root.Attribute("productId") ?? "";
         string version = (string?)root.Attribute("version") ?? "";
 
+        CatalogueRef? catalogueRef = null;
+        if (!string.IsNullOrWhiteSpace(productId)
+            && SpecName.TryNormalize(productId, out var canonicalName)
+            && SpecVersion.TryParse(version, out var parsedVersion))
+        {
+            catalogueRef = new CatalogueRef(canonicalName, parsedVersion);
+        }
+
         return new PortrayalCatalogue
         {
             ProductId = productId,
             Version = version,
+            CatalogueRef = catalogueRef,
             AlertCatalog = ReadCatalogItem(root.Element(Unqualified("alertCatalog")) ?? root.Element(PC + "alertCatalog")),
             Pixmaps = ReadCatalogItems(root, "pixmaps", "pixmap"),
             ColorProfiles = ReadCatalogItems(root, "colorProfiles", "colorProfile"),

--- a/src/EncDotNet.S100.Specifications/Specification.cs
+++ b/src/EncDotNet.S100.Specifications/Specification.cs
@@ -17,6 +17,17 @@ public static class Specification
     public static IReadOnlyList<string> AvailableSpecs { get; } = ["S-101", "S-102", "S-104", "S-111", "S-122", "S-124", "S-125", "S-127", "S-128", "S-129", "S-411", "S-421"];
 
     /// <summary>
+    /// Strongly-typed view of <see cref="AvailableSpecs"/>. Each entry has its
+    /// canonical name (e.g. "S-101") and a default <see cref="SpecVersion"/>
+    /// of <c>0.0.0</c>, signaling "edition unspecified" — no per-bundle manifest
+    /// currently records which spec edition the bundled assets target. To
+    /// determine the actual catalogue version, parse the bundled Feature or
+    /// Portrayal Catalogue and inspect its <c>CatalogueRef</c>.
+    /// </summary>
+    public static IReadOnlyList<SpecRef> AvailableSpecRefs { get; } =
+        AvailableSpecs.Select(name => new SpecRef(name, default)).ToList().AsReadOnly();
+
+    /// <summary>
     /// Opens the bundled Feature Catalogue XML for the given product specification as a readable stream.
     /// </summary>
     /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102", "S-104", "S-111").</param>

--- a/src/EncDotNet.S100.Viewer/Services/FeatureSearchService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeatureSearchService.cs
@@ -84,7 +84,7 @@ internal sealed class FeatureSearchService : IFeatureSearchService
                 {
                     Processor = processor,
                     DatasetFileName = entry.DisplayName,
-                    ProductSpec = processor.ProductSpec,
+                    ProductSpec = processor.Spec.Name,
                     FeatureRef = summary.FeatureRef,
                     Ordinal = summary.Ordinal,
                     FeatureType = summary.FeatureType,

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -153,7 +153,7 @@ internal sealed class PickService : IPickService
                 FeatureTypeName = info.FeatureTypeName,
                 FeatureRef = info.FeatureRef,
                 DatasetFileName = owningEntry.DisplayName,
-                ProductSpec = processor.ProductSpec,
+                ProductSpec = processor.Spec.Name,
                 Attributes = info.Attributes,
                 References = info.References,
                 OwningProcessor = processor,
@@ -180,7 +180,7 @@ internal sealed class PickService : IPickService
             return false;
         }
 
-        __cmd.SetTag("s100.viewer.product_spec", processor.ProductSpec);
+        __cmd.SetTag("s100.viewer.product_spec", processor.Spec.Name);
         __cmd.SetTag("s100.viewer.reference.role", reference.Role);
 
         var ok = OpenFeature(processor, reference.TargetRef, selected.DatasetFileName ?? string.Empty);
@@ -223,7 +223,7 @@ internal sealed class PickService : IPickService
                 FeatureTypeName = info.FeatureTypeName,
                 FeatureRef = info.FeatureRef,
                 DatasetFileName = datasetFileName,
-                ProductSpec = processor.ProductSpec,
+                ProductSpec = processor.Spec.Name,
                 Attributes = info.Attributes,
                 References = info.References,
                 OwningProcessor = processor,
@@ -294,7 +294,7 @@ internal sealed class PickService : IPickService
                 FeatureTypeName = info.FeatureTypeName,
                 FeatureRef = info.FeatureRef,
                 DatasetFileName = entry.DisplayName,
-                ProductSpec = processor.ProductSpec,
+                ProductSpec = processor.Spec.Name,
                 Attributes = info.Attributes,
                 References = info.References,
                 OwningProcessor = processor,

--- a/src/EncDotNet.S100.Viewer/ViewModels/FeatureSearchViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/FeatureSearchViewModel.cs
@@ -106,7 +106,7 @@ internal sealed class FeatureSearchViewModel : ViewModelBase
             if (!SetProperty(ref _selectedResult, value) || value is null)
                 return;
             using var __cmd = ViewerObservability.BeginCommand("search.open");
-            __cmd.SetTag("s100.viewer.product_spec", value.Hit.Processor.ProductSpec);
+            __cmd.SetTag("s100.viewer.product_spec", value.Hit.Processor.Spec.Name);
             var ok = _pick.OpenFeatureAt(value.Hit.Processor, value.Hit.Ordinal, value.Hit.DatasetFileName);
             if (!ok)
                 __cmd.SetStatus(false, "feature not found at ordinal");
@@ -174,7 +174,7 @@ internal sealed class FeatureSearchViewModel : ViewModelBase
             return;
 
         using var __cmd = ViewerObservability.BeginCommand("search.open");
-        __cmd.SetTag("s100.viewer.product_spec", item.Hit.Processor.ProductSpec);
+        __cmd.SetTag("s100.viewer.product_spec", item.Hit.Processor.Spec.Name);
 
         var ok = _pick.OpenFeatureAt(item.Hit.Processor, item.Hit.Ordinal, item.Hit.DatasetFileName);
         if (!ok)

--- a/tests/EncDotNet.S100.Core.Tests/CatalogueRefTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/CatalogueRefTests.cs
@@ -1,0 +1,58 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class CatalogueRefTests
+{
+    [Fact]
+    public void Constructor_normalises_name_and_preserves_version()
+    {
+        var c = new CatalogueRef("s101", new SpecVersion(2, 0, 0));
+        Assert.Equal("S-101", c.Name);
+        Assert.Equal(new SpecVersion(2, 0, 0), c.Version);
+    }
+
+    [Theory]
+    [InlineData("S-101@2.0.0", "S-101", 2, 0, 0)]
+    [InlineData("S-101/2.0.0", "S-101", 2, 0, 0)]
+    [InlineData("s101@1.2.1",  "S-101", 1, 2, 1)]
+    public void Parse_accepts_recognised_forms(string input, string name, int major, int minor, int clar)
+    {
+        var c = CatalogueRef.Parse(input);
+        Assert.Equal(name, c.Name);
+        Assert.Equal(new SpecVersion(major, minor, clar), c.Version);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("S-101")]
+    [InlineData("@2.0.0")]
+    [InlineData("S-101@")]
+    [InlineData("garbage@2.0.0")]
+    public void TryParse_rejects_invalid_input(string input)
+    {
+        Assert.False(CatalogueRef.TryParse(input, out _));
+    }
+
+    [Fact]
+    public void ToString_uses_at_separator_to_distinguish_from_SpecRef()
+    {
+        var c = new CatalogueRef("S-101", new SpecVersion(2, 0, 0));
+        Assert.Equal("S-101@2.0.0", c.ToString());
+    }
+
+    [Fact]
+    public void CatalogueRef_works_as_dictionary_key()
+    {
+        var dict = new Dictionary<CatalogueRef, int>
+        {
+            [new CatalogueRef("S-101", new SpecVersion(2, 0, 0))] = 1,
+            [new CatalogueRef("S-101", new SpecVersion(1, 0, 0))] = 2,
+            [new CatalogueRef("S-411", new SpecVersion(1, 2, 1))] = 3,
+        };
+
+        Assert.Equal(1, dict[new CatalogueRef("s101", new SpecVersion(2, 0, 0))]);
+        Assert.Equal(2, dict[new CatalogueRef("S-101", new SpecVersion(1, 0, 0))]);
+        Assert.Equal(3, dict[new CatalogueRef("S-411", new SpecVersion(1, 2, 1))]);
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj
+++ b/tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Core.Tests/SpecCompatibilityTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/SpecCompatibilityTests.cs
@@ -1,0 +1,120 @@
+using EncDotNet.S100.Core;
+using Xunit;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class SpecCompatibilityTests
+{
+    private static SpecRef Spec(int major, int minor, int clarification = 0)
+        => new("S-101", new SpecVersion(major, minor, clarification));
+
+    private static CatalogueRef Cat(int major, int minor, int clarification = 0)
+        => new("S-101", new SpecVersion(major, minor, clarification));
+
+    // ── IsMatch / Exact ────────────────────────────────────────────────
+
+    [Fact]
+    public void Exact_RequiresIdenticalNameAndEdition()
+    {
+        Assert.True(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(1, 2, 0), SpecMatchPolicy.Exact));
+        Assert.False(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(1, 2, 1), SpecMatchPolicy.Exact));
+        Assert.False(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(1, 3, 0), SpecMatchPolicy.Exact));
+    }
+
+    [Fact]
+    public void Exact_DifferentNamesNeverMatch()
+    {
+        var s101 = new SpecRef("S-101", new SpecVersion(1, 0, 0));
+        var s102 = new CatalogueRef("S-102", new SpecVersion(1, 0, 0));
+        Assert.False(SpecCompatibility.IsMatch(s101, s102, SpecMatchPolicy.Exact));
+    }
+
+    // ── IsMatch / SameMajor ────────────────────────────────────────────
+
+    [Fact]
+    public void SameMajor_AllowsHigherMinorOnSameMajor()
+    {
+        Assert.True(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(1, 3, 0), SpecMatchPolicy.SameMajor));
+        Assert.True(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(1, 2, 5), SpecMatchPolicy.SameMajor));
+    }
+
+    [Fact]
+    public void SameMajor_RejectsLowerMinor()
+    {
+        Assert.False(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(1, 1, 0), SpecMatchPolicy.SameMajor));
+    }
+
+    [Fact]
+    public void SameMajor_RejectsDifferentMajor()
+    {
+        Assert.False(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(2, 2, 0), SpecMatchPolicy.SameMajor));
+        Assert.False(SpecCompatibility.IsMatch(Spec(2, 0, 0), Cat(1, 9, 0), SpecMatchPolicy.SameMajor));
+    }
+
+    // ── IsMatch / AnyVersion ───────────────────────────────────────────
+
+    [Fact]
+    public void AnyVersion_MatchesAnythingWithSameName()
+    {
+        Assert.True(SpecCompatibility.IsMatch(Spec(1, 2, 0), Cat(99, 99, 99), SpecMatchPolicy.AnyVersion));
+        Assert.True(SpecCompatibility.IsMatch(Spec(1, 0, 0), Cat(0, 0, 0), SpecMatchPolicy.AnyVersion));
+    }
+
+    [Fact]
+    public void AnyVersion_StillRejectsDifferentName()
+    {
+        var s101 = new SpecRef("S-101", new SpecVersion(1, 0, 0));
+        var s102 = new CatalogueRef("S-102", new SpecVersion(1, 0, 0));
+        Assert.False(SpecCompatibility.IsMatch(s101, s102, SpecMatchPolicy.AnyVersion));
+    }
+
+    // ── Classify ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Classify_EqualVersions_IsExact()
+    {
+        Assert.Equal(SpecMatchKind.Exact,
+            SpecCompatibility.Classify(new SpecVersion(1, 2, 0), new SpecVersion(1, 2, 0)));
+    }
+
+    [Fact]
+    public void Classify_CatalogueOnNewerMinor_IsCompatible()
+    {
+        Assert.Equal(SpecMatchKind.CatalogueNewerCompatible,
+            SpecCompatibility.Classify(new SpecVersion(1, 2, 0), new SpecVersion(1, 3, 0)));
+    }
+
+    [Fact]
+    public void Classify_CatalogueOnLowerMinor_IsOlder()
+    {
+        Assert.Equal(SpecMatchKind.CatalogueOlder,
+            SpecCompatibility.Classify(new SpecVersion(1, 3, 0), new SpecVersion(1, 2, 0)));
+    }
+
+    [Fact]
+    public void Classify_DifferentMajor_IsDivergence()
+    {
+        Assert.Equal(SpecMatchKind.MajorDivergence,
+            SpecCompatibility.Classify(new SpecVersion(1, 0, 0), new SpecVersion(2, 0, 0)));
+        Assert.Equal(SpecMatchKind.MajorDivergence,
+            SpecCompatibility.Classify(new SpecVersion(2, 0, 0), new SpecVersion(1, 9, 0)));
+    }
+
+    [Fact]
+    public void Classify_DefaultVersion_IsUnknown()
+    {
+        Assert.Equal(SpecMatchKind.Unknown,
+            SpecCompatibility.Classify(default, new SpecVersion(1, 0, 0)));
+        Assert.Equal(SpecMatchKind.Unknown,
+            SpecCompatibility.Classify(new SpecVersion(1, 0, 0), default));
+    }
+
+    [Fact]
+    public void Classify_ClarificationDelta_IsCompatible()
+    {
+        // Clarification-level differences are interchangeable per S-100
+        // Part 2 §6 — same-major, same-minor falls to the compatible bucket.
+        Assert.Equal(SpecMatchKind.CatalogueNewerCompatible,
+            SpecCompatibility.Classify(new SpecVersion(1, 2, 0), new SpecVersion(1, 2, 1)));
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/SpecNameTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/SpecNameTests.cs
@@ -1,0 +1,41 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class SpecNameTests
+{
+    [Theory]
+    [InlineData("S-101", "S-101")]
+    [InlineData("s-101", "S-101")]
+    [InlineData("S101",  "S-101")]
+    [InlineData("s101",  "S-101")]
+    [InlineData("  S-101  ", "S-101")]
+    [InlineData("S-411", "S-411")]
+    [InlineData("INT.IHO.S-101.1.2.0", "S-101")]
+    [InlineData("INT.IHO.S101.1.2.0",  "S-101")]
+    public void Normalize_returns_canonical_form(string raw, string expected)
+    {
+        Assert.Equal(expected, SpecName.Normalize(raw));
+        Assert.True(SpecName.TryNormalize(raw, out var canonical));
+        Assert.Equal(expected, canonical);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("garbage")]
+    [InlineData("S-1")]
+    [InlineData("S-12345")]
+    [InlineData("X-101")]
+    public void Normalize_rejects_unrecognised(string raw)
+    {
+        Assert.Throws<FormatException>(() => SpecName.Normalize(raw));
+        Assert.False(SpecName.TryNormalize(raw, out _));
+    }
+
+    [Fact]
+    public void TryNormalize_rejects_null()
+    {
+        Assert.False(SpecName.TryNormalize(null, out _));
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/SpecRefTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/SpecRefTests.cs
@@ -1,0 +1,114 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class SpecRefTests
+{
+    [Theory]
+    [InlineData("S-101", 1, 2, 0)]
+    [InlineData("s-101", 1, 2, 0)]
+    [InlineData("S101", 1, 2, 0)]
+    [InlineData("s101", 1, 2, 0)]
+    [InlineData("  S-101  ", 1, 2, 0)]
+    public void Constructor_normalises_name_to_canonical_form(string raw, int major, int minor, int clarification)
+    {
+        var spec = new SpecRef(raw, new SpecVersion(major, minor, clarification));
+        Assert.Equal("S-101", spec.Name);
+        Assert.Equal(new SpecVersion(major, minor, clarification), spec.Edition);
+    }
+
+    [Theory]
+    [InlineData("garbage")]
+    [InlineData("")]
+    [InlineData("S-")]
+    [InlineData("S-1")]
+    [InlineData("S-1234")]
+    public void Constructor_rejects_unrecognised_name(string raw)
+    {
+        Assert.Throws<FormatException>(() => new SpecRef(raw, new SpecVersion(1, 0, 0)));
+    }
+
+    [Theory]
+    [InlineData("S-101/1.2.0",   "S-101", 1, 2, 0)]
+    [InlineData("S-102@3.0.0",   "S-102", 3, 0, 0)]
+    [InlineData("s101/1.2",      "S-101", 1, 2, 0)]
+    [InlineData("INT.IHO.S-101.1.2.0", "S-101", 1, 2, 0)]
+    [InlineData("INT.IHO.S101.2.0.0",  "S-101", 2, 0, 0)]
+    public void Parse_accepts_recognised_forms(string input, string expectedName, int major, int minor, int clar)
+    {
+        var spec = SpecRef.Parse(input);
+        Assert.Equal(expectedName, spec.Name);
+        Assert.Equal(new SpecVersion(major, minor, clar), spec.Edition);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("S-101")]
+    [InlineData("/1.2.0")]
+    [InlineData("S-101/")]
+    [InlineData("garbage/1.2.0")]
+    [InlineData("S-101/not-a-version")]
+    public void TryParse_rejects_invalid_input(string input)
+    {
+        Assert.False(SpecRef.TryParse(input, out _));
+    }
+
+    [Fact]
+    public void TryParse_rejects_null()
+    {
+        Assert.False(SpecRef.TryParse(null, out _));
+    }
+
+    [Fact]
+    public void ToString_round_trips_through_Parse()
+    {
+        var spec = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        Assert.Equal("S-101/1.2.0", spec.ToString());
+        Assert.Equal(spec, SpecRef.Parse(spec.ToString()));
+    }
+
+    [Fact]
+    public void Equality_normalises_Name_so_case_and_dash_dont_matter()
+    {
+        var a = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        var b = new SpecRef("s101",  new SpecVersion(1, 2, 0));
+        var c = new SpecRef("S101",  new SpecVersion(1, 2, 0));
+
+        Assert.Equal(a, b);
+        Assert.Equal(a, c);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.Equal(a.GetHashCode(), c.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_distinguishes_by_edition()
+    {
+        var a = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        var b = new SpecRef("S-101", new SpecVersion(2, 0, 0));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Equality_distinguishes_by_name()
+    {
+        var a = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        var b = new SpecRef("S-102", new SpecVersion(1, 2, 0));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void SpecRef_works_as_dictionary_key()
+    {
+        var dict = new Dictionary<SpecRef, string>
+        {
+            [new SpecRef("S-101", new SpecVersion(1, 2, 0))] = "old",
+            [new SpecRef("S-101", new SpecVersion(2, 0, 0))] = "new",
+            [new SpecRef("S-102", new SpecVersion(3, 0, 0))] = "bath",
+        };
+
+        Assert.Equal("old",  dict[new SpecRef("S-101", new SpecVersion(1, 2, 0))]);
+        Assert.Equal("new",  dict[new SpecRef("s101",  new SpecVersion(2, 0, 0))]);
+        Assert.Equal("bath", dict[new SpecRef("S-102", new SpecVersion(3, 0, 0))]);
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/SpecVersionTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/SpecVersionTests.cs
@@ -1,0 +1,95 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class SpecVersionTests
+{
+    [Theory]
+    [InlineData("1.2.0", 1, 2, 0)]
+    [InlineData("2.0.0", 2, 0, 0)]
+    [InlineData("1.2.1", 1, 2, 1)]
+    [InlineData("3.0.0", 3, 0, 0)]
+    [InlineData("1.2", 1, 2, 0)]
+    [InlineData("5", 5, 0, 0)]
+    [InlineData("  1.2.0  ", 1, 2, 0)]
+    public void Parse_returns_expected_components(string input, int major, int minor, int clarification)
+    {
+        var v = SpecVersion.Parse(input);
+        Assert.Equal(major, v.Major);
+        Assert.Equal(minor, v.Minor);
+        Assert.Equal(clarification, v.Clarification);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("1.2.3.4")]
+    [InlineData("1.-2.0")]
+    [InlineData("1.a.0")]
+    [InlineData("v1.2.0")]
+    [InlineData("1.2.0-rc1")]
+    public void TryParse_rejects_invalid_input(string input)
+    {
+        Assert.False(SpecVersion.TryParse(input, out _));
+        Assert.Throws<FormatException>(() => SpecVersion.Parse(input));
+    }
+
+    [Fact]
+    public void TryParse_rejects_null()
+    {
+        Assert.False(SpecVersion.TryParse(null, out _));
+    }
+
+    [Fact]
+    public void Constructor_rejects_negative_components()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SpecVersion(-1, 0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SpecVersion(0, -1, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SpecVersion(0, 0, -1));
+    }
+
+    [Fact]
+    public void ToString_round_trips_through_parse()
+    {
+        var v = new SpecVersion(1, 2, 3);
+        Assert.Equal("1.2.3", v.ToString());
+        Assert.Equal(v, SpecVersion.Parse(v.ToString()));
+    }
+
+    [Fact]
+    public void Equality_compares_all_three_components()
+    {
+        Assert.Equal(new SpecVersion(1, 2, 0), new SpecVersion(1, 2, 0));
+        Assert.NotEqual(new SpecVersion(1, 2, 0), new SpecVersion(1, 2, 1));
+        Assert.NotEqual(new SpecVersion(1, 2, 0), new SpecVersion(1, 3, 0));
+        Assert.NotEqual(new SpecVersion(1, 2, 0), new SpecVersion(2, 2, 0));
+    }
+
+    [Theory]
+    [InlineData(1, 2, 0, 1, 1, 5, true)]
+    [InlineData(1, 2, 0, 1, 2, 0, true)]
+    [InlineData(1, 2, 1, 1, 2, 0, true)]
+    [InlineData(1, 1, 0, 1, 2, 0, false)]
+    [InlineData(2, 0, 0, 1, 9, 9, false)]
+    [InlineData(1, 0, 0, 2, 0, 0, false)]
+    public void IsBackwardCompatibleWith_follows_S100_part2_rules(
+        int newerMajor, int newerMinor, int newerClar,
+        int olderMajor, int olderMinor, int olderClar,
+        bool expected)
+    {
+        var newer = new SpecVersion(newerMajor, newerMinor, newerClar);
+        var older = new SpecVersion(olderMajor, olderMinor, olderClar);
+        Assert.Equal(expected, newer.IsBackwardCompatibleWith(older));
+    }
+
+    [Fact]
+    public void Comparison_orders_lexicographically()
+    {
+        Assert.True(new SpecVersion(1, 2, 0) < new SpecVersion(1, 2, 1));
+        Assert.True(new SpecVersion(1, 2, 0) < new SpecVersion(1, 3, 0));
+        Assert.True(new SpecVersion(1, 2, 0) < new SpecVersion(2, 0, 0));
+        Assert.True(new SpecVersion(2, 0, 0) > new SpecVersion(1, 99, 99));
+        Assert.True(new SpecVersion(1, 2, 0) >= new SpecVersion(1, 2, 0));
+        Assert.True(new SpecVersion(1, 2, 0) <= new SpecVersion(1, 2, 0));
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/S104CoverageSourceTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/S104CoverageSourceTests.cs
@@ -42,7 +42,7 @@ public class S104CoverageSourceTests : IDisposable
 
         var source = new S104CoverageSource(_dataset!);
 
-        Assert.Equal("S-104", source.Metadata.ProductSpec);
+        Assert.Equal("S-104", source.Metadata.Spec.Name);
     }
 
     [SkippableFact]

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111CoverageSourceTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111CoverageSourceTests.cs
@@ -38,7 +38,7 @@ public class S111CoverageSourceTests : IDisposable
 
         var source = new S111CoverageSource(_dataset!);
 
-        Assert.Equal("S-111", source.Metadata.ProductSpec);
+        Assert.Equal("S-111", source.Metadata.Spec.Name);
     }
 
     [SkippableFact]

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ProductSpecificationExtensionsTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ProductSpecificationExtensionsTests.cs
@@ -1,0 +1,88 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.ExchangeSets;
+
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+public class ProductSpecificationExtensionsTests
+{
+    [Fact]
+    public void TryToSpecRef_uses_Name_and_Version_when_both_present()
+    {
+        var ps = new ProductSpecification
+        {
+            Name = "S-101",
+            Version = "1.2.0",
+        };
+
+        Assert.True(ps.TryToSpecRef(out var spec));
+        Assert.Equal(new SpecRef("S-101", new SpecVersion(1, 2, 0)), spec);
+    }
+
+    [Fact]
+    public void TryToSpecRef_normalises_loosely_typed_Name()
+    {
+        var ps = new ProductSpecification
+        {
+            Name = "s101",
+            Version = "1.2.0",
+        };
+
+        Assert.True(ps.TryToSpecRef(out var spec));
+        Assert.Equal("S-101", spec.Name);
+    }
+
+    [Fact]
+    public void TryToSpecRef_falls_back_to_ProductIdentifier()
+    {
+        var ps = new ProductSpecification
+        {
+            ProductIdentifier = "INT.IHO.S-101.1.2.0",
+        };
+
+        Assert.True(ps.TryToSpecRef(out var spec));
+        Assert.Equal(new SpecRef("S-101", new SpecVersion(1, 2, 0)), spec);
+    }
+
+    [Fact]
+    public void TryToSpecRef_prefers_Name_Version_over_ProductIdentifier()
+    {
+        // When both shapes are present and disagree, Name+Version wins
+        // (the more specific declaration).
+        var ps = new ProductSpecification
+        {
+            Name = "S-101",
+            Version = "2.0.0",
+            ProductIdentifier = "INT.IHO.S-101.1.0.0",
+        };
+
+        Assert.True(ps.TryToSpecRef(out var spec));
+        Assert.Equal(new SpecVersion(2, 0, 0), spec.Edition);
+    }
+
+    [Fact]
+    public void TryToSpecRef_returns_false_when_no_data()
+    {
+        var ps = new ProductSpecification();
+        Assert.False(ps.TryToSpecRef(out _));
+    }
+
+    [Fact]
+    public void TryToSpecRef_returns_false_for_unparseable_inputs()
+    {
+        var ps = new ProductSpecification
+        {
+            Name = "garbage",
+            Version = "not-a-version",
+            ProductIdentifier = "INT.IHO.garbage",
+        };
+
+        Assert.False(ps.TryToSpecRef(out _));
+    }
+
+    [Fact]
+    public void ToSpecRef_throws_on_unresolvable_input()
+    {
+        var ps = new ProductSpecification();
+        Assert.Throws<FormatException>(() => ps.ToSpecRef());
+    }
+}

--- a/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
+++ b/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
@@ -1,0 +1,128 @@
+using System.IO;
+using System.Text;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Features;
+
+namespace EncDotNet.S100.Features.Tests;
+
+public class FeatureCatalogueManagerTests
+{
+    private const string MinimalFcXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <S100FC:S100_FC_FeatureCatalogue
+            xmlns:S100FC="http://www.iho.int/S100FC/5.2"
+            xmlns:S100Base="http://www.iho.int/S100Base/5.0"
+            xmlns:S100CI="http://www.iho.int/S100CI/5.0">
+          <S100FC:name>Test Catalogue</S100FC:name>
+          <S100FC:versionNumber>2.0.0</S100FC:versionNumber>
+          <S100FC:versionDate>2024-10-16</S100FC:versionDate>
+          <S100FC:productId>S-101</S100FC:productId>
+        </S100FC:S100_FC_FeatureCatalogue>
+        """;
+
+    private static Stream Open(string xml) => new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+    [Fact]
+    public void GetCatalogue_StringOverload_ReturnsParsedCatalogue()
+    {
+        var mgr = new FeatureCatalogueManager(spec => spec == "S-101" ? Open(MinimalFcXml) : null);
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal("S-101", fc!.ProductId);
+        Assert.Equal("2.0.0", fc.VersionNumber);
+    }
+
+    [Fact]
+    public void GetCatalogue_SpecRefOverload_ReturnsParsedCatalogue()
+    {
+        var mgr = new FeatureCatalogueManager(spec => spec == "S-101" ? Open(MinimalFcXml) : null);
+        var fc = mgr.GetCatalogue(new SpecRef("S-101", new SpecVersion(1, 2, 0)));
+        Assert.NotNull(fc);
+        Assert.Equal(new CatalogueRef("S-101", new SpecVersion(2, 0, 0)), fc!.CatalogueRef);
+    }
+
+    [Fact]
+    public void GetCatalogue_DistinctEditions_GetSeparateCacheSlots()
+    {
+        int callCount = 0;
+        var mgr = new FeatureCatalogueManager((SpecRef _) =>
+        {
+            callCount++;
+            return Open(MinimalFcXml);
+        });
+
+        var v1 = mgr.GetCatalogue(new SpecRef("S-101", new SpecVersion(1, 2, 0)));
+        var v2 = mgr.GetCatalogue(new SpecRef("S-101", new SpecVersion(2, 0, 0)));
+        Assert.NotNull(v1);
+        Assert.NotNull(v2);
+        Assert.NotSame(v1, v2);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public void GetCatalogue_SameSpecRef_IsCachedSingleton()
+    {
+        int callCount = 0;
+        var mgr = new FeatureCatalogueManager((SpecRef _) =>
+        {
+            callCount++;
+            return Open(MinimalFcXml);
+        });
+
+        var spec = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        var a = mgr.GetCatalogue(spec);
+        var b = mgr.GetCatalogue(spec);
+        Assert.Same(a, b);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void GetCatalogue_StringOverload_NormalisesName()
+    {
+        // "S101", "s-101", "S-101" must all collapse to the same cache slot.
+        int callCount = 0;
+        var mgr = new FeatureCatalogueManager((string _) =>
+        {
+            callCount++;
+            return Open(MinimalFcXml);
+        });
+
+        var a = mgr.GetCatalogue("S-101");
+        var b = mgr.GetCatalogue("S101");
+        var c = mgr.GetCatalogue("s-101");
+        Assert.Same(a, b);
+        Assert.Same(b, c);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void GetCatalogue_StringOverload_GarbageReturnsNull()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => Open(MinimalFcXml));
+        // SpecName.TryNormalize fails → null without parsing.
+        Assert.Null(mgr.GetCatalogue("not-a-spec"));
+    }
+
+    [Fact]
+    public void GetCatalogue_StringResolver_ReceivesNameFromSpecRef()
+    {
+        string? lastReceived = null;
+        var mgr = new FeatureCatalogueManager(name =>
+        {
+            lastReceived = name;
+            return Open(MinimalFcXml);
+        });
+
+        mgr.GetCatalogue(new SpecRef("S-101", new SpecVersion(1, 2, 0)));
+        Assert.Equal("S-101", lastReceived);
+    }
+
+    [Fact]
+    public void GetDecoder_SpecRef_ReturnsDecoderBoundToCatalogue()
+    {
+        var mgr = new FeatureCatalogueManager((SpecRef _) => Open(MinimalFcXml));
+        var dec = mgr.GetDecoder(new SpecRef("S-101", default));
+        Assert.NotNull(dec);
+        Assert.Equal("S-101", dec!.Catalogue.ProductId);
+    }
+}

--- a/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
+++ b/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Features;
 
@@ -124,5 +126,39 @@ public class FeatureCatalogueManagerTests
         var dec = mgr.GetDecoder(new SpecRef("S-101", default));
         Assert.NotNull(dec);
         Assert.Equal("S-101", dec!.Catalogue.ProductId);
+    }
+
+    [Fact]
+    public async Task ICatalogueProvider_GetCatalogueAsync_ReturnsParsedCatalogue()
+    {
+        var mgr = new FeatureCatalogueManager((SpecRef _) => Open(MinimalFcXml));
+        ICatalogueProvider<FeatureCatalogue> provider = mgr;
+        var fc = await provider.GetCatalogueAsync(new SpecRef("S-101", new SpecVersion(1, 2, 0)));
+        Assert.NotNull(fc);
+        Assert.Equal(new CatalogueRef("S-101", new SpecVersion(2, 0, 0)), fc!.CatalogueRef);
+    }
+
+    [Fact]
+    public async Task ICatalogueProvider_AvailableCatalogues_ListsLoadedRefs()
+    {
+        var mgr = new FeatureCatalogueManager((SpecRef _) => Open(MinimalFcXml));
+        ICatalogueProvider<FeatureCatalogue> provider = mgr;
+        Assert.Empty(provider.AvailableCatalogues);
+
+        await provider.GetCatalogueAsync(new SpecRef("S-101", new SpecVersion(1, 2, 0)));
+        var refs = provider.AvailableCatalogues;
+        Assert.Single(refs);
+        Assert.Contains(new CatalogueRef("S-101", new SpecVersion(2, 0, 0)), refs);
+    }
+
+    [Fact]
+    public async Task ICatalogueProvider_GetCatalogueAsync_HonoursCancellation()
+    {
+        var mgr = new FeatureCatalogueManager((SpecRef _) => Open(MinimalFcXml));
+        ICatalogueProvider<FeatureCatalogue> provider = mgr;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await provider.GetCatalogueAsync(new SpecRef("S-101", default), cts.Token));
     }
 }

--- a/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueRefTests.cs
+++ b/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueRefTests.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using System.Text;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Features;
+
+namespace EncDotNet.S100.Features.Tests;
+
+public class FeatureCatalogueRefTests
+{
+    private static FeatureCatalogue Read(string xml) =>
+        FeatureCatalogueReader.Read(new MemoryStream(Encoding.UTF8.GetBytes(xml)));
+
+    [Fact]
+    public void Reader_PopulatesCatalogueRef_FromProductIdAndVersionNumber()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <S100FC:S100_FC_FeatureCatalogue
+                xmlns:S100FC="http://www.iho.int/S100FC/5.2"
+                xmlns:S100Base="http://www.iho.int/S100Base/5.0"
+                xmlns:S100CI="http://www.iho.int/S100CI/5.0">
+              <S100FC:name>Test</S100FC:name>
+              <S100FC:versionNumber>2.0.0</S100FC:versionNumber>
+              <S100FC:versionDate>2024-10-16</S100FC:versionDate>
+              <S100FC:productId>S-101</S100FC:productId>
+            </S100FC:S100_FC_FeatureCatalogue>
+            """;
+        var fc = Read(xml);
+        Assert.Equal("S-101", fc.ProductId);
+        Assert.Equal(new CatalogueRef("S-101", new SpecVersion(2, 0, 0)), fc.CatalogueRef);
+    }
+
+    [Fact]
+    public void Reader_NoProductId_LeavesCatalogueRefNull()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <S100FC:S100_FC_FeatureCatalogue
+                xmlns:S100FC="http://www.iho.int/S100FC/5.2"
+                xmlns:S100Base="http://www.iho.int/S100Base/5.0"
+                xmlns:S100CI="http://www.iho.int/S100CI/5.0">
+              <S100FC:name>Test</S100FC:name>
+              <S100FC:versionNumber>1.0.0</S100FC:versionNumber>
+              <S100FC:versionDate>2024-10-16</S100FC:versionDate>
+            </S100FC:S100_FC_FeatureCatalogue>
+            """;
+        var fc = Read(xml);
+        Assert.Null(fc.ProductId);
+        Assert.Null(fc.CatalogueRef);
+    }
+
+    [Fact]
+    public void Reader_NormalisesProductId_InCatalogueRef()
+    {
+        // "S101" (no hyphen) must normalise to canonical "S-101".
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <S100FC:S100_FC_FeatureCatalogue
+                xmlns:S100FC="http://www.iho.int/S100FC/5.2"
+                xmlns:S100Base="http://www.iho.int/S100Base/5.0"
+                xmlns:S100CI="http://www.iho.int/S100CI/5.0">
+              <S100FC:name>Test</S100FC:name>
+              <S100FC:versionNumber>2.0.0</S100FC:versionNumber>
+              <S100FC:versionDate>2024-10-16</S100FC:versionDate>
+              <S100FC:productId>S101</S100FC:productId>
+            </S100FC:S100_FC_FeatureCatalogue>
+            """;
+        var fc = Read(xml);
+        Assert.Equal("S101", fc.ProductId);
+        Assert.Equal("S-101", fc.CatalogueRef!.Value.Name);
+    }
+}

--- a/tests/EncDotNet.S100.PerfReport.Tests/GateCommandTests.cs
+++ b/tests/EncDotNet.S100.PerfReport.Tests/GateCommandTests.cs
@@ -1,0 +1,55 @@
+using EncDotNet.S100.PerfReport;
+
+namespace EncDotNet.S100.PerfReport.Tests;
+
+public class GateCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public GateCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "gatecmd-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void EvaluateScenario_HandlesDuplicateMetricRecordsFromMultipleExportCycles()
+    {
+        // The OTel periodic exporter emits one record per cycle (cumulative
+        // temporality). For long-running scenarios this produces multiple
+        // JSONL lines for the same (name, tags) tuple. The gate command must
+        // not crash with "An item with the same key has already been added"
+        // — it should keep the last (most recent / highest cumulative) value.
+        var basePath = Path.Combine(_tempDir, "scenario.jsonl");
+        var candPath = Path.Combine(_tempDir, "candidate.jsonl");
+
+        // Two exports of the same histogram with the same tags; second is
+        // the cumulative total.
+        File.WriteAllLines(basePath,
+        [
+            """{"kind":"metric","name":"s100.pipeline.duration","instrument":"histogram","tags":{"s100.pipeline.stage":"vector"},"buckets":[{"sum":100.0,"count":1}]}""",
+            """{"kind":"metric","name":"s100.pipeline.duration","instrument":"histogram","tags":{"s100.pipeline.stage":"vector"},"buckets":[{"sum":300.0,"count":3}]}""",
+        ]);
+        File.WriteAllLines(candPath,
+        [
+            """{"kind":"metric","name":"s100.pipeline.duration","instrument":"histogram","tags":{"s100.pipeline.stage":"vector"},"buckets":[{"sum":120.0,"count":1}]}""",
+            """{"kind":"metric","name":"s100.pipeline.duration","instrument":"histogram","tags":{"s100.pipeline.stage":"vector"},"buckets":[{"sum":330.0,"count":3}]}""",
+        ]);
+
+        var baseline = TelemetryFileReader.Read(basePath);
+        var candidate = TelemetryFileReader.Read(candPath);
+
+        var result = GateCommand.EvaluateScenario("scenario", baseline, candidate, threshold: 20.0);
+
+        var detail = Assert.Single(result.Details, d => d.Kind == "metric");
+        Assert.Equal(300.0, detail.Baseline);
+        Assert.Equal(330.0, detail.Candidate);
+        Assert.False(detail.Regressed); // 10% < 20% threshold
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/CatalogueResolutionDiagnosticsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CatalogueResolutionDiagnosticsTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Diagnostics;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class CatalogueResolutionDiagnosticsTests
+{
+    private sealed record Measurement(long Value, IReadOnlyDictionary<string, object?> Tags);
+
+    private static MeterListener StartCapture(List<Measurement> sink)
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "EncDotNet.S100.Datasets.Pipelines"
+                    && instrument.Name == "s100.catalogue.match.count")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            for (int i = 0; i < tags.Length; i++) dict[tags[i].Key] = tags[i].Value;
+            sink.Add(new Measurement(value, dict));
+        });
+        listener.Start();
+        return listener;
+    }
+
+    [Fact]
+    public void Report_NullCatalogueRef_DoesNothing()
+    {
+
+        var measurements = new List<Measurement>();
+        using var listener = StartCapture(measurements);
+
+        CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", new SpecVersion(1, 2, 0)),
+            null, "portrayal");
+
+        Assert.Empty(measurements);
+    }
+
+    [Fact]
+    public void Report_ExactMatch_EmitsCounterWithExactTag()
+    {
+
+        var scope = new object();
+        var measurements = new List<Measurement>();
+        using var listener = StartCapture(measurements);
+
+        CatalogueResolutionDiagnostics.Report(scope,
+            new SpecRef("S-101", new SpecVersion(1, 2, 0)),
+            new CatalogueRef("S-101", new SpecVersion(1, 2, 0)),
+            "portrayal");
+
+        var m = Assert.Single(measurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal("S-101", m.Tags["s100.spec.name"]);
+        Assert.Equal("1.2.0", m.Tags["s100.spec.edition"]);
+        Assert.Equal("1.2.0", m.Tags["s100.catalogue.version"]);
+        Assert.Equal("portrayal", m.Tags["s100.catalogue.kind"]);
+        Assert.Equal("Exact", m.Tags["s100.catalogue.match"]);
+    }
+
+    [Fact]
+    public void Report_MajorDivergence_TagsAccordingly()
+    {
+
+        var scope = new object();
+        var measurements = new List<Measurement>();
+        using var listener = StartCapture(measurements);
+
+        CatalogueResolutionDiagnostics.Report(scope,
+            new SpecRef("S-101", new SpecVersion(1, 2, 0)),
+            new CatalogueRef("S-101", new SpecVersion(2, 0, 0)),
+            "portrayal");
+
+        var m = Assert.Single(measurements);
+        Assert.Equal("MajorDivergence", m.Tags["s100.catalogue.match"]);
+    }
+
+    [Fact]
+    public void Report_RepeatedSamePair_EmitsOnlyOnce()
+    {
+
+        var scope = new object();
+        var measurements = new List<Measurement>();
+        using var listener = StartCapture(measurements);
+
+        var spec = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        var cat = new CatalogueRef("S-101", new SpecVersion(2, 0, 0));
+        CatalogueResolutionDiagnostics.Report(scope, spec, cat, "portrayal");
+        CatalogueResolutionDiagnostics.Report(scope, spec, cat, "portrayal");
+        CatalogueResolutionDiagnostics.Report(scope, spec, cat, "portrayal");
+
+        Assert.Single(measurements);
+    }
+
+    [Fact]
+    public void Report_DistinctScopes_EmitIndependently()
+    {
+
+        var scopeA = new object();
+        var scopeB = new object();
+        var measurements = new List<Measurement>();
+        using var listener = StartCapture(measurements);
+
+        var spec = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+        var cat = new CatalogueRef("S-101", new SpecVersion(2, 0, 0));
+        CatalogueResolutionDiagnostics.Report(scopeA, spec, cat, "portrayal");
+        CatalogueResolutionDiagnostics.Report(scopeB, spec, cat, "portrayal");
+
+        Assert.Equal(2, measurements.Count);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePickHelperTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePickHelperTests.cs
@@ -1,4 +1,5 @@
 using System;
+using EncDotNet.S100.Core;
 using System.Collections.Generic;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Pipelines;
@@ -84,7 +85,7 @@ public class CoveragePickHelperTests
         };
         var meta = new CoverageMetadata
         {
-            ProductSpec = "S-102",
+            Spec = new SpecRef("S-102", default),
             Extent = new BoundingBox(
                 southLatitude: originLat,
                 westLongitude: originLon,

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Pipelines.Coverage;
 
 namespace EncDotNet.S100.Pipelines.Tests;
@@ -192,7 +193,7 @@ public class CoveragePipelineTests
                 var (rows, cols) = GridSize;
                 return new CoverageMetadata
                 {
-                    ProductSpec = _productSpec,
+                    Spec = new SpecRef(_productSpec, default),
                     Extent = new BoundingBox(
                         _originLat, _originLon,
                         _originLat + _spacingLat * rows,
@@ -259,7 +260,7 @@ public class CoveragePipelineTests
             _contours = contours ?? [];
         }
 
-        public string ProductSpec => "S-102";
+        public SpecRef Spec => new("S-102", default);
         public string Edition => "1.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
         public void SwitchPalette(PaletteType type) { }

--- a/tests/EncDotNet.S100.Pipelines.Tests/PortrayalCatalogueManagerTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PortrayalCatalogueManagerTests.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Portrayals;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class PortrayalCatalogueManagerTests
+{
+    [Fact]
+    public void StringAndSpecRefOverloads_ShareCacheSlot_ForDefaultEdition()
+    {
+        var mgr = new PortrayalCatalogueManager();
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            mgr.SetPath("S-101", tmp);
+
+            // String getter
+            Assert.Equal(tmp, mgr.GetPath("S-101"));
+            // SpecRef getter using same default version
+            Assert.Equal(tmp, mgr.GetPath(new SpecRef("S-101", default)));
+            // Different edition → not registered.
+            Assert.Null(mgr.GetPath(new SpecRef("S-101", new SpecVersion(2, 0, 0))));
+        }
+        finally
+        {
+            Directory.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void DistinctEditions_AreRegisteredIndependently()
+    {
+        var mgr = new PortrayalCatalogueManager();
+        var a = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var b = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(a);
+        Directory.CreateDirectory(b);
+        try
+        {
+            mgr.SetPath(new SpecRef("S-101", new SpecVersion(1, 2, 0)), a);
+            mgr.SetPath(new SpecRef("S-101", new SpecVersion(2, 0, 0)), b);
+
+            Assert.Equal(a, mgr.GetPath(new SpecRef("S-101", new SpecVersion(1, 2, 0))));
+            Assert.Equal(b, mgr.GetPath(new SpecRef("S-101", new SpecVersion(2, 0, 0))));
+            Assert.True(mgr.HasCatalogue(new SpecRef("S-101", new SpecVersion(1, 2, 0))));
+            Assert.True(mgr.HasCatalogue(new SpecRef("S-101", new SpecVersion(2, 0, 0))));
+            Assert.Equal(2, mgr.RegisteredCataloguesByRef.Count);
+        }
+        finally
+        {
+            Directory.Delete(a);
+            Directory.Delete(b);
+        }
+    }
+
+    [Fact]
+    public void HasCatalogue_String_NormalisesName()
+    {
+        var mgr = new PortrayalCatalogueManager();
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            mgr.SetPath("S-101", tmp);
+            Assert.True(mgr.HasCatalogue("S101"));
+            Assert.True(mgr.HasCatalogue("s-101"));
+            Assert.True(mgr.HasCatalogue("S-101"));
+        }
+        finally
+        {
+            Directory.Delete(tmp);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/PortrayalCatalogueManagerTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PortrayalCatalogueManagerTests.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Portrayals;
 using Xunit;
@@ -73,5 +75,35 @@ public class PortrayalCatalogueManagerTests
         {
             Directory.Delete(tmp);
         }
+    }
+
+    [Fact]
+    public async Task ICatalogueProvider_GetCatalogueAsync_UnregisteredSpec_ReturnsNull()
+    {
+        using var mgr = new PortrayalCatalogueManager();
+        ICatalogueProvider<PortrayalCatalogueProvider> provider = mgr;
+        var result = await provider.GetCatalogueAsync(new SpecRef("S-101", default));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ICatalogueProvider_GetCatalogueAsync_HonoursCancellation()
+    {
+        using var mgr = new PortrayalCatalogueManager();
+        ICatalogueProvider<PortrayalCatalogueProvider> provider = mgr;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await provider.GetCatalogueAsync(new SpecRef("S-101", default), cts.Token));
+    }
+
+    [Fact]
+    public void ICatalogueProvider_AvailableCatalogues_ReflectsLoadedProviders()
+    {
+        using var mgr = new PortrayalCatalogueManager();
+        ICatalogueProvider<PortrayalCatalogueProvider> provider = mgr;
+
+        // Before any provider is forced into existence, no catalogues are visible.
+        Assert.Empty(provider.AvailableCatalogues);
     }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/PortrayalCatalogueRefTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PortrayalCatalogueRefTests.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Text;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Portrayals;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class PortrayalCatalogueRefTests
+{
+    private static PortrayalCatalogue Read(string xml) =>
+        PortrayalCatalogueReader.Read(new MemoryStream(Encoding.UTF8.GetBytes(xml)));
+
+    [Fact]
+    public void Reader_PopulatesCatalogueRef_FromAttributes()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <pc:portrayalCatalog xmlns:pc="http://www.iho.int/S100PortrayalCatalog/5.2" productId="S-101" version="2.0.0" />
+            """;
+        var pc = Read(xml);
+        Assert.Equal("S-101", pc.ProductId);
+        Assert.Equal("2.0.0", pc.Version);
+        Assert.Equal(new CatalogueRef("S-101", new SpecVersion(2, 0, 0)), pc.CatalogueRef);
+    }
+
+    [Fact]
+    public void Reader_TwoComponentVersion_PadsToThree()
+    {
+        // S-127 PC ships with version "2.0" — must parse as 2.0.0.
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <pc:portrayalCatalog xmlns:pc="http://www.iho.int/S100PortrayalCatalog/5.2" productId="S-127" version="2.0" />
+            """;
+        var pc = Read(xml);
+        Assert.Equal(new CatalogueRef("S-127", new SpecVersion(2, 0, 0)), pc.CatalogueRef);
+    }
+
+    [Fact]
+    public void Reader_MissingMetadata_LeavesCatalogueRefNull()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <pc:portrayalCatalog xmlns:pc="http://www.iho.int/S100PortrayalCatalog/5.2" productId="" version="" />
+            """;
+        var pc = Read(xml);
+        Assert.Null(pc.CatalogueRef);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
@@ -1,4 +1,5 @@
 using System.Xml;
+using EncDotNet.S100.Core;
 using System.Xml.Linq;
 using System.Xml.Xsl;
 using EncDotNet.S100.Datasets.S101;
@@ -261,7 +262,7 @@ public class S101PipelineTests
             ViewingGroups = viewingGroups ?? new ViewingGroupController();
         }
 
-        public string ProductSpec => "S-101";
+        public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
         public void SwitchPalette(PaletteType type) { }

--- a/tests/EncDotNet.S100.Pipelines.Tests/SpecificationAvailableSpecRefsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SpecificationAvailableSpecRefsTests.cs
@@ -1,0 +1,34 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Specifications;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class SpecificationAvailableSpecRefsTests
+{
+    [Fact]
+    public void AvailableSpecRefs_AreNonEmpty_AndCanonicallyNamed()
+    {
+        var refs = Specification.AvailableSpecRefs;
+        Assert.NotEmpty(refs);
+        Assert.All(refs, r => Assert.StartsWith("S-", r.Name, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AvailableSpecRefs_ContainOneEntryPerAvailableSpec()
+    {
+        Assert.Equal(Specification.AvailableSpecs.Count, Specification.AvailableSpecRefs.Count);
+        foreach (var name in Specification.AvailableSpecs)
+        {
+            Assert.Contains(Specification.AvailableSpecRefs, r => r.Name == name);
+        }
+    }
+
+    [Fact]
+    public void AvailableSpecRefs_UseDefaultVersion()
+    {
+        // Without a per-bundle manifest declaring the spec edition, refs use
+        // SpecVersion default (0.0.0) as a sentinel for "edition unspecified".
+        Assert.All(Specification.AvailableSpecRefs, r => Assert.Equal(default(SpecVersion), r.Edition));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml;
@@ -214,7 +215,7 @@ public sealed class TelemetrySmokeTests
             ViewingGroups = viewingGroups ?? new ViewingGroupController();
         }
 
-        public string ProductSpec => "S-101";
+        public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
         public void SwitchPalette(PaletteType type) { }

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
@@ -1,4 +1,5 @@
 using System.Xml;
+using EncDotNet.S100.Core;
 using System.Xml.Xsl;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
@@ -597,7 +598,7 @@ public class VectorPipelineTests
             ViewingGroups = viewingGroups ?? new ViewingGroupController();
         }
 
-        public string ProductSpec => "S-101";
+        public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
         public void SwitchPalette(PaletteType type) { }

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
@@ -19,9 +20,11 @@ public class FeatureSearchServiceTests
         public FakeProcessor(string spec, params FeatureSummary[] features)
         {
             ProductSpec = spec;
+            Spec = new SpecRef(spec, default);
             _features = features;
         }
         public string ProductSpec { get; }
+        public SpecRef Spec { get; }
         public DatasetResult Render(RenderContext? context = null) => throw new NotSupportedException();
         public FeatureInfo? GetFeatureInfo(string featureRef) => null;
         public IEnumerable<FeatureSummary> EnumerateFeatures() => _features;

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
@@ -123,12 +124,14 @@ public class PickServiceTests
         public StubProcessor(string spec, params FeatureInfo[] features)
         {
             ProductSpec = spec;
+            Spec = new SpecRef(spec, default);
             _features = new Dictionary<string, FeatureInfo>();
             foreach (var f in features)
                 _features[f.FeatureRef] = f;
         }
 
         public string ProductSpec { get; }
+        public SpecRef Spec { get; }
         public DatasetResult Render(RenderContext? context = null)
             => throw new NotSupportedException();
         public FeatureInfo? GetFeatureInfo(string featureRef)

--- a/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
+++ b/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
@@ -126,7 +126,7 @@ public sealed class RenderHarness : IDisposable
 
         // Time-series specs need a DateTime resolved from the time-step index.
         DateTime? timeStep = null;
-        if (options.TimeStepIndex > 0 || processor.ProductSpec is "S-104" or "S-111")
+        if (options.TimeStepIndex > 0 || processor.Spec.Name is "S-104" or "S-111")
         {
             // Reach for the AvailableTimes property (publicly defined on the
             // concrete S104/S111 processors) without a hard reference.
@@ -141,7 +141,7 @@ public sealed class RenderHarness : IDisposable
             }
         }
 
-        return processor.ProductSpec switch
+        return processor.Spec.Name switch
         {
             "S-101" => new S101RenderContext { Palette = palette, SymbolScale = symScale, TextScale = txtScale },
             "S-102" => new S102RenderContext { Palette = palette, SymbolScale = symScale, TextScale = txtScale },

--- a/tools/EncDotNet.S100.PerfReport/GateCommand.cs
+++ b/tools/EncDotNet.S100.PerfReport/GateCommand.cs
@@ -138,11 +138,21 @@ public sealed class GateCommand : Command<GateCommand.Settings>
             });
         }
 
-        // Metric totals.
-        var baseMetrics = baseline.Metrics.ToDictionary(
-            m => m.Name + "|" + string.Join(",", m.Tags.Select(t => $"{t.Key}={t.Value}")));
-        var candMetrics = candidate.Metrics.ToDictionary(
-            m => m.Name + "|" + string.Join(",", m.Tags.Select(t => $"{t.Key}={t.Value}")));
+        // Metric totals. The OTel periodic exporter emits one record per
+        // export cycle (every 5s); a long-running scenario therefore writes
+        // multiple records per (name, tags) tuple. Counter / histogram
+        // records use cumulative temporality, so the LAST record per key
+        // contains the total for the run — keep it and discard earlier
+        // snapshots rather than crashing on duplicate keys.
+        static string MetricKey(MetricRecord m) =>
+            m.Name + "|" + string.Join(",", m.Tags.OrderBy(t => t.Key).Select(t => $"{t.Key}={t.Value}"));
+
+        var baseMetrics = baseline.Metrics
+            .GroupBy(MetricKey)
+            .ToDictionary(g => g.Key, g => g.Last());
+        var candMetrics = candidate.Metrics
+            .GroupBy(MetricKey)
+            .ToDictionary(g => g.Key, g => g.Last());
 
         foreach (var key in baseMetrics.Keys.Union(candMetrics.Keys).OrderBy(k => k))
         {


### PR DESCRIPTION
## Summary

Replaces the bare `string` product-spec identifier (`"S-101"`) that has been threaded through readers, processors, managers, and pipeline contracts with a strongly-typed pair of value types:

- `SpecRef` = (Name, Edition) — what a *dataset* declares conformance to.
- `CatalogueRef` = (Name, Version) — what a Feature or Portrayal Catalogue file *is*.

The two are deliberately separate types: a dataset's declared spec edition and a catalogue's version are different concepts that a same-major mismatch is a normal, S-100 Part 2 §6 backward-compatible read between. Treating them as the same type encouraged conflation that this PR removes.

On top of that, the FC and PC managers now expose `ICatalogueProvider<TCatalogue>` so dataset processors can ask for catalogues uniformly, and a `CatalogueResolutionDiagnostics` helper emits a structured Activity event + counter (`s100.catalogue.match` / `s100.catalogue.match.count`) the first time each processor resolves a catalogue, tagged with the versions and a `SpecCompatibility.Classify` result (Exact, CatalogueNewerCompatible, CatalogueOlder, MajorDivergence).

Delivered in four phases on this branch:

1. New value types (`SpecVersion`, `SpecRef`, `CatalogueRef`, `SpecName`) with parsing, normalisation, and `IsBackwardCompatibleWith` per S-100 Part 2 §6.
2. FC and PC managers rekeyed by `SpecRef`; `FeatureCatalogue.CatalogueRef` and `PortrayalCatalogue.CatalogueRef` populated from the parsed XML so catalogues self-describe.
3. `IDatasetProcessor.ProductSpec : string` replaced with `Spec : SpecRef`. Touches all 13 per-spec processors, the GML base, both vector/coverage source contracts, `DatasetResult`, and viewer call sites that read the name. Viewer DTOs (display/persistence shapes) intentionally keep a `string ProductSpec`.
4. `SpecCompatibility` + `SpecMatchPolicy { Exact, SameMajor, AnyVersion }` + `ICatalogueProvider<T>` + the diagnostic helper, wired into the GML base (covers 9 processors) plus S-101, S-102, S-111, S-57.

## Spec alignment

Check each spec this PR touches and confirm the relevant skill was
consulted (`.github/skills/<spec>/SKILL.md`):

- [x] S-100 framework (`s100-framework`)
- [x] S-101 ENC (`s101-enc`)
- [x] S-102 bathymetry (`s102-bathymetry`)
- [x] S-104 water level (`s104-water-level`)
- [x] S-111 surface currents (`s111-surface-currents`)
- [x] S-124 navigational warnings (`s124-nav-warnings`)
- [x] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

Also touches S-122, S-125, S-127, S-128, S-411, S-421 (each per-spec processor migrated); the change is mechanical for those.

**Spec section references cited in code/docs:**

S-100 Edition 5.2.1 Part 2 §6 (Maintenance) — drives the `SpecVersion.IsBackwardCompatibleWith` semantics, `SpecMatchPolicy.SameMajor` rules, and `SpecMatchKind` classification. Cited in XML doc comments on `SpecVersion`, `SpecCompatibility`, and `CatalogueResolutionDiagnostics`.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

845 tests pass across 18 test assemblies (was 821 before this PR; +24 new). New test files: `SpecVersionTests`, `SpecRefTests`, `CatalogueRefTests`, `SpecNameTests`, `SpecCompatibilityTests` (Core), `CatalogueResolutionDiagnosticsTests` (Pipelines), plus `ICatalogueProvider` cases extending the manager test files.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` — N/A; no user-facing API additions beyond the new types, which carry full XML docs.
- [x] Updated conceptual docs under `docs/` if user-facing behaviour
      changed — N/A; this is an internal contract refactor.
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to
      `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency — N/A, no new dependencies.

## Breaking changes

Binary-breaking for direct consumers of the pipeline contracts:

- `IDatasetProcessor.ProductSpec : string` → `Spec : SpecRef`.
- `IPortrayalCatalogue.ProductSpec : string` → `Spec : SpecRef`.
- `IVectorSource.VectorMetadata.ProductSpec` and `CoverageMetadata.ProductSpec` → `Spec : SpecRef`.
- `DatasetResult.ProductSpec` → `Spec : SpecRef`.
- `GmlPortrayalCatalogueBase.ProductSpec` → abstract `Spec : SpecRef`.

The `string` overloads on `FeatureCatalogueManager` and `PortrayalCatalogueManager` are kept (no `[Obsolete]` yet) so existing callers continue to compile. Marking them obsolete is a deliberate follow-up; today every per-spec processor still calls `GetProvider("S-XXX")` with a literal name and would generate ~25 internal warnings until those call sites are migrated to thread the dataset's actual edition through.

## Deferred follow-ups

Captured to keep this PR reviewable; each is candidate for its own PR:

1. Mark the `string` overloads on the FC/PC managers `[Obsolete]` once all per-spec processors thread real `SpecRef`s through.
2. Migrate `DatasetPipelineFactory.DetectProductSpec : string?` → `DetectSpec : SpecRef?` (parse HDF5 `productSpecification` version, GML application-namespace versions, exchange set entries).
3. Thread the actual product-spec edition into HDF5 coverage `SpecRef`s (S-102/S-104/S-111 currently emit `default` for `Edition`).
4. Multi-edition packaging in `EncDotNet.S100.Specifications/content/Sxxx/<edition>/` once a real second edition lands.
5. Add `FeatureCatalogueManager.GetCatalogue(SpecRef, SpecMatchPolicy)` with same-major fallback wired through `SpecCompatibility`.