### PR TITLE
Add typed leg/waypoint endpoint references to S-421 data model

### DIFF
--- a/src/EncDotNet.S100.Datasets.S421/DataModel/S421RoutePlan.cs
+++ b/src/EncDotNet.S100.Datasets.S421/DataModel/S421RoutePlan.cs
@@ -225,7 +225,46 @@ public sealed class S421RoutePlan
             waypoints.Add(ProjectWaypoint(wptFeature, leg, ctx));
         }
 
-        return (waypoints.ToImmutable(), legs.ToImmutable());
+        var waypointArray = waypoints.ToImmutable();
+        LinkLegEndpoints(waypointArray, ctx);
+        return (waypointArray, legs.ToImmutable());
+    }
+
+    /// <summary>
+    /// Second pass that wires <see cref="S421Leg.StartWaypoint"/>,
+    /// <see cref="S421Leg.EndWaypoint"/>, and
+    /// <see cref="S421Waypoint.IncomingLeg"/> from the ordered waypoint
+    /// array. Topology is taken from document order plus the
+    /// <c>routeWaypointLeg</c> xlinks already resolved in the first pass —
+    /// we do not match by coordinates. Emits a
+    /// <c>"route.leg.endpoint.missing"</c> warning if the final waypoint
+    /// still carries an <see cref="S421Waypoint.OutgoingLeg"/> (i.e. the
+    /// leg has no successor waypoint to terminate at).
+    /// </summary>
+    private static void LinkLegEndpoints(ImmutableArray<S421Waypoint> waypoints, ProjectionContext ctx)
+    {
+        for (int i = 0; i < waypoints.Length; i++)
+        {
+            var leg = waypoints[i].OutgoingLeg;
+            if (leg is null) continue;
+
+            leg.StartWaypoint = waypoints[i];
+            if (i + 1 < waypoints.Length)
+            {
+                leg.EndWaypoint = waypoints[i + 1];
+                waypoints[i + 1].IncomingLeg = leg;
+            }
+            else
+            {
+                ctx.Report(new ProjectionDiagnostic
+                {
+                    Severity = DiagnosticSeverity.Warning,
+                    Message = $"RouteWaypointLeg '{leg.Id}' has no successor waypoint to terminate at.",
+                    Code = "route.leg.endpoint.missing",
+                    RelatedId = leg.Id,
+                });
+            }
+        }
     }
 
     private static S421Waypoint ProjectWaypoint(S421Feature f, S421Leg? leg, ProjectionContext ctx)

--- a/src/EncDotNet.S100.Datasets.S421/DataModel/S421Waypoint.cs
+++ b/src/EncDotNet.S100.Datasets.S421/DataModel/S421Waypoint.cs
@@ -40,6 +40,15 @@ public sealed class S421Waypoint
     /// </summary>
     public S421Leg? OutgoingLeg { get; init; }
 
+    /// <summary>
+    /// The leg arriving at this waypoint — the <see cref="OutgoingLeg"/> of
+    /// the previous waypoint in route order. The first waypoint of a route
+    /// has no incoming leg. Populated during projection in a second pass
+    /// after all waypoints and legs are materialised; see
+    /// <see cref="S421RoutePlan.From"/>.
+    /// </summary>
+    public S421Leg? IncomingLeg { get; internal set; }
+
     /// <summary>Unrecognised / extension attributes preserved verbatim.</summary>
     public required ImmutableDictionary<string, string> ExtraAttributes { get; init; }
 }
@@ -55,6 +64,29 @@ public sealed class S421Leg
 
     /// <summary>The leg's curve geometry as an ordered sequence of positions.</summary>
     public required ImmutableArray<GeoPosition> Coordinates { get; init; }
