### PR TITLE
PR-3: Spec-level portrayal asset cache

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -20,21 +20,29 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     private readonly PortrayalCatalogueProvider _provider;
     private readonly ILuaEngine? _luaEngine;
 
+    // PR-3 (asset-caching audit §6): decoded-asset storage lives on the
+    // provider's IPortrayalAssetCache, so two S101PortrayalCatalogue
+    // instances sharing a provider — or two providers sharing a
+    // PortrayalCatalogueManager-owned cache for SpecRef("S-101", _) —
+    // pay each XSLT compile / SVG read / line style / area fill /
+    // palette / Lua source decode at most once.
+    //
+    // Thread-safety: PortrayalAssetCache uses non-concurrent
+    // dictionaries. Today the S-101 dataset processor reads and writes
+    // these slots on a single pipeline thread per dataset, so the only
+    // race risk is two pipelines running concurrently against
+    // S-101 catalogues that share a manager-owned cache. PR-6 of the
+    // audit tracks hardening to ConcurrentDictionary.
+    private readonly IPortrayalAssetCache _cache;
+
     private IReadOnlyList<PortrayalRule>? _rules;
-    private readonly Dictionary<string, XslCompiledTransform> _compiledXslt = new();
-    private readonly Dictionary<string, Script> _luaScripts = new();
-    private readonly Dictionary<string, string?> _luaSources = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, SvgSymbol> _symbols = new();
-    private readonly Dictionary<string, LineStyle> _lineStyles = new();
-    private readonly Dictionary<string, AreaFill> _areaFills = new();
-    private readonly Dictionary<PaletteType, ColorPalette> _palettes = new();
-    private bool _palettesLoaded;
 
     public S101PortrayalCatalogue(PortrayalCatalogueProvider provider, ILuaEngine? luaEngine = null)
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
         _luaEngine = luaEngine;
+        _cache = provider.AssetCache;
         DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
@@ -49,7 +57,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         EnsurePalettesLoaded();
 
-        if (!_palettes.TryGetValue(type, out var palette))
+        if (!_cache.Palettes.TryGetValue(type, out var palette))
         {
             throw new KeyNotFoundException($"Color palette '{type}' not found in the portrayal catalogue.");
         }
@@ -68,8 +76,15 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     private void EnsurePalettesLoaded()
     {
-        if (_palettesLoaded) return;
-        _palettesLoaded = true;
+        if (_cache.PalettesLoaded)
+        {
+            if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+            {
+                ActivePalette = dayPalette;
+            }
+            return;
+        }
+        _cache.PalettesLoaded = true;
 
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
@@ -93,7 +108,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
                 {
                     using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
                     var palette = ColorProfileReader.Read(stream, paletteName);
-                    _palettes[paletteType.Value] = palette;
+                    _cache.Palettes[paletteType.Value] = palette;
                 }
                 catch (Exception)
                 {
@@ -107,14 +122,14 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
                 // try loading each one from the same file.
                 foreach (var (type, name) in new[] { (PaletteType.Day, "Day"), (PaletteType.Dusk, "Dusk"), (PaletteType.Night, "Night") })
                 {
-                    if (_palettes.ContainsKey(type)) continue;
+                    if (_cache.Palettes.ContainsKey(type)) continue;
                     try
                     {
                         using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
                         var palette = ColorProfileReader.Read(stream, name);
                         if (palette.Colors.Count > 0)
                         {
-                            _palettes[type] = palette;
+                            _cache.Palettes[type] = palette;
                         }
                     }
                     catch (Exception)
@@ -126,9 +141,9 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
         }
 
         // Set Day palette as active if available
-        if (_palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayFinal))
         {
-            ActivePalette = dayPalette;
+            ActivePalette = dayFinal;
         }
     }
 
@@ -206,11 +221,11 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public XslCompiledTransform GetCompiledRule(string ruleName)
     {
-        if (_compiledXslt.TryGetValue(ruleName, out var cached)) return cached;
+        if (_cache.CompiledXslt.TryGetValue(ruleName, out var cached)) return cached;
 
         var ruleFile = FindRuleFile(ruleName);
         var transform = LoadXsltRule(ruleFile);
-        _compiledXslt[ruleName] = transform;
+        _cache.CompiledXslt[ruleName] = transform;
         return transform;
     }
 
@@ -236,11 +251,11 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public Script GetLuaScript(string scriptName)
     {
-        if (_luaScripts.TryGetValue(scriptName, out var cached)) return cached;
+        if (_cache.LuaScripts.TryGetValue(scriptName, out var cached)) return cached;
 
         var ruleFile = FindRuleFile(scriptName);
         var script = LoadLuaScript(ruleFile);
-        _luaScripts[scriptName] = script;
+        _cache.LuaScripts[scriptName] = script;
         return script;
     }
 
@@ -280,7 +295,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentException.ThrowIfNullOrEmpty(fileName);
 
-        if (_luaSources.TryGetValue(fileName, out var cached))
+        if (_cache.LuaSources.TryGetValue(fileName, out var cached))
             return cached;
 
         string? source;
@@ -296,7 +311,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
             source = null;
         }
 
-        _luaSources[fileName] = source;
+        _cache.LuaSources[fileName] = source;
         return source;
     }
 
@@ -307,10 +322,10 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public SvgSymbol GetSymbol(string symbolName)
     {
-        if (_symbols.TryGetValue(symbolName, out var cached)) return cached;
+        if (_cache.Symbols.TryGetValue(symbolName, out var cached)) return cached;
 
         var symbol = LoadSymbol(symbolName);
-        _symbols[symbolName] = symbol;
+        _cache.Symbols[symbolName] = symbol;
         return symbol;
     }
 
