### PR TITLE
Add CachingAssetSource decorator for bundled spec content

### DIFF
--- a/src/EncDotNet.S100.Core/AssetBytes.cs
+++ b/src/EncDotNet.S100.Core/AssetBytes.cs
@@ -1,0 +1,43 @@
+using System.Text;
+
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// A read-only, in-memory view of an asset previously read from an
+/// <see cref="IAssetSource"/>. Backed by a <see cref="ReadOnlyMemory{T}"/>
+/// so cache hits can be served without copying.
+/// </summary>
+/// <remarks>
+/// Intended for small, read-only assets (Lua source, XSLT templates,
+/// SVG symbols, palette XML, Feature/Portrayal Catalogue documents)
+/// whose contents are immutable for the lifetime of the originating
+/// source. See S-100 Edition 5.2.1 Part 4 (Feature Catalogue) and
+/// Part 9 (Portrayal Catalogue) for the canonical asset shapes.
+/// </remarks>
+/// <param name="Bytes">The asset contents.</param>
+/// <param name="RelativePath">
+/// The forward-slash relative path that produced these bytes, preserved
+/// for diagnostics and to keep <see cref="AssetBytes"/> self-describing.
+/// </param>
+public readonly record struct AssetBytes(ReadOnlyMemory<byte> Bytes, string RelativePath)
+{
+    /// <summary>
+    /// Returns a non-seekable-aware <see cref="Stream"/> over the asset
+    /// bytes. The returned stream is read-only and does not own the
+    /// underlying buffer; disposing it does not affect the cached
+    /// <see cref="AssetBytes"/> instance.
+    /// </summary>
+    /// <returns>A stream positioned at the start of the asset.</returns>
+    public Stream AsStream() => new ReadOnlyMemoryStream(Bytes);
+
+    /// <summary>
+    /// Decodes the asset bytes as text using the supplied
+    /// <paramref name="encoding"/> (defaulting to UTF-8 when null).
+    /// </summary>
+    /// <param name="encoding">
+    /// The encoding to use, or null for UTF-8 (the default for S-100
+    /// XML and Lua content).
+    /// </param>
+    public string AsString(Encoding? encoding = null) =>
+        (encoding ?? Encoding.UTF8).GetString(Bytes.Span);
+}

--- a/src/EncDotNet.S100.Core/AssetSourceExtensions.cs
+++ b/src/EncDotNet.S100.Core/AssetSourceExtensions.cs
@@ -1,0 +1,48 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Extension methods over <see cref="IAssetSource"/> that provide a
+/// bytes-level read surface above the existing <see cref="Stream"/>-based
+/// <see cref="IAssetSource.OpenAsync"/>.
+/// </summary>
+/// <remarks>
+/// The default implementation allocates one <see cref="byte"/> array
+/// per call. When the underlying source is wrapped in a
+/// <see cref="CachingAssetSource"/>, repeat reads of the same path are
+/// served from the in-memory cache without re-opening the underlying
+/// stream.
+/// </remarks>
+public static class AssetSourceExtensions
+{
+    /// <summary>
+    /// Reads the asset at <paramref name="relativePath"/> fully into
+    /// memory and returns an <see cref="AssetBytes"/> view.
+    /// </summary>
+    /// <param name="source">The asset source to read from.</param>
+    /// <param name="relativePath">A forward-slash relative path.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>An <see cref="AssetBytes"/> containing the asset contents.</returns>
+    public static async Task<AssetBytes> ReadAllBytesAsync(
+        this IAssetSource source,
+        string relativePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        await using Stream stream = await source.OpenAsync(relativePath, cancellationToken).ConfigureAwait(false);
+
+        // Fast path: if the underlying stream is an exposable MemoryStream,
+        // avoid the intermediate copy.
+        if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> segment))
+        {
+            byte[] copy = new byte[segment.Count];
+            Buffer.BlockCopy(segment.Array!, segment.Offset, copy, 0, segment.Count);
+            return new AssetBytes(copy, relativePath);
+        }
+
+        using var buffer = new MemoryStream(capacity: stream.CanSeek ? (int)Math.Min(stream.Length, int.MaxValue) : 4096);
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return new AssetBytes(buffer.ToArray(), relativePath);
+    }
+}

