### PR TITLE
Add S-100 exchange set digital signature verification

### DIFF
--- a/src/EncDotNet.S100.ExchangeSets/CatalogueDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/CatalogueDiscoveryMetadata.cs
@@ -18,6 +18,17 @@ public sealed class CatalogueDiscoveryMetadata
 
     public string? DigitalSignatureReference { get; init; }
 
+    /// <summary>
+    /// The parsed digital signature algorithm, derived from <see cref="DigitalSignatureReference"/>.
+    /// </summary>
+    public DigitalSignatureAlgorithm DigitalSignatureAlgorithm { get; init; }
+
+    /// <summary>
+    /// The digital signature value for this catalogue file, if present.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
+    public DigitalSignatureValue? DigitalSignatureValue { get; init; }
+
     public bool CompressionFlag { get; init; }
 
     public string? DefaultLocaleLanguage { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/CertificateBlock.cs
+++ b/src/EncDotNet.S100.ExchangeSets/CertificateBlock.cs
@@ -1,0 +1,23 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Represents the <c>certificates</c> block in an exchange catalogue, containing
+/// the scheme administrator identifier and the certificate chain.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-5. The block embeds the public-key certificates
+/// used to verify the per-file digital signatures in the catalogue.
+/// </remarks>
+public sealed class CertificateBlock
+{
+    /// <summary>
+    /// The <c>id</c> attribute of the <c>schemeAdministrator</c> element
+    /// (e.g. <c>"urn:mrn:iho:s62:iic:2C:key1"</c>).
+    /// </summary>
+    public string? SchemeAdministratorId { get; init; }
+
+    /// <summary>
+    /// The certificates declared in this block.
+    /// </summary>
+    public IReadOnlyList<CertificateEntry> Certificates { get; init; } = [];
+}

--- a/src/EncDotNet.S100.ExchangeSets/CertificateEntry.cs
+++ b/src/EncDotNet.S100.ExchangeSets/CertificateEntry.cs
@@ -1,0 +1,29 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// A single certificate entry from the <c>certificates</c> block in an exchange catalogue.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-5.2. Each entry contains an X.509 certificate
+/// (DER-encoded, base64-wrapped) with an <c>id</c> attribute that digital signatures
+/// reference via <see cref="DigitalSignatureValue.CertificateRef"/>.
+/// </remarks>
+public sealed class CertificateEntry
+{
+    /// <summary>
+    /// The <c>id</c> attribute — a URI that signatures use to reference this certificate
+    /// (e.g. <c>"urn:mrn:iho:s62:iic:2C:key1"</c>).
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The <c>issuer</c> attribute — the issuing authority name
+    /// (e.g. <c>"IHO Scretariat"</c>).
+    /// </summary>
+    public string? Issuer { get; init; }
+
+    /// <summary>
+    /// The raw base64-decoded certificate bytes (DER-encoded X.509).
+    /// </summary>
+    public required byte[] Value { get; init; }
+}

--- a/src/EncDotNet.S100.ExchangeSets/DatasetDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/DatasetDiscoveryMetadata.cs
@@ -12,6 +12,17 @@ public sealed class DatasetDiscoveryMetadata
 
     public string? DigitalSignatureReference { get; init; }
 
+    /// <summary>
+    /// The parsed digital signature algorithm, derived from <see cref="DigitalSignatureReference"/>.
+    /// </summary>
+    public DigitalSignatureAlgorithm DigitalSignatureAlgorithm { get; init; }
+
+    /// <summary>
+    /// The digital signature value for this dataset file, if present.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
+    public DigitalSignatureValue? DigitalSignatureValue { get; init; }
+
     public bool Copyright { get; init; }
 
     public string? Classification { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/DigitalSignatureAlgorithm.cs
+++ b/src/EncDotNet.S100.ExchangeSets/DigitalSignatureAlgorithm.cs
@@ -1,0 +1,21 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Identifies the digital signature algorithm used to sign an exchange set file.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-4.1. The <c>digitalSignatureReference</c> element
+/// in <c>S100_DatasetDiscoveryMetadata</c> and related types uses these values to
+/// indicate which algorithm was used to produce the accompanying signature.
+/// </remarks>
+public enum DigitalSignatureAlgorithm
+{
+    /// <summary>The algorithm is not recognised.</summary>
+    Unknown = 0,
+
+    /// <summary>Digital Signature Algorithm (DSA) — legacy, S-63 derived.</summary>
+    DSA = 1,
+
+    /// <summary>Elliptic Curve Digital Signature Algorithm (ECDSA P-256) — S-100 Part 15.</summary>
+    ECDSA = 2,
+}

--- a/src/EncDotNet.S100.ExchangeSets/DigitalSignatureValue.cs
+++ b/src/EncDotNet.S100.ExchangeSets/DigitalSignatureValue.cs
@@ -1,0 +1,30 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Represents a parsed <c>S100_SE_DigitalSignature</c> element from an exchange catalogue.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-4.2. Each dataset, support file, and catalogue
+/// discovery metadata entry may carry a digital signature value that can be verified
+/// against the certificate identified by <see cref="CertificateRef"/>.
+/// </remarks>
+public sealed class DigitalSignatureValue
+{
+    /// <summary>
+    /// The <c>id</c> attribute of the <c>S100_SE_DigitalSignature</c> element
+    /// (e.g. <c>"SIG101AA0000DS0009"</c>).
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The <c>certificateRef</c> attribute — a URI that identifies the certificate
+    /// whose public key should be used to verify this signature
+    /// (e.g. <c>"urn:mrn:iho:s62:iic:2C:key1"</c>).
+    /// </summary>
+    public required string CertificateRef { get; init; }
+
+    /// <summary>
+    /// The raw base64-decoded signature bytes.
+    /// </summary>
+    public required byte[] Value { get; init; }
+}

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogue.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogue.cs
@@ -23,4 +23,11 @@ public sealed class ExchangeCatalogue
     public IReadOnlyList<SupportFileDiscoveryMetadata> SupportFileDiscoveryMetadata { get; init; } = [];
 
     public IReadOnlyList<CatalogueDiscoveryMetadata> CatalogueDiscoveryMetadata { get; init; } = [];
+
+    /// <summary>
+    /// The certificate block from the catalogue, containing the scheme administrator
+    /// identifier and embedded X.509 certificates used to verify per-file signatures.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-5.</remarks>
+    public CertificateBlock? Certificates { get; init; }
 }

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -11,6 +11,7 @@ public static class ExchangeCatalogueReader
     private static readonly XNamespace Gex = "http://standards.iso.org/iso/19115/-3/gex/1.0";
     private static readonly XNamespace Cit = "http://standards.iso.org/iso/19115/-3/cit/2.0";
     private static readonly XNamespace Mri = "http://standards.iso.org/iso/19115/-3/mri/1.0";
+    private static readonly XNamespace S100SE = "http://www.iho.int/s100/se/5.0";
 
     public static ExchangeCatalogue Read(Stream stream)
     {
@@ -51,6 +52,7 @@ public static class ExchangeCatalogueReader
             Description = ReadCharacterString(root.Element(xc + "exchangeCatalogueDescription")),
             Comment = ReadCharacterString(root.Element(xc + "exchangeCatalogueComment")),
             DataServerIdentifier = (string?)root.Element(xc + "dataServerIdentifier"),
+            Certificates = ReadCertificateBlock(root.Element(xc + "certificates")),
             DatasetDiscoveryMetadata = root
                 .Element(xc + "datasetDiscoveryMetadata")?
                 .Elements(xc + "S100_DatasetDiscoveryMetadata")
@@ -115,6 +117,8 @@ public static class ExchangeCatalogueReader
             CompressionFlag = ParseBool(element, "compressionFlag", xc),
             DataProtection = ParseBool(element, "dataProtection", xc),
             DigitalSignatureReference = (string?)element.Element(xc + "digitalSignatureReference"),
+            DigitalSignatureAlgorithm = ParseSignatureAlgorithm(element, xc),
+            DigitalSignatureValue = ReadDigitalSignatureValue(element.Element(xc + "digitalSignatureValue")),
             Copyright = ParseBool(element, "copyright", xc),
             Classification = ReadCodeListValue(element.Element(xc + "classification")),
             Purpose = (string?)element.Element(xc + "purpose"),
@@ -153,6 +157,8 @@ public static class ExchangeCatalogueReader
             DataType = (string?)element.Element(xc + "dataType"),
             CompressionFlag = ParseBool(element, "compressionFlag", xc),
             DigitalSignatureReference = (string?)element.Element(xc + "digitalSignatureReference"),
+            DigitalSignatureAlgorithm = ParseSignatureAlgorithm(element, xc),
+            DigitalSignatureValue = ReadDigitalSignatureValue(element.Element(xc + "digitalSignatureValue")),
             SupportedResources = element
                 .Elements(xc + "supportedResource")
                 .Select(e => e.Value.Trim())
@@ -175,6 +181,8 @@ public static class ExchangeCatalogueReader
             IssueDate = (string?)element.Element(xc + "issueDate"),
             ProductSpecification = ReadProductSpecification(element.Element(xc + "productSpecification"), xc),
             DigitalSignatureReference = (string?)element.Element(xc + "digitalSignatureReference"),
+            DigitalSignatureAlgorithm = ParseSignatureAlgorithm(element, xc),
+            DigitalSignatureValue = ReadDigitalSignatureValue(element.Element(xc + "digitalSignatureValue")),
             CompressionFlag = ParseBool(element, "compressionFlag", xc),
             DefaultLocaleLanguage = ReadLocaleLanguage(defaultLocaleEl, lan),
             DefaultLocaleCharacterEncoding = ReadLocaleCharacterEncoding(defaultLocaleEl, lan),
@@ -292,5 +300,86 @@ public static class ExchangeCatalogueReader
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Parses the <c>digitalSignatureReference</c> element value into a
+    /// <see cref="DigitalSignatureAlgorithm"/> enum.
+    /// </summary>
+    private static DigitalSignatureAlgorithm ParseSignatureAlgorithm(XElement parent, XNamespace xc)
+    {
+        var value = (string?)parent.Element(xc + "digitalSignatureReference");
+        return value?.Trim().ToUpperInvariant() switch
+        {
+            "DSA" => DigitalSignatureAlgorithm.DSA,
+            "ECDSA" => DigitalSignatureAlgorithm.ECDSA,
+            _ => DigitalSignatureAlgorithm.Unknown,
+        };
+    }
+
+    /// <summary>
+    /// Parses an <c>S100_SE_DigitalSignature</c> element nested inside a
+    /// <c>digitalSignatureValue</c> wrapper.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
+    private static DigitalSignatureValue? ReadDigitalSignatureValue(XElement? wrapper)
+    {
+        if (wrapper is null) return null;
+
+        var sigEl = wrapper.Element(S100SE + "S100_SE_DigitalSignature");
+        if (sigEl is null) return null;
+
+        var id = (string?)sigEl.Attribute("id");
+        var certRef = (string?)sigEl.Attribute("certificateRef");
+        var base64 = sigEl.Value.Trim();
+
+        if (id is null || certRef is null || base64.Length == 0)
+            return null;
+
+        return new DigitalSignatureValue
+        {
+            Id = id,
+            CertificateRef = certRef,
+            Value = Convert.FromBase64String(base64),
+        };
+    }
+
+    /// <summary>
+    /// Parses the <c>certificates</c> block containing the scheme administrator
+    /// identifier and embedded X.509 certificates.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-5.</remarks>
+    private static CertificateBlock? ReadCertificateBlock(XElement? element)
+    {
+        if (element is null) return null;
+
+        var saId = (string?)element.Element(S100SE + "schemeAdministrator")?.Attribute("id");
+
+        var certs = element
+            .Elements(S100SE + "certificate")
+            .Select(c =>
+            {
+                var id = (string?)c.Attribute("id");
+                var issuer = (string?)c.Attribute("issuer");
+                var base64 = c.Value.Trim();
+
+                if (id is null || base64.Length == 0)
+                    return null;
+
+                return new CertificateEntry
+                {
+                    Id = id,
+                    Issuer = issuer,
+                    Value = Convert.FromBase64String(base64),
+                };
+            })
+            .Where(c => c is not null)
+            .ToList()!;
+
+        return new CertificateBlock
+        {
+            SchemeAdministratorId = saId,
+            Certificates = certs!,
+        };
     }
 }

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerificationResult.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerificationResult.cs
@@ -1,0 +1,28 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// The aggregate result of verifying all files in an exchange set.
+/// </summary>
+public sealed class ExchangeSetVerificationResult
+{
+    /// <summary>Per-file verification results.</summary>
+    public required IReadOnlyList<FileVerificationResult> FileResults { get; init; }
+
+    /// <summary>
+    /// Returns <c>true</c> when every file in the exchange set has
+    /// <see cref="VerificationOutcome.Ok"/> as its outcome.
+    /// </summary>
+    public bool AllValid => FileResults.All(r => r.Outcome == VerificationOutcome.Ok);
+
+    /// <summary>
+    /// Returns <c>true</c> when at least one file has
+    /// <see cref="VerificationOutcome.SignatureInvalid"/>.
+    /// </summary>
+    public bool HasInvalidSignatures => FileResults.Any(r => r.Outcome == VerificationOutcome.SignatureInvalid);
+
+    /// <summary>
+    /// Returns <c>true</c> when no file carries a signature
+    /// (all are <see cref="VerificationOutcome.NotSigned"/>).
+    /// </summary>
+    public bool IsUnsigned => FileResults.All(r => r.Outcome == VerificationOutcome.NotSigned);
+}

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerifier.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerifier.cs
@@ -1,0 +1,302 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.ExchangeSets.Diagnostics;
+
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Verifies the per-file digital signatures in an S-100 exchange set.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15. Signatures are computed over the raw bytes of
+/// each referenced file and verified against the certificate identified by
+/// <see cref="DigitalSignatureValue.CertificateRef"/>.
+/// </remarks>
+public sealed class ExchangeSetVerifier : IExchangeSetVerifier
+{
+    /// <summary>Buffer size used when streaming file content for hashing.</summary>
+    private const int StreamBufferSize = 81920;
+
+    /// <inheritdoc />
+    public async Task<ExchangeSetVerificationResult> VerifyAsync(
+        IAssetSource source,
+        ExchangeCatalogue catalogue,
+        TrustAnchorOptions trustAnchors,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(catalogue);
+        ArgumentNullException.ThrowIfNull(trustAnchors);
+
+        using var activity = Telemetry.ActivitySource.StartActivity("s100.exchangeset.verify");
+
+        // Build a lookup of certificateRef → CertificateEntry from the catalogue.
+        var certLookup = BuildCertificateLookup(catalogue);
+
+        var results = new List<FileVerificationResult>();
+
+        // Verify datasets
+        foreach (var ds in catalogue.DatasetDiscoveryMetadata)
+        {
+            var result = await VerifyFileAsync(
+                source, ds.FileName, ds.DigitalSignatureValue, ds.DigitalSignatureAlgorithm,
+                certLookup, trustAnchors, cancellationToken);
+            results.Add(result);
+        }
+
+        // Verify support files
+        foreach (var sf in catalogue.SupportFileDiscoveryMetadata)
+        {
+            var result = await VerifyFileAsync(
+                source, sf.FileName, sf.DigitalSignatureValue, sf.DigitalSignatureAlgorithm,
+                certLookup, trustAnchors, cancellationToken);
+            results.Add(result);
+        }
+
+        // Verify catalogue files
+        foreach (var cf in catalogue.CatalogueDiscoveryMetadata)
+        {
+            var result = await VerifyFileAsync(
+                source, cf.FileName, cf.DigitalSignatureValue, cf.DigitalSignatureAlgorithm,
+                certLookup, trustAnchors, cancellationToken);
+            results.Add(result);
+        }
+
+        activity?.SetTag("s100.exchangeset.verify.file_count", results.Count);
+        activity?.SetTag("s100.exchangeset.verify.ok_count",
+            results.Count(r => r.Outcome == VerificationOutcome.Ok));
+
+        return new ExchangeSetVerificationResult { FileResults = results };
+    }
+
+    private static async Task<FileVerificationResult> VerifyFileAsync(
+        IAssetSource source,
+        string fileName,
+        DigitalSignatureValue? signatureValue,
+        DigitalSignatureAlgorithm algorithm,
+        Dictionary<string, CertificateEntry> certLookup,
+        TrustAnchorOptions trustAnchors,
+        CancellationToken cancellationToken)
+    {
+        if (signatureValue is null)
+        {
+            return new FileVerificationResult
+            {
+                FileName = fileName,
+                Outcome = VerificationOutcome.NotSigned,
+            };
+        }
+
+        // Resolve the certificate
+        if (!certLookup.TryGetValue(signatureValue.CertificateRef, out var certEntry))
+        {
+            return new FileVerificationResult
+            {
+                FileName = fileName,
+                Outcome = VerificationOutcome.CertificateNotFound,
+                Detail = $"Certificate '{signatureValue.CertificateRef}' not found in catalogue.",
+            };
+        }
+
+        X509Certificate2 cert;
+        try
+        {
+#if NET10_0_OR_GREATER
+            cert = X509CertificateLoader.LoadCertificate(certEntry.Value);
+#else
+            cert = new X509Certificate2(certEntry.Value);
+#endif
+        }
+        catch (CryptographicException ex)
+        {
+            return new FileVerificationResult
+            {
+                FileName = fileName,
+                Outcome = VerificationOutcome.Error,
+                Detail = $"Failed to parse certificate '{signatureValue.CertificateRef}': {ex.Message}",
+            };
+        }
+
+        using (cert)
+        {
+            // Check certificate trust
+            var trustOutcome = ValidateCertificateTrust(cert, trustAnchors);
+            if (trustOutcome is not null)
+            {
+                return new FileVerificationResult
+                {
+                    FileName = fileName,
+                    Outcome = trustOutcome.Value,
+                    Detail = trustOutcome.Value == VerificationOutcome.CertificateExpired
+                        ? $"Certificate '{signatureValue.CertificateRef}' expired on {cert.NotAfter:O}."
+                        : $"Certificate '{signatureValue.CertificateRef}' is not trusted.",
+                };
+            }
+
+            // Hash the file content
+            byte[] fileHash;
+            try
+            {
+                var normalizedPath = ExchangeSet.NormalizeFileName(fileName);
+                await using var stream = await source.OpenAsync(normalizedPath, cancellationToken);
+                fileHash = await ComputeSha256HashAsync(stream, cancellationToken);
+            }
+            catch (FileNotFoundException)
+            {
+                return new FileVerificationResult
+                {
+                    FileName = fileName,
+                    Outcome = VerificationOutcome.FileMissing,
+                };
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return new FileVerificationResult
+                {
+                    FileName = fileName,
+                    Outcome = VerificationOutcome.Error,
+                    Detail = $"Failed to read file: {ex.Message}",
+                };
+            }
+
+            // Verify the signature
+            bool valid;
+            try
+            {
+                valid = VerifySignature(cert, algorithm, fileHash, signatureValue.Value);
+            }
+            catch (CryptographicException ex)
+            {
+                return new FileVerificationResult
+                {
+                    FileName = fileName,
+                    Outcome = VerificationOutcome.Error,
+                    Detail = $"Signature verification error: {ex.Message}",
+                };
+            }
+
+            return new FileVerificationResult
+            {
+                FileName = fileName,
+                Outcome = valid ? VerificationOutcome.Ok : VerificationOutcome.SignatureInvalid,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Validates the certificate against the configured trust anchors.
+    /// Returns <c>null</c> if the certificate is trusted (or trust validation is skipped),
+    /// otherwise returns the appropriate <see cref="VerificationOutcome"/>.
+    /// </summary>
+    private static VerificationOutcome? ValidateCertificateTrust(
+        X509Certificate2 cert,
+        TrustAnchorOptions trustAnchors)
+    {
+        // Check expiry
+        var now = DateTimeOffset.UtcNow;
+        if (now < cert.NotBefore || now > cert.NotAfter)
+        {
+            return VerificationOutcome.CertificateExpired;
+        }
+
+        // If caller allows untrusted certs, skip chain validation
+        if (trustAnchors.AllowUntrustedCertificates)
+        {
+            return null;
+        }
+
+        // If no trusted roots configured, we cannot validate
+        if (trustAnchors.TrustedRoots.Count == 0)
+        {
+            return VerificationOutcome.CertificateUntrusted;
+        }
+
+        // Check if the certificate was issued by one of the trusted roots.
+        // S-100 Part 15 uses a simple two-level hierarchy:
+        //   SA root → Data Server certificate.
+        // We check if the cert's issuer matches any trusted root's subject.
+        foreach (var root in trustAnchors.TrustedRoots)
+        {
+            if (cert.Issuer == root.Subject ||
+                cert.Thumbprint == root.Thumbprint)
+            {
+                return null;
+            }
+        }
+
+        return VerificationOutcome.CertificateUntrusted;
+    }
+
+    /// <summary>
+    /// Verifies a signature over a SHA-256 file hash using the certificate's public key.
+    /// Supports both DSA and ECDSA algorithms.
+    /// </summary>
+    private static bool VerifySignature(
+        X509Certificate2 cert,
+        DigitalSignatureAlgorithm algorithm,
+        byte[] hash,
+        byte[] signature)
+    {
+        switch (algorithm)
+        {
+            case DigitalSignatureAlgorithm.ECDSA:
+            {
+                using var ecdsa = cert.GetECDsaPublicKey();
+                if (ecdsa is null)
+                    throw new CryptographicException("Certificate does not contain an ECDSA public key.");
+                return ecdsa.VerifyHash(hash, signature);
+            }
+
+            case DigitalSignatureAlgorithm.DSA:
+            {
+                using var dsa = cert.GetDSAPublicKey();
+                if (dsa is null)
+                    throw new CryptographicException("Certificate does not contain a DSA public key.");
+                return dsa.VerifySignature(hash, signature);
+            }
+
+            default:
+                throw new CryptographicException(
+                    $"Unsupported digital signature algorithm: {algorithm}");
+        }
+    }
+
+    /// <summary>
+    /// Computes a SHA-256 hash of the stream content, reading in chunks to
+    /// avoid loading the entire file into memory.
+    /// </summary>
+    private static async Task<byte[]> ComputeSha256HashAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        using var sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[StreamBufferSize];
+        int bytesRead;
+
+        while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+        {
+            sha256.AppendData(buffer, 0, bytesRead);
+        }
+
+        return sha256.GetHashAndReset();
+    }
+
+    /// <summary>
+    /// Builds a lookup from certificate <c>id</c> to <see cref="CertificateEntry"/>.
+    /// </summary>
+    private static Dictionary<string, CertificateEntry> BuildCertificateLookup(ExchangeCatalogue catalogue)
+    {
+        var lookup = new Dictionary<string, CertificateEntry>(StringComparer.Ordinal);
+
+        if (catalogue.Certificates is { } block)
+        {
+            foreach (var cert in block.Certificates)
+            {
+                lookup[cert.Id] = cert;
+            }
+        }
+
+        return lookup;
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/FileVerificationResult.cs
+++ b/src/EncDotNet.S100.ExchangeSets/FileVerificationResult.cs
@@ -1,0 +1,16 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// The verification result for a single file in an exchange set.
+/// </summary>
+public sealed class FileVerificationResult
+{
+    /// <summary>The file name as declared in the catalogue discovery metadata.</summary>
+    public required string FileName { get; init; }
+
+    /// <summary>The verification outcome for this file.</summary>
+    public required VerificationOutcome Outcome { get; init; }
+
+    /// <summary>Optional detail message (e.g. exception message on <see cref="VerificationOutcome.Error"/>).</summary>
+    public string? Detail { get; init; }
+}

--- a/src/EncDotNet.S100.ExchangeSets/IExchangeSetVerifier.cs
+++ b/src/EncDotNet.S100.ExchangeSets/IExchangeSetVerifier.cs
@@ -1,0 +1,25 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Verifies the digital signatures in an S-100 exchange set catalogue.
+/// </summary>
+/// <remarks>S-100 Edition 5.2.1 Part 15.</remarks>
+public interface IExchangeSetVerifier
+{
+    /// <summary>
+    /// Verifies the per-file digital signatures declared in <paramref name="catalogue"/>
+    /// against the files accessible through <paramref name="source"/>.
+    /// </summary>
+    /// <param name="source">The asset source containing the exchange set files.</param>
+    /// <param name="catalogue">The parsed exchange catalogue whose signatures to verify.</param>
+    /// <param name="trustAnchors">Trust anchor options controlling certificate chain validation.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A result enumerating per-file verification outcomes without throwing.</returns>
+    Task<ExchangeSetVerificationResult> VerifyAsync(
+        IAssetSource source,
+        ExchangeCatalogue catalogue,
+        TrustAnchorOptions trustAnchors,
+        CancellationToken cancellationToken = default);
+}

--- a/src/EncDotNet.S100.ExchangeSets/README.md
+++ b/src/EncDotNet.S100.ExchangeSets/README.md
@@ -1,6 +1,6 @@
 # EncDotNet.S100.ExchangeSets
 
-Reader for S-100 Exchange Set catalogues and dataset/support file discovery.
+Reader for S-100 Exchange Set catalogues, dataset/support file discovery, and digital signature verification.
 
 ## Overview
 
@@ -12,6 +12,90 @@ This library parses S-100 Exchange Set `CATALOG.XML` files and provides access t
 - **`DatasetDiscoveryMetadata`** — metadata for each dataset in the exchange set (file name, bounding box, product specification).
 - **`SupportFileDiscoveryMetadata`** — metadata for support files.
 - **`CatalogueDiscoveryMetadata`** — metadata for embedded catalogues.
+
+## Digital Signature Verification
+
+The library implements the S-100 Part 15 Data Protection Scheme for **signature verification**. Exchange sets may include per-file digital signatures (DSA or ECDSA P-256 over SHA-256) embedded in `CATALOG.XML`, along with a certificate block referencing the signing data provider.
+
+### Model types
+
+| Type | Description | S-100 Part 15 ref |
+|---|---|---|
+| `DigitalSignatureAlgorithm` | Enum: `DSA`, `ECDSA` | §15-4.1 |
+| `DigitalSignatureValue` | Parsed `S100_SE_DigitalSignature` (id, certificateRef, raw signature bytes) | §15-4.2 |
+| `CertificateBlock` | Certificate collection from the catalogue (scheme administrator ID + certificate entries) | §15-5 |
+| `CertificateEntry` | Individual X.509 certificate (id, issuer, DER-encoded bytes) | §15-5.2 |
+
+These are surfaced as properties on `DatasetDiscoveryMetadata`, `SupportFileDiscoveryMetadata`, `CatalogueDiscoveryMetadata` (via `DigitalSignatureAlgorithm` and `DigitalSignatureValue?`), and on `ExchangeCatalogue` (via `CertificateBlock?`).
+
+### Verification API
+
+```csharp
+// Create a verifier
+IExchangeSetVerifier verifier = new ExchangeSetVerifier();
+
+// Configure trust anchors (optional — pass trusted SA root certificates)
+var trust = new TrustAnchorOptions
+{
+    // For development/testing, skip certificate chain validation:
+    AllowUntrustedCertificates = true,
+
+    // For production, supply IHO SA root certificates:
+    // TrustedRoots = [saRootCert],
+};
+
+// Verify an exchange set
+ExchangeSetVerificationResult result = await verifier.VerifyAsync(
+    assetSource,    // IAssetSource (filesystem or ZIP)
+    catalogue,      // ExchangeCatalogue (from ExchangeCatalogueReader)
+    trust,
+    cancellationToken);
+
+// Inspect results
+if (result.IsUnsigned)
+{
+    // No signatures present — exchange set is unsigned
+}
+else if (result.AllValid)
+{
+    // All files have valid signatures
+}
+else if (result.HasInvalidSignatures)
+{
+    // At least one file has an invalid or untrusted signature
+    foreach (var file in result.FileResults)
+    {
+        Console.WriteLine($"{file.FileName}: {file.Outcome} — {file.Detail}");
+    }
+}
+```
+
+### Verification outcomes
+
+| `VerificationOutcome` | Meaning |
+|---|---|
+| `Ok` | Signature is valid and certificate is trusted (or trust check skipped) |
+| `NotSigned` | No digital signature present for this file |
+| `SignatureInvalid` | Signature does not match the file contents |
+| `CertificateUntrusted` | Signature is valid but the certificate is not trusted |
+| `CertificateExpired` | Certificate has expired |
+| `FileMissing` | Referenced file not found in the asset source |
+| `Error` | Unexpected error during verification |
+
+### Trust anchor model
+
+`TrustAnchorOptions` controls how certificate trust is evaluated:
+
+- **`TrustedRoots`** — a list of `X509Certificate2` instances representing trusted Scheme Administrator (SA) root certificates. A signing certificate's `Issuer` field is matched against these roots.
+- **`AllowUntrustedCertificates`** — when `true`, signatures are verified for correctness but certificate chain validation is skipped. This is useful during development or when loading exchange sets from unknown sources.
+
+The IHO publishes test SA certificates for interoperability testing. For production use, supply the official IHO SA root certificate.
+
+### Scope and limitations
+
+- **Verification only** — signing/authoring of exchange sets is not yet implemented.
+- **Encryption is out of scope** — Part 15 §3 Confidentiality (ENC permits, cell-level decryption) is not supported.
+- File hashing uses streaming SHA-256 to avoid loading large HDF5 files into memory.
 
 ## Installation
 

--- a/src/EncDotNet.S100.ExchangeSets/SupportFileDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/SupportFileDiscoveryMetadata.cs
@@ -18,6 +18,17 @@ public sealed class SupportFileDiscoveryMetadata
 
     public string? DigitalSignatureReference { get; init; }
 
+    /// <summary>
+    /// The parsed digital signature algorithm, derived from <see cref="DigitalSignatureReference"/>.
+    /// </summary>
+    public DigitalSignatureAlgorithm DigitalSignatureAlgorithm { get; init; }
+
+    /// <summary>
+    /// The digital signature value for this support file, if present.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
+    public DigitalSignatureValue? DigitalSignatureValue { get; init; }
+
     public IReadOnlyList<string> SupportedResources { get; init; } = [];
 
     public string? ResourcePurpose { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/TrustAnchorOptions.cs
+++ b/src/EncDotNet.S100.ExchangeSets/TrustAnchorOptions.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Options that configure the trust anchors used during exchange set signature verification.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15. The IHO Scheme Administrator (SA) public key is the
+/// root of trust. For interoperability testing, the IHO publishes test SA keys.
+/// </remarks>
+public sealed class TrustAnchorOptions
+{
+    /// <summary>
+    /// Trusted root certificates (IHO Scheme Administrator public keys).
+    /// When empty, certificate chain validation is skipped and
+    /// <see cref="AllowUntrustedCertificates"/> controls behaviour.
+    /// </summary>
+    public IReadOnlyList<X509Certificate2> TrustedRoots { get; init; } = [];
+
+    /// <summary>
+    /// When <c>true</c>, signature verification proceeds even when the
+    /// signing certificate cannot be chained to a trusted root. Useful
+    /// for development and inspection workflows.
+    /// </summary>
+    public bool AllowUntrustedCertificates { get; init; }
+}

--- a/src/EncDotNet.S100.ExchangeSets/VerificationOutcome.cs
+++ b/src/EncDotNet.S100.ExchangeSets/VerificationOutcome.cs
@@ -1,0 +1,32 @@
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// The outcome of verifying a single file or the catalogue as a whole.
+/// </summary>
+/// <remarks>S-100 Edition 5.2.1 Part 15.</remarks>
+public enum VerificationOutcome
+{
+    /// <summary>The signature was verified successfully.</summary>
+    Ok,
+
+    /// <summary>The file or catalogue carries no digital signature.</summary>
+    NotSigned,
+
+    /// <summary>The signature does not match the file content.</summary>
+    SignatureInvalid,
+
+    /// <summary>The signing certificate is not trusted by the configured trust anchors.</summary>
+    CertificateUntrusted,
+
+    /// <summary>The signing certificate has expired.</summary>
+    CertificateExpired,
+
+    /// <summary>The referenced file was not found in the asset source.</summary>
+    FileMissing,
+
+    /// <summary>The referenced certificate was not found in the catalogue.</summary>
+    CertificateNotFound,
+
+    /// <summary>An unexpected error occurred during verification.</summary>
+    Error,
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -94,6 +94,13 @@ internal static class Strings
     public static string Pane_ExchangeSetHeader_Count => Get(nameof(Pane_ExchangeSetHeader_Count));
     public static string Pane_ExchangeSetHeader_Unsupported => Get(nameof(Pane_ExchangeSetHeader_Unsupported));
     public static string Tooltip_CloseExchangeSet => Get(nameof(Tooltip_CloseExchangeSet));
+    public static string Tooltip_SignatureVerified => Get(nameof(Tooltip_SignatureVerified));
+    public static string Tooltip_SignatureUnsigned => Get(nameof(Tooltip_SignatureUnsigned));
+    public static string Tooltip_SignatureInvalid => Get(nameof(Tooltip_SignatureInvalid));
+    public static string Tooltip_SignatureUntrusted => Get(nameof(Tooltip_SignatureUntrusted));
+    public static string Tooltip_SignatureMixed => Get(nameof(Tooltip_SignatureMixed));
+    public static string Tooltip_SignatureChecking => Get(nameof(Tooltip_SignatureChecking));
+    public static string Tooltip_SignatureError => Get(nameof(Tooltip_SignatureError));
     public static string Tooltip_ShowAllDatasets => Get(nameof(Tooltip_ShowAllDatasets));
     public static string Tooltip_HideAllDatasets => Get(nameof(Tooltip_HideAllDatasets));
     public static string Menu_IsolateDataset => Get(nameof(Menu_IsolateDataset));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -166,6 +166,27 @@
   <data name="Tooltip_CloseExchangeSet" xml:space="preserve">
     <value>Close this exchange set and remove every dataset it contributed</value>
   </data>
+  <data name="Tooltip_SignatureVerified" xml:space="preserve">
+    <value>All digital signatures verified</value>
+  </data>
+  <data name="Tooltip_SignatureUnsigned" xml:space="preserve">
+    <value>This exchange set is not digitally signed</value>
+  </data>
+  <data name="Tooltip_SignatureInvalid" xml:space="preserve">
+    <value>One or more digital signatures are invalid</value>
+  </data>
+  <data name="Tooltip_SignatureUntrusted" xml:space="preserve">
+    <value>The signing certificate is not trusted</value>
+  </data>
+  <data name="Tooltip_SignatureMixed" xml:space="preserve">
+    <value>Mixed signature verification results</value>
+  </data>
+  <data name="Tooltip_SignatureChecking" xml:space="preserve">
+    <value>Verifying digital signatures…</value>
+  </data>
+  <data name="Tooltip_SignatureError" xml:space="preserve">
+    <value>An error occurred during signature verification</value>
+  </data>
   <data name="Tooltip_ShowAllDatasets" xml:space="preserve">
     <value>Show every dataset</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -222,6 +222,13 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 tracked.ExchangeSet.Dispose();
                 _tracked.Remove(tracked);
             }
+            else
+            {
+                // Fire-and-forget: verify exchange set signatures in the
+                // background. The result is surfaced as a non-blocking badge
+                // on the header — we never refuse to load unsigned data.
+                _ = VerifySignaturesAsync(tracked);
+            }
 
             return new ExchangeSetOpenResult
             {
@@ -401,6 +408,56 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 latest = s;
         }
         return latest;
+    }
+
+    /// <summary>
+    /// Runs signature verification in the background and updates the
+    /// exchange set header with the result. Non-blocking — errors are
+    /// swallowed and surfaced as <see cref="SignatureStatus.Error"/>.
+    /// </summary>
+    private async Task VerifySignaturesAsync(TrackedExchangeSet tracked)
+    {
+        if (tracked.Header is null) return;
+
+        tracked.Header.SignatureStatus = SignatureStatus.Checking;
+        tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureChecking;
+
+        try
+        {
+            var verifier = new ExchangeSetVerifier();
+            var result = await verifier.VerifyAsync(
+                tracked.ExchangeSet.Source,
+                tracked.ExchangeSet.Catalogue,
+                new TrustAnchorOptions { AllowUntrustedCertificates = true },
+                CancellationToken.None).ConfigureAwait(true);
+
+            if (result.IsUnsigned)
+            {
+                tracked.Header.SignatureStatus = SignatureStatus.Unsigned;
+                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureUnsigned;
+            }
+            else if (result.AllValid)
+            {
+                tracked.Header.SignatureStatus = SignatureStatus.Verified;
+                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureVerified;
+            }
+            else if (result.HasInvalidSignatures)
+            {
+                tracked.Header.SignatureStatus = SignatureStatus.Invalid;
+                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureInvalid;
+            }
+            else
+            {
+                // Some files ok, some not — e.g. certificate issues
+                tracked.Header.SignatureStatus = SignatureStatus.Mixed;
+                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureMixed;
+            }
+        }
+        catch (Exception)
+        {
+            tracked.Header.SignatureStatus = SignatureStatus.Error;
+            tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureError;
+        }
     }
 
     public void Dispose()

--- a/src/EncDotNet.S100.Viewer/SignatureStatusConverter.cs
+++ b/src/EncDotNet.S100.Viewer/SignatureStatusConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Converts <see cref="SignatureStatus"/> to a boolean indicating whether a
+/// specific status value matches. Used to toggle visibility of badge icons
+/// in the exchange set header template.
+/// </summary>
+internal sealed class SignatureStatusConverter : IValueConverter
+{
+    /// <summary>Comma-separated list of matching <see cref="SignatureStatus"/> names.</summary>
+    public string Match { get; set; } = "";
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not SignatureStatus status) return false;
+        var statusName = status.ToString();
+        foreach (var part in Match.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.Equals(part, statusName, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
@@ -54,6 +54,12 @@ internal sealed partial class ExchangeSetHeader : ViewModelBase
     [ObservableProperty]
     private int _unsupportedCount;
 
+    [ObservableProperty]
+    private SignatureStatus _signatureStatus = SignatureStatus.Unknown;
+
+    [ObservableProperty]
+    private string? _signatureTooltip;
+
     /// <summary>Single-line summary combining loaded/unsupported counts,
     /// producer and issue date, joined with " · ". Bound to the
     /// trimmable secondary line in the header so any of the three

--- a/src/EncDotNet.S100.Viewer/ViewModels/SignatureStatus.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SignatureStatus.cs
@@ -1,0 +1,32 @@
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Aggregate signature verification status for an exchange set,
+/// surfaced as a non-blocking badge in the Datasets panel.
+/// </summary>
+internal enum SignatureStatus
+{
+    /// <summary>Verification has not yet been attempted.</summary>
+    Unknown,
+
+    /// <summary>Verification is in progress.</summary>
+    Checking,
+
+    /// <summary>All files verified successfully.</summary>
+    Verified,
+
+    /// <summary>The exchange set carries no digital signatures.</summary>
+    Unsigned,
+
+    /// <summary>At least one file's signature is invalid.</summary>
+    Invalid,
+
+    /// <summary>At least one certificate is not trusted.</summary>
+    Untrusted,
+
+    /// <summary>Mixed results across files (some ok, some not).</summary>
+    Mixed,
+
+    /// <summary>An error occurred during verification.</summary>
+    Error,
+}

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -4,8 +4,16 @@
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"
+             xmlns:conv="using:EncDotNet.S100.Viewer"
              x:Class="EncDotNet.S100.Viewer.Views.DatasetsView"
              x:DataType="vm:DatasetsViewModel">
+
+    <UserControl.Resources>
+        <conv:SignatureStatusConverter x:Key="SignatureStatusVerifiedConverter" Match="Verified" />
+        <conv:SignatureStatusConverter x:Key="SignatureStatusUnsignedConverter" Match="Unsigned" />
+        <conv:SignatureStatusConverter x:Key="SignatureStatusInvalidConverter" Match="Invalid,Untrusted,Mixed,Error" />
+        <conv:SignatureStatusConverter x:Key="SignatureStatusCheckingConverter" Match="Checking,Unknown" />
+    </UserControl.Resources>
 
     <UserControl.Styles>
         <!--
@@ -115,7 +123,7 @@
                             Padding="8,6"
                             Margin="0,0,0,4"
                             HorizontalAlignment="Stretch">
-                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                        <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto,Auto">
                             <TextBlock Grid.Column="0" Grid.Row="0"
                                        Text="{Binding DisplayName}"
                                        FontWeight="SemiBold"
@@ -127,7 +135,30 @@
                                        Text="{Binding MetadataSummary}"
                                        TextTrimming="CharacterEllipsis"
                                        ToolTip.Tip="{Binding MetadataSummary}" />
-                            <Button Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
+                            <!-- Signature verification badge -->
+                            <Panel Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
+                                   VerticalAlignment="Center"
+                                   Margin="4,0,0,0"
+                                   ToolTip.Tip="{Binding SignatureTooltip}"
+                                   IsVisible="{Binding SignatureStatus, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                <ic:FluentIcon FontSize="14"
+                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusVerifiedConverter}}"
+                                               Icon="ShieldCheckmark" IconVariant="Filled"
+                                               Foreground="#16a34a" />
+                                <ic:FluentIcon FontSize="14"
+                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusUnsignedConverter}}"
+                                               Icon="ShieldDismiss" IconVariant="Regular"
+                                               Opacity="0.5" />
+                                <ic:FluentIcon FontSize="14"
+                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusInvalidConverter}}"
+                                               Icon="ShieldError" IconVariant="Filled"
+                                               Foreground="#dc2626" />
+                                <ic:FluentIcon FontSize="14"
+                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusCheckingConverter}}"
+                                               Icon="Shield" IconVariant="Regular"
+                                               Opacity="0.4" />
+                            </Panel>
+                            <Button Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
                                     Classes="Icon"
                                     VerticalAlignment="Center"
                                     Margin="6,0,0,0"

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -141,19 +141,19 @@
                                    Margin="4,0,0,0"
                                    ToolTip.Tip="{Binding SignatureTooltip}"
                                    IsVisible="{Binding SignatureStatus, Converter={x:Static ObjectConverters.IsNotNull}}">
