### PR TITLE
Add S-128 typed DataModel projection with resolved supersedes navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ into focused packages:
 | **EncDotNet.S100.Datasets.S124** | S-124 navigational warnings reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S125** | S-125 marine aids to navigation reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S127** | S-127 marine resources and services reader and XSLT portrayal pipeline. |
-| **EncDotNet.S100.Datasets.S128** | S-128 catalogue of nautical products reader and XSLT portrayal pipeline. |
+| **EncDotNet.S100.Datasets.S128** | S-128 catalogue of nautical products reader, XSLT portrayal pipeline, and typed `DataModel` projection with resolved supersedes navigation. |
 | **EncDotNet.S100.Datasets.S129** | S-129 under keel clearance reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S131** | S-131 marine harbour infrastructure reader and Lua portrayal pipeline (GML+Lua hybrid). |
 | **EncDotNet.S100.Datasets.S201** | S-201 aids to navigation information (IALA, authority-to-authority exchange) reader and XSLT portrayal pipeline. |

--- a/src/EncDotNet.S100.Datasets.S128/DataModel/S128ProductCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S128/DataModel/S128ProductCatalogue.cs
@@ -1,0 +1,526 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S128.DataModel;
+
+/// <summary>
+/// Strongly-typed projection of an <see cref="S128Dataset"/> as a catalogue
+/// of nautical products (S-128 Edition 2.0.0).
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-128 datasets describe the nautical products produced by an agency.
+/// The typed model surfaces three product subclasses
+/// (<see cref="S128ElectronicProduct"/>, <see cref="S128PhysicalProduct"/>,
+/// <see cref="S128Service"/>) through a common
+/// <see cref="S128CatalogueEntry"/> base, plus dedicated typed records
+/// for producer, distributor, contact, and section-header metadata.
+/// </para>
+/// <para>
+/// The headline value-add is supersedes resolution: every product
+/// entry's <see cref="S128CatalogueEntry.Supersedes"/> and
+/// <see cref="S128CatalogueEntry.SupersededBy"/> collections are
+/// populated from the dataset's <c>theReference</c> xlinks whose
+/// companion <c>ProductMapping/categoryOfProductMapping</c> classifies
+/// as <see cref="S128ProductMappingCategory.HigherPriorityAlternative"/>
+/// (S-128 § 12). All other mappings land in
+/// <see cref="S128CatalogueEntry.RelatedProducts"/> with their raw
+/// category text preserved for forward compatibility.
+/// </para>
+/// <para>
+/// Projection issues — unresolved xlinks, attribute parse failures —
+/// surface as <see cref="ProjectionDiagnostic"/> entries rather than
+/// exceptions. The projection only throws when the source dataset is
+/// fully empty (no features and no information types).
+/// </para>
+/// </remarks>
+public sealed class S128ProductCatalogue
+{
+    /// <summary>The dataset identifier carried by the source GML <c>Dataset</c> element.</summary>
+    public string? DatasetIdentifier { get; init; }
+
+    /// <summary>The S-128 product identifier (typically <c>"S-128"</c>).</summary>
+    public string? ProductIdentifier { get; init; }
+
+    /// <summary>All catalogue product entries, polymorphic over the three product subclasses.</summary>
+    public required ImmutableArray<S128CatalogueEntry> Products { get; init; }
+
+    /// <summary>Producer metadata records.</summary>
+    public ImmutableArray<S128ProducerInformation> Producers { get; init; } =
+        ImmutableArray<S128ProducerInformation>.Empty;
+
+    /// <summary>Distributor metadata records.</summary>
+    public ImmutableArray<S128DistributorInformation> Distributors { get; init; } =
+        ImmutableArray<S128DistributorInformation>.Empty;
+
+    /// <summary>Contact-details metadata records.</summary>
+    public ImmutableArray<S128ContactDetails> Contacts { get; init; } =
+        ImmutableArray<S128ContactDetails>.Empty;
+
+    /// <summary>Catalogue section header records.</summary>
+    public ImmutableArray<S128CatalogueSectionHeader> SectionHeaders { get; init; } =
+        ImmutableArray<S128CatalogueSectionHeader>.Empty;
+
+    /// <summary>The originating feature-bag dataset.</summary>
+    public required S128Dataset Source { get; init; }
+
+    /// <summary>
+    /// Projects a feature-bag <see cref="S128Dataset"/> into the typed data
+    /// model. Issues encountered during projection are reported via
+    /// <paramref name="diagnostics"/>; the projection only throws for a
+    /// fully empty dataset (no features and no information types).
+    /// </summary>
+    /// <param name="dataset">The source dataset.</param>
+    /// <param name="diagnostics">Out parameter receiving the projection diagnostics.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <paramref name="dataset"/> contains neither features nor
+    /// information types.
+    /// </exception>
+    public static S128ProductCatalogue From(S128Dataset dataset, out IReadOnlyList<ProjectionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        if (dataset.Features.IsDefaultOrEmpty && dataset.InformationTypes.IsDefaultOrEmpty)
+            throw new InvalidOperationException("Dataset contains no features and no information types.");
+
+        // First pass: build typed entries (without cross-references yet).
+        var productsBuilder = ImmutableArray.CreateBuilder<S128CatalogueEntry>();
+        var producersBuilder = ImmutableArray.CreateBuilder<S128ProducerInformation>();
+        var distributorsBuilder = ImmutableArray.CreateBuilder<S128DistributorInformation>();
+        var contactsBuilder = ImmutableArray.CreateBuilder<S128ContactDetails>();
+        var headersBuilder = ImmutableArray.CreateBuilder<S128CatalogueSectionHeader>();
+
+        // The xlink resolver and diagnostics get filled during pass 2, so
+        // build the context up front so we can hand it to the per-feature
+        // helpers below.
+        var ctx = new ProjectionContext(XlinkResolver.Build(Array.Empty<KeyValuePair<string, object>>()));
+
+        foreach (var f in dataset.Features)
+        {
+            switch (f.FeatureType)
+            {
+                case var t when t.Equals("ElectronicProduct", StringComparison.OrdinalIgnoreCase):
+                    productsBuilder.Add(ProjectElectronicProduct(f, ctx));
+                    break;
+                case var t when t.Equals("PhysicalProduct", StringComparison.OrdinalIgnoreCase):
+                    productsBuilder.Add(ProjectPhysicalProduct(f, ctx));
+                    break;
+                case var t when t.Equals("S100Service", StringComparison.OrdinalIgnoreCase):
+                    productsBuilder.Add(ProjectService(f, ctx));
+                    break;
+                case var t when t.Equals("ProducerInformation", StringComparison.OrdinalIgnoreCase):
+                    producersBuilder.Add(ProjectProducer(f));
+                    break;
+                case var t when t.Equals("DistributorInformation", StringComparison.OrdinalIgnoreCase):
+                    distributorsBuilder.Add(ProjectDistributor(f));
+                    break;
+                case var t when t.Equals("ContactDetails", StringComparison.OrdinalIgnoreCase):
+                    contactsBuilder.Add(ProjectContact(f));
+                    break;
+                case var t when t.Equals("CatalogueSectionHeader", StringComparison.OrdinalIgnoreCase):
+                    headersBuilder.Add(ProjectSectionHeader(f));
+                    break;
+                default:
+                    // Unknown feature type: silently skip — the catalogue
+                    // model is closed; producer extensions remain visible
+                    // on dataset.Features.
+                    break;
+            }
+        }
+
+        var products = productsBuilder.ToImmutable();
+
+        // Second pass: build a real xlink resolver that knows about every
+        // entry, then resolve theReference xlinks and populate the
+        // forward Supersedes / RelatedProducts collections.
+        var resolverEntries = new List<KeyValuePair<string, object>>(
+            products.Length
+            + producersBuilder.Count
+            + distributorsBuilder.Count
+            + contactsBuilder.Count
+            + headersBuilder.Count);
+        foreach (var p in products) resolverEntries.Add(new(p.Id, p));
+        foreach (var p in producersBuilder) resolverEntries.Add(new(p.Id, p));
+        foreach (var d in distributorsBuilder) resolverEntries.Add(new(d.Id, d));
+        foreach (var c in contactsBuilder) resolverEntries.Add(new(c.Id, c));
+        foreach (var h in headersBuilder) resolverEntries.Add(new(h.Id, h));
+
+        // Re-create the context with the real resolver, preserving any
+        // diagnostics already collected during pass 1.
+        var resolver = XlinkResolver.Build(resolverEntries);
+        var ctx2 = new ProjectionContext(resolver);
+        foreach (var d in ctx.Diagnostics) ctx2.Report(d);
+
+        // Resolve theReference cross-references on each product entry.
+        // Forward map: referrer.Id → list of resolved targets to supersede.
+        var supersedesByReferrer = new Dictionary<string, List<S128CatalogueEntry>>(StringComparer.OrdinalIgnoreCase);
+        var relatedByReferrer = new Dictionary<string, List<S128ProductReference>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in products)
+        {
+            ResolveProductReferences(entry, ctx2, supersedesByReferrer, relatedByReferrer);
+        }
+
+        // Mutate Supersedes / RelatedProducts on each entry.
+        foreach (var entry in products)
+        {
+            if (supersedesByReferrer.TryGetValue(entry.Id, out var supTargets))
+                entry.Supersedes = supTargets.ToImmutableArray();
+
+            if (relatedByReferrer.TryGetValue(entry.Id, out var rel))
+            {
+                entry.RelatedProducts = rel.ToImmutableArray();
+            }
+        }
+
+        // Reverse map: target.Id → list of referrers that supersede it.
+        var supersededByMap = new Dictionary<string, List<S128CatalogueEntry>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (referrerId, targets) in supersedesByReferrer)
+        {
+            // Find the referrer entry.
+            S128CatalogueEntry? referrer = null;
+            foreach (var p in products)
+            {
+                if (string.Equals(p.Id, referrerId, StringComparison.OrdinalIgnoreCase))
+                {
+                    referrer = p;
+                    break;
+                }
+            }
+            if (referrer is null) continue;
+
+            foreach (var target in targets)
+            {
+                if (!supersededByMap.TryGetValue(target.Id, out var list))
+                    supersededByMap[target.Id] = list = new List<S128CatalogueEntry>();
+                list.Add(referrer);
+            }
+        }
+        foreach (var entry in products)
+        {
+            if (supersededByMap.TryGetValue(entry.Id, out var referrers))
+                entry.SupersededBy = referrers.ToImmutableArray();
+        }
+
+        diagnostics = ctx2.ToImmutableDiagnostics();
+        return new S128ProductCatalogue
+        {
+            DatasetIdentifier = dataset.DatasetIdentifier,
+            ProductIdentifier = dataset.ProductIdentifier,
+            Products = products,
+            Producers = producersBuilder.ToImmutable(),
+            Distributors = distributorsBuilder.ToImmutable(),
+            Contacts = contactsBuilder.ToImmutable(),
+            SectionHeaders = headersBuilder.ToImmutable(),
+            Source = dataset,
+        };
+    }
+
+    // ── Per-feature projection ─────────────────────────────────────────
+
+    private readonly record struct CommonFields(
+        string? ProductNumber,
+        int? EditionNumber,
+        int? UpdateNumber,
+        DateTimeOffset? IssueDate,
+        DateTimeOffset? UpdateDate,
+        string? Classification,
+        bool? NotForNavigation,
+        string? ProductSpecificationName,
+        string? ProductSpecificationVersion,
+        S128GeometryKind GeometryKind,
+        ImmutableArray<GeoPosition> Coordinates,
+        ImmutableArray<S128OnlineResource> OnlineResources,
+        ImmutableDictionary<string, string> ExtraAttributes);
+
+    private static CommonFields ExtractCommon(S128Feature f, ProjectionContext ctx)
+    {
+        S128ComplexAttribute? ps = null;
+        foreach (var c in f.ComplexAttributes)
+        {
+            if (c.Code.Equals("productSpecification", StringComparison.OrdinalIgnoreCase))
+            {
+                ps = c;
+                break;
+            }
+        }
+
+        var (kind, coords) = ProjectGeometry(f);
+        var online = ProjectOnlineResources(f);
+
+        bool? notForNav = null;
+        if (f.Attributes.TryGetValue("notForNavigation", out var nfn))
+            notForNav = AttributeParser.TryParseBool(nfn, ctx, f.Id, "notForNavigation");
+
+        return new CommonFields(
+            ProductNumber:
+                f.Attributes.GetValueOrDefault("productNumber") ??
+                f.Attributes.GetValueOrDefault("datasetName"),
+            EditionNumber: AttributeParser.TryParseInt(
+                f.Attributes.GetValueOrDefault("editionNumber"), ctx, f.Id, "editionNumber"),
+            UpdateNumber: AttributeParser.TryParseInt(
+                f.Attributes.GetValueOrDefault("updateNumber"), ctx, f.Id, "updateNumber"),
+            IssueDate: AttributeParser.TryParseDateTimeOffset(
+                f.Attributes.GetValueOrDefault("issueDate"), ctx, f.Id, "issueDate"),
+            UpdateDate: AttributeParser.TryParseDateTimeOffset(
+                f.Attributes.GetValueOrDefault("updateDate")
+                    ?? f.Attributes.GetValueOrDefault("editionDate"),
+                ctx, f.Id, "updateDate"),
+            Classification: f.Attributes.GetValueOrDefault("catalogueElementClassification"),
+            NotForNavigation: notForNav,
+            ProductSpecificationName: ps?.SubAttributes.GetValueOrDefault("name"),
+            ProductSpecificationVersion: ps?.SubAttributes.GetValueOrDefault("version"),
+            GeometryKind: kind,
+            Coordinates: coords,
+            OnlineResources: online,
+            ExtraAttributes: BuildExtraAttributes(f));
+    }
+
+    private static S128ElectronicProduct ProjectElectronicProduct(S128Feature f, ProjectionContext ctx)
+    {
+        var c = ExtractCommon(f, ctx);
+        return new S128ElectronicProduct
+        {
+            Id = f.Id,
+            FeatureType = f.FeatureType,
+            Source = f,
+            ProductNumber = c.ProductNumber,
+            EditionNumber = c.EditionNumber,
+            UpdateNumber = c.UpdateNumber,
+            IssueDate = c.IssueDate,
+            UpdateDate = c.UpdateDate,
+            Classification = c.Classification,
+            NotForNavigation = c.NotForNavigation,
+            ProductSpecificationName = c.ProductSpecificationName,
+            ProductSpecificationVersion = c.ProductSpecificationVersion,
+            GeometryKind = c.GeometryKind,
+            Coordinates = c.Coordinates,
+            OnlineResources = c.OnlineResources,
+            ExtraAttributes = c.ExtraAttributes,
+        };
+    }
+
+    private static S128PhysicalProduct ProjectPhysicalProduct(S128Feature f, ProjectionContext ctx)
+    {
+        var c = ExtractCommon(f, ctx);
+        return new S128PhysicalProduct
+        {
+            Id = f.Id,
+            FeatureType = f.FeatureType,
+            Source = f,
+            ProductNumber = c.ProductNumber,
+            EditionNumber = c.EditionNumber,
+            UpdateNumber = c.UpdateNumber,
+            IssueDate = c.IssueDate,
+            UpdateDate = c.UpdateDate,
+            Classification = c.Classification,
+            NotForNavigation = c.NotForNavigation,
+            ProductSpecificationName = c.ProductSpecificationName,
+            ProductSpecificationVersion = c.ProductSpecificationVersion,
+            GeometryKind = c.GeometryKind,
+            Coordinates = c.Coordinates,
+            OnlineResources = c.OnlineResources,
+            ExtraAttributes = c.ExtraAttributes,
+        };
+    }
+
+    private static S128Service ProjectService(S128Feature f, ProjectionContext ctx)
+    {
+        var c = ExtractCommon(f, ctx);
+        return new S128Service
+        {
+            Id = f.Id,
+            FeatureType = f.FeatureType,
+            Source = f,
+            ServiceStatus = ClassifyServiceStatus(f.Attributes.GetValueOrDefault("serviceStatus")),
+            ProductNumber = c.ProductNumber,
+            EditionNumber = c.EditionNumber,
+            UpdateNumber = c.UpdateNumber,
+            IssueDate = c.IssueDate,
+            UpdateDate = c.UpdateDate,
+            Classification = c.Classification,
+            NotForNavigation = c.NotForNavigation,
+            ProductSpecificationName = c.ProductSpecificationName,
+            ProductSpecificationVersion = c.ProductSpecificationVersion,
+            GeometryKind = c.GeometryKind,
+            Coordinates = c.Coordinates,
+            OnlineResources = c.OnlineResources,
+            ExtraAttributes = c.ExtraAttributes,
+        };
+    }
+
+    private static S128ServiceStatus ClassifyServiceStatus(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return S128ServiceStatus.Unknown;
+        if (raw == "1" || raw.Contains("Planned", StringComparison.OrdinalIgnoreCase))
+            return S128ServiceStatus.Planned;
+        if (raw == "2" || raw.Contains("Released", StringComparison.OrdinalIgnoreCase))
+            return S128ServiceStatus.Released;
+        if (raw == "3" || raw.Contains("Withdrawn", StringComparison.OrdinalIgnoreCase))
+            return S128ServiceStatus.Withdrawn;
+        return S128ServiceStatus.Unknown;
+    }
+
+    private static ImmutableDictionary<string, string> BuildExtraAttributes(S128Feature f) =>
+        ExtraAttributes.ExcludeKnown(f.Attributes,
+            "productNumber", "datasetName",
+            "editionNumber", "updateNumber",
+            "issueDate", "updateDate", "editionDate",
+            "catalogueElementClassification",
+            "notForNavigation",
+            "serviceStatus");
+
+    private static S128ProducerInformation ProjectProducer(S128Feature f) => new()
+    {
+        Id = f.Id,
+        AgencyResponsibleForProduction = f.Attributes.GetValueOrDefault("agencyResponsibleForProduction"),
+        ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, "agencyResponsibleForProduction"),
+        Source = f,
+    };
+
+    private static S128DistributorInformation ProjectDistributor(S128Feature f) => new()
+    {
+        Id = f.Id,
+        DistributorName = f.Attributes.GetValueOrDefault("distributorName"),
+        ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, "distributorName"),
+        Source = f,
+    };
+
+    private static S128ContactDetails ProjectContact(S128Feature f) => new()
+    {
+        Id = f.Id,
+        ContactInstructions = f.Attributes.GetValueOrDefault("contactInstructions"),
+        ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, "contactInstructions"),
+        Source = f,
+    };
+
+    private static S128CatalogueSectionHeader ProjectSectionHeader(S128Feature f) => new()
+    {
+        Id = f.Id,
+        CatalogueSectionNumber = f.Attributes.GetValueOrDefault("catalogueSectionNumber"),
+        ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, "catalogueSectionNumber"),
+        Source = f,
+    };
+
+    private static (S128GeometryKind, ImmutableArray<GeoPosition>) ProjectGeometry(S128Feature f)
+    {
+        switch (f.GeometryType)
+        {
+            case GmlGeometryType.Point:
+                if (f.Points.IsDefaultOrEmpty) return (S128GeometryKind.Point, ImmutableArray<GeoPosition>.Empty);
+                return (S128GeometryKind.Point, f.Points
+                    .Select(p => new GeoPosition(p.Latitude, p.Longitude))
+                    .ToImmutableArray());
+            case GmlGeometryType.Curve:
+                if (f.Curves.IsDefaultOrEmpty) return (S128GeometryKind.Curve, ImmutableArray<GeoPosition>.Empty);
+                return (S128GeometryKind.Curve, f.Curves
+                    .SelectMany(c => c)
+                    .Select(p => new GeoPosition(p.Latitude, p.Longitude))
+                    .ToImmutableArray());
+            case GmlGeometryType.Surface:
+                if (f.ExteriorRing.IsDefaultOrEmpty) return (S128GeometryKind.Surface, ImmutableArray<GeoPosition>.Empty);
+                return (S128GeometryKind.Surface, f.ExteriorRing
+                    .Select(p => new GeoPosition(p.Latitude, p.Longitude))
+                    .ToImmutableArray());
+            default:
+                return (S128GeometryKind.None, ImmutableArray<GeoPosition>.Empty);
+        }
+    }
+
+    private static ImmutableArray<S128OnlineResource> ProjectOnlineResources(S128Feature f)
+    {
+        var b = ImmutableArray.CreateBuilder<S128OnlineResource>();
+        foreach (var c in f.ComplexAttributes)
+        {
+            if (!c.Code.Equals("onlineResource", StringComparison.OrdinalIgnoreCase)) continue;
+            b.Add(new S128OnlineResource
+            {
+                ApplicationProfile = c.SubAttributes.GetValueOrDefault("applicationProfile"),
+                Linkage = c.SubAttributes.GetValueOrDefault("linkage"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    // ── theReference resolution ────────────────────────────────────────
+
+    private static void ResolveProductReferences(
+        S128CatalogueEntry entry,
+        ProjectionContext ctx,
+        Dictionary<string, List<S128CatalogueEntry>> supersedes,
+        Dictionary<string, List<S128ProductReference>> related)
+    {
+        var feature = entry.Source;
+
+        // Collect theReference xlinks and their companion ProductMapping
+        // complex-attribute payloads. The reader walks element children in
+        // source order in both ParseReferences and ParseAttributes, so the
+        // i-th theReference xlink lines up with the i-th theReference
+        // complex attribute.
+        var xlinks = new List<S128XlinkReference>();
+        foreach (var r in feature.References)
+        {
+            if (r.Role.Equals("theReference", StringComparison.OrdinalIgnoreCase))
+                xlinks.Add(r);
+        }
+        if (xlinks.Count == 0) return;
+
+        var payloads = new List<S128ComplexAttribute>();
+        foreach (var c in feature.ComplexAttributes)
+        {
+            if (c.Code.Equals("theReference", StringComparison.OrdinalIgnoreCase))
+                payloads.Add(c);
+        }
+
+        var count = Math.Min(xlinks.Count, payloads.Count == 0 ? xlinks.Count : payloads.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var x = xlinks[i];
+            var payload = i < payloads.Count ? payloads[i] : null;
+
+            string? rawCategory = null;
+            if (payload is not null)
+            {
+                foreach (var nested in payload.NestedAttributes)
+                {
+                    if (!nested.Code.Equals("ProductMapping", StringComparison.OrdinalIgnoreCase)) continue;
+                    rawCategory = nested.SubAttributes.GetValueOrDefault("categoryOfProductMapping");
+                    if (rawCategory is not null) break;
+                }
+            }
+
+            var category = ClassifyMappingCategory(rawCategory);
+
+            var target = ctx.Xlinks.Resolve<S128CatalogueEntry>(x.Href, "theReference", ctx, feature.Id);
+            if (target is null) continue;
+
+            if (category == S128ProductMappingCategory.HigherPriorityAlternative)
+            {
+                if (!supersedes.TryGetValue(entry.Id, out var list))
+                    supersedes[entry.Id] = list = new List<S128CatalogueEntry>();
+                list.Add(target);
+            }
+            else
+            {
+                if (!related.TryGetValue(entry.Id, out var list))
+                    related[entry.Id] = list = new List<S128ProductReference>();
+                list.Add(new S128ProductReference(target, category, rawCategory));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Maps a raw <c>categoryOfProductMapping</c> value to a typed enum
+    /// (S-128 § 12). Recognises both the numeric code <c>1</c> and the
+    /// localised label "Higher Priority Alternative" published by the
+    /// upstream 2.0.0 sample.
+    /// </summary>
+    private static S128ProductMappingCategory ClassifyMappingCategory(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return S128ProductMappingCategory.Unknown;
+        if (raw == "1" || raw.Contains("Higher Priority Alternative", StringComparison.OrdinalIgnoreCase))
+            return S128ProductMappingCategory.HigherPriorityAlternative;
+        return S128ProductMappingCategory.Other;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S128/DataModel/S128Types.cs
+++ b/src/EncDotNet.S100.Datasets.S128/DataModel/S128Types.cs
@@ -1,0 +1,294 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S128.DataModel;
+
+/// <summary>
+/// The geometry primitive kind of an S-128 catalogue entry.
+/// </summary>
+public enum S128GeometryKind
+{
+    /// <summary>No geometry. Common for container / metadata features (S-128 § 12).</summary>
+    None,
+
+    /// <summary>Single point (<see cref="GeoPosition"/>).</summary>
+    Point,
+
+    /// <summary>Curve (ordered sequence of <see cref="GeoPosition"/>).</summary>
+    Curve,
+
+    /// <summary>Surface exterior ring (closed sequence of <see cref="GeoPosition"/>).</summary>
+    Surface,
+}
+
+/// <summary>
+/// Classification of an S-128 <c>ProductMapping/categoryOfProductMapping</c>
+/// value (S-128 § 12).
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-128 Edition 2.0.0's published <c>categoryOfProductMapping</c>
+/// enumeration carries a single defined code: <c>1</c> — "Higher Priority
+/// Alternative" — which is the carrier the official sample uses to encode
+/// supersession. Future enumeration values fall through to
+/// <see cref="Other"/> without breaking the projection; the raw text is
+/// preserved on <see cref="S128ProductReference.RawCategoryText"/>.
+/// </para>
+/// </remarks>
+public enum S128ProductMappingCategory
+{
+    /// <summary>The mapping carries no recognisable category value.</summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// S-128 § 12 code <c>1</c> — Higher Priority Alternative. The
+    /// referring product supersedes the referenced product.
+    /// </summary>
+    HigherPriorityAlternative,
+
+    /// <summary>A category code outside the recognised set; raw text preserved.</summary>
+    Other,
+}
+
+/// <summary>
+/// A typed product cross-reference resolved from an S-128
+/// <c>theReference</c> xlink and its companion <c>ProductMapping</c>
+/// complex attribute (S-128 § 12).
+/// </summary>
+/// <param name="Target">The resolved catalogue entry the xlink points to.</param>
+/// <param name="Category">Classified mapping category.</param>
+/// <param name="RawCategoryText">The raw text content of <c>categoryOfProductMapping</c>, when present.</param>
+public sealed record S128ProductReference(
+    S128CatalogueEntry Target,
+    S128ProductMappingCategory Category,
+    string? RawCategoryText);
+
+/// <summary>
+/// A typed online-resource record, projected from the S-128
+/// <c>onlineResource</c> complex attribute (S-128 § 12).
+/// </summary>
+public sealed record S128OnlineResource
+{
+    /// <summary>Application profile (e.g. <c>"Kinds of publications and Information Summary"</c>).</summary>
+    public string? ApplicationProfile { get; init; }
+
+    /// <summary>The linkage URL.</summary>
+    public string? Linkage { get; init; }
+}
+
+/// <summary>
+/// Abstract base for the three S-128 product feature classes
+/// (<c>ElectronicProduct</c>, <c>PhysicalProduct</c>, <c>S100Service</c>).
+/// </summary>
+/// <remarks>
+/// The strongly-typed projection of an <see cref="S128Dataset"/> exposes
+/// products through this base type so that callers can iterate the
+/// catalogue uniformly without pattern matching on the concrete subclass.
+/// Use <see cref="FeatureType"/> or runtime type tests when product-class
+/// dispatch is required.
+/// </remarks>
+public abstract class S128CatalogueEntry
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The product feature class (<c>ElectronicProduct</c> / <c>PhysicalProduct</c> / <c>S100Service</c>).</summary>
+    public required string FeatureType { get; init; }
+
+    /// <summary>The product number / dataset name carried by the feature (S-128 § 12 attribute <c>productNumber</c>, falling back to <c>datasetName</c>).</summary>
+    public string? ProductNumber { get; init; }
+
+    /// <summary>The product edition number (S-128 § 12 attribute <c>editionNumber</c>).</summary>
+    public int? EditionNumber { get; init; }
+
+    /// <summary>The product update number (S-128 § 12 attribute <c>updateNumber</c>).</summary>
+    public int? UpdateNumber { get; init; }
+
+    /// <summary>The product issue date (S-128 § 12 attribute <c>issueDate</c>).</summary>
+    public DateTimeOffset? IssueDate { get; init; }
+
+    /// <summary>The product update / edition date (<c>updateDate</c> falling back to <c>editionDate</c>).</summary>
+    public DateTimeOffset? UpdateDate { get; init; }
+
+    /// <summary>The catalogue element classification text (S-128 § 12 <c>catalogueElementClassification</c>).</summary>
+    public string? Classification { get; init; }
+
+    /// <summary>Whether the feature carries <c>notForNavigation="true"</c>.</summary>
+    public bool? NotForNavigation { get; init; }
+
+    /// <summary>Referenced product specification name (e.g. <c>"S-101"</c>, <c>"S-104"</c>) from <c>productSpecification/name</c>.</summary>
+    public string? ProductSpecificationName { get; init; }
+
+    /// <summary>Referenced product specification version (from <c>productSpecification/version</c>).</summary>
+    public string? ProductSpecificationVersion { get; init; }
+
+    /// <summary>Geometry primitive kind of the source feature.</summary>
+    public S128GeometryKind GeometryKind { get; init; }
+
+    /// <summary>Coordinates of the source feature (semantics depend on <see cref="GeometryKind"/>).</summary>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } = ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Online-resource records projected from <c>onlineResource</c> complex attributes.</summary>
+    public ImmutableArray<S128OnlineResource> OnlineResources { get; init; } = ImmutableArray<S128OnlineResource>.Empty;
+
+    /// <summary>
+    /// Resolved targets that this entry supersedes — populated from
+    /// <c>theReference</c> xlinks whose companion
+    /// <c>ProductMapping/categoryOfProductMapping</c> classifies as
+    /// <see cref="S128ProductMappingCategory.HigherPriorityAlternative"/>
+    /// (S-128 § 12).
+    /// </summary>
+    public ImmutableArray<S128CatalogueEntry> Supersedes { get; internal set; } =
+        ImmutableArray<S128CatalogueEntry>.Empty;
+
+    /// <summary>
+    /// Resolved entries that supersede this one — the inverse traversal of
+    /// <see cref="Supersedes"/>.
+    /// </summary>
+    public ImmutableArray<S128CatalogueEntry> SupersededBy { get; internal set; } =
+        ImmutableArray<S128CatalogueEntry>.Empty;
+
+    /// <summary>
+    /// All <c>theReference</c> cross-references whose mapping category did
+    /// **not** classify as supersession. Raw category text is preserved so
+    /// callers can dispatch on future enumeration extensions without an
+    /// enum revision (S-128 § 12).
+    /// </summary>
+    public ImmutableArray<S128ProductReference> RelatedProducts { get; internal set; } =
+        ImmutableArray<S128ProductReference>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>The originating parsed feature.</summary>
+    public required S128Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>ElectronicProduct</c> feature
+/// (S-128 § 12) — a digital nautical product such as an ENC or HDF5 cell.
+/// </summary>
+public sealed class S128ElectronicProduct : S128CatalogueEntry
+{
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>PhysicalProduct</c> feature
+/// (S-128 § 12) — a paper chart or printed publication.
+/// </summary>
+public sealed class S128PhysicalProduct : S128CatalogueEntry
+{
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>S100Service</c> feature (S-128 § 12)
+/// — a discoverable S-100 service endpoint (e.g. SECOM-served S-104).
+/// </summary>
+public sealed class S128Service : S128CatalogueEntry
+{
+    /// <summary>
+    /// Service status classified from S-128 § 12 attribute
+    /// <c>serviceStatus</c>.
+    /// </summary>
+    public S128ServiceStatus ServiceStatus { get; init; } = S128ServiceStatus.Unknown;
+}
+
+/// <summary>
+/// Service-lifecycle status of an <see cref="S128Service"/>
+/// (S-128 § 12 <c>serviceStatus</c>).
+/// </summary>
+public enum S128ServiceStatus
+{
+    /// <summary>The attribute is absent or unrecognised.</summary>
+    Unknown = 0,
+
+    /// <summary>S-128 § 12 code <c>1</c> — Planned.</summary>
+    Planned,
+
+    /// <summary>S-128 § 12 code <c>2</c> — Released (in force).</summary>
+    Released,
+
+    /// <summary>S-128 § 12 code <c>3</c> — Withdrawn.</summary>
+    Withdrawn,
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>ProducerInformation</c> feature
+/// (S-128 § 12).
+/// </summary>
+public sealed class S128ProducerInformation
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The agency responsible for production, when supplied.</summary>
+    public string? AgencyResponsibleForProduction { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>The originating parsed feature.</summary>
+    public required S128Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>DistributorInformation</c> feature
+/// (S-128 § 12).
+/// </summary>
+public sealed class S128DistributorInformation
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The distributor name, when supplied.</summary>
+    public string? DistributorName { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>The originating parsed feature.</summary>
+    public required S128Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>ContactDetails</c> feature
+/// (S-128 § 12).
+/// </summary>
+public sealed class S128ContactDetails
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Free-text contact instructions, when supplied.</summary>
+    public string? ContactInstructions { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>The originating parsed feature.</summary>
+    public required S128Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-128 <c>CatalogueSectionHeader</c> feature
+/// (S-128 § 12) — a logical grouping marker inside the catalogue.
+/// </summary>
+public sealed class S128CatalogueSectionHeader
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The catalogue section number, when supplied.</summary>
+    public string? CatalogueSectionNumber { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>The originating parsed feature.</summary>
+    public required S128Feature Source { get; init; }
+}

--- a/src/EncDotNet.S100.Datasets.S128/README.md
+++ b/src/EncDotNet.S100.Datasets.S128/README.md
@@ -44,6 +44,7 @@ upstream sample (`DistributorInformation`, `ProducerInformation`,
 | `S128ProductEntry` | Façade over an `S128Feature` whose type is one of the navigational product classes; surfaces strongly-typed accessors (`ProductSpecificationName`, `Status`, `CoverageRing`, etc.) |
 | `S128ProductStatus` | Heuristic enum: `InForce | Superseded | Withdrawn | Planned | Unknown` |
 | `S128CatalogueQuery` | Static helpers: `FilterByExtent`, `FilterByProductType`, `FilterBySpecification`, `FilterByStatus` |
+| `S128ProductCatalogue` (`DataModel/`) | Strongly-typed projection of the dataset as a catalogue of typed `S128CatalogueEntry` subclasses with resolved `Supersedes`/`SupersededBy` navigation. See [Strongly-typed data model](#strongly-typed-data-model). |
 | `S128FeatureXmlSource` | Projects the dataset into the S-100 Part 9 FeatureXML neutral form consumed by the bundled XSLT |
 | `S128FeatureGeometryProvider` | `IFeatureGeometryProvider` adapter for the unified Mapsui display-list renderer |
 | `S128PortrayalCatalogue` | `IVectorPortrayalCatalogue` over the bundled PC (Day / Dusk / Night palettes) |
@@ -81,9 +82,57 @@ S-128 2.0.0 does not surface a single `status` enum on product entries.
 3. Otherwise defaults to `InForce`.
 
 Resolution of `theReference` xlink references with
-`ProductMapping/categoryOfProductMapping=1` (supersedes) is **not yet
-implemented** — see TODO in `S128CatalogueQuery`. Callers that need
-"superseded" semantics should resolve them at the catalogue level.
+`ProductMapping/categoryOfProductMapping=1` (supersedes) is handled by
+the typed-model projection — see
+[Strongly-typed data model](#strongly-typed-data-model).
+
+## Strongly-typed data model
+
+`EncDotNet.S100.Datasets.S128.DataModel.S128ProductCatalogue` projects
+the feature-bag `S128Dataset` into a strongly-typed catalogue with:
+
+- Polymorphic `Products` collection over the common
+  `S128CatalogueEntry` base; instances are sealed
+  `S128ElectronicProduct`, `S128PhysicalProduct`, or `S128Service`.
+- Dedicated typed records for `Producers`, `Distributors`,
+  `Contacts`, and `SectionHeaders` metadata.
+- **Resolved supersedes navigation.** Every `theReference` xlink with
+  `ProductMapping/categoryOfProductMapping=1`
+  ("Higher Priority Alternative", S-128 § 12) is resolved at
+  projection time. Each entry exposes `Supersedes` (forward
+  traversal) and `SupersededBy` (reverse traversal, populated by
+  inverting the forward map). Cycles and chains tolerated.
+- Other `categoryOfProductMapping` values surface in
+  `RelatedProducts` with their raw category text preserved for
+  future-edition compatibility.
+- Permissive projection: unresolved xlinks and parse failures emit
+  `ProjectionDiagnostic` entries rather than throwing. The projection
+  only throws when both `Features` and `InformationTypes` are empty.
+
+### Quick start (typed model)
+
+```csharp
+using EncDotNet.S100.Datasets.S128;
+using EncDotNet.S100.Datasets.S128.DataModel;
+
+var dataset = S128Dataset.Open("catalogue.gml");
+var catalogue = S128ProductCatalogue.From(dataset, out var diagnostics);
+
+foreach (var product in catalogue.Products)
+{
+    Console.WriteLine($"{product.FeatureType} {product.Id} " +
+        $"(ed. {product.EditionNumber}, spec {product.ProductSpecificationName})");
+
+    foreach (var superseded in product.Supersedes)
+        Console.WriteLine($"  supersedes → {superseded.Id}");
+
+    foreach (var successor in product.SupersededBy)
+        Console.WriteLine($"  superseded by → {successor.Id}");
+}
+
+foreach (var d in diagnostics)
+    Console.WriteLine(d);
+```
 
 ## Coordinate ordering
 
@@ -101,7 +150,10 @@ planned) styling is not in the upstream PC and is left as a TODO.
 
 ## Out of scope (this release)
 
-- Status-styled local XSLT rules.
+- Status-driven local XSLT styling (in-force / superseded /
+  withdrawn / planned). The data-model side of supersedes is now
+  resolved via `S128ProductCatalogue`; the corresponding XSLT
+  portrayal hook is still deferred.
 - Auto-downloading datasets pointed at by `onlineResource.linkage` URLs.
 - Dataset authoring / serialisation.
 - Multi-language label resolution.

--- a/tests/EncDotNet.S100.Datasets.S128.Tests/DataModelTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S128.Tests/DataModelTests.cs
@@ -1,0 +1,308 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S128.DataModel;
+
+namespace EncDotNet.S100.Datasets.S128.Tests;
+
+/// <summary>
+/// Tests for the strongly-typed projection
+/// <see cref="S128ProductCatalogue"/>.
+/// </summary>
+public class DataModelTests
+{
+    private const string TestDataDir = "TestData";
+    private const string SampleFile = "S128_TDS_sample.gml";
+
+    private static S128Dataset LoadSample() =>
+        S128Dataset.Open(Path.Combine(TestDataDir, SampleFile));
+
+    private static S128ProductCatalogue ProjectSample(out IReadOnlyList<ProjectionDiagnostic> diagnostics) =>
+        S128ProductCatalogue.From(LoadSample(), out diagnostics);
+
+    private static S128Dataset OpenGml(string gml)
+    {
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(gml));
+        return S128Dataset.Open(stream);
+    }
+
+    [Fact]
+    public void From_OfficialSample_ProjectsProductSubclassesAndSupersedesLink()
+    {
+        var catalogue = ProjectSample(out _);
+
+        Assert.Equal("S-128", catalogue.ProductIdentifier);
+        Assert.Equal(5, catalogue.Products.Length);
+
+        var electronic = catalogue.Products.OfType<S128ElectronicProduct>().ToList();
+        var physical = catalogue.Products.OfType<S128PhysicalProduct>().ToList();
+        var services = catalogue.Products.OfType<S128Service>().ToList();
+        Assert.Equal(2, electronic.Count);
+        Assert.Equal(2, physical.Count);
+        Assert.Single(services);
+
+        // CNP00005 (PhysicalProduct) supersedes ID0002 (ElectronicProduct)
+        // via theReference with categoryOfProductMapping=1
+        // ("Higher Priority Alternative").
+        var cnp5 = catalogue.Products.Single(p => p.Id == "CNP00005");
+        var id0002 = catalogue.Products.Single(p => p.Id == "ID0002");
+
+        Assert.Contains(cnp5.Supersedes, t => t.Id == "ID0002");
+        Assert.Contains(id0002.SupersededBy, t => t.Id == "CNP00005");
+    }
+
+    [Fact]
+    public void From_OfficialSample_TypesMetadataFeaturesCorrectly()
+    {
+        var catalogue = ProjectSample(out _);
+
+        Assert.Single(catalogue.Producers);
+        Assert.Equal("CNP00010", catalogue.Producers[0].Id);
+        Assert.Equal("KHOA", catalogue.Producers[0].AgencyResponsibleForProduction);
+
+        Assert.Single(catalogue.Distributors);
+        Assert.Equal("CNP00007", catalogue.Distributors[0].Id);
+        Assert.Equal("KHOA", catalogue.Distributors[0].DistributorName);
+
+        Assert.Single(catalogue.Contacts);
+        Assert.Equal("CNP00009", catalogue.Contacts[0].Id);
+
+        Assert.Single(catalogue.SectionHeaders);
+        Assert.Equal("CNP00008", catalogue.SectionHeaders[0].Id);
+        Assert.Equal("5005", catalogue.SectionHeaders[0].CatalogueSectionNumber);
+    }
+
+    [Fact]
+    public void From_OfficialSample_ServiceCarriesReleasedStatus()
+    {
+        var catalogue = ProjectSample(out _);
+        var service = catalogue.Products.OfType<S128Service>().Single();
+        Assert.Equal("CNP00006", service.Id);
+        Assert.Equal(S128ServiceStatus.Released, service.ServiceStatus);
+    }
+
+    [Fact]
+    public void From_OfficialSample_DistributorHasNoGeometry()
+    {
+        // Metadata feature surfaces with no geometry — projection must not throw.
+        var catalogue = ProjectSample(out _);
+        var distributor = catalogue.Distributors.Single();
+        Assert.NotNull(distributor.Source);
+        Assert.True(distributor.Source.ExteriorRing.IsDefaultOrEmpty);
+    }
+
+    [Fact]
+    public void From_TwoLinkSupersedes_ResolvesBothDirections()
+    {
+        // B supersedes A.
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/2.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/5.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <S128:members>
+                <S128:ElectronicProduct gml:id="A">
+                  <S128:productNumber>A</S128:productNumber>
+                </S128:ElectronicProduct>
+                <S128:ElectronicProduct gml:id="B">
+                  <S128:productNumber>B</S128:productNumber>
+                  <S128:theReference xlink:href="#A">
+                    <ProductMapping>
+                      <categoryOfProductMapping code="1">Higher Priority Alternative</categoryOfProductMapping>
+                    </ProductMapping>
+                  </S128:theReference>
+                </S128:ElectronicProduct>
+              </S128:members>
+            </S128:Dataset>
+            """;
+        var catalogue = S128ProductCatalogue.From(OpenGml(gml), out var diagnostics);
+
+        var a = catalogue.Products.Single(p => p.Id == "A");
+        var b = catalogue.Products.Single(p => p.Id == "B");
+
+        Assert.Contains(b.Supersedes, t => t.Id == "A");
+        Assert.Contains(a.SupersededBy, t => t.Id == "B");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void From_ThreeLinkChain_ResolvesEachStepBothDirections()
+    {
+        // C supersedes B; B supersedes A. No transitive flattening.
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/2.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/5.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <S128:members>
+                <S128:ElectronicProduct gml:id="A">
+                  <S128:productNumber>A</S128:productNumber>
+                </S128:ElectronicProduct>
+                <S128:ElectronicProduct gml:id="B">
+                  <S128:productNumber>B</S128:productNumber>
+                  <S128:theReference xlink:href="#A">
+                    <ProductMapping>
+                      <categoryOfProductMapping code="1">Higher Priority Alternative</categoryOfProductMapping>
+                    </ProductMapping>
+                  </S128:theReference>
+                </S128:ElectronicProduct>
+                <S128:ElectronicProduct gml:id="C">
+                  <S128:productNumber>C</S128:productNumber>
+                  <S128:theReference xlink:href="#B">
+                    <ProductMapping>
+                      <categoryOfProductMapping code="1">Higher Priority Alternative</categoryOfProductMapping>
+                    </ProductMapping>
+                  </S128:theReference>
+                </S128:ElectronicProduct>
+              </S128:members>
+            </S128:Dataset>
+            """;
+        var catalogue = S128ProductCatalogue.From(OpenGml(gml), out _);
+
+        var a = catalogue.Products.Single(p => p.Id == "A");
+        var b = catalogue.Products.Single(p => p.Id == "B");
+        var c = catalogue.Products.Single(p => p.Id == "C");
+
+        // No transitive flattening.
+        Assert.Single(b.Supersedes);
+        Assert.Equal("A", b.Supersedes[0].Id);
+        Assert.Single(c.Supersedes);
+        Assert.Equal("B", c.Supersedes[0].Id);
+
+        Assert.Single(a.SupersededBy);
+        Assert.Equal("B", a.SupersededBy[0].Id);
+        Assert.Single(b.SupersededBy);
+        Assert.Equal("C", b.SupersededBy[0].Id);
+        Assert.Empty(c.SupersededBy);
+    }
+
+    [Fact]
+    public void From_UnresolvedTheReference_EmitsDiagnostic_DoesNotThrow()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/2.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/5.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <S128:members>
+                <S128:ElectronicProduct gml:id="B">
+                  <S128:productNumber>B</S128:productNumber>
+                  <S128:theReference xlink:href="#NONEXISTENT">
+                    <ProductMapping>
+                      <categoryOfProductMapping code="1">Higher Priority Alternative</categoryOfProductMapping>
+                    </ProductMapping>
+                  </S128:theReference>
+                </S128:ElectronicProduct>
+              </S128:members>
+            </S128:Dataset>
+            """;
+        var catalogue = S128ProductCatalogue.From(OpenGml(gml), out var diagnostics);
+
+        var b = catalogue.Products.Single(p => p.Id == "B");
+        Assert.Empty(b.Supersedes);
+        Assert.Empty(b.SupersededBy);
+        Assert.Contains(diagnostics, d => d.Code == "xlink.unresolved");
+    }
+
+    [Fact]
+    public void From_NonSupersedesMapping_LandsInRelatedProducts()
+    {
+        // A theReference whose category text does NOT classify as "Higher
+        // Priority Alternative" lands in RelatedProducts, not Supersedes.
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/2.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/5.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <S128:members>
+                <S128:ElectronicProduct gml:id="A">
+                  <S128:productNumber>A</S128:productNumber>
+                </S128:ElectronicProduct>
+                <S128:ElectronicProduct gml:id="B">
+                  <S128:productNumber>B</S128:productNumber>
+                  <S128:theReference xlink:href="#A">
+                    <ProductMapping>
+                      <categoryOfProductMapping code="99">Some Future Mapping</categoryOfProductMapping>
+                    </ProductMapping>
+                  </S128:theReference>
+                </S128:ElectronicProduct>
+              </S128:members>
+            </S128:Dataset>
+            """;
+        var catalogue = S128ProductCatalogue.From(OpenGml(gml), out _);
+
+        var a = catalogue.Products.Single(p => p.Id == "A");
+        var b = catalogue.Products.Single(p => p.Id == "B");
+
+        Assert.Empty(b.Supersedes);
+        Assert.Empty(a.SupersededBy);
+        Assert.Single(b.RelatedProducts);
+        Assert.Equal("A", b.RelatedProducts[0].Target.Id);
+        Assert.Equal(S128ProductMappingCategory.Other, b.RelatedProducts[0].Category);
+        Assert.Equal("Some Future Mapping", b.RelatedProducts[0].RawCategoryText);
+    }
+
+    [Fact]
+    public void From_UnknownAttribute_RoundTripsThroughExtraAttributes()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/2.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/5.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <S128:members>
+                <S128:ElectronicProduct gml:id="X">
+                  <S128:productNumber>X</S128:productNumber>
+                  <S128:editionNumber>3</S128:editionNumber>
+                  <S128:vendorSpecificFlag>experimental-value</S128:vendorSpecificFlag>
+                </S128:ElectronicProduct>
+              </S128:members>
+            </S128:Dataset>
+            """;
+        var catalogue = S128ProductCatalogue.From(OpenGml(gml), out _);
+        var x = catalogue.Products.Single();
+        Assert.Equal(3, x.EditionNumber);
+        Assert.True(x.ExtraAttributes.ContainsKey("vendorSpecificFlag"));
+        Assert.Equal("experimental-value", x.ExtraAttributes["vendorSpecificFlag"]);
+        // Known columns must NOT be duplicated into ExtraAttributes.
+        Assert.False(x.ExtraAttributes.ContainsKey("productNumber"));
+        Assert.False(x.ExtraAttributes.ContainsKey("editionNumber"));
+    }
+
+    [Fact]
+    public void From_EmptyDataset_Throws()
+    {
+        var empty = new S128Dataset
+        {
+            ProductIdentifier = "S-128",
+            DatasetIdentifier = "EMPTY",
+            Features = ImmutableArray<S128Feature>.Empty,
+            InformationTypes = ImmutableArray<S128InformationType>.Empty,
+        };
+        Assert.Throws<InvalidOperationException>(() => S128ProductCatalogue.From(empty, out _));
+    }
+}


### PR DESCRIPTION
Pass 2 of the typed-projection rollout. Adds `EncDotNet.S100.Datasets.S128.DataModel.S128ProductCatalogue`, mirroring the Pass-1 pattern (S-421, S-124), and uses it as the resolution site for the long-standing `theReference` supersedes-xlink TODO that the S-128 README has been carrying since release.

## Highlights

- **Polymorphic typed catalogue.** Root `S128ProductCatalogue` exposes a `Products` collection over abstract `S128CatalogueEntry` with sealed `S128ElectronicProduct` / `S128PhysicalProduct` / `S128Service` subclasses. Producers, distributors, contacts, and section headers project to dedicated typed records.
- **Resolved supersedes navigation.** Every `theReference` xlink whose companion `ProductMapping/categoryOfProductMapping` is `1` ("Higher Priority Alternative", S-128 § 12) is resolved at projection time into a forward `Supersedes` collection and an inverted `SupersededBy` collection. Cycles, chains (A→B→C), and dangling refs all degrade gracefully.
- **Other mapping categories preserved.** Non-supersedes mappings surface under `RelatedProducts` with the raw `categoryOfProductMapping` text retained for future FC editions.
- **Permissive projection.** Unresolved xlinks emit `ProjectionDiagnostic` (`xlink.unresolved`) and the projection continues; only an entirely empty dataset throws.
- **Back-compat preserved.** `S128Dataset`, `S128Feature`, `S128ProductEntry`, and `S128CatalogueQuery` are unchanged. The typed model is additive.

## Tests

9 new tests in `DataModelTests.cs` covering: official sample round-trip with one resolved supersedes link, two-link and three-link synthetic chains, unresolved xlinks, non-supersedes mappings landing in `RelatedProducts`, service vs. product typing, producer/distributor typing, geometry-less metadata, unknown-attribute round-trip via `ExtraAttributes`, and empty-dataset throws. Full S-128 test project: 26/26 passing. Full solution build clean.

## Docs

- `src/EncDotNet.S100.Datasets.S128/README.md`: removed the "not yet implemented" supersedes paragraph; added a "Strongly-typed data model" section with a quick-start code block demonstrating supersedes resolution; reframed the "Out of scope" bullet to clarify that only XSLT status-driven *styling* remains deferred.
- Root `README.md`: S-128 Libraries entry now mentions typed `DataModel` + resolved supersedes navigation.

## Out of scope

Status-driven XSLT portrayal styling stays deferred — this PR is about the data model only.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;