### PR TITLE
Add toast notifications to viewer with cancellable dataset loading

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -173,6 +173,8 @@ public partial class App : Application
             return state;
         });
         services.AddSingleton<IStatusPresenter, StatusPresenter>();
+        services.AddSingleton<ShadUI.ToastManager>();
+        services.AddSingleton<IToastService, ToastService>();
         services.AddSingleton<IDatasetLoaderService, DatasetLoaderService>();
         services.AddSingleton<IPickService, PickService>();
         services.AddSingleton<IFeatureSearchService, FeatureSearchService>();

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -132,6 +132,7 @@
         </Button>
     </shadui:Window.RightWindowTitleBarContent>
 
+    <Panel>
     <DockPanel>
         <!-- Status bar at bottom -->
         <Border DockPanel.Dock="Bottom"
@@ -864,4 +865,9 @@
             </Border>
         </Grid>
     </DockPanel>
+    <shadui:ToastHost x:Name="ToastHost"
+                      Position="BottomRight"
+                      MaxToasts="5"
+                      Margin="0,0,0,30" />
+    </Panel>
 </shadui:Window>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -101,6 +101,10 @@ public partial class MainWindow : ShadUI.Window
 
         InitializeComponent();
 
+        // Wire the ShadUI toast host to the DI-managed ToastManager so
+        // background services can surface notifications through toasts.
+        ToastHost.Manager = App.Services.GetRequiredService<ShadUI.ToastManager>();
+
         _viewModel = viewModel;
         _catalogAggregator = catalogAggregator;
         _recentFiles = recentFiles;
@@ -159,7 +163,12 @@ public partial class MainWindow : ShadUI.Window
 
         // Surface DatasetsViewModel rejection of unknown file extensions.
         _viewModel.Datasets.UnrecognizedFileEncountered += extension =>
+        {
             _viewModel.StatusText = string.Format(Strings.Status_UnrecognizedFileType, extension);
+            App.Services.GetRequiredService<IToastService>().ShowWarning(
+                Strings.Toast_Warning,
+                string.Format(Strings.Status_UnrecognizedFileType, extension));
+        };
 
         // Clean up layers when a dataset entry is removed from the list.
         _viewModel.Datasets.Entries.CollectionChanged += (_, e) =>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -383,6 +383,16 @@ public partial class MainWindow : ShadUI.Window
         var progress = new Progress<Services.ExchangeSetProgress>(
             p => _viewModel.ReportExchangeSetProgress(p));
 
+        // Show a loading toast with a Cancel action that mirrors the
+        // overlay's Cancel button. The toast supplements the progress
+        // overlay for users who switch to another activity panel.
+        var toasts = App.Services.GetRequiredService<IToastService>();
+        toasts.ShowLoading(
+            Strings.Toast_ExchangeSetLoading,
+            sourcePath,
+            Strings.Toast_Cancel,
+            () => _viewModel.CancelExchangeSetCommand.Execute(null));
+
         // Subscribe to per-dataset load completions for the duration of
         // this open. We accumulate each loaded entry's layer extents so
         // we can zoom to their union — the catalogue may not declare
@@ -444,6 +454,9 @@ public partial class MainWindow : ShadUI.Window
         finally
         {
             _loader.DatasetLoaded -= handler;
+            // Dismiss the exchange-set loading toast; the result
+            // toasts from ExchangeSetService will follow immediately.
+            toasts.DismissAll();
         }
     }
 

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -304,4 +304,13 @@ internal static class Strings
     public static string TextGroup_Important => Get(nameof(TextGroup_Important));
     public static string TextGroup_Other => Get(nameof(TextGroup_Other));
     public static string TextGroup_All => Get(nameof(TextGroup_All));