-                                <ic:FluentIcon FontSize="14"
+                                <ic:FluentIcon FontSize="20"
                                                IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusVerifiedConverter}}"
                                                Icon="ShieldCheckmark" IconVariant="Filled"
                                                Foreground="#16a34a" />
-                                <ic:FluentIcon FontSize="14"
+                                <ic:FluentIcon FontSize="20"
                                                IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusUnsignedConverter}}"
                                                Icon="ShieldDismiss" IconVariant="Regular"
                                                Opacity="0.5" />
-                                <ic:FluentIcon FontSize="14"
+                                <ic:FluentIcon FontSize="20"
                                                IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusInvalidConverter}}"
                                                Icon="ShieldError" IconVariant="Filled"
                                                Foreground="#dc2626" />
-                                <ic:FluentIcon FontSize="14"
+                                <ic:FluentIcon FontSize="20"
                                                IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusCheckingConverter}}"
                                                Icon="Shield" IconVariant="Regular"
                                                Opacity="0.4" />

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/DigitalSignatureTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/DigitalSignatureTests.cs
@@ -1,0 +1,436 @@
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+public class DigitalSignatureTests
+{
+    private static string GetCatalogPath([CallerFilePath] string callerFilePath = "")
+    {
+        return Path.Combine(Path.GetDirectoryName(callerFilePath)!, "..", "datasets", "S101", "CATALOG.XML");
+    }
+
+    private static ExchangeCatalogue ReadTestCatalogue()
+    {
+        return ExchangeCatalogueReader.Read(GetCatalogPath());
+    }
+
+    // ── Model parsing tests ──────────────────────────────────────────
+
+    [Fact]
+    public void Certificates_AreParsed()
+    {
+        var catalogue = ReadTestCatalogue();
+
+        Assert.NotNull(catalogue.Certificates);
+        Assert.Equal("urn:mrn:iho:s62:iic:2C:key1", catalogue.Certificates.SchemeAdministratorId);
+        Assert.Single(catalogue.Certificates.Certificates);
+    }
+
+    [Fact]
+    public void Certificate_HasExpectedFields()
+    {
+        var catalogue = ReadTestCatalogue();
+        var cert = catalogue.Certificates!.Certificates[0];
+
+        Assert.Equal("urn:mrn:iho:s62:iic:2C:key1", cert.Id);
+        Assert.Equal("IHO Scretariat", cert.Issuer);
+        Assert.NotEmpty(cert.Value);
+    }
+
+    [Fact]
+    public void Certificate_IsValidX509()
+    {
+        var catalogue = ReadTestCatalogue();
+        var certEntry = catalogue.Certificates!.Certificates[0];
+
+        // Should parse as a valid X.509 certificate
+#if NET10_0_OR_GREATER
+        using var cert = X509CertificateLoader.LoadCertificate(certEntry.Value);
+#else
+        using var cert = new X509Certificate2(certEntry.Value);
+#endif
+        Assert.NotNull(cert.Subject);
+        Assert.NotNull(cert.Issuer);
+    }
+
+    [Fact]
+    public void FirstDataset_HasDigitalSignatureValue()
+    {
+        var catalogue = ReadTestCatalogue();
+        var dataset = catalogue.DatasetDiscoveryMetadata[0];
+
+        Assert.NotNull(dataset.DigitalSignatureValue);
+        Assert.Equal("SIG101AA0000DS0009", dataset.DigitalSignatureValue.Id);
+        Assert.Equal("urn:mrn:iho:s62:iic:2C:key1", dataset.DigitalSignatureValue.CertificateRef);
+        Assert.NotEmpty(dataset.DigitalSignatureValue.Value);
+    }
+
+    [Fact]
+    public void FirstDataset_HasDSAAlgorithm()
+    {
+        var catalogue = ReadTestCatalogue();
+        var dataset = catalogue.DatasetDiscoveryMetadata[0];
+
+        Assert.Equal(DigitalSignatureAlgorithm.DSA, dataset.DigitalSignatureAlgorithm);
+    }
+
+    [Fact]
+    public void AllDatasets_HaveSignatures()
+    {
+        var catalogue = ReadTestCatalogue();
+
+        Assert.All(catalogue.DatasetDiscoveryMetadata, dataset =>
+        {
+            Assert.NotNull(dataset.DigitalSignatureValue);
+            Assert.NotEmpty(dataset.DigitalSignatureValue.Id);
+            Assert.NotEmpty(dataset.DigitalSignatureValue.CertificateRef);
+            Assert.NotEmpty(dataset.DigitalSignatureValue.Value);
+            Assert.Equal(DigitalSignatureAlgorithm.DSA, dataset.DigitalSignatureAlgorithm);
+        });
+    }
+
+    // ── Verification tests (synthetic) ───────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_UnsignedExchangeSet_ReturnsNotSigned()
+    {
+        // Create a catalogue with no signatures
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    DigitalSignatureReference = null,
+                    DigitalSignatureValue = null,
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", "hello"u8.ToArray());
+
+        var verifier = new ExchangeSetVerifier();
+        var result = await verifier.VerifyAsync(source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        Assert.True(result.IsUnsigned);
+        Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.NotSigned, result.FileResults[0].Outcome);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ValidEcdsaSignature_ReturnsOk()
+    {
+        // Generate a test ECDSA P-256 key pair and self-signed certificate
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certReq = new CertificateRequest("CN=TestSA", ecdsa, HashAlgorithmName.SHA256);
+        using var cert = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        // Create test file content and sign it
+        var fileContent = "test file content"u8.ToArray();
+        var hash = SHA256.HashData(fileContent);
+        var signature = ecdsa.SignHash(hash);
+
+        var certBytes = cert.RawData;
+        var certId = "urn:test:cert1";
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock
+            {
+                SchemeAdministratorId = certId,
+                Certificates = [new CertificateEntry { Id = certId, Issuer = "TestSA", Value = certBytes }],
+            },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    DigitalSignatureReference = "ECDSA",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue
+                    {
+                        Id = "SIG1",
+                        CertificateRef = certId,
+                        Value = signature,
+                    },
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", fileContent);
+
+        var verifier = new ExchangeSetVerifier();
+        var trustAnchors = new TrustAnchorOptions
+        {
+            TrustedRoots = [cert],
+            AllowUntrustedCertificates = false,
+        };
+
+        var result = await verifier.VerifyAsync(source, catalogue, trustAnchors);
+
+        Assert.True(result.AllValid);
+        Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.Ok, result.FileResults[0].Outcome);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_TamperedFile_ReturnsSignatureInvalid()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certReq = new CertificateRequest("CN=TestSA", ecdsa, HashAlgorithmName.SHA256);
+        using var cert = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        // Sign original content
+        var originalContent = "original content"u8.ToArray();
+        var hash = SHA256.HashData(originalContent);
+        var signature = ecdsa.SignHash(hash);
+
+        var certId = "urn:test:cert1";
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock
+            {
+                Certificates = [new CertificateEntry { Id = certId, Issuer = "TestSA", Value = cert.RawData }],
+            },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    DigitalSignatureReference = "ECDSA",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue
+                    {
+                        Id = "SIG1",
+                        CertificateRef = certId,
+                        Value = signature,
+                    },
+                },
+            ],
+        };
+
+        // Tamper: serve different content
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", "tampered content"u8.ToArray());
+
+        var verifier = new ExchangeSetVerifier();
+        var result = await verifier.VerifyAsync(source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        Assert.True(result.HasInvalidSignatures);
+        Assert.Equal(VerificationOutcome.SignatureInvalid, result.FileResults[0].Outcome);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_UntrustedCertificate_ReturnsUntrusted()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certReq = new CertificateRequest("CN=UntrustedSA", ecdsa, HashAlgorithmName.SHA256);
+        using var cert = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        var fileContent = "test"u8.ToArray();
+        var hash = SHA256.HashData(fileContent);
+        var signature = ecdsa.SignHash(hash);
+
+        var certId = "urn:test:untrusted";
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock
+            {
+                Certificates = [new CertificateEntry { Id = certId, Issuer = "UntrustedSA", Value = cert.RawData }],
+            },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    DigitalSignatureReference = "ECDSA",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue
+                    {
+                        Id = "SIG1",
+                        CertificateRef = certId,
+                        Value = signature,
+                    },
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", fileContent);
+
+        // Verify with a different trust root
+        using var otherEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var otherReq = new CertificateRequest("CN=OtherSA", otherEcdsa, HashAlgorithmName.SHA256);
+        using var otherCert = otherReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        var verifier = new ExchangeSetVerifier();
+        var result = await verifier.VerifyAsync(source, catalogue, new TrustAnchorOptions
+        {
+            TrustedRoots = [otherCert],
+        });
+
+        Assert.Equal(VerificationOutcome.CertificateUntrusted, result.FileResults[0].Outcome);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_MissingFile_ReturnsFileMissing()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certReq = new CertificateRequest("CN=TestSA", ecdsa, HashAlgorithmName.SHA256);
+        using var cert = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        var certId = "urn:test:cert1";
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock
+            {
+                Certificates = [new CertificateEntry { Id = certId, Issuer = "TestSA", Value = cert.RawData }],
+            },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "missing.000",
+                    DigitalSignatureReference = "ECDSA",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue
+                    {
+                        Id = "SIG1",
+                        CertificateRef = certId,
+                        Value = [1, 2, 3],
+                    },
+                },
+            ],
+        };
+
+        // Empty source — file doesn't exist
+        var source = new InMemoryAssetSource();
+
+        var verifier = new ExchangeSetVerifier();
+        var result = await verifier.VerifyAsync(source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        Assert.Equal(VerificationOutcome.FileMissing, result.FileResults[0].Outcome);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_CertificateNotInCatalogue_ReturnsCertificateNotFound()
+    {
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock { Certificates = [] },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    DigitalSignatureReference = "ECDSA",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue
+                    {
+                        Id = "SIG1",
+                        CertificateRef = "urn:test:nonexistent",
+                        Value = [1, 2, 3],
+                    },
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", "content"u8.ToArray());
+
+        var verifier = new ExchangeSetVerifier();
+        var result = await verifier.VerifyAsync(source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        Assert.Equal(VerificationOutcome.CertificateNotFound, result.FileResults[0].Outcome);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_MultipleFiles_MixedResults()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certReq = new CertificateRequest("CN=TestSA", ecdsa, HashAlgorithmName.SHA256);
+        using var cert = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        var file1Content = "file1"u8.ToArray();
+        var file1Hash = SHA256.HashData(file1Content);
+        var file1Sig = ecdsa.SignHash(file1Hash);
+
+        var certId = "urn:test:cert1";
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock
+            {
+                Certificates = [new CertificateEntry { Id = certId, Issuer = "TestSA", Value = cert.RawData }],
+            },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "file1.000",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue { Id = "SIG1", CertificateRef = certId, Value = file1Sig },
+                },
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "file2.000",
+                    // Not signed
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("file1.000", file1Content);
+        source.AddFile("file2.000", "file2"u8.ToArray());
+
+        var verifier = new ExchangeSetVerifier();
+        var result = await verifier.VerifyAsync(source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        Assert.Equal(2, result.FileResults.Count);
+        Assert.Equal(VerificationOutcome.Ok, result.FileResults[0].Outcome);
+        Assert.Equal(VerificationOutcome.NotSigned, result.FileResults[1].Outcome);
+        Assert.False(result.AllValid);
+        Assert.False(result.IsUnsigned);
+    }
+
+    // ── In-memory asset source for testing ───────────────────────────
+
+    private sealed class InMemoryAssetSource : IAssetSource
+    {
+        private readonly Dictionary<string, byte[]> _files = new(StringComparer.OrdinalIgnoreCase);
+
+        public void AddFile(string path, byte[] content)
+        {
+            _files[path] = content;
+        }
+
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            if (_files.TryGetValue(relativePath, out var content))
+            {
+                return Task.FromResult<Stream>(new MemoryStream(content));
+            }
+
+            throw new FileNotFoundException($"File not found: {relativePath}", relativePath);
+        }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary

Implements read-side digital signature verification for S-100 Exchange Sets per **S-100 Part 15 Data Protection Scheme** (Ed 5.2.1).

### What's included

**Model extensions** — New types for Part 15 signature/certificate structures:
- `DigitalSignatureAlgorithm` enum (DSA, ECDSA) — §15-4.1
- `DigitalSignatureValue`, `CertificateEntry`, `CertificateBlock` — §15-4.2, §15-5
- Extended discovery metadata types with signature properties
- Updated `ExchangeCatalogueReader` to parse `S100SE` namespace

**Verification engine** (`ExchangeSetVerifier`):
- `IExchangeSetVerifier` interface with `VerifyAsync`
- Streaming SHA-256 hashing, DSA + ECDSA P-256 verification
- Certificate trust chain validation with `TrustAnchorOptions`
- Non-throwing API — callers decide policy

**Viewer integration**:
- Signature status badge in exchange set header
- Fire-and-forget verification on load

**Tests** — 13 new tests with synthetic PKI material

### Deferred items

- Signing/authoring, Part 15 §3 Confidentiality, IDSC.XML issuance, CLI tool