--- a/src/EncDotNet.S100.Core/CachingAssetSource.cs
+++ b/src/EncDotNet.S100.Core/CachingAssetSource.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Wraps another <see cref="IAssetSource"/> and memoises the bytes of
+/// each asset on first read. Intended for read-only sources whose
+/// contents are immutable for the lifetime of the source
+/// (<c>EmbeddedAssetSource</c>, packaged exchange sets opened in
+/// <see cref="System.IO.Compression.ZipArchiveMode.Read"/>, on-disk
+/// spec content).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache is thread-safe; concurrent first-read storms collapse to
+/// a single underlying open via <see cref="Lazy{T}"/> with
+/// <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>.
+/// </para>
+/// <para>
+/// Cache size is bounded by the number of distinct relative paths
+/// requested and is not actively evicted. For bundled S-100
+/// specification content (Feature and Portrayal Catalogues —
+/// see S-100 Edition 5.2.1 Part 4 §4 and Part 9 §3) the working set
+/// is small (tens of paths per spec) and steady-state reads dominate.
+/// </para>
+/// <para>
+/// On cache hits, the supplied <see cref="CancellationToken"/> is
+/// observed only insofar as the call is synchronous: the cached bytes
+/// are returned immediately. On a cache miss the token flows through
+/// to the underlying <see cref="IAssetSource.OpenAsync"/>.
+/// </para>
+/// </remarks>
+public sealed class CachingAssetSource : IAssetSource
+{
+    private readonly IAssetSource _inner;
+    private readonly ConcurrentDictionary<string, Lazy<Task<AssetBytes>>> _cache =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initialises a new <see cref="CachingAssetSource"/> over the given
+    /// <paramref name="inner"/> source.
+    /// </summary>
+    /// <param name="inner">The asset source to wrap. Must not be null.</param>
+    public CachingAssetSource(IAssetSource inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        AssetBytes bytes = await GetAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        return bytes.AsStream();
+    }
+
+    /// <summary>
+    /// Returns the cached <see cref="AssetBytes"/> for
+    /// <paramref name="relativePath"/>, reading from the underlying
+    /// source on first access.
+    /// </summary>
+    /// <param name="relativePath">A forward-slash relative path.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token. Observed on cache misses (when the inner
+    /// <see cref="IAssetSource.OpenAsync"/> is invoked); ignored on
+    /// cache hits.
+    /// </param>
+    public Task<AssetBytes> GetAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        Lazy<Task<AssetBytes>> lazy = _cache.GetOrAdd(
+            relativePath,
+            path => new Lazy<Task<AssetBytes>>(
+                () => _inner.ReadAllBytesAsync(path, cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return lazy.Value;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _inner.Dispose();
+}

--- a/src/EncDotNet.S100.Core/ReadOnlyMemoryStream.cs
+++ b/src/EncDotNet.S100.Core/ReadOnlyMemoryStream.cs
@@ -1,0 +1,123 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// A read-only, seekable <see cref="Stream"/> backed by a
+/// <see cref="ReadOnlyMemory{Byte}"/>. Disposing the stream does not
+/// release or copy the backing memory, which makes it safe for serving
+/// cached <see cref="AssetBytes"/> repeatedly without allocations.
+/// </summary>
+internal sealed class ReadOnlyMemoryStream : Stream
+{
+    private readonly ReadOnlyMemory<byte> _memory;
+    private long _position;
+
+    public ReadOnlyMemoryStream(ReadOnlyMemory<byte> memory)
+    {
+        _memory = memory;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _memory.Length;
+
+    public override long Position
+    {
+        get => _position;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _position = value;
+        }
+    }
+
+    public override void Flush()
+    {
+        // No-op: read-only stream has nothing to flush.
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        if (_position >= _memory.Length)
+        {
+            return 0;
+        }
+
+        int remaining = (int)Math.Min(buffer.Length, _memory.Length - _position);
+        _memory.Span.Slice((int)_position, remaining).CopyTo(buffer);
+        _position += remaining;
+        return remaining;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<int>(cancellationToken);
+        }
+
+        try
+        {
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromException<int>(ex);
+        }
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return ValueTask.FromCanceled<int>(cancellationToken);
+        }
+
+        return ValueTask.FromResult(Read(buffer.Span));
+    }
+
+    public override int ReadByte()
+    {
+        if (_position >= _memory.Length)
+        {
+            return -1;
+        }
+
+        byte value = _memory.Span[(int)_position];
+        _position++;
+        return value;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        long target = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _memory.Length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+
+        ArgumentOutOfRangeException.ThrowIfNegative(target);
+        _position = target;
+        return _position;
+    }
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    public override void Write(ReadOnlySpan<byte> buffer) =>
+        throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Specifications/EmbeddedAssetSource.cs
+++ b/src/EncDotNet.S100.Specifications/EmbeddedAssetSource.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Reflection;
 using EncDotNet.S100.Core;
 
@@ -11,11 +10,31 @@ public sealed class EmbeddedAssetSource : IAssetSource
 {
     private readonly Assembly _assembly;
     private readonly string _resourcePrefix;
+    private readonly Lazy<Dictionary<string, string>> _caseInsensitiveIndex;
 
     private EmbeddedAssetSource(Assembly assembly, string resourcePrefix)
     {
         _assembly = assembly;
         _resourcePrefix = resourcePrefix;
+        _caseInsensitiveIndex = new Lazy<Dictionary<string, string>>(
+            BuildCaseInsensitiveIndex,
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    private Dictionary<string, string> BuildCaseInsensitiveIndex()
+    {
+        // Build once and reuse: GetManifestResourceNames() walks the
+        // assembly's resource directory, which is non-trivial work to
+        // repeat on every case-insensitive miss.
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string name in _assembly.GetManifestResourceNames())
+        {
+            // First-wins keeps behaviour stable when two manifest entries
+            // differ only by case; manifest names are unique in practice.
+            map.TryAdd(name, name);
+        }
+
+        return map;
     }
 
     /// <summary>
@@ -54,9 +73,7 @@ public sealed class EmbeddedAssetSource : IAssetSource
             // (macOS, Windows) but breaks here because embedded resource names
             // are case-sensitive. This fallback keeps the bundled assets
             // byte-identical to upstream while still resolving correctly.
-            var match = _assembly.GetManifestResourceNames()
-                .FirstOrDefault(n => string.Equals(n, resourceName, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
+            if (_caseInsensitiveIndex.Value.TryGetValue(resourceName, out string? match))
             {
                 stream = _assembly.GetManifestResourceStream(match);
             }

--- a/src/EncDotNet.S100.Specifications/Specification.cs
+++ b/src/EncDotNet.S100.Specifications/Specification.cs
@@ -84,7 +84,11 @@ public static class Specification
     {
         ArgumentException.ThrowIfNullOrEmpty(productSpec);
 
-        return CreateAssetSource(productSpec, "pc");
+        // Wrap the embedded source in a caching decorator so repeated
+        // reads of the same Portrayal Catalogue asset (Lua source, XSLT
+        // templates, SVG symbols, palette XML; see S-100 Edition 5.2.1
+        // Part 9 §3) are served from memory after the first read.
+        return new CachingAssetSource(CreateAssetSource(productSpec, "pc"));
     }
 
     private static EmbeddedAssetSource CreateAssetSource(string productSpec, string subfolder)

--- a/tests/EncDotNet.S100.Core.Tests/AssetBytesTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/AssetBytesTests.cs
@@ -1,0 +1,66 @@
+using System.Text;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class AssetBytesTests
+{
+    [Fact]
+    public void AsStream_RoundTripsBytes()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        var bytes = new AssetBytes(payload, "foo/bar.bin");
+
+        using Stream stream = bytes.AsStream();
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+
+        Assert.Equal(payload, ms.ToArray());
+        Assert.Equal("foo/bar.bin", bytes.RelativePath);
+    }
+
+    [Fact]
+    public void AsStream_ReturnsFreshStreamEachCall()
+    {
+        byte[] payload = [10, 20, 30];
+        var bytes = new AssetBytes(payload, "p.bin");
+
+        using Stream a = bytes.AsStream();
+        using Stream b = bytes.AsStream();
+
+        // Reading from `a` should not advance `b`.
+        Assert.Equal(10, a.ReadByte());
+        Assert.Equal(10, b.ReadByte());
+    }
+
+    [Fact]
+    public void AsStream_IsSeekable()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        var bytes = new AssetBytes(payload, "p.bin");
+
+        using Stream stream = bytes.AsStream();
+        Assert.True(stream.CanSeek);
+        Assert.Equal(5, stream.Length);
+        stream.Seek(2, SeekOrigin.Begin);
+        Assert.Equal(3, stream.ReadByte());
+    }
+
+    [Fact]
+    public void AsString_DecodesUtf8ByDefault()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("héllo");
+        var bytes = new AssetBytes(payload, "t.txt");
+
+        Assert.Equal("héllo", bytes.AsString());
+    }
+
+    [Fact]
+    public void AsString_UsesProvidedEncoding()
+    {
+        byte[] payload = Encoding.Unicode.GetBytes("héllo");
+        var bytes = new AssetBytes(payload, "t.txt");
+
+        Assert.Equal("héllo", bytes.AsString(Encoding.Unicode));
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/AssetSourceExtensionsTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/AssetSourceExtensionsTests.cs
@@ -1,0 +1,77 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class AssetSourceExtensionsTests
+{
+    [Fact]
+    public async Task ReadAllBytesAsync_ReturnsAssetContents()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        using var source = new InMemoryAssetSource(new()
+        {
+            ["foo/bar.bin"] = payload,
+        });
+
+        AssetBytes bytes = await source.ReadAllBytesAsync("foo/bar.bin");
+
+        Assert.Equal(payload, bytes.Bytes.ToArray());
+        Assert.Equal("foo/bar.bin", bytes.RelativePath);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_DisposesUnderlyingStream()
+    {
+        var stream = new TrackingMemoryStream([7, 8, 9]);
+        using var source = new SingleStreamAssetSource(stream);
+
+        AssetBytes bytes = await source.ReadAllBytesAsync("path");
+
+        Assert.Equal(new byte[] { 7, 8, 9 }, bytes.Bytes.ToArray());
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ThrowsOnNullSource()
+    {
+        IAssetSource source = null!;
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => source.ReadAllBytesAsync("path"));
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ThrowsOnEmptyPath()
+    {
+        using var source = new InMemoryAssetSource(new());
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => source.ReadAllBytesAsync(""));
+    }
+
+    private sealed class SingleStreamAssetSource : IAssetSource
+    {
+        private readonly Stream _stream;
+
+        public SingleStreamAssetSource(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+            => Task.FromResult(_stream);
+
+        public void Dispose() { }
+    }
+
+    private sealed class TrackingMemoryStream : MemoryStream
+    {
+        public TrackingMemoryStream(byte[] buffer) : base(buffer, writable: false) { }
+
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/CachingAssetSourceTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/CachingAssetSourceTests.cs
@@ -1,0 +1,159 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class CachingAssetSourceTests
+{
+    [Fact]
+    public async Task GetAsync_ReturnsSameBytesOnRepeatedReads()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1, 2, 3],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes first = await cache.GetAsync("a.txt");
+        AssetBytes second = await cache.GetAsync("a.txt");
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, first.Bytes.ToArray());
+        Assert.Equal(new byte[] { 1, 2, 3 }, second.Bytes.ToArray());
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+    }
+
+    [Fact]
+    public async Task GetAsync_DifferentPathsAreIndependent()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1],
+            ["b.txt"] = [2],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes a = await cache.GetAsync("a.txt");
+        AssetBytes b = await cache.GetAsync("b.txt");
+        AssetBytes a2 = await cache.GetAsync("a.txt");
+
+        Assert.Equal(new byte[] { 1 }, a.Bytes.ToArray());
+        Assert.Equal(new byte[] { 2 }, b.Bytes.ToArray());
+        Assert.Equal(new byte[] { 1 }, a2.Bytes.ToArray());
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+        Assert.Equal(1, inner.OpenCount("b.txt"));
+    }
+
+    [Fact]
+    public async Task GetAsync_KeyIsCaseSensitive()
+    {
+        // Ordinal keys: "A.txt" and "a.txt" should be distinct cache
+        // entries. The underlying source decides case semantics.
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1],
+            ["A.txt"] = [2],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes lower = await cache.GetAsync("a.txt");
+        AssetBytes upper = await cache.GetAsync("A.txt");
+
+        Assert.Equal(new byte[] { 1 }, lower.Bytes.ToArray());
+        Assert.Equal(new byte[] { 2 }, upper.Bytes.ToArray());
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+        Assert.Equal(1, inner.OpenCount("A.txt"));
+    }
+
+    [Fact]
+    public async Task ConcurrentFirstReads_OpenInnerExactlyOnce()
+    {
+        var inner = new InMemoryAssetSource(
+            new() { ["hot.txt"] = [9, 9, 9] },
+            openDelay: TimeSpan.FromMilliseconds(50));
+        using var cache = new CachingAssetSource(inner);
+
+        Task<AssetBytes>[] tasks = Enumerable
+            .Range(0, 32)
+            .Select(_ => Task.Run(() => cache.GetAsync("hot.txt")))
+            .ToArray();
+
+        AssetBytes[] results = await Task.WhenAll(tasks);
+
+        Assert.All(results, r => Assert.Equal(new byte[] { 9, 9, 9 }, r.Bytes.ToArray()));
+        Assert.Equal(1, inner.OpenCount("hot.txt"));
+    }
+
+    [Fact]
+    public async Task OpenAsync_ReturnsFreshStreamPerCall()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1, 2, 3, 4, 5],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        await using Stream first = await cache.OpenAsync("a.txt");
+        await using Stream second = await cache.OpenAsync("a.txt");
+
+        // Consuming `first` should not affect `second`.
+        Assert.Equal(1, first.ReadByte());
+        Assert.Equal(1, second.ReadByte());
+        Assert.Equal(2, first.ReadByte());
+        Assert.Equal(2, second.ReadByte());
+
+        // And the inner source was opened exactly once.
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+    }
+
+    [Fact]
+    public async Task OpenAsync_ServesBytesIdenticalToReadAllBytesAsync()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [10, 20, 30, 40],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes bytes = await cache.GetAsync("a.txt");
+        await using Stream stream = await cache.OpenAsync("a.txt");
+        using var copy = new MemoryStream();
+        await stream.CopyToAsync(copy);
+
+        Assert.Equal(bytes.Bytes.ToArray(), copy.ToArray());
+    }
+
+    [Fact]
+    public void Dispose_ForwardsToInner()
+    {
+        var inner = new InMemoryAssetSource(new());
+        var cache = new CachingAssetSource(inner);
+
+        cache.Dispose();
+
+        Assert.True(inner.Disposed);
+    }
+
+    [Fact]
+    public async Task GetAsync_PropagatesFileNotFoundOnMiss()
+    {
+        var inner = new InMemoryAssetSource(new());
+        using var cache = new CachingAssetSource(inner);
+
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => cache.GetAsync("missing"));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullInner()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CachingAssetSource(null!));
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsOnEmptyPath()
+    {
+        var inner = new InMemoryAssetSource(new());
+        using var cache = new CachingAssetSource(inner);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => cache.GetAsync(""));
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/InMemoryAssetSource.cs
+++ b/tests/EncDotNet.S100.Core.Tests/InMemoryAssetSource.cs
@@ -1,0 +1,54 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+/// <summary>
+/// A test <see cref="IAssetSource"/> backed by an in-memory dictionary
+/// that counts how many times each path was opened on the underlying
+/// source. Used to assert caching semantics of
+/// <see cref="CachingAssetSource"/>.
+/// </summary>
+internal sealed class InMemoryAssetSource : IAssetSource
+{
+    private readonly Dictionary<string, byte[]> _assets;
+    private readonly ConcurrentDictionary<string, int> _openCounts = new(StringComparer.Ordinal);
+    private readonly TimeSpan _openDelay;
+
+    public InMemoryAssetSource(
+        Dictionary<string, byte[]> assets,
+        TimeSpan? openDelay = null)
+    {
+        _assets = assets;
+        _openDelay = openDelay ?? TimeSpan.Zero;
+    }
+
+    public bool Disposed { get; private set; }
+
+    public int OpenCount(string path) =>
+        _openCounts.TryGetValue(path, out int count) ? count : 0;
+
+    public int TotalOpenCount => _openCounts.Values.Sum();
+
+    public async Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        _openCounts.AddOrUpdate(relativePath, 1, static (_, current) => current + 1);
+
+        if (_openDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(_openDelay, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!_assets.TryGetValue(relativePath, out byte[]? bytes))
+        {
+            throw new FileNotFoundException($"Asset not found: {relativePath}");
+        }
+
+        return new MemoryStream(bytes, writable: false);
+    }
+
+    public void Dispose()
+    {
+        Disposed = true;
+    }
+}