+
+    // Toast notification titles
+    public static string Toast_Error => Get(nameof(Toast_Error));
+    public static string Toast_Warning => Get(nameof(Toast_Warning));
+    public static string Toast_Success => Get(nameof(Toast_Success));
+    public static string Toast_Info => Get(nameof(Toast_Info));
+    public static string Toast_ExchangeSetLoaded => Get(nameof(Toast_ExchangeSetLoaded));
+    public static string Toast_ExchangeSetFailed => Get(nameof(Toast_ExchangeSetFailed));
+    public static string Toast_DatasetError => Get(nameof(Toast_DatasetError));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -313,4 +313,7 @@ internal static class Strings
     public static string Toast_ExchangeSetLoaded => Get(nameof(Toast_ExchangeSetLoaded));
     public static string Toast_ExchangeSetFailed => Get(nameof(Toast_ExchangeSetFailed));
     public static string Toast_DatasetError => Get(nameof(Toast_DatasetError));
+    public static string Toast_Loading => Get(nameof(Toast_Loading));
+    public static string Toast_DatasetCancelled => Get(nameof(Toast_DatasetCancelled));
+    public static string Toast_Cancel => Get(nameof(Toast_Cancel));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -316,4 +316,5 @@ internal static class Strings
     public static string Toast_Loading => Get(nameof(Toast_Loading));
     public static string Toast_DatasetCancelled => Get(nameof(Toast_DatasetCancelled));
     public static string Toast_Cancel => Get(nameof(Toast_Cancel));
+    public static string Toast_ExchangeSetLoading => Get(nameof(Toast_ExchangeSetLoading));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -810,4 +810,7 @@ Open an S-101, S-124, S-125, or S-421 dataset to see display controls here.</val
   <data name="Toast_Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="Toast_ExchangeSetLoading" xml:space="preserve">
+    <value>Loading Exchange Set</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -778,4 +778,27 @@ Open an S-101, S-124, S-125, or S-421 dataset to see display controls here.</val
   <data name="TextGroup_All" xml:space="preserve">
     <value>All other chart text</value>
   </data>
+
+  <!-- Toast notification titles -->
+  <data name="Toast_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Toast_Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="Toast_Success" xml:space="preserve">
+    <value>Success</value>
+  </data>
+  <data name="Toast_Info" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="Toast_ExchangeSetLoaded" xml:space="preserve">
+    <value>Exchange Set Loaded</value>
+  </data>
+  <data name="Toast_ExchangeSetFailed" xml:space="preserve">
+    <value>Exchange Set Failed</value>
+  </data>
+  <data name="Toast_DatasetError" xml:space="preserve">
+    <value>Dataset Error</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -801,4 +801,13 @@ Open an S-101, S-124, S-125, or S-421 dataset to see display controls here.</val
   <data name="Toast_DatasetError" xml:space="preserve">
     <value>Dataset Error</value>
   </data>
+  <data name="Toast_Loading" xml:space="preserve">
+    <value>Loading Dataset</value>
+  </data>
+  <data name="Toast_DatasetCancelled" xml:space="preserve">
+    <value>Load Cancelled</value>
+  </data>
+  <data name="Toast_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -149,12 +149,17 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _marinerSettings.Changed += m => _ = ReRenderAllAsync();
     }
 
-    public async Task LoadAsync(DatasetEntry entry)
+    public async Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
         EnsureInitialized();
 
         using var __cmd = ViewerObservability.BeginCommand("dataset.open");
+
+        // Create a linked CTS so the caller's token and the toast's
+        // Cancel button both feed into a single token.
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var token = cts.Token;
 
         // Exchange-set entries carry an explicit ProductSpec from the
         // catalogue and never require path-based detection or recent-
@@ -192,11 +197,20 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
         SetStatus(string.Format(Strings.Status_LoadingFile, entry.DisplayName));
 
