### PR TITLE
Cache S-101/S-131 Lua sources at the catalogue level

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -102,7 +102,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         // Drive the unified VectorPipeline with the S-101 Lua rule executor
         // (Part 9A). XSLT rules in the S-101 catalogue (if any) are also
         // honoured by the pipeline.
-        var executor = new S101LuaRuleExecutor(_luaEngine, _dataset, _provider, fc);
+        var executor = new S101LuaRuleExecutor(_luaEngine, _dataset, s101Cat, fc);
         var featureSource = new S101FeatureXmlSource(_dataset);
         var pipeline = new PortrayalPipeline(executor);
         var portrayalLayer = pipeline.ProcessAsync(featureSource, s101Cat, mariner: mariner)

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -127,7 +127,7 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
         // XSLT rules — so we provide an empty FeatureXML source to satisfy
         // the VectorPipeline contract. All drawing instructions come from the
         // Lua executor (Stage 4).
-        var executor = new S131LuaRuleExecutor(_luaEngine, _dataset, _provider, fc);
+        var executor = new S131LuaRuleExecutor(_luaEngine, _dataset, _catalogue, fc);
         var featureSource = new EmptyFeatureXmlSource();
         var pipeline = new PortrayalPipeline(executor);
         var portrayalLayer = pipeline.ProcessAsync(

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -106,7 +106,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         s101Cat.SwitchPalette(paletteType);
         var palette = s101Cat.ActivePalette;
 
-        var executor = new S101LuaRuleExecutor(_luaEngine, _translatedDataset, _provider, fc);
+        var executor = new S101LuaRuleExecutor(_luaEngine, _translatedDataset, s101Cat, fc);
         var featureSource = new S101FeatureXmlSource(_translatedDataset);
         var pipeline = new PortrayalPipeline(executor);
         var portrayalLayer = pipeline.ProcessAsync(featureSource, s101Cat, mariner: mariner)

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -23,7 +23,7 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
 {
     private readonly ILuaEngine _luaEngine;
     private readonly S101Dataset _dataset;
-    private readonly PortrayalCatalogueProvider _provider;
+    private readonly S101PortrayalCatalogue _catalogue;
     private readonly FeatureCatalogue _featureCatalogue;
 
     /// <summary>
@@ -105,17 +105,17 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     public S101LuaRuleExecutor(
         ILuaEngine luaEngine,
         S101Dataset dataset,
-        PortrayalCatalogueProvider provider,
+        S101PortrayalCatalogue catalogue,
         FeatureCatalogue featureCatalogue)
     {
         ArgumentNullException.ThrowIfNull(luaEngine);
         ArgumentNullException.ThrowIfNull(dataset);
-        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(catalogue);
         ArgumentNullException.ThrowIfNull(featureCatalogue);
 
         _luaEngine = luaEngine;
         _dataset = dataset;
-        _provider = provider;
+        _catalogue = catalogue;
         _featureCatalogue = featureCatalogue;
     }
 
@@ -201,10 +201,11 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
 
         using var lua = _luaEngine.CreateContext();
 
-        // 1. Configure require() to resolve modules from the Rules/ subdirectory.
-        //    Module source strings are cached so repeated require() calls (and
-        //    any future context re-creation) avoid redundant stream I/O.
-        var moduleCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        // 1. Configure require() to resolve modules from the Rules/ subdirectory
+        //    via the catalogue's shared source cache. The catalogue caches the
+        //    raw source string across renders, so repeated require() calls for
+        //    the same dataset re-use the same in-memory string and never re-
+        //    open the underlying asset stream.
         lua.SetModuleLoader(moduleName =>
         {
             // MoonSharp may pass the bare name (e.g. "S100Scripting") or with
@@ -213,30 +214,16 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
                 ? moduleName
                 : $"{moduleName}.lua";
 
-            if (moduleCache.TryGetValue(fileName, out var cached))
-                return cached;
-
-            try
-            {
-                using var stream = _provider.FetchRuleAsync(fileName)
-                    .GetAwaiter().GetResult();
-                using var reader = new StreamReader(stream);
-                var source = reader.ReadToEnd();
-                moduleCache[fileName] = source;
-                return source;
-            }
-            catch
-            {
-                moduleCache[fileName] = null;
-                return null;
-            }
+            return _catalogue.GetLuaSource(fileName);
         });
 
         // 2. Register all Host* functions on the Lua context
         dataProvider.RegisterHostFunctions(lua);
 
         // 3. Load and execute main.lua (which will require S100Scripting, PortrayalModel, etc.)
-        string mainSource = LoadRuleSource("main.lua");
+        string mainSource = _catalogue.GetLuaSource("main.lua")
+            ?? throw new InvalidOperationException(
+                "S-101 portrayal catalogue is missing required rule file 'main.lua'.");
         lua.Execute(mainSource);
 
         // 3a. Wrap HostFeatureGetSpatialAssociations so the raw data from the host
@@ -320,7 +307,7 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
         var sb = new System.Text.StringBuilder();
         sb.AppendLine("local _cp = {}");
 
-        foreach (var cp in _provider.Catalogue.ContextParameters)
+        foreach (var cp in _catalogue.Provider.Catalogue.ContextParameters)
         {
             // Escape the default value for Lua string literal
             var escapedId = EscapeLuaString(cp.Id);
@@ -379,14 +366,6 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     {
         if (string.IsNullOrEmpty(s)) return "";
         return s.Replace("\\", "\\\\").Replace("'", "\\'");
-    }
-
-    private string LoadRuleSource(string fileName)
-    {
-        using var stream = _provider.FetchRuleAsync(fileName)
-            .GetAwaiter().GetResult();
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
     }
 }
 

--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -23,6 +23,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     private IReadOnlyList<PortrayalRule>? _rules;
     private readonly Dictionary<string, XslCompiledTransform> _compiledXslt = new();
     private readonly Dictionary<string, Script> _luaScripts = new();
+    private readonly Dictionary<string, string?> _luaSources = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, SvgSymbol> _symbols = new();
     private readonly Dictionary<string, LineStyle> _lineStyles = new();
     private readonly Dictionary<string, AreaFill> _areaFills = new();
@@ -255,6 +256,52 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
             Source = source,
         };
     }