+
+    /// <summary>
+    /// The waypoint at the start of this leg — the waypoint whose
+    /// <see cref="S421Waypoint.OutgoingLeg"/> is this leg. Populated during
+    /// projection in a second pass after all waypoints and legs are
+    /// materialised; see <see cref="S421RoutePlan.From"/>. Nullable to
+    /// tolerate malformed fixtures where the leg is referenced from no
+    /// waypoint.
+    /// Spec reference: S-421 Annex A "RouteWaypointLeg" / "RouteWaypoint"
+    /// (FC) — a leg connects two consecutive waypoints in route order.
+    /// </summary>
+    public S421Waypoint? StartWaypoint { get; internal set; }
+
+    /// <summary>
+    /// The waypoint at the end of this leg — the next waypoint in route
+    /// order after <see cref="StartWaypoint"/>. Populated during projection
+    /// in a second pass after all waypoints and legs are materialised; see
+    /// <see cref="S421RoutePlan.From"/>. Nullable to tolerate malformed
+    /// fixtures where the originating waypoint has no successor.
+    /// Spec reference: S-421 Annex A "RouteWaypointLeg" / "RouteWaypoint"
+    /// (FC) — a leg connects two consecutive waypoints in route order.
+    /// </summary>
+    public S421Waypoint? EndWaypoint { get; internal set; }
 
     /// <summary>FC code <c>routeWaypointLegStarboardXTDL</c> (metres).</summary>
     public double? StarboardCrossTrackDistanceLimit { get; init; }

--- a/src/EncDotNet.S100.Datasets.S421/README.md
+++ b/src/EncDotNet.S100.Datasets.S421/README.md
@@ -44,7 +44,11 @@ projection on top:
   `xlink:href` cross-references and parsing primitive values
   (`int`, `double`, `bool`, `DateTimeOffset`).
 - **`S421Route`** with `Info`, `Waypoints`, `Legs`, `ActionPoints`, `Schedules`.
-- **`S421Waypoint`** with `OutgoingLeg` graph navigation.
+- **`S421Waypoint`** with typed `OutgoingLeg` and `IncomingLeg`
+  bidirectional navigation along the route.
+- **`S421Leg`** with typed `StartWaypoint` / `EndWaypoint` endpoint
+  references, so consumers holding a leg can reach both of its
+  bounding waypoints without coordinate matching.
 - **`S421ActionPoint`**, **`S421Schedule`** + variants (Manual / Calculated /
   Recommended), **`S421ScheduleElement`**.
 - Anything the typed model does not understand is preserved on each object's
@@ -106,6 +110,14 @@ foreach (var wp in plan.Route.Waypoints)
     Console.WriteLine(
         $"  WP{wp.WaypointNumber} {wp.Position.Latitude:F4}, {wp.Position.Longitude:F4}"
         + (leg is not null ? $" → leg {leg.Id}" : ""));
+}
+
+// Walk the route via typed endpoint references — no href parsing required.
+var cursor = plan.Route.Waypoints.FirstOrDefault();
+while (cursor?.OutgoingLeg is { } leg)
+{
+    Console.WriteLine($"  leg {leg.Id}: {leg.StartWaypoint?.Id} → {leg.EndWaypoint?.Id}");
+    cursor = leg.EndWaypoint;
 }
 
 foreach (var d in diagnostics) Console.WriteLine(d);

--- a/tests/EncDotNet.S100.Datasets.S421.Tests/S421RoutePlanTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S421.Tests/S421RoutePlanTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using EncDotNet.S100.DataModel;
 using EncDotNet.S100.Datasets.S421;
 using EncDotNet.S100.Datasets.S421.DataModel;
+using EncDotNet.S100.Gml;
 
 namespace EncDotNet.S100.Datasets.S421.Tests;
 
@@ -247,6 +248,223 @@ public class S421RoutePlanTests
         var extra = plan.Route.Info!.ExtraAttributes;
         Assert.True(extra.ContainsKey("routeInfoDraftMax"));
         Assert.Equal("1000.0", extra["routeInfoDraftMax"]);
