### PR TITLE
Wire bundled FC IAssetSource through FeatureCatalogueManager.SetSource

### DIFF
--- a/src/EncDotNet.S100.Core/AssetBytes.cs
+++ b/src/EncDotNet.S100.Core/AssetBytes.cs
@@ -1,0 +1,43 @@
+using System.Text;
+
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// A read-only, in-memory view of an asset previously read from an
+/// <see cref="IAssetSource"/>. Backed by a <see cref="ReadOnlyMemory{T}"/>
+/// so cache hits can be served without copying.
+/// </summary>
+/// <remarks>
+/// Intended for small, read-only assets (Lua source, XSLT templates,
+/// SVG symbols, palette XML, Feature/Portrayal Catalogue documents)
+/// whose contents are immutable for the lifetime of the originating
+/// source. See S-100 Edition 5.2.1 Part 4 (Feature Catalogue) and
+/// Part 9 (Portrayal Catalogue) for the canonical asset shapes.
+/// </remarks>
+/// <param name="Bytes">The asset contents.</param>
+/// <param name="RelativePath">
+/// The forward-slash relative path that produced these bytes, preserved
+/// for diagnostics and to keep <see cref="AssetBytes"/> self-describing.
+/// </param>
+public readonly record struct AssetBytes(ReadOnlyMemory<byte> Bytes, string RelativePath)
+{
+    /// <summary>
+    /// Returns a non-seekable-aware <see cref="Stream"/> over the asset
+    /// bytes. The returned stream is read-only and does not own the
+    /// underlying buffer; disposing it does not affect the cached
+    /// <see cref="AssetBytes"/> instance.
+    /// </summary>
+    /// <returns>A stream positioned at the start of the asset.</returns>
+    public Stream AsStream() => new ReadOnlyMemoryStream(Bytes);
+
+    /// <summary>
+    /// Decodes the asset bytes as text using the supplied
+    /// <paramref name="encoding"/> (defaulting to UTF-8 when null).
+    /// </summary>
+    /// <param name="encoding">
+    /// The encoding to use, or null for UTF-8 (the default for S-100
+    /// XML and Lua content).
+    /// </param>
+    public string AsString(Encoding? encoding = null) =>
+        (encoding ?? Encoding.UTF8).GetString(Bytes.Span);
+}

--- a/src/EncDotNet.S100.Core/AssetSourceExtensions.cs
+++ b/src/EncDotNet.S100.Core/AssetSourceExtensions.cs
@@ -1,0 +1,48 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Extension methods over <see cref="IAssetSource"/> that provide a
+/// bytes-level read surface above the existing <see cref="Stream"/>-based
+/// <see cref="IAssetSource.OpenAsync"/>.
+/// </summary>
+/// <remarks>
+/// The default implementation allocates one <see cref="byte"/> array
+/// per call. When the underlying source is wrapped in a
+/// <see cref="CachingAssetSource"/>, repeat reads of the same path are
+/// served from the in-memory cache without re-opening the underlying
+/// stream.
+/// </remarks>
+public static class AssetSourceExtensions
+{
+    /// <summary>
+    /// Reads the asset at <paramref name="relativePath"/> fully into
+    /// memory and returns an <see cref="AssetBytes"/> view.
+    /// </summary>
+    /// <param name="source">The asset source to read from.</param>
+    /// <param name="relativePath">A forward-slash relative path.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>An <see cref="AssetBytes"/> containing the asset contents.</returns>
+    public static async Task<AssetBytes> ReadAllBytesAsync(
+        this IAssetSource source,
+        string relativePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        await using Stream stream = await source.OpenAsync(relativePath, cancellationToken).ConfigureAwait(false);
+
+        // Fast path: if the underlying stream is an exposable MemoryStream,
+        // avoid the intermediate copy.
+        if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> segment))
+        {
+            byte[] copy = new byte[segment.Count];
+            Buffer.BlockCopy(segment.Array!, segment.Offset, copy, 0, segment.Count);
+            return new AssetBytes(copy, relativePath);
+        }
+
+        using var buffer = new MemoryStream(capacity: stream.CanSeek ? (int)Math.Min(stream.Length, int.MaxValue) : 4096);
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return new AssetBytes(buffer.ToArray(), relativePath);
+    }
+}