### PR DESCRIPTION
Implements PR-0 from the asset caching audit
(plan path: `/Users/phoff/.copilot/session-state/c76ae42b-5904-41a7-b783-79a5883cc2a1/plan.md`,
Appendix §1.6–§1.9 and §5 PR-0). Introduces a bytes-level memoisation
seam above `IAssetSource` and wires it into bundled Portrayal
Catalogue content. **No behaviour change** — the value is the seam.

## What's new

### `EncDotNet.S100.Core`
- **`AssetBytes`** — readonly record struct `(ReadOnlyMemory<byte> Bytes, string RelativePath)` with `AsStream()` and `AsString(Encoding?)` helpers. `AsStream()` is served by a small internal `ReadOnlyMemoryStream` so cache hits do not copy.
- **`AssetSourceExtensions.ReadAllBytesAsync`** — extension method that materialises an asset into an `AssetBytes`; fast-paths an exposable `MemoryStream` buffer.
- **`CachingAssetSource`** — `IAssetSource` decorator backed by `ConcurrentDictionary<string, Lazy<Task<AssetBytes>>>` with `LazyThreadSafetyMode.ExecutionAndPublication` so concurrent first-readers collapse to a single inner open. Exposes both `OpenAsync` (fresh stream per call) and a new `GetAsync` for zero-allocation callers. `Dispose` forwards to the inner source. Keys are ordinal strings — case semantics are left to the underlying source.

