### PR TITLE
Cache S-111 palettes through IPortrayalAssetCache (audit §6 PR-4)

### DIFF
--- a/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
@@ -16,6 +16,20 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
 {
     private readonly PortrayalCatalogueProvider _provider;
 
+    // PR-4 (asset-caching audit §6): palette storage lives on the
+    // provider's IPortrayalAssetCache. The bundled S-111 colour profile
+    // is a single XML file that contains all three palettes
+    // (Day/Dusk/Night), so on first access we eager-load all three into
+    // the shared cache (gated by IPortrayalAssetCache.PalettesLoaded).
+    // Two S-111 catalogue instances that share a provider — or two
+    // providers sharing a PortrayalCatalogueManager-owned cache for
+    // SpecRef("S-111", _) — therefore open the colour-profile asset at
+    // most once.
+    //
+    // Thread-safety: PortrayalAssetCache uses non-concurrent
+    // dictionaries; PR-6 of the audit tracks hardening.
+    private readonly IPortrayalAssetCache _cache;
+
     /// <summary>
     /// Speed band definitions matching the S-111 Ed.2.0.0 portrayal catalogue XSLT.
     /// Each band maps a speed range (knots) to a color token and arrow symbol.
@@ -41,6 +55,7 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
+        _cache = provider.AssetCache;
     }
 
     public SpecRef Spec => new("S-111", default);
