### PR TITLE
Allow FeatureCatalogueManager to be configured via IAssetSource

### DIFF
--- a/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
@@ -24,11 +24,22 @@ namespace EncDotNet.S100.Features;
 /// cache slot per product name.
 /// </para>
 /// </remarks>
-public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogue>
+public sealed class FeatureCatalogueManager : IDisposable, ICatalogueProvider<FeatureCatalogue>
 {
     private readonly Func<SpecRef, Stream?> _resolver;
     private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogue?>> _catalogues = new();
     private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogueDecoder?>> _decoders = new();
+    private readonly ConcurrentDictionary<SpecRef, IAssetSource> _sources = new();
+
+    private const string FeatureCatalogueAssetName = "FeatureCatalogue.xml";
+
+    private static SpecRef ToSpec(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        if (!SpecName.TryNormalize(productSpec, out var name))
+            throw new ArgumentException($"'{productSpec}' is not a recognised product specification name.", nameof(productSpec));
+        return new SpecRef(name, default);
+    }
 
     /// <summary>
     /// Initializes a new <see cref="FeatureCatalogueManager"/> with a string-based
@@ -120,7 +131,24 @@ public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogu
     {
         Stream? stream;
         try { stream = _resolver(spec); }
-        catch { return null; }
+        catch { stream = null; }
+
+        // Resolver wins; the IAssetSource registered via SetSource is a
+        // bundled fallback for specs the resolver does not handle. This
+        // preserves the existing CLI / settings override behaviour while
+        // letting Specification.CreateFeatureCatalogueSource provide
+        // caching access to bundled FCs.
+        if (stream is null && _sources.TryGetValue(spec, out var source))
+        {
+            try
+            {
+                stream = source.OpenAsync(FeatureCatalogueAssetName).GetAwaiter().GetResult();
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
         if (stream is null) return null;
 
@@ -137,6 +165,68 @@ public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogu
             // degrades to raw codes and portrayal falls back gracefully.
             return null;
         }
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IAssetSource"/> as the bundled fallback for
+    /// the given product specification. The resolver delegate supplied to
+    /// the manager constructor still takes precedence; the source is only
+    /// consulted when the resolver returns <c>null</c> for that spec.
+    /// </summary>
+    /// <remarks>
+    /// The manager assumes ownership of <paramref name="source"/> for
+    /// disposal purposes — a subsequent <see cref="SetSource(SpecRef, IAssetSource)"/>
+    /// for the same spec disposes the previous source, and
+    /// <see cref="Dispose"/> disposes every registered source. The source
+    /// is expected to expose a <c>FeatureCatalogue.xml</c> asset matching
+    /// the convention used by
+    /// <c>EncDotNet.S100.Specifications.Specification</c>.
+    /// </remarks>
+    public void SetSource(string productSpec, IAssetSource source) =>
+        SetSource(ToSpec(productSpec), source);
+
+    /// <summary>
+    /// Registers an <see cref="IAssetSource"/> for the given spec reference.
+    /// See <see cref="SetSource(string, IAssetSource)"/> for the precedence
+    /// rules and disposal semantics.
+    /// </summary>
+    public void SetSource(SpecRef spec, IAssetSource source)
+    {
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
+        ArgumentNullException.ThrowIfNull(source);
+
+        // Evict any cached parse result so the new source is consulted on
+        // the next access.
+        _catalogues.TryRemove(spec, out _);
+        _decoders.TryRemove(spec, out _);
+
+        // Atomically swap the source and dispose any prior entry.
+        var previous = _sources.AddOrUpdate(
+            spec,
+            _ => source,
+            (_, existing) =>
+            {
+                if (!ReferenceEquals(existing, source))
+                {
+                    try { existing.Dispose(); } catch { /* best-effort */ }
+                }
+                return source;
+            });
+        _ = previous; // suppress unused
+    }
+
+    /// <summary>
+    /// Disposes every <see cref="IAssetSource"/> registered through
+    /// <see cref="SetSource(SpecRef, IAssetSource)"/>. Cached catalogues
+    /// themselves are plain in-memory objects and do not require disposal.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var source in _sources.Values)
+        {
+            try { source.Dispose(); } catch { /* best-effort */ }
+        }
+        _sources.Clear();
     }
 
     /// <inheritdoc />

--- a/src/EncDotNet.S100.Specifications/Specification.cs
+++ b/src/EncDotNet.S100.Specifications/Specification.cs
@@ -63,6 +63,40 @@ public static class Specification
     }
 
     /// <summary>
+    /// Returns true if a bundled Feature Catalogue exists for the given product specification.
+    /// </summary>
+    public static bool HasFeatureCatalogue(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+
+        string normalized = productSpec.Replace("-", "");
+        string resourceName = $"{ContentPrefix}.{normalized}.fc.FeatureCatalogue.xml";
+        return ResourceAssembly.GetManifestResourceInfo(resourceName) is not null;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IAssetSource"/> rooted at the bundled Feature
+    /// Catalogue directory for the given product specification. The source
+    /// is wrapped in a <see cref="CachingAssetSource"/> so repeated reads
+    /// of <c>FeatureCatalogue.xml</c> are served from memory after the
+    /// first read.
+    /// </summary>
+    /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102").</param>
+    /// <returns>An asset source for the bundled Feature Catalogue contents.</returns>
+    /// <remarks>
+    /// This parallels <see cref="CreatePortrayalCatalogueSource(string)"/>
+    /// and lets callers register the bundled FC with
+    /// <c>FeatureCatalogueManager.SetSource</c> so the parse cache can be
+    /// preceded by an asset-bytes cache. See S-100 Edition 5.2.1 Part 4 §6
+    /// for the Feature Catalogue model.
+    /// </remarks>
+    public static IAssetSource CreateFeatureCatalogueSource(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        return new CachingAssetSource(CreateAssetSource(productSpec, "fc"));
+    }
+
+    /// <summary>
     /// Returns true if a bundled Portrayal Catalogue exists for the given product specification.
     /// </summary>
     public static bool HasPortrayalCatalogue(string productSpec)

--- a/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
+++ b/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
@@ -161,4 +161,93 @@ public class FeatureCatalogueManagerTests
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await provider.GetCatalogueAsync(new SpecRef("S-101", default), cts.Token));
     }