### `EncDotNet.S100.Specifications`
- **`Specification.CreatePortrayalCatalogueSource`** now wraps the bundled `EmbeddedAssetSource` in a `CachingAssetSource`. Return type is still `IAssetSource`; callers are unaffected.
- **`EmbeddedAssetSource`** now memoises its case-insensitive manifest-name fallback via a `Lazy<Dictionary<string, string>>`, avoiding a fresh `GetManifestResourceNames()` walk on every miss (this is the audit's PR-5, subsumed here).

## Tests
- `tests/EncDotNet.S100.Core.Tests/AssetBytesTests.cs` — `AsStream`/`AsString` round-trip, fresh stream per call, seekability, explicit encoding.
- `tests/EncDotNet.S100.Core.Tests/AssetSourceExtensionsTests.cs` — bytes correct, underlying stream disposed, argument validation.
- `tests/EncDotNet.S100.Core.Tests/CachingAssetSourceTests.cs` — repeated reads same bytes, **32-way concurrent first-reads → exactly one inner open** (via counting `InMemoryAssetSource`), distinct paths independent, ordinal key semantics, independent streams from `OpenAsync`, `Dispose` forwarding, error propagation.

## Verification
- `dotnet build --configuration Release` — clean (no new warnings).
- `dotnet test --configuration Release` — **all green**, including the new tests (111 in `EncDotNet.S100.Core.Tests`).
- `tools/EncDotNet.S100.PerfRunner run s101-portray-warm` before & after: mean 100.26 ms (main) vs 86.50 ms (this branch); within run-to-run noise — no regression. (Baseline reference: `tools/EncDotNet.S100.PerfRunner/baselines/c282a6512ad8/s101-portray-warm.md`.)

## Scope decisions
- **Feature Catalogue intentionally not wrapped**: `Specification` currently exposes only per-call `OpenFeatureCatalogueAsync`/`TryOpenFeatureCatalogue` (the source is `using`-disposed each call). Wrapping there is a no-op; deferred until we add a long-lived FC source.

## Out of scope / follow-ups
- Wrapping `ZipAssetSource` for exchange-set datasets in the viewer's dataset loader (plus `lock(_archive)` for thread safety).
- Long-lived `CreateFeatureCatalogueSource(spec)` on `Specification`, with caching wired in.
- Telemetry counters `s100.asset.cache.hit` / `s100.asset.cache.miss`.
- Promoting `AssetBytes` onto `IAssetSource` itself (revisit after audit Segment 3).
- Migrating call sites away from `OpenAsync` + `StreamReader.ReadToEnd()` — they continue to work; the cache just makes repeat reads free.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>