+
+    /// <summary>
+    /// Returns the raw Lua source for the given bare filename inside the
+    /// portrayal catalogue's <c>Rules/</c> directory (e.g. <c>"main.lua"</c>,
+    /// <c>"S100Scripting.lua"</c>), caching the decoded string so subsequent
+    /// reads do not re-open the underlying <see cref="Core.IAssetSource"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returns <see langword="null"/> (and caches <see langword="null"/>) if
+    /// the file cannot be fetched, so the MoonSharp module loader's
+    /// "missing module → return null" contract is preserved without retrying
+    /// failed lookups on every <c>require()</c> call.
+    /// </para>
+    /// <para>
+    /// This caches only the immutable <see cref="string"/> source. The
+    /// compiled Lua <c>Script</c> instance is intentionally constructed
+    /// per execution to preserve sandbox isolation (S-100 Part 9A).
+    /// </para>
+    /// </remarks>
+    public string? GetLuaSource(string fileName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fileName);
+
+        if (_luaSources.TryGetValue(fileName, out var cached))
+            return cached;
+
+        string? source;
+        try
+        {
+            using var stream = _provider.FetchRuleAsync(fileName)
+                .GetAwaiter().GetResult();
+            using var reader = new StreamReader(stream);
+            source = reader.ReadToEnd();
+        }
+        catch
+        {
+            source = null;
+        }
+
+        _luaSources[fileName] = source;
+        return source;
+    }
+
+    /// <summary>The underlying portrayal catalogue provider.</summary>
+    internal PortrayalCatalogueProvider Provider => _provider;
 
     // ── Symbols ────────────────────────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