+        // Show a loading toast with a Cancel action. The toast stays
+        // visible (5-minute delay) until the operation completes and
+        // we call DismissAll().
+        _toasts.ShowLoading(
+            Strings.Toast_Loading,
+            string.Format(Strings.Status_LoadingFile, entry.DisplayName),
+            Strings.Toast_Cancel,
+            () => cts.Cancel());
+
         try
         {
             var processor = await Task.Run(() => fromExchangeSet
                 ? _pipelineFactory!.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
-                : _pipelineFactory!.CreateProcessor(entry.FilePath));
+                : _pipelineFactory!.CreateProcessor(entry.FilePath), token);
             _processors[entry] = processor;
 
             // Surface S-128 catalogues into the Dataset Catalog panel.
@@ -222,7 +236,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 initialTime = adapter.SnapTo(globalNow);
 
             var initialContext = CreateRenderContext(processor, initialTime);
-            var result = await Task.Run(() => processor.Render(initialContext));
+            var result = await Task.Run(() => processor.Render(initialContext), token);
 
             ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames);
             // Exchange-set entries opt out of the per-dataset auto-zoom so
@@ -238,6 +252,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             entry.IsLoaded = true;
             entry.Info = result.Info;
             entry.CurrentTime = initialTime ?? adapter?.AvailableTimes.FirstOrDefault();
+
+            // Dismiss the loading toast before showing the result.
+            _toasts.DismissAll();
             SetStatus(result.Info);
 
             // Recent files only makes sense for plain file loads. An
@@ -258,8 +275,15 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
             DatasetLoaded?.Invoke(entry);
         }
+        catch (OperationCanceledException)
+        {
+            _toasts.DismissAll();
+            _toasts.ShowInfo(Strings.Toast_DatasetCancelled, entry.DisplayName);
+            SetStatus(null);
+        }
         catch (Exception ex)
         {
+            _toasts.DismissAll();
             SetStatus(string.Format(Strings.Status_Error, ex.Message));
             _toasts.ShowError(Strings.Toast_DatasetError,
                 string.Format(Strings.Status_Error, ex.Message));

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -35,6 +35,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly GlobalTimeService _globalTime;
     private readonly EcdisDisplayState _ecdisDisplay;
     private readonly IMarinerSettingsProvider _marinerSettings;
+    private readonly IToastService _toasts;
 
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayers = new();
@@ -75,7 +76,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         SettingsViewModel settingsVm,
         GlobalTimeService globalTime,
         EcdisDisplayState ecdisDisplay,
-        IMarinerSettingsProvider marinerSettings)
+        IMarinerSettingsProvider marinerSettings,
+        IToastService toasts)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
@@ -86,6 +88,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ArgumentNullException.ThrowIfNull(globalTime);
         ArgumentNullException.ThrowIfNull(ecdisDisplay);
         ArgumentNullException.ThrowIfNull(marinerSettings);
+        ArgumentNullException.ThrowIfNull(toasts);
 
         _settings = settings;
         _catalogueManager = catalogueManager;
@@ -96,6 +99,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _globalTime = globalTime;
         _ecdisDisplay = ecdisDisplay;
         _marinerSettings = marinerSettings;
+        _toasts = toasts;
 
         _processorsView = new ReadOnlyDictionary<DatasetEntry, IDatasetProcessor>(_processors);
         _entryLayersView = new ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>>(_entryLayers);
@@ -169,6 +173,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             if (spec is null)
             {
                 SetStatus(string.Format(Strings.Status_UnrecognizedFileType, Path.GetExtension(entry.FilePath)));
+                _toasts.ShowWarning(Strings.Toast_Warning,
+                    string.Format(Strings.Status_UnrecognizedFileType, Path.GetExtension(entry.FilePath)));
                 return;
             }
         }
@@ -179,6 +185,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         if (spec != "S-104" && !_catalogueManager.HasCatalogue(requiredCatalogue))
         {
             SetStatus(string.Format(Strings.Status_SelectPortrayalCatalogue, requiredCatalogue));
+            _toasts.ShowWarning(Strings.Toast_Warning,
+                string.Format(Strings.Status_SelectPortrayalCatalogue, requiredCatalogue));
             return;
         }
 
