### PR TITLE
Build and publish a notarized macOS DMG from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,83 @@ jobs:
           echo "::warning::Stapling failed after 5 attempts. The app is still notarized; Gatekeeper will verify online."
           exit 1
 
+      - name: Read viewer version
+        if: matrix.rid == 'osx-arm64'
+        id: viewer_version
+        run: |
+          VERSION=$(grep -oE '<Version>[^<]+' src/Directory.Build.props | sed 's/<Version>//')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read <Version> from src/Directory.Build.props"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build macOS DMG
+        if: matrix.rid == 'osx-arm64'
+        env:
+          VERSION: ${{ steps.viewer_version.outputs.version }}
+        run: |
+          DMG_NAME="EncDotNet.S100.Viewer-${VERSION}.dmg"
+          STAGING="$(mktemp -d)/dmg"
+          mkdir -p "$STAGING"
+          cp -R EncDotNet.S100.Viewer.app "$STAGING/"
+          ln -s /Applications "$STAGING/Applications"
+          hdiutil create \
+            -volname "S-100 Viewer" \
+            -srcfolder "$STAGING" \
+            -ov -format UDZO \
+            "$DMG_NAME"
+          echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
+
+      - name: Sign macOS DMG
+        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "$DMG_NAME"
+
+      - name: Notarize macOS DMG
+        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          xcrun notarytool submit "$DMG_NAME" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait \
+            --output-format json | tee dmg-notarization-result.json
+          STATUS=$(python3 -c "import json,sys; print(json.load(sys.stdin)['status'])" < dmg-notarization-result.json)
+          ID=$(python3 -c "import json,sys; print(json.load(sys.stdin)['id'])" < dmg-notarization-result.json)
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "::error::DMG notarization failed with status: $STATUS"
+            xcrun notarytool log "$ID" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_PASSWORD"
+            exit 1
+          fi
+
+      - name: Staple notarization ticket to DMG
+        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        continue-on-error: true
+        run: |
+          # Same retry shape as the .app stapler step: the notarization
+          # ticket may not yet be available in CloudKit. The DMG is
+          # still notarized — Gatekeeper will verify online if the
+          # ticket is absent.
+          for i in 1 2 3 4 5; do
+            if xcrun stapler staple "$DMG_NAME"; then
+              exit 0
+            fi
+            echo "DMG staple attempt $i failed, waiting 30s..."
+            sleep 30
+          done
+          echo "::warning::DMG stapling failed after 5 attempts. The DMG is still notarized; Gatekeeper will verify online."
+          exit 1
+
       - name: Archive macOS .app bundle
         if: matrix.rid == 'osx-arm64'
         run: tar -czf "${{ matrix.artifact }}.tar.gz" EncDotNet.S100.Viewer.app
@@ -256,6 +333,13 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.tar.gz
+
+      - name: Upload macOS DMG
+        if: matrix.rid == 'osx-arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}-dmg
+          path: ${{ env.DMG_NAME }}
 
   publish-nuget:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -305,3 +389,4 @@ jobs:
           files: |
             artifacts/nupkgs/*.nupkg
             artifacts/Viewer-*/*.tar.gz
+            artifacts/Viewer-*-dmg/*.dmg

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -3,6 +3,23 @@
 Cross-platform desktop viewer for IHO S-100 nautical chart data,
 built on Avalonia 11 + Mapsui 5.
 
+## Installation
+
+Each release attaches per-platform builds at
+[github.com/philliphoff/EncDotNet.S100/releases](https://github.com/philliphoff/EncDotNet.S100/releases).
+
+- **macOS (Apple Silicon)** — download
+  `EncDotNet.S100.Viewer-<version>.dmg`, open it, and drag
+  **S-100 Viewer** to **Applications**. The DMG, the bundled `.app`,
+  and the embedded executable are all signed with a Developer ID
+  certificate and notarized by Apple, so Gatekeeper will accept them
+  without a manual override. A legacy
+  `Viewer-osx-arm64.tar.gz` is also published during a transition
+  period; expanding it produces the same `.app`.
+- **Windows / Linux** — download `Viewer-<rid>.tar.gz` for your
+  architecture and extract it; run `EncDotNet.S100.Viewer` from the
+  extracted directory.
+
 ## Pick / Object Information panel
 
 Toggle **Pick Mode** (cross-hair toolbar button, **View → Appearance →


### PR DESCRIPTION
## Summary

The viewer's release pipeline already builds, signs, notarizes, and staples an `EncDotNet.S100.Viewer.app` on macOS, but only ships it as `Viewer-osx-arm64.tar.gz`. macOS users expect a DMG with a drag-to-Applications symlink; this PR adds one to the existing `publish` job's `osx-arm64` branch, signs and notarizes it with the same Developer ID credentials already in use, and attaches it to GitHub Releases.

The tarball stays during a transition period so existing consumers don't break.

### What changed

Six new steps in `.github/workflows/ci.yml`, all gated on `matrix.rid == 'osx-arm64'` (and `HAS_SIGNING_SECRETS` for the sign/notarize/staple steps):

1. Read `<Version>` from `src/Directory.Build.props`.
2. `hdiutil create` a UDZO DMG from a staging dir containing the already-stapled `.app` plus an `/Applications` symlink (volume name `S-100 Viewer`, filename `EncDotNet.S100.Viewer-<version>.dmg`).
3. `codesign --timestamp` the DMG with the existing Developer ID identity.
4. Submit the DMG to `xcrun notarytool` reusing the existing Apple ID / team ID / app password secrets.
5. `xcrun stapler staple` with the same 5x30s retry pattern used for the `.app`.
6. Upload the DMG as its own workflow artifact (`Viewer-osx-arm64-dmg`); extend the `create-release` files glob to include `artifacts/Viewer-*-dmg/*.dmg`.

`src/EncDotNet.S100.Viewer/README.md` gains a short "Installation" section pointing macOS users at the DMG.

### Out of scope (deliberate follow-ups)

- Custom DMG layout (background image, icon positions).
- Retiring the `.tar.gz` artifact and dropping the redundant zipped-`.app` notarization (the DMG notarization covers the nested `.app`).
- Universal binary (`osx-x64` + `osx-arm64` lipo). The release is arm64-only today; that's orthogonal to packaging format.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

CI-only change; no unit-testable surface. The new steps will be exercised end-to-end by the next tag push (notarization requires the production secrets, which only exist on `main`).

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No dependencies added. The DMG flow uses stock `hdiutil`, `codesign`, `xcrun notarytool`, and `xcrun stapler` from the macOS runner image.

## Breaking changes

None. The existing `Viewer-osx-arm64.tar.gz` artifact and release attachment are unchanged.