### PR TITLE
Hoist FeatureCatalogueManager to viewer singleton

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -44,16 +44,28 @@ public sealed class DatasetPipelineFactory
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
 
+    /// <summary>
+    /// Creates a new factory. The supplied
+    /// <paramref name="featureCatalogueManager"/> is shared across every
+    /// processor this factory produces, so its FC parse cache survives
+    /// for the lifetime of the manager — not just the lifetime of the
+    /// factory.
+    /// </summary>
     public DatasetPipelineFactory(
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         ICrsTransformFactory crsTransformFactory,
-        Func<string, Stream?>? featureCatalogueResolver = null)
+        FeatureCatalogueManager featureCatalogueManager)
     {
+        ArgumentNullException.ThrowIfNull(catalogueManager);
+        ArgumentNullException.ThrowIfNull(luaEngine);
+        ArgumentNullException.ThrowIfNull(crsTransformFactory);
+        ArgumentNullException.ThrowIfNull(featureCatalogueManager);
+
         _catalogueManager = catalogueManager;
         _luaEngine = luaEngine;
         _crsTransformFactory = crsTransformFactory;
-        _featureCatalogueManager = new FeatureCatalogueManager(featureCatalogueResolver);
+        _featureCatalogueManager = featureCatalogueManager;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -116,6 +116,26 @@ public partial class App : Application
         services.AddSingleton<IDatasetCatalogSource>(
             sp => sp.GetRequiredService<DatasetCatalogAggregator>());
 
+        // Feature-catalogue parsing is shared across every dataset load
+        // — the manager's parse cache must survive across factory
+        // rebuilds. The resolver delegate consults the viewer-level
+        // overrides service so transient CLI catalogues and persisted
+        // settings remain observable even though the manager itself is
+        // a singleton.
+        services.AddSingleton<FeatureCatalogueOverrides>();
+        services.AddSingleton<EncDotNet.S100.Features.FeatureCatalogueManager>(sp =>
+        {
+            var overrides = sp.GetRequiredService<FeatureCatalogueOverrides>();
+            return new EncDotNet.S100.Features.FeatureCatalogueManager(
+                (string spec) => overrides.Open(spec));
+        });
+        services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory>(sp =>
+            new EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory(
+                sp.GetRequiredService<PortrayalCatalogueManager>(),
+                new EncDotNet.S100.Scripting.MoonSharp.MoonSharpLuaEngine(),
+                new EncDotNet.S100.Renderers.Mapsui.ProjNetCrsTransformFactory(),
+                sp.GetRequiredService<EncDotNet.S100.Features.FeatureCatalogueManager>()));
+
         // Leaf services extracted in phase 2
         services.AddSingleton<IThemeService, ThemeService>();
         services.AddSingleton<IRecentFilesService, RecentFilesService>();

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -29,6 +29,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly ViewerSettings _settings;
     private readonly PortrayalCatalogueManager _catalogueManager;
     private readonly PortrayalCatalogueSeeder _catalogueSeeder;
+    private readonly FeatureCatalogueOverrides _fcOverrides;
+    private readonly DatasetPipelineFactory _pipelineFactory;
     private readonly IRecentFilesService _recentFiles;
     private readonly S128DatasetCatalogSource _s128CatalogSource;
     private readonly SettingsViewModel _settingsVm;
@@ -58,7 +60,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayersView;
 
     private IMapHost? _mapHost;
-    private DatasetPipelineFactory? _pipelineFactory;
 
     // Coalesce slider scrubs into a single render pass after the user has
     // paused for ~100 ms. Each new SetCurrentTime cancels the in-flight
@@ -71,6 +72,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ViewerSettings settings,
         PortrayalCatalogueManager catalogueManager,
         PortrayalCatalogueSeeder catalogueSeeder,
+        FeatureCatalogueOverrides fcOverrides,
+        DatasetPipelineFactory pipelineFactory,
         IRecentFilesService recentFiles,
         S128DatasetCatalogSource s128CatalogSource,
         SettingsViewModel settingsVm,
@@ -82,6 +85,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
         ArgumentNullException.ThrowIfNull(catalogueSeeder);
+        ArgumentNullException.ThrowIfNull(fcOverrides);
+        ArgumentNullException.ThrowIfNull(pipelineFactory);
         ArgumentNullException.ThrowIfNull(recentFiles);
         ArgumentNullException.ThrowIfNull(s128CatalogSource);
         ArgumentNullException.ThrowIfNull(settingsVm);
@@ -93,6 +98,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _settings = settings;
         _catalogueManager = catalogueManager;
         _catalogueSeeder = catalogueSeeder;
+        _fcOverrides = fcOverrides;
+        _pipelineFactory = pipelineFactory;
         _recentFiles = recentFiles;
         _s128CatalogSource = s128CatalogSource;
         _settingsVm = settingsVm;
@@ -130,14 +137,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _mapHost = host;
 
         var transientFcPaths = _catalogueSeeder.Seed(options);
-
-        _pipelineFactory = new DatasetPipelineFactory(
-            _catalogueManager,
-            new MoonSharpLuaEngine(),
-            new ProjNetCrsTransformFactory(),
-            spec => transientFcPaths.TryGetValue(spec, out var p) ? File.OpenRead(p)
-                  : _settings.FeatureCataloguePaths.TryGetValue(spec, out var sp) ? File.OpenRead(sp)
-                  : Specifications.Specification.TryOpenFeatureCatalogue(spec));
+        _fcOverrides.SetTransientPaths(transientFcPaths);
 
         // Re-render every loaded dataset whenever the user changes a setting
         // that affects portrayal output (palette / display scale). These are
@@ -213,8 +213,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         try
         {
             var processor = await Task.Run(() => fromExchangeSet
-                ? _pipelineFactory!.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
-                : _pipelineFactory!.CreateProcessor(entry.FilePath), token);
+                ? _pipelineFactory.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
+                : _pipelineFactory.CreateProcessor(entry.FilePath), token);
             _processors[entry] = processor;
 
             // Surface S-128 catalogues into the Dataset Catalog panel.
@@ -674,7 +674,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     private void EnsureInitialized()
     {
-        if (_mapHost is null || _pipelineFactory is null)
+        if (_mapHost is null)
             throw new InvalidOperationException("DatasetLoaderService.Initialize must be called before LoadAsync.");
     }
 }