@@ -335,10 +350,10 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public LineStyle GetLineStyle(string name)
     {
-        if (_lineStyles.TryGetValue(name, out var cached)) return cached;
+        if (_cache.LineStyles.TryGetValue(name, out var cached)) return cached;
 
         var style = LoadLineStyle(name);
-        _lineStyles[name] = style;
+        _cache.LineStyles[name] = style;
         return style;
     }
 
@@ -356,10 +371,10 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     public AreaFill GetAreaFill(string name)
     {
-        if (_areaFills.TryGetValue(name, out var cached)) return cached;
+        if (_cache.AreaFills.TryGetValue(name, out var cached)) return cached;
 
         var fill = LoadAreaFill(name);
-        _areaFills[name] = fill;
+        _cache.AreaFills[name] = fill;
         return fill;
     }
 

--- a/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
@@ -29,15 +29,14 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     private readonly PortrayalCatalogueProvider _provider;
     private readonly ILuaEngine? _luaEngine;
 
+    // PR-3 (asset-caching audit §6): see S101PortrayalCatalogue for the
+    // long-form rationale + thread-safety note. Identical model: the
+    // catalogue still owns the loading logic but storage lives on the
+    // provider's IPortrayalAssetCache so two S-131 catalogue wrappers
+    // for the same SpecRef share their decoded assets.
+    private readonly IPortrayalAssetCache _cache;
+
     private IReadOnlyList<PortrayalRule>? _rules;
-    private readonly Dictionary<string, XslCompiledTransform> _compiledXslt = new();
-    private readonly Dictionary<string, Script> _luaScripts = new();
-    private readonly Dictionary<string, string?> _luaSources = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, SvgSymbol> _symbols = new();
-    private readonly Dictionary<string, LineStyle> _lineStyles = new();
-    private readonly Dictionary<string, AreaFill> _areaFills = new();
-    private readonly Dictionary<PaletteType, ColorPalette> _palettes = new();
-    private bool _palettesLoaded;
 
     /// <summary>
     /// Initialises a new <see cref="S131PortrayalCatalogue"/> from the given
@@ -48,6 +47,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
         _luaEngine = luaEngine;
+        _cache = provider.AssetCache;
         DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
@@ -68,7 +68,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         EnsurePalettesLoaded();
 
-        if (!_palettes.TryGetValue(type, out var palette))
+        if (!_cache.Palettes.TryGetValue(type, out var palette))
             throw new KeyNotFoundException($"Color palette '{type}' not found in the S-131 portrayal catalogue.");
 
         ActivePalette = palette;
@@ -87,8 +87,13 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 
     private void EnsurePalettesLoaded()
     {
-        if (_palettesLoaded) return;
-        _palettesLoaded = true;
+        if (_cache.PalettesLoaded)
+        {
+            if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayCached))
+                ActivePalette = dayCached;
+            return;
+        }
+        _cache.PalettesLoaded = true;
 
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
@@ -110,7 +115,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
                 {
                     using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
                     var palette = ColorProfileReader.Read(stream, paletteName);
-                    _palettes[paletteType.Value] = palette;
+                    _cache.Palettes[paletteType.Value] = palette;
                 }
                 catch
                 {
@@ -121,20 +126,20 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
             {
                 foreach (var (type, name) in new[] { (PaletteType.Day, "Day"), (PaletteType.Dusk, "Dusk"), (PaletteType.Night, "Night") })
                 {
-                    if (_palettes.ContainsKey(type)) continue;
+                    if (_cache.Palettes.ContainsKey(type)) continue;
                     try
                     {
                         using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
                         var palette = ColorProfileReader.Read(stream, name);
                         if (palette.Colors.Count > 0)
-                            _palettes[type] = palette;
+                            _cache.Palettes[type] = palette;
                     }
                     catch { }
                 }
             }
         }
 
-        if (_palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
             ActivePalette = dayPalette;
     }
 
@@ -201,14 +206,14 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <inheritdoc/>
     public XslCompiledTransform GetCompiledRule(string ruleName)
     {
-        if (_compiledXslt.TryGetValue(ruleName, out var cached)) return cached;
+        if (_cache.CompiledXslt.TryGetValue(ruleName, out var cached)) return cached;
 
         var ruleFile = FindRuleFile(ruleName);
         using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
         using var reader = XmlReader.Create(stream);
         var transform = new XslCompiledTransform();
         transform.Load(reader);
-        _compiledXslt[ruleName] = transform;
+        _cache.CompiledXslt[ruleName] = transform;
         return transform;
     }
 
@@ -217,14 +222,14 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <inheritdoc/>
     public Script GetLuaScript(string scriptName)
     {
-        if (_luaScripts.TryGetValue(scriptName, out var cached)) return cached;
+        if (_cache.LuaScripts.TryGetValue(scriptName, out var cached)) return cached;
 
         var ruleFile = FindRuleFile(scriptName);
         using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
         using var reader = new StreamReader(stream);
         var source = reader.ReadToEnd();
         var script = new Script { Name = ruleFile.Id, Source = source };
-        _luaScripts[scriptName] = script;
+        _cache.LuaScripts[scriptName] = script;
         return script;
     }
 
@@ -251,7 +256,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         ArgumentException.ThrowIfNullOrEmpty(fileName);
 
-        if (_luaSources.TryGetValue(fileName, out var cached))
+        if (_cache.LuaSources.TryGetValue(fileName, out var cached))
             return cached;
 
         string? source;
@@ -267,7 +272,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
             source = null;
         }
 
-        _luaSources[fileName] = source;
+        _cache.LuaSources[fileName] = source;
         return source;
     }
 
