### PR TITLE
Add strongly-typed DataModel projection to S-125

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ into focused packages:
 | **EncDotNet.S100.Datasets.S111** | S-111 surface current reader and coverage pipeline. |
 | **EncDotNet.S100.Datasets.S122** | S-122 marine protected areas reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S124** | S-124 navigational warnings reader and XSLT portrayal pipeline. |
-| **EncDotNet.S100.Datasets.S125** | S-125 marine aids to navigation reader and XSLT portrayal pipeline. |
+| **EncDotNet.S100.Datasets.S125** | S-125 marine aids to navigation reader, strongly-typed `DataModel` projection (with xlink-resolved AtoN status), and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S127** | S-127 marine resources and services reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S128** | S-128 catalogue of nautical products reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S129** | S-129 under keel clearance reader and XSLT portrayal pipeline. |

--- a/src/EncDotNet.S100.Datasets.S125/DataModel/S125Aids.cs
+++ b/src/EncDotNet.S100.Datasets.S125/DataModel/S125Aids.cs
@@ -1,0 +1,303 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S125.DataModel;
+
+/// <summary>
+/// Common contract exposed by every typed S-125 aid to navigation
+/// (buoys, beacons, lights, AIS aids, structures, equipment). Allows
+/// callers to enumerate <see cref="S125AtonDataset.Aids"/> uniformly and
+/// dispatch on <see cref="FeatureType"/> when the discriminator matters.
+/// </summary>
+/// <remarks>
+/// S-125 Edition 1.0.0 declares all concrete AtoN feature types as
+/// point primitives (§AidsToNavigation <c>permittedPrimitives=point</c>).
+/// Callers may therefore treat <see cref="Position"/> as the canonical
+/// location of the aid.
+/// </remarks>
+public interface IS125Aid
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    string Id { get; }
+
+    /// <summary>The raw S-125 feature type code (e.g. <c>"LateralBuoy"</c>).</summary>
+    string FeatureType { get; }
+
+    /// <summary>The position of the aid, when supplied.</summary>
+    GeoPosition? Position { get; }
+
+    /// <summary>The resolved AtoN status payload, when the source feature carries an <c>AtoNStatus</c> binding.</summary>
+    S125AtonStatusInformation? Status { get; }
+
+    /// <summary>
+    /// The host structure feature this aid sits on, when resolved from a
+    /// feature-to-feature xlink (typically the <c>parent</c> role of the
+    /// <c>StructureEquipment</c> association — S-125 Edition 1.0.0
+    /// §StructureEquipment).
+    /// </summary>
+    IS125Aid? HostStructure { get; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    ImmutableDictionary<string, string> ExtraAttributes { get; }
+}
+
+/// <summary>The flavour of an S-125 buoy.</summary>
+public enum S125BuoyKind
+{
+    /// <summary>Unrecognised buoy type.</summary>
+    Unknown,
+    /// <summary>§LateralBuoy.</summary>
+    Lateral,
+    /// <summary>§CardinalBuoy.</summary>
+    Cardinal,
+    /// <summary>§IsolatedDangerBuoy.</summary>
+    IsolatedDanger,
+    /// <summary>§SafeWaterBuoy.</summary>
+    SafeWater,
+    /// <summary>§SpecialPurposeGeneralBuoy.</summary>
+    SpecialPurposeGeneral,
+    /// <summary>§EmergencyWreckMarkingBuoy.</summary>
+    EmergencyWreckMarking,
+    /// <summary>§MooringBuoy.</summary>
+    Mooring,
+    /// <summary>§InstallationBuoy.</summary>
+    Installation,
+}
+
+/// <summary>The flavour of an S-125 beacon.</summary>
+public enum S125BeaconKind
+{
+    /// <summary>Unrecognised beacon type.</summary>
+    Unknown,
+    /// <summary>§LateralBeacon.</summary>
+    Lateral,
+    /// <summary>§CardinalBeacon.</summary>
+    Cardinal,
+    /// <summary>§IsolatedDangerBeacon.</summary>
+    IsolatedDanger,
+    /// <summary>§SafeWaterBeacon.</summary>
+    SafeWater,
+    /// <summary>§SpecialPurposeGeneralBeacon.</summary>
+    SpecialPurposeGeneral,
+}
+
+/// <summary>The flavour of an S-125 light.</summary>
+public enum S125LightKind
+{
+    /// <summary>Unrecognised light type.</summary>
+    Unknown,
+    /// <summary>§LightAllAround.</summary>
+    AllAround,
+    /// <summary>§LightSectored.</summary>
+    Sectored,
+    /// <summary>§LightAirObstruction.</summary>
+    AirObstruction,
+    /// <summary>§LightFloat — a floating, anchored light platform.</summary>
+    Float,
+    /// <summary>§LightVessel — a moored vessel acting as a light.</summary>
+    Vessel,
+    /// <summary>§LightFogDetector.</summary>
+    FogDetector,
+}
+
+/// <summary>The flavour of an S-125 AIS aid to navigation.</summary>
+public enum S125AisKind
+{
+    /// <summary>Unrecognised AIS aid type.</summary>
+    Unknown,
+    /// <summary>§PhysicalAISAidToNavigation — a real AtoN that broadcasts AIS.</summary>
+    Physical,
+    /// <summary>§SyntheticAISAidToNavigation — a real AtoN whose AIS signal is generated remotely.</summary>
+    Synthetic,
+    /// <summary>§VirtualAISAidToNavigation — an AIS signal with no physical AtoN behind it.</summary>
+    Virtual,
+}
+
+/// <summary>The flavour of an S-125 structure feature.</summary>
+public enum S125StructureKind
+{
+    /// <summary>Unrecognised structure type.</summary>
+    Unknown,
+    /// <summary>§Landmark.</summary>
+    Landmark,
+    /// <summary>§Daymark.</summary>
+    Daymark,
+    /// <summary>§OffshorePlatform.</summary>
+    OffshorePlatform,
+    /// <summary>§Pile.</summary>
+    Pile,
+    /// <summary>§SiloTank.</summary>
+    SiloTank,
+    /// <summary>§WindTurbine.</summary>
+    WindTurbine,
+    /// <summary>§Topmark.</summary>
+    Topmark,
+}
+
+/// <summary>The flavour of an S-125 equipment feature.</summary>
+public enum S125EquipmentKind
+{
+    /// <summary>Unrecognised equipment type.</summary>
+    Unknown,
+    /// <summary>§FogSignal.</summary>
+    FogSignal,
+    /// <summary>§RadarReflector.</summary>
+    RadarReflector,
+    /// <summary>§Retroreflector.</summary>
+    Retroreflector,
+    /// <summary>§RadarTransponderBeacon — a Racon.</summary>
+    RadarTransponderBeacon,
+    /// <summary>§RadioStation.</summary>
+    RadioStation,
+}
+
+/// <summary>
+/// Typed projection of an S-125 buoy feature
+/// (S-125 Edition 1.0.0, all <c>*Buoy</c> feature classes).
+/// </summary>
+public sealed class S125Buoy : IS125Aid
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <summary>The buoy flavour, decoded from <see cref="FeatureType"/>.</summary>
+    public S125BuoyKind Kind { get; init; }
+    /// <inheritdoc/>
+    public GeoPosition? Position { get; init; }
+    /// <inheritdoc/>
+    public S125AtonStatusInformation? Status { get; init; }
+    /// <inheritdoc/>
+    public IS125Aid? HostStructure { get; init; }
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an S-125 beacon feature
+/// (S-125 Edition 1.0.0, all <c>*Beacon</c> feature classes).
+/// </summary>
+public sealed class S125Beacon : IS125Aid
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <summary>The beacon flavour, decoded from <see cref="FeatureType"/>.</summary>
+    public S125BeaconKind Kind { get; init; }
+    /// <inheritdoc/>
+    public GeoPosition? Position { get; init; }
+    /// <inheritdoc/>
+    public S125AtonStatusInformation? Status { get; init; }
+    /// <inheritdoc/>
+    public IS125Aid? HostStructure { get; init; }
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an S-125 light feature
+/// (S-125 Edition 1.0.0, all <c>Light*</c> feature classes).
+/// </summary>
+public sealed class S125Light : IS125Aid
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <summary>The light flavour, decoded from <see cref="FeatureType"/>.</summary>
+    public S125LightKind Kind { get; init; }
+    /// <inheritdoc/>
+    public GeoPosition? Position { get; init; }
+    /// <inheritdoc/>
+    public S125AtonStatusInformation? Status { get; init; }
+    /// <inheritdoc/>
+    public IS125Aid? HostStructure { get; init; }
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an S-125 AIS aid to navigation
+/// (S-125 Edition 1.0.0 §PhysicalAISAidToNavigation,
+/// §SyntheticAISAidToNavigation, §VirtualAISAidToNavigation).
+/// </summary>
+public sealed class S125AisAton : IS125Aid
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <summary>The AIS-aid flavour, decoded from <see cref="FeatureType"/>.</summary>
+    public S125AisKind Kind { get; init; }
+
+    /// <summary>
+    /// <c>true</c> when <see cref="Kind"/> is <see cref="S125AisKind.Virtual"/>.
+    /// Virtual AIS aids have no physical presence — the broadcast position
+    /// is purely synthetic. Distinguishing them is the most common
+    /// predicate placed on AIS aids.
+    /// </summary>
+    public bool IsVirtual => Kind == S125AisKind.Virtual;
+
+    /// <inheritdoc/>
+    public GeoPosition? Position { get; init; }
+    /// <inheritdoc/>
+    public S125AtonStatusInformation? Status { get; init; }
+    /// <inheritdoc/>
+    public IS125Aid? HostStructure { get; init; }
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an S-125 structure feature (a fixed object that may
+/// host equipment) — S-125 Edition 1.0.0 §Landmark, §Daymark,
+/// §OffshorePlatform, §Pile, §SiloTank, §WindTurbine, §Topmark.
+/// </summary>
+public sealed class S125Structure : IS125Aid
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <summary>The structure flavour, decoded from <see cref="FeatureType"/>.</summary>
+    public S125StructureKind Kind { get; init; }
+    /// <inheritdoc/>
+    public GeoPosition? Position { get; init; }
+    /// <inheritdoc/>
+    public S125AtonStatusInformation? Status { get; init; }
+    /// <inheritdoc/>
+    public IS125Aid? HostStructure { get; init; }
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an S-125 equipment feature (a piece of AtoN
+/// equipment typically hosted by a <see cref="S125Structure"/>) —
+/// S-125 Edition 1.0.0 §FogSignal, §RadarReflector, §Retroreflector,
+/// §RadarTransponderBeacon, §RadioStation.
+/// </summary>
+public sealed class S125Equipment : IS125Aid
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <summary>The equipment flavour, decoded from <see cref="FeatureType"/>.</summary>
+    public S125EquipmentKind Kind { get; init; }
+    /// <inheritdoc/>
+    public GeoPosition? Position { get; init; }
+    /// <inheritdoc/>
+    public S125AtonStatusInformation? Status { get; init; }
+    /// <inheritdoc/>
+    public IS125Aid? HostStructure { get; init; }
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Datasets.S125/DataModel/S125AtonDataset.cs
+++ b/src/EncDotNet.S100.Datasets.S125/DataModel/S125AtonDataset.cs
@@ -1,0 +1,651 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S125.DataModel;
+
+/// <summary>
+/// Strongly-typed projection of an <see cref="S125Dataset"/> as a
+/// collection of aids to navigation plus supporting status / quality
+/// information types (S-125 Edition 1.0.0).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projection mirrors the S-421 / S-124 pattern: a static
+/// <see cref="From"/> factory walks the source feature bag and produces a
+/// graph of typed shapes (<see cref="S125Buoy"/>, <see cref="S125Beacon"/>,
+/// <see cref="S125Light"/>, <see cref="S125AisAton"/>,
+/// <see cref="S125Structure"/>, <see cref="S125Equipment"/>) implementing
+/// the common <see cref="IS125Aid"/> contract. Each aid has its
+/// <see cref="IS125Aid.Status"/> resolved by following the source
+/// feature's <c>AtoNStatus</c> information binding, and its
+/// <see cref="IS125Aid.HostStructure"/> resolved by following the
+/// <c>parent</c> role of the <c>StructureEquipment</c> feature
+/// association.
+/// </para>
+/// <para>
+/// Projection issues — unresolved xlinks, attribute parse failures —
+/// surface as <see cref="ProjectionDiagnostic"/> entries rather than
+/// exceptions. The projection only throws when the source dataset has
+/// no features and no information types (i.e. is fully empty).
+/// </para>
+/// </remarks>
+public sealed class S125AtonDataset
+{
+    /// <summary>The dataset identifier carried by the source GML <c>Dataset</c> element.</summary>
+    public string? DatasetIdentifier { get; init; }
+
+    /// <summary>The S-125 product identifier (typically <c>"S-125"</c>).</summary>
+    public string? ProductIdentifier { get; init; }
+
+    /// <summary>All typed aids to navigation in the dataset (buoys, beacons, lights, AIS aids, structures, equipment).</summary>
+    public required ImmutableArray<IS125Aid> Aids { get; init; }
+
+    /// <summary>All <c>AtonStatusInformation</c> info types in the dataset, keyed by GML id.</summary>
+    public required ImmutableArray<S125AtonStatusInformation> StatusInformation { get; init; }
+
+    /// <summary>All <c>AtonStatusIndication</c> features in the dataset.</summary>
+    public required ImmutableArray<S125AtonStatusIndication> StatusIndications { get; init; }
+
+    /// <summary>All <c>SpatialQuality</c> info types in the dataset.</summary>
+    public required ImmutableArray<S125SpatialQuality> SpatialQualities { get; init; }
+
+    /// <summary>All AtoN aggregations / associations in the dataset.</summary>
+    public required ImmutableArray<S125Aggregation> Aggregations { get; init; }
+
+    /// <summary>
+    /// All other S-125 features that are not modeled as typed aids
+    /// (lines, areas, metadata features — see <see cref="S125OtherFeature"/>).
+    /// </summary>
+    public required ImmutableArray<S125OtherFeature> OtherFeatures { get; init; }
+
+    /// <summary>The originating feature-bag dataset.</summary>
+    public required S125Dataset Source { get; init; }
+
+    /// <summary>
+    /// Projects a feature-bag <see cref="S125Dataset"/> into the typed
+    /// data model. Issues encountered during projection are reported via
+    /// <paramref name="diagnostics"/>; the projection only throws for a
+    /// fully empty source.
+    /// </summary>
+    /// <param name="dataset">The source dataset to project.</param>
+    /// <param name="diagnostics">
+    /// Receives the accumulated projection diagnostics (unresolved xlinks,
+    /// parse failures, etc.) as an immutable snapshot.
+    /// </param>
+    /// <exception cref="ArgumentNullException">If <paramref name="dataset"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the dataset contains neither features nor information
+    /// types.
+    /// </exception>
+    public static S125AtonDataset From(S125Dataset dataset, out IReadOnlyList<ProjectionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        if (dataset.Features.IsDefaultOrEmpty && dataset.InformationTypes.IsDefaultOrEmpty)
+            throw new InvalidOperationException("Dataset contains no features and no information types.");
+
+        // Project supporting info types up-front so xlink resolution can
+        // hand back fully-typed objects (and shared status instances stay
+        // shared across all aids that bind to them).
+        var statusInfoById = new Dictionary<string, S125AtonStatusInformation>(StringComparer.OrdinalIgnoreCase);
+        var spatialQualityById = new Dictionary<string, S125SpatialQuality>(StringComparer.OrdinalIgnoreCase);
+
+        // Diagnostics for the info-type pass are gathered with a temporary
+        // context whose xlink index is empty — info types don't follow
+        // xlinks themselves. The diagnostics are merged into the final
+        // result.
+        var emptyResolver = XlinkResolver.Build(Array.Empty<KeyValuePair<string, object>>());
+        var preCtx = new ProjectionContext(emptyResolver);
+
+        foreach (var i in dataset.InformationTypes)
+        {
+            if (string.Equals(i.TypeCode, "AtonStatusInformation", StringComparison.OrdinalIgnoreCase))
+            {
+                var info = ProjectStatusInformation(i, preCtx);
+                if (!string.IsNullOrEmpty(info.Id))
+                    statusInfoById[info.Id] = info;
+            }
+            else if (string.Equals(i.TypeCode, "SpatialQuality", StringComparison.OrdinalIgnoreCase))
+            {
+                var sq = ProjectSpatialQuality(i, preCtx);
+                if (!string.IsNullOrEmpty(sq.Id))
+                    spatialQualityById[sq.Id] = sq;
+            }
+        }
+
+        // Build the xlink resolver over everything addressable by gml:id.
+        // Aids are added lazily through a feature-id → feature lookup; the
+        // typed aids are constructed in two passes so HostStructure can
+        // reference fully-constructed peers.
+        var featureById = dataset.Features.ToImmutableDictionary(f => f.Id, StringComparer.OrdinalIgnoreCase);
+        var resolver = BuildXlinkResolver(featureById, statusInfoById, spatialQualityById);
+        var ctx = new ProjectionContext(resolver);
+        foreach (var d in preCtx.Diagnostics) ctx.Report(d);
+
+        // Pass 1: project every feature into a typed shape, but with
+        // HostStructure left null so we don't depend on construction order.
+        var aidsById = new Dictionary<string, IS125Aid>(StringComparer.OrdinalIgnoreCase);
+        var aidsList = ImmutableArray.CreateBuilder<IS125Aid>();
+        var indications = ImmutableArray.CreateBuilder<S125AtonStatusIndication>();
+        var aggregations = ImmutableArray.CreateBuilder<S125Aggregation>();
+        var otherFeatures = ImmutableArray.CreateBuilder<S125OtherFeature>();
+
+        foreach (var f in dataset.Features)
+        {
+            switch (f.FeatureType)
+            {
+                case "AtonStatusIndication":
+                    indications.Add(ProjectStatusIndication(f, statusInfoById, ctx));
+                    break;
+                case "AtonAggregation":
+                case "AtonAssociation":
+                    // Members resolved in pass 2 once typed aids exist.
+                    aggregations.Add(ProjectAggregation(f, ctx));
+                    break;
+                default:
+                    var aid = TryProjectAid(f, statusInfoById, ctx);
+                    if (aid is not null)
+                    {
+                        aidsList.Add(aid);
+                        if (!string.IsNullOrEmpty(aid.Id))
+                            aidsById[aid.Id] = aid;
+                    }
+                    else
+                    {
+                        otherFeatures.Add(ProjectOtherFeature(f));
+                    }
+                    break;
+            }
+        }
+
+        // Pass 2: walk aids and aggregations again to resolve feature-to-
+        // feature xlinks now that every aid has been constructed.
+        var aidsFinal = ImmutableArray.CreateBuilder<IS125Aid>(aidsList.Count);
+        foreach (var aid in aidsList)
+        {
+            var src = featureById.GetValueOrDefault(aid.Id);
+            var host = src is null ? null : ResolveHostStructure(src, aidsById, ctx);
+            aidsFinal.Add(host is null ? aid : AttachHost(aid, host));
+        }
+
+        for (var i = 0; i < aggregations.Count; i++)
+        {
+            var current = aggregations[i];
+            var src = featureById.GetValueOrDefault(current.Id);
+            if (src is null) continue;
+            var members = ResolveAggregationMembers(src, aidsById, ctx);
+            aggregations[i] = new S125Aggregation
+            {
+                Id = current.Id,
+                Kind = current.Kind,
+                CategoryCode = current.CategoryCode,
+                Members = members,
+                ExtraAttributes = current.ExtraAttributes,
+            };
+        }
+
+        diagnostics = ctx.ToImmutableDiagnostics();
+        return new S125AtonDataset
+        {
+            DatasetIdentifier = dataset.DatasetIdentifier,
+            ProductIdentifier = dataset.ProductIdentifier,
+            Aids = aidsFinal.ToImmutable(),
+            StatusInformation = statusInfoById.Values.ToImmutableArray(),
+            StatusIndications = indications.ToImmutable(),
+            SpatialQualities = spatialQualityById.Values.ToImmutableArray(),
+            Aggregations = aggregations.ToImmutable(),
+            OtherFeatures = otherFeatures.ToImmutable(),
+            Source = dataset,
+        };
+    }
+
+    // ── Xlink resolver build ──────────────────────────────────────────
+
+    private static XlinkResolver BuildXlinkResolver(
+        ImmutableDictionary<string, S125Feature> featureById,
+        IReadOnlyDictionary<string, S125AtonStatusInformation> statusById,
+        IReadOnlyDictionary<string, S125SpatialQuality> spatialQualityById)
+    {
+        IEnumerable<KeyValuePair<string, object>> All()
+        {
+            foreach (var kv in featureById)
+                yield return new KeyValuePair<string, object>(kv.Key, kv.Value);
+            foreach (var kv in statusById)
+                yield return new KeyValuePair<string, object>(kv.Key, kv.Value);
+            foreach (var kv in spatialQualityById)
+                yield return new KeyValuePair<string, object>(kv.Key, kv.Value);
+        }
+        return XlinkResolver.Build(All());
+    }
+
+    // ── Info-type projections ─────────────────────────────────────────
+
+    private static S125AtonStatusInformation ProjectStatusInformation(S125InformationType i, ProjectionContext ctx)
+    {
+        var changeTypeCode = AttributeParser.TryParseInt(
+            i.Attributes.GetValueOrDefault("changeTypes"), ctx, i.Id, "changeTypes");
+        var changeType = changeTypeCode switch
+        {
+            1 => S125ChangeType.AdvanceNoticeOfChange,
+            2 => S125ChangeType.Discrepancy,
+            3 => S125ChangeType.ProposedChange,
+            4 => S125ChangeType.TemporaryChange,
+            5 => S125ChangeType.PermanentChange,
+            _ => S125ChangeType.Unknown,
+        };
+
+        var fixedRange = TryProjectDateRange(i.ComplexAttributes, "fixedDateRange", ctx, i.Id);
+        var periodic = i.ComplexAttributes
+            .Where(c => string.Equals(c.Code, "periodicDateRange", StringComparison.OrdinalIgnoreCase))
+            .Select(c => BuildDateRange(c, ctx, i.Id))
+            .Where(r => r is not null)
+            .Select(r => r!)
+            .ToImmutableArray();
+
+        return new S125AtonStatusInformation
+        {
+            Id = i.Id,
+            ChangeTypeCode = changeTypeCode,
+            ChangeType = changeType,
+            ChangeDetails = i.Attributes.GetValueOrDefault("changeDetails"),
+            FixedDateRange = fixedRange,
+            PeriodicDateRanges = periodic,
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes, "changeTypes", "changeDetails"),
+        };
+    }
+
+    private static S125SpatialQuality ProjectSpatialQuality(S125InformationType i, ProjectionContext ctx)
+    {
+        return new S125SpatialQuality
+        {
+            Id = i.Id,
+            QualityOfPosition = AttributeParser.TryParseInt(
+                i.Attributes.GetValueOrDefault("qualityOfPosition"), ctx, i.Id, "qualityOfPosition"),
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes, "qualityOfPosition"),
+        };
+    }
+
+    private static S125DateRange? TryProjectDateRange(
+        ImmutableArray<S125ComplexAttribute> complex, string code,
+        ProjectionContext ctx, string relatedId)
+    {
+        var block = complex.FirstOrDefault(c => string.Equals(c.Code, code, StringComparison.OrdinalIgnoreCase));
+        return block is null ? null : BuildDateRange(block, ctx, relatedId);
+    }
+
+    private static S125DateRange? BuildDateRange(S125ComplexAttribute block, ProjectionContext ctx, string relatedId)
+    {
+        var start = AttributeParser.TryParseDateTimeOffset(
+            block.SubAttributes.GetValueOrDefault("dateStart"), ctx, relatedId, "dateStart");
+        var end = AttributeParser.TryParseDateTimeOffset(
+            block.SubAttributes.GetValueOrDefault("dateEnd"), ctx, relatedId, "dateEnd");
+        if (start is null && end is null) return null;
+        return new S125DateRange { Start = start, End = end };
+    }
+
+    // ── Feature projections ───────────────────────────────────────────
+
+    /// <summary>
+    /// Attempts to project a feature into a typed <see cref="IS125Aid"/>.
+    /// Returns <c>null</c> when the feature type is not an AtoN class
+    /// (caller falls back to <see cref="S125OtherFeature"/>).
+    /// </summary>
+    private static IS125Aid? TryProjectAid(
+        S125Feature f,
+        IReadOnlyDictionary<string, S125AtonStatusInformation> statusById,
+        ProjectionContext ctx)
+    {
+        var position = ExtractPoint(f);
+        var status = ResolveStatus(f, statusById, ctx);
+        var extras = f.Attributes; // No consumed keys at this level; subclasses may consume more in the future.
+
+        switch (f.FeatureType)
+        {
+            // ── Buoys ──
+            case "LateralBuoy":
+            case "CardinalBuoy":
+            case "IsolatedDangerBuoy":
+            case "SafeWaterBuoy":
+            case "SpecialPurposeGeneralBuoy":
+            case "EmergencyWreckMarkingBuoy":
+            case "MooringBuoy":
+            case "InstallationBuoy":
+                return new S125Buoy
+                {
+                    Id = f.Id,
+                    FeatureType = f.FeatureType,
+                    Kind = ClassifyBuoy(f.FeatureType),
+                    Position = position,
+                    Status = status,
+                    ExtraAttributes = extras,
+                };
+            // ── Beacons ──
+            case "LateralBeacon":
+            case "CardinalBeacon":
+            case "IsolatedDangerBeacon":
+            case "SafeWaterBeacon":
+            case "SpecialPurposeGeneralBeacon":
+                return new S125Beacon
+                {
+                    Id = f.Id,
+                    FeatureType = f.FeatureType,
+                    Kind = ClassifyBeacon(f.FeatureType),
+                    Position = position,
+                    Status = status,
+                    ExtraAttributes = extras,
+                };
+            // ── Lights ──
+            case "LightAllAround":
+            case "LightSectored":
+            case "LightAirObstruction":
+            case "LightFloat":
+            case "LightVessel":
+            case "LightFogDetector":
+                return new S125Light
+                {
+                    Id = f.Id,
+                    FeatureType = f.FeatureType,
+                    Kind = ClassifyLight(f.FeatureType),
+                    Position = position,
+                    Status = status,
+                    ExtraAttributes = extras,
+                };
+            // ── AIS ──
+            case "PhysicalAISAidToNavigation":
+            case "SyntheticAISAidToNavigation":
+            case "VirtualAISAidToNavigation":
+                return new S125AisAton
+                {
+                    Id = f.Id,
+                    FeatureType = f.FeatureType,
+                    Kind = ClassifyAis(f.FeatureType),
+                    Position = position,
+                    Status = status,
+                    ExtraAttributes = extras,
+                };
+            // ── Structures ──
+            case "Landmark":
+            case "Daymark":
+            case "OffshorePlatform":
+            case "Pile":
+            case "SiloTank":
+            case "WindTurbine":
+            case "Topmark":
+                return new S125Structure
+                {
+                    Id = f.Id,
+                    FeatureType = f.FeatureType,
+                    Kind = ClassifyStructure(f.FeatureType),
+                    Position = position,
+                    Status = status,
+                    ExtraAttributes = extras,
+                };
+            // ── Equipment ──
+            case "FogSignal":
+            case "RadarReflector":
+            case "Retroreflector":
+            case "RadarTransponderBeacon":
+            case "RadioStation":
+                return new S125Equipment
+                {
+                    Id = f.Id,
+                    FeatureType = f.FeatureType,
+                    Kind = ClassifyEquipment(f.FeatureType),
+                    Position = position,
+                    Status = status,
+                    ExtraAttributes = extras,
+                };
+            default:
+                return null;
+        }
+    }
+
+    private static S125BuoyKind ClassifyBuoy(string ft) => ft switch
+    {
+        "LateralBuoy" => S125BuoyKind.Lateral,
+        "CardinalBuoy" => S125BuoyKind.Cardinal,
+        "IsolatedDangerBuoy" => S125BuoyKind.IsolatedDanger,
+        "SafeWaterBuoy" => S125BuoyKind.SafeWater,
+        "SpecialPurposeGeneralBuoy" => S125BuoyKind.SpecialPurposeGeneral,
+        "EmergencyWreckMarkingBuoy" => S125BuoyKind.EmergencyWreckMarking,
+        "MooringBuoy" => S125BuoyKind.Mooring,
+        "InstallationBuoy" => S125BuoyKind.Installation,
+        _ => S125BuoyKind.Unknown,
+    };
+
+    private static S125BeaconKind ClassifyBeacon(string ft) => ft switch
+    {
+        "LateralBeacon" => S125BeaconKind.Lateral,
+        "CardinalBeacon" => S125BeaconKind.Cardinal,
+        "IsolatedDangerBeacon" => S125BeaconKind.IsolatedDanger,
+        "SafeWaterBeacon" => S125BeaconKind.SafeWater,
+        "SpecialPurposeGeneralBeacon" => S125BeaconKind.SpecialPurposeGeneral,
+        _ => S125BeaconKind.Unknown,
+    };
+
+    private static S125LightKind ClassifyLight(string ft) => ft switch
+    {
+        "LightAllAround" => S125LightKind.AllAround,
+        "LightSectored" => S125LightKind.Sectored,
+        "LightAirObstruction" => S125LightKind.AirObstruction,
+        "LightFloat" => S125LightKind.Float,
+        "LightVessel" => S125LightKind.Vessel,
+        "LightFogDetector" => S125LightKind.FogDetector,
+        _ => S125LightKind.Unknown,
+    };
+
+    private static S125AisKind ClassifyAis(string ft) => ft switch
+    {
+        "PhysicalAISAidToNavigation" => S125AisKind.Physical,
+        "SyntheticAISAidToNavigation" => S125AisKind.Synthetic,
+        "VirtualAISAidToNavigation" => S125AisKind.Virtual,
+        _ => S125AisKind.Unknown,
+    };
+
+    private static S125StructureKind ClassifyStructure(string ft) => ft switch
+    {
+        "Landmark" => S125StructureKind.Landmark,
+        "Daymark" => S125StructureKind.Daymark,
+        "OffshorePlatform" => S125StructureKind.OffshorePlatform,
+        "Pile" => S125StructureKind.Pile,
+        "SiloTank" => S125StructureKind.SiloTank,
+        "WindTurbine" => S125StructureKind.WindTurbine,
+        "Topmark" => S125StructureKind.Topmark,
+        _ => S125StructureKind.Unknown,
+    };
+
+    private static S125EquipmentKind ClassifyEquipment(string ft) => ft switch
+    {
+        "FogSignal" => S125EquipmentKind.FogSignal,
+        "RadarReflector" => S125EquipmentKind.RadarReflector,
+        "Retroreflector" => S125EquipmentKind.Retroreflector,
+        "RadarTransponderBeacon" => S125EquipmentKind.RadarTransponderBeacon,
+        "RadioStation" => S125EquipmentKind.RadioStation,
+        _ => S125EquipmentKind.Unknown,
+    };
+
+    private static S125AtonStatusIndication ProjectStatusIndication(
+        S125Feature f,
+        IReadOnlyDictionary<string, S125AtonStatusInformation> statusById,
+        ProjectionContext ctx)
+    {
+        return new S125AtonStatusIndication
+        {
+            Id = f.Id,
+            Position = ExtractPoint(f),
+            ExpectedOutage = TryProjectDateRange(f.ComplexAttributes, "expectedOutage", ctx, f.Id),
+            Status = ResolveStatus(f, statusById, ctx),
+            ExtraAttributes = f.Attributes,
+        };
+    }
+
+    private static S125Aggregation ProjectAggregation(S125Feature f, ProjectionContext ctx)
+    {
+        var isAggregation = string.Equals(f.FeatureType, "AtonAggregation", StringComparison.OrdinalIgnoreCase);
+        var categoryKey = isAggregation ? "categoryOfAggregation" : "categoryOfAssociation";
+        return new S125Aggregation
+        {
+            Id = f.Id,
+            Kind = isAggregation ? S125AggregationKind.Aggregation : S125AggregationKind.Association,
+            CategoryCode = AttributeParser.TryParseInt(
+                f.Attributes.GetValueOrDefault(categoryKey), ctx, f.Id, categoryKey),
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, categoryKey),
+        };
+    }
+
+    private static S125OtherFeature ProjectOtherFeature(S125Feature f)
+    {
+        var (kind, coords) = ProjectGeometry(f);
+        return new S125OtherFeature
+        {
+            Id = f.Id,
+            FeatureType = f.FeatureType,
+            GeometryKind = kind,
+            Coordinates = coords,
+            ExtraAttributes = f.Attributes,
+        };
+    }
+
+    // ── Xlink resolution helpers ──────────────────────────────────────
+
+    private static S125AtonStatusInformation? ResolveStatus(
+        S125Feature f,
+        IReadOnlyDictionary<string, S125AtonStatusInformation> statusById,
+        ProjectionContext ctx)
+    {
+        foreach (var r in f.InformationReferences)
+        {
+            if (!string.Equals(r.Role, "AtoNStatus", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(r.Role, "AtonStatus", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (statusById.TryGetValue(r.InformationRef, out var info))
+                return info;
+            ctx.Warn(
+                $"Unresolved {r.Role} reference '#{r.InformationRef}'.",
+                code: "xlink.unresolved",
+                relatedId: f.Id,
+                relatedAttribute: r.Role);
+        }
+        return null;
+    }
+
+    private static IS125Aid? ResolveHostStructure(
+        S125Feature f,
+        IReadOnlyDictionary<string, IS125Aid> aidsById,
+        ProjectionContext ctx)
+    {
+        foreach (var r in f.FeatureReferences)
+        {
+            if (!string.Equals(r.Role, "parent", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (aidsById.TryGetValue(r.FeatureRef, out var host))
+                return host;
+            ctx.Warn(
+                $"Unresolved {r.Role} reference '#{r.FeatureRef}'.",
+                code: "xlink.unresolved",
+                relatedId: f.Id,
+                relatedAttribute: r.Role);
+        }
+        return null;
+    }
+
+    private static ImmutableArray<IS125Aid> ResolveAggregationMembers(
+        S125Feature f,
+        IReadOnlyDictionary<string, IS125Aid> aidsById,
+        ProjectionContext ctx)
+    {
+        if (f.FeatureReferences.IsDefaultOrEmpty) return ImmutableArray<IS125Aid>.Empty;
+        var b = ImmutableArray.CreateBuilder<IS125Aid>();
+        foreach (var r in f.FeatureReferences)
+        {
+            if (aidsById.TryGetValue(r.FeatureRef, out var aid))
+            {
+                b.Add(aid);
+            }
+            else
+            {
+                ctx.Warn(
+                    $"Unresolved {r.Role} reference '#{r.FeatureRef}'.",
+                    code: "xlink.unresolved",
+                    relatedId: f.Id,
+                    relatedAttribute: r.Role);
+            }
+        }
+        return b.ToImmutable();
+    }
+
+    // ── Geometry helpers ──────────────────────────────────────────────
+
+    private static GeoPosition? ExtractPoint(S125Feature f)
+    {
+        if (f.GeometryType != GmlGeometryType.Point || f.Points.IsDefaultOrEmpty)
+            return null;
+        var (lat, lon) = f.Points[0];
+        return new GeoPosition(lat, lon);
+    }
+
+    private static (S125GeometryKind, ImmutableArray<GeoPosition>) ProjectGeometry(S125Feature f)
+    {
+        switch (f.GeometryType)
+        {
+            case GmlGeometryType.Point:
+                return (S125GeometryKind.Point, f.Points.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.Points.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            case GmlGeometryType.Curve:
+                return (S125GeometryKind.Curve, f.Curves.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.Curves.SelectMany(c => c).Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            case GmlGeometryType.Surface:
+                return (S125GeometryKind.Surface, f.ExteriorRing.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.ExteriorRing.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            default:
+                return (S125GeometryKind.None, ImmutableArray<GeoPosition>.Empty);
+        }
+    }
+
+    // ── Host-attach helper (returns a new aid with HostStructure set) ──
+
+    private static IS125Aid AttachHost(IS125Aid aid, IS125Aid host) => aid switch
+    {
+        S125Buoy b => new S125Buoy
+        {
+            Id = b.Id, FeatureType = b.FeatureType, Kind = b.Kind,
+            Position = b.Position, Status = b.Status,
+            HostStructure = host, ExtraAttributes = b.ExtraAttributes,
+        },
+        S125Beacon b => new S125Beacon
+        {
+            Id = b.Id, FeatureType = b.FeatureType, Kind = b.Kind,
+            Position = b.Position, Status = b.Status,
+            HostStructure = host, ExtraAttributes = b.ExtraAttributes,
+        },
+        S125Light l => new S125Light
+        {
+            Id = l.Id, FeatureType = l.FeatureType, Kind = l.Kind,
+            Position = l.Position, Status = l.Status,
+            HostStructure = host, ExtraAttributes = l.ExtraAttributes,
+        },
+        S125AisAton a => new S125AisAton
+        {
+            Id = a.Id, FeatureType = a.FeatureType, Kind = a.Kind,
+            Position = a.Position, Status = a.Status,
+            HostStructure = host, ExtraAttributes = a.ExtraAttributes,
+        },
+        S125Structure s => new S125Structure
+        {
+            Id = s.Id, FeatureType = s.FeatureType, Kind = s.Kind,
+            Position = s.Position, Status = s.Status,
+            HostStructure = host, ExtraAttributes = s.ExtraAttributes,
+        },
+        S125Equipment e => new S125Equipment
+        {
+            Id = e.Id, FeatureType = e.FeatureType, Kind = e.Kind,
+            Position = e.Position, Status = e.Status,
+            HostStructure = host, ExtraAttributes = e.ExtraAttributes,
+        },
+        _ => aid,
+    };
+}

--- a/src/EncDotNet.S100.Datasets.S125/DataModel/S125AtonStatus.cs
+++ b/src/EncDotNet.S100.Datasets.S125/DataModel/S125AtonStatus.cs
@@ -1,0 +1,130 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S125.DataModel;
+
+/// <summary>
+/// Classification of a change reported against an aid to navigation,
+/// per S-125 Edition 1.0.0 §changeTypes (Feature Catalogue listed values).
+/// </summary>
+public enum S125ChangeType
+{
+    /// <summary>The change type was absent or unrecognised in the source data.</summary>
+    Unknown = 0,
+
+    /// <summary>Code <c>1</c> — Advance Notice of Change.</summary>
+    AdvanceNoticeOfChange = 1,
+
+    /// <summary>Code <c>2</c> — Discrepancy.</summary>
+    Discrepancy = 2,
+
+    /// <summary>Code <c>3</c> — Proposed Change.</summary>
+    ProposedChange = 3,
+
+    /// <summary>Code <c>4</c> — Temporary Change.</summary>
+    TemporaryChange = 4,
+
+    /// <summary>Code <c>5</c> — Permanent Change.</summary>
+    PermanentChange = 5,
+}
+
+/// <summary>
+/// A date range used by S-125 AtoN status reporting
+/// (S-125 Edition 1.0.0 §fixedDateRange / §periodicDateRange).
+/// </summary>
+public sealed record S125DateRange
+{
+    /// <summary>Start of the validity period (UTC, ISO 8601 round-trip).</summary>
+    public DateTimeOffset? Start { get; init; }
+
+    /// <summary>End of the validity period (UTC, ISO 8601 round-trip).</summary>
+    public DateTimeOffset? End { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an <c>AtonStatusInformation</c> information type
+/// (S-125 Edition 1.0.0 §AtonStatusInformation): the payload bound to an
+/// aid to navigation via the <c>AtonStatus</c> information association
+/// (role <c>AtoNStatus</c> as written in datasets).
+/// </summary>
+public sealed class S125AtonStatusInformation
+{
+    /// <summary>The GML identifier of the source <c>AtonStatusInformation</c>.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The raw numeric <c>changeTypes</c> code, when present.</summary>
+    public int? ChangeTypeCode { get; init; }
+
+    /// <summary>Strongly-typed change classification.</summary>
+    public S125ChangeType ChangeType { get; init; }
+
+    /// <summary>Free-text <c>changeDetails</c> description, when present.</summary>
+    public string? ChangeDetails { get; init; }
+
+    /// <summary>The fixed validity range, when present (§fixedDateRange).</summary>
+    public S125DateRange? FixedDateRange { get; init; }
+
+    /// <summary>Periodic validity ranges, when present (§periodicDateRange).</summary>
+    public ImmutableArray<S125DateRange> PeriodicDateRanges { get; init; } =
+        ImmutableArray<S125DateRange>.Empty;
+
+    /// <summary>
+    /// Convenience derived flag indicating whether the bound aid is judged
+    /// operational by the status payload.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returns <c>null</c> when no <see cref="ChangeType"/> was recorded;
+    /// returns <c>false</c> for <see cref="S125ChangeType.Discrepancy"/> and
+    /// <see cref="S125ChangeType.TemporaryChange"/> (the change codes that
+    /// typically denote an outage or temporary alteration); returns
+    /// <c>true</c> for all other recorded codes. This is a heuristic
+    /// interpretation of the FC enumeration — callers needing precise
+    /// classification should inspect <see cref="ChangeType"/> directly.
+    /// </para>
+    /// </remarks>
+    public bool? IsOperational => ChangeType switch
+    {
+        S125ChangeType.Unknown => null,
+        S125ChangeType.Discrepancy => false,
+        S125ChangeType.TemporaryChange => false,
+        _ => true,
+    };
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the <c>AtonStatusIndication</c> feature
+/// (S-125 Edition 1.0.0 §AtonStatusIndication): a positioned, portrayable
+/// feature that visualises status changes against one or more
+/// aids to navigation.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="S125AtonStatusInformation"/>, which is the
+/// information type carrying the change payload. An
+/// <c>AtonStatusIndication</c> feature binds to the AtoN(s) via the
+/// <c>AtonStatusIndicationAssociation</c> feature association and
+/// optionally references an <c>AtonStatusInformation</c> imember via the
+/// <c>AtonStatus</c> information association.
+/// </remarks>
+public sealed class S125AtonStatusIndication
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The feature's position, when present.</summary>
+    public GeoPosition? Position { get; init; }
+
+    /// <summary>The expected outage period, when present (§expectedOutage).</summary>
+    public S125DateRange? ExpectedOutage { get; init; }
+
+    /// <summary>The resolved status payload, when the feature carries an <c>AtoNStatus</c> binding.</summary>
+    public S125AtonStatusInformation? Status { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Datasets.S125/DataModel/S125Types.cs
+++ b/src/EncDotNet.S100.Datasets.S125/DataModel/S125Types.cs
@@ -1,0 +1,106 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S125.DataModel;
+
+/// <summary>The geometry primitive kind of an S-125 feature.</summary>
+public enum S125GeometryKind
+{
+    /// <summary>No geometry (e.g. an <c>AtonAggregation</c>).</summary>
+    None,
+    /// <summary>Single point.</summary>
+    Point,
+    /// <summary>Curve (ordered sequence of coordinates).</summary>
+    Curve,
+    /// <summary>Surface exterior ring (closed sequence of coordinates).</summary>
+    Surface,
+}
+
+/// <summary>
+/// The flavour of an S-125 aggregation / association feature
+/// (S-125 Edition 1.0.0 §AtonAggregation, §AtonAssociation).
+/// </summary>
+public enum S125AggregationKind
+{
+    /// <summary>Unrecognised aggregation type.</summary>
+    Unknown,
+    /// <summary>§AtonAggregation.</summary>
+    Aggregation,
+    /// <summary>§AtonAssociation.</summary>
+    Association,
+}
+
+/// <summary>
+/// Typed projection of an S-125 aggregation or association feature
+/// (S-125 Edition 1.0.0 §AtonAggregation, §AtonAssociation). These
+/// features are geometry-less containers that bind one or more
+/// aids to navigation by xlink.
+/// </summary>
+public sealed class S125Aggregation
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Whether this is an aggregation or an association.</summary>
+    public S125AggregationKind Kind { get; init; }
+
+    /// <summary>The category code, when supplied (§categoryOfAggregation / §categoryOfAssociation).</summary>
+    public int? CategoryCode { get; init; }
+
+    /// <summary>The aids to navigation bound by this aggregation, resolved from feature xlinks.</summary>
+    public ImmutableArray<IS125Aid> Members { get; init; } = ImmutableArray<IS125Aid>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of a <c>SpatialQuality</c> information type
+/// (S-125 Edition 1.0.0 §SpatialQuality).
+/// </summary>
+public sealed class S125SpatialQuality
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The quality-of-position code, when supplied (§qualityOfPosition).</summary>
+    public int? QualityOfPosition { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Catch-all typed projection for S-125 feature classes that the typed
+/// model does not break out individually — the line/area/metadata
+/// features that fall outside the AtoN-status spotlight
+/// (S-125 Edition 1.0.0 §NavigationLine, §RecommendedTrack,
+/// §LocalDirectionOfBuoyage, §NavigationalSystemOfMarks,
+/// §DangerousFeature, §DataCoverage, §QualityOfBathymetricData,
+/// §SoundingDatum, §VerticalDatumOfData).
+/// </summary>
+/// <remarks>
+/// All source attributes survive round-trip via <see cref="ExtraAttributes"/>
+/// so future passes can break individual classes out into dedicated typed
+/// shapes without breaking callers.
+/// </remarks>
+public sealed class S125OtherFeature
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The raw S-125 feature type code.</summary>
+    public required string FeatureType { get; init; }
+
+    /// <summary>The geometry primitive kind.</summary>
+    public S125GeometryKind GeometryKind { get; init; }
+
+    /// <summary>Coordinates whose semantics depend on <see cref="GeometryKind"/>.</summary>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } = ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Datasets.S125/README.md
+++ b/src/EncDotNet.S100.Datasets.S125/README.md
@@ -26,6 +26,50 @@ Key types:
 - **`S125FeatureGeometryProvider`** — `IFeatureGeometryProvider` adapter for the unified Mapsui display-list renderer.
 - **`S125PortrayalCatalogue`** — `IVectorPortrayalCatalogue` implementation that loads XSLT rules, symbols, line styles, area fills, and color palettes.
 
+## Strongly-typed data model
+
+The `EncDotNet.S100.Datasets.S125.DataModel` namespace provides a
+read-only projection of `S125Dataset` into a domain-shaped object graph
+rooted at `S125AtonDataset`. Aids are exposed as typed shapes
+(`S125Buoy`, `S125Beacon`, `S125Light`, `S125AisAton`, `S125Structure`,
+`S125Equipment`) under the common `IS125Aid` interface. AtoN status
+bindings (`AtoNStatus` xlink → `AtonStatusInformation`) and
+equipment-on-structure relationships (`parent` xlink → host beacon /
+landmark) are resolved into navigable properties so callers can ask
+domain questions without walking the feature bag.
+
+The projection is permissive — unresolved xlinks, attribute parse
+failures, and similar issues surface as `ProjectionDiagnostic` entries
+rather than exceptions. Only a fully empty dataset (no features and no
+information types) causes `From(...)` to throw.
+
+### Quick start (typed model)
+
+```csharp
+using EncDotNet.S100.Datasets.S125;
+using EncDotNet.S100.Datasets.S125.DataModel;
+
+var dataset = S125Dataset.Open("path/to/aton.gml");
+var typed = S125AtonDataset.From(dataset, out var diagnostics);
+
+foreach (var aid in typed.Aids)
+{
+    var status = aid.Status?.IsOperational switch
+    {
+        true => "operational",
+        false => "non-operational",
+        null => "no status",
+    };
+    Console.WriteLine($"{aid.FeatureType} {aid.Id}: {status}");
+
+    if (aid is S125AisAton ais && ais.IsVirtual)
+        Console.WriteLine("  (virtual AIS — no physical presence)");
+
+    if (aid.HostStructure is { } host)
+        Console.WriteLine($"  mounted on {host.FeatureType} {host.Id}");
+}
+```
+
 ## Notes
 
 - S-125 application schema namespace is `http://www.iho.int/S125/1.0`; geometry uses the S-100 GML 5.0 profile namespace `http://www.iho.int/s100gml/5.0`. Older sample datasets that still declare the S-100 GML 1.0 profile are read transparently.

--- a/src/EncDotNet.S100.Datasets.S125/S125Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125Dataset.cs
@@ -91,6 +91,20 @@ public sealed class S125Feature : IGmlFeature
     /// rules can resolve cross-references.
     /// </summary>
     public required ImmutableArray<S125InformationReference> InformationReferences { get; init; }
+
+    /// <summary>
+    /// Feature-to-feature association references (e.g. the <c>parent</c> role of
+    /// the <c>StructureEquipment</c> association binding a light to its host
+    /// beacon, or the <c>peerAtonAggregation</c> role on
+    /// <c>AtonAggregation</c>). Each entry preserves the original role name and
+    /// the raw <c>xlink:href</c> value so the strongly-typed projection (S-125
+    /// Edition 1.0.0 §AtonStatusIndicationAssociation, §StructureEquipment,
+    /// §AtonAggregations, §AtonAssociations, §PhysicalAIS, §SyntheticAIS,
+    /// §VirtualAIS, §DangerousFeatureAssociation, §RangeSystem) can resolve
+    /// them at projection time.
+    /// </summary>
+    public ImmutableArray<S125FeatureReference> FeatureReferences { get; init; } =
+        ImmutableArray<S125FeatureReference>.Empty;
 }
 
 /// <summary>
@@ -137,6 +151,25 @@ public sealed class S125InformationReference
 
     /// <summary>The referenced information type's gml:id (without leading <c>#</c>).</summary>
     public required string InformationRef { get; init; }
+}
+
+/// <summary>
+/// A reference from a feature to another feature, captured from an
+/// <c>xlink:href</c>-bearing child element whose target is a
+/// <see cref="S125Feature"/> rather than an <see cref="S125InformationType"/>.
+/// Examples include the <c>parent</c> / <c>child</c> roles of the
+/// <c>StructureEquipment</c> feature association (S-125 Edition 1.0.0
+/// §StructureEquipment), the <c>peerAtonAggregation</c> /
+/// <c>atonAggregationBy</c> roles of <c>AtonAggregations</c>, and the AIS
+/// broadcast association roles.
+/// </summary>
+public sealed class S125FeatureReference
+{
+    /// <summary>The role / association name as written in the source GML.</summary>
+    public required string Role { get; init; }
+
+    /// <summary>The referenced feature's gml:id (without leading <c>#</c>).</summary>
+    public required string FeatureRef { get; init; }
 }
 
 

--- a/src/EncDotNet.S100.Datasets.S125/S125DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125DatasetReader.cs
@@ -84,23 +84,30 @@ internal static class S125DatasetReader
             productId = dsInfo.Element(s100Ns + "productIdentifier")?.Value;
         }
 
-        var features = ImmutableArray.CreateBuilder<S125Feature>();
-        foreach (var member in EnumerateChildren(root, datasetNs, "member"))
-        {
-            foreach (var element in member.Elements())
-            {
-                if (!IsFeatureType(element.Name, datasetNs)) continue;
-                features.Add(ParseFeature(element, s100Ns));
-            }
-        }
-
+        // Two-pass parse: index information-type ids first so xlink-href
+        // children on features can be classified as information references
+        // (target is an imember) vs. feature references (target is a member).
+        var informationTypeIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var informationTypes = ImmutableArray.CreateBuilder<S125InformationType>();
         foreach (var imember in EnumerateChildren(root, datasetNs, "imember"))
         {
             foreach (var element in imember.Elements())
             {
                 if (!IsInformationType(element.Name, datasetNs)) continue;
-                informationTypes.Add(ParseInformationType(element, s100Ns));
+                var info = ParseInformationType(element, s100Ns);
+                informationTypes.Add(info);
+                if (!string.IsNullOrEmpty(info.Id))
+                    informationTypeIds.Add(info.Id);
+            }
+        }
+
+        var features = ImmutableArray.CreateBuilder<S125Feature>();
+        foreach (var member in EnumerateChildren(root, datasetNs, "member"))
+        {
+            foreach (var element in member.Elements())
+            {
+                if (!IsFeatureType(element.Name, datasetNs)) continue;
+                features.Add(ParseFeature(element, s100Ns, informationTypeIds));
             }
         }
 
@@ -142,7 +149,7 @@ internal static class S125DatasetReader
         return S100Ns_5_0;
     }
 
-    private static S125Feature ParseFeature(XElement element, XNamespace s100Ns)
+    private static S125Feature ParseFeature(XElement element, XNamespace s100Ns, HashSet<string> informationTypeIds)
     {
         var id = element.Attribute(GmlNamespaces.Gml + "id")?.Value
             ?? element.Attribute("id")?.Value
@@ -150,7 +157,7 @@ internal static class S125DatasetReader
         var featureType = element.Name.LocalName;
 
         var (geometryType, points, curves, exteriorRing, interiorRings) = ParseGeometry(element, s100Ns);
-        var (simpleAttrs, complexAttrs, infoRefs) = ParseAttributes(element, s100Ns);
+        var (simpleAttrs, complexAttrs, infoRefs, featureRefs) = ParseAttributes(element, s100Ns, informationTypeIds);
 
         return new S125Feature
         {
@@ -164,6 +171,7 @@ internal static class S125DatasetReader
             Attributes = simpleAttrs,
             ComplexAttributes = complexAttrs,
             InformationReferences = infoRefs,
+            FeatureReferences = featureRefs,
         };
     }
 
@@ -174,7 +182,11 @@ internal static class S125DatasetReader
             ?? "";
         var typeCode = element.Name.LocalName;
 
-        var (simpleAttrs, complexAttrs, _) = ParseAttributes(element, s100Ns);
+        // Information types do not themselves carry feature-to-feature xlinks
+        // in the S-125 1.0.0 model. Pass an empty id-set so any xlink child
+        // (if encountered) falls through to the information-reference branch
+        // for backwards compatibility.
+        var (simpleAttrs, complexAttrs, _, _) = ParseAttributes(element, s100Ns, _emptyIdSet);
 
         return new S125InformationType
         {
@@ -184,6 +196,8 @@ internal static class S125DatasetReader
             ComplexAttributes = complexAttrs,
         };
     }
+
+    private static readonly HashSet<string> _emptyIdSet = new(StringComparer.OrdinalIgnoreCase);
 
     // ── Geometry ───────────────────────────────────────────────────────
 
@@ -234,11 +248,12 @@ internal static class S125DatasetReader
         return (geometryType, points, curves, exteriorRing, interiorRings);
     }    // ── Attributes ─────────────────────────────────────────────────────
 
-    private static (ImmutableDictionary<string, string>, ImmutableArray<S125ComplexAttribute>, ImmutableArray<S125InformationReference>) ParseAttributes(XElement element, XNamespace s100Ns)
+    private static (ImmutableDictionary<string, string>, ImmutableArray<S125ComplexAttribute>, ImmutableArray<S125InformationReference>, ImmutableArray<S125FeatureReference>) ParseAttributes(XElement element, XNamespace s100Ns, HashSet<string> informationTypeIds)
     {
         var simple = ImmutableDictionary.CreateBuilder<string, string>();
         var complex = ImmutableArray.CreateBuilder<S125ComplexAttribute>();
         var infoRefs = ImmutableArray.CreateBuilder<S125InformationReference>();
+        var featureRefs = ImmutableArray.CreateBuilder<S125FeatureReference>();
 
         foreach (var child in element.Elements())
         {
@@ -249,17 +264,33 @@ internal static class S125DatasetReader
                 child.Name.Namespace == s100Ns)
                 continue;
 
-            // Information binding: child carries an xlink:href or informationRef
-            // pointing at an imember's gml:id. (S-125 PC's AtoNStatus association.)
+            // Cross-reference binding: child carries an xlink:href or
+            // informationRef. Classify by target:
+            //  - if the fragment id is a known information-type id, emit an
+            //    information reference (existing behaviour);
+            //  - otherwise emit a feature reference (S-125 1.0.0
+            //    §StructureEquipment / §AtonAggregations / §PhysicalAIS / …).
             var href = child.Attribute(XlinkNs + "href")?.Value
                 ?? child.Attribute("informationRef")?.Value;
             if (!string.IsNullOrEmpty(href) && !child.HasElements && string.IsNullOrEmpty(child.Value))
             {
-                infoRefs.Add(new S125InformationReference
+                var trimmed = href.TrimStart('#');
+                if (informationTypeIds.Contains(trimmed))
                 {
-                    Role = localName,
-                    InformationRef = href.TrimStart('#'),
-                });
+                    infoRefs.Add(new S125InformationReference
+                    {
+                        Role = localName,
+                        InformationRef = trimmed,
+                    });
+                }
+                else
+                {
+                    featureRefs.Add(new S125FeatureReference
+                    {
+                        Role = localName,
+                        FeatureRef = trimmed,
+                    });
+                }
                 continue;
             }
 
@@ -287,7 +318,7 @@ internal static class S125DatasetReader
             }
         }
 
-        return (simple.ToImmutable(), complex.ToImmutable(), infoRefs.ToImmutable());
+        return (simple.ToImmutable(), complex.ToImmutable(), infoRefs.ToImmutable(), featureRefs.ToImmutable());
     }
 
     private static bool IsFeatureType(XName name, XNamespace datasetNs)

--- a/tests/EncDotNet.S100.Datasets.S125.Tests/DataModelTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S125.Tests/DataModelTests.cs
@@ -1,0 +1,164 @@
+using System.Linq;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S125.DataModel;
+
+namespace EncDotNet.S100.Datasets.S125.Tests;
+
+public class DataModelTests
+{
+    private static string GetTestDataPath(string filename) =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", filename);
+
+    [Fact]
+    public void From_PointDataset_ProjectsAidsAndResolvesStatus()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_point.gml"));
+
+        var typed = S125AtonDataset.From(dataset, out var diagnostics);
+
+        Assert.Equal("S-125", typed.ProductIdentifier);
+        Assert.Equal(2, typed.Aids.Length);
+        Assert.Single(typed.StatusInformation);
+        Assert.Empty(diagnostics);
+
+        var buoy = Assert.IsType<S125Buoy>(typed.Aids.Single(a => a is S125Buoy));
+        Assert.Equal(S125BuoyKind.Lateral, buoy.Kind);
+        Assert.NotNull(buoy.Position);
+        Assert.Equal(36.95, buoy.Position!.Value.Latitude, 4);
+
+        // xlink-resolved status — the headline value-add.
+        Assert.NotNull(buoy.Status);
+        Assert.Equal(S125ChangeType.AdvanceNoticeOfChange, buoy.Status!.ChangeType);
+        Assert.True(buoy.Status.IsOperational);
+        Assert.NotNull(buoy.Status.FixedDateRange);
+
+        var landmark = Assert.IsType<S125Structure>(typed.Aids.Single(a => a is S125Structure));
+        Assert.Equal(S125StructureKind.Landmark, landmark.Kind);
+        Assert.Null(landmark.Status);
+    }
+
+    [Fact]
+    public void From_RelationshipsDataset_ResolvesHostStructure()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_relationships.gml"));
+
+        var typed = S125AtonDataset.From(dataset, out _);
+
+        var light = typed.Aids.OfType<S125Light>().Single();
+        Assert.NotNull(light.HostStructure);
+        Assert.Equal("beacon1", light.HostStructure!.Id);
+        Assert.IsType<S125Beacon>(light.HostStructure);
+    }
+
+    [Fact]
+    public void From_RelationshipsDataset_DistinguishesVirtualAndPhysicalAis()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_relationships.gml"));
+
+        var typed = S125AtonDataset.From(dataset, out _);
+
+        var ais = typed.Aids.OfType<S125AisAton>().ToList();
+        Assert.Equal(2, ais.Count);
+
+        var virt = ais.Single(a => a.IsVirtual);
+        Assert.Equal(S125AisKind.Virtual, virt.Kind);
+        Assert.Equal("vais1", virt.Id);
+
+        var phys = ais.Single(a => !a.IsVirtual);
+        Assert.Equal(S125AisKind.Physical, phys.Kind);
+    }
+
+    [Fact]
+    public void From_RelationshipsDataset_ResolvesDiscrepancyStatusAsNonOperational()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_relationships.gml"));
+
+        var typed = S125AtonDataset.From(dataset, out _);
+
+        var light = typed.Aids.OfType<S125Light>().Single();
+        Assert.NotNull(light.Status);
+        Assert.Equal(S125ChangeType.Discrepancy, light.Status!.ChangeType);
+        Assert.False(light.Status.IsOperational);
+        Assert.Equal("Light reported unreliable", light.Status.ChangeDetails);
+    }
+
+    [Fact]
+    public void From_RelationshipsDataset_RoundTripsUnknownAttributeViaExtraAttributes()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_relationships.gml"));
+
+        var typed = S125AtonDataset.From(dataset, out _);
+
+        var beacon = typed.Aids.OfType<S125Beacon>().Single();
+        Assert.True(beacon.ExtraAttributes.ContainsKey("customAttribute"));
+        Assert.Equal("extension-value", beacon.ExtraAttributes["customAttribute"]);
+    }
+
+    [Fact]
+    public void From_RelationshipsDataset_ResolvesAggregationMembers()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_relationships.gml"));
+
+        var typed = S125AtonDataset.From(dataset, out _);
+
+        var agg = typed.Aggregations.Single();
+        Assert.Equal(S125AggregationKind.Aggregation, agg.Kind);
+        Assert.Equal(3, agg.Members.Length);
+        Assert.Contains(agg.Members, m => m.Id == "beacon1");
+        Assert.Contains(agg.Members, m => m.Id == "light1");
+        Assert.Contains(agg.Members, m => m.Id == "vais1");
+    }
+
+    [Fact]
+    public void From_RelationshipsDataset_EmitsParseFailureDiagnostic()
+    {
+        var dataset = S125Dataset.Open(GetTestDataPath("aton_relationships.gml"));
+
+        S125AtonDataset.From(dataset, out var diagnostics);
+
+        // categoryOfAggregation="not-a-number" should produce a parse warning.
+        Assert.Contains(diagnostics, d =>
+            d.Code == "attribute.parse.int" &&
+            d.RelatedAttribute == "categoryOfAggregation");
+    }
+
+    [Fact]
+    public void From_UnresolvedStatusXlink_EmitsDiagnosticDoesNotThrow()
+    {
+        var dataset = new S125Dataset
+        {
+            ProductIdentifier = "S-125",
+            DatasetIdentifier = "dangling",
+            Features = System.Collections.Immutable.ImmutableArray.Create(new S125Feature
+            {
+                Id = "buoyX",
+                FeatureType = "LateralBuoy",
+                GeometryType = EncDotNet.S100.Gml.GmlGeometryType.None,
+                Attributes = System.Collections.Immutable.ImmutableDictionary<string, string>.Empty,
+                ComplexAttributes = System.Collections.Immutable.ImmutableArray<S125ComplexAttribute>.Empty,
+                InformationReferences = System.Collections.Immutable.ImmutableArray.Create(
+                    new S125InformationReference { Role = "AtoNStatus", InformationRef = "missing" }),
+            }),
+            InformationTypes = System.Collections.Immutable.ImmutableArray<S125InformationType>.Empty,
+        };
+
+        var typed = S125AtonDataset.From(dataset, out var diagnostics);
+
+        var buoy = typed.Aids.OfType<S125Buoy>().Single();
+        Assert.Null(buoy.Status);
+        Assert.Contains(diagnostics, d => d.Code == "xlink.unresolved");
+    }
+
+    [Fact]
+    public void From_EmptyDataset_Throws()
+    {
+        var empty = new S125Dataset
+        {
+            ProductIdentifier = "S-125",
+            Features = System.Collections.Immutable.ImmutableArray<S125Feature>.Empty,
+            InformationTypes = System.Collections.Immutable.ImmutableArray<S125InformationType>.Empty,
+        };
+
+        Assert.Throws<InvalidOperationException>(() => S125AtonDataset.From(empty, out _));
+    }
+}

