### PR TITLE
Share MapsuiDisplayListRenderer symbol/pattern caches per-processor

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -36,6 +36,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
     private readonly GmlPortrayalCatalogueBase _catalogue;
     private readonly FeatureCatalogueDecoder? _decoder;
     private readonly string _fileName;
+    private readonly MapsuiRenderAssetCache _renderAssetCache = new();
 
     /// <summary>
     /// Initializes the shared processor state. Called by subclass constructors
@@ -136,6 +137,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
         {
             LayerName = $"{Spec.Name}: {_fileName}",
             Palette = catalogue.ActivePalette,
+            AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
             SymbolProvider = symbolName =>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -23,6 +23,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
     private readonly ILuaEngine _luaEngine;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
     private readonly string _fileName;
+    private readonly MapsuiRenderAssetCache _renderAssetCache = new();
     private Dictionary<long, EncDotNet.S100.Pipelines.Vector.Feature>? _featureIndex;
     private FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
@@ -114,6 +115,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         {
             LayerName = $"S-101: {_fileName}",
             Palette = palette,
+            AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
             SymbolProvider = symbolName =>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -46,6 +46,7 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
     private readonly ILuaEngine _luaEngine;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
     private readonly string _fileName;
+    private readonly MapsuiRenderAssetCache _renderAssetCache = new();
     private FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
 
@@ -139,6 +140,7 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
         {
             LayerName = $"S-131: {_fileName}",
             Palette = palette,
+            AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
             SymbolProvider = symbolName =>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -28,6 +28,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
     private readonly ILuaEngine _luaEngine;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
     private readonly string _fileName;
+    private readonly MapsuiRenderAssetCache _renderAssetCache = new();
     private Dictionary<long, EncDotNet.S100.Pipelines.Vector.Feature>? _featureIndex;
     private EncDotNet.S100.Features.FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
@@ -117,6 +118,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         {
             LayerName = $"S-57: {_fileName}",
             Palette = palette,
+            AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
             SymbolProvider = symbolName =>

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -85,8 +85,19 @@ public sealed class MapsuiDisplayListRenderer
     /// </summary>
     public double TextScale { get; set; } = 1.0;
 
-    // Caches processed SVG data URIs and pivot metrics keyed by symbol name.
-    private readonly Dictionary<string, SymbolEntry> _symbolDataUriCache = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// Optional shared cache for processed-SVG symbol entries and rasterised
+    /// pattern tiles. When set, the renderer routes its symbol/pattern
+    /// lookups through this cache so re-renders of the same dataset (e.g.
+    /// after a palette toggle, time-step scrub, or mariner-setting change)
+    /// reuse the SVG processing + pattern rasterization work. When unset
+    /// (the default), a per-renderer cache is used, preserving legacy
+    /// behaviour for ad-hoc / one-shot callers such as tests.
+    /// </summary>
+    public MapsuiRenderAssetCache? AssetCache { get; set; }
+
+    // Per-renderer fallback used when AssetCache is null.
+    private readonly MapsuiRenderAssetCache _localAssetCache = new();
 
     /// <summary>
     /// A cached SVG symbol: its Mapsui <c>svg-content://</c> source URI plus
@@ -96,15 +107,12 @@ public sealed class MapsuiDisplayListRenderer
     /// <c>RelativeOffset</c> consumes; the millimetre offset is retained in
     /// case a future code path needs an absolute-pixel translation.
     /// </summary>
-    private readonly record struct SymbolEntry(
+    internal readonly record struct SymbolEntry(
         string? Source,
         double PivotOffsetXMm,
         double PivotOffsetYMm,
         double RelativeOffsetX,
         double RelativeOffsetY);
-
-    // Caches rasterized pattern tile PNG bytes keyed by area fill name.
-    private readonly Dictionary<string, byte[]?> _patternTileCache = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Renders the supplied display list against the geometry provided by
@@ -802,23 +810,31 @@ public sealed class MapsuiDisplayListRenderer
             return default;
 
         var resolveStart = Stopwatch.GetTimestamp();
+        var cache = AssetCache ?? _localAssetCache;
 
-        if (_symbolDataUriCache.TryGetValue(symbolRef, out var cached))
+        var entry = cache.GetOrAddSymbol(Palette, symbolRef, out var wasCached, ProduceSymbolEntry);
+
+        if (wasCached)
         {
             S100Diag.Telemetry.SymbolCacheHit.Add(1);
             S100Diag.Telemetry.SymbolResolveDuration.Record(
                 (Stopwatch.GetTimestamp() - resolveStart) * 1000.0 / Stopwatch.Frequency,
                 new KeyValuePair<string, object?>(TelemetryTags.SymbolResult, "hit"));
-            return cached;
+            return entry;
         }
 
         S100Diag.Telemetry.SymbolCacheMiss.Add(1);
+        S100Diag.Telemetry.SymbolResolveDuration.Record(
+            (Stopwatch.GetTimestamp() - resolveStart) * 1000.0 / Stopwatch.Frequency,
+            new KeyValuePair<string, object?>(TelemetryTags.SymbolResult, entry.Source is null ? "fallback" : "miss"));
+        return entry;
+    }
 
-        SymbolEntry entry = default;
-        string resultTag = "fallback";
+    private SymbolEntry ProduceSymbolEntry(string symbolRef)
+    {
         try
         {
-            var svgContent = SymbolProvider(symbolRef);
+            var svgContent = SymbolProvider!(symbolRef);
             if (svgContent is not null)
             {
                 // Recover S-100 Part 9 §11.5 pivot placement from the *raw*
@@ -828,13 +844,12 @@ public sealed class MapsuiDisplayListRenderer
                 // collapse onto the same point.
                 var pivot = SvgPivotMetrics.TryParse(svgContent);
                 var processed = SvgProcessor.Process(svgContent, Palette);
-                entry = new SymbolEntry(
+                return new SymbolEntry(
                     "svg-content://" + processed,
                     pivot?.PivotToBoundsCenterMm.X ?? 0.0,
                     pivot?.PivotToBoundsCenterMm.Y ?? 0.0,
                     pivot?.RelativeOffset.X ?? 0.0,
                     pivot?.RelativeOffset.Y ?? 0.0);
-                resultTag = "miss";
             }
         }
         catch
@@ -842,11 +857,7 @@ public sealed class MapsuiDisplayListRenderer
             // Symbol not found or malformed — fall back to dot
         }
 
-        _symbolDataUriCache[symbolRef] = entry;
-        S100Diag.Telemetry.SymbolResolveDuration.Record(
-            (Stopwatch.GetTimestamp() - resolveStart) * 1000.0 / Stopwatch.Frequency,
-            new KeyValuePair<string, object?>(TelemetryTags.SymbolResult, resultTag));
-        return entry;
+        return default;
     }
 
     // ── Pattern tile rasterization ─────────────────────────────────────
@@ -860,20 +871,22 @@ public sealed class MapsuiDisplayListRenderer
         if (string.IsNullOrEmpty(fillName) || AreaFillProvider is null || SymbolProvider is null)
             return null;
 
-        if (_patternTileCache.TryGetValue(fillName, out var cached))
-            return cached;
+        var cache = AssetCache ?? _localAssetCache;
+        return cache.GetOrAddPatternTile(Palette, fillName, out _, ProducePatternTile);
+    }
 
-        byte[]? result = null;
+    private byte[]? ProducePatternTile(string fillName)
+    {
         try
         {
-            var areaFill = AreaFillProvider(fillName);
+            var areaFill = AreaFillProvider!(fillName);
             if (areaFill?.PatternSymbol is not null)
             {
-                var svgContent = SymbolProvider(areaFill.PatternSymbol);
+                var svgContent = SymbolProvider!(areaFill.PatternSymbol);
                 if (svgContent is not null)
                 {
                     var processed = SvgProcessor.Process(svgContent, Palette);
-                    result = SkiaSvgRasterizer.RasterizePatternTile(processed, areaFill);
+                    return SkiaSvgRasterizer.RasterizePatternTile(processed, areaFill);
                 }
             }
         }
@@ -882,8 +895,7 @@ public sealed class MapsuiDisplayListRenderer
             // Area fill or symbol not found — skip pattern
         }
 
-        _patternTileCache[fillName] = result;
-        return result;
+        return null;
     }
 
     // ── S-100 Color resolution ─────────────────────────────────────────

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiRenderAssetCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiRenderAssetCache.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// Per-palette cache of processed-SVG symbol entries and rasterised pattern
+/// tiles produced by <see cref="MapsuiDisplayListRenderer"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both <see cref="MapsuiDisplayListRenderer"/>'s processed-SVG ("data URI"
+/// string post <c>SvgProcessor.Process</c>) and rasterised pattern-tile PNG
+/// caches were originally instance-scoped. Because every dataset processor
+/// constructs a fresh renderer on each <c>Render()</c> call, every palette
+/// toggle / time-step scrub / mariner-setting change re-paid the full SVG
+/// processing + PNG rasterization cost.
+/// </para>
+/// <para>
+/// Lifting these caches into a dataset-processor-owned
+/// <see cref="MapsuiRenderAssetCache"/> instance lets re-renders of the same
+/// dataset reuse that work. The cache is keyed by palette name (Day/Dusk/
+/// Night) so flipping between palettes does not invalidate sibling-palette
+/// entries: each palette gets its own slot, populated lazily on first
+/// access.
+/// </para>
+/// <para>
+/// Processed SVG output depends on the active <see cref="ColorPalette"/>
+/// (the processor recolours fills/strokes), so per-palette segmentation is
+/// required for correctness.
+/// </para>
+/// <para>
+/// The dictionaries are <see cref="ConcurrentDictionary{TKey,TValue}"/> to
+/// allow safe sharing if a future caller renders concurrently.
+/// </para>
+/// </remarks>
+public sealed class MapsuiRenderAssetCache
+{
+    private readonly ConcurrentDictionary<string, PerPaletteCache> _byPalette =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns a cached <see cref="MapsuiDisplayListRenderer.SymbolEntry"/>
+    /// for <paramref name="symbolName"/> under the given palette, invoking
+    /// <paramref name="factory"/> on miss.
+    /// </summary>
+    internal MapsuiDisplayListRenderer.SymbolEntry GetOrAddSymbol(
+        ColorPalette? palette,
+        string symbolName,
+        out bool wasCached,
+        Func<string, MapsuiDisplayListRenderer.SymbolEntry> factory)
+    {
+        var bucket = GetBucket(palette);
+        if (bucket.Symbols.TryGetValue(symbolName, out var existing))
+        {
+            wasCached = true;
+            return existing;
+        }
+
+        wasCached = false;
+        var produced = factory(symbolName);
+        // GetOrAdd here (instead of the simpler indexer) keeps a parallel
+        // factory call from racing past a cached entry.
+        return bucket.Symbols.GetOrAdd(symbolName, produced);
+    }
+
+    /// <summary>
+    /// Returns the cached pattern-tile PNG bytes for <paramref name="fillName"/>
+    /// under the given palette, invoking <paramref name="factory"/> on miss.
+    /// </summary>
+    internal byte[]? GetOrAddPatternTile(
+        ColorPalette? palette,
+        string fillName,
+        out bool wasCached,
+        Func<string, byte[]?> factory)
+    {
+        var bucket = GetBucket(palette);
+        if (bucket.PatternTiles.TryGetValue(fillName, out var existing))
+        {
+            wasCached = true;
+            return existing;
+        }
+
+        wasCached = false;
+        var produced = factory(fillName);
+        return bucket.PatternTiles.GetOrAdd(fillName, produced);
+    }
+
+    private PerPaletteCache GetBucket(ColorPalette? palette)
+    {
+        var key = palette?.Name ?? string.Empty;
+        return _byPalette.GetOrAdd(key, _ => new PerPaletteCache());
+    }
+
+    private sealed class PerPaletteCache
+    {
+        public ConcurrentDictionary<string, MapsuiDisplayListRenderer.SymbolEntry> Symbols { get; }
+            = new(StringComparer.OrdinalIgnoreCase);
+
+        public ConcurrentDictionary<string, byte[]?> PatternTiles { get; }
+            = new(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -18,6 +18,27 @@ This library bridges the S-100 portrayal pipeline output to Mapsui map layers, i
 - Text alignment, mm offsets, and `textLine` start/end offsets (Relative or Absolute) are honoured per S-100 Part 9 §11.4.
 - `LineStyleProvider`, `SymbolProvider`, and `AreaFillProvider` callbacks let the host project plug in a portrayal catalogue without coupling the renderer to a specific dataset library.
 
+### Sharing processed-SVG and pattern-tile work across renders
+
+`MapsuiDisplayListRenderer` resolves SVG symbols and rasterises area-fill pattern tiles lazily on first reference. The processed-SVG output depends on the active `ColorPalette` (fill/stroke colours are recoloured against the palette), and pattern-tile rasterisation is comparatively expensive.
+
+When a single dataset is re-rendered repeatedly — typical when toggling palettes, scrubbing time-steps, or changing mariner settings — assign a single `MapsuiRenderAssetCache` instance to the renderer's `AssetCache` property on every `Render()` call:
+
+```csharp
+private readonly MapsuiRenderAssetCache _renderAssetCache = new();
+
+// per Render():
+var renderer = new MapsuiDisplayListRenderer
+{
+    Palette = palette,
+    AssetCache = _renderAssetCache,
+    SymbolProvider = name => catalogue.GetSymbol(name).SvgContent,
+    AreaFillProvider = name => catalogue.GetAreaFill(name),
+};
+```
+
+The cache segments entries per palette (`Day` / `Dusk` / `Night`) so flipping back and forth keeps every palette warm. When `AssetCache` is unset, the renderer falls back to a per-instance cache, which preserves legacy behaviour for ad-hoc / one-shot callers.
+
 ## Installation
 
 ```sh

--- a/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
+++ b/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Skia\EncDotNet.S100.Renderers.Skia.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
   </ItemGroup>

--- a/tests/EncDotNet.S100.Pipelines.Tests/MapsuiRenderAssetCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/MapsuiRenderAssetCacheTests.cs
@@ -1,0 +1,167 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Mapsui;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="MapsuiRenderAssetCache"/> shared between renderer
+/// instances reuses processed-SVG and pattern-tile work across renders, so a
+/// dataset processor that holds the cache for its lifetime stops re-paying
+/// the SVG processing cost on every <see cref="MapsuiDisplayListRenderer.Render"/>.
+/// </summary>
+/// <remarks>
+/// Backs PR-1 of <c>docs/internal/asset-caching-audit.md</c>.
+/// </remarks>
+public class MapsuiRenderAssetCacheTests
+{
+    private const string SymbolName = "TESTSYM";
+    private const string FeatureRef = "F1";
+
+    /// <summary>
+    /// A counting symbol provider stand-in that returns a small, valid SVG
+    /// the first time it is asked for any name and increments a counter on
+    /// every call. Subsequent calls return the same content; the test
+    /// asserts the counter remains at 1 across two renders.
+    /// </summary>
+    private sealed class CountingSymbolProvider
+    {
+        private readonly Dictionary<string, int> _calls = new(StringComparer.OrdinalIgnoreCase);
+
+        public int CallsFor(string name) => _calls.TryGetValue(name, out var c) ? c : 0;
+
+        public string? Resolve(string name)
+        {
+            _calls[name] = CallsFor(name) + 1;
+            // Minimal viewBox SVG so SvgProcessor.Process succeeds and Mapsui
+            // can host it as a "svg-content://" source.
+            return """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="3" fill="black"/></svg>""";
+        }
+    }
+
+    private sealed class StubGeometryProvider : IFeatureGeometryProvider
+    {
+        public FeatureGeometry? GetGeometry(string featureReference) =>
+            featureReference == FeatureRef
+                ? new FeatureGeometry
+                {
+                    Type = GeometryType.Point,
+                    Coordinates = new[] { (Latitude: 0.0, Longitude: 0.0) },
+                }
+                : null;
+    }
+
+    [Fact]
+    public void SharedCache_AcrossTwoRenderers_OnlyResolvesSymbolOnce()
+    {
+        var cache = new MapsuiRenderAssetCache();
+        var provider = new CountingSymbolProvider();
+        var palette = ColorPalette.Default;
+
+        var instructions = new DrawingInstruction[]
+        {
+            new PointInstruction
+            {
+                FeatureReference = FeatureRef,
+                SymbolReference = SymbolName,
+            },
+        };
+        var geometryProvider = new StubGeometryProvider();
+
+        var first = new MapsuiDisplayListRenderer
+        {
+            Palette = palette,
+            AssetCache = cache,
+            SymbolProvider = provider.Resolve,
+        };
+        first.Render(instructions, geometryProvider);
+
+        Assert.Equal(1, provider.CallsFor(SymbolName));
+
+        // A *new* renderer with the same cache simulates the dataset
+        // processor's "render again after a palette toggle / time scrub /
+        // mariner-setting change" code path. Without a shared cache the
+        // symbol provider would be hit a second time.
+        var second = new MapsuiDisplayListRenderer
+        {
+            Palette = palette,
+            AssetCache = cache,
+            SymbolProvider = provider.Resolve,
+        };
+        second.Render(instructions, geometryProvider);
+
+        Assert.Equal(1, provider.CallsFor(SymbolName));
+    }
+
+    [Fact]
+    public void SharedCache_DifferentPalettes_RecomputeIndependently()
+    {
+        // Per-palette segmentation is required for correctness because
+        // SvgProcessor.Process recolours fills/strokes from the palette.
+        // Two distinct palettes must therefore produce two cache entries.
+        var cache = new MapsuiRenderAssetCache();
+        var provider = new CountingSymbolProvider();
+
+        var day = new ColorPalette("Day", new Dictionary<string, string>());
+        var night = new ColorPalette("Night", new Dictionary<string, string>());
+        var instructions = new DrawingInstruction[]
+        {
+            new PointInstruction { FeatureReference = FeatureRef, SymbolReference = SymbolName },
+        };
+        var geometryProvider = new StubGeometryProvider();
+
+        new MapsuiDisplayListRenderer
+        {
+            Palette = day,
+            AssetCache = cache,
+            SymbolProvider = provider.Resolve,
+        }.Render(instructions, geometryProvider);
+
+        new MapsuiDisplayListRenderer
+        {
+            Palette = night,
+            AssetCache = cache,
+            SymbolProvider = provider.Resolve,
+        }.Render(instructions, geometryProvider);
+
+        // Once for Day, once for Night.
+        Assert.Equal(2, provider.CallsFor(SymbolName));
+
+        // Re-rendering Day must still hit the cache.
+        new MapsuiDisplayListRenderer
+        {
+            Palette = day,
+            AssetCache = cache,
+            SymbolProvider = provider.Resolve,
+        }.Render(instructions, geometryProvider);
+
+        Assert.Equal(2, provider.CallsFor(SymbolName));
+    }
+
+    [Fact]
+    public void NoSharedCache_AcrossTwoRenderers_ResolvesSymbolEachRender()
+    {
+        // Sanity check: without an explicit shared cache the legacy
+        // per-renderer fallback re-resolves the symbol on each new instance.
+        var provider = new CountingSymbolProvider();
+        var instructions = new DrawingInstruction[]
+        {
+            new PointInstruction { FeatureReference = FeatureRef, SymbolReference = SymbolName },
+        };
+        var geometryProvider = new StubGeometryProvider();
+
+        new MapsuiDisplayListRenderer
+        {
+            Palette = ColorPalette.Default,
+            SymbolProvider = provider.Resolve,
+        }.Render(instructions, geometryProvider);
+
+        new MapsuiDisplayListRenderer
+        {
+            Palette = ColorPalette.Default,
+            SymbolProvider = provider.Resolve,
+        }.Render(instructions, geometryProvider);
+
+        Assert.Equal(2, provider.CallsFor(SymbolName));
+    }
+}


### PR DESCRIPTION
Implements **PR-1** of `docs/internal/asset-caching-audit.md` ("Share `MapsuiDisplayListRenderer` symbol/pattern caches"; see audit §6 PR-1, §2 inventory rows for "Processed SVG" and "Rasterised pattern tile PNG", §3 footnote ²).

## Problem

Today every `IDatasetProcessor.Render()` call constructs a fresh `MapsuiDisplayListRenderer`. The renderer's two hot caches (`_symbolDataUriCache` for processed-SVG data URIs, `_patternTileCache` for rasterised PNG bytes) are instance-scoped and therefore discarded between renders. Every palette toggle / time-step scrub / mariner-setting change / display-scale change re-pays the full `SvgProcessor.Process` + `SkiaSvgRasterizer.RasterizePatternTile` cost on the same SVG content for the same dataset.

## Change

- New **`MapsuiRenderAssetCache`** in `EncDotNet.S100.Renderers.Mapsui`. Holds, per palette name (`Day` / `Dusk` / `Night`), `ConcurrentDictionary` sub-caches for symbol entries and pattern-tile PNG bytes. Per-palette segmentation is required for correctness — `SvgProcessor.Process` recolours fills/strokes against the active palette — so flipping palettes does not invalidate sibling-palette entries.
- `MapsuiDisplayListRenderer` exposes an additive **`AssetCache`** property. Lookups are routed through it; when unset, a per-instance fallback cache preserves legacy behaviour for ad-hoc / one-shot callers (tests, third-party hosts).
- Every dataset processor that constructs the renderer now holds a `private readonly MapsuiRenderAssetCache _renderAssetCache = new()` field and assigns it on every `Render()`:
  - `S101DatasetProcessor`
  - `S131DatasetProcessor`
  - `S57DatasetProcessor`
  - `GmlDatasetProcessorBase<TFeature>`

## Verification

- `dotnet build` clean.
- `dotnet test --configuration Release` — all suites green; Pipelines.Tests goes from 237 → **240 passing** with three new cases:
  - `SharedCache_AcrossTwoRenderers_OnlyResolvesSymbolOnce` — shared cache + counting `SymbolProvider` across two renderer instances; provider hit exactly once.
  - `SharedCache_DifferentPalettes_RecomputeIndependently` — Day → Night → Day round-trip; provider hit twice (once per palette), Day repeat is a hit.
  - `NoSharedCache_AcrossTwoRenderers_ResolvesSymbolEachRender` — sanity check that the legacy unshared path still re-resolves each render.

## Risk

Low — internal-only change. Public surface is purely additive (`AssetCache` property + new `MapsuiRenderAssetCache` type); `SymbolEntry` was already private and is now `internal` only because the cache class lives in the same assembly. No existing caller (including the S-421 renderer integration tests) needed updating.

## Follow-ups (out of scope, tracked by audit doc)

- Cross-processor cache sharing (audit PR-3 — "all-processors" cache via `IPortrayalAssetCache`).
- Lua source caching for S-101 / S-131 (audit PR-2).
- S-111 palette caching (audit PR-4).