@@ -276,7 +281,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     /// <inheritdoc/>
     public SvgSymbol GetSymbol(string symbolName)
     {
-        if (_symbols.TryGetValue(symbolName, out var cached))
+        if (_cache.Symbols.TryGetValue(symbolName, out var cached))
             return cached;
 
         var catalogItem = _provider.Catalogue.Symbols
@@ -287,14 +292,14 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
         using var reader = new StreamReader(stream);
         var svgContent = reader.ReadToEnd();
         var symbol = new SvgSymbol { Name = symbolName, SvgContent = svgContent };
-        _symbols[symbolName] = symbol;
+        _cache.Symbols[symbolName] = symbol;
         return symbol;
     }
 
     /// <inheritdoc/>
     public LineStyle GetLineStyle(string name)
     {
-        if (_lineStyles.TryGetValue(name, out var cached))
+        if (_cache.LineStyles.TryGetValue(name, out var cached))
             return cached;
 
         var catalogItem = _provider.Catalogue.LineStyles
@@ -303,14 +308,14 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 
         using var stream = _provider.FetchAssetAsync(catalogItem, "LineStyles").GetAwaiter().GetResult();
         var lineStyle = LineStyleReader.Read(stream, name);
-        _lineStyles[name] = lineStyle;
+        _cache.LineStyles[name] = lineStyle;
         return lineStyle;
     }
 
     /// <inheritdoc/>
     public AreaFill GetAreaFill(string name)
     {
-        if (_areaFills.TryGetValue(name, out var cached))
+        if (_cache.AreaFills.TryGetValue(name, out var cached))
             return cached;
 
         var catalogItem = _provider.Catalogue.AreaFills
@@ -319,7 +324,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 
         using var stream = _provider.FetchAssetAsync(catalogItem, "AreaFills").GetAwaiter().GetResult();
         var fill = AreaFillReader.Read(stream, name);
-        _areaFills[name] = fill;
+        _cache.AreaFills[name] = fill;
         return fill;
     }
 

--- a/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
+++ b/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
@@ -24,13 +24,22 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 {
     private readonly PortrayalCatalogueProvider _provider;
 
+    // PR-3 (asset-caching audit §6): every GML-XSLT catalogue subclass
+    // (S-122, S-124, S-125, S-127, S-128, S-129, S-201, S-411, S-421)
+    // routes its decoded XSLT / SVG / line-style / area-fill / palette
+    // storage through the provider's IPortrayalAssetCache. When
+    // PortrayalCatalogueManager owns the cache, two open datasets of
+    // the same spec pay each underlying asset open at most once.
+    //
+    // Thread-safety: PortrayalAssetCache uses non-concurrent
+    // dictionaries. Today each GML dataset processor reads and writes
+    // these slots on a single pipeline thread per dataset; two
+    // pipelines running concurrently against catalogues that share a
+    // manager-owned cache would race. PR-6 of the audit tracks
+    // hardening to ConcurrentDictionary.
+    private readonly IPortrayalAssetCache _cache;
+
     private IReadOnlyList<PortrayalRule>? _rules;
-    private readonly Dictionary<string, XslCompiledTransform> _compiledXslt = new();
-    private readonly Dictionary<string, SvgSymbol> _symbols = new();
-    private readonly Dictionary<string, LineStyle> _lineStyles = new();
-    private readonly Dictionary<string, AreaFill> _areaFills = new();
-    private readonly Dictionary<PaletteType, ColorPalette> _palettes = new();
-    private bool _palettesLoaded;
 
     /// <summary>
     /// Initializes a new <see cref="GmlPortrayalCatalogueBase"/> backed by
@@ -40,6 +49,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        _cache = provider.AssetCache;
         DisplayModeMembership.Bind(DisplayModes, ViewingGroups, _provider.Catalogue);
     }
 
@@ -68,7 +78,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     {
         EnsurePalettesLoaded();
 
-        if (_palettes.TryGetValue(type, out var palette))
+        if (_cache.Palettes.TryGetValue(type, out var palette))
         {
             ActivePalette = palette;
         }
@@ -87,11 +97,18 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     private void EnsurePalettesLoaded()
     {
-        if (_palettesLoaded) return;
-        _palettesLoaded = true;
-        LoadPalettes(_palettes);
+        if (_cache.PalettesLoaded)
+        {
+            if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayCached))
+            {
+                ActivePalette = dayCached;
+            }
+            return;
+        }
+        _cache.PalettesLoaded = true;
+        LoadPalettes(((PortrayalAssetCache)_cache).PalettesDictionary);
 
-        if (_palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
         {
             ActivePalette = dayPalette;
         }
@@ -205,14 +222,14 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// </summary>
     public virtual XslCompiledTransform GetCompiledRule(string ruleName)
     {
-        if (_compiledXslt.TryGetValue(ruleName, out var cached)) return cached;
+        if (_cache.CompiledXslt.TryGetValue(ruleName, out var cached)) return cached;
 
         var ruleFile = _provider.Catalogue.RuleFiles
             .FirstOrDefault(r => r.Id.Equals(ruleName, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Rule '{ruleName}' not found in the portrayal catalogue.");
 
         var transform = LoadXsltRule(ruleFile);
-        _compiledXslt[ruleName] = transform;
+        _cache.CompiledXslt[ruleName] = transform;
         return transform;
     }
 
@@ -222,7 +239,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// </summary>
     protected void CacheCompiledRule(string ruleName, XslCompiledTransform transform)
     {
-        _compiledXslt[ruleName] = transform;
+        _cache.CompiledXslt[ruleName] = transform;
     }
 
     /// <summary>Loads and compiles an XSLT rule file with telemetry.</summary>
@@ -284,7 +301,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// <summary>Returns the SVG symbol with the given name, loading and caching it on first access.</summary>
     public SvgSymbol GetSymbol(string symbolName)
     {
-        if (_symbols.TryGetValue(symbolName, out var cached)) return cached;
+        if (_cache.Symbols.TryGetValue(symbolName, out var cached)) return cached;
 
         var catalogItem = _provider.Catalogue.Symbols
             .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase))
@@ -300,7 +317,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
             SvgContent = svgContent,
         };
 
-        _symbols[symbolName] = symbol;
+        _cache.Symbols[symbolName] = symbol;
         return symbol;
     }
 