+    }
+
+    // ── Cross-reference resolution: Route → WP → Leg → endpoint WP ──
+
+    /// <summary>
+    /// Builds a synthetic, fully self-consistent S-421 dataset with
+    /// <paramref name="waypointCount"/> waypoints and (waypointCount - 1)
+    /// legs, so the typed-model bidirectional endpoint linking can be
+    /// exercised on a fixture whose <c>gml:id</c>s actually resolve. The
+    /// IEC sample fixtures (GFULL/GBASIC) have intentional id mismatches
+    /// that make most waypoints unresolvable and so cannot drive these
+    /// tests on their own.
+    /// </summary>
+    private static S421Dataset BuildSyntheticRoute(int waypointCount, bool referenceLegBeyondLastWaypoint = false)
+    {
+        if (waypointCount < 2)
+            throw new ArgumentOutOfRangeException(nameof(waypointCount));
+
+        var emptyAttrs = ImmutableDictionary<string, string>.Empty;
+        var emptyComplex = ImmutableArray<S421ComplexAttribute>.Empty;
+
+        var features = ImmutableArray.CreateBuilder<S421Feature>();
+
+        // Route → routeWaypoints container.
+        features.Add(new S421Feature
+        {
+            Id = "RTE",
+            FeatureType = "Route",
+            GeometryType = GmlGeometryType.None,
+            Points = ImmutableArray<(double, double)>.Empty,
+            Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            ExteriorRing = ImmutableArray<(double, double)>.Empty,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Attributes = emptyAttrs,
+            ComplexAttributes = emptyComplex,
+            References = ImmutableArray.Create(new GmlReference
+            {
+                Role = "routeWaypoints",
+                Href = "#RTE.WPTS",
+            }),
+        });
+
+        // RouteWaypoints container with routeWaypoint xlinks.
+        var containerRefs = ImmutableArray.CreateBuilder<GmlReference>();
+        for (int i = 1; i <= waypointCount; i++)
+        {
+            containerRefs.Add(new GmlReference { Role = "routeWaypoint", Href = $"#RTE.WPT.{i}" });
+        }
+        features.Add(new S421Feature
+        {
+            Id = "RTE.WPTS",
+            FeatureType = "RouteWaypoints",
+            GeometryType = GmlGeometryType.None,
+            Points = ImmutableArray<(double, double)>.Empty,
+            Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            ExteriorRing = ImmutableArray<(double, double)>.Empty,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Attributes = emptyAttrs,
+            ComplexAttributes = emptyComplex,
+            References = containerRefs.ToImmutable(),
+        });
+
+        // Waypoints + legs. Each waypoint except the last gets an outgoing
+        // leg; the legs themselves are added as separate features.
+        int legCount = waypointCount - 1 + (referenceLegBeyondLastWaypoint ? 1 : 0);
+        for (int i = 1; i <= waypointCount; i++)
+        {
+            var refs = ImmutableArray.CreateBuilder<GmlReference>();
+            bool hasOutgoing = i < waypointCount || referenceLegBeyondLastWaypoint;
+            if (hasOutgoing)
+            {
+                refs.Add(new GmlReference
+                {
+                    Role = "routeWaypointLeg",
+                    Href = $"#RTE.WPT.LEG.{i}",
+                });
+            }
+
+            features.Add(new S421Feature
+            {
+                Id = $"RTE.WPT.{i}",
+                FeatureType = "RouteWaypoint",
+                GeometryType = GmlGeometryType.Point,
+                Points = ImmutableArray.Create((60.0 + 0.01 * i, 25.0 + 0.01 * i)),
+                Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+                ExteriorRing = ImmutableArray<(double, double)>.Empty,
+                InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+                Attributes = ImmutableDictionary<string, string>.Empty.Add("routeWaypointID", i.ToString()),
+                ComplexAttributes = emptyComplex,
+                References = refs.ToImmutable(),
+            });
+        }
+
+        for (int i = 1; i <= legCount; i++)
+        {
+            features.Add(new S421Feature
+            {
+                Id = $"RTE.WPT.LEG.{i}",
+                FeatureType = "RouteWaypointLeg",
+                GeometryType = GmlGeometryType.Curve,
+                Points = ImmutableArray<(double, double)>.Empty,
+                Curves = ImmutableArray.Create(
+                    ImmutableArray.Create(
+                        (60.0 + 0.01 * i, 25.0 + 0.01 * i),
+                        (60.0 + 0.01 * (i + 1), 25.0 + 0.01 * (i + 1)))),
+                ExteriorRing = ImmutableArray<(double, double)>.Empty,
+                InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+                Attributes = emptyAttrs,
+                ComplexAttributes = emptyComplex,
+                References = ImmutableArray<GmlReference>.Empty,
+            });
+        }
+
+        return new S421Dataset
+        {
+            ProductIdentifier = "S-421",
+            DatasetIdentifier = "synthetic",
+            Features = features.ToImmutable(),
+            InformationTypes = ImmutableArray<S421InformationType>.Empty,
+        };
+    }
+
+    [Fact]
+    public void Synthetic_LegStartWaypointMatchesOriginatingWaypoint()
+    {
+        var plan = S421RoutePlan.From(BuildSyntheticRoute(4), out _);
+        Assert.Equal(4, plan.Route.Waypoints.Length);
+        Assert.Equal(3, plan.Route.Legs.Length);
+
+        for (int i = 0; i < plan.Route.Waypoints.Length - 1; i++)
+        {
+            var wp = plan.Route.Waypoints[i];
+            Assert.NotNull(wp.OutgoingLeg);
+            Assert.Same(wp, wp.OutgoingLeg!.StartWaypoint);
+        }
+    }
+
+    [Fact]
+    public void Synthetic_LegEndWaypointMatchesNextWaypoint()
+    {
+        var plan = S421RoutePlan.From(BuildSyntheticRoute(4), out _);
+
+        for (int i = 0; i < plan.Route.Waypoints.Length - 1; i++)
+        {
+            var wp = plan.Route.Waypoints[i];
+            var next = plan.Route.Waypoints[i + 1];
+            Assert.Same(next, wp.OutgoingLeg!.EndWaypoint);
+        }
+    }
+
+    [Fact]
+    public void Synthetic_IncomingLegMirrorsPreviousOutgoingLeg()
+    {
+        var plan = S421RoutePlan.From(BuildSyntheticRoute(4), out _);
+
+        // First waypoint has no incoming leg.
+        Assert.Null(plan.Route.Waypoints[0].IncomingLeg);
+
+        for (int i = 1; i < plan.Route.Waypoints.Length; i++)
+        {
+            var prev = plan.Route.Waypoints[i - 1];
+            var current = plan.Route.Waypoints[i];
+            Assert.NotNull(current.IncomingLeg);
+            Assert.Same(prev.OutgoingLeg, current.IncomingLeg);
+        }
+    }
+
+    [Fact]
+    public void Synthetic_LastWaypointHasNoOutgoingLeg()
+    {
+        var plan = S421RoutePlan.From(BuildSyntheticRoute(4), out _);
+        var last = plan.Route.Waypoints[^1];
+        Assert.Null(last.OutgoingLeg);
+    }
+
+    [Fact]
+    public void Synthetic_FullWalkFromRouteThroughLegsBackToWaypoints()
+    {
+        // End-to-end traversal: starting at plan.Route, walk forward via
+        // wp.OutgoingLeg.EndWaypoint and collect waypoint ids; the result
+        // must match plan.Route.Waypoints in order.
+        var plan = S421RoutePlan.From(BuildSyntheticRoute(5), out var diagnostics);
+        Assert.Empty(diagnostics);
+
+        var walked = new List<string>();
+        var cursor = plan.Route.Waypoints[0];
+        walked.Add(cursor.Id);
+        while (cursor.OutgoingLeg is { } leg)
+        {
+            Assert.Same(cursor, leg.StartWaypoint);
+            Assert.NotNull(leg.EndWaypoint);
+            cursor = leg.EndWaypoint!;
+            walked.Add(cursor.Id);
+        }
+
+        Assert.Equal(
+            plan.Route.Waypoints.Select(w => w.Id).ToArray(),
+            walked.ToArray());
+    }
+
+    [Fact]
+    public void Synthetic_EmitsDiagnosticWhenTerminalWaypointHasOutgoingLeg()
+    {
+        // Build a dataset where the LAST waypoint also references a leg —
+        // the projection should flag this as route.leg.endpoint.missing
+        // (there is no successor waypoint to terminate at), not throw.
+        var plan = S421RoutePlan.From(
+            BuildSyntheticRoute(3, referenceLegBeyondLastWaypoint: true),
+            out var diagnostics);
+
+        var terminalLeg = plan.Route.Waypoints[^1].OutgoingLeg;
+        Assert.NotNull(terminalLeg);
+        Assert.Null(terminalLeg!.EndWaypoint);
+
+        Assert.Contains(diagnostics, d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Code == "route.leg.endpoint.missing");
     }
 
     [Fact]