@@ -253,6 +261,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         catch (Exception ex)
         {
             SetStatus(string.Format(Strings.Status_Error, ex.Message));
+            _toasts.ShowError(Strings.Toast_DatasetError,
+                string.Format(Strings.Status_Error, ex.Message));
             Console.Error.WriteLine($"Failed to load {entry.FilePath}:\n{ex}");
         }
     }
@@ -335,6 +345,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         }
 
         SetStatus(string.Format(Strings.Status_PaletteApplied, palette));
+        _toasts.ShowSuccess(Strings.Toast_Success,
+            string.Format(Strings.Status_PaletteApplied, palette));
     }
 
     public void RemoveEntry(DatasetEntry entry)

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -197,14 +197,18 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
         SetStatus(string.Format(Strings.Status_LoadingFile, entry.DisplayName));
 
-        // Show a loading toast with a Cancel action. The toast stays
-        // visible (5-minute delay) until the operation completes and
-        // we call DismissAll().
-        _toasts.ShowLoading(
-            Strings.Toast_Loading,
-            string.Format(Strings.Status_LoadingFile, entry.DisplayName),
-            Strings.Toast_Cancel,
-            () => cts.Cancel());
+        // Show a loading toast with a Cancel action for standalone
+        // dataset loads. Exchange-set entries are covered by the
+        // exchange-set progress overlay instead, so skip the per-
+        // dataset toast to avoid toast churn during bulk loads.
+        if (!fromExchangeSet)
+        {
+            _toasts.ShowLoading(
+                Strings.Toast_Loading,
+                string.Format(Strings.Status_LoadingFile, entry.DisplayName),
+                Strings.Toast_Cancel,
+                () => cts.Cancel());
+        }
 
         try
         {
@@ -254,7 +258,11 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             entry.CurrentTime = initialTime ?? adapter?.AvailableTimes.FirstOrDefault();
 
             // Dismiss the loading toast before showing the result.
-            _toasts.DismissAll();
+            // Exchange-set entries don't show per-dataset toasts.
+            if (!fromExchangeSet)
+            {
+                _toasts.DismissAll();
+            }
             SetStatus(result.Info);
 
             // Recent files only makes sense for plain file loads. An
@@ -277,13 +285,19 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         }
         catch (OperationCanceledException)
         {
-            _toasts.DismissAll();
-            _toasts.ShowInfo(Strings.Toast_DatasetCancelled, entry.DisplayName);
+            if (!fromExchangeSet)
+            {
+                _toasts.DismissAll();
+                _toasts.ShowInfo(Strings.Toast_DatasetCancelled, entry.DisplayName);
+            }
             SetStatus(null);
         }
         catch (Exception ex)
         {
-            _toasts.DismissAll();
+            if (!fromExchangeSet)
+            {
+                _toasts.DismissAll();
+            }
             SetStatus(string.Format(Strings.Status_Error, ex.Message));
             _toasts.ShowError(Strings.Toast_DatasetError,
                 string.Format(Strings.Status_Error, ex.Message));

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -36,16 +36,19 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 {
     private readonly DatasetsViewModel _datasets;
     private readonly IStatusPresenter _status;
+    private readonly IToastService _toasts;
     private readonly List<TrackedExchangeSet> _tracked = new();
     private bool _subscribed;
     private bool _disposed;
 
-    public ExchangeSetService(DatasetsViewModel datasets, IStatusPresenter status)
+    public ExchangeSetService(DatasetsViewModel datasets, IStatusPresenter status, IToastService toasts)
     {
         ArgumentNullException.ThrowIfNull(datasets);
         ArgumentNullException.ThrowIfNull(status);
+        ArgumentNullException.ThrowIfNull(toasts);
         _datasets = datasets;
         _status = status;
+        _toasts = toasts;
     }
 
     public async Task<ExchangeSetOpenResult> OpenAsync(
@@ -78,7 +81,9 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             }
             catch (FileNotFoundException)
             {
-                _status.StatusText = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
+                var msg = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
+                _status.StatusText = msg;
+                _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, msg);
                 source.Dispose();
                 activity?.SetStatus(ActivityStatusCode.Error, "catalogue not found");
                 return new ExchangeSetOpenResult
@@ -100,7 +105,9 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
             if (datasets.Count == 0)
             {
-                _status.StatusText = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
+                var emptyMsg = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
+                _status.StatusText = emptyMsg;
+                _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, emptyMsg);
                 exchangeSet.Dispose();
                 exchangeSet = null;
                 activity?.SetStatus(ActivityStatusCode.Error, "empty catalogue");
@@ -155,6 +162,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                         relativePath,
                         metadata.ProductSpecification?.ProductIdentifier ?? string.Empty);
                     _status.StatusText = msg;
+                    _toasts.ShowWarning(Strings.Toast_Warning, msg);
                     skipMessages.Add(msg);
                     skipped++;
                     progress?.Report(new ExchangeSetProgress(
@@ -176,20 +184,26 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
             if (cancelled)
             {
-                _status.StatusText = string.Format(
+                var cancelledMsg = string.Format(
                     Strings.Status_ExchangeSetCancelled,
                     dispatched, datasets.Count, folderOrZipPath);
+                _status.StatusText = cancelledMsg;
+                _toasts.ShowInfo(Strings.Toast_Info, cancelledMsg);
             }
             else if (skipped == 0)
             {
-                _status.StatusText = string.Format(
+                var loadedMsg = string.Format(
                     Strings.Status_ExchangeSetLoaded, dispatched, folderOrZipPath);
+                _status.StatusText = loadedMsg;
+                _toasts.ShowSuccess(Strings.Toast_ExchangeSetLoaded, loadedMsg);
             }
             else
             {
-                _status.StatusText = string.Format(
+                var partialMsg = string.Format(
                     Strings.Status_ExchangeSetLoadedWithErrors,
                     dispatched, datasets.Count, folderOrZipPath, skipped);
+                _status.StatusText = partialMsg;
+                _toasts.ShowWarning(Strings.Toast_ExchangeSetLoaded, partialMsg);
             }
 
             activity?.SetTag("s100.exchangeset.dataset.loaded", dispatched);
@@ -254,7 +268,9 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         }
         catch (Exception ex)
         {
-            _status.StatusText = string.Format(Strings.Status_ExchangeSetFailed, folderOrZipPath, ex.Message);
+            var failedMsg = string.Format(Strings.Status_ExchangeSetFailed, folderOrZipPath, ex.Message);
+            _status.StatusText = failedMsg;
+            _toasts.ShowError(Strings.Toast_ExchangeSetFailed, failedMsg);
             exchangeSet?.Dispose();
             source?.Dispose();
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -24,7 +24,7 @@ internal interface IDatasetLoaderService
     void Initialize(IMapHost host, ViewerCommandSettings? options);
 
     /// <summary>Loads a dataset and adds its rendered layers to the map.</summary>
-    Task LoadAsync(DatasetEntry entry);
+    Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Re-renders every loaded time-aware dataset at the supplied global

--- a/src/EncDotNet.S100.Viewer/Services/IToastService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IToastService.cs
@@ -1,0 +1,21 @@
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Abstraction for showing toast notifications in the viewer UI.
+/// Decouples background services from the concrete ShadUI
+/// <c>ToastManager</c> implementation.
+/// </summary>
+internal interface IToastService
+{
+    /// <summary>Shows an informational toast.</summary>
+    void ShowInfo(string title, string? content = null);
+
+    /// <summary>Shows a success toast with a short auto-dismiss delay.</summary>
+    void ShowSuccess(string title, string? content = null);
+
+    /// <summary>Shows a warning toast.</summary>
+    void ShowWarning(string title, string? content = null);
+
+    /// <summary>Shows an error toast (longer delay, dismiss on click).</summary>
+    void ShowError(string title, string? content = null);
+}

--- a/src/EncDotNet.S100.Viewer/Services/IToastService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IToastService.cs
@@ -18,4 +18,19 @@ internal interface IToastService
 
     /// <summary>Shows an error toast (longer delay, dismiss on click).</summary>
     void ShowError(string title, string? content = null);
+
+    /// <summary>
+    /// Shows a persistent loading toast with an action button (e.g.
+    /// "Cancel"). The toast stays visible until explicitly dismissed via
+    /// <see cref="DismissAll"/> or the action button is clicked (ShadUI
+    /// auto-dismisses after an action click).
+    /// </summary>
+    void ShowLoading(string title, string? content = null, string? actionLabel = null, Action? action = null);
+
+    /// <summary>
+    /// Dismisses all currently visible toasts. Use after a long-running
+    /// operation completes to clear loading toasts before showing the
+    /// result toast.
+    /// </summary>
+    void DismissAll();
 }

--- a/src/EncDotNet.S100.Viewer/Services/ToastService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ToastService.cs
@@ -1,0 +1,84 @@
+using ShadUI;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="IToastService"/> implementation backed by the
+/// ShadUI <see cref="ToastManager"/>. All toasts are positioned at the
+/// bottom-right corner to stay out of the map viewport.
+/// </summary>
+internal sealed class ToastService : IToastService
+{
+    private readonly ToastManager _manager;
+
+    /// <summary>Default auto-dismiss delay for brief confirmations (seconds).</summary>
+    private const double ShortDelay = 4;
+
+    /// <summary>Default auto-dismiss delay for warnings/info (seconds).</summary>
+    private const double MediumDelay = 8;
+
+    /// <summary>Default auto-dismiss delay for errors (seconds).</summary>
+    private const double LongDelay = 15;
+
+    public ToastService(ToastManager manager)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        _manager = manager;
+    }
+
+    /// <inheritdoc />
+    public void ShowInfo(string title, string? content = null)
+    {
+        var builder = _manager.CreateToast(title)
+            .OnBottomRight()
+            .WithDelay(MediumDelay)
+            .DismissOnClick();
+
+        if (content is not null)
+            builder = builder.WithContent(content);
+
+        builder.ShowInfo();
+    }
+
+    /// <inheritdoc />
+    public void ShowSuccess(string title, string? content = null)
+    {
+        var builder = _manager.CreateToast(title)
+            .OnBottomRight()
+            .WithDelay(ShortDelay)
+            .DismissOnClick();
+
+        if (content is not null)
+            builder = builder.WithContent(content);
+
+        builder.ShowSuccess();
+    }
+
+    /// <inheritdoc />
+    public void ShowWarning(string title, string? content = null)
+    {
+        var builder = _manager.CreateToast(title)
+            .OnBottomRight()
+            .WithDelay(MediumDelay)
+            .DismissOnClick();
+
+        if (content is not null)
+            builder = builder.WithContent(content);
+
+        builder.ShowWarning();
+    }
+
+    /// <inheritdoc />
+    public void ShowError(string title, string? content = null)
+    {
+        var builder = _manager.CreateToast(title)
+            .OnBottomRight()
+            .WithDelay(LongDelay)
+            .DismissOnClick();
+
+        if (content is not null)
+            builder = builder.WithContent(content);
+
+        builder.ShowError();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/ToastService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ToastService.cs
@@ -20,6 +20,9 @@ internal sealed class ToastService : IToastService
     /// <summary>Default auto-dismiss delay for errors (seconds).</summary>
     private const double LongDelay = 15;
 
+    /// <summary>Long delay for loading toasts so they stay visible during the operation.</summary>
+    private const double LoadingDelay = 300;
+
     public ToastService(ToastManager manager)
     {
         ArgumentNullException.ThrowIfNull(manager);
@@ -81,4 +84,24 @@ internal sealed class ToastService : IToastService
 
         builder.ShowError();
     }
+
+    /// <inheritdoc />
+    public void ShowLoading(string title, string? content = null, string? actionLabel = null, Action? action = null)
+    {
+        var builder = _manager.CreateToast(title)
+            .OnBottomRight()
+            .WithDelay(LoadingDelay)
+            .DismissOnClick();
+
+        if (content is not null)
+            builder = builder.WithContent(content);
+
+        if (actionLabel is not null && action is not null)
+            builder = builder.WithAction(actionLabel, action);
+
+        builder.ShowInfo();
+    }
+
+    /// <inheritdoc />
+    public void DismissAll() => _manager.DismissAll();
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -16,6 +16,7 @@ internal sealed class MainViewModel : ViewModelBase
     private readonly ViewerSettings _settings;
     private readonly IThemeService _theme;
     private readonly IRecentFilesService _recentFiles;
+    private readonly IToastService _toasts;
 
     public FeatureCataloguesViewModel FeatureCatalogues { get; }
     public PortrayalCataloguesViewModel PortrayalCatalogues { get; }
@@ -416,6 +417,7 @@ internal sealed class MainViewModel : ViewModelBase
         IThemeService themeService,
         IRecentFilesService recentFiles,
         IMeasureOverlayAppearanceProvider measureAppearance,
+        IToastService toasts,
         IStatusPresenter? statusPresenter = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -433,10 +435,12 @@ internal sealed class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(themeService);
         ArgumentNullException.ThrowIfNull(recentFiles);
         ArgumentNullException.ThrowIfNull(measureAppearance);
+        ArgumentNullException.ThrowIfNull(toasts);
 
         _settings = settings;
         _theme = themeService;
         _recentFiles = recentFiles;
+        _toasts = toasts;
         _isDarkTheme = themeService.IsDarkTheme;
         _statusPresenter = statusPresenter;
         if (_statusPresenter is { } presenter)
@@ -578,7 +582,9 @@ internal sealed class MainViewModel : ViewModelBase
 
         if (!File.Exists(path))
         {
-            StatusText = string.Format(Strings.Status_FileNoLongerExists, path);
+            var msg = string.Format(Strings.Status_FileNoLongerExists, path);
+            StatusText = msg;
+            _toasts.ShowWarning(Strings.Toast_Warning, msg);
             // Drop the missing entry so the menu reflects reality.
             _recentFiles.Remove(path);
             return;

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
@@ -30,7 +30,7 @@ public class DatasetsViewModelExchangeSetHeaderTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
@@ -22,7 +22,7 @@ public class DatasetsViewModelTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry)
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default)
         {
             LoadCalls.Add(entry);
             return Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
@@ -19,7 +19,7 @@ public class EcdisDisplayPanelViewModelTests
         public event System.Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event System.Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -52,7 +52,7 @@ public class ExchangeSetServiceLoaderTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
@@ -62,7 +62,7 @@ public class ExchangeSetServiceLoaderTests
     private static (DatasetsViewModel datasets, ExchangeSetService service) CreateSystem()
     {
         var datasets = new DatasetsViewModel(new NoopLoader());
-        var service = new ExchangeSetService(datasets, new StubStatus());
+        var service = new ExchangeSetService(datasets, new StubStatus(), new StubToastService());
         return (datasets, service);
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
@@ -39,7 +39,7 @@ public class FeatureSearchServiceTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -47,7 +47,7 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
@@ -74,7 +74,8 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
-            measureAppearance: new StubMeasureOverlayAppearanceProvider());
+            measureAppearance: new StubMeasureOverlayAppearanceProvider(),
+            toasts: new StubToastService());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -53,7 +53,7 @@ public class MainViewModelOpenRecentTests : IDisposable
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) { Loaded.Add(entry); return Task.CompletedTask; }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) { Loaded.Add(entry); return Task.CompletedTask; }
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
@@ -84,7 +84,8 @@ public class MainViewModelOpenRecentTests : IDisposable
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: recent,
-            measureAppearance: new StubMeasureOverlayAppearanceProvider());
+            measureAppearance: new StubMeasureOverlayAppearanceProvider(),
+            toasts: new StubToastService());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -35,7 +35,7 @@ public class MainViewModelPickModeTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
@@ -67,7 +67,8 @@ public class MainViewModelPickModeTests
             ecdisDisplayPanel: new EcdisDisplayPanelViewModel(new EcdisDisplayState(), catalogues, datasets),
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
-            measureAppearance: new StubMeasureOverlayAppearanceProvider());
+            measureAppearance: new StubMeasureOverlayAppearanceProvider(),
+            toasts: new StubToastService());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -51,7 +51,7 @@ public class PickServiceTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
@@ -83,6 +83,7 @@ public class PickServiceTests
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider(),
+            toasts: new StubToastService(),
             statusPresenter: statusPresenter);
     }
 