@@ -309,7 +326,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// <summary>Returns the line style with the given name, loading and caching it on first access.</summary>
     public LineStyle GetLineStyle(string name)
     {
-        if (_lineStyles.TryGetValue(name, out var cached)) return cached;
+        if (_cache.LineStyles.TryGetValue(name, out var cached)) return cached;
 
         var catalogItem = _provider.Catalogue.LineStyles
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
@@ -318,7 +335,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
         using var stream = _provider.FetchAssetAsync(catalogItem, "LineStyles").GetAwaiter().GetResult();
         var style = LineStyleReader.Read(stream, name);
 
-        _lineStyles[name] = style;
+        _cache.LineStyles[name] = style;
         return style;
     }
 
@@ -327,7 +344,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// <summary>Returns the area fill with the given name, loading and caching it on first access.</summary>
     public AreaFill GetAreaFill(string name)
     {
-        if (_areaFills.TryGetValue(name, out var cached)) return cached;
+        if (_cache.AreaFills.TryGetValue(name, out var cached)) return cached;
 
         var catalogItem = _provider.Catalogue.AreaFills
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
@@ -336,7 +353,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
         using var stream = _provider.FetchAssetAsync(catalogItem, "AreaFills").GetAwaiter().GetResult();
         var fill = AreaFillReader.Read(stream, name);
 
-        _areaFills[name] = fill;
+        _cache.AreaFills[name] = fill;
         return fill;
     }
 

--- a/src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs
@@ -1,0 +1,152 @@
+using System.Xml.Xsl;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Portrayals;
+
+/// <summary>
+/// Process-scoped, spec-segmented storage for decoded portrayal assets
+/// (compiled XSLT transforms, parsed SVG symbols, line styles, area
+/// fills, colour palettes, compiled Lua scripts, and raw Lua source
+/// strings).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Introduced by PR-3 of the asset-caching audit
+/// (<c>docs/internal/asset-caching-audit.md</c> §6 PR-3) to lift the
+/// per-catalogue-instance caches up to the spec level. A single
+/// <see cref="IPortrayalAssetCache"/> instance is owned by
+/// <see cref="PortrayalCatalogueManager"/> per <c>SpecRef</c> and shared
+/// by every <c>S101PortrayalCatalogue</c> / <c>S131PortrayalCatalogue</c>
+/// / <c>GmlPortrayalCatalogueBase</c> wrapper that the manager hands
+/// out for that spec. This means two open datasets of the same product
+/// pay the underlying <see cref="Core.IAssetSource.OpenAsync"/> cost
+/// for each asset only once, not once per dataset.
+/// </para>
+/// <para>
+/// The catalogues continue to own the loading logic; they only
+/// delegate <em>storage</em> to the injected cache.
+/// </para>
+/// </remarks>
+public interface IPortrayalAssetCache
+{
+    /// <summary>
+    /// Cache of compiled XSLT transforms keyed by rule name. Populated
+    /// on first call to <c>GetCompiledRule</c>.
+    /// </summary>
+    IDictionary<string, XslCompiledTransform> CompiledXslt { get; }
+
+    /// <summary>
+    /// Cache of parsed SVG symbols keyed by symbol id. Populated on
+    /// first call to <c>GetSymbol</c>.
+    /// </summary>
+    IDictionary<string, SvgSymbol> Symbols { get; }
+
+    /// <summary>
+    /// Cache of parsed line styles keyed by line-style id. Populated
+    /// on first call to <c>GetLineStyle</c>.
+    /// </summary>
+    IDictionary<string, LineStyle> LineStyles { get; }
+
+    /// <summary>
+    /// Cache of parsed area fills keyed by area-fill id. Populated on
+    /// first call to <c>GetAreaFill</c>.
+    /// </summary>
+    IDictionary<string, AreaFill> AreaFills { get; }
+
+    /// <summary>
+    /// Cache of loaded colour palettes keyed by palette type
+    /// (Day/Dusk/Night). Populated together by the catalogue's palette
+    /// scan; the scan happens once per cache (see
+    /// <see cref="PalettesLoaded"/>).
+    /// </summary>
+    IDictionary<PaletteType, ColorPalette> Palettes { get; }
+
+    /// <summary>
+    /// Cache of compiled Lua <see cref="Script"/> instances keyed by
+    /// script name. Populated on first call to <c>GetLuaScript</c>.
+    /// </summary>
+    IDictionary<string, Script> LuaScripts { get; }
+
+    /// <summary>
+    /// Cache of raw Lua source strings keyed (case-insensitively) by
+    /// bare file name. A cached <see langword="null"/> records a
+    /// negative lookup so missing-module <c>require()</c> calls do
+    /// not re-open the asset source on every miss (see PR-2 of the
+    /// asset-caching audit).
+    /// </summary>
+    IDictionary<string, string?> LuaSources { get; }
+
+    /// <summary>
+    /// Sticky flag set by the catalogue once it has performed the
+    /// one-shot scan of <c>Catalogue.ColorProfiles</c> that populates
+    /// <see cref="Palettes"/>. When two catalogues share a cache this
+    /// flag prevents the second catalogue from re-running the scan
+    /// (and re-opening the underlying colour-profile assets).
+    /// </summary>
+    bool PalettesLoaded { get; set; }
+}
+
+/// <summary>
+/// Default <see cref="IPortrayalAssetCache"/> implementation backed by
+/// plain <see cref="Dictionary{TKey, TValue}"/> instances.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread-safety:</b> this implementation is <em>not</em>
+/// thread-safe. All slots are non-concurrent dictionaries. Today the
+/// dataset processors that consume catalogues read and write the cache
+/// on a single pipeline thread per dataset, which makes this safe in
+/// practice — but two pipelines running in parallel against catalogues
+/// for the same spec would race. Hardening to
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>
+/// is tracked separately by PR-6 of the asset-caching audit
+/// (<c>docs/internal/asset-caching-audit.md</c> §6 PR-6).
+/// </para>
+/// <para>
+/// The <see cref="LuaSources"/> dictionary uses
+/// <see cref="StringComparer.OrdinalIgnoreCase"/> to preserve PR-2's
+/// case-insensitive lookup semantics (Lua <c>require</c> name lookups
+/// from MoonSharp are case-insensitive on Windows-style fs).
+/// </para>
+/// </remarks>
+public sealed class PortrayalAssetCache : IPortrayalAssetCache
+{
+    /// <inheritdoc/>
+    public IDictionary<string, XslCompiledTransform> CompiledXslt { get; } =
+        new Dictionary<string, XslCompiledTransform>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public IDictionary<string, SvgSymbol> Symbols { get; } =
+        new Dictionary<string, SvgSymbol>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public IDictionary<string, LineStyle> LineStyles { get; } =
+        new Dictionary<string, LineStyle>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public IDictionary<string, AreaFill> AreaFills { get; } =
+        new Dictionary<string, AreaFill>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public IDictionary<PaletteType, ColorPalette> Palettes => PalettesDictionary;
+
+    /// <summary>
+    /// Concrete-typed view of the palette dictionary, used by
+    /// <c>GmlPortrayalCatalogueBase.LoadPalettes</c> whose signature is
+    /// part of the protected API and remains <c>Dictionary&lt;,&gt;</c>.
+    /// </summary>
+    internal Dictionary<PaletteType, ColorPalette> PalettesDictionary { get; } =
+        new Dictionary<PaletteType, ColorPalette>();
+
+    /// <inheritdoc/>
+    public IDictionary<string, Script> LuaScripts { get; } =
+        new Dictionary<string, Script>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public IDictionary<string, string?> LuaSources { get; } =
+        new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public bool PalettesLoaded { get; set; }
+}

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
@@ -22,6 +22,14 @@ public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<
     private readonly ConcurrentDictionary<SpecRef, string> _paths = new();
     private readonly ConcurrentDictionary<SpecRef, Lazy<PortrayalCatalogueProvider>> _providers = new();
 