--- a/tests/datasets/S125/aton_relationships.gml
+++ b/tests/datasets/S125/aton_relationships.gml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<S125:Dataset xmlns:S125="http://www.iho.int/S125/1.0"
+              xmlns:S100="http://www.iho.int/s100gml/5.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              gml:id="DS_S125_Relationships">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-125</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <!-- Status information with discrepancy (non-operational) -->
+  <S125:imember>
+    <S125:AtonStatusInformation gml:id="info_disc">
+      <S125:changeTypes>2</S125:changeTypes>
+      <S125:changeDetails>Light reported unreliable</S125:changeDetails>
+      <S125:fixedDateRange>
+        <S125:dateStart>2026-02-01T00:00:00Z</S125:dateStart>
+        <S125:dateEnd>2026-02-28T23:59:59Z</S125:dateEnd>
+      </S125:fixedDateRange>
+    </S125:AtonStatusInformation>
+  </S125:imember>
+
+  <!-- Host beacon -->
+  <S125:member>
+    <S125:CardinalBeacon gml:id="beacon1">
+      <S125:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt_b">
+            <gml:pos>37.0000 -76.0000</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S125:geometry>
+      <S125:categoryOfCardinalMark>1</S125:categoryOfCardinalMark>
+      <S125:customAttribute>extension-value</S125:customAttribute>
+    </S125:CardinalBeacon>
+  </S125:member>
+
+  <!-- Light mounted on the beacon, with discrepancy status -->
+  <S125:member>
+    <S125:LightAllAround gml:id="light1">
+      <S125:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt_l">
+            <gml:pos>37.0000 -76.0000</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S125:geometry>
+      <S125:colour>3</S125:colour>
+      <S125:AtoNStatus xlink:href="#info_disc"/>
+      <S125:parent xlink:href="#beacon1"/>
+    </S125:LightAllAround>
+  </S125:member>
+
+  <!-- Virtual AIS AtoN -->
+  <S125:member>
+    <S125:VirtualAISAidToNavigation gml:id="vais1">
+      <S125:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt_v">
+            <gml:pos>37.0500 -76.1000</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S125:geometry>
+      <S125:virtualAISAidToNavigationType>1</S125:virtualAISAidToNavigationType>
+    </S125:VirtualAISAidToNavigation>
+  </S125:member>
+
+  <!-- Physical AIS AtoN with bogus integer to exercise parse failure path -->
+  <S125:member>
+    <S125:PhysicalAISAidToNavigation gml:id="pais1">
+      <S125:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt_p">
+            <gml:pos>37.0600 -76.1100</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S125:geometry>
+    </S125:PhysicalAISAidToNavigation>
+  </S125:member>
+
+  <!-- Aggregation tying the beacon, light, and virtual AIS together (bad CategoryCode) -->
+  <S125:member>
+    <S125:AtonAggregation gml:id="agg1">
+      <S125:categoryOfAggregation>not-a-number</S125:categoryOfAggregation>
+      <S125:peerAtonAggregation xlink:href="#beacon1"/>
+      <S125:peerAtonAggregation xlink:href="#light1"/>
+      <S125:peerAtonAggregation xlink:href="#vais1"/>
+    </S125:AtonAggregation>
+  </S125:member>
+
+</S125:Dataset>


