### PR TITLE
Add strongly-typed DataModel projection to S-201

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ into focused packages:
 | **EncDotNet.S100.Datasets.S128** | S-128 catalogue of nautical products reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S129** | S-129 under keel clearance reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S131** | S-131 marine harbour infrastructure reader and Lua portrayal pipeline (GML+Lua hybrid). |
-| **EncDotNet.S100.Datasets.S201** | S-201 aids to navigation information (IALA, authority-to-authority exchange) reader and XSLT portrayal pipeline. |
+| **EncDotNet.S100.Datasets.S201** | S-201 aids to navigation information (IALA, authority-to-authority exchange) reader, XSLT portrayal pipeline, and strongly-typed AtoN inventory data model. |
 | **EncDotNet.S100.Datasets.S411** | S-411 sea ice reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S421** | S-421 route plan reader and XSLT portrayal pipeline. |
 | **EncDotNet.S100.Datasets.S57** | Legacy S-57 ENC reader that translates to the in-memory S-101 model. |

--- a/src/EncDotNet.S100.Datasets.S201/DataModel/S201AtonInventory.cs
+++ b/src/EncDotNet.S100.Datasets.S201/DataModel/S201AtonInventory.cs
@@ -1,0 +1,913 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S201.DataModel;
+
+/// <summary>
+/// Strongly-typed projection of an <see cref="S201Dataset"/> as an
+/// authoritative AtoN inventory (S-201 Edition 2.0.0).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The inventory exposes typed AtoN objects (structures, equipment,
+/// lights, electronic AIS aids), back-resolved equipment ↔ host-structure
+/// subordination chains, lifecycle attributes, AtoN status timelines,
+/// and aggregation / association graphs.
+/// </para>
+/// <para>
+/// Projection issues — unresolved xlinks, attribute parse failures,
+/// duplicate identifiers — surface as <see cref="ProjectionDiagnostic"/>
+/// entries rather than exceptions. The projection only throws when the
+/// source dataset has no features and no information types (i.e. is
+/// fully empty).
+/// </para>
+/// <para>
+/// <b>Distinct from S-125:</b> the S-201 typed model exposes equipment
+/// ↔ host-structure subordination, AtoN lifecycle, AtoN status
+/// timelines, positioning / fixing-method bindings, AIS-AtoN MMSI, and
+/// remote-monitoring-system metadata — none of which appear in the
+/// (ECDIS-focused) S-125 typed model.
+/// </para>
+/// </remarks>
+public sealed class S201AtonInventory
+{
+    /// <summary>The dataset identifier carried by the source GML <c>Dataset</c> element.</summary>
+    public string? DatasetIdentifier { get; init; }
+
+    /// <summary>The S-201 product identifier (typically <c>"S-201"</c>).</summary>
+    public string? ProductIdentifier { get; init; }
+
+    /// <summary>Every AtoN object in the dataset, in source order.</summary>
+    public required ImmutableArray<S201AtonObject> AtoNs { get; init; }
+
+    /// <summary>Typed view of <see cref="AtoNs"/> filtered to <see cref="S201StructureObject"/>s.</summary>
+    public ImmutableArray<S201StructureObject> Structures { get; init; } =
+        ImmutableArray<S201StructureObject>.Empty;
+
+    /// <summary>Typed view of <see cref="AtoNs"/> filtered to <see cref="S201Equipment"/> (includes lights).</summary>
+    public ImmutableArray<S201Equipment> Equipment { get; init; } =
+        ImmutableArray<S201Equipment>.Empty;
+
+    /// <summary>Typed view of <see cref="AtoNs"/> filtered to <see cref="S201ElectronicAtoN"/>s.</summary>
+    public ImmutableArray<S201ElectronicAtoN> ElectronicAtoNs { get; init; } =
+        ImmutableArray<S201ElectronicAtoN>.Empty;
+
+    /// <summary>AtoN aggregations declared in the dataset.</summary>
+    public ImmutableArray<S201AtonAggregation> Aggregations { get; init; } =
+        ImmutableArray<S201AtonAggregation>.Empty;
+
+    /// <summary>AtoN associations declared in the dataset.</summary>
+    public ImmutableArray<S201AtonAssociation> Associations { get; init; } =
+        ImmutableArray<S201AtonAssociation>.Empty;
+
+    /// <summary>AtoN status information records (FC: <c>AtonStatusInformation</c>).</summary>
+    public ImmutableArray<S201AtonStatusInformation> StatusInformation { get; init; } =
+        ImmutableArray<S201AtonStatusInformation>.Empty;
+
+    /// <summary>Positioning information records (FC: <c>PositioningInformation</c>).</summary>
+    public ImmutableArray<S201PositioningInformationRecord> PositioningInformation { get; init; } =
+        ImmutableArray<S201PositioningInformationRecord>.Empty;
+
+    /// <summary>Fixing-method records (FC: <c>AtoNFixingMethod</c>).</summary>
+    public ImmutableArray<S201AtoNFixingMethodRecord> FixingMethods { get; init; } =
+        ImmutableArray<S201AtoNFixingMethodRecord>.Empty;
+
+    /// <summary>Spatial quality records (FC: <c>SpatialQuality</c>).</summary>
+    public ImmutableArray<S201SpatialQuality> SpatialQualities { get; init; } =
+        ImmutableArray<S201SpatialQuality>.Empty;
+
+    /// <summary>The originating feature-bag dataset.</summary>
+    public required S201Dataset Source { get; init; }
+
+    /// <summary>
+    /// Projects a feature-bag <see cref="S201Dataset"/> into the typed
+    /// data model. Issues encountered during projection are reported
+    /// via <paramref name="diagnostics"/>; the projection only throws
+    /// for a fully empty dataset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the dataset contains neither features nor information
+    /// types.
+    /// </exception>
+    public static S201AtonInventory From(S201Dataset dataset, out IReadOnlyList<ProjectionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        if (dataset.Features.IsDefaultOrEmpty && dataset.InformationTypes.IsDefaultOrEmpty)
+            throw new InvalidOperationException("Dataset contains no features and no information types.");
+
+        var ctx = new ProjectionContext(BuildXlinkResolver(dataset));
+
+        // Pass 1: project information types (no cross-refs).
+        var statusInfo = ProjectStatusInformation(dataset, ctx);
+        var positioning = ProjectPositioningInformation(dataset, ctx);
+        var fixing = ProjectFixingMethods(dataset, ctx);
+        var spatialQuality = ProjectSpatialQuality(dataset, ctx);
+
+        var statusInfoById = statusInfo.ToImmutableDictionary(s => s.Id, StringComparer.OrdinalIgnoreCase);
+        var positioningById = positioning.ToImmutableDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
+        var fixingById = fixing.ToImmutableDictionary(f => f.Id, StringComparer.OrdinalIgnoreCase);
+
+        // Pass 2: project all AtoN features (cross-refs left empty for now).
+        var atons = ImmutableArray.CreateBuilder<S201AtonObject>();
+        var aggregationFeatures = new List<S201Feature>();
+        var associationFeatures = new List<S201Feature>();
+
+        if (!dataset.Features.IsDefaultOrEmpty)
+        {
+            foreach (var f in dataset.Features)
+            {
+                if (IsAggregationContainer(f.FeatureType))
+                {
+                    aggregationFeatures.Add(f);
+                    continue;
+                }
+                if (IsAssociationContainer(f.FeatureType))
+                {
+                    associationFeatures.Add(f);
+                    continue;
+                }
+
+                atons.Add(ProjectAton(f, ctx, statusInfoById, positioningById, fixingById));
+            }
+        }
+
+        var atonArray = atons.ToImmutable();
+        var atonsById = new Dictionary<string, S201AtonObject>(StringComparer.OrdinalIgnoreCase);
+        foreach (var a in atonArray)
+            atonsById[a.Id] = a;
+
+        // Pass 3: wire equipment ↔ host-structure subordination.
+        ResolveSubordination(atonArray, atonsById, ctx);
+
+        // Pass 4: project aggregations / associations (now that AtoNs are indexed).
+        var aggregations = ProjectAggregations(aggregationFeatures, atonsById, ctx);
+        var associations = ProjectAssociations(associationFeatures, atonsById, ctx);
+
+        // Pass 5: back-fill aggregation / association membership on each AtoN.
+        BackFillMembership(atonArray, aggregations, associations);
+
+        // Typed views.
+        var structures = atonArray.OfType<S201StructureObject>().ToImmutableArray();
+        var equipment = atonArray.OfType<S201Equipment>().ToImmutableArray();
+        var electronic = atonArray.OfType<S201ElectronicAtoN>().ToImmutableArray();
+
+        diagnostics = ctx.ToImmutableDiagnostics();
+        return new S201AtonInventory
+        {
+            DatasetIdentifier = dataset.DatasetIdentifier,
+            ProductIdentifier = dataset.ProductIdentifier,
+            AtoNs = atonArray,
+            Structures = structures,
+            Equipment = equipment,
+            ElectronicAtoNs = electronic,
+            Aggregations = aggregations,
+            Associations = associations,
+            StatusInformation = statusInfo,
+            PositioningInformation = positioning,
+            FixingMethods = fixing,
+            SpatialQualities = spatialQuality,
+            Source = dataset,
+        };
+    }
+
+    private static XlinkResolver BuildXlinkResolver(S201Dataset dataset)
+    {
+        IEnumerable<KeyValuePair<string, object>> All()
+        {
+            if (!dataset.Features.IsDefaultOrEmpty)
+                foreach (var f in dataset.Features)
+                    yield return new KeyValuePair<string, object>(f.Id, f);
+            if (!dataset.InformationTypes.IsDefaultOrEmpty)
+                foreach (var i in dataset.InformationTypes)
+                    yield return new KeyValuePair<string, object>(i.Id, i);
+        }
+        return XlinkResolver.Build(All());
+    }
+
+    private static bool IsAggregationContainer(string featureType) =>
+        string.Equals(featureType, "AtonAggregation", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAssociationContainer(string featureType) =>
+        string.Equals(featureType, "AtonAssociation", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsParentRole(string role) =>
+        string.Equals(role, "theParentFeature", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(role, "parent", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPeerRole(string role) =>
+        string.Equals(role, "peer", StringComparison.OrdinalIgnoreCase);
+
+    // -------------------------------------------------------------------
+    // Information-type projections
+    // -------------------------------------------------------------------
+
+    private static ImmutableArray<S201AtonStatusInformation> ProjectStatusInformation(S201Dataset dataset, ProjectionContext ctx)
+    {
+        var b = ImmutableArray.CreateBuilder<S201AtonStatusInformation>();
+        if (dataset.InformationTypes.IsDefaultOrEmpty) return b.ToImmutable();
+        foreach (var i in dataset.InformationTypes)
+        {
+            if (!string.Equals(i.TypeCode, "AtonStatusInformation", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var changeDetails = i.ComplexAttributes
+                .FirstOrDefault(c => string.Equals(c.Code, "ChangeDetails", StringComparison.OrdinalIgnoreCase))
+                ?.SubAttributes ?? ImmutableDictionary<string, string>.Empty;
+            b.Add(new S201AtonStatusInformation
+            {
+                Id = i.Id,
+                ChangeTypes = AttributeParser.TryParseInt(
+                    i.Attributes.GetValueOrDefault("ChangeTypes")
+                        ?? i.Attributes.GetValueOrDefault("changeTypes"),
+                    ctx, i.Id, "ChangeTypes"),
+                ChangeDetails = changeDetails,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes, "ChangeTypes", "changeTypes"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201PositioningInformationRecord> ProjectPositioningInformation(S201Dataset dataset, ProjectionContext ctx)
+    {
+        var b = ImmutableArray.CreateBuilder<S201PositioningInformationRecord>();
+        if (dataset.InformationTypes.IsDefaultOrEmpty) return b.ToImmutable();
+        foreach (var i in dataset.InformationTypes)
+        {
+            if (!string.Equals(i.TypeCode, "PositioningInformation", StringComparison.OrdinalIgnoreCase))
+                continue;
+            b.Add(new S201PositioningInformationRecord
+            {
+                Id = i.Id,
+                PositioningDevice = i.Attributes.GetValueOrDefault("positioningDevice"),
+                PositioningMethod = i.Attributes.GetValueOrDefault("positioningMethod"),
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes, "positioningDevice", "positioningMethod"),
+            });
+        }
+        _ = ctx; // no parse calls yet
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201AtoNFixingMethodRecord> ProjectFixingMethods(S201Dataset dataset, ProjectionContext ctx)
+    {
+        var b = ImmutableArray.CreateBuilder<S201AtoNFixingMethodRecord>();
+        if (dataset.InformationTypes.IsDefaultOrEmpty) return b.ToImmutable();
+        foreach (var i in dataset.InformationTypes)
+        {
+            if (!string.Equals(i.TypeCode, "AtoNFixingMethod", StringComparison.OrdinalIgnoreCase))
+                continue;
+            b.Add(new S201AtoNFixingMethodRecord
+            {
+                Id = i.Id,
+                ReferencePoint = i.Attributes.GetValueOrDefault("referencePoint"),
+                HorizontalDatum = AttributeParser.TryParseInt(
+                    i.Attributes.GetValueOrDefault("horizontalDatum"), ctx, i.Id, "horizontalDatum"),
+                SourceDate = AttributeParser.TryParseDateTimeOffset(
+                    i.Attributes.GetValueOrDefault("sourceDate"), ctx, i.Id, "sourceDate"),
+                PositioningProcedure = i.Attributes.GetValueOrDefault("positioningProcedure"),
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    "referencePoint", "horizontalDatum", "sourceDate", "positioningProcedure"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201SpatialQuality> ProjectSpatialQuality(S201Dataset dataset, ProjectionContext ctx)
+    {
+        var b = ImmutableArray.CreateBuilder<S201SpatialQuality>();
+        if (dataset.InformationTypes.IsDefaultOrEmpty) return b.ToImmutable();
+        foreach (var i in dataset.InformationTypes)
+        {
+            if (!string.Equals(i.TypeCode, "SpatialQuality", StringComparison.OrdinalIgnoreCase))
+                continue;
+            b.Add(new S201SpatialQuality
+            {
+                Id = i.Id,
+                QualityOfHorizontalMeasurement = AttributeParser.TryParseInt(
+                    i.Attributes.GetValueOrDefault("qualityOfHorizontalMeasurement"),
+                    ctx, i.Id, "qualityOfHorizontalMeasurement"),
+                SpatialAccuracy = AttributeParser.TryParseDouble(
+                    i.Attributes.GetValueOrDefault("spatialAccuracy"), ctx, i.Id, "spatialAccuracy"),
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    "qualityOfHorizontalMeasurement", "spatialAccuracy"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    // -------------------------------------------------------------------
+    // AtoN projection (dispatch on feature class)
+    // -------------------------------------------------------------------
+
+    private static S201AtonObject ProjectAton(S201Feature f, ProjectionContext ctx,
+        IReadOnlyDictionary<string, S201AtonStatusInformation> statusInfo,
+        IReadOnlyDictionary<string, S201PositioningInformationRecord> positioning,
+        IReadOnlyDictionary<string, S201AtoNFixingMethodRecord> fixing)
+    {
+        // Resolve AtoNStatus information bindings.
+        var status = ResolveStatusInformation(f, ctx, statusInfo);
+        var (kind, coords) = ProjectGeometry(f);
+
+        // Light? → S201Light (Equipment subclass)
+        if (TryGetLightKind(f.FeatureType, out var lightKind))
+        {
+            return new S201Light
+            {
+                Id = f.Id,
+                FeatureClass = f.FeatureType,
+                Source = f,
+                GeometryKind = kind,
+                Coordinates = coords,
+                Kind = lightKind,
+                IdCode = f.Attributes.GetValueOrDefault("iDCode"),
+                Information = f.Attributes.GetValueOrDefault("information"),
+                FeatureNames = ProjectFeatureNames(f, ctx),
+                ScaleMinimum = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+                SourceDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("sourceDate"), ctx, f.Id, "sourceDate"),
+                SourceText = f.Attributes.GetValueOrDefault("source"),
+                PictorialRepresentation = f.Attributes.GetValueOrDefault("pictorialRepresentation"),
+                InspectionFrequency = f.Attributes.GetValueOrDefault("inspectionFrequency"),
+                InspectionRequirements = f.Attributes.GetValueOrDefault("inspectionRequirements"),
+                AtoNMaintenanceRecord = f.Attributes.GetValueOrDefault("aToNMaintenanceRecord"),
+                InstallationDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("installationDate"), ctx, f.Id, "installationDate"),
+                FixedDateRange = ProjectDateRange(f, "fixedDateRange", ctx),
+                PeriodicDateRange = ProjectDateRange(f, "periodicDateRange", ctx),
+                SeasonalActionRequired = ImmutableArray<string>.Empty,
+                StatusInformation = status,
+                RemoteMonitoringSystem = f.Attributes.GetValueOrDefault("remoteMonitoringSystem"),
+                Height = AttributeParser.TryParseDouble(
+                    f.Attributes.GetValueOrDefault("height"), ctx, f.Id, "height"),
+                Status = ParseIntList(f.Attributes.GetValueOrDefault("status"), ctx, f.Id, "status"),
+                VerticalDatum = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("verticalDatum"), ctx, f.Id, "verticalDatum"),
+                VerticalLength = AttributeParser.TryParseDouble(
+                    f.Attributes.GetValueOrDefault("verticalLength"), ctx, f.Id, "verticalLength"),
+                EffectiveIntensity = AttributeParser.TryParseDouble(
+                    f.Attributes.GetValueOrDefault("effectiveIntensity"), ctx, f.Id, "effectiveIntensity"),
+                PeakIntensity = AttributeParser.TryParseDouble(
+                    f.Attributes.GetValueOrDefault("peakIntensity"), ctx, f.Id, "peakIntensity"),
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, LightKnownAttributes),
+            };
+        }
+
+        // Electronic AIS AtoN?
+        if (TryGetAisAtonKind(f.FeatureType, out var aisKind))
+        {
+            return new S201ElectronicAtoN
+            {
+                Id = f.Id,
+                FeatureClass = f.FeatureType,
+                Source = f,
+                GeometryKind = kind,
+                Coordinates = coords,
+                Kind = aisKind,
+                IdCode = f.Attributes.GetValueOrDefault("iDCode"),
+                Information = f.Attributes.GetValueOrDefault("information"),
+                FeatureNames = ProjectFeatureNames(f, ctx),
+                ScaleMinimum = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+                SourceDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("sourceDate"), ctx, f.Id, "sourceDate"),
+                SourceText = f.Attributes.GetValueOrDefault("source"),
+                PictorialRepresentation = f.Attributes.GetValueOrDefault("pictorialRepresentation"),
+                InspectionFrequency = f.Attributes.GetValueOrDefault("inspectionFrequency"),
+                InspectionRequirements = f.Attributes.GetValueOrDefault("inspectionRequirements"),
+                AtoNMaintenanceRecord = f.Attributes.GetValueOrDefault("aToNMaintenanceRecord"),
+                InstallationDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("installationDate"), ctx, f.Id, "installationDate"),
+                FixedDateRange = ProjectDateRange(f, "fixedDateRange", ctx),
+                PeriodicDateRange = ProjectDateRange(f, "periodicDateRange", ctx),
+                SeasonalActionRequired = ImmutableArray<string>.Empty,
+                StatusInformation = status,
+                AtoNNumber = f.Attributes.GetValueOrDefault("AtoNNumber"),
+                MmsiCode = f.Attributes.GetValueOrDefault("mMSICode"),
+                Status = ParseIntList(f.Attributes.GetValueOrDefault("status"), ctx, f.Id, "status"),
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, ElectronicKnownAttributes),
+            };
+        }
+
+        // Equipment? (anything with theParentFeature reference but not a light or AIS — heuristic
+        // based on FC `superType=Equipment`; we use the role/structural cue here.)
+        var hasParentRef = !f.FeatureReferences.IsDefaultOrEmpty
+            && f.FeatureReferences.Any(r => IsParentRole(r.Role));
+        if (hasParentRef && !IsKnownStructureType(f.FeatureType))
+        {
+            return new S201Equipment
+            {
+                Id = f.Id,
+                FeatureClass = f.FeatureType,
+                Source = f,
+                GeometryKind = kind,
+                Coordinates = coords,
+                IdCode = f.Attributes.GetValueOrDefault("iDCode"),
+                Information = f.Attributes.GetValueOrDefault("information"),
+                FeatureNames = ProjectFeatureNames(f, ctx),
+                ScaleMinimum = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+                SourceDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("sourceDate"), ctx, f.Id, "sourceDate"),
+                SourceText = f.Attributes.GetValueOrDefault("source"),
+                PictorialRepresentation = f.Attributes.GetValueOrDefault("pictorialRepresentation"),
+                InspectionFrequency = f.Attributes.GetValueOrDefault("inspectionFrequency"),
+                InspectionRequirements = f.Attributes.GetValueOrDefault("inspectionRequirements"),
+                AtoNMaintenanceRecord = f.Attributes.GetValueOrDefault("aToNMaintenanceRecord"),
+                InstallationDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("installationDate"), ctx, f.Id, "installationDate"),
+                FixedDateRange = ProjectDateRange(f, "fixedDateRange", ctx),
+                PeriodicDateRange = ProjectDateRange(f, "periodicDateRange", ctx),
+                SeasonalActionRequired = ImmutableArray<string>.Empty,
+                StatusInformation = status,
+                RemoteMonitoringSystem = f.Attributes.GetValueOrDefault("remoteMonitoringSystem"),
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, EquipmentKnownAttributes),
+            };
+        }
+
+        // Structure? (anything with structure-typed attributes or known structure-class names.)
+        if (IsKnownStructureType(f.FeatureType) || HasStructureSignal(f))
+        {
+            var positioningInfo = ResolvePositioningInformation(f, ctx, positioning);
+            var fixingInfo = ResolveFixingMethods(f, ctx, fixing);
+
+            return new S201StructureObject
+            {
+                Id = f.Id,
+                FeatureClass = f.FeatureType,
+                Source = f,
+                GeometryKind = kind,
+                Coordinates = coords,
+                IdCode = f.Attributes.GetValueOrDefault("iDCode"),
+                Information = f.Attributes.GetValueOrDefault("information"),
+                FeatureNames = ProjectFeatureNames(f, ctx),
+                ScaleMinimum = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+                SourceDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("sourceDate"), ctx, f.Id, "sourceDate"),
+                SourceText = f.Attributes.GetValueOrDefault("source"),
+                PictorialRepresentation = f.Attributes.GetValueOrDefault("pictorialRepresentation"),
+                InspectionFrequency = f.Attributes.GetValueOrDefault("inspectionFrequency"),
+                InspectionRequirements = f.Attributes.GetValueOrDefault("inspectionRequirements"),
+                AtoNMaintenanceRecord = f.Attributes.GetValueOrDefault("aToNMaintenanceRecord"),
+                InstallationDate = AttributeParser.TryParseDateTimeOffset(
+                    f.Attributes.GetValueOrDefault("installationDate"), ctx, f.Id, "installationDate"),
+                FixedDateRange = ProjectDateRange(f, "fixedDateRange", ctx),
+                PeriodicDateRange = ProjectDateRange(f, "periodicDateRange", ctx),
+                SeasonalActionRequired = ImmutableArray<string>.Empty,
+                StatusInformation = status,
+                AtoNNumber = f.Attributes.GetValueOrDefault("AtoNNumber"),
+                AidAvailabilityCategory = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("aidAvailabilityCategory"), ctx, f.Id, "aidAvailabilityCategory"),
+                Condition = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("condition"), ctx, f.Id, "condition"),
+                ContactAddress = f.Attributes.GetValueOrDefault("contactAddress"),
+                PositioningInformation = positioningInfo,
+                FixingMethods = fixingInfo,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, StructureKnownAttributes),
+            };
+        }
+
+        // Fallback: generic AtoN object (NavigationLine, DangerousFeature, DataCoverage, etc.).
+        return new S201GenericAtonObject
+        {
+            Id = f.Id,
+            FeatureClass = f.FeatureType,
+            Source = f,
+            GeometryKind = kind,
+            Coordinates = coords,
+            IdCode = f.Attributes.GetValueOrDefault("iDCode"),
+            Information = f.Attributes.GetValueOrDefault("information"),
+            FeatureNames = ProjectFeatureNames(f, ctx),
+            ScaleMinimum = AttributeParser.TryParseInt(
+                f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+            SourceDate = AttributeParser.TryParseDateTimeOffset(
+                f.Attributes.GetValueOrDefault("sourceDate"), ctx, f.Id, "sourceDate"),
+            SourceText = f.Attributes.GetValueOrDefault("source"),
+            PictorialRepresentation = f.Attributes.GetValueOrDefault("pictorialRepresentation"),
+            InspectionFrequency = f.Attributes.GetValueOrDefault("inspectionFrequency"),
+            InspectionRequirements = f.Attributes.GetValueOrDefault("inspectionRequirements"),
+            AtoNMaintenanceRecord = f.Attributes.GetValueOrDefault("aToNMaintenanceRecord"),
+            InstallationDate = AttributeParser.TryParseDateTimeOffset(
+                f.Attributes.GetValueOrDefault("installationDate"), ctx, f.Id, "installationDate"),
+            FixedDateRange = ProjectDateRange(f, "fixedDateRange", ctx),
+            PeriodicDateRange = ProjectDateRange(f, "periodicDateRange", ctx),
+            SeasonalActionRequired = ImmutableArray<string>.Empty,
+            StatusInformation = status,
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, CommonKnownAttributes),
+        };
+    }
+
+    private static readonly string[] CommonKnownAttributes =
+    {
+        "iDCode", "information", "scaleMinimum", "sourceDate", "source",
+        "pictorialRepresentation", "inspectionFrequency", "inspectionRequirements",
+        "aToNMaintenanceRecord", "installationDate",
+    };
+
+    private static readonly string[] EquipmentKnownAttributes =
+    {
+        "iDCode", "information", "scaleMinimum", "sourceDate", "source",
+        "pictorialRepresentation", "inspectionFrequency", "inspectionRequirements",
+        "aToNMaintenanceRecord", "installationDate", "remoteMonitoringSystem",
+    };
+
+    private static readonly string[] LightKnownAttributes =
+    {
+        "iDCode", "information", "scaleMinimum", "sourceDate", "source",
+        "pictorialRepresentation", "inspectionFrequency", "inspectionRequirements",
+        "aToNMaintenanceRecord", "installationDate", "remoteMonitoringSystem",
+        "height", "status", "verticalDatum", "verticalLength",
+        "effectiveIntensity", "peakIntensity",
+    };
+
+    private static readonly string[] ElectronicKnownAttributes =
+    {
+        "iDCode", "information", "scaleMinimum", "sourceDate", "source",
+        "pictorialRepresentation", "inspectionFrequency", "inspectionRequirements",
+        "aToNMaintenanceRecord", "installationDate",
+        "AtoNNumber", "mMSICode", "status",
+    };
+
+    private static readonly string[] StructureKnownAttributes =
+    {
+        "iDCode", "information", "scaleMinimum", "sourceDate", "source",
+        "pictorialRepresentation", "inspectionFrequency", "inspectionRequirements",
+        "aToNMaintenanceRecord", "installationDate",
+        "AtoNNumber", "aidAvailabilityCategory", "condition", "contactAddress",
+    };
+
+    private static bool TryGetLightKind(string featureType, out LightKind kind)
+    {
+        switch (featureType)
+        {
+            case "LightSectored": kind = LightKind.Sectored; return true;
+            case "LightAllAround": kind = LightKind.AllAround; return true;
+            case "LightAirObstruction": kind = LightKind.AirObstruction; return true;
+            case "LightFogDetector": kind = LightKind.FogDetector; return true;
+            case "Light":
+                // Generic placeholder used in some encodings — preserve via Unknown kind.
+                kind = LightKind.Unknown;
+                return true;
+        }
+        kind = LightKind.Unknown;
+        return false;
+    }
+
+    private static bool TryGetAisAtonKind(string featureType, out AisAtonKind kind)
+    {
+        switch (featureType)
+        {
+            case "VirtualAISAidToNavigation": kind = AisAtonKind.Virtual; return true;
+            case "PhysicalAISAidToNavigation": kind = AisAtonKind.Physical; return true;
+            case "SyntheticAISAidToNavigation": kind = AisAtonKind.Synthetic; return true;
+        }
+        kind = AisAtonKind.Unknown;
+        return false;
+    }
+
+    // Direct StructureObject concrete leaves declared in S-201 Edition 2.0.0 Annex C.
+    // This list intentionally excludes Equipment / GenericLight / ElectronicAton subclasses,
+    // dataset-metadata features (DataCoverage, etc.), and direct AidsToNavigation children
+    // that are not structures (NavigationLine, Topmark, …).
+    private static readonly HashSet<string> KnownStructureTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Direct StructureObject concretes and their FC-leaf subclasses.
+        "Landmark", "Lighthouse", "LightFloat", "LightVessel",
+        "OffshorePlatform", "SiloTank", "Pile", "Building", "Bridge",
+        // Beacons.
+        "CardinalBeacon", "IsolatedDangerBeacon", "LateralBeacon",
+        "SafeWaterBeacon", "SpecialPurposeGeneralBeacon",
+        // Buoys.
+        "CardinalBuoy", "InstallationBuoy", "IsolatedDangerBuoy",
+        "LateralBuoy", "SafeWaterBuoy", "SpecialPurposeGeneralBuoy",
+        "EmergencyWreckMarkingBuoy",
+        // Generic abstract supertypes used as concrete in some encodings.
+        "GenericBeacon", "GenericBuoy", "StructureObject",
+    };
+
+    private static bool IsKnownStructureType(string featureType) =>
+        KnownStructureTypes.Contains(featureType);
+
+    private static bool HasStructureSignal(S201Feature f) =>
+        f.Attributes.ContainsKey("AtoNNumber")
+        || f.Attributes.ContainsKey("aidAvailabilityCategory")
+        || f.Attributes.ContainsKey("condition")
+        || f.Attributes.ContainsKey("contactAddress");
+
+    // -------------------------------------------------------------------
+    // Per-feature helpers
+    // -------------------------------------------------------------------
+
+    private static ImmutableArray<S201FeatureNameRecord> ProjectFeatureNames(S201Feature f, ProjectionContext ctx)
+    {
+        if (f.ComplexAttributes.IsDefaultOrEmpty) return ImmutableArray<S201FeatureNameRecord>.Empty;
+        var b = ImmutableArray.CreateBuilder<S201FeatureNameRecord>();
+        foreach (var ca in f.ComplexAttributes)
+        {
+            if (!string.Equals(ca.Code, "featureName", StringComparison.OrdinalIgnoreCase))
+                continue;
+            b.Add(new S201FeatureNameRecord
+            {
+                Name = ca.SubAttributes.GetValueOrDefault("name"),
+                Language = ca.SubAttributes.GetValueOrDefault("language"),
+                DisplayName = AttributeParser.TryParseBool(
+                    ca.SubAttributes.GetValueOrDefault("displayName"), ctx, f.Id, "displayName"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    private static S201DateRange? ProjectDateRange(S201Feature f, string code, ProjectionContext ctx)
+    {
+        if (f.ComplexAttributes.IsDefaultOrEmpty) return null;
+        foreach (var ca in f.ComplexAttributes)
+        {
+            if (!string.Equals(ca.Code, code, StringComparison.OrdinalIgnoreCase))
+                continue;
+            var start = AttributeParser.TryParseDateTimeOffset(
+                ca.SubAttributes.GetValueOrDefault("dateStart"), ctx, f.Id, $"{code}/dateStart");
+            var end = AttributeParser.TryParseDateTimeOffset(
+                ca.SubAttributes.GetValueOrDefault("dateEnd"), ctx, f.Id, $"{code}/dateEnd");
+            if (start is null && end is null) return null;
+            return new S201DateRange { Start = start, End = end };
+        }
+        return null;
+    }
+
+    private static ImmutableArray<int> ParseIntList(string? value, ProjectionContext ctx,
+        string? relatedId, string? attributeName)
+    {
+        if (string.IsNullOrEmpty(value)) return ImmutableArray<int>.Empty;
+        var b = ImmutableArray.CreateBuilder<int>();
+        foreach (var token in value.Split(new[] { ' ', '\t', ',' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var n = AttributeParser.TryParseInt(token, ctx, relatedId, attributeName);
+            if (n.HasValue) b.Add(n.Value);
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201AtonStatusInformation> ResolveStatusInformation(S201Feature f,
+        ProjectionContext ctx, IReadOnlyDictionary<string, S201AtonStatusInformation> byId)
+    {
+        if (f.InformationReferences.IsDefaultOrEmpty) return ImmutableArray<S201AtonStatusInformation>.Empty;
+        var b = ImmutableArray.CreateBuilder<S201AtonStatusInformation>();
+        foreach (var r in f.InformationReferences)
+        {
+            if (!string.Equals(r.Role, "AtoNStatus", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (byId.TryGetValue(r.InformationRef, out var info))
+                b.Add(info);
+            else
+                ctx.Warn(
+                    $"Unresolved AtoNStatus reference '{r.InformationRef}'.",
+                    code: "xlink.unresolved", relatedId: f.Id, relatedAttribute: r.Role);
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201PositioningInformationRecord> ResolvePositioningInformation(S201Feature f,
+        ProjectionContext ctx, IReadOnlyDictionary<string, S201PositioningInformationRecord> byId)
+    {
+        if (f.InformationReferences.IsDefaultOrEmpty) return ImmutableArray<S201PositioningInformationRecord>.Empty;
+        var b = ImmutableArray.CreateBuilder<S201PositioningInformationRecord>();
+        foreach (var r in f.InformationReferences)
+        {
+            if (!string.Equals(r.Role, "positioningMethod", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(r.Role, "Positioning", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (byId.TryGetValue(r.InformationRef, out var info))
+                b.Add(info);
+            else
+                ctx.Warn(
+                    $"Unresolved positioningMethod reference '{r.InformationRef}'.",
+                    code: "xlink.unresolved", relatedId: f.Id, relatedAttribute: r.Role);
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201AtoNFixingMethodRecord> ResolveFixingMethods(S201Feature f,
+        ProjectionContext ctx, IReadOnlyDictionary<string, S201AtoNFixingMethodRecord> byId)
+    {
+        if (f.InformationReferences.IsDefaultOrEmpty) return ImmutableArray<S201AtoNFixingMethodRecord>.Empty;
+        var b = ImmutableArray.CreateBuilder<S201AtoNFixingMethodRecord>();
+        foreach (var r in f.InformationReferences)
+        {
+            if (!string.Equals(r.Role, "fixingMethod", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (byId.TryGetValue(r.InformationRef, out var info))
+                b.Add(info);
+            else
+                ctx.Warn(
+                    $"Unresolved fixingMethod reference '{r.InformationRef}'.",
+                    code: "xlink.unresolved", relatedId: f.Id, relatedAttribute: r.Role);
+        }
+        return b.ToImmutable();
+    }
+
+    // -------------------------------------------------------------------
+    // Pass 3: equipment ↔ host-structure subordination
+    // -------------------------------------------------------------------
+
+    private static void ResolveSubordination(ImmutableArray<S201AtonObject> atons,
+        IReadOnlyDictionary<string, S201AtonObject> byId, ProjectionContext ctx)
+    {
+        var perStructureMounted = new Dictionary<string, ImmutableArray<S201Equipment>.Builder>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var atom in atons)
+        {
+            if (atom is not S201Equipment eq) continue;
+            if (atom.Source.FeatureReferences.IsDefaultOrEmpty) continue;
+            foreach (var r in atom.Source.FeatureReferences)
+            {
+                if (!IsParentRole(r.Role)) continue;
+                if (!byId.TryGetValue(r.TargetRef, out var target))
+                {
+                    ctx.Warn(
+                        $"Unresolved {r.Role} reference '{r.TargetRef}'.",
+                        code: "xlink.unresolved", relatedId: atom.Id, relatedAttribute: r.Role);
+                    continue;
+                }
+                if (target is not S201StructureObject structure)
+                {
+                    ctx.Warn(
+                        $"{r.Role} target '{r.TargetRef}' is not a structure (got {target.GetType().Name}).",
+                        code: "xlink.unexpectedType", relatedId: atom.Id, relatedAttribute: r.Role);
+                    continue;
+                }
+                eq.HostStructure = structure;
+                if (!perStructureMounted.TryGetValue(structure.Id, out var builder))
+                {
+                    builder = ImmutableArray.CreateBuilder<S201Equipment>();
+                    perStructureMounted[structure.Id] = builder;
+                }
+                builder.Add(eq);
+                break; // one host per equipment per FC
+            }
+        }
+
+        // Also resolve electronic-AtoN host where present (Physical / Synthetic).
+        foreach (var atom in atons)
+        {
+            if (atom is not S201ElectronicAtoN electronic) continue;
+            if (atom.Source.FeatureReferences.IsDefaultOrEmpty) continue;
+            foreach (var r in atom.Source.FeatureReferences)
+            {
+                if (!IsParentRole(r.Role)) continue;
+                if (!byId.TryGetValue(r.TargetRef, out var target))
+                {
+                    ctx.Warn(
+                        $"Unresolved {r.Role} reference '{r.TargetRef}'.",
+                        code: "xlink.unresolved", relatedId: atom.Id, relatedAttribute: r.Role);
+                    continue;
+                }
+                if (target is S201StructureObject structure)
+                    electronic.HostStructure = structure;
+                break;
+            }
+        }
+
+        // Materialise MountedEquipment on each structure.
+        foreach (var atom in atons)
+        {
+            if (atom is not S201StructureObject structure) continue;
+            if (!perStructureMounted.TryGetValue(structure.Id, out var builder)) continue;
+            structure.MountedEquipment = builder.ToImmutable();
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Pass 4: aggregations / associations
+    // -------------------------------------------------------------------
+
+    private static ImmutableArray<S201AtonAggregation> ProjectAggregations(
+        List<S201Feature> features, IReadOnlyDictionary<string, S201AtonObject> byId, ProjectionContext ctx)
+    {
+        var b = ImmutableArray.CreateBuilder<S201AtonAggregation>(features.Count);
+        foreach (var f in features)
+        {
+            var peers = ResolvePeers(f, byId, ctx);
+            b.Add(new S201AtonAggregation
+            {
+                Id = f.Id,
+                CategoryOfAssociation = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("CategoryOfAssociation")
+                        ?? f.Attributes.GetValueOrDefault("categoryOfAssociation"),
+                    ctx, f.Id, "CategoryOfAssociation"),
+                Peers = peers,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    "CategoryOfAssociation", "categoryOfAssociation"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201AtonAssociation> ProjectAssociations(
+        List<S201Feature> features, IReadOnlyDictionary<string, S201AtonObject> byId, ProjectionContext ctx)
+    {
+        var b = ImmutableArray.CreateBuilder<S201AtonAssociation>(features.Count);
+        foreach (var f in features)
+        {
+            var peers = ResolvePeers(f, byId, ctx);
+            b.Add(new S201AtonAssociation
+            {
+                Id = f.Id,
+                CategoryOfAssociation = AttributeParser.TryParseInt(
+                    f.Attributes.GetValueOrDefault("CategoryOfAssociation")
+                        ?? f.Attributes.GetValueOrDefault("categoryOfAssociation"),
+                    ctx, f.Id, "CategoryOfAssociation"),
+                Peers = peers,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    "CategoryOfAssociation", "categoryOfAssociation"),
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    private static ImmutableArray<S201AtonObject> ResolvePeers(S201Feature f,
+        IReadOnlyDictionary<string, S201AtonObject> byId, ProjectionContext ctx)
+    {
+        if (f.FeatureReferences.IsDefaultOrEmpty) return ImmutableArray<S201AtonObject>.Empty;
+        var b = ImmutableArray.CreateBuilder<S201AtonObject>();
+        foreach (var r in f.FeatureReferences)
+        {
+            if (!IsPeerRole(r.Role)) continue;
+            if (byId.TryGetValue(r.TargetRef, out var target))
+                b.Add(target);
+            else
+                ctx.Warn(
+                    $"Unresolved peer reference '{r.TargetRef}'.",
+                    code: "xlink.unresolved", relatedId: f.Id, relatedAttribute: r.Role);
+        }
+        return b.ToImmutable();
+    }
+
+    private static void BackFillMembership(ImmutableArray<S201AtonObject> atons,
+        ImmutableArray<S201AtonAggregation> aggregations,
+        ImmutableArray<S201AtonAssociation> associations)
+    {
+        if (aggregations.IsDefaultOrEmpty && associations.IsDefaultOrEmpty) return;
+
+        var aggBuilders = new Dictionary<string, ImmutableArray<S201AtonAggregation>.Builder>(StringComparer.OrdinalIgnoreCase);
+        var assocBuilders = new Dictionary<string, ImmutableArray<S201AtonAssociation>.Builder>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var agg in aggregations)
+        {
+            foreach (var peer in agg.Peers)
+            {
+                if (!aggBuilders.TryGetValue(peer.Id, out var bld))
+                {
+                    bld = ImmutableArray.CreateBuilder<S201AtonAggregation>();
+                    aggBuilders[peer.Id] = bld;
+                }
+                bld.Add(agg);
+            }
+        }
+        foreach (var ass in associations)
+        {
+            foreach (var peer in ass.Peers)
+            {
+                if (!assocBuilders.TryGetValue(peer.Id, out var bld))
+                {
+                    bld = ImmutableArray.CreateBuilder<S201AtonAssociation>();
+                    assocBuilders[peer.Id] = bld;
+                }
+                bld.Add(ass);
+            }
+        }
+
+        foreach (var atom in atons)
+        {
+            if (aggBuilders.TryGetValue(atom.Id, out var aggs))
+                atom.Aggregations = aggs.ToImmutable();
+            if (assocBuilders.TryGetValue(atom.Id, out var ass))
+                atom.Associations = ass.ToImmutable();
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Geometry
+    // -------------------------------------------------------------------
+
+    private static (S201GeometryKind, ImmutableArray<GeoPosition>) ProjectGeometry(S201Feature f)
+    {
+        switch (f.GeometryType)
+        {
+            case GmlGeometryType.Point:
+                return (S201GeometryKind.Point, f.Points.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.Points.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            case GmlGeometryType.Curve:
+                return (S201GeometryKind.Curve, f.Curves.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.Curves.SelectMany(c => c).Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            case GmlGeometryType.Surface:
+                return (S201GeometryKind.Surface, f.ExteriorRing.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.ExteriorRing.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            default:
+                return (S201GeometryKind.None, ImmutableArray<GeoPosition>.Empty);
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S201/DataModel/S201AtonObject.cs
+++ b/src/EncDotNet.S100.Datasets.S201/DataModel/S201AtonObject.cs
@@ -1,0 +1,260 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S201.DataModel;
+
+/// <summary>
+/// Abstract base for every Aid to Navigation object surfaced by the
+/// S-201 typed projection — mirrors the FC <c>AidsToNavigation</c>
+/// abstract supertype (S-201 Edition 2.0.0 Annex C).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Concrete FC leaf identity is preserved on <see cref="FeatureClass"/>
+/// rather than producing one C# class per FC code. Callers that need
+/// to switch on the concrete type should compare
+/// <see cref="FeatureClass"/> to the FC code (e.g. <c>"LateralBuoy"</c>,
+/// <c>"Lighthouse"</c>, <c>"PowerSource"</c>).
+/// </para>
+/// <para>
+/// Common AtoN attributes (identifier, lifecycle dates,
+/// inspection requirements, source metadata) are typed at this level;
+/// subclass-specific attributes appear on
+/// <see cref="S201StructureObject"/>, <see cref="S201Equipment"/>,
+/// <see cref="S201Light"/>, and <see cref="S201ElectronicAtoN"/>.
+/// </para>
+/// </remarks>
+public abstract class S201AtonObject
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The concrete FC feature class code (e.g. <c>"LateralBuoy"</c>,
+    /// <c>"Lighthouse"</c>, <c>"VirtualAISAidToNavigation"</c>).
+    /// </summary>
+    public required string FeatureClass { get; init; }
+
+    /// <summary>The originating feature record from the feature-bag dataset.</summary>
+    public required S201Feature Source { get; init; }
+
+    /// <summary>The geometry primitive kind of <see cref="Coordinates"/>.</summary>
+    public S201GeometryKind GeometryKind { get; init; }
+
+    /// <summary>
+    /// Flat coordinate list whose semantics depend on
+    /// <see cref="GeometryKind"/>. Multi-curve or multi-ring source
+    /// geometry is flattened in source order — full structure is
+    /// available on <see cref="Source"/>.
+    /// </summary>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } = ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>The unique AtoN identifier (FC: <c>iDCode</c>), when supplied.</summary>
+    public string? IdCode { get; init; }
+
+    /// <summary>Free-form information text (FC: <c>information</c>), when supplied.</summary>
+    public string? Information { get; init; }
+
+    /// <summary>Typed feature names (FC: <c>featureName</c>, multiplicity 0..*).</summary>
+    public ImmutableArray<S201FeatureNameRecord> FeatureNames { get; init; } =
+        ImmutableArray<S201FeatureNameRecord>.Empty;
+
+    /// <summary>Minimum display scale (FC: <c>scaleMinimum</c>), when supplied.</summary>
+    public int? ScaleMinimum { get; init; }
+
+    /// <summary>Source date (FC: <c>sourceDate</c>), when supplied.</summary>
+    public DateTimeOffset? SourceDate { get; init; }
+
+    /// <summary>Source description (FC: <c>source</c>), when supplied.</summary>
+    public string? SourceText { get; init; }
+
+    /// <summary>Pictorial representation reference (FC: <c>pictorialRepresentation</c>), when supplied.</summary>
+    public string? PictorialRepresentation { get; init; }
+
+    /// <summary>Inspection frequency (FC: <c>inspectionFrequency</c>), when supplied.</summary>
+    public string? InspectionFrequency { get; init; }
+
+    /// <summary>Inspection requirements (FC: <c>inspectionRequirements</c>), when supplied.</summary>
+    public string? InspectionRequirements { get; init; }
+
+    /// <summary>AtoN maintenance record reference (FC: <c>aToNMaintenanceRecord</c>), when supplied.</summary>
+    public string? AtoNMaintenanceRecord { get; init; }
+
+    /// <summary>Date the aid was installed (FC: <c>installationDate</c>), when supplied.</summary>
+    public DateTimeOffset? InstallationDate { get; init; }
+
+    /// <summary>Validity range for a fixed (non-recurring) deployment (FC: <c>fixedDateRange</c>).</summary>
+    public S201DateRange? FixedDateRange { get; init; }
+
+    /// <summary>Validity range for a periodic deployment (FC: <c>periodicDateRange</c>).</summary>
+    public S201DateRange? PeriodicDateRange { get; init; }
+
+    /// <summary>Seasonal action codes (FC: <c>SeasonalActionRequired</c>, multiplicity 0..*).</summary>
+    public ImmutableArray<string> SeasonalActionRequired { get; init; } = ImmutableArray<string>.Empty;
+
+    /// <summary>
+    /// AtoN status information resolved through the
+    /// <c>AtoNStatus</c> information binding (S-201 Edition 2.0.0
+    /// Annex C — <c>Atonstatus</c> association). Multiple bindings
+    /// project as a timeline of status records.
+    /// </summary>
+    public ImmutableArray<S201AtonStatusInformation> StatusInformation { get; init; } =
+        ImmutableArray<S201AtonStatusInformation>.Empty;
+
+    /// <summary>Aggregations this AtoN participates in (back-resolved).</summary>
+    public ImmutableArray<S201AtonAggregation> Aggregations { get; internal set; } =
+        ImmutableArray<S201AtonAggregation>.Empty;
+
+    /// <summary>Associations this AtoN participates in (back-resolved).</summary>
+    public ImmutableArray<S201AtonAssociation> Associations { get; internal set; } =
+        ImmutableArray<S201AtonAssociation>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of a <c>StructureObject</c> (S-201 Edition 2.0.0
+/// Annex C) — beacons, buoys, landmarks, lighthouses, light vessels,
+/// offshore platforms, piles, buildings, bridges, etc.
+/// </summary>
+/// <remarks>
+/// Structures act as the physical host for <see cref="S201Equipment"/>
+/// instances. The two-way back-reference (<see cref="MountedEquipment"/>
+/// here, <see cref="S201Equipment.HostStructure"/> there) is resolved
+/// from <c>theParentFeature</c> / <c>parent</c> xlinks emitted by the
+/// FC <c>StructureEquipment</c> association.
+/// </remarks>
+public class S201StructureObject : S201AtonObject
+{
+    /// <summary>The AtoN number (FC: <c>AtoNNumber</c>), when supplied.</summary>
+    public string? AtoNNumber { get; init; }
+
+    /// <summary>Aid availability category code (FC: <c>aidAvailabilityCategory</c>, codelist 1–3).</summary>
+    public int? AidAvailabilityCategory { get; init; }
+
+    /// <summary>Condition code (FC: <c>condition</c>, codelist 1–5).</summary>
+    public int? Condition { get; init; }
+
+    /// <summary>Contact address (FC: <c>contactAddress</c>), when supplied.</summary>
+    public string? ContactAddress { get; init; }
+
+    /// <summary>Equipment mounted on this structure (resolved from <c>StructureEquipment</c> xlinks).</summary>
+    public ImmutableArray<S201Equipment> MountedEquipment { get; internal set; } =
+        ImmutableArray<S201Equipment>.Empty;
+
+    /// <summary>Positioning information records resolved through the <c>AtonPositioningInformationAssociation</c> binding.</summary>
+    public ImmutableArray<S201PositioningInformationRecord> PositioningInformation { get; init; } =
+        ImmutableArray<S201PositioningInformationRecord>.Empty;
+
+    /// <summary>Fixing method records resolved through the <c>AtonFixingMethodAssociation</c> binding.</summary>
+    public ImmutableArray<S201AtoNFixingMethodRecord> FixingMethods { get; init; } =
+        ImmutableArray<S201AtoNFixingMethodRecord>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an <c>Equipment</c> (S-201 Edition 2.0.0
+/// Annex C) — daymarks, fog signals, radar reflectors, racons,
+/// retroreflectors, environment-observation gear, power sources,
+/// radio stations.
+/// </summary>
+public class S201Equipment : S201AtonObject
+{
+    /// <summary>Remote monitoring system reference (FC: <c>remoteMonitoringSystem</c>), when supplied.</summary>
+    public string? RemoteMonitoringSystem { get; init; }
+
+    /// <summary>
+    /// The host structure this equipment is mounted on, resolved from
+    /// <c>theParentFeature</c> / <c>parent</c> xlinks emitted by the
+    /// FC <c>StructureEquipment</c> association. <c>null</c> for
+    /// orphaned equipment, free-standing equipment, or when the xlink
+    /// could not be resolved (the latter raises an
+    /// <c>xlink.unresolved</c> diagnostic).
+    /// </summary>
+    public S201StructureObject? HostStructure { get; internal set; }
+}
+
+/// <summary>
+/// Typed projection of a <c>GenericLight</c> concrete subclass
+/// (S-201 Edition 2.0.0 Annex C — <c>LightSectored</c>,
+/// <c>LightAllAround</c>, <c>LightAirObstruction</c>, or
+/// <c>LightFogDetector</c>).
+/// </summary>
+/// <remarks>
+/// The four FC subclasses share an identical attribute schema, so the
+/// typed model collapses them into a single class discriminated by
+/// <see cref="Kind"/>. Use <see cref="S201AtonObject.FeatureClass"/>
+/// to get the original FC code if needed.
+/// </remarks>
+public sealed class S201Light : S201Equipment
+{
+    /// <summary>The light kind discriminator (derived from <see cref="S201AtonObject.FeatureClass"/>).</summary>
+    public required LightKind Kind { get; init; }
+
+    /// <summary>Height of the light (FC: <c>height</c>, in metres), when supplied.</summary>
+    public double? Height { get; init; }
+
+    /// <summary>Status codes (FC: <c>status</c>, multiplicity 0..*).</summary>
+    public ImmutableArray<int> Status { get; init; } = ImmutableArray<int>.Empty;
+
+    /// <summary>Vertical datum code (FC: <c>verticalDatum</c>, codelist), when supplied.</summary>
+    public int? VerticalDatum { get; init; }
+
+    /// <summary>Vertical length (FC: <c>verticalLength</c>, in metres), when supplied.</summary>
+    public double? VerticalLength { get; init; }
+
+    /// <summary>Effective intensity (FC: <c>effectiveIntensity</c>, candela), when supplied.</summary>
+    public double? EffectiveIntensity { get; init; }
+
+    /// <summary>Peak intensity (FC: <c>peakIntensity</c>, candela), when supplied.</summary>
+    public double? PeakIntensity { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an <c>ElectronicAton</c> concrete subclass
+/// (S-201 Edition 2.0.0 Annex C — <c>VirtualAISAidToNavigation</c>,
+/// <c>PhysicalAISAidToNavigation</c>, <c>SyntheticAISAidToNavigation</c>).
+/// </summary>
+/// <remarks>
+/// The three FC subclasses share an identical attribute schema, so the
+/// typed model collapses them into a single class discriminated by
+/// <see cref="Kind"/>. Physical and Synthetic variants may carry a
+/// <see cref="HostStructure"/>; virtual AIS AtoNs typically do not.
+/// The typed model does not enforce this convention beyond resolving
+/// the xlink when present.
+/// </remarks>
+public sealed class S201ElectronicAtoN : S201AtonObject
+{
+    /// <summary>The AIS AtoN kind discriminator (derived from <see cref="S201AtonObject.FeatureClass"/>).</summary>
+    public required AisAtonKind Kind { get; init; }
+
+    /// <summary>The AtoN number (FC: <c>AtoNNumber</c>), when supplied.</summary>
+    public string? AtoNNumber { get; init; }
+
+    /// <summary>The MMSI code (FC: <c>mMSICode</c>) — required by the FC for Physical/Synthetic AIS-AtoNs.</summary>
+    public string? MmsiCode { get; init; }
+
+    /// <summary>AIS operational status codes (FC: <c>status</c>, multiplicity 0..*).</summary>
+    public ImmutableArray<int> Status { get; init; } = ImmutableArray<int>.Empty;
+
+    /// <summary>
+    /// The host structure this AIS AtoN is bound to, when supplied by
+    /// the encoder (typically only for Physical / Synthetic variants).
+    /// </summary>
+    public S201StructureObject? HostStructure { get; internal set; }
+}
+
+/// <summary>
+/// A concrete fallback for AtoN features the typed model does not have
+/// a dedicated subclass for (e.g. <c>NavigationLine</c>,
+/// <c>RecommendedTrack</c>, <c>DataCoverage</c>,
+/// <c>DangerousFeature</c>, dataset-metadata features). Carries the
+/// common <see cref="S201AtonObject"/> attributes plus geometry and
+/// extras; callers needing specific attributes should read them from
+/// <see cref="S201AtonObject.Source"/> or
+/// <see cref="S201AtonObject.ExtraAttributes"/>.
+/// </summary>
+public sealed class S201GenericAtonObject : S201AtonObject
+{
+}

--- a/src/EncDotNet.S100.Datasets.S201/DataModel/S201Types.cs
+++ b/src/EncDotNet.S100.Datasets.S201/DataModel/S201Types.cs
@@ -1,0 +1,242 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S201.DataModel;
+
+/// <summary>
+/// The geometry primitive kind of an S-201 feature when surfaced through
+/// the typed projection. Mirrors the S-124 typed-model geometry shape:
+/// callers get an enum discriminator plus a single
+/// <see cref="ImmutableArray{T}"/> of <see cref="GeoPosition"/>s whose
+/// semantics depend on the kind.
+/// </summary>
+public enum S201GeometryKind
+{
+    /// <summary>No geometry. Abstract supertypes and aggregation containers may carry this.</summary>
+    None,
+
+    /// <summary>A single point (one coordinate).</summary>
+    Point,
+
+    /// <summary>A curve — an ordered, open sequence of coordinates.</summary>
+    Curve,
+
+    /// <summary>A surface — a closed exterior ring (interior rings are accessible on <c>Source</c>).</summary>
+    Surface,
+}
+
+/// <summary>
+/// AIS-AtoN discriminator for <see cref="S201ElectronicAtoN"/>
+/// (S-201 Edition 2.0.0 Annex C — <c>VirtualAISAidToNavigation</c>,
+/// <c>PhysicalAISAidToNavigation</c>, <c>SyntheticAISAidToNavigation</c>).
+/// </summary>
+public enum AisAtonKind
+{
+    /// <summary>Forward-compatibility fallback when the feature class is not one of the three FC-declared AIS AtoN types.</summary>
+    Unknown,
+
+    /// <summary>Virtual AIS AtoN: no physical structure; the AIS message describes a notional aid (e.g. a virtual cardinal mark on a wreck).</summary>
+    Virtual,
+
+    /// <summary>Physical AIS AtoN: a real AtoN broadcasting its own AIS message.</summary>
+    Physical,
+
+    /// <summary>Synthetic AIS AtoN: AIS messages transmitted from another station on behalf of an unmonitored AtoN.</summary>
+    Synthetic,
+}
+
+/// <summary>
+/// Discriminator for <see cref="S201Light"/> (S-201 Edition 2.0.0
+/// Annex C — concrete <c>GenericLight</c> subclasses).
+/// </summary>
+public enum LightKind
+{
+    /// <summary>Forward-compatibility fallback when the feature class is not a recognised <c>GenericLight</c> subclass.</summary>
+    Unknown,
+
+    /// <summary>A light with one or more sectors (<c>LightSectored</c>).</summary>
+    Sectored,
+
+    /// <summary>An all-round light (<c>LightAllAround</c>).</summary>
+    AllAround,
+
+    /// <summary>An air-obstruction light (<c>LightAirObstruction</c>).</summary>
+    AirObstruction,
+
+    /// <summary>A fog-detector light (<c>LightFogDetector</c>).</summary>
+    FogDetector,
+}
+
+/// <summary>
+/// A date range carried by AtoN lifecycle attributes such as
+/// <c>fixedDateRange</c> and <c>periodicDateRange</c>
+/// (S-201 Edition 2.0.0 §4 / Annex C). Either bound may be absent.
+/// </summary>
+public sealed record S201DateRange
+{
+    /// <summary>Start of the range, when present.</summary>
+    public DateTimeOffset? Start { get; init; }
+
+    /// <summary>End of the range, when present.</summary>
+    public DateTimeOffset? End { get; init; }
+
+    /// <summary>True when at least one bound is present.</summary>
+    public bool HasValue => Start.HasValue || End.HasValue;
+}
+
+/// <summary>
+/// The typed projection of the <c>featureName</c> complex attribute
+/// (S-201 Edition 2.0.0 Annex C) — a single language-tagged name plus
+/// a "display name" flag. Multiplicity in the FC is 0..* so a feature
+/// may carry several of these.
+/// </summary>
+public sealed record S201FeatureNameRecord
+{
+    /// <summary>The name text.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>The language code (ISO 639), when supplied.</summary>
+    public string? Language { get; init; }
+
+    /// <summary>True when the encoder flagged this as the display name.</summary>
+    public bool? DisplayName { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the <c>AtonStatusInformation</c> information
+/// type (S-201 Edition 2.0.0 Annex C2).
+/// </summary>
+public sealed class S201AtonStatusInformation
+{
+    /// <summary>The GML identifier of the source information type.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The change-type code (S-201 Edition 2.0.0 Annex C2 —
+    /// <c>ChangeTypes</c> codelist, values 1–4).
+    /// </summary>
+    public int? ChangeTypes { get; init; }
+
+    /// <summary>The verbatim sub-attributes of the <c>ChangeDetails</c> complex attribute, when present.</summary>
+    public ImmutableDictionary<string, string> ChangeDetails { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the <c>PositioningInformation</c> information
+/// type (S-201 Edition 2.0.0 Annex C2 — "Information about how a
+/// position was obtained").
+/// </summary>
+public sealed class S201PositioningInformationRecord
+{
+    /// <summary>The GML identifier of the source information type.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The positioning device (FC: <c>positioningDevice</c>), when supplied.</summary>
+    public string? PositioningDevice { get; init; }
+
+    /// <summary>The positioning method (FC: <c>positioningMethod</c>), when supplied.</summary>
+    public string? PositioningMethod { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the <c>AtoNFixingMethod</c> information type
+/// (S-201 Edition 2.0.0 Annex C2).
+/// </summary>
+public sealed class S201AtoNFixingMethodRecord
+{
+    /// <summary>The GML identifier of the source information type.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The reference point used (FC: <c>referencePoint</c>), when supplied.</summary>
+    public string? ReferencePoint { get; init; }
+
+    /// <summary>The horizontal datum code (FC: <c>horizontalDatum</c>, S-100 enumeration), when supplied.</summary>
+    public int? HorizontalDatum { get; init; }
+
+    /// <summary>The source date of the fix (FC: <c>sourceDate</c>), when supplied.</summary>
+    public DateTimeOffset? SourceDate { get; init; }
+
+    /// <summary>The positioning procedure (FC: <c>positioningProcedure</c>), when supplied.</summary>
+    public string? PositioningProcedure { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the <c>SpatialQuality</c> information type
+/// (S-201 Edition 2.0.0 Annex C2).
+/// </summary>
+public sealed class S201SpatialQuality
+{
+    /// <summary>The GML identifier of the source information type.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The quality-of-horizontal-measurement code (FC:
+    /// <c>qualityOfHorizontalMeasurement</c>, codelist values 1–11).
+    /// </summary>
+    public int? QualityOfHorizontalMeasurement { get; init; }
+
+    /// <summary>The spatial accuracy value (FC: <c>spatialAccuracy</c>), when supplied.</summary>
+    public double? SpatialAccuracy { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an <c>AtonAggregation</c> feature
+/// (S-201 Edition 2.0.0 Annex C). An aggregation gathers two or more
+/// AtoNs that act together as a single navigational aid (e.g. a leading
+/// line of two beacons). <see cref="Peers"/> holds the resolved
+/// typed members; unresolved xlinks surface as
+/// <c>xlink.unresolved</c> diagnostics on the projection context.
+/// </summary>
+public sealed class S201AtonAggregation
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The aggregation-category code (FC: <c>CategoryOfAssociation</c>), when supplied.</summary>
+    public int? CategoryOfAssociation { get; init; }
+
+    /// <summary>The resolved peer AtoNs (order preserved from the source GML).</summary>
+    public ImmutableArray<S201AtonObject> Peers { get; init; } = ImmutableArray<S201AtonObject>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an <c>AtonAssociation</c> feature
+/// (S-201 Edition 2.0.0 Annex C). An association links AtoNs that share
+/// a navigational meaning without acting as a single aid.
+/// </summary>
+public sealed class S201AtonAssociation
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The association-category code (FC: <c>CategoryOfAssociation</c>), when supplied.</summary>
+    public int? CategoryOfAssociation { get; init; }
+
+    /// <summary>The resolved peer AtoNs (order preserved from the source GML).</summary>
+    public ImmutableArray<S201AtonObject> Peers { get; init; } = ImmutableArray<S201AtonObject>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Datasets.S201/README.md
+++ b/src/EncDotNet.S100.Datasets.S201/README.md
@@ -79,6 +79,111 @@ Key types:
   implementation that loads XSLT rules, symbols, line styles, area
   fills, and color palettes from the bundled catalogue.
 
+## Strongly-typed data model
+
+`S201Dataset` is a faithful but loosely-typed feature bag — attributes
+arrive as `ImmutableDictionary<string, string>`, xlinks are unresolved
+strings, and equipment ↔ host-structure subordination must be walked
+by hand. The **`EncDotNet.S100.Datasets.S201.DataModel`** namespace
+adds a strongly-typed projection on top of that bag:
+
+- **`S201AtonInventory`** — root entity. Exposes typed views
+  (`Structures`, `Equipment`, `ElectronicAtoNs`), plus the resolved
+  `Aggregations`, `Associations`, `StatusInformation`,
+  `PositioningInformation`, `FixingMethods`, and `SpatialQualities`
+  collections.
+- **`S201AtonObject`** (abstract base) — the common AtoN attributes
+  shared by every concrete leaf: identifier, lifecycle dates
+  (`InstallationDate`, `FixedDateRange`, `PeriodicDateRange`),
+  inspection metadata, source provenance, AtoN status timeline, and
+  geometry as an enum (`S201GeometryKind`) plus a flat
+  `ImmutableArray<GeoPosition>`.
+- **`S201StructureObject`** — concrete subclass for beacons, buoys,
+  landmarks, lighthouses, light vessels, offshore platforms, etc.
+  Adds `AtoNNumber`, `AidAvailabilityCategory`, `Condition`,
+  `ContactAddress`, the resolved `MountedEquipment`, and typed
+  `PositioningInformation` / `FixingMethods` bindings.
+- **`S201Equipment`** — concrete subclass for daymarks, fog signals,
+  radar reflectors, racons, power sources, etc. Exposes the
+  back-resolved `HostStructure` (the headline subordination
+  value-add).
+- **`S201Light`** — `Equipment` subclass collapsing the four FC
+  light leaves (`LightSectored`, `LightAllAround`,
+  `LightAirObstruction`, `LightFogDetector`) into a single class
+  discriminated by `LightKind`. Adds `Height`, `Status` codes,
+  `VerticalDatum`, `VerticalLength`, `EffectiveIntensity`,
+  `PeakIntensity`.
+- **`S201ElectronicAtoN`** — collapses the three AIS-AtoN FC leaves
+  (`VirtualAISAidToNavigation`, `PhysicalAISAidToNavigation`,
+  `SyntheticAISAidToNavigation`) into one class discriminated by
+  `AisAtonKind`. Carries `MmsiCode`, AIS `Status`, and (for
+  Physical / Synthetic variants) the resolved `HostStructure`.
+- **`S201GenericAtonObject`** — fallback for AtoN features the
+  typed model has no dedicated subclass for (e.g. `NavigationLine`,
+  `DataCoverage`, `DangerousFeature`). Carries the common
+  `S201AtonObject` attributes plus geometry and round-trips
+  everything else through `ExtraAttributes`.
+
+The projection is **read-only** and **never throws** except when the
+source dataset has neither features nor information types. Every
+other failure — unresolved xlinks, attribute parse errors,
+unexpected target types — surfaces as a
+`ProjectionDiagnostic` entry on the `out` parameter.
+
+### How this differs from the S-125 typed model
+
+Both S-201 and S-125 carry AtoN data, but they are independent
+specifications with different audiences (operational vs ECDIS
+display). The S-201 typed model exposes:
+
+1. **Equipment ↔ host-structure subordination** as a typed
+   bidirectional reference (`Equipment.HostStructure`,
+   `Structure.MountedEquipment`).
+2. **AtoN lifecycle** (`InstallationDate`, `FixedDateRange`,
+   `PeriodicDateRange`) on every AtoN.
+3. **AtoN status timeline** via the `AtoNStatus` info-binding,
+   including the `ChangeTypes` codelist.
+4. **Positioning / fixing-method bindings** on structures.
+5. **Remote monitoring system** metadata on equipment.
+
+The two typed models share **only** the abstractions in
+`EncDotNet.S100.Core.DataModel` (`GeoPosition`,
+`ProjectionDiagnostic`, `ProjectionContext`, `XlinkResolver`,
+`AttributeParser`, `ExtraAttributes`). They do **not** share any
+spec-level types. If your application consumes both, project each
+dataset to its own typed model and reconcile at the call site.
+
+### Quick start (typed model)
+
+```csharp
+using EncDotNet.S100.Datasets.S201;
+using EncDotNet.S100.Datasets.S201.DataModel;
+
+var dataset = S201Dataset.Open("aton.gml");
+var inventory = S201AtonInventory.From(dataset, out var diagnostics);
+
+// Walk the inventory by host structure.
+foreach (var structure in inventory.Structures)
+{
+    Console.WriteLine($"{structure.FeatureClass} {structure.AtoNNumber}");
+    foreach (var equipment in structure.MountedEquipment)
+    {
+        var kind = equipment is S201Light light
+            ? $"Light/{light.Kind}"
+            : equipment.FeatureClass;
+        Console.WriteLine($"  → {kind} {equipment.Id}");
+    }
+}
+
+// Filter AIS AtoNs by kind.
+foreach (var ais in inventory.ElectronicAtoNs.Where(a => a.Kind == AisAtonKind.Virtual))
+    Console.WriteLine($"Virtual AIS {ais.Id} MMSI={ais.MmsiCode}");
+
+// Diagnostics are non-fatal.
+foreach (var d in diagnostics)
+    Console.Error.WriteLine($"{d.Severity} {d.Code}: {d.Message}");
+```
+
 ## Notes
 
 - S-201 Edition 2.0.0 application schema namespace is

--- a/tests/EncDotNet.S100.Datasets.S201.Tests/DataModelTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S201.Tests/DataModelTests.cs
@@ -1,0 +1,194 @@
+using System.Linq;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S201.DataModel;
+
+namespace EncDotNet.S100.Datasets.S201.Tests;
+
+public class DataModelTests
+{
+    private static string GetTestDataPath(string filename)
+    {
+        var basePath = AppContext.BaseDirectory;
+        return Path.Combine(basePath, "TestData", filename);
+    }
+
+    private static S201Dataset OpenFixture(string filename) => S201Dataset.Open(GetTestDataPath(filename));
+
+    [Fact]
+    public void From_EmptyDataset_Throws()
+    {
+        var empty = new S201Dataset
+        {
+            ProductIdentifier = "S-201",
+            DatasetIdentifier = "EMPTY",
+            Features = System.Collections.Immutable.ImmutableArray<S201Feature>.Empty,
+            InformationTypes = System.Collections.Immutable.ImmutableArray<S201InformationType>.Empty,
+        };
+        Assert.Throws<InvalidOperationException>(() => S201AtonInventory.From(empty, out _));
+    }
+
+    [Fact]
+    public void From_PointDataset_ProjectsLateralBuoyWithStatusInformation()
+    {
+        var ds = OpenFixture("aton_point.gml");
+        var inv = S201AtonInventory.From(ds, out var diagnostics);
+
+        Assert.Equal("S-201", inv.ProductIdentifier);
+        Assert.Equal(2, inv.AtoNs.Length);
+
+        var buoy = Assert.IsType<S201StructureObject>(inv.AtoNs.Single(a => a.Id == "f1"));
+        Assert.Equal("LateralBuoy", buoy.FeatureClass);
+        Assert.Equal(S201GeometryKind.Point, buoy.GeometryKind);
+        Assert.Single(buoy.Coordinates);
+
+        // AtoNStatus information binding resolved.
+        Assert.Single(buoy.StatusInformation);
+        Assert.Equal("info1", buoy.StatusInformation[0].Id);
+        Assert.Equal(1, buoy.StatusInformation[0].ChangeTypes);
+
+        // categoryOfLateralMark is not consumed by the structure projection;
+        // it round-trips through extras.
+        Assert.True(buoy.ExtraAttributes.ContainsKey("categoryOfLateralMark"));
+
+        // Landmark has a featureName complex attribute.
+        var landmark = Assert.IsType<S201StructureObject>(inv.AtoNs.Single(a => a.Id == "f2"));
+        Assert.Single(landmark.FeatureNames);
+        Assert.Equal("Cape Henry Light", landmark.FeatureNames[0].Name);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void From_XlinkDataset_ResolvesEquipmentToHostStructure()
+    {
+        var ds = OpenFixture("aton_xlink.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        var structure = Assert.IsType<S201StructureObject>(inv.AtoNs.Single(a => a.Id == "structure1"));
+        var light = Assert.IsType<S201Light>(inv.AtoNs.Single(a => a.Id == "equipment1"));
+
+        Assert.NotNull(light.HostStructure);
+        Assert.Equal("structure1", light.HostStructure!.Id);
+        Assert.Contains(light, structure.MountedEquipment);
+    }
+
+    [Fact]
+    public void From_XlinkDataset_ProjectsAggregationWithResolvedPeers()
+    {
+        var ds = OpenFixture("aton_xlink.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        Assert.Single(inv.Aggregations);
+        var agg = inv.Aggregations[0];
+        Assert.Equal("agg1", agg.Id);
+        Assert.Equal(2, agg.Peers.Length);
+        Assert.Contains(agg.Peers, p => p.Id == "structure1");
+        Assert.Contains(agg.Peers, p => p.Id == "equipment1");
+
+        // Back-fill: each peer should report this aggregation in its Aggregations list.
+        var structure = inv.AtoNs.Single(a => a.Id == "structure1");
+        Assert.Contains(agg, structure.Aggregations);
+    }
+
+    [Fact]
+    public void From_UnresolvedXlink_EmitsDiagnosticNoThrow()
+    {
+        var ds = OpenFixture("aton_unresolved.gml");
+        var inv = S201AtonInventory.From(ds, out var diagnostics);
+
+        var orphan = Assert.IsType<S201Light>(inv.AtoNs.Single(a => a.Id == "orphanLight"));
+        Assert.Null(orphan.HostStructure);
+
+        Assert.Contains(diagnostics, d =>
+            d.Code == "xlink.unresolved" && d.RelatedId == "orphanLight");
+    }
+
+    [Fact]
+    public void From_AisAtonDataset_DistinguishesVirtualAndPhysical()
+    {
+        var ds = OpenFixture("aton_ais.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        Assert.Equal(2, inv.ElectronicAtoNs.Length);
+
+        var virtualAis = inv.ElectronicAtoNs.Single(e => e.Id == "virtualAis");
+        Assert.Equal(AisAtonKind.Virtual, virtualAis.Kind);
+        Assert.Equal("993672111", virtualAis.MmsiCode);
+        Assert.Null(virtualAis.HostStructure);
+
+        var physicalAis = inv.ElectronicAtoNs.Single(e => e.Id == "physicalAis");
+        Assert.Equal(AisAtonKind.Physical, physicalAis.Kind);
+        Assert.Equal("993672222", physicalAis.MmsiCode);
+        Assert.NotNull(physicalAis.HostStructure);
+        Assert.Equal("hostBuoy", physicalAis.HostStructure!.Id);
+
+        Assert.Contains(1, physicalAis.Status);
+    }
+
+    [Fact]
+    public void From_LightDataset_TypesLightAndLifecycleAttributes()
+    {
+        var ds = OpenFixture("aton_light.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        var house = Assert.IsType<S201StructureObject>(inv.AtoNs.Single(a => a.Id == "house1"));
+        Assert.Equal("USCG-99001", house.AtoNNumber);
+        Assert.Equal(1, house.AidAvailabilityCategory);
+        Assert.NotNull(house.InstallationDate);
+        Assert.Equal(1995, house.InstallationDate!.Value.Year);
+        Assert.NotNull(house.FixedDateRange);
+        Assert.NotNull(house.FixedDateRange!.Start);
+        Assert.NotNull(house.FixedDateRange.End);
+        Assert.Equal(2099, house.FixedDateRange.End!.Value.Year);
+
+        var light = Assert.IsType<S201Light>(inv.AtoNs.Single(a => a.Id == "lamp1"));
+        Assert.Equal(LightKind.AllAround, light.Kind);
+        Assert.Equal(26.5, light.Height);
+        Assert.Equal(30, light.VerticalDatum);
+        Assert.Equal(3.0, light.VerticalLength);
+        Assert.Equal(1200.0, light.EffectiveIntensity);
+        Assert.Equal(1500.0, light.PeakIntensity);
+        Assert.Equal(new[] { 1, 5 }, light.Status.ToArray());
+        Assert.NotNull(light.HostStructure);
+        Assert.Equal("house1", light.HostStructure!.Id);
+    }
+
+    [Fact]
+    public void From_LightDataset_RoundTripsUnknownAttributes()
+    {
+        var ds = OpenFixture("aton_light.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        var house = inv.AtoNs.Single(a => a.Id == "house1");
+        Assert.True(house.ExtraAttributes.ContainsKey("customExperimentalAttr"));
+        Assert.Equal("experiment-value", house.ExtraAttributes["customExperimentalAttr"]);
+    }
+
+    [Fact]
+    public void From_PointDataset_ExposesTypedViewsOverAtoNs()
+    {
+        var ds = OpenFixture("aton_point.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        // Both LateralBuoy and Landmark are structures.
+        Assert.Equal(2, inv.Structures.Length);
+        Assert.Empty(inv.Equipment);
+        Assert.Empty(inv.ElectronicAtoNs);
+        Assert.Single(inv.StatusInformation);
+    }
+
+    [Fact]
+    public void From_SurfaceDataset_ProjectsDataCoverageGenerically()
+    {
+        var ds = OpenFixture("aton_surface.gml");
+        var inv = S201AtonInventory.From(ds, out _);
+
+        // DataCoverage is in the "deliberately omitted" set — should fall through
+        // to S201GenericAtonObject with the geometry preserved.
+        var coverage = inv.AtoNs.SingleOrDefault(a => a.FeatureClass == "DataCoverage");
+        Assert.NotNull(coverage);
+        Assert.IsType<S201GenericAtonObject>(coverage);
+        Assert.Equal(S201GeometryKind.Surface, coverage!.GeometryKind);
+        Assert.NotEmpty(coverage.Coordinates);
+    }
+}

--- a/tests/datasets/S201/aton_ais.gml
+++ b/tests/datasets/S201/aton_ais.gml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic S-201 Edition 2.0.0 GML fixture: AIS AtoN classification.
+
+  Demonstrates Virtual vs Physical AIS aids to navigation, each with
+  an MMSI code; the Physical variant binds to a host structure via
+  theParentFeature.
+-->
+<S201:Dataset xmlns:S201="http://www.iho.int/S-201/gml/cs0/1.0"
+              xmlns:S100="http://www.iho.int/s100gml/5.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              gml:id="DS_S201_Ais">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-201</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <S201:member>
+    <S201:LateralBuoy gml:id="hostBuoy">
+      <S201:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-host"><gml:pos>40.0 -73.0</gml:pos></gml:Point>
+        </S100:pointProperty>
+      </S201:geometry>
+      <S201:AtoNNumber>USCG-12345</S201:AtoNNumber>
+    </S201:LateralBuoy>
+  </S201:member>
+
+  <S201:member>
+    <S201:VirtualAISAidToNavigation gml:id="virtualAis">
+      <S201:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-virtual"><gml:pos>40.1 -73.1</gml:pos></gml:Point>
+        </S100:pointProperty>
+      </S201:geometry>
+      <S201:mMSICode>993672111</S201:mMSICode>
+      <S201:status>1</S201:status>
+    </S201:VirtualAISAidToNavigation>
+  </S201:member>
+
+  <S201:member>
+    <S201:PhysicalAISAidToNavigation gml:id="physicalAis">
+      <S201:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-physical"><gml:pos>40.0 -73.0</gml:pos></gml:Point>
+        </S100:pointProperty>
+      </S201:geometry>
+      <S201:mMSICode>993672222</S201:mMSICode>
+      <S201:status>1</S201:status>
+      <S201:theParentFeature xlink:href="#hostBuoy"/>
+    </S201:PhysicalAISAidToNavigation>
+  </S201:member>
+
+</S201:Dataset>

--- a/tests/datasets/S201/aton_light.gml
+++ b/tests/datasets/S201/aton_light.gml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic S-201 Edition 2.0.0 GML fixture: light attribute typing.
+
+  Demonstrates typed light attributes (height, status, verticalDatum,
+  effectiveIntensity, peakIntensity), lifecycle dates (installationDate,
+  fixedDateRange), and an extra/unknown attribute that should
+  round-trip through ExtraAttributes.
+-->
+<S201:Dataset xmlns:S201="http://www.iho.int/S-201/gml/cs0/1.0"
+              xmlns:S100="http://www.iho.int/s100gml/5.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              gml:id="DS_S201_Light">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-201</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <S201:member>
+    <S201:Lighthouse gml:id="house1">
+      <S201:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-house"><gml:pos>36.93 -76.01</gml:pos></gml:Point>
+        </S100:pointProperty>
+      </S201:geometry>
+      <S201:AtoNNumber>USCG-99001</S201:AtoNNumber>
+      <S201:aidAvailabilityCategory>1</S201:aidAvailabilityCategory>
+      <S201:installationDate>1995-04-12T00:00:00Z</S201:installationDate>
+      <S201:fixedDateRange>
+        <S201:dateStart>1995-04-12T00:00:00Z</S201:dateStart>
+        <S201:dateEnd>2099-12-31T00:00:00Z</S201:dateEnd>
+      </S201:fixedDateRange>
+      <S201:customExperimentalAttr>experiment-value</S201:customExperimentalAttr>
+    </S201:Lighthouse>
+  </S201:member>
+
+  <S201:member>
+    <S201:LightAllAround gml:id="lamp1">
+      <S201:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-lamp"><gml:pos>36.93 -76.01</gml:pos></gml:Point>
+        </S100:pointProperty>
+      </S201:geometry>
+      <S201:height>26.5</S201:height>
+      <S201:verticalDatum>30</S201:verticalDatum>
+      <S201:verticalLength>3.0</S201:verticalLength>
+      <S201:effectiveIntensity>1200.0</S201:effectiveIntensity>
+      <S201:peakIntensity>1500.0</S201:peakIntensity>
+      <S201:status>1 5</S201:status>
+      <S201:theParentFeature xlink:href="#house1"/>
+    </S201:LightAllAround>
+  </S201:member>
+
+</S201:Dataset>

--- a/tests/datasets/S201/aton_unresolved.gml
+++ b/tests/datasets/S201/aton_unresolved.gml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic S-201 Edition 2.0.0 GML fixture.
+
+  Equipment references a non-existent structure via theParentFeature;
+  the typed projection must emit an xlink.unresolved diagnostic
+  rather than throwing.
+-->
+<S201:Dataset xmlns:S201="http://www.iho.int/S-201/gml/cs0/1.0"
+              xmlns:S100="http://www.iho.int/s100gml/5.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              gml:id="DS_S201_Unresolved">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-201</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <S201:member>
+    <S201:LightAllAround gml:id="orphanLight">
+      <S201:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-orphan">
+            <gml:pos>36.95 -76.01</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S201:geometry>
+      <S201:theParentFeature xlink:href="#missingStructure"/>
+    </S201:LightAllAround>
+  </S201:member>
+
+</S201:Dataset>


### PR DESCRIPTION
Pass 2 of the typed-model rollout — adds a strongly-typed
`DataModel` projection of `S201Dataset` for IHO/IALA S-201
(Aids to Navigation Information, Edition 2.0.0,
authority-to-authority exchange).

Sibling to the S-124 / S-421 typed models. Consumes the shared
scaffolding in `EncDotNet.S100.Core.DataModel`
(`ProjectionContext`, `XlinkResolver`, `AttributeParser`,
`ExtraAttributes`, `GeoPosition`, `ProjectionDiagnostic`) — does
**not** modify it.

## Object graph

- **`S201AtonInventory`** — root entity. Exposes typed views
  (`Structures`, `Equipment`, `ElectronicAtoNs`) plus resolved
  `Aggregations`, `Associations`, `StatusInformation`,
  `PositioningInformation`, `FixingMethods`, `SpatialQualities`.
- **`S201AtonObject`** (abstract) — common AtoN attributes:
  identifier, feature class, lifecycle dates
  (`InstallationDate`, `FixedDateRange`, `PeriodicDateRange`),
  inspection metadata, source provenance, `StatusInformation`
  timeline, `Aggregations` / `Associations` back-references,
  geometry as `S201GeometryKind` + flat
  `ImmutableArray<GeoPosition>`, and `ExtraAttributes`.
- **`S201StructureObject`** — beacons, buoys, landmarks,
  lighthouses, light vessels, platforms. Adds `AtoNNumber`,
  `AidAvailabilityCategory`, `Condition`, `ContactAddress`,
  resolved `MountedEquipment`, and typed
  `PositioningInformation` / `FixingMethods` bindings.
- **`S201Equipment`** — daymarks, fog signals, radar
  reflectors, racons, power sources. Exposes the back-resolved
  `HostStructure` (the headline subordination affordance).
- **`S201Light : S201Equipment`** — collapses
  `LightSectored` / `LightAllAround` / `LightAirObstruction` /
  `LightFogDetector` into one class discriminated by
  `LightKind`. Adds `Height`, `Status`, `VerticalDatum`,
  `VerticalLength`, `EffectiveIntensity`, `PeakIntensity`.
- **`S201ElectronicAtoN`** — collapses
  `VirtualAISAidToNavigation` /
  `PhysicalAISAidToNavigation` /
  `SyntheticAISAidToNavigation` into one class discriminated by
  `AisAtonKind`. Carries `MmsiCode`, AIS `Status`, and (for
  Physical / Synthetic) the resolved `HostStructure`.
- **`S201GenericAtonObject`** — fallback for out-of-hierarchy
  features (`NavigationLine`, `DataCoverage`,
  `DangerousFeature`). Preserves geometry + common attrs +
  `ExtraAttributes`.

## Behaviour

- Single static factory:
  `S201AtonInventory.From(dataset, out diagnostics)`.
- **Never throws** except when the dataset is fully empty
  (no features and no information types).
- All resolution failures — unresolved xlinks, attribute parse
  errors, unexpected target types — surface as
  `ProjectionDiagnostic` entries.
- Tolerates both `theParentFeature` and `parent` role spellings
  for the FC `StructureEquipment` association.
- `ImmutableArray<T>` for collections; no LINQ in hot loops.

## Distinct from the S-125 typed model

S-201 and S-125 cover overlapping physical objects but are
separate product specifications with separate FCs and audiences.
The S-201 typed model exposes attributes / relationships absent
from the (ECDIS-focused) S-125 typed model:

1. Equipment ↔ host-structure bidirectional refs.
2. AtoN lifecycle (`InstallationDate`, date ranges).
3. AtoN status timeline (`AtoNStatus` info-binding).
4. Positioning / fixing-method bindings on structures.
5. Remote-monitoring-system metadata on equipment.

**Zero spec-level types** are shared with S-125 — only the
abstractions in `EncDotNet.S100.Core.DataModel` are common
ground. README's S-125-vs-S-201 distinction is restated in the
new typed-model section.

## Tests

10 new tests under
`tests/EncDotNet.S100.Datasets.S201.Tests/DataModelTests.cs`:

- Empty-dataset throw.
- Round-trip projection from `aton_point.gml` (typed structures,
  status-info binding, extras).
- Equipment ↔ host-structure subordination via `aton_xlink.gml`.
- Aggregation projection with resolved typed peers and
  back-filled membership.
- Unresolved xlink → diagnostic, no throw (new
  `aton_unresolved.gml`).
- AIS AtoN virtual / physical discrimination, MMSI, host
  binding (new `aton_ais.gml`).
- Light attribute typing + lifecycle dates (new
  `aton_light.gml`).
- `ExtraAttributes` round-trip for unknown attributes.
- Typed views over `AtoNs` collection.
- Surface `DataCoverage` falls through to
  `S201GenericAtonObject`.

3 new synthetic fixtures hand-authored against the FC; no
third-party data committed.

## Validation

- `dotnet build` of the S-201 project: clean (0 warnings,
  0 errors).
- `dotnet test` over the S-201 test project: 18 passed, 1
  skipped (pre-existing real-dataset gate).
- No changes to S-421, S-124, S-125, or
  `EncDotNet.S100.Core.DataModel`.

## Spec citations

Sections from S-201 Edition 2.0.0 cited in XML doc comments:
Annex C (feature catalogue inheritance — `AidsToNavigation`,
`StructureObject`, `Equipment`, `GenericLight`,
`ElectronicAton`), Annex C2 (information types —
`AtonStatusInformation`, `PositioningInformation`,
`AtoNFixingMethod`, `SpatialQuality`).