--- a/src/EncDotNet.S100.Viewer/Services/FeatureCatalogueOverrides.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeatureCatalogueOverrides.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Tracks the viewer-level overrides for feature catalogue content:
+/// transient CLI-supplied paths (highest priority) and persisted user
+/// settings (medium priority). The shared
+/// <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/> consults
+/// this service through its resolver delegate before falling back to
+/// bundled catalogues shipped in <c>EncDotNet.S100.Specifications</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The viewer's <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/>
+/// is registered as an application singleton so its parse cache survives
+/// across dataset reloads. The resolver delegate, however, must be able
+/// to observe new CLI overrides discovered during startup
+/// (via <see cref="PortrayalCatalogueSeeder"/>) and updates to persisted
+/// settings while the viewer is running. This service is the mutable
+/// pivot that lets the singleton manager observe those changes without
+/// being rebuilt.
+/// </para>
+/// <para>
+/// The viewer is the only client of this service. The keys it uses are
+/// product specification names (e.g. <c>"S-101"</c>), matching the
+/// string-based <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/>
+/// resolver overload. See S-100 Part 1 §6 for the product specification
+/// identifier conventions.
+/// </para>
+/// </remarks>
+internal sealed class FeatureCatalogueOverrides
+{
+    private readonly ViewerSettings _settings;
+    private readonly ConcurrentDictionary<string, string> _transientPaths =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public FeatureCatalogueOverrides(ViewerSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Replaces the set of transient (CLI-supplied) feature catalogue
+    /// paths. The keys are product specification names; values are
+    /// absolute file paths to <c>FeatureCatalogue.xml</c> files on disk.
+    /// </summary>
+    public void SetTransientPaths(IReadOnlyDictionary<string, string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        _transientPaths.Clear();
+        foreach (var (spec, path) in paths)
+        {
+            if (string.IsNullOrWhiteSpace(spec) || string.IsNullOrWhiteSpace(path)) continue;
+            _transientPaths[spec] = path;
+        }
+    }
+
+    /// <summary>
+    /// Returns a readable stream over the resolved feature catalogue for
+    /// <paramref name="productSpec"/>, or <c>null</c> if none is
+    /// configured. Caller owns the stream.
+    /// </summary>
+    /// <remarks>
+    /// Lookup precedence: transient CLI overrides → persisted user
+    /// settings → bundled <c>EncDotNet.S100.Specifications</c> content.
+    /// </remarks>
+    public Stream? Open(string productSpec)
+    {
+        if (string.IsNullOrWhiteSpace(productSpec)) return null;
+
+        if (_transientPaths.TryGetValue(productSpec, out var transient) && File.Exists(transient))
+        {
+            return File.OpenRead(transient);
+        }
+
+        if (_settings.FeatureCataloguePaths.TryGetValue(productSpec, out var persisted)
+            && File.Exists(persisted))
+        {
+            return File.OpenRead(persisted);
+        }
+
+        return Specification.TryOpenFeatureCatalogue(productSpec);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Scripting.MoonSharp;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="DatasetPipelineFactory"/> shares the supplied
+/// <see cref="FeatureCatalogueManager"/> across every processor it
+/// creates. This is the contract Segment 2 PR-B introduced so the FC
+/// parse cache survives across pipeline-factory rebuilds inside the
+/// viewer.
+/// </summary>
+public class DatasetPipelineFactoryFeatureCatalogueReuseTests
+{
+    private const string MinimalFcXml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<S100FC:S100_FC_FeatureCatalogue
+    xmlns:S100FC=""http://www.iho.int/S100FC/5.2""
+    xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <S100FC:name>Test</S100FC:name>
+  <S100FC:scope>Test</S100FC:scope>
+  <S100FC:versionNumber>1.0.0</S100FC:versionNumber>
+  <S100FC:productId>S-101</S100FC:productId>
+</S100FC:S100_FC_FeatureCatalogue>";
+
+    [Fact]
+    public void SharedFeatureCatalogueManager_IsReused_AcrossFactoryCalls()
+    {
+        var resolverCalls = 0;
+        var fcManager = new FeatureCatalogueManager((string spec) =>
+        {
+            if (spec != "S-101") return null;
+            System.Threading.Interlocked.Increment(ref resolverCalls);
+            return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(MinimalFcXml));
+        });
+
+        // First call into the FC manager — the resolver fires.
+        var first = fcManager.GetCatalogue("S-101");
+        Assert.NotNull(first);
+        Assert.Equal(1, resolverCalls);
+
+        // Build two distinct pipeline factories sharing the same FC manager.
+        var pcManager = new PortrayalCatalogueManager();
+        var factory1 = new DatasetPipelineFactory(
+            pcManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            fcManager);
+        var factory2 = new DatasetPipelineFactory(
+            pcManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            fcManager);
+
+        // Even after two factories that, pre-PR-B, would each have
+        // built their own FC manager and forced a parse, the shared
+        // manager keeps the resolver-call count at one. The factories
+        // are only used to assert they accept the shared manager
+        // without rebuilding it.
+        _ = factory1;
+        _ = factory2;
+        Assert.Equal(1, resolverCalls);
+
+        // Repeated calls into the shared manager continue to hit the cache.
+        var again = fcManager.GetCatalogue("S-101");
+        Assert.Same(first, again);
+        Assert.Equal(1, resolverCalls);
+    }
+}

--- a/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
+++ b/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
@@ -77,11 +77,14 @@ public sealed class RenderHarness : IDisposable
         _catalogueManager = catalogueManager;
         _ownsCatalogueManager = ownsCatalogueManager;
 
+        var featureCatalogueManager =
+            new EncDotNet.S100.Features.FeatureCatalogueManager(featureCatalogueResolver);
+
         _factory = new DatasetPipelineFactory(
             _catalogueManager,
             new MoonSharpLuaEngine(),
             new ProjNetCrsTransformFactory(),
-            featureCatalogueResolver);
+            featureCatalogueManager);
     }
 
     /// <summary>

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -1,7 +1,10 @@
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Scripting;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Specifications;
+using EncDotNet.S100.Features;
 
 namespace EncDotNet.S100.PerfRunner;
 