### PR DESCRIPTION
Pass 2 of the typed-data-model rollout. Adds `EncDotNet.S100.Datasets.S125.DataModel` — a read-only projection rooted at `S125AtonDataset`, mirroring the S-421/S-124 reference consumers over the shared abstractions in `EncDotNet.S100.Core/DataModel/` (no changes to those abstractions).

## Headline value-add

AtoN status is xlink-resolved at projection time, so callers no longer walk the feature bag:

```csharp
var typed = S125AtonDataset.From(dataset, out var diagnostics);
foreach (var aid in typed.Aids)
    Console.WriteLine($"{aid.FeatureType} {aid.Id}: {aid.Status?.IsOperational}");
```

## What's new

**Typed feature graph (all implement `IS125Aid`):**

| Typed shape | FC families covered | Discriminator |
|---|---|---|
| `S125Buoy` | All `*Buoy` classes (8) | `S125BuoyKind` |
| `S125Beacon` | All `*Beacon` classes (5) | `S125BeaconKind` |
| `S125Light` | All `Light*` classes (6) | `S125LightKind` |
| `S125AisAton` | Physical / Synthetic / Virtual AIS | `S125AisKind` + `IsVirtual` |
| `S125Structure` | Landmark, Daymark, OffshorePlatform, Pile, SiloTank, WindTurbine, Topmark | `S125StructureKind` |
| `S125Equipment` | FogSignal, RadarReflector, Retroreflector, RadarTransponderBeacon, RadioStation | `S125EquipmentKind` |