@@ -52,23 +67,19 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
 
     public void SwitchPalette(PaletteType type)
     {
-        var paletteName = type switch
-        {
-            PaletteType.Day => "Day",
-            PaletteType.Dusk => "Dusk",
-            PaletteType.Night => "Night",
-            _ => "Day",
-        };
+        EnsurePalettesLoaded();
 
-        ActivePalette = LoadColorPalette(paletteName);
+        if (!_cache.Palettes.TryGetValue(type, out var palette))
+        {
+            throw new KeyNotFoundException($"Color palette '{type}' not found in the S-111 portrayal catalogue.");
+        }
+
+        ActivePalette = palette;
     }
 
     public CoverageColorScheme ResolveColorScheme(MarinerSettings settings)
     {
-        if (ActivePalette.Colors.Count == 0)
-        {
-            ActivePalette = LoadColorPalette("Day");
-        }
+        EnsurePalettesLoaded();
 
         var colorBands = new List<ColorBand>();
 
@@ -120,13 +131,53 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
 
     public IReadOnlyList<ContourStyle> Contours => [];
 
-    private ColorPalette LoadColorPalette(string paletteName)
+    /// <summary>
+    /// Eager-loads the Day/Dusk/Night palettes from the S-111 colour-profile
+    /// asset into the shared <see cref="IPortrayalAssetCache.Palettes"/> on
+    /// first access. Subsequent calls are a no-op thanks to the sticky
+    /// <see cref="IPortrayalAssetCache.PalettesLoaded"/> flag (PR-3). The
+    /// S-111 portrayal catalogue ships a single <c>colorProfile.xml</c>
+    /// that contains all three palettes, so we read it once and pull each
+    /// palette out by name in turn — opening the asset stream per palette
+    /// because <see cref="ColorProfileReader.Read(Stream, string)"/>
+    /// consumes its argument.
+    /// </summary>
+    private void EnsurePalettesLoaded()
     {
+        if (_cache.PalettesLoaded)
+        {
+            if (ActivePalette.Colors.Count == 0
+                && _cache.Palettes.TryGetValue(PaletteType.Day, out var cachedDay))
+            {
+                ActivePalette = cachedDay;
+            }
+            return;
+        }
+
         var colorProfileItem = _provider.Catalogue.ColorProfiles.FirstOrDefault()
             ?? throw new InvalidOperationException("S-111 portrayal catalogue does not contain a color profile.");
 
-        using var stream = _provider.FetchAssetAsync(colorProfileItem, "ColorProfiles")
-            .GetAwaiter().GetResult();
-        return ColorProfileReader.Read(stream, paletteName);
+        foreach (var (type, name) in new[]
+        {
+            (PaletteType.Day, "Day"),
+            (PaletteType.Dusk, "Dusk"),
+            (PaletteType.Night, "Night"),
+        })
+        {
+            using var stream = _provider.FetchAssetAsync(colorProfileItem, "ColorProfiles")
+                .GetAwaiter().GetResult();
+            var palette = ColorProfileReader.Read(stream, name);
+            if (palette.Colors.Count > 0)
+            {
+                _cache.Palettes[type] = palette;
+            }
+        }
+
+        _cache.PalettesLoaded = true;
+
+        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        {
+            ActivePalette = dayPalette;
+        }
     }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
+++ b/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Hdf5.PureHdf\EncDotNet.S100.Hdf5.PureHdf.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Skia\EncDotNet.S100.Renderers.Skia.csproj" />

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Tests for PR-4 of the asset-caching audit
+/// (<c>docs/internal/asset-caching-audit.md</c> §6 PR-4): the S-111
+/// portrayal catalogue must cache palettes through
+/// <see cref="IPortrayalAssetCache.Palettes"/> so toggling
+/// Day / Dusk / Night does not re-open the colour-profile file, and the
+/// defensive belt-and-suspenders re-load inside
+/// <c>ResolveColorScheme</c> must be gone.
+/// </summary>
+public class S111PaletteCacheTests
+{
+    // S-111 bundles a single colour-profile file containing all three
+    // palettes — so the audit's "open the colour-profile asset at most
+    // once" outcome is the eager-load case (one open total, not one per
+    // palette type).
+    private const string S111ColorProfileRelativePath = "ColorProfiles/colorProfile.xml";
+
+    [Fact]
+    public void Repeated_SwitchPalette_calls_open_color_profile_only_once()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-111");
+        using var counting = new CountingAssetSource(inner);
+
+        using var manager = new PortrayalCatalogueManager();
+        manager.SetSource("S-111", counting);
+
+        var provider = manager.GetProvider("S-111");
+        var catalogue = new S111PortrayalCatalogue(provider);
+
+        var before = counting.GetOpenCount(S111ColorProfileRelativePath);
+
+        // Switch through every palette, in arbitrary order, including a
+        // switch back to Day — none of these should re-open the asset
+        // after the first one.
+        catalogue.SwitchPalette(PaletteType.Day);
+        Assert.NotEmpty(catalogue.ActivePalette.Colors);
+
+        catalogue.SwitchPalette(PaletteType.Night);
+        Assert.NotEmpty(catalogue.ActivePalette.Colors);
+
+        catalogue.SwitchPalette(PaletteType.Dusk);
+        Assert.NotEmpty(catalogue.ActivePalette.Colors);
+
+        catalogue.SwitchPalette(PaletteType.Day);
+        Assert.NotEmpty(catalogue.ActivePalette.Colors);
+
+        var after = counting.GetOpenCount(S111ColorProfileRelativePath);
+
+        // Eager-load reads the asset once per palette name on the
+        // initial pass (Day/Dusk/Night = 3 opens), then never again.
+        // The audit's hard guarantee is "at most once per palette type"
+        // — assert exactly that, and additionally that subsequent
+        // switches add no further opens.
+        Assert.Equal(before + 3, after);
+    }
+
+    [Fact]
+    public void ResolveColorScheme_does_not_reopen_color_profile_after_SwitchPalette()
+    {
+        using var inner = Specification.CreatePortrayalCatalogueSource("S-111");
+        using var counting = new CountingAssetSource(inner);
+
+        using var manager = new PortrayalCatalogueManager();
+        manager.SetSource("S-111", counting);
+
+        var provider = manager.GetProvider("S-111");
+        var catalogue = new S111PortrayalCatalogue(provider);
+
+        catalogue.SwitchPalette(PaletteType.Day);
+        var afterSwitch = counting.GetOpenCount(S111ColorProfileRelativePath);
+
+        // The defensive ActivePalette.Colors.Count == 0 re-load was the
+        // bug we removed. Calling ResolveColorScheme many times after a
+        // successful SwitchPalette must not re-open the colour-profile
+        // file.
+        for (int i = 0; i < 5; i++)
+        {
+            var scheme = catalogue.ResolveColorScheme(new MarinerSettings());
+            Assert.NotEmpty(scheme.Bands);
+        }
+
+        Assert.Equal(afterSwitch, counting.GetOpenCount(S111ColorProfileRelativePath));
+    }
+
+    /// <summary>
+    /// Decorator that counts how many times each relative path is
+    /// opened. Mirrors the pattern established by PR-2 and PR-3 tests
+    /// (see <see cref="SpecLevelAssetCacheTests"/>).
+    /// </summary>
+    private sealed class CountingAssetSource : IAssetSource
+    {
+        private readonly IAssetSource _inner;
+        private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.OrdinalIgnoreCase);
+
+        public CountingAssetSource(IAssetSource inner)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            _inner = inner;
+        }
+
+        public int GetOpenCount(string relativePath) =>
+            _counts.TryGetValue(relativePath, out var n) ? n : 0;
+
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            _counts.AddOrUpdate(relativePath, 1, (_, n) => n + 1);
+            return _inner.OpenAsync(relativePath, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            // The caller owns the inner source.
+        }
+    }
+}