--- a/src/EncDotNet.S100.Core/CachingAssetSource.cs
+++ b/src/EncDotNet.S100.Core/CachingAssetSource.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// Wraps another <see cref="IAssetSource"/> and memoises the bytes of
+/// each asset on first read. Intended for read-only sources whose
+/// contents are immutable for the lifetime of the source
+/// (<c>EmbeddedAssetSource</c>, packaged exchange sets opened in
+/// <see cref="System.IO.Compression.ZipArchiveMode.Read"/>, on-disk
+/// spec content).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache is thread-safe; concurrent first-read storms collapse to
+/// a single underlying open via <see cref="Lazy{T}"/> with
+/// <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>.
+/// </para>
+/// <para>
+/// Cache size is bounded by the number of distinct relative paths
+/// requested and is not actively evicted. For bundled S-100
+/// specification content (Feature and Portrayal Catalogues —
+/// see S-100 Edition 5.2.1 Part 4 §4 and Part 9 §3) the working set
+/// is small (tens of paths per spec) and steady-state reads dominate.
+/// </para>
+/// <para>
+/// On cache hits, the supplied <see cref="CancellationToken"/> is
+/// observed only insofar as the call is synchronous: the cached bytes
+/// are returned immediately. On a cache miss the token flows through
+/// to the underlying <see cref="IAssetSource.OpenAsync"/>.
+/// </para>
+/// </remarks>
+public sealed class CachingAssetSource : IAssetSource
+{
+    private readonly IAssetSource _inner;
+    private readonly ConcurrentDictionary<string, Lazy<Task<AssetBytes>>> _cache =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initialises a new <see cref="CachingAssetSource"/> over the given
+    /// <paramref name="inner"/> source.
+    /// </summary>
+    /// <param name="inner">The asset source to wrap. Must not be null.</param>
+    public CachingAssetSource(IAssetSource inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        AssetBytes bytes = await GetAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        return bytes.AsStream();
+    }
+
+    /// <summary>
+    /// Returns the cached <see cref="AssetBytes"/> for
+    /// <paramref name="relativePath"/>, reading from the underlying
+    /// source on first access.
+    /// </summary>
+    /// <param name="relativePath">A forward-slash relative path.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token. Observed on cache misses (when the inner
+    /// <see cref="IAssetSource.OpenAsync"/> is invoked); ignored on
+    /// cache hits.
+    /// </param>
+    public Task<AssetBytes> GetAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        Lazy<Task<AssetBytes>> lazy = _cache.GetOrAdd(
+            relativePath,
+            path => new Lazy<Task<AssetBytes>>(
+                () => _inner.ReadAllBytesAsync(path, cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return lazy.Value;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _inner.Dispose();
+}

--- a/src/EncDotNet.S100.Core/ReadOnlyMemoryStream.cs
+++ b/src/EncDotNet.S100.Core/ReadOnlyMemoryStream.cs
@@ -1,0 +1,123 @@
+namespace EncDotNet.S100.Core;
+
+/// <summary>
+/// A read-only, seekable <see cref="Stream"/> backed by a
+/// <see cref="ReadOnlyMemory{Byte}"/>. Disposing the stream does not
+/// release or copy the backing memory, which makes it safe for serving
+/// cached <see cref="AssetBytes"/> repeatedly without allocations.
+/// </summary>
+internal sealed class ReadOnlyMemoryStream : Stream
+{
+    private readonly ReadOnlyMemory<byte> _memory;
+    private long _position;
+
+    public ReadOnlyMemoryStream(ReadOnlyMemory<byte> memory)
+    {
+        _memory = memory;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _memory.Length;
+
+    public override long Position
+    {
+        get => _position;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _position = value;
+        }
+    }
+
+    public override void Flush()
+    {
+        // No-op: read-only stream has nothing to flush.
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        if (_position >= _memory.Length)
+        {
+            return 0;
+        }
+
+        int remaining = (int)Math.Min(buffer.Length, _memory.Length - _position);
+        _memory.Span.Slice((int)_position, remaining).CopyTo(buffer);
+        _position += remaining;
+        return remaining;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<int>(cancellationToken);
+        }
+
+        try
+        {
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromException<int>(ex);
+        }
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return ValueTask.FromCanceled<int>(cancellationToken);
+        }
+
+        return ValueTask.FromResult(Read(buffer.Span));
+    }
+
+    public override int ReadByte()
+    {
+        if (_position >= _memory.Length)
+        {
+            return -1;
+        }
+
+        byte value = _memory.Span[(int)_position];
+        _position++;
+        return value;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        long target = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _memory.Length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+
+        ArgumentOutOfRangeException.ThrowIfNegative(target);
+        _position = target;
+        return _position;
+    }
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    public override void Write(ReadOnlySpan<byte> buffer) =>
+        throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -44,16 +44,28 @@ public sealed class DatasetPipelineFactory
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
 
+    /// <summary>
+    /// Creates a new factory. The supplied
+    /// <paramref name="featureCatalogueManager"/> is shared across every
+    /// processor this factory produces, so its FC parse cache survives
+    /// for the lifetime of the manager — not just the lifetime of the
+    /// factory.
+    /// </summary>
     public DatasetPipelineFactory(
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         ICrsTransformFactory crsTransformFactory,
-        Func<string, Stream?>? featureCatalogueResolver = null)
+        FeatureCatalogueManager featureCatalogueManager)
     {
+        ArgumentNullException.ThrowIfNull(catalogueManager);
+        ArgumentNullException.ThrowIfNull(luaEngine);
+        ArgumentNullException.ThrowIfNull(crsTransformFactory);
+        ArgumentNullException.ThrowIfNull(featureCatalogueManager);
+
         _catalogueManager = catalogueManager;
         _luaEngine = luaEngine;
         _crsTransformFactory = crsTransformFactory;
-        _featureCatalogueManager = new FeatureCatalogueManager(featureCatalogueResolver);
+        _featureCatalogueManager = featureCatalogueManager;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
@@ -24,11 +24,22 @@ namespace EncDotNet.S100.Features;
 /// cache slot per product name.
 /// </para>
 /// </remarks>
-public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogue>
+public sealed class FeatureCatalogueManager : IDisposable, ICatalogueProvider<FeatureCatalogue>
 {
     private readonly Func<SpecRef, Stream?> _resolver;
     private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogue?>> _catalogues = new();
     private readonly ConcurrentDictionary<SpecRef, Lazy<FeatureCatalogueDecoder?>> _decoders = new();
+    private readonly ConcurrentDictionary<SpecRef, IAssetSource> _sources = new();
+
+    private const string FeatureCatalogueAssetName = "FeatureCatalogue.xml";
+
+    private static SpecRef ToSpec(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        if (!SpecName.TryNormalize(productSpec, out var name))
+            throw new ArgumentException($"'{productSpec}' is not a recognised product specification name.", nameof(productSpec));
+        return new SpecRef(name, default);
+    }
 
     /// <summary>
     /// Initializes a new <see cref="FeatureCatalogueManager"/> with a string-based
@@ -120,7 +131,24 @@ public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogu
     {
         Stream? stream;
         try { stream = _resolver(spec); }
-        catch { return null; }
+        catch { stream = null; }
+
+        // Resolver wins; the IAssetSource registered via SetSource is a
+        // bundled fallback for specs the resolver does not handle. This
+        // preserves the existing CLI / settings override behaviour while
+        // letting Specification.CreateFeatureCatalogueSource provide
+        // caching access to bundled FCs.
+        if (stream is null && _sources.TryGetValue(spec, out var source))
+        {
+            try
+            {
+                stream = source.OpenAsync(FeatureCatalogueAssetName).GetAwaiter().GetResult();
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
         if (stream is null) return null;
 
@@ -137,6 +165,68 @@ public sealed class FeatureCatalogueManager : ICatalogueProvider<FeatureCatalogu
             // degrades to raw codes and portrayal falls back gracefully.
             return null;
         }
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IAssetSource"/> as the bundled fallback for
+    /// the given product specification. The resolver delegate supplied to
+    /// the manager constructor still takes precedence; the source is only
+    /// consulted when the resolver returns <c>null</c> for that spec.
+    /// </summary>
+    /// <remarks>
+    /// The manager assumes ownership of <paramref name="source"/> for
+    /// disposal purposes — a subsequent <see cref="SetSource(SpecRef, IAssetSource)"/>
+    /// for the same spec disposes the previous source, and
+    /// <see cref="Dispose"/> disposes every registered source. The source
+    /// is expected to expose a <c>FeatureCatalogue.xml</c> asset matching
+    /// the convention used by
+    /// <c>EncDotNet.S100.Specifications.Specification</c>.
+    /// </remarks>
+    public void SetSource(string productSpec, IAssetSource source) =>
+        SetSource(ToSpec(productSpec), source);
+
+    /// <summary>
+    /// Registers an <see cref="IAssetSource"/> for the given spec reference.
+    /// See <see cref="SetSource(string, IAssetSource)"/> for the precedence
+    /// rules and disposal semantics.
+    /// </summary>
+    public void SetSource(SpecRef spec, IAssetSource source)
+    {
+        if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
+        ArgumentNullException.ThrowIfNull(source);
+
+        // Evict any cached parse result so the new source is consulted on
+        // the next access.
+        _catalogues.TryRemove(spec, out _);
+        _decoders.TryRemove(spec, out _);
+
+        // Atomically swap the source and dispose any prior entry.
+        var previous = _sources.AddOrUpdate(
+            spec,
+            _ => source,
+            (_, existing) =>
+            {
+                if (!ReferenceEquals(existing, source))
+                {
+                    try { existing.Dispose(); } catch { /* best-effort */ }
+                }
+                return source;
+            });
+        _ = previous; // suppress unused
+    }
+
+    /// <summary>
+    /// Disposes every <see cref="IAssetSource"/> registered through
+    /// <see cref="SetSource(SpecRef, IAssetSource)"/>. Cached catalogues
+    /// themselves are plain in-memory objects and do not require disposal.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var source in _sources.Values)
+        {
+            try { source.Dispose(); } catch { /* best-effort */ }
+        }
+        _sources.Clear();
     }
 
     /// <inheritdoc />

--- a/src/EncDotNet.S100.Specifications/EmbeddedAssetSource.cs
+++ b/src/EncDotNet.S100.Specifications/EmbeddedAssetSource.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Reflection;
 using EncDotNet.S100.Core;
 
@@ -11,11 +10,31 @@ public sealed class EmbeddedAssetSource : IAssetSource
 {
     private readonly Assembly _assembly;
     private readonly string _resourcePrefix;
+    private readonly Lazy<Dictionary<string, string>> _caseInsensitiveIndex;
 
     private EmbeddedAssetSource(Assembly assembly, string resourcePrefix)
     {
         _assembly = assembly;
         _resourcePrefix = resourcePrefix;
+        _caseInsensitiveIndex = new Lazy<Dictionary<string, string>>(
+            BuildCaseInsensitiveIndex,
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    private Dictionary<string, string> BuildCaseInsensitiveIndex()
+    {
+        // Build once and reuse: GetManifestResourceNames() walks the
+        // assembly's resource directory, which is non-trivial work to
+        // repeat on every case-insensitive miss.
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string name in _assembly.GetManifestResourceNames())
+        {
+            // First-wins keeps behaviour stable when two manifest entries
+            // differ only by case; manifest names are unique in practice.
+            map.TryAdd(name, name);
+        }
+
+        return map;
     }
 
     /// <summary>
@@ -54,9 +73,7 @@ public sealed class EmbeddedAssetSource : IAssetSource
             // (macOS, Windows) but breaks here because embedded resource names
             // are case-sensitive. This fallback keeps the bundled assets
             // byte-identical to upstream while still resolving correctly.
-            var match = _assembly.GetManifestResourceNames()
-                .FirstOrDefault(n => string.Equals(n, resourceName, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
+            if (_caseInsensitiveIndex.Value.TryGetValue(resourceName, out string? match))
             {
                 stream = _assembly.GetManifestResourceStream(match);
             }

--- a/src/EncDotNet.S100.Specifications/Specification.cs
+++ b/src/EncDotNet.S100.Specifications/Specification.cs
@@ -84,7 +84,11 @@ public static class Specification
     {
         ArgumentException.ThrowIfNullOrEmpty(productSpec);
 
-        return CreateAssetSource(productSpec, "pc");
+        // Wrap the embedded source in a caching decorator so repeated
+        // reads of the same Portrayal Catalogue asset (Lua source, XSLT
+        // templates, SVG symbols, palette XML; see S-100 Edition 5.2.1
+        // Part 9 §3) are served from memory after the first read.
+        return new CachingAssetSource(CreateAssetSource(productSpec, "pc"));
     }
 
     private static EmbeddedAssetSource CreateAssetSource(string productSpec, string subfolder)

--- a/src/EncDotNet.S100.Specifications/Specification.cs
+++ b/src/EncDotNet.S100.Specifications/Specification.cs
@@ -63,6 +63,40 @@ public static class Specification
     }
 
     /// <summary>
+    /// Returns true if a bundled Feature Catalogue exists for the given product specification.
+    /// </summary>
+    public static bool HasFeatureCatalogue(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+
+        string normalized = productSpec.Replace("-", "");
+        string resourceName = $"{ContentPrefix}.{normalized}.fc.FeatureCatalogue.xml";
+        return ResourceAssembly.GetManifestResourceInfo(resourceName) is not null;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IAssetSource"/> rooted at the bundled Feature
+    /// Catalogue directory for the given product specification. The source
+    /// is wrapped in a <see cref="CachingAssetSource"/> so repeated reads
+    /// of <c>FeatureCatalogue.xml</c> are served from memory after the
+    /// first read.
+    /// </summary>
+    /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102").</param>
+    /// <returns>An asset source for the bundled Feature Catalogue contents.</returns>
+    /// <remarks>
+    /// This parallels <see cref="CreatePortrayalCatalogueSource(string)"/>
+    /// and lets callers register the bundled FC with
+    /// <c>FeatureCatalogueManager.SetSource</c> so the parse cache can be
+    /// preceded by an asset-bytes cache. See S-100 Edition 5.2.1 Part 4 §6
+    /// for the Feature Catalogue model.
+    /// </remarks>
+    public static IAssetSource CreateFeatureCatalogueSource(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        return new CachingAssetSource(CreateAssetSource(productSpec, "fc"));
+    }
+
+    /// <summary>
     /// Returns true if a bundled Portrayal Catalogue exists for the given product specification.
     /// </summary>
     public static bool HasPortrayalCatalogue(string productSpec)

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -116,6 +116,26 @@ public partial class App : Application
         services.AddSingleton<IDatasetCatalogSource>(
             sp => sp.GetRequiredService<DatasetCatalogAggregator>());
 
+        // Feature-catalogue parsing is shared across every dataset load
+        // — the manager's parse cache must survive across factory
+        // rebuilds. The resolver delegate consults the viewer-level
+        // overrides service so transient CLI catalogues and persisted
+        // settings remain observable even though the manager itself is
+        // a singleton.
+        services.AddSingleton<FeatureCatalogueOverrides>();
+        services.AddSingleton<EncDotNet.S100.Features.FeatureCatalogueManager>(sp =>
+        {
+            var overrides = sp.GetRequiredService<FeatureCatalogueOverrides>();
+            return new EncDotNet.S100.Features.FeatureCatalogueManager(
+                (string spec) => overrides.Open(spec));
+        });
+        services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory>(sp =>
+            new EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory(
+                sp.GetRequiredService<PortrayalCatalogueManager>(),
+                new EncDotNet.S100.Scripting.MoonSharp.MoonSharpLuaEngine(),
+                new EncDotNet.S100.Renderers.Mapsui.ProjNetCrsTransformFactory(),
+                sp.GetRequiredService<EncDotNet.S100.Features.FeatureCatalogueManager>()));
+
         // Leaf services extracted in phase 2
         services.AddSingleton<IThemeService, ThemeService>();
         services.AddSingleton<IRecentFilesService, RecentFilesService>();

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -126,8 +126,26 @@ public partial class App : Application
         services.AddSingleton<EncDotNet.S100.Features.FeatureCatalogueManager>(sp =>
         {
             var overrides = sp.GetRequiredService<FeatureCatalogueOverrides>();
-            return new EncDotNet.S100.Features.FeatureCatalogueManager(
+            var manager = new EncDotNet.S100.Features.FeatureCatalogueManager(
                 (string spec) => overrides.Open(spec));
+
+            // Register the bundled Feature Catalogue for every available
+            // spec as a long-lived IAssetSource so repeated parses go
+            // through CachingAssetSource (see PR #59 / Specification
+            // .CreateFeatureCatalogueSource). The resolver delegate still
+            // wins, so transient CLI overrides and persisted user
+            // settings continue to take precedence; this only changes
+            // how the bundled fallback is opened. Mirrors the bundled
+            // Portrayal Catalogue seeding in PortrayalCatalogueSeeder.
+            foreach (var spec in Specifications.Specification.AvailableSpecs)
+            {
+                if (Specifications.Specification.HasFeatureCatalogue(spec))
+                {
+                    manager.SetSource(spec, Specifications.Specification.CreateFeatureCatalogueSource(spec));
+                }
+            }
+
+            return manager;
         });
         services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory>(sp =>
             new EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory(

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -29,6 +29,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly ViewerSettings _settings;
     private readonly PortrayalCatalogueManager _catalogueManager;
     private readonly PortrayalCatalogueSeeder _catalogueSeeder;
+    private readonly FeatureCatalogueOverrides _fcOverrides;
+    private readonly DatasetPipelineFactory _pipelineFactory;
     private readonly IRecentFilesService _recentFiles;
     private readonly S128DatasetCatalogSource _s128CatalogSource;
     private readonly SettingsViewModel _settingsVm;
@@ -58,7 +60,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayersView;
 
     private IMapHost? _mapHost;
-    private DatasetPipelineFactory? _pipelineFactory;
 
     // Coalesce slider scrubs into a single render pass after the user has
     // paused for ~100 ms. Each new SetCurrentTime cancels the in-flight
@@ -71,6 +72,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ViewerSettings settings,
         PortrayalCatalogueManager catalogueManager,
         PortrayalCatalogueSeeder catalogueSeeder,
+        FeatureCatalogueOverrides fcOverrides,
+        DatasetPipelineFactory pipelineFactory,
         IRecentFilesService recentFiles,
         S128DatasetCatalogSource s128CatalogSource,
         SettingsViewModel settingsVm,
@@ -82,6 +85,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
         ArgumentNullException.ThrowIfNull(catalogueSeeder);
+        ArgumentNullException.ThrowIfNull(fcOverrides);
+        ArgumentNullException.ThrowIfNull(pipelineFactory);
         ArgumentNullException.ThrowIfNull(recentFiles);
         ArgumentNullException.ThrowIfNull(s128CatalogSource);
         ArgumentNullException.ThrowIfNull(settingsVm);
@@ -93,6 +98,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _settings = settings;
         _catalogueManager = catalogueManager;
         _catalogueSeeder = catalogueSeeder;
+        _fcOverrides = fcOverrides;
+        _pipelineFactory = pipelineFactory;
         _recentFiles = recentFiles;
         _s128CatalogSource = s128CatalogSource;
         _settingsVm = settingsVm;
@@ -130,14 +137,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _mapHost = host;
 
         var transientFcPaths = _catalogueSeeder.Seed(options);
-
-        _pipelineFactory = new DatasetPipelineFactory(
-            _catalogueManager,
-            new MoonSharpLuaEngine(),
-            new ProjNetCrsTransformFactory(),
-            spec => transientFcPaths.TryGetValue(spec, out var p) ? File.OpenRead(p)
-                  : _settings.FeatureCataloguePaths.TryGetValue(spec, out var sp) ? File.OpenRead(sp)
-                  : Specifications.Specification.TryOpenFeatureCatalogue(spec));
+        _fcOverrides.SetTransientPaths(transientFcPaths);
 
         // Re-render every loaded dataset whenever the user changes a setting
         // that affects portrayal output (palette / display scale). These are
@@ -213,8 +213,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         try
         {
             var processor = await Task.Run(() => fromExchangeSet
-                ? _pipelineFactory!.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
-                : _pipelineFactory!.CreateProcessor(entry.FilePath), token);
+                ? _pipelineFactory.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
+                : _pipelineFactory.CreateProcessor(entry.FilePath), token);
             _processors[entry] = processor;
 
             // Surface S-128 catalogues into the Dataset Catalog panel.
@@ -674,7 +674,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     private void EnsureInitialized()
     {
-        if (_mapHost is null || _pipelineFactory is null)
+        if (_mapHost is null)
             throw new InvalidOperationException("DatasetLoaderService.Initialize must be called before LoadAsync.");
     }
 }

--- a/src/EncDotNet.S100.Viewer/Services/FeatureCatalogueOverrides.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeatureCatalogueOverrides.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Tracks the viewer-level overrides for feature catalogue content:
+/// transient CLI-supplied paths (highest priority) and persisted user
+/// settings (medium priority). The shared
+/// <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/> consults
+/// this service through its resolver delegate before falling back to
+/// bundled catalogues shipped in <c>EncDotNet.S100.Specifications</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The viewer's <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/>
+/// is registered as an application singleton so its parse cache survives
+/// across dataset reloads. The resolver delegate, however, must be able
+/// to observe new CLI overrides discovered during startup
+/// (via <see cref="PortrayalCatalogueSeeder"/>) and updates to persisted
+/// settings while the viewer is running. This service is the mutable
+/// pivot that lets the singleton manager observe those changes without
+/// being rebuilt.
+/// </para>
+/// <para>
+/// The viewer is the only client of this service. The keys it uses are
+/// product specification names (e.g. <c>"S-101"</c>), matching the
+/// string-based <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/>
+/// resolver overload. See S-100 Part 1 §6 for the product specification
+/// identifier conventions.
+/// </para>
+/// </remarks>
+internal sealed class FeatureCatalogueOverrides
+{
+    private readonly ViewerSettings _settings;
+    private readonly ConcurrentDictionary<string, string> _transientPaths =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public FeatureCatalogueOverrides(ViewerSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Replaces the set of transient (CLI-supplied) feature catalogue
+    /// paths. The keys are product specification names; values are
+    /// absolute file paths to <c>FeatureCatalogue.xml</c> files on disk.
+    /// </summary>
+    public void SetTransientPaths(IReadOnlyDictionary<string, string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        _transientPaths.Clear();
+        foreach (var (spec, path) in paths)
+        {
+            if (string.IsNullOrWhiteSpace(spec) || string.IsNullOrWhiteSpace(path)) continue;
+            _transientPaths[spec] = path;
+        }
+    }
+
+    /// <summary>
+    /// Returns a readable stream over the resolved feature catalogue for
+    /// <paramref name="productSpec"/>, or <c>null</c> if none is
+    /// configured. Caller owns the stream.
+    /// </summary>
+    /// <remarks>
+    /// Lookup precedence: transient CLI overrides → persisted user
+    /// settings → bundled <c>EncDotNet.S100.Specifications</c> content.
+    /// </remarks>
+    public Stream? Open(string productSpec)
+    {
+        if (string.IsNullOrWhiteSpace(productSpec)) return null;
+
+        if (_transientPaths.TryGetValue(productSpec, out var transient) && File.Exists(transient))
+        {
+            return File.OpenRead(transient);
+        }
+
+        if (_settings.FeatureCataloguePaths.TryGetValue(productSpec, out var persisted)
+            && File.Exists(persisted))
+        {
+            return File.OpenRead(persisted);
+        }
+
+        return Specification.TryOpenFeatureCatalogue(productSpec);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/FeatureCatalogueOverrides.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeatureCatalogueOverrides.cs
@@ -62,13 +62,21 @@ internal sealed class FeatureCatalogueOverrides
     }
 
     /// <summary>
-    /// Returns a readable stream over the resolved feature catalogue for
-    /// <paramref name="productSpec"/>, or <c>null</c> if none is
+    /// Returns a readable stream over the user-supplied feature catalogue
+    /// for <paramref name="productSpec"/>, or <c>null</c> if none is
     /// configured. Caller owns the stream.
     /// </summary>
     /// <remarks>
     /// Lookup precedence: transient CLI overrides → persisted user
-    /// settings → bundled <c>EncDotNet.S100.Specifications</c> content.
+    /// settings. When neither is configured, the method returns
+    /// <c>null</c> so the
+    /// <see cref="EncDotNet.S100.Features.FeatureCatalogueManager"/>
+    /// falls through to its registered <c>IAssetSource</c> for the
+    /// bundled fallback (wired in <c>App.ConfigureServices</c> via
+    /// <see cref="Specification.CreateFeatureCatalogueSource(string)"/>),
+    /// allowing repeated parses to hit the
+    /// <c>CachingAssetSource</c> instead of re-opening a fresh manifest
+    /// stream each time.
     /// </remarks>
     public Stream? Open(string productSpec)
     {
@@ -85,6 +93,9 @@ internal sealed class FeatureCatalogueOverrides
             return File.OpenRead(persisted);
         }
 
-        return Specification.TryOpenFeatureCatalogue(productSpec);
+        // Bundled fallback is handled by FeatureCatalogueManager via a
+        // registered IAssetSource (see App.ConfigureServices). Returning
+        // null here is what lets that fallback fire.
+        return null;
     }
 }

--- a/tests/EncDotNet.S100.Core.Tests/AssetBytesTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/AssetBytesTests.cs
@@ -1,0 +1,66 @@
+using System.Text;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class AssetBytesTests
+{
+    [Fact]
+    public void AsStream_RoundTripsBytes()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        var bytes = new AssetBytes(payload, "foo/bar.bin");
+
+        using Stream stream = bytes.AsStream();
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+
+        Assert.Equal(payload, ms.ToArray());
+        Assert.Equal("foo/bar.bin", bytes.RelativePath);
+    }
+
+    [Fact]
+    public void AsStream_ReturnsFreshStreamEachCall()
+    {
+        byte[] payload = [10, 20, 30];
+        var bytes = new AssetBytes(payload, "p.bin");
+
+        using Stream a = bytes.AsStream();
+        using Stream b = bytes.AsStream();
+
+        // Reading from `a` should not advance `b`.
+        Assert.Equal(10, a.ReadByte());
+        Assert.Equal(10, b.ReadByte());
+    }
+
+    [Fact]
+    public void AsStream_IsSeekable()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        var bytes = new AssetBytes(payload, "p.bin");
+
+        using Stream stream = bytes.AsStream();
+        Assert.True(stream.CanSeek);
+        Assert.Equal(5, stream.Length);
+        stream.Seek(2, SeekOrigin.Begin);
+        Assert.Equal(3, stream.ReadByte());
+    }
+
+    [Fact]
+    public void AsString_DecodesUtf8ByDefault()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("héllo");
+        var bytes = new AssetBytes(payload, "t.txt");
+
+        Assert.Equal("héllo", bytes.AsString());
+    }
+
+    [Fact]
+    public void AsString_UsesProvidedEncoding()
+    {
+        byte[] payload = Encoding.Unicode.GetBytes("héllo");
+        var bytes = new AssetBytes(payload, "t.txt");
+
+        Assert.Equal("héllo", bytes.AsString(Encoding.Unicode));
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/AssetSourceExtensionsTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/AssetSourceExtensionsTests.cs
@@ -1,0 +1,77 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class AssetSourceExtensionsTests
+{
+    [Fact]
+    public async Task ReadAllBytesAsync_ReturnsAssetContents()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        using var source = new InMemoryAssetSource(new()
+        {
+            ["foo/bar.bin"] = payload,
+        });
+
+        AssetBytes bytes = await source.ReadAllBytesAsync("foo/bar.bin");
+
+        Assert.Equal(payload, bytes.Bytes.ToArray());
+        Assert.Equal("foo/bar.bin", bytes.RelativePath);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_DisposesUnderlyingStream()
+    {
+        var stream = new TrackingMemoryStream([7, 8, 9]);
+        using var source = new SingleStreamAssetSource(stream);
+
+        AssetBytes bytes = await source.ReadAllBytesAsync("path");
+
+        Assert.Equal(new byte[] { 7, 8, 9 }, bytes.Bytes.ToArray());
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ThrowsOnNullSource()
+    {
+        IAssetSource source = null!;
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => source.ReadAllBytesAsync("path"));
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ThrowsOnEmptyPath()
+    {
+        using var source = new InMemoryAssetSource(new());
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => source.ReadAllBytesAsync(""));
+    }
+
+    private sealed class SingleStreamAssetSource : IAssetSource
+    {
+        private readonly Stream _stream;
+
+        public SingleStreamAssetSource(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+            => Task.FromResult(_stream);
+
+        public void Dispose() { }
+    }
+
+    private sealed class TrackingMemoryStream : MemoryStream
+    {
+        public TrackingMemoryStream(byte[] buffer) : base(buffer, writable: false) { }
+
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/CachingAssetSourceTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/CachingAssetSourceTests.cs
@@ -1,0 +1,159 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+public class CachingAssetSourceTests
+{
+    [Fact]
+    public async Task GetAsync_ReturnsSameBytesOnRepeatedReads()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1, 2, 3],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes first = await cache.GetAsync("a.txt");
+        AssetBytes second = await cache.GetAsync("a.txt");
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, first.Bytes.ToArray());
+        Assert.Equal(new byte[] { 1, 2, 3 }, second.Bytes.ToArray());
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+    }
+
+    [Fact]
+    public async Task GetAsync_DifferentPathsAreIndependent()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1],
+            ["b.txt"] = [2],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes a = await cache.GetAsync("a.txt");
+        AssetBytes b = await cache.GetAsync("b.txt");
+        AssetBytes a2 = await cache.GetAsync("a.txt");
+
+        Assert.Equal(new byte[] { 1 }, a.Bytes.ToArray());
+        Assert.Equal(new byte[] { 2 }, b.Bytes.ToArray());
+        Assert.Equal(new byte[] { 1 }, a2.Bytes.ToArray());
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+        Assert.Equal(1, inner.OpenCount("b.txt"));
+    }
+
+    [Fact]
+    public async Task GetAsync_KeyIsCaseSensitive()
+    {
+        // Ordinal keys: "A.txt" and "a.txt" should be distinct cache
+        // entries. The underlying source decides case semantics.
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1],
+            ["A.txt"] = [2],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes lower = await cache.GetAsync("a.txt");
+        AssetBytes upper = await cache.GetAsync("A.txt");
+
+        Assert.Equal(new byte[] { 1 }, lower.Bytes.ToArray());
+        Assert.Equal(new byte[] { 2 }, upper.Bytes.ToArray());
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+        Assert.Equal(1, inner.OpenCount("A.txt"));
+    }
+
+    [Fact]
+    public async Task ConcurrentFirstReads_OpenInnerExactlyOnce()
+    {
+        var inner = new InMemoryAssetSource(
+            new() { ["hot.txt"] = [9, 9, 9] },
+            openDelay: TimeSpan.FromMilliseconds(50));
+        using var cache = new CachingAssetSource(inner);
+
+        Task<AssetBytes>[] tasks = Enumerable
+            .Range(0, 32)
+            .Select(_ => Task.Run(() => cache.GetAsync("hot.txt")))
+            .ToArray();
+
+        AssetBytes[] results = await Task.WhenAll(tasks);
+
+        Assert.All(results, r => Assert.Equal(new byte[] { 9, 9, 9 }, r.Bytes.ToArray()));
+        Assert.Equal(1, inner.OpenCount("hot.txt"));
+    }
+
+    [Fact]
+    public async Task OpenAsync_ReturnsFreshStreamPerCall()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [1, 2, 3, 4, 5],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        await using Stream first = await cache.OpenAsync("a.txt");
+        await using Stream second = await cache.OpenAsync("a.txt");
+
+        // Consuming `first` should not affect `second`.
+        Assert.Equal(1, first.ReadByte());
+        Assert.Equal(1, second.ReadByte());
+        Assert.Equal(2, first.ReadByte());
+        Assert.Equal(2, second.ReadByte());
+
+        // And the inner source was opened exactly once.
+        Assert.Equal(1, inner.OpenCount("a.txt"));
+    }
+
+    [Fact]
+    public async Task OpenAsync_ServesBytesIdenticalToReadAllBytesAsync()
+    {
+        var inner = new InMemoryAssetSource(new()
+        {
+            ["a.txt"] = [10, 20, 30, 40],
+        });
+        using var cache = new CachingAssetSource(inner);
+
+        AssetBytes bytes = await cache.GetAsync("a.txt");
+        await using Stream stream = await cache.OpenAsync("a.txt");
+        using var copy = new MemoryStream();
+        await stream.CopyToAsync(copy);
+
+        Assert.Equal(bytes.Bytes.ToArray(), copy.ToArray());
+    }
+
+    [Fact]
+    public void Dispose_ForwardsToInner()
+    {
+        var inner = new InMemoryAssetSource(new());
+        var cache = new CachingAssetSource(inner);
+
+        cache.Dispose();
+
+        Assert.True(inner.Disposed);
+    }
+
+    [Fact]
+    public async Task GetAsync_PropagatesFileNotFoundOnMiss()
+    {
+        var inner = new InMemoryAssetSource(new());
+        using var cache = new CachingAssetSource(inner);
+
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => cache.GetAsync("missing"));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullInner()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CachingAssetSource(null!));
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsOnEmptyPath()
+    {
+        var inner = new InMemoryAssetSource(new());
+        using var cache = new CachingAssetSource(inner);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => cache.GetAsync(""));
+    }
+}

--- a/tests/EncDotNet.S100.Core.Tests/InMemoryAssetSource.cs
+++ b/tests/EncDotNet.S100.Core.Tests/InMemoryAssetSource.cs
@@ -1,0 +1,54 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Core.Tests;
+
+/// <summary>
+/// A test <see cref="IAssetSource"/> backed by an in-memory dictionary
+/// that counts how many times each path was opened on the underlying
+/// source. Used to assert caching semantics of
+/// <see cref="CachingAssetSource"/>.
+/// </summary>
+internal sealed class InMemoryAssetSource : IAssetSource
+{
+    private readonly Dictionary<string, byte[]> _assets;
+    private readonly ConcurrentDictionary<string, int> _openCounts = new(StringComparer.Ordinal);
+    private readonly TimeSpan _openDelay;
+
+    public InMemoryAssetSource(
+        Dictionary<string, byte[]> assets,
+        TimeSpan? openDelay = null)
+    {
+        _assets = assets;
+        _openDelay = openDelay ?? TimeSpan.Zero;
+    }
+
+    public bool Disposed { get; private set; }
+
+    public int OpenCount(string path) =>
+        _openCounts.TryGetValue(path, out int count) ? count : 0;
+
+    public int TotalOpenCount => _openCounts.Values.Sum();
+
+    public async Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        _openCounts.AddOrUpdate(relativePath, 1, static (_, current) => current + 1);
+
+        if (_openDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(_openDelay, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!_assets.TryGetValue(relativePath, out byte[]? bytes))
+        {
+            throw new FileNotFoundException($"Asset not found: {relativePath}");
+        }
+
+        return new MemoryStream(bytes, writable: false);
+    }
+
+    public void Dispose()
+    {
+        Disposed = true;
+    }
+}

--- a/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
+++ b/tests/EncDotNet.S100.Features.Tests/FeatureCatalogueManagerTests.cs
@@ -161,4 +161,93 @@ public class FeatureCatalogueManagerTests
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await provider.GetCatalogueAsync(new SpecRef("S-101", default), cts.Token));
     }
+
+    /// <summary>
+    /// Minimal <see cref="IAssetSource"/> that hands out a single in-memory
+    /// asset on demand and counts how many times it has been opened.
+    /// </summary>
+    private sealed class CountingSource : IAssetSource
+    {
+        private readonly byte[] _bytes;
+        public int OpenCount;
+        public int DisposeCount;
+        public CountingSource(string content) => _bytes = Encoding.UTF8.GetBytes(content);
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref OpenCount);
+            return Task.FromResult<Stream>(new MemoryStream(_bytes));
+        }
+        public void Dispose() => Interlocked.Increment(ref DisposeCount);
+    }
+
+    [Fact]
+    public void SetSource_OpensFeatureCatalogueXml_WhenResolverReturnsNull()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => null);
+        var source = new CountingSource(MinimalFcXml);
+        mgr.SetSource("S-101", source);
+
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal("S-101", fc!.ProductId);
+        Assert.Equal(1, source.OpenCount);
+
+        // Second access hits the parse cache, not the source.
+        var fc2 = mgr.GetCatalogue("S-101");
+        Assert.Same(fc, fc2);
+        Assert.Equal(1, source.OpenCount);
+    }
+
+    [Fact]
+    public void SetSource_ResolverWins_OverSetSource()
+    {
+        // Resolver returns a valid FC: SetSource must not be consulted.
+        var source = new CountingSource(MinimalFcXml);
+        var resolverCalls = 0;
+        var mgr = new FeatureCatalogueManager((string _) =>
+        {
+            Interlocked.Increment(ref resolverCalls);
+            return Open(MinimalFcXml);
+        });
+        mgr.SetSource("S-101", source);
+
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal(1, resolverCalls);
+        Assert.Equal(0, source.OpenCount);
+    }
+
+    [Fact]
+    public void SetSource_Replace_DisposesPreviousSource()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => null);
+        var first = new CountingSource(MinimalFcXml);
+        var second = new CountingSource(MinimalFcXml);
+
+        mgr.SetSource("S-101", first);
+        mgr.GetCatalogue("S-101");
+        Assert.Equal(1, first.OpenCount);
+
+        mgr.SetSource("S-101", second);
+        Assert.Equal(1, first.DisposeCount);
+
+        // Cache was evicted; the new source is opened on the next access.
+        mgr.GetCatalogue("S-101");
+        Assert.Equal(1, second.OpenCount);
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllRegisteredSources()
+    {
+        var mgr = new FeatureCatalogueManager((string _) => null);
+        var s101 = new CountingSource(MinimalFcXml);
+        var s102 = new CountingSource(MinimalFcXml.Replace("S-101", "S-102"));
+        mgr.SetSource("S-101", s101);
+        mgr.SetSource("S-102", s102);
+
+        mgr.Dispose();
+
+        Assert.Equal(1, s101.DisposeCount);
+        Assert.Equal(1, s102.DisposeCount);
+    }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Scripting.MoonSharp;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="DatasetPipelineFactory"/> shares the supplied
+/// <see cref="FeatureCatalogueManager"/> across every processor it
+/// creates. This is the contract Segment 2 PR-B introduced so the FC
+/// parse cache survives across pipeline-factory rebuilds inside the
+/// viewer.
+/// </summary>
+public class DatasetPipelineFactoryFeatureCatalogueReuseTests
+{
+    private const string MinimalFcXml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<S100FC:S100_FC_FeatureCatalogue
+    xmlns:S100FC=""http://www.iho.int/S100FC/5.2""
+    xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <S100FC:name>Test</S100FC:name>
+  <S100FC:scope>Test</S100FC:scope>
+  <S100FC:versionNumber>1.0.0</S100FC:versionNumber>
+  <S100FC:productId>S-101</S100FC:productId>
+</S100FC:S100_FC_FeatureCatalogue>";
+
+    [Fact]
+    public void SharedFeatureCatalogueManager_IsReused_AcrossFactoryCalls()
+    {
+        var resolverCalls = 0;
+        var fcManager = new FeatureCatalogueManager((string spec) =>
+        {
+            if (spec != "S-101") return null;
+            System.Threading.Interlocked.Increment(ref resolverCalls);
+            return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(MinimalFcXml));
+        });
+
+        // First call into the FC manager — the resolver fires.
+        var first = fcManager.GetCatalogue("S-101");
+        Assert.NotNull(first);
+        Assert.Equal(1, resolverCalls);
+
+        // Build two distinct pipeline factories sharing the same FC manager.
+        var pcManager = new PortrayalCatalogueManager();
+        var factory1 = new DatasetPipelineFactory(
+            pcManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            fcManager);
+        var factory2 = new DatasetPipelineFactory(
+            pcManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            fcManager);
+
+        // Even after two factories that, pre-PR-B, would each have
+        // built their own FC manager and forced a parse, the shared
+        // manager keeps the resolver-call count at one. The factories
+        // are only used to assert they accept the shared manager
+        // without rebuilding it.
+        _ = factory1;
+        _ = factory2;
+        Assert.Equal(1, resolverCalls);
+
+        // Repeated calls into the shared manager continue to hit the cache.
+        var again = fcManager.GetCatalogue("S-101");
+        Assert.Same(first, again);
+        Assert.Equal(1, resolverCalls);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/SpecificationFeatureCatalogueSourceTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SpecificationFeatureCatalogueSourceTests.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Specifications;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="Specification.CreateFeatureCatalogueSource(string)"/>
+/// produces an <see cref="EncDotNet.S100.Core.IAssetSource"/> that the
+/// <see cref="FeatureCatalogueManager"/> can consume through its
+/// <c>SetSource</c> API, parallel to the existing
+/// <see cref="Specification.CreatePortrayalCatalogueSource(string)"/> +
+/// <c>PortrayalCatalogueManager.SetSource</c> integration.
+/// </summary>
+public class SpecificationFeatureCatalogueSourceTests
+{
+    [Fact]
+    public async Task CreateFeatureCatalogueSource_OpensFeatureCatalogueXml()
+    {
+        using var source = Specification.CreateFeatureCatalogueSource("S-101");
+        using var stream = await source.OpenAsync("FeatureCatalogue.xml");
+        Assert.True(stream.Length > 0);
+    }
+
+    [Fact]
+    public void FeatureCatalogueManager_ConsumesBundledFcSource()
+    {
+        using var mgr = new FeatureCatalogueManager((string _) => null);
+        mgr.SetSource("S-101", Specification.CreateFeatureCatalogueSource("S-101"));
+
+        var fc = mgr.GetCatalogue("S-101");
+        Assert.NotNull(fc);
+        Assert.Equal("S-101", fc!.ProductId);
+    }
+
+    [Fact]
+    public void HasFeatureCatalogue_AgreesWithAvailableSpecs()
+    {
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            // Every advertised spec must have a bundled FeatureCatalogue.xml.
+            Assert.True(Specification.HasFeatureCatalogue(spec),
+                $"Expected bundled FC for '{spec}'.");
+        }
+        Assert.False(Specification.HasFeatureCatalogue("S-999"));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureCatalogueOverridesTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureCatalogueOverridesTests.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Specifications;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests for <see cref="FeatureCatalogueOverrides"/> covering the
+/// PR-C follow-up wiring: with no transient/persisted overrides in
+/// scope, <c>Open</c> must return <c>null</c> so that the bundled
+/// fallback registered through
+/// <c>FeatureCatalogueManager.SetSource</c> (using
+/// <see cref="Specification.CreateFeatureCatalogueSource(string)"/>)
+/// fires. Mirrors the bundled-source seeding done for Portrayal
+/// Catalogues via <c>PortrayalCatalogueSeeder</c>.
+/// </summary>
+public class FeatureCatalogueOverridesTests
+{
+    private static ViewerSettings NewSettings()
+    {
+        return new ViewerSettings
+        {
+            SettingsFilePath = Path.Combine(Path.GetTempPath(), "fco-tests-" + System.Guid.NewGuid() + ".json"),
+        };
+    }
+
+    [Fact]
+    public void Open_NoOverrides_ReturnsNull_SoBundledSetSourceFires()
+    {
+        var settings = NewSettings();
+        var overrides = new FeatureCatalogueOverrides(settings);
+
+        // Pre PR-C-wiring this returned a fresh bundled stream every
+        // call, which prevented FeatureCatalogueManager.SetSource (with
+        // CachingAssetSource) from ever being consulted because the
+        // resolver always won. After the wiring it must return null so
+        // the SetSource path takes over for the bundled fallback.
+        Assert.Null(overrides.Open("S-101"));
+        Assert.Null(overrides.Open("S-131"));
+    }
+
+    [Fact]
+    public void Open_TransientPath_Wins()
+    {
+        var settings = NewSettings();
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, "<fc/>");
+            var overrides = new FeatureCatalogueOverrides(settings);
+            overrides.SetTransientPaths(new System.Collections.Generic.Dictionary<string, string>
+            {
+                ["S-101"] = tmp,
+            });
+
+            using var s = overrides.Open("S-101");
+            Assert.NotNull(s);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void BundledSetSource_AndEmptyOverrides_ResolvesEveryAvailableSpec()
+    {
+        // Replicates the App.ConfigureServices wiring: a manager whose
+        // resolver consults FeatureCatalogueOverrides (which now returns
+        // null on no override) plus a SetSource registration per
+        // bundled spec. Every advertised spec must round-trip a parsed
+        // catalogue through the bundled fallback path.
+        var settings = NewSettings();
+        var overrides = new FeatureCatalogueOverrides(settings);
+        using var manager = new FeatureCatalogueManager((string spec) => overrides.Open(spec));
+
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasFeatureCatalogue(spec))
+            {
+                manager.SetSource(spec, Specification.CreateFeatureCatalogueSource(spec));
+            }
+        }
+
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            var fc = manager.GetCatalogue(spec);
+            Assert.NotNull(fc);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
+++ b/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
@@ -77,11 +77,14 @@ public sealed class RenderHarness : IDisposable
         _catalogueManager = catalogueManager;
         _ownsCatalogueManager = ownsCatalogueManager;
 
+        var featureCatalogueManager =
+            new EncDotNet.S100.Features.FeatureCatalogueManager(featureCatalogueResolver);
+
         _factory = new DatasetPipelineFactory(
             _catalogueManager,
             new MoonSharpLuaEngine(),
             new ProjNetCrsTransformFactory(),
-            featureCatalogueResolver);
+            featureCatalogueManager);
     }
 
     /// <summary>

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -15,13 +15,17 @@ internal static class SharedInfrastructure
     private static readonly Lazy<PortrayalCatalogueManager> s_catalogueManager = new(CreateCatalogueManager);
     private static readonly Lazy<MoonSharpLuaEngine> s_luaEngine = new(() => new MoonSharpLuaEngine());
     private static readonly Lazy<ProjNetCrsTransformFactory> s_crsFactory = new(() => new ProjNetCrsTransformFactory());