+
+    /// <summary>
+    /// Minimal <see cref="IAssetSource"/> that hands out a single in-memory
+    /// asset on demand and counts how many times it has been opened.
+    /// </summary>
+    private sealed class CountingSource : IAssetSource
+    {
+        private readonly byte[] _bytes;
+        public int OpenCount;
+        public int DisposeCount;
+        public CountingSource(string content) => _bytes = Encoding.UTF8.GetBytes(content);
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref OpenCount);
+            return Task.FromResult<Stream>(new MemoryStream(_bytes));
+        }
+        public void Dispose() => Interlocked.Increment(ref DisposeCount);
+    }
+
+    [Fact]
+    public void SetSource_OpensFeatureCatalogueXml_WhenResolverReturnsNull()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => null);
+        var source = new CountingSource(MinimalFcXml);
+        mgr.SetSource("S-101", source);
+
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal("S-101", fc!.ProductId);
+        Assert.Equal(1, source.OpenCount);
+
+        // Second access hits the parse cache, not the source.
+        var fc2 = mgr.GetCatalogue("S-101");
+        Assert.Same(fc, fc2);
+        Assert.Equal(1, source.OpenCount);
+    }
+
+    [Fact]
+    public void SetSource_ResolverWins_OverSetSource()
+    {
+        // Resolver returns a valid FC: SetSource must not be consulted.
+        var source = new CountingSource(MinimalFcXml);
+        var resolverCalls = 0;
+        var mgr = new FeatureCatalogueManager((string _) =>
+        {
+            Interlocked.Increment(ref resolverCalls);
+            return Open(MinimalFcXml);
+        });
+        mgr.SetSource("S-101", source);
+
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal(1, resolverCalls);
+        Assert.Equal(0, source.OpenCount);
+    }
+
+    [Fact]
+    public void SetSource_Replace_DisposesPreviousSource()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => null);
+        var first = new CountingSource(MinimalFcXml);
+        var second = new CountingSource(MinimalFcXml);
+
+        mgr.SetSource("S-101", first);
+        mgr.GetCatalogue("S-101");
+        Assert.Equal(1, first.OpenCount);
+
+        mgr.SetSource("S-101", second);
+        Assert.Equal(1, first.DisposeCount);
+
+        // Cache was evicted; the new source is opened on the next access.
+        mgr.GetCatalogue("S-101");
+        Assert.Equal(1, second.OpenCount);
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllRegisteredSources()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => null);
+        var s101 = new CountingSource(MinimalFcXml);
+        var s102 = new CountingSource(MinimalFcXml.Replace("S-101", "S-102"));
+        mgr.SetSource("S-101", s101);
+        mgr.SetSource("S-102", s102);
+
+        mgr.Dispose();
+
+        Assert.Equal(1, s101.DisposeCount);
+        Assert.Equal(1, s102.DisposeCount);
+    }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/SpecificationFeatureCatalogueSourceTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SpecificationFeatureCatalogueSourceTests.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Specifications;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="Specification.CreateFeatureCatalogueSource(string)"/>
+/// produces an <see cref="EncDotNet.S100.Core.IAssetSource"/> that the
+/// <see cref="FeatureCatalogueManager"/> can consume through its
+/// <c>SetSource</c> API, parallel to the existing
+/// <see cref="Specification.CreatePortrayalCatalogueSource(string)"/> +
+/// <c>PortrayalCatalogueManager.SetSource</c> integration.
+/// </summary>
+public class SpecificationFeatureCatalogueSourceTests
+{
+    [Fact]
+    public async Task CreateFeatureCatalogueSource_OpensFeatureCatalogueXml()
+    {
+        using var source = Specification.CreateFeatureCatalogueSource("S-101");
+        using var stream = await source.OpenAsync("FeatureCatalogue.xml");
+        Assert.True(stream.Length > 0);
+    }
+
+    [Fact]
+    public void FeatureCatalogueManager_ConsumesBundledFcSource()
+    {
+        using var mgr = new FeatureCatalogueManager((string _) => null);
+        mgr.SetSource("S-101", Specification.CreateFeatureCatalogueSource("S-101"));
+
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal("S-101", fc!.ProductId);
+    }
+
+    [Fact]
+    public void HasFeatureCatalogue_AgreesWithAvailableSpecs()
+    {
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            // Every advertised spec must have a bundled FeatureCatalogue.xml.
+            Assert.True(Specification.HasFeatureCatalogue(spec),
+                $"Expected bundled FC for '{spec}'.");
+        }
+        Assert.False(Specification.HasFeatureCatalogue("S-999"));
+    }
+}