+    // PR-3 (asset-caching audit §6): one decoded-asset cache per
+    // SpecRef, shared by every PortrayalCatalogueProvider — and
+    // therefore every catalogue wrapper — that this manager hands
+    // out for the spec. Two open datasets of the same product stop
+    // paying duplicate XSLT compile + SVG read + line style /
+    // area fill / palette / Lua source decode cost.
+    private readonly ConcurrentDictionary<SpecRef, IPortrayalAssetCache> _assetCaches = new();
+
     private static SpecRef ToSpec(string productSpec)
     {
         ArgumentException.ThrowIfNullOrEmpty(productSpec);
@@ -49,11 +57,14 @@ public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<
 
         _paths[spec] = cataloguePath;
 
-        // Evict stale cached provider
+        // Evict stale cached provider + its asset cache (the assets on
+        // disk may have changed; we cannot keep serving decoded copies
+        // of the previous edition).
         if (_providers.TryRemove(spec, out var old) && old.IsValueCreated)
         {
             old.Value.Dispose();
         }
+        _assetCaches.TryRemove(spec, out _);
     }
 
     /// <summary>
@@ -113,15 +124,17 @@ public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<
         if (spec.Name is null) throw new ArgumentException("SpecRef must have a name.", nameof(spec));
         ArgumentNullException.ThrowIfNull(source);
 
-        // Evict stale cached provider
+        // Evict stale cached provider + asset cache
         if (_providers.TryRemove(spec, out var old) && old.IsValueCreated)
         {
             old.Value.Dispose();
         }
+        _assetCaches.TryRemove(spec, out _);
 
         _paths.TryRemove(spec, out _);
 
         var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
+        provider.AttachAssetCache(GetOrCreateAssetCache(spec));
         // Pre-materialised lazy: callers see the provider immediately, and
         // the slot participates in the same Lazy-based eviction/Dispose
         // semantics as lazily-built providers.
@@ -176,12 +189,19 @@ public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<
             () =>
             {
                 var source = FileSystemAssetSource.Create(path);
-                return PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
+                var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
+                provider.AttachAssetCache(GetOrCreateAssetCache(spec));
+                return provider;
             },
             LazyThreadSafetyMode.ExecutionAndPublication));
 
         return lazy.Value;
     }
+
+    // PR-3: ensure every provider for a given SpecRef hands its
+    // catalogue wrapper the same IPortrayalAssetCache instance.
+    private IPortrayalAssetCache GetOrCreateAssetCache(SpecRef spec) =>
+        _assetCaches.GetOrAdd(spec, static _ => new PortrayalAssetCache());
 
     /// <summary>
     /// Returns true if a catalogue is available for the given product spec
@@ -209,6 +229,7 @@ public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<
         }
 
         _providers.Clear();
+        _assetCaches.Clear();
     }
 
     /// <inheritdoc />

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogueProvider.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogueProvider.cs
@@ -43,6 +43,56 @@ public sealed class PortrayalCatalogueProvider : IDisposable
     /// </summary>
     public PortrayalCatalogue Catalogue { get; }
 