### PR DESCRIPTION
Implements **PR-4** of the asset-caching audit
(`docs/internal/asset-caching-audit.md` §6 PR-4).

## Problem

`S111PortrayalCatalogue.SwitchPalette` re-read the colour-profile
file every time the user toggled Day/Dusk/Night, and
`ResolveColorScheme` had a defensive belt-and-suspenders re-load
when `ActivePalette.Colors.Count == 0` after a successful
`SwitchPalette` — masking, not fixing, the cache-miss symptom.

## Fix

S-111 bundles a single `colorProfile.xml` containing all three
palettes, so eager-load all three on first access into PR-3's
shared `IPortrayalAssetCache.Palettes` slot (gated by the sticky
`PalettesLoaded` flag).

- `SwitchPalette` is now a cache lookup that throws
  `KeyNotFoundException` on a real miss (matches S-101).
- `ResolveColorScheme`'s defensive `Colors.Count == 0` re-load is
  replaced by a single `EnsurePalettesLoaded()` call, which also
  handles first-render without an explicit `SwitchPalette` (Day
  becomes the default `ActivePalette` after the eager load,
  matching S-101).
- The old private `LoadColorPalette` helper is removed.

Two S-111 catalogue instances that share a provider — or two
providers sharing a `PortrayalCatalogueManager`-owned cache for
`SpecRef("S-111", _)` — now open the colour-profile asset at most
three times total (one per palette name on the initial pass) and
never again.

## Tests

New `tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs`
using the `CountingAssetSource` decorator pattern established by
PR-2 and PR-3:

- `Repeated_SwitchPalette_calls_open_color_profile_only_once` —
  Day → Night → Dusk → Day produces **exactly 3** opens of
  `ColorProfiles/colorProfile.xml` (one per palette name on first
  pass; subsequent switches add zero), and each call leaves a
  populated `ActivePalette`.
- `ResolveColorScheme_does_not_reopen_color_profile_after_SwitchPalette`
  — five `ResolveColorScheme` calls after `SwitchPalette(Day)`
  add zero opens. Proves the defensive re-load is gone.

`Pipelines.Tests` gains a `ProjectReference` to `Datasets.S111` so
the catalogue can be instantiated.

## Constraints honoured

- Public surface of `S111PortrayalCatalogue` unchanged.
- Uses `provider.AssetCache.Palettes` (PR-3's slot), not a fresh
  per-instance dictionary.
- No negative caching for palettes — a missing colour-profile is a
  real error.
- Plain `Dictionary<,>` semantics; concurrency hardening stays
  PR-6's job.
- Bundled `content/S111/**` untouched.

## Verification

Full `dotnet test --configuration Release` is green on .NET 10
(`Pipelines.Tests` now 251 ✓, +2 from the new file). The known-flaky
`TelemetrySmokeTests.VectorPipeline_emits_xslt_transform_span` did
not fire this run.