### PR DESCRIPTION
**Goal**: let bundled Feature Catalogue content benefit from `CachingAssetSource` (#59) the way bundled Portrayal Catalogue content already does.

Before this change, `FeatureCatalogueManager` could only be configured through a `Func<…, Stream?>` resolver. The bundled FC stream returned by `Specification.TryOpenFeatureCatalogue` therefore could not be wrapped in `CachingAssetSource`.

**Changes**:

- `FeatureCatalogueManager.SetSource(SpecRef, IAssetSource)` and a string overload register an asset source whose `FeatureCatalogue.xml` entry is consumed as the bundled fallback for that spec. The resolver delegate still wins — sources are only consulted when the resolver returns `null`, preserving CLI / settings override behaviour.
- The manager now implements `IDisposable`. Replacing or disposing an entry disposes its prior `IAssetSource`. Replacing a source also evicts the cached parse result so the new source is consulted on the next access.
- `Specification.CreateFeatureCatalogueSource(string)` and `Specification.HasFeatureCatalogue(string)` mirror the existing Portrayal Catalogue helpers. The FC source is wrapped in `CachingAssetSource` so repeated reads hit memory after the first parse.

**Tests**:

- Extended `FeatureCatalogueManagerTests` (Features.Tests): `SetSource` open-on-demand, resolver-wins precedence, replace-disposes-previous, `Dispose` disposes all.
- New `SpecificationFeatureCatalogueSourceTests` (Pipelines.Tests): end-to-end check that `Specification.CreateFeatureCatalogueSource("S-101")` is consumable by `FeatureCatalogueManager.SetSource`, plus a parity check between `HasFeatureCatalogue` and `AvailableSpecs`.

**Note on wiring**: this PR is intentionally additive. Seeding the App-level FC manager singleton with `manager.SetSource(spec, Specification.CreateFeatureCatalogueSource(spec))` (parallel to the existing PC seeding in `PortrayalCatalogueSeeder`) depends on PR-B's singleton, which lands separately (#61). A follow-up after both PR-B and PR-C merge will wire the seeding in `App.axaml.cs`.

This is Segment 2, PR-C of the asset caching audit. See appendix §2.7 PR-C in the audit plan.

---

Segment 2 audit follow-up (PR-C of 3 — independent off `main`, not stacked).