### PR DESCRIPTION
Completes the S-421 strongly-typed `DataModel` projection, continuing the typed-data-model initiative landed in #69 (shared Core abstractions), #70 (S-128 supersedes navigation), #71 (S-125), and #72 (S-201).

## Context

The bulk of the `EncDotNet.S100.Datasets.S421.DataModel` namespace —
`S421RoutePlan`, `S421Route`, `S421Waypoint`, `S421Leg`, `S421RouteInfo`/`S421VesselInfo`,
`S421ActionPoint`, `S421Schedule` + variants + elements, GMIN/GFULL test coverage,
and adoption of the Core abstractions from #69 — already exists on `main`. The
remaining gap from the task brief was the explicit **typed cross-reference walk**
from a `Route` through its `Waypoints` to a specific `Leg`'s endpoint waypoints,
without parsing href strings.

Previously consumers could walk waypoint → leg via `S421Waypoint.OutgoingLeg`,
but **legs had no back-reference to their bounding waypoints**, and waypoints had
no `IncomingLeg`. A consumer holding an `S421Leg` had to fall back to coordinate
matching or re-walk the route from `plan.Route.Waypoints`.

## Change

Adds three typed references that complete the bidirectional graph:

- **`S421Leg.StartWaypoint`** — the waypoint whose `OutgoingLeg` is this leg
- **`S421Leg.EndWaypoint`** — the next waypoint in route order
- **`S421Waypoint.IncomingLeg`** — mirror of the previous waypoint's `OutgoingLeg`