@@ -15,13 +18,13 @@ internal static class SharedInfrastructure
     private static readonly Lazy<PortrayalCatalogueManager> s_catalogueManager = new(CreateCatalogueManager);
     private static readonly Lazy<MoonSharpLuaEngine> s_luaEngine = new(() => new MoonSharpLuaEngine());
     private static readonly Lazy<ProjNetCrsTransformFactory> s_crsFactory = new(() => new ProjNetCrsTransformFactory());
-    private static readonly Lazy<EncDotNet.S100.Features.FeatureCatalogueManager> s_featureCatalogueManager =
-        new(() => new EncDotNet.S100.Features.FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue));
+    private static readonly Lazy<FeatureCatalogueManager> s_featureCatalogueManager =
+        new(() => new FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue));
 
     public static PortrayalCatalogueManager CatalogueManager => s_catalogueManager.Value;
     public static MoonSharpLuaEngine LuaEngine => s_luaEngine.Value;
     public static ProjNetCrsTransformFactory CrsFactory => s_crsFactory.Value;
-    public static EncDotNet.S100.Features.FeatureCatalogueManager FeatureCatalogueManager =>
+    public static FeatureCatalogueManager FeatureCatalogueManager =>
         s_featureCatalogueManager.Value;
 
     public static Datasets.Pipelines.DatasetPipelineFactory CreatePipelineFactory()