+    private IPortrayalAssetCache? _assetCache;
+
+    /// <summary>
+    /// The decoded-asset cache that backs every catalogue wrapper
+    /// (compiled XSLT, SVG symbols, line styles, area fills, palettes,
+    /// Lua scripts, Lua source strings).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to a fresh per-provider <see cref="PortrayalAssetCache"/>
+    /// the first time it is read. <see cref="PortrayalCatalogueManager"/>
+    /// stamps a <em>shared</em> per-<c>SpecRef</c> cache here (via
+    /// <see cref="AttachAssetCache"/>) before handing the provider out,
+    /// so two catalogue wrappers for the same spec share asset storage
+    /// (asset-caching audit §6 PR-3).
+    /// </para>
+    /// <para>
+    /// Direct callers of <see cref="OpenAsync(IAssetSource, string, CancellationToken)"/>
+    /// — primarily tests — get an isolated per-provider cache, which
+    /// preserves the contract verified by
+    /// <c>LuaSourceCacheTests.S101_GetLuaSource_independent_caches_per_catalogue_instance</c>.
+    /// </para>
+    /// </remarks>
+    public IPortrayalAssetCache AssetCache => _assetCache ??= new PortrayalAssetCache();
+
+    /// <summary>
+    /// Attaches a pre-existing <see cref="IPortrayalAssetCache"/> to
+    /// this provider. Called by <see cref="PortrayalCatalogueManager"/>
+    /// when materialising a provider so all catalogue wrappers for the
+    /// same <c>SpecRef</c> share one cache. May be called at most once
+    /// before any catalogue reads <see cref="AssetCache"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="cache"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// An asset cache has already been associated with this provider
+    /// (either through a prior <see cref="AttachAssetCache"/> call or
+    /// through lazy default-construction on first <see cref="AssetCache"/>
+    /// read).
+    /// </exception>
+    internal void AttachAssetCache(IPortrayalAssetCache cache)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        if (_assetCache is not null)
+        {
+            throw new InvalidOperationException(
+                "An asset cache has already been associated with this provider.");
+        }
+        _assetCache = cache;
+    }
+
     /// <summary>
     /// Opens a <see cref="PortrayalCatalogueProvider"/> by reading the catalogue from the given source.
     /// </summary>