@@ -35,7 +35,7 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
 {
     private readonly ILuaEngine _luaEngine;
     private readonly S131Dataset _dataset;
-    private readonly PortrayalCatalogueProvider _provider;
+    private readonly S131PortrayalCatalogue _catalogue;
     private readonly FeatureCatalogue _featureCatalogue;
 
     /// <summary>
@@ -145,17 +145,17 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
     public S131LuaRuleExecutor(
         ILuaEngine luaEngine,
         S131Dataset dataset,
-        PortrayalCatalogueProvider provider,
+        S131PortrayalCatalogue catalogue,
         FeatureCatalogue featureCatalogue)
     {
         ArgumentNullException.ThrowIfNull(luaEngine);
         ArgumentNullException.ThrowIfNull(dataset);
-        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(catalogue);
         ArgumentNullException.ThrowIfNull(featureCatalogue);
 
         _luaEngine = luaEngine;
         _dataset = dataset;
-        _provider = provider;
+        _catalogue = catalogue;
         _featureCatalogue = featureCatalogue;
     }
 
@@ -209,38 +209,25 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
 
         using var lua = _luaEngine.CreateContext();
 
-        // 1. Configure require() module loader
-        var moduleCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        // 1. Configure require() module loader via the catalogue's shared
+        //    source cache so repeated require() calls across renders re-use
+        //    the same in-memory string and never re-open the asset stream.
         lua.SetModuleLoader(moduleName =>
         {
             var fileName = moduleName.EndsWith(".lua", StringComparison.OrdinalIgnoreCase)
                 ? moduleName
                 : $"{moduleName}.lua";
 
-            if (moduleCache.TryGetValue(fileName, out var cached))
-                return cached;
-
-            try
-            {
-                using var stream = _provider.FetchRuleAsync(fileName)
-                    .GetAwaiter().GetResult();
-                using var reader = new StreamReader(stream);
-                var source = reader.ReadToEnd();
-                moduleCache[fileName] = source;
-                return source;
-            }
-            catch
-            {
-                moduleCache[fileName] = null;
-                return null;
-            }
+            return _catalogue.GetLuaSource(fileName);
         });
 
         // 2. Register all Host* functions
         dataProvider.RegisterHostFunctions(lua);
 
         // 3. Load and execute main.lua
-        string mainSource = LoadRuleSource("main.lua");
+        string mainSource = _catalogue.GetLuaSource("main.lua")
+            ?? throw new InvalidOperationException(
+                "S-131 portrayal catalogue is missing required rule file 'main.lua'.");
         lua.Execute(mainSource);
 
         // 3a. Spatial association shim
@@ -302,7 +289,7 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
         var sb = new System.Text.StringBuilder();
         sb.AppendLine("local _cp = {}");
 
-        foreach (var cp in _provider.Catalogue.ContextParameters)
+        foreach (var cp in _catalogue.Provider.Catalogue.ContextParameters)
         {
             var escapedId = EscapeLuaString(cp.Id);
             var escapedType = EscapeLuaString(cp.Type);
@@ -342,14 +329,6 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
     {
         if (string.IsNullOrEmpty(s)) return "";
         return s.Replace("\\", "\\\\").Replace("'", "\\'");
-    }
-
-    private string LoadRuleSource(string fileName)
-    {
-        using var stream = _provider.FetchRuleAsync(fileName)
-            .GetAwaiter().GetResult();
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
     }
 }
 

--- a/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
@@ -32,6 +32,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     private IReadOnlyList<PortrayalRule>? _rules;
     private readonly Dictionary<string, XslCompiledTransform> _compiledXslt = new();
     private readonly Dictionary<string, Script> _luaScripts = new();
+    private readonly Dictionary<string, string?> _luaSources = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, SvgSymbol> _symbols = new();
     private readonly Dictionary<string, LineStyle> _lineStyles = new();
     private readonly Dictionary<string, AreaFill> _areaFills = new();
@@ -225,6 +226,49 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
         var script = new Script { Name = ruleFile.Id, Source = source };
         _luaScripts[scriptName] = script;
         return script;
+    }
+
+    /// <summary>
+    /// Returns the raw Lua source for the given bare filename inside the
+    /// portrayal catalogue's <c>Rules/</c> directory (e.g. <c>"main.lua"</c>,
+    /// <c>"S100Scripting.lua"</c>), caching the decoded string so subsequent
+    /// reads do not re-open the underlying <see cref="Core.IAssetSource"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returns <see langword="null"/> (and caches <see langword="null"/>) if
+    /// the file cannot be fetched, so the MoonSharp module loader's
+    /// "missing module → return null" contract is preserved without retrying
+    /// failed lookups on every <c>require()</c> call.
+    /// </para>
+    /// <para>
+    /// This caches only the immutable <see cref="string"/> source. The
+    /// compiled Lua <c>Script</c> instance is intentionally constructed
+    /// per execution to preserve sandbox isolation (S-100 Part 9A).
+    /// </para>
+    /// </remarks>
+    public string? GetLuaSource(string fileName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fileName);
+
+        if (_luaSources.TryGetValue(fileName, out var cached))
+            return cached;
+
+        string? source;
+        try
+        {
+            using var stream = _provider.FetchRuleAsync(fileName)
+                .GetAwaiter().GetResult();
+            using var reader = new StreamReader(stream);
+            source = reader.ReadToEnd();
+        }
+        catch
+        {
+            source = null;
+        }
+
+        _luaSources[fileName] = source;
+        return source;
     }
 
     // ── Symbols ────────────────────────────────────────────────────────