+    private static readonly Lazy<EncDotNet.S100.Features.FeatureCatalogueManager> s_featureCatalogueManager =
+        new(() => new EncDotNet.S100.Features.FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue));
 
     public static PortrayalCatalogueManager CatalogueManager => s_catalogueManager.Value;
     public static MoonSharpLuaEngine LuaEngine => s_luaEngine.Value;
     public static ProjNetCrsTransformFactory CrsFactory => s_crsFactory.Value;
+    public static EncDotNet.S100.Features.FeatureCatalogueManager FeatureCatalogueManager =>
+        s_featureCatalogueManager.Value;
 
     public static Datasets.Pipelines.DatasetPipelineFactory CreatePipelineFactory() =>
-        new(CatalogueManager, LuaEngine, CrsFactory, Specification.TryOpenFeatureCatalogue);
+        new(CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager);
 
     private static PortrayalCatalogueManager CreateCatalogueManager()
     {


### PR DESCRIPTION
Completes the PR-C follow-up from the asset caching audit (`docs/internal/asset-caching-audit.md`, "Implementation status" row *Wire FC `SetSource` into `App.axaml.cs`* — listed as pending, ~10 lines).

**Depends on #61 (PR-B) and #62 (PR-C).** Until those merge, the diff here will show all three sets of changes; once #61 and #62 land this reduces to ~30 lines of net change.

## Problem

After PR-B (#61) the viewer's `FeatureCatalogueManager` became a singleton whose resolver delegate routes through `FeatureCatalogueOverrides`. PR-C (#62) then added an `IAssetSource`-shaped `SetSource` API on the manager plus `Specification.CreateFeatureCatalogueSource` (a `CachingAssetSource` over bundled FC content).

But the two pieces were not connected: `FeatureCatalogueOverrides.Open` still fell back to `Specification.TryOpenFeatureCatalogue(spec)` — a fresh manifest stream every call — so the resolver always succeeded for bundled specs and the `SetSource` / `CachingAssetSource` path was never consulted. Cold parses re-read the embedded resource stream every time.

## Fix

- `App.ConfigureServices` now registers `Specification.CreateFeatureCatalogueSource(spec)` with the singleton `FeatureCatalogueManager` for every `Specification.AvailableSpecs` entry that has a bundled FC. Mirrors the bundled-source loop in `PortrayalCatalogueSeeder` (`PortrayalCatalogueSeeder.cs:81-88`).
- `FeatureCatalogueOverrides.Open` drops the `Specification.TryOpenFeatureCatalogue` fallback and returns `null` when no CLI / persisted-settings path applies. Per `FeatureCatalogueManager.ParseCatalogue`, returning `null` from the resolver is what lets the registered `IAssetSource` fire — so bundled FCs now flow through `CachingAssetSource`.

Transient CLI overrides and persisted user-settings FC paths continue to win over the bundled source, preserving existing override behaviour.

## Tests

New `FeatureCatalogueOverridesTests`:

1. `Open_NoOverrides_ReturnsNull_SoBundledSetSourceFires` — guards against re-introducing the bundled-stream fallback in `Open`.
2. `Open_TransientPath_Wins` — CLI-supplied path still takes precedence.
3. `BundledSetSource_AndEmptyOverrides_ResolvesEveryAvailableSpec` — replicates the App wiring (resolver routes through `FeatureCatalogueOverrides`, every `AvailableSpecs` entry gets a `SetSource` registration) and asserts every advertised spec round-trips a parsed catalogue through the bundled fallback.

Full `dotnet test --configuration Release` is green on each test project run individually. One pre-existing flaky telemetry test (`TelemetrySmokeTests.VectorPipeline_emits_xslt_transform_span`) can fail under the full parallel solution run due to ActivityListener cross-test bleed; it passes on its own and is unrelated to this change.

## Audit reference

Updates this row in the audit's *Implementation status* table:

| Wire FC `SetSource` into `App.axaml.cs` | PR-C follow-up | ~~Pending (small, ~10 lines)~~ → Shipped here | after PR-B/C merge |