--- a/tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs
@@ -1,0 +1,277 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S131;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Tests for the spec-level portrayal asset cache introduced by PR-3 of
+/// the asset-caching audit
+/// (<c>docs/internal/asset-caching-audit.md</c> §6 PR-3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-3 hoists the per-catalogue caches (compiled XSLT, SVG symbols,
+/// line styles, area fills, palettes, Lua sources, compiled Lua
+/// scripts) up to a shared <see cref="IPortrayalAssetCache"/> owned by
+/// <see cref="PortrayalCatalogueManager"/> per <see cref="SpecRef"/>.
+/// </para>
+/// <para>
+/// These tests verify that:
+/// <list type="bullet">
+///   <item>two catalogue instances for the same spec share decoded
+///   assets when constructed against the manager's provider, so the
+///   underlying <see cref="IAssetSource"/> is opened exactly once per
+///   asset (S-101 Lua portrayal + S-124 XSLT/GML portrayal);</item>
+///   <item>negative-cached Lua source lookups (PR-2) survive the
+///   hoist;</item>
+///   <item>two specs registered with the same manager keep their
+///   caches segmented;</item>
+///   <item>providers opened directly (not through the manager) still
+///   get isolated per-provider caches, preserving the existing
+///   contract verified by
+///   <see cref="LuaSourceCacheTests.S101_GetLuaSource_independent_caches_per_catalogue_instance"/>.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public class SpecLevelAssetCacheTests
+{
+    [Fact]
+    public void S101_two_catalogues_via_manager_share_xslt_symbol_lineStyle_areaFill_and_lua_source_caches()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var counting = new CountingAssetSource(inner);
+
+        using var manager = new PortrayalCatalogueManager();
+        manager.SetSource("S-101", counting);
+
+        var providerA = manager.GetProvider("S-101");
+        var providerB = manager.GetProvider("S-101");
+
+        // The manager hands out one provider per spec — and stamps one
+        // shared IPortrayalAssetCache on it. The two catalogue wrappers
+        // below therefore see the same cache, which is the whole point
+        // of PR-3.
+        var catalogueA = new S101PortrayalCatalogue(providerA);
+        var catalogueB = new S101PortrayalCatalogue(providerB);
+
+        Assert.Same(providerA, providerB);
+        Assert.Same(providerA.AssetCache, providerB.AssetCache);
+
+        // Lua source: the most representative asset, also exercises the
+        // PR-2 cache that we just lifted.
+        var openMainLuaBefore = counting.GetOpenCount("Rules/main.lua");
+        var srcA = catalogueA.GetLuaSource("main.lua");
+        var srcB = catalogueB.GetLuaSource("main.lua");
+        Assert.NotNull(srcA);
+        Assert.Same(srcA, srcB);
+        Assert.Equal(openMainLuaBefore + 1, counting.GetOpenCount("Rules/main.lua"));
+
+        // Compiled XSLT — pick the first catalogued .xsl rule.
+        var xsltRule = providerA.Catalogue.RuleFiles
+            .FirstOrDefault(r => r.FileName.EndsWith(".xsl", StringComparison.OrdinalIgnoreCase));
+        if (xsltRule is not null)
+        {
+            var xsltAssetPath = $"Rules/{xsltRule.FileName}";
+            var openXsltBefore = counting.GetOpenCount(xsltAssetPath);
+            var transformA = catalogueA.GetCompiledRule(xsltRule.Id);
+            var transformB = catalogueB.GetCompiledRule(xsltRule.Id);
+            Assert.Same(transformA, transformB);
+            Assert.Equal(openXsltBefore + 1, counting.GetOpenCount(xsltAssetPath));
+        }
+
+        // SVG symbol.
+        var symbol = providerA.Catalogue.Symbols.FirstOrDefault();
+        if (symbol is not null)
+        {
+            var assetPath = $"Symbols/{symbol.FileName}";
+            var openBefore = counting.GetOpenCount(assetPath);
+            var svgA = catalogueA.GetSymbol(symbol.Id);
+            var svgB = catalogueB.GetSymbol(symbol.Id);
+            Assert.Same(svgA, svgB);
+            Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
+        }
+
+        // Line style.
+        var lineStyle = providerA.Catalogue.LineStyles.FirstOrDefault();
+        if (lineStyle is not null)
+        {
+            var assetPath = $"LineStyles/{lineStyle.FileName}";
+            var openBefore = counting.GetOpenCount(assetPath);
+            var lsA = catalogueA.GetLineStyle(lineStyle.Id);
+            var lsB = catalogueB.GetLineStyle(lineStyle.Id);
+            Assert.Same(lsA, lsB);
+            Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
+        }
+
+        // Area fill.
+        var areaFill = providerA.Catalogue.AreaFills.FirstOrDefault();
+        if (areaFill is not null)
+        {
+            var assetPath = $"AreaFills/{areaFill.FileName}";
+            var openBefore = counting.GetOpenCount(assetPath);
+            var afA = catalogueA.GetAreaFill(areaFill.Id);
+            var afB = catalogueB.GetAreaFill(areaFill.Id);
+            Assert.Same(afA, afB);
+            Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
+        }
+    }
+
+    [Fact]
+    public void S101_negative_lua_lookup_is_shared_across_catalogues_via_manager()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var counting = new CountingAssetSource(inner);
+
+        using var manager = new PortrayalCatalogueManager();
+        manager.SetSource("S-101", counting);
+
+        var catalogueA = new S101PortrayalCatalogue(manager.GetProvider("S-101"));
+        var catalogueB = new S101PortrayalCatalogue(manager.GetProvider("S-101"));
+
+        const string missing = "definitely-not-a-real-rule.lua";
+        var openCountBefore = counting.GetOpenCount($"Rules/{missing}");
+
+        Assert.Null(catalogueA.GetLuaSource(missing));
+        Assert.Null(catalogueB.GetLuaSource(missing));
+        Assert.Null(catalogueA.GetLuaSource(missing));
+
+        var attempts = counting.GetOpenCount($"Rules/{missing}") - openCountBefore;
+        // At most one underlying open across both catalogues: PR-2's
+        // negative cache survives the PR-3 hoist.
+        Assert.True(attempts <= 1,
+            $"Expected ≤1 underlying open for missing file across two manager-shared catalogues, got {attempts}.");
+    }
+
+    [Fact]
+    public void S124_two_GML_catalogues_via_manager_share_xslt_symbol_lineStyle_and_areaFill_caches()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-124");
+        using var counting = new CountingAssetSource(inner);
+
+        using var manager = new PortrayalCatalogueManager();
+        manager.SetSource("S-124", counting);
+
+        var providerA = manager.GetProvider("S-124");
+        var providerB = manager.GetProvider("S-124");
+        Assert.Same(providerA.AssetCache, providerB.AssetCache);
+
+        var catalogueA = new S124PortrayalCatalogue(providerA);
+        var catalogueB = new S124PortrayalCatalogue(providerB);
+
+        var xsltRule = providerA.Catalogue.RuleFiles
+            .FirstOrDefault(r => r.RuleType.Equals("TopLevelTemplate", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(xsltRule);
+        var xsltAssetPath = $"Rules/{xsltRule!.FileName}";
+        var openBefore = counting.GetOpenCount(xsltAssetPath);
+
+        var transformA = catalogueA.GetCompiledRule(xsltRule.Id);
+        var transformB = catalogueB.GetCompiledRule(xsltRule.Id);
+        Assert.Same(transformA, transformB);
+
+        // Exactly one underlying open of the XSLT rule across both
+        // catalogues. (The XSLT compiler may open included sub-templates
+        // through the AssetSourceXmlResolver — those don't count toward
+        // the top-level rule asset.)
+        Assert.Equal(openBefore + 1, counting.GetOpenCount(xsltAssetPath));
+
+        var symbol = providerA.Catalogue.Symbols.FirstOrDefault();
+        if (symbol is not null)
+        {
+            var assetPath = $"Symbols/{symbol.FileName}";
+            var symOpenBefore = counting.GetOpenCount(assetPath);
+            var svgA = catalogueA.GetSymbol(symbol.Id);
+            var svgB = catalogueB.GetSymbol(symbol.Id);
+            Assert.Same(svgA, svgB);
+            Assert.Equal(symOpenBefore + 1, counting.GetOpenCount(assetPath));
+        }
+    }
+
+    [Fact]
+    public void S101_and_S131_specs_keep_independent_caches()
+    {
+        using var s101Inner = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var s101Counting = new CountingAssetSource(s101Inner);
+        using var s131Inner = Specification.CreatePortrayalCatalogueSource("S-131");
+        using var s131Counting = new CountingAssetSource(s131Inner);
+
+        using var manager = new PortrayalCatalogueManager();
+        manager.SetSource("S-101", s101Counting);
+        manager.SetSource("S-131", s131Counting);
+
+        var s101Provider = manager.GetProvider("S-101");
+        var s131Provider = manager.GetProvider("S-131");
+        Assert.NotSame(s101Provider.AssetCache, s131Provider.AssetCache);
+
+        var s101Catalogue = new S101PortrayalCatalogue(s101Provider);
+        var s131Catalogue = new S131PortrayalCatalogue(s131Provider);
+
+        var s101OpenBefore = s101Counting.GetOpenCount("Rules/main.lua");
+        var s131OpenBefore = s131Counting.GetOpenCount("Rules/main.lua");
+
+        var s101Src = s101Catalogue.GetLuaSource("main.lua");
+        var s131Src = s131Catalogue.GetLuaSource("main.lua");
+
+        Assert.NotNull(s101Src);
+        Assert.NotNull(s131Src);
+
+        // Each spec opens its own bundled main.lua exactly once. Cache
+        // segmentation by SpecRef means a hit on one doesn't satisfy
+        // the other.
+        Assert.Equal(s101OpenBefore + 1, s101Counting.GetOpenCount("Rules/main.lua"));
+        Assert.Equal(s131OpenBefore + 1, s131Counting.GetOpenCount("Rules/main.lua"));
+    }
+
+    [Fact]
+    public async Task Provider_opened_directly_outside_manager_gets_its_own_cache()
+    {
+        // Direct callers of OpenAsync (tests, ad-hoc tooling) must not
+        // be coupled to whatever cache the manager would have stamped
+        // — this is what keeps
+        // LuaSourceCacheTests.S101_GetLuaSource_independent_caches_per_catalogue_instance
+        // honest after PR-3.
+        using var innerA = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var countingA = new CountingAssetSource(innerA);
+        var providerA = await PortrayalCatalogueProvider.OpenAsync(countingA);
+
+        using var innerB = Specification.CreatePortrayalCatalogueSource("S-101");
+        using var countingB = new CountingAssetSource(innerB);
+        var providerB = await PortrayalCatalogueProvider.OpenAsync(countingB);
+
+        Assert.NotSame(providerA.AssetCache, providerB.AssetCache);
+    }
+
+    /// <summary>
+    /// Thin <see cref="IAssetSource"/> decorator that counts
+    /// <see cref="OpenAsync"/> calls per relative path.
+    /// </summary>
+    private sealed class CountingAssetSource : IAssetSource
+    {
+        private readonly IAssetSource _inner;
+        private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.OrdinalIgnoreCase);
+
+        public CountingAssetSource(IAssetSource inner)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            _inner = inner;
+        }
+
+        public int GetOpenCount(string relativePath) =>
+            _counts.TryGetValue(relativePath, out var n) ? n : 0;
+
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            _counts.AddOrUpdate(relativePath, 1, (_, n) => n + 1);
+            return _inner.OpenAsync(relativePath, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            // The caller owns the inner source.
+        }
+    }
+}