**Supporting shapes:**
- `S125AtonStatusInformation` — change classification with `IsOperational` heuristic over the FC `changeTypes` enumeration; shared by reference across all aids bound to it.
- `S125AtonStatusIndication`, `S125SpatialQuality`, `S125Aggregation` (covers `AtonAggregation`+`AtonAssociation`), `S125OtherFeature` catch-all for line/area/metadata features.

**Xlink resolution:**
- `aid.Status` — `AtoNStatus` info-type binding (case-insensitive role lookup).
- `aid.HostStructure` — `parent` feature-association role (e.g. light → host beacon).
- `aggregation.Members` — `peerAtonAggregation` feature xlinks.

## Reader extension (additive, S-125-local)

`S125Feature` gains a `FeatureReferences` collection to support feature-to-feature xlinks. The reader now indexes `imember` ids first, then classifies each child `xlink:href` as info-ref vs feature-ref. All pre-existing tests continue to pass without modification.

## Tests

9 new tests in `DataModelTests.cs` covering all required scenarios:
- Projection round-trip
- xlink status resolution (operational + discrepancy)
- Host-structure resolution (light → beacon)
- Virtual vs physical AIS distinction
- Unknown-attribute round-trip via `ExtraAttributes`
- Aggregation member resolution
- Parse-failure diagnostic (`attribute.parse.int`)
- Unresolved-xlink diagnostic (no throw)
- Missing-root throw

Existing `aton_point.gml` reused; new `aton_relationships.gml` fixture added for the relationship scenarios. Total S-125 tests: 15/15 passing.

## Docs

- `src/EncDotNet.S100.Datasets.S125/README.md` — added "Strongly-typed data model" section with quick-start snippet.
- Root `README.md` — S-125 libraries entry mentions the typed model.

## Constraints honoured

- No changes to `EncDotNet.S100.Core/DataModel/` (stable from Pass 1).
- No changes to S-421 or S-124 typed models.
- Permissive projection — only throws for the missing-root condition (no features and no information types).
- Nullable correctness, XML doc comments on all public APIs, `ArgumentNullException.ThrowIfNull`.
- Cites S-125 Edition 1.0.0 sections in XML docs for spec-derived constants.