@@ -153,7 +154,7 @@ public class PickServiceTests
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
-        public Task LoadAsync(DatasetEntry entry) => Task.CompletedTask;
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }

--- a/tests/EncDotNet.S100.Viewer.Tests/StubToastService.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/StubToastService.cs
@@ -1,0 +1,15 @@
+using System;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>No-op <see cref="IToastService"/> for unit tests.</summary>
+internal sealed class StubToastService : IToastService
+{
+    public void ShowInfo(string title, string? content = null) { }
+    public void ShowSuccess(string title, string? content = null) { }
+    public void ShowWarning(string title, string? content = null) { }
+    public void ShowError(string title, string? content = null) { }
+    public void ShowLoading(string title, string? content = null, string? actionLabel = null, Action? action = null) { }
+    public void DismissAll() { }
+}


### PR DESCRIPTION
## Motivation

Status messages in the viewer (errors, warnings, loading indicators) were previously shown only in the status bar, which is easy to miss and provides no way to interact with long-running operations. For large datasets, users had no visibility into how long a load would take and no way to cancel it.

This PR introduces toast notifications using ShadUI's built-in Toast system, giving users dismissible, interactive feedback for errors, warnings, and loading operations -- including a Cancel button for in-progress dataset loads.

## Approach

The work is split across three commits, each building on the last:

### Phase 1: Toast infrastructure and message migration
- Adds `IToastService` / `ToastService` wrapping ShadUI's `ToastManager` with severity-based delays (success 4s, warning/info 8s, error 15s)
- Registers `ToastManager` and `IToastService` in DI; adds `ToastHost` overlay to `MainWindow`
- Shifts 12 existing status-bar messages to toasts: dataset errors, exchange set load results, unrecognized files, missing files

### Phase 2: Cancellable dataset loading
- Adds `CancellationToken` to `IDatasetLoaderService.LoadAsync`
- Shows a persistent loading toast (5 min timeout) with a Cancel button for standalone dataset loads
- Uses `CancellationTokenSource.CreateLinkedTokenSource` so the toast's Cancel button and any caller-provided token both feed into one token
- Handles `OperationCanceledException` with a cancellation toast

### Phase 3: Exchange set loading toast
- Adds a loading toast with Cancel for exchange set loads, wired to the existing `CancelExchangeSetCommand`
- Suppresses per-dataset loading toasts during bulk exchange set loads (via `IsFromExchangeSet` guard) to avoid toast churn and `DismissAll` conflicts

## Notable design decisions

- **`DismissAll` limitation**: ShadUI's `Toast` class and `ToastManager.Dismiss(Toast)` are `internal`, so individual toasts can't be dismissed programmatically. `DismissAll()` is used when loading completes, which clears all visible toasts. Per-dataset toasts are suppressed during exchange set loads to mitigate this.
- **Cooperative cancellation**: The cancellation token is passed to the `Task.Run` scheduling level. The actual pipeline work inside is not yet cancellation-aware, so cancellation takes effect between pipeline stages rather than mid-computation.
- **Shared test stub**: A `StubToastService` is shared across all viewer test projects to keep test updates minimal.
- All UI strings follow the existing localization pattern (`Strings.resx` + `Strings.cs`).