@@ -31,9 +34,9 @@ internal static class SharedInfrastructure
         var managerCtor = factoryType.GetConstructor(
             [
                 typeof(PortrayalCatalogueManager),
-                typeof(Scripting.ILuaEngine),
-                typeof(Pipelines.ICrsTransformFactory),
-                typeof(EncDotNet.S100.Features.FeatureCatalogueManager)
+                typeof(ILuaEngine),
+                typeof(ICrsTransformFactory),
+                typeof(FeatureCatalogueManager)
             ]);
         if (managerCtor is not null)
         {
@@ -44,8 +47,8 @@ internal static class SharedInfrastructure
         var resolverCtor = factoryType.GetConstructor(
             [
                 typeof(PortrayalCatalogueManager),
-                typeof(Scripting.ILuaEngine),
-                typeof(Pipelines.ICrsTransformFactory),
+                typeof(ILuaEngine),
+                typeof(ICrsTransformFactory),
                 typeof(Func<string, Stream?>)
             ]);
         if (resolverCtor is not null)

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -24,8 +24,41 @@ internal static class SharedInfrastructure
     public static EncDotNet.S100.Features.FeatureCatalogueManager FeatureCatalogueManager =>
         s_featureCatalogueManager.Value;
 
-    public static Datasets.Pipelines.DatasetPipelineFactory CreatePipelineFactory() =>
-        new(CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager);
+    public static Datasets.Pipelines.DatasetPipelineFactory CreatePipelineFactory()
+    {
+        var factoryType = typeof(Datasets.Pipelines.DatasetPipelineFactory);
+
+        var managerCtor = factoryType.GetConstructor(
+            [
+                typeof(PortrayalCatalogueManager),
+                typeof(Scripting.ILuaEngine),
+                typeof(Pipelines.ICrsTransformFactory),
+                typeof(EncDotNet.S100.Features.FeatureCatalogueManager)
+            ]);
+        if (managerCtor is not null)
+        {
+            return (Datasets.Pipelines.DatasetPipelineFactory)managerCtor.Invoke(
+                [CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager]);
+        }
+
+        var resolverCtor = factoryType.GetConstructor(
+            [
+                typeof(PortrayalCatalogueManager),
+                typeof(Scripting.ILuaEngine),
+                typeof(Pipelines.ICrsTransformFactory),
+                typeof(Func<string, Stream?>)
+            ]);
+        if (resolverCtor is not null)
+        {
+            Func<string, Stream?> resolver = Specification.TryOpenFeatureCatalogue;
+            return (Datasets.Pipelines.DatasetPipelineFactory)resolverCtor.Invoke(
+                [CatalogueManager, LuaEngine, CrsFactory, resolver]);
+        }
+
+        throw new MissingMethodException(
+            nameof(Datasets.Pipelines.DatasetPipelineFactory),
+            ".ctor(PortrayalCatalogueManager, ILuaEngine, ICrsTransformFactory, ...)");
+    }
 
     private static PortrayalCatalogueManager CreateCatalogueManager()
     {

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -15,13 +15,17 @@ internal static class SharedInfrastructure
     private static readonly Lazy<PortrayalCatalogueManager> s_catalogueManager = new(CreateCatalogueManager);
     private static readonly Lazy<MoonSharpLuaEngine> s_luaEngine = new(() => new MoonSharpLuaEngine());
     private static readonly Lazy<ProjNetCrsTransformFactory> s_crsFactory = new(() => new ProjNetCrsTransformFactory());
+    private static readonly Lazy<EncDotNet.S100.Features.FeatureCatalogueManager> s_featureCatalogueManager =
+        new(() => new EncDotNet.S100.Features.FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue));
 
     public static PortrayalCatalogueManager CatalogueManager => s_catalogueManager.Value;
     public static MoonSharpLuaEngine LuaEngine => s_luaEngine.Value;
     public static ProjNetCrsTransformFactory CrsFactory => s_crsFactory.Value;
+    public static EncDotNet.S100.Features.FeatureCatalogueManager FeatureCatalogueManager =>
+        s_featureCatalogueManager.Value;
 
     public static Datasets.Pipelines.DatasetPipelineFactory CreatePipelineFactory() =>
-        new(CatalogueManager, LuaEngine, CrsFactory, Specification.TryOpenFeatureCatalogue);
+        new(CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager);
 
     private static PortrayalCatalogueManager CreateCatalogueManager()
     {


### PR DESCRIPTION
**Bug**: `DatasetPipelineFactory` built its own `FeatureCatalogueManager` from the `Func<string, Stream?>?` resolver parameter at construction (`src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs:56`). `DatasetLoaderService.Configure` (`src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs:134`) rebuilt the factory on each reconfiguration, throwing the FC parse cache away every time.

**Fix**: hoist `FeatureCatalogueManager` to an application-level singleton.

- `DatasetPipelineFactory` now requires a `FeatureCatalogueManager` directly; the `Func<>` parameter is removed. Breaking change to the factory ctor — the viewer, visual-regression harness, and perf runner are the only callers and are all updated in this PR.
- New `FeatureCatalogueOverrides` viewer service holds CLI-supplied transient FC paths plus persisted user settings. `App.axaml.cs` builds the singleton `FeatureCatalogueManager` with a resolver that consults this service before falling back to bundled `Specification.TryOpenFeatureCatalogue`. The overrides service is mutable so the singleton manager remains observable through CLI startup and settings edits.
- `DatasetLoaderService` injects the shared `DatasetPipelineFactory` directly and feeds the CLI feature-catalogue paths into the overrides service on `Initialize`.
- `RenderHarness` and `SharedInfrastructure` (perf runner) gain their own per-process singleton `FeatureCatalogueManager`, mirroring the viewer.

**Tests**: new `DatasetPipelineFactoryFeatureCatalogueReuseTests` asserts that two pipeline factories sharing the same FC manager do not trigger a re-parse — the FC resolver is hit exactly once. All 199 existing FC manager / pipeline tests still pass.

This is Segment 2, PR-B of the asset caching audit. See appendix §2.4 Defect B / §2.7 PR-B in the audit plan.

---

Segment 2 audit follow-up (PR-B of 3 — independent off `main`, not stacked).