--- a/tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S131;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Tests for the catalogue-level Lua source cache introduced by PR-2 of the
+/// asset-caching audit (<c>docs/internal/asset-caching-audit.md</c> §6 PR-2).
+/// Verifies that <see cref="S101PortrayalCatalogue.GetLuaSource"/> and
+/// <see cref="S131PortrayalCatalogue.GetLuaSource"/> serve repeated reads of
+/// the same Lua source file from an in-memory cache without re-opening the
+/// underlying <see cref="IAssetSource"/>.
+/// </summary>
+public class LuaSourceCacheTests
+{
+    [Fact]
+    public async Task S101_GetLuaSource_returns_cached_string_and_opens_underlying_source_once()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var counting = new CountingAssetSource(inner);
+
+        var provider = await PortrayalCatalogueProvider.OpenAsync(counting);
+        var catalogue = new S101PortrayalCatalogue(provider);
+
+        // Prime the path counters: snapshot the open count for "Rules/main.lua"
+        // *before* the first GetLuaSource call so the catalogue.xml read does
+        // not leak in.
+        var openCountBefore = counting.GetOpenCount("Rules/main.lua");
+
+        var first = catalogue.GetLuaSource("main.lua");
+        var second = catalogue.GetLuaSource("main.lua");
+        var third = catalogue.GetLuaSource("main.lua");
+
+        Assert.NotNull(first);
+        Assert.NotEmpty(first!);
+        // Reference-equal: the cache must return the same string instance,
+        // not a freshly decoded copy.
+        Assert.Same(first, second);
+        Assert.Same(first, third);
+
+        // The underlying asset source must be opened exactly once across the
+        // three GetLuaSource calls.
+        Assert.Equal(openCountBefore + 1, counting.GetOpenCount("Rules/main.lua"));
+    }
+
+    [Fact]
+    public async Task S101_GetLuaSource_caches_negative_lookups_so_missing_files_do_not_retry()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var counting = new CountingAssetSource(inner);
+
+        var provider = await PortrayalCatalogueProvider.OpenAsync(counting);
+        var catalogue = new S101PortrayalCatalogue(provider);
+
+        const string missing = "definitely-not-a-real-rule.lua";
+        var openCountBefore = counting.GetOpenCount($"Rules/{missing}");
+
+        var a = catalogue.GetLuaSource(missing);
+        var b = catalogue.GetLuaSource(missing);
+        var c = catalogue.GetLuaSource(missing);
+
+        Assert.Null(a);
+        Assert.Null(b);
+        Assert.Null(c);
+
+        var attemptedOpens = counting.GetOpenCount($"Rules/{missing}") - openCountBefore;
+        // At most one attempted underlying open — the second and third calls
+        // hit the cached null.
+        Assert.True(attemptedOpens <= 1,
+            $"Expected ≤1 underlying open for missing file, got {attemptedOpens}.");
+    }
+
+    [Fact]
+    public async Task S131_GetLuaSource_returns_cached_string_and_opens_underlying_source_once()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-131");
+        using var counting = new CountingAssetSource(inner);
+
+        var provider = await PortrayalCatalogueProvider.OpenAsync(counting);
+        var catalogue = new S131PortrayalCatalogue(provider);
+
+        var openCountBefore = counting.GetOpenCount("Rules/main.lua");
+
+        var first = catalogue.GetLuaSource("main.lua");
+        var second = catalogue.GetLuaSource("main.lua");
+        var third = catalogue.GetLuaSource("main.lua");
+
+        Assert.NotNull(first);
+        Assert.NotEmpty(first!);
+        Assert.Same(first, second);
+        Assert.Same(first, third);
+
+        Assert.Equal(openCountBefore + 1, counting.GetOpenCount("Rules/main.lua"));
+    }
+
+    [Fact]
+    public async Task S101_GetLuaSource_independent_caches_per_catalogue_instance()
+    {
+        // Sandbox isolation behavioural test: two separate catalogue instances
+        // (each its own provider) must each cache independently. This proves
+        // the cache lives on the catalogue, not as a hidden static — so two
+        // dataset processors with two catalogues each pay one open per file,
+        // not zero. (PR-3 will lift these to a shared per-spec cache; PR-2
+        // does not.)
+        using var innerA = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var countingA = new CountingAssetSource(innerA);
+        var providerA = await PortrayalCatalogueProvider.OpenAsync(countingA);
+        var catalogueA = new S101PortrayalCatalogue(providerA);
+
+        using var innerB = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var countingB = new CountingAssetSource(innerB);
+        var providerB = await PortrayalCatalogueProvider.OpenAsync(countingB);
+        var catalogueB = new S101PortrayalCatalogue(providerB);
+
+        var srcA = catalogueA.GetLuaSource("main.lua");
+        var srcB = catalogueB.GetLuaSource("main.lua");
+
+        Assert.NotNull(srcA);
+        Assert.NotNull(srcB);
+        // The string contents are equal — they read the same bundled bytes.
+        Assert.Equal(srcA, srcB);
+
+        // But each catalogue opened its own underlying source exactly once.
+        Assert.Equal(1, countingA.GetOpenCount("Rules/main.lua"));
+        Assert.Equal(1, countingB.GetOpenCount("Rules/main.lua"));
+    }
+
+    /// <summary>
+    /// Thin <see cref="IAssetSource"/> decorator that counts <see cref="OpenAsync"/>
+    /// calls per relative path. Used to assert that the catalogue's Lua source
+    /// cache short-circuits repeated reads.
+    /// </summary>
+    private sealed class CountingAssetSource : IAssetSource
+    {
+        private readonly IAssetSource _inner;
+        private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.OrdinalIgnoreCase);
+
+        public CountingAssetSource(IAssetSource inner)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            _inner = inner;
+        }
+
+        public int GetOpenCount(string relativePath) =>
+            _counts.TryGetValue(relativePath, out var n) ? n : 0;
+
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            _counts.AddOrUpdate(relativePath, 1, (_, n) => n + 1);
+            return _inner.OpenAsync(relativePath, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            // Do not dispose _inner — the caller owns it.
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PatternFillDiagnosticTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PatternFillDiagnosticTests.cs
@@ -450,7 +450,7 @@ public class S101PatternFillDiagnosticTests
         var palette = catalogue.ActivePalette;
 
         // Run Lua portrayal
-        var portrayal = new S101LuaRuleExecutor(luaEngine, dataset, provider, fc);
+        var portrayal = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
         var emitted = portrayal.ExecuteRaw(MarinerSettings.Default);
 
         // Dump raw emit strings for key features

--- a/tools/TestS101Lua/TestS101Lua.cs
+++ b/tools/TestS101Lua/TestS101Lua.cs
@@ -64,7 +64,8 @@ var mariner = MarinerSettings.Default;
 Console.WriteLine();
 Console.WriteLine("Running S-101 Lua portrayal pipeline...");
 var luaEngine = new MoonSharpLuaEngine();
-var portrayal = new S101LuaRuleExecutor(luaEngine, dataset, provider, fc);
+var catalogue = new S101PortrayalCatalogue(provider, luaEngine);
+var portrayal = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
 
 var sw = System.Diagnostics.Stopwatch.StartNew();
 var emitted = portrayal.ExecuteRaw(mariner);


### PR DESCRIPTION
Implements **PR-2** of the asset-caching audit — see
`docs/internal/asset-caching-audit.md` §6 PR-2 on branch
`philliphoff/asset-caching-audit`.

## What changed

- New `public string? GetLuaSource(string fileName)` on
  `S101PortrayalCatalogue` and `S131PortrayalCatalogue`, backed by a
  per-catalogue case-insensitive `Dictionary<string,string?>`. On miss
  it opens via `_provider.FetchRuleAsync(fileName)`, reads the stream
  to a string, and caches the result. Exceptions are cached as `null`
  so MoonSharp's `require()` does not retry missing files every call.
- `S101LuaRuleExecutor` and `S131LuaRuleExecutor` now route both
  `LoadRuleSource("main.lua")` **and** the
  `Script.Options.ScriptLoader` delegate through the catalogue's
  cache. The per-execution `moduleCache` is removed (redundant).
- Executor constructors now take the per-spec catalogue instead of
  the raw `PortrayalCatalogueProvider`; the catalogue exposes the
  provider internally. Call sites updated:
  `S101DatasetProcessor`, `S131DatasetProcessor`,
  `S57DatasetProcessor`, `S101PatternFillDiagnosticTests`,
  `tools/TestS101Lua`.

## What does **not** change

- The compiled MoonSharp `Script` instance is still constructed per
  `Execute()` to preserve sandbox isolation (S-100 Part 9A). Only the
  raw `string` source is hoisted into the catalogue.
- The bundled `content/S101/pc/Rules/**` and `content/S131/pc/**`
  trees are untouched.
- The existing `GetLuaScript(scriptName)` cache (which returns a
  `Script` wrapper keyed by rule **Id**) is left in place — different
  lookup path, removing it is out of PR-2 scope.

## Impact

Eliminates the ~10–15 per-render `OpenAsync` + `StreamReader` +
`ReadToEnd()` round-trips for `main.lua` + `S100Scripting.lua` +
`PortrayalAPI.lua` + `PortrayalModel.lua` + per-feature-type rule
files on every S-101 / S-131 render of the same dataset.

## Tests

New `tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs`:

1. `S101_GetLuaSource_returns_cached_string_and_opens_underlying_source_once`
2. `S101_GetLuaSource_caches_negative_lookups_so_missing_files_do_not_retry`
3. `S131_GetLuaSource_returns_cached_string_and_opens_underlying_source_once`
4. `S101_GetLuaSource_independent_caches_per_catalogue_instance`

Each wraps the bundled PC `IAssetSource` in a `CountingAssetSource`
decorator and asserts the underlying `OpenAsync(path)` call count
stays at exactly 1 (or 0 for negative re-lookups) regardless of how
many `GetLuaSource` calls the catalogue receives. Strings are
asserted reference-equal across reads.

Full `dotnet test --configuration Release` is green
(Pipelines.Tests 240 → 244).

## Deferred to follow-ups

- `ConcurrentDictionary` swap → PR-6.
- Lifting per-catalogue caches into a shared per-spec
  `IPortrayalAssetCache` → PR-3.
- Cache hit/miss telemetry counters → PR-7.