Wire-up follows the S-128 supersedes-resolution pattern from #70: properties are
declared as `{ get; internal set; }` and populated by a second pass in
`S421RoutePlan.ResolveWaypointsAndLegs` after the per-waypoint projection loop
completes. Topology is taken from document order plus the `routeWaypointLeg`
xlinks already resolved in the first pass — there is no coordinate matching.

A malformed fixture where the **terminal** waypoint still references a leg
surfaces as a `route.leg.endpoint.missing` diagnostic warning rather than
throwing — consistent with the "diagnostics, not exceptions" semantics of the
typed-model layer.

## Tests

Six new tests in `S421RoutePlanTests` cover:

1. `Synthetic_LegStartWaypointMatchesOriginatingWaypoint`
2. `Synthetic_LegEndWaypointMatchesNextWaypoint`
3. `Synthetic_IncomingLegMirrorsPreviousOutgoingLeg`
4. `Synthetic_LastWaypointHasNoOutgoingLeg`
5. `Synthetic_FullWalkFromRouteThroughLegsBackToWaypoints` — explicit end-to-end
   walk that the task brief asked for: starting at `plan.Route`, follow
   `OutgoingLeg.EndWaypoint` until termination and verify the chain matches
   `plan.Route.Waypoints` in order
6. `Synthetic_EmitsDiagnosticWhenTerminalWaypointHasOutgoingLeg`

The IEC `GFULL`/`GBASIC` sample fixtures intentionally contain xlink id
mismatches (container references `#RTE.WPTS.WPT.7` but waypoints use ids
`RTE.WPT.1`–`RTE.WPT.10`, with only one alignment by coincidence — already
covered by the existing `Full_RecordsDiagnosticsForMismatchedWaypointReferences`
test), so the new tests build small synthetic in-memory datasets. This matches
the existing `From_DatasetWithoutRoute_Throws` synthetic-dataset pattern in the
same test class.

## Out of scope

Matches what #69–#72 actually did:

- No changes to `S421DatasetProcessor`, `MapsuiDisplayListRenderer`, or any
  portrayal asset — the pipeline still operates on raw `S421Feature`, same as
  every other typed-model PR. The typed model is an additive consumer-facing
  API, not a pipeline replacement.
- No `S421ScheduleElement.WaypointNumber` resolution to typed waypoint — that
  attribute is an integer (not an `xlink:href`), so it falls outside the
  "xlink:href cross-references should resolve through typed reference objects"
  scope.
- No S-129 ↔ S-421 route binding (Tier 1, separate session per task brief).

## Verification

- `dotnet build -c Release` — clean (3 pre-existing warnings unrelated to this
  change)
- `dotnet test -c Release` — all suites pass; S-421 suite goes from 43 → 49
  tests, full solution count grows by 6

## Files changed

```
src/EncDotNet.S100.Datasets.S421/DataModel/S421RoutePlan.cs    |  41 +++++++-
src/EncDotNet.S100.Datasets.S421/DataModel/S421Waypoint.cs     |  32 ++++++
src/EncDotNet.S100.Datasets.S421/README.md                     |  14 ++-
tests/EncDotNet.S100.Datasets.S421.Tests/S421RoutePlanTests.cs | 218 +++++++++++
```