### PR DESCRIPTION
Implements asset-caching audit §6 PR-3 (`docs/internal/asset-caching-audit.md` on `philliphoff/asset-caching-audit`).

## Problem

Each per-spec portrayal catalogue (`S101PortrayalCatalogue`, `S131PortrayalCatalogue`, and every subclass of `GmlPortrayalCatalogueBase`) currently owns its own private dictionaries for compiled XSLT, SVG symbols, line styles, area fills, colour palettes, compiled Lua `Script` instances, and (from PR-2) raw Lua source strings with negative caching. Two open datasets of the same spec therefore pay duplicate `IAssetSource.OpenAsync` costs for every shared asset.

## Approach

Introduce a shared, **per-`SpecRef`** cache owned by `PortrayalCatalogueManager` and attached to `PortrayalCatalogueProvider`. Catalogues read it from the provider in their ctor, so the **public surface of `S101PortrayalCatalogue`, `S131PortrayalCatalogue`, `GmlPortrayalCatalogueBase`, and `PortrayalCatalogueManager` is unchanged**. When a provider is constructed outside the manager (tests, ad-hoc callers), it lazily gets its own per-instance cache.

## Changes

**New file:**
- `src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs` — `IPortrayalAssetCache` interface + `PortrayalAssetCache` impl with slots: `CompiledXslt`, `Symbols`, `LineStyles`, `AreaFills`, `Palettes` (case-insensitive), `LuaScripts`, `LuaSources` (case-insensitive, nullable values to preserve PR-2 negative caching), and a sticky `PalettesLoaded` flag. Plain `Dictionary<,>` per audit; `ConcurrentDictionary` hardening is PR-6's job.

**Edits:**
- `PortrayalCatalogueProvider`: lazy `AssetCache` property + internal `AttachAssetCache`. Throws if late-attached over a non-default cache.
- `PortrayalCatalogueManager`: `ConcurrentDictionary<SpecRef, IPortrayalAssetCache> _assetCaches` + `GetOrCreateAssetCache`. Attached in both `SetSource` and the `GetProvider` lazy factory. Evicted when the backing path/source changes; cleared on `Dispose`.
- `S101PortrayalCatalogue`, `S131PortrayalCatalogue`, `GmlPortrayalCatalogueBase`: removed per-instance `_compiledXslt`, `_symbols`, `_lineStyles`, `_areaFills`, `_palettes`, `_palettesLoaded`, `_luaScripts`, `_luaSources`; routed storage through `_cache = provider.AssetCache`. Loading logic stays in the catalogue. `ActivePalette` and `_rules` remain per-instance.
- `LoadPalettes(Dictionary<,>)` `protected virtual` signature preserved so `S411PortrayalCatalogue`'s override keeps working — the cache exposes an internal `PalettesDictionary` view of the same data.

## Tests

`tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs` (+5 tests, using a `CountingAssetSource` decorator mirroring PR-2's pattern):

1. Two `S101PortrayalCatalogue` instances from the same manager share XSLT / symbol / line-style / area-fill / Lua-source caches.
2. Two GML-base catalogues (S-124) from the same manager share the XSLT cache.
3. Two providers for different specs (S-101 vs S-131) through the same manager have **distinct** caches.
4. Direct (non-manager) provider construction yields its own per-provider cache (preserves `LuaSourceCacheTests.S101_GetLuaSource_independent_caches_per_catalogue_instance`).
5. Negative Lua-source caching is shared across two catalogues backed by the same provider.

Full suite green (`dotnet test --configuration Release`): `EncDotNet.S100.Pipelines.Tests` now reports 249 passing.

## Out of scope

- S-111 palette re-load (PR-4).
- `ConcurrentDictionary` hardening (PR-6).
- Bundled `content/**` is untouched.