### PR TITLE
Add strongly-typed DataModel projection for S-129

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -42,6 +42,7 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S125.Tests/EncDotNet.S100.Datasets.S125.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S127.Tests/EncDotNet.S100.Datasets.S127.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S128.Tests/EncDotNet.S100.Datasets.S128.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Datasets.S129.Tests/EncDotNet.S100.Datasets.S129.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S131.Tests/EncDotNet.S100.Datasets.S131.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S201.Tests/EncDotNet.S100.Datasets.S201.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S411.Tests/EncDotNet.S100.Datasets.S411.Tests.csproj" />

--- a/src/EncDotNet.S100.Datasets.S129/DataModel/S129Types.cs
+++ b/src/EncDotNet.S100.Datasets.S129/DataModel/S129Types.cs
@@ -1,0 +1,264 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.DataModel;
+
+/// <summary>
+/// A time range (S-129 Edition 2.0.0 §<c>fixedTimeRange</c>) — the validity
+/// window during which a UKC plan or control-point measurement applies.
+/// </summary>
+/// <remarks>
+/// Either bound may be <c>null</c>: a missing <see cref="Start"/> indicates
+/// an open-start interval, a missing <see cref="End"/> indicates an
+/// open-end interval. Per S-100 Part 5 §10, both values are normalised to
+/// UTC by <see cref="AttributeParser.TryParseDateTimeOffset"/>.
+/// </remarks>
+public sealed record S129TimeRange
+{
+    /// <summary>Start of the interval (inclusive), or <c>null</c> if open-start.</summary>
+    public DateTimeOffset? Start { get; init; }
+
+    /// <summary>End of the interval (inclusive), or <c>null</c> if open-end.</summary>
+    public DateTimeOffset? End { get; init; }
+}
+
+/// <summary>
+/// A multilingual feature name as carried by S-129 Edition 2.0.0
+/// §<c>featureName</c> — a complex attribute with a language code, a
+/// display name, and a name-usage classifier.
+/// </summary>
+public sealed record S129FeatureName
+{
+    /// <summary>ISO 639 language code (e.g. <c>"en"</c>).</summary>
+    public string? Language { get; init; }
+
+    /// <summary>The display name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>The name-usage text label (S-129 listed value <c>nameUsage</c>; e.g. <c>"Default Name Display"</c>).</summary>
+    public string? NameUsage { get; init; }
+}
+
+/// <summary>
+/// A cross-product reference carried by an S-129 dataset to another S-100
+/// product instance (typically S-421 route, S-102 bathymetry, or S-104
+/// water level).
+/// </summary>
+/// <remarks>
+/// <para>
+/// In S-129 Edition 2.0.0, these links are usually <em>textual</em>: a
+/// vessel MMSI / IMO number, a route name plus version, etc. — i.e. the
+/// referenced dataset is identified by its producer-assigned identifier
+/// rather than by a GML <c>xlink:href</c> URL. This type preserves that
+/// information verbatim so downstream code can resolve it against a
+/// catalogue (e.g. an S-421 route library) at its own discretion.
+/// </para>
+/// <para>
+/// <see cref="Identifier"/> is the producer identifier (e.g. the route
+/// name); <see cref="Version"/> is the optional version stamp (e.g. the
+/// S-421 <c>routeInfoEditionNumber</c>). Neither field is resolved
+/// eagerly — the typed projection never requires the referenced dataset
+/// to be present.
+/// </para>
+/// </remarks>
+public sealed record S129ExternalReference
+{
+    /// <summary>The kind of referenced object (e.g. <c>"S-421 route"</c>, <c>"vessel"</c>).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The producer-assigned identifier of the referenced object.</summary>
+    public required string Identifier { get; init; }
+
+    /// <summary>Optional version / edition stamp (e.g. an S-421 route version number).</summary>
+    public string? Version { get; init; }
+}
+
+/// <summary>
+/// The geometry primitive kind of an S-129 feature.
+/// </summary>
+public enum S129GeometryKind
+{
+    /// <summary>No geometry (e.g. the metadata-only <c>UnderKeelClearancePlan</c>).</summary>
+    None,
+    /// <summary>Single point (<see cref="GeoPosition"/>).</summary>
+    Point,
+    /// <summary>Surface exterior ring (closed sequence of <see cref="GeoPosition"/>).</summary>
+    Surface,
+}
+
+/// <summary>
+/// Typed projection of the <c>UnderKeelClearancePlan</c> feature
+/// (S-129 Edition 2.0.0): the metadata header that describes the
+/// computed UKC plan as a whole.
+/// </summary>
+/// <remarks>
+/// This is the "plan" feature itself — a metadata record with no
+/// geometry. The plan's spatial extent is carried by a separate
+/// <see cref="S129UkcPlanArea"/> feature; the per-waypoint UKC
+/// measurements are carried by <see cref="S129ControlPoint"/> features.
+/// </remarks>
+public sealed class S129UkcPlanMetadata
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The fixed time range during which the plan applies (S-129 §<c>fixedTimeRange</c>).</summary>
+    public S129TimeRange? FixedTimeRange { get; init; }
+
+    /// <summary>The instant at which the producer generated the plan (S-129 §<c>generationTime</c>).</summary>
+    public DateTimeOffset? GenerationTime { get; init; }
+
+    /// <summary>Vessel identifier (MMSI / IMO) the plan applies to (S-129 §<c>vesselID</c>).</summary>
+    public string? VesselId { get; init; }
+
+    /// <summary>
+    /// Typed reference to the source S-421 route the plan was computed
+    /// against. <c>null</c> when <c>sourceRouteName</c> is absent on the
+    /// source feature.
+    /// </summary>
+    public S129ExternalReference? SourceRoute { get; init; }
+
+    /// <summary>The maximum draught used as input to the UKC calculation (S-129 §<c>maximumDraught</c>).</summary>
+    public double? MaximumDraught { get; init; }
+
+    /// <summary>The UKC purpose text label (S-129 listed value <c>underKeelClearancePurpose</c>).</summary>
+    public string? UnderKeelClearancePurpose { get; init; }
+
+    /// <summary>The UKC calculation-requested text label (S-129 listed value <c>underKeelClearanceCalculationRequested</c>).</summary>
+    public string? UnderKeelClearanceCalculationRequested { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the <c>UnderKeelClearancePlanArea</c> feature
+/// (S-129 Edition 2.0.0): the spatial extent of a UKC plan as a single
+/// surface.
+/// </summary>
+public sealed class S129UkcPlanArea
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Geometry primitive kind. Expected to be <see cref="S129GeometryKind.Surface"/>.</summary>
+    public S129GeometryKind GeometryKind { get; init; }
+
+    /// <summary>The exterior-ring coordinates of the plan area.</summary>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } =
+        ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Interior-ring coordinates (holes), if any.</summary>
+    public ImmutableArray<ImmutableArray<GeoPosition>> InteriorRings { get; init; } =
+        ImmutableArray<ImmutableArray<GeoPosition>>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an <c>UnderKeelClearanceNonNavigableArea</c>
+/// feature (S-129 Edition 2.0.0): a surface inside the plan area that the
+/// producer has classified as non-navigable for the given draught and
+/// time window.
+/// </summary>
+public sealed class S129NonNavigableArea
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The minimum display scale (S-129 §<c>scaleMinimum</c>).</summary>
+    public int? ScaleMinimum { get; init; }
+
+    /// <summary>Geometry primitive kind. Expected to be <see cref="S129GeometryKind.Surface"/>.</summary>
+    public S129GeometryKind GeometryKind { get; init; }
+
+    /// <summary>Exterior-ring coordinates.</summary>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } =
+        ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Interior-ring coordinates (holes), if any.</summary>
+    public ImmutableArray<ImmutableArray<GeoPosition>> InteriorRings { get; init; } =
+        ImmutableArray<ImmutableArray<GeoPosition>>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an <c>UnderKeelClearanceAlmostNonNavigableArea</c>
+/// feature (S-129 Edition 2.0.0): a surface with marginal under-keel
+/// clearance — navigable but with limited margin.
+/// </summary>
+public sealed class S129AlmostNonNavigableArea
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The minimum display scale (S-129 §<c>scaleMinimum</c>).</summary>
+    public int? ScaleMinimum { get; init; }
+
+    /// <summary>Geometry primitive kind. Expected to be <see cref="S129GeometryKind.Surface"/>.</summary>
+    public S129GeometryKind GeometryKind { get; init; }
+
+    /// <summary>Exterior-ring coordinates.</summary>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } =
+        ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Interior-ring coordinates (holes), if any.</summary>
+    public ImmutableArray<ImmutableArray<GeoPosition>> InteriorRings { get; init; } =
+        ImmutableArray<ImmutableArray<GeoPosition>>.Empty;
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of an <c>UnderKeelClearanceControlPoint</c> feature
+/// (S-129 Edition 2.0.0): a per-waypoint UKC time-step record — the
+/// producer-computed UKC value at a specific point along the route at
+/// the expected passing time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The typed projection's root <see cref="S129UnderKeelClearancePlan"/>
+/// orders these by <see cref="ExpectedPassingTime"/> (stable, with
+/// gaps preserved per S-129 skill checklist #5).
+/// </para>
+/// <para>
+/// <see cref="DistanceAboveUkcLimit"/> is the headline UKC value: the
+/// vertical margin between the actual under-keel clearance and the
+/// configured limit at this point, in metres.
+/// </para>
+/// </remarks>
+public sealed class S129ControlPoint
+{
+    /// <summary>The GML identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The control-point name (S-129 §<c>featureName</c>), when supplied.</summary>
+    public S129FeatureName? FeatureName { get; init; }
+
+    /// <summary>The instant the vessel is expected to pass this control point (S-129 §<c>expectedPassingTime</c>).</summary>
+    public DateTimeOffset? ExpectedPassingTime { get; init; }
+
+    /// <summary>The vessel speed expected at this control point, in knots (S-129 §<c>expectedPassingSpeed</c>).</summary>
+    public double? ExpectedPassingSpeed { get; init; }
+
+    /// <summary>The margin between actual UKC and the configured UKC limit, in metres (S-129 §<c>distanceAboveUKCLimit</c>).</summary>
+    public double? DistanceAboveUkcLimit { get; init; }
+
+    /// <summary>An optional per-CP fixed time range (S-129 §<c>fixedTimeRange</c>); usually empty when the plan itself carries one.</summary>
+    public S129TimeRange? FixedTimeRange { get; init; }
+
+    /// <summary>The point position (lat / lon, WGS-84).</summary>
+    public GeoPosition? Position { get; init; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Datasets.S129/DataModel/S129UnderKeelClearancePlan.cs
+++ b/src/EncDotNet.S100.Datasets.S129/DataModel/S129UnderKeelClearancePlan.cs
@@ -1,0 +1,398 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S129.DataModel;
+
+/// <summary>
+/// Strongly-typed projection of an <see cref="S129Dataset"/> as a single
+/// Under Keel Clearance Management plan (S-129 Edition 2.0.0).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An S-129 dataset carries one UKC plan per file: a single
+/// <c>UnderKeelClearancePlan</c> metadata feature, a single
+/// <c>UnderKeelClearancePlanArea</c> surface feature describing the
+/// plan's spatial extent, zero or more <c>UnderKeelClearance*Area</c>
+/// surfaces marking non-navigable / almost-non-navigable regions, and an
+/// ordered sequence of <c>UnderKeelClearanceControlPoint</c> features
+/// carrying the per-waypoint UKC time-step measurements.
+/// </para>
+/// <para>
+/// This typed projection surfaces all of the above as strongly-typed
+/// records, with control points ordered by
+/// <see cref="S129ControlPoint.ExpectedPassingTime"/> (stable; gaps are
+/// preserved — per S-129 expert checklist, the typed model does not
+/// interpolate across explicit gaps declared by the producer).
+/// </para>
+/// <para>
+/// Cross-product links — to the source S-421 route, to the S-102
+/// bathymetry the producer used as input, and to the S-104 water-level
+/// forecast — are <em>textual</em> in S-129 Edition 2.0.0: the producer
+/// records identifiers (<c>vesselID</c>, <c>sourceRouteName</c> /
+/// <c>sourceRouteVersion</c>) rather than GML <c>xlink:href</c> URLs.
+/// They are surfaced as <see cref="S129ExternalReference"/> values with
+/// no eager resolution; downstream code is free to resolve them
+/// against its own catalogue.
+/// </para>
+/// <para>
+/// Projection issues — duplicate plan / plan-area features, attribute
+/// parse failures, unresolved xlinks — surface as
+/// <see cref="ProjectionDiagnostic"/> entries rather than exceptions.
+/// The projection only throws when the source dataset is fully empty
+/// (no features).
+/// </para>
+/// </remarks>
+public sealed class S129UnderKeelClearancePlan
+{
+    /// <summary>The dataset identifier carried by the source GML <c>Dataset</c> element.</summary>
+    public string? DatasetIdentifier { get; init; }
+
+    /// <summary>The S-129 product identifier (typically <c>"S-129"</c>).</summary>
+    public string? ProductIdentifier { get; init; }
+
+    /// <summary>The plan metadata header, or <c>null</c> if absent.</summary>
+    public S129UkcPlanMetadata? Plan { get; init; }
+
+    /// <summary>The plan area surface, or <c>null</c> if absent.</summary>
+    public S129UkcPlanArea? PlanArea { get; init; }
+
+    /// <summary>Non-navigable surface features.</summary>
+    public ImmutableArray<S129NonNavigableArea> NonNavigableAreas { get; init; } =
+        ImmutableArray<S129NonNavigableArea>.Empty;
+
+    /// <summary>Almost-non-navigable surface features.</summary>
+    public ImmutableArray<S129AlmostNonNavigableArea> AlmostNonNavigableAreas { get; init; } =
+        ImmutableArray<S129AlmostNonNavigableArea>.Empty;
+
+    /// <summary>
+    /// Control points carrying the per-waypoint UKC time-step measurements,
+    /// ordered by <see cref="S129ControlPoint.ExpectedPassingTime"/> (control
+    /// points with no expected-passing-time are sorted last, in their
+    /// source-document order).
+    /// </summary>
+    public ImmutableArray<S129ControlPoint> ControlPoints { get; init; } =
+        ImmutableArray<S129ControlPoint>.Empty;
+
+    /// <summary>The originating feature-bag dataset.</summary>
+    public required S129Dataset Source { get; init; }
+
+    /// <summary>
+    /// Projects a feature-bag <see cref="S129Dataset"/> into the typed data
+    /// model. Issues encountered during projection are reported via
+    /// <paramref name="diagnostics"/>; the projection only throws for a
+    /// fully empty dataset.
+    /// </summary>
+    /// <param name="dataset">The source dataset.</param>
+    /// <param name="diagnostics">Out parameter receiving the projection diagnostics.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <paramref name="dataset"/> contains no features.
+    /// </exception>
+    public static S129UnderKeelClearancePlan From(
+        S129Dataset dataset,
+        out IReadOnlyList<ProjectionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        if (dataset.Features.IsDefaultOrEmpty)
+            throw new InvalidOperationException("Dataset contains no features.");
+
+        var ctx = new ProjectionContext(BuildXlinkResolver(dataset));
+
+        S129UkcPlanMetadata? plan = null;
+        S129UkcPlanArea? planArea = null;
+        var nonNav = ImmutableArray.CreateBuilder<S129NonNavigableArea>();
+        var almostNonNav = ImmutableArray.CreateBuilder<S129AlmostNonNavigableArea>();
+        var controlPoints = ImmutableArray.CreateBuilder<S129ControlPoint>();
+
+        foreach (var f in dataset.Features)
+        {
+            switch (f.FeatureType)
+            {
+                case var t when t.Equals("UnderKeelClearancePlan", StringComparison.OrdinalIgnoreCase):
+                    if (plan is not null)
+                        ctx.Warn(
+                            "Dataset contains more than one UnderKeelClearancePlan feature; using the first.",
+                            code: "feature.duplicate",
+                            relatedId: f.Id);
+                    else
+                        plan = ProjectPlanMetadata(f, ctx);
+                    break;
+
+                case var t when t.Equals("UnderKeelClearancePlanArea", StringComparison.OrdinalIgnoreCase):
+                    if (planArea is not null)
+                        ctx.Warn(
+                            "Dataset contains more than one UnderKeelClearancePlanArea feature; using the first.",
+                            code: "feature.duplicate",
+                            relatedId: f.Id);
+                    else
+                        planArea = ProjectPlanArea(f, ctx);
+                    break;
+
+                case var t when t.Equals("UnderKeelClearanceNonNavigableArea", StringComparison.OrdinalIgnoreCase):
+                    nonNav.Add(ProjectNonNavigable(f, ctx));
+                    break;
+
+                case var t when t.Equals("UnderKeelClearanceAlmostNonNavigableArea", StringComparison.OrdinalIgnoreCase):
+                    almostNonNav.Add(ProjectAlmostNonNavigable(f, ctx));
+                    break;
+
+                case var t when t.Equals("UnderKeelClearanceControlPoint", StringComparison.OrdinalIgnoreCase):
+                    controlPoints.Add(ProjectControlPoint(f, ctx));
+                    break;
+
+                default:
+                    // Unknown feature type — preserved on .Source for
+                    // forward compatibility.
+                    break;
+            }
+        }
+
+        // Resolve any xlink references carried on features. Current S-129
+        // 2.0.0 fixtures do not emit xlinks, but the resolver is wired
+        // up so that future producer extensions or tier-1 cross-spec
+        // binding work surfaces unresolved-target diagnostics through
+        // the same channel as the other typed-model projections.
+        foreach (var f in dataset.Features)
+        {
+            foreach (var r in f.References)
+            {
+                ctx.Xlinks.ResolveAny(r.Href, r.Role, ctx, f.Id);
+            }
+        }
+
+        // Sort control points by expected passing time (stable). CPs with
+        // no time stay in source-document order at the tail.
+        var orderedControlPoints = controlPoints
+            .ToImmutable()
+            .Sort(static (a, b) =>
+            {
+                if (a.ExpectedPassingTime is null && b.ExpectedPassingTime is null) return 0;
+                if (a.ExpectedPassingTime is null) return 1;
+                if (b.ExpectedPassingTime is null) return -1;
+                return a.ExpectedPassingTime.Value.CompareTo(b.ExpectedPassingTime.Value);
+            });
+
+        diagnostics = ctx.ToImmutableDiagnostics();
+        return new S129UnderKeelClearancePlan
+        {
+            DatasetIdentifier = dataset.DatasetIdentifier,
+            ProductIdentifier = dataset.ProductIdentifier,
+            Plan = plan,
+            PlanArea = planArea,
+            NonNavigableAreas = nonNav.ToImmutable(),
+            AlmostNonNavigableAreas = almostNonNav.ToImmutable(),
+            ControlPoints = orderedControlPoints,
+            Source = dataset,
+        };
+    }
+
+    private static XlinkResolver BuildXlinkResolver(S129Dataset dataset)
+    {
+        IEnumerable<KeyValuePair<string, object>> All()
+        {
+            foreach (var f in dataset.Features)
+                if (!string.IsNullOrEmpty(f.Id))
+                    yield return new KeyValuePair<string, object>(f.Id, f);
+        }
+        return XlinkResolver.Build(All());
+    }
+
+    // ── Per-feature projection ─────────────────────────────────────────
+
+    private static S129UkcPlanMetadata ProjectPlanMetadata(S129Feature f, ProjectionContext ctx)
+    {
+        S129TimeRange? timeRange = ExtractTimeRange(f, "fixedTimeRange");
+
+        S129ExternalReference? sourceRoute = null;
+        if (f.Attributes.TryGetValue("sourceRouteName", out var routeName) && !string.IsNullOrEmpty(routeName))
+        {
+            sourceRoute = new S129ExternalReference
+            {
+                Kind = "S-421 route",
+                Identifier = routeName,
+                Version = f.Attributes.GetValueOrDefault("sourceRouteVersion"),
+            };
+        }
+
+        return new S129UkcPlanMetadata
+        {
+            Id = f.Id,
+            FixedTimeRange = timeRange,
+            GenerationTime = AttributeParser.TryParseDateTimeOffset(
+                f.Attributes.GetValueOrDefault("generationTime"), ctx, f.Id, "generationTime"),
+            VesselId = f.Attributes.GetValueOrDefault("vesselID"),
+            SourceRoute = sourceRoute,
+            MaximumDraught = AttributeParser.TryParseDouble(
+                f.Attributes.GetValueOrDefault("maximumDraught"), ctx, f.Id, "maximumDraught"),
+            UnderKeelClearancePurpose = f.Attributes.GetValueOrDefault("underKeelClearancePurpose"),
+            UnderKeelClearanceCalculationRequested =
+                f.Attributes.GetValueOrDefault("underKeelClearanceCalculationRequested"),
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(
+                f.Attributes,
+                "generationTime", "vesselID", "sourceRouteName", "sourceRouteVersion",
+                "maximumDraught", "underKeelClearancePurpose",
+                "underKeelClearanceCalculationRequested"),
+        };
+    }
+
+    private static S129UkcPlanArea ProjectPlanArea(S129Feature f, ProjectionContext ctx)
+    {
+        var (kind, coords, holes) = ProjectGeometry(f, ctx);
+        return new S129UkcPlanArea
+        {
+            Id = f.Id,
+            GeometryKind = kind,
+            Coordinates = coords,
+            InteriorRings = holes,
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes),
+        };
+    }
+
+    private static S129NonNavigableArea ProjectNonNavigable(S129Feature f, ProjectionContext ctx)
+    {
+        var (kind, coords, holes) = ProjectGeometry(f, ctx);
+        return new S129NonNavigableArea
+        {
+            Id = f.Id,
+            ScaleMinimum = AttributeParser.TryParseInt(
+                f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+            GeometryKind = kind,
+            Coordinates = coords,
+            InteriorRings = holes,
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, "scaleMinimum"),
+        };
+    }
+
+    private static S129AlmostNonNavigableArea ProjectAlmostNonNavigable(S129Feature f, ProjectionContext ctx)
+    {
+        var (kind, coords, holes) = ProjectGeometry(f, ctx);
+        return new S129AlmostNonNavigableArea
+        {
+            Id = f.Id,
+            ScaleMinimum = AttributeParser.TryParseInt(
+                f.Attributes.GetValueOrDefault("scaleMinimum"), ctx, f.Id, "scaleMinimum"),
+            GeometryKind = kind,
+            Coordinates = coords,
+            InteriorRings = holes,
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, "scaleMinimum"),
+        };
+    }
+
+    private static S129ControlPoint ProjectControlPoint(S129Feature f, ProjectionContext ctx)
+    {
+        S129FeatureName? name = null;
+        var nameBlock = f.ComplexAttributes.FirstOrDefault(c =>
+            string.Equals(c.Code, "featureName", StringComparison.OrdinalIgnoreCase));
+        if (nameBlock is not null)
+        {
+            var sub = nameBlock.SubAttributes;
+            name = new S129FeatureName
+            {
+                Language = sub.GetValueOrDefault("language"),
+                Name = sub.GetValueOrDefault("name"),
+                NameUsage = sub.GetValueOrDefault("nameUsage"),
+            };
+        }
+
+        var timeRange = ExtractTimeRange(f, "fixedTimeRange");
+
+        GeoPosition? position = null;
+        if (!f.Points.IsDefaultOrEmpty)
+        {
+            var (lat, lon) = f.Points[0];
+            position = new GeoPosition(lat, lon);
+        }
+
+        return new S129ControlPoint
+        {
+            Id = f.Id,
+            FeatureName = name,
+            ExpectedPassingTime = AttributeParser.TryParseDateTimeOffset(
+                f.Attributes.GetValueOrDefault("expectedPassingTime"), ctx, f.Id, "expectedPassingTime"),
+            ExpectedPassingSpeed = AttributeParser.TryParseDouble(
+                f.Attributes.GetValueOrDefault("expectedPassingSpeed"), ctx, f.Id, "expectedPassingSpeed"),
+            DistanceAboveUkcLimit = AttributeParser.TryParseDouble(
+                f.Attributes.GetValueOrDefault("distanceAboveUKCLimit"), ctx, f.Id, "distanceAboveUKCLimit"),
+            FixedTimeRange = timeRange,
+            Position = position,
+            ExtraAttributes = ExtraAttributes.ExcludeKnown(
+                f.Attributes,
+                "expectedPassingTime", "expectedPassingSpeed", "distanceAboveUKCLimit"),
+        };
+    }
+
+    private static S129TimeRange? ExtractTimeRange(S129Feature f, string complexCode)
+    {
+        var block = f.ComplexAttributes.FirstOrDefault(c =>
+            string.Equals(c.Code, complexCode, StringComparison.OrdinalIgnoreCase));
+        if (block is null) return null;
+
+        var sub = block.SubAttributes;
+        var startText = sub.GetValueOrDefault("timeStart");
+        var endText = sub.GetValueOrDefault("timeEnd");
+        if (string.IsNullOrEmpty(startText) && string.IsNullOrEmpty(endText))
+            return null;
+
+        DateTimeOffset? start = null;
+        DateTimeOffset? end = null;
+        if (!string.IsNullOrEmpty(startText) &&
+            DateTimeOffset.TryParse(
+                startText,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal |
+                System.Globalization.DateTimeStyles.AdjustToUniversal,
+                out var s))
+        {
+            start = s;
+        }
+        if (!string.IsNullOrEmpty(endText) &&
+            DateTimeOffset.TryParse(
+                endText,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal |
+                System.Globalization.DateTimeStyles.AdjustToUniversal,
+                out var e))
+        {
+            end = e;
+        }
+        return new S129TimeRange { Start = start, End = end };
+    }
+
+    private static (S129GeometryKind, ImmutableArray<GeoPosition>, ImmutableArray<ImmutableArray<GeoPosition>>)
+        ProjectGeometry(S129Feature f, ProjectionContext ctx)
+    {
+        switch (f.GeometryType)
+        {
+            case GmlGeometryType.Point:
+                return (
+                    S129GeometryKind.Point,
+                    f.Points.IsDefaultOrEmpty
+                        ? ImmutableArray<GeoPosition>.Empty
+                        : f.Points.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray(),
+                    ImmutableArray<ImmutableArray<GeoPosition>>.Empty);
+
+            case GmlGeometryType.Surface:
+                var ext = f.ExteriorRing.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.ExteriorRing.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray();
+                var holes = f.InteriorRings.IsDefaultOrEmpty
+                    ? ImmutableArray<ImmutableArray<GeoPosition>>.Empty
+                    : f.InteriorRings
+                        .Select(r => r.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray())
+                        .ToImmutableArray();
+                if (ext.IsEmpty)
+                    ctx.Warn(
+                        "Surface feature has no exterior-ring coordinates.",
+                        code: "feature.geometry.missing",
+                        relatedId: f.Id);
+                return (S129GeometryKind.Surface, ext, holes);
+
+            default:
+                return (
+                    S129GeometryKind.None,
+                    ImmutableArray<GeoPosition>.Empty,
+                    ImmutableArray<ImmutableArray<GeoPosition>>.Empty);
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129/README.md
+++ b/src/EncDotNet.S100.Datasets.S129/README.md
@@ -4,14 +4,49 @@ Support for S-129 Under Keel Clearance Management datasets (S-100 Part 10b GML e
 
 ## Overview
 
-This library reads S-129 datasets from GML files and provides an XSLT-based portrayal pipeline for under keel clearance features. Key types include:
+This library reads S-129 datasets from GML files and provides an XSLT-based portrayal pipeline for under keel clearance features. Two API surfaces are offered:
+
+### Raw GML (feature-bag) surface
 
 - **`S129Dataset`** — root model containing parsed features and dataset identification.
-- **`S129Feature`** — a geographic feature with type code, geometry, simple attributes, and complex attributes.
+- **`S129Feature`** — a geographic feature with type code, geometry, simple attributes, complex attributes, and `xlink:href` references.
 - **`S129ComplexAttribute`** — a complex attribute instance containing sub-attribute values.
+- **`S129Reference`** — an `xlink:href` cross-reference carried on a feature's child element (S-100 Part 10b §7.2).
 - **`GmlGeometryType`** — enum describing the geometry primitive type of a feature.
-- **`S129FeatureXmlSource`** — `IFeatureXmlSource` adapter that projects an `S129Dataset` into S-100 Part 9 FeatureXML for XSLT portrayal rules.
 - **`S129PortrayalCatalogue`** — `IVectorPortrayalCatalogue` implementation that loads XSLT rules, symbols, line styles, area fills, and color palettes.
+
+### Strongly-typed data model
+
+Mirrors the projection pattern introduced for S-124 / S-125 / S-128 / S-201 (PRs #69–#72). Lives under `DataModel/`:
+
+- **`S129UnderKeelClearancePlan`** — root typed projection of an `S129Dataset` as a single UKC plan (one plan, one plan area, N non-navigable / almost-non-navigable surfaces, ordered control points). Built via `S129UnderKeelClearancePlan.From(dataset, out diagnostics)`.
+- **`S129UkcPlanMetadata`** — the `UnderKeelClearancePlan` feature with typed `fixedTimeRange`, `generationTime`, `maximumDraught`, vessel id, and a typed `S129ExternalReference` to the source S-421 route.
+- **`S129UkcPlanArea`**, **`S129NonNavigableArea`**, **`S129AlmostNonNavigableArea`** — typed surface features.
+- **`S129ControlPoint`** — typed point feature with the per-waypoint UKC time-step measurement (`distanceAboveUKCLimit`, `expectedPassingTime`, `expectedPassingSpeed`). Control points are returned **ordered by expected passing time** (stable; gaps preserved — the typed model does not interpolate across explicit producer gaps).
+- **`S129TimeRange`**, **`S129FeatureName`**, **`S129ExternalReference`** — shared sub-types.
+- **`S129GeometryKind`** — `None` / `Point` / `Surface`.
+
+Projection issues — duplicate plan features, attribute parse failures, unresolved xlinks — surface as `ProjectionDiagnostic` entries (codes from the shared `EncDotNet.S100.DataModel` set: `feature.duplicate`, `attribute.parse.double`, `attribute.parse.datetime`, `xlink.unresolved`, `feature.geometry.missing`). The projection only throws `InvalidOperationException` for a fully empty dataset.
+
+### Cross-product references
+
+In S-129 Edition 2.0.0, links to the source S-421 route / S-102 bathymetry / S-104 water level are **textual** (the producer records identifiers, not `xlink:href` URLs). The typed projection preserves these on the plan as `S129ExternalReference` values; resolving them against an actual S-421 / S-102 / S-104 dataset is the caller's responsibility, and the typed model never requires those datasets to be present.
+
+```csharp
+var dataset = S129Dataset.Open("12900MCTDS130TS.gml");
+var typed = S129UnderKeelClearancePlan.From(dataset, out var diagnostics);
+
+Console.WriteLine($"Vessel: {typed.Plan?.VesselId}");
+Console.WriteLine($"Route:  {typed.Plan?.SourceRoute?.Identifier} v{typed.Plan?.SourceRoute?.Version}");
+Console.WriteLine($"Plan window: {typed.Plan?.FixedTimeRange?.Start} → {typed.Plan?.FixedTimeRange?.End}");
+
+foreach (var cp in typed.ControlPoints)
+{
+    Console.WriteLine(
+        $"  {cp.FeatureName?.Name,-6} @ {cp.ExpectedPassingTime:HH:mm:ss}  " +
+        $"UKC margin: {cp.DistanceAboveUkcLimit:F2} m");
+}
+```
 
 ## Installation
 

--- a/src/EncDotNet.S100.Datasets.S129/S129Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129Dataset.cs
@@ -66,8 +66,32 @@ public sealed class S129Feature : IGmlFeature
     /// <summary>Complex attribute groups keyed by code, each containing sub-attribute dictionaries.</summary>
     public required ImmutableArray<S129ComplexAttribute> ComplexAttributes { get; init; }
 
+    /// <summary>
+    /// xlink:href references carried on this feature's child elements
+    /// (S-100 Part 10b §7.2). Default empty when no cross-references are
+    /// present.
+    /// </summary>
+    public ImmutableArray<S129Reference> References { get; init; } =
+        ImmutableArray<S129Reference>.Empty;
+
     /// <inheritdoc/>
     IEnumerable<IGmlComplexAttribute> IGmlFeature.GmlComplexAttributes => ComplexAttributes.Cast<IGmlComplexAttribute>();
+}
+
+/// <summary>
+/// An <c>xlink:href</c> cross-reference carried on a child element of an
+/// <see cref="S129Feature"/> (S-100 Part 10b §7.2). The <see cref="Role"/>
+/// is the local name of the child element (e.g. <c>"sourceRoute"</c>);
+/// the <see cref="Href"/> is the raw <c>xlink:href</c> value (either a
+/// fragment identifier like <c>"#WAYPOINT_03"</c> or an external URL).
+/// </summary>
+public sealed record S129Reference
+{
+    /// <summary>The local name of the referring child element (association role).</summary>
+    public required string Role { get; init; }
+
+    /// <summary>The raw <c>xlink:href</c> value.</summary>
+    public required string Href { get; init; }
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.S129/S129DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129DatasetReader.cs
@@ -11,6 +11,7 @@ namespace EncDotNet.S100.Datasets.S129;
 internal static class S129DatasetReader
 {
     // S-100 Part 10b GML namespaces
+    private static readonly XNamespace XlinkNs = "http://www.w3.org/1999/xlink";
     private static readonly XNamespace S100Ns1 = "http://www.iho.int/S100/profile/s100gml/1.0";
     private static readonly XNamespace S100Ns5 = "http://www.iho.int/s100gml/5.0";
 
@@ -81,7 +82,7 @@ internal static class S129DatasetReader
         var (geometryType, points, curves, exteriorRing, interiorRings) = ParseGeometry(element, s100Ns);
 
         // Parse attributes
-        var (simpleAttrs, complexAttrs) = ParseAttributes(element, s100Ns);
+        var (simpleAttrs, complexAttrs, references) = ParseAttributes(element, s100Ns);
 
         return new S129Feature
         {
@@ -94,6 +95,7 @@ internal static class S129DatasetReader
             InteriorRings = interiorRings,
             Attributes = simpleAttrs,
             ComplexAttributes = complexAttrs,
+            References = references,
         };
     }
 
@@ -161,10 +163,11 @@ internal static class S129DatasetReader
         }
 
         return (geometryType, points, curves, exteriorRing, interiorRings);
-    }    private static (ImmutableDictionary<string, string>, ImmutableArray<S129ComplexAttribute>) ParseAttributes(XElement element, XNamespace s100Ns)
+    }    private static (ImmutableDictionary<string, string>, ImmutableArray<S129ComplexAttribute>, ImmutableArray<S129Reference>) ParseAttributes(XElement element, XNamespace s100Ns)
     {
         var simple = ImmutableDictionary.CreateBuilder<string, string>();
         var complex = ImmutableArray.CreateBuilder<S129ComplexAttribute>();
+        var references = ImmutableArray.CreateBuilder<S129Reference>();
         var ns = element.Name.Namespace;
 
         foreach (var child in element.Elements())
@@ -175,6 +178,20 @@ internal static class S129DatasetReader
                 child.Name.Namespace == GmlNamespaces.Gml ||
                 child.Name.Namespace == s100Ns)
                 continue;
+
+            // xlink:href cross-reference on an empty-leaf element. Capture
+            // it as an S129Reference rather than as a simple attribute so
+            // the typed projection can resolve it through XlinkResolver.
+            var href = child.Attribute(XlinkNs + "href")?.Value;
+            if (!string.IsNullOrEmpty(href) && !child.HasElements && string.IsNullOrEmpty(child.Value))
+            {
+                references.Add(new S129Reference
+                {
+                    Role = localName,
+                    Href = href,
+                });
+                continue;
+            }
 
             if (child.HasElements)
             {
@@ -202,7 +219,7 @@ internal static class S129DatasetReader
             }
         }
 
-        return (simple.ToImmutable(), complex.ToImmutable());
+        return (simple.ToImmutable(), complex.ToImmutable(), references.ToImmutable());
     }
 
     private static bool IsFeatureType(XName name, XNamespace datasetNs)

--- a/tests/EncDotNet.S100.Datasets.S129.Tests/DataModelTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Tests/DataModelTests.cs
@@ -1,0 +1,261 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S129.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Tests;
+
+/// <summary>
+/// Tests for the strongly-typed projection
+/// <see cref="S129UnderKeelClearancePlan"/>.
+/// </summary>
+public class DataModelTests
+{
+    private const string TestDataDir = "TestData";
+
+    private static S129Dataset LoadFixture(string name) =>
+        S129Dataset.Open(Path.Combine(TestDataDir, name));
+
+    private static S129UnderKeelClearancePlan Project(
+        string name,
+        out IReadOnlyList<ProjectionDiagnostic> diagnostics) =>
+        S129UnderKeelClearancePlan.From(LoadFixture(name), out diagnostics);
+
+    private static S129Dataset OpenGml(string gml)
+    {
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(gml));
+        return S129Dataset.Open(stream);
+    }
+
+    // ── Real-fixture coverage ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("12900MCTDS130TS.gml")]
+    [InlineData("12900MCTDS200TS.gml")]
+    public void From_RealFixture_PopulatesPlanAndPlanArea(string fileName)
+    {
+        var typed = Project(fileName, out var diagnostics);
+
+        Assert.Equal("S-129", typed.ProductIdentifier);
+        Assert.NotNull(typed.Plan);
+        Assert.NotNull(typed.PlanArea);
+        Assert.Equal(S129GeometryKind.Surface, typed.PlanArea!.GeometryKind);
+        Assert.NotEmpty(typed.PlanArea.Coordinates);
+
+        // No parse errors expected against the bundled fixtures.
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void From_TorresStraitFixture_ParsesPlanMetadata()
+    {
+        var typed = Project("12900MCTDS130TS.gml", out _);
+        var plan = typed.Plan!;
+
+        Assert.Equal("TEST_PLAN_TORRES_STRAIT", plan.Id);
+        Assert.Equal("9800738", plan.VesselId);
+        Assert.Equal(12.2, plan.MaximumDraught);
+        Assert.NotNull(plan.SourceRoute);
+        Assert.Equal("S-421 route", plan.SourceRoute!.Kind);
+        Assert.Equal("Test Route Name", plan.SourceRoute.Identifier);
+        Assert.Equal("1152192", plan.SourceRoute.Version);
+
+        Assert.NotNull(plan.FixedTimeRange);
+        Assert.Equal(
+            new DateTimeOffset(2024, 4, 17, 21, 41, 0, TimeSpan.Zero),
+            plan.FixedTimeRange!.Start);
+        Assert.Equal(
+            new DateTimeOffset(2024, 4, 18, 1, 13, 0, TimeSpan.Zero),
+            plan.FixedTimeRange.End);
+    }
+
+    [Fact]
+    public void From_TorresStraitFixture_ControlPointsCarryUkcMeasurements()
+    {
+        var typed = Project("12900MCTDS130TS.gml", out _);
+
+        Assert.NotEmpty(typed.ControlPoints);
+        var cp01 = typed.ControlPoints.Single(cp => cp.Id == "CP_01");
+        Assert.Equal(0.113, cp01.DistanceAboveUkcLimit);
+        Assert.Equal(6.0, cp01.ExpectedPassingSpeed);
+        Assert.Equal(
+            new DateTimeOffset(2024, 4, 17, 22, 0, 0, TimeSpan.Zero),
+            cp01.ExpectedPassingTime);
+        Assert.NotNull(cp01.Position);
+        Assert.InRange(cp01.Position!.Value.Latitude, -10.6, -10.4);
+        Assert.InRange(cp01.Position.Value.Longitude, 142.3, 142.4);
+
+        Assert.NotNull(cp01.FeatureName);
+        Assert.Equal("en", cp01.FeatureName!.Language);
+        Assert.Equal("CP01", cp01.FeatureName.Name);
+    }
+
+    [Fact]
+    public void From_TorresStraitFixture_ControlPointsOrderedByPassingTime()
+    {
+        // S-129 skill checklist #2: preserve the temporal ordering of UKC
+        // values. The fixture lists CPs in id order, which also happens
+        // to be passing-time order — verify the projection holds the
+        // invariant regardless.
+        var typed = Project("12900MCTDS130TS.gml", out _);
+
+        var times = typed.ControlPoints
+            .Select(cp => cp.ExpectedPassingTime)
+            .Where(t => t.HasValue)
+            .Select(t => t!.Value)
+            .ToList();
+
+        Assert.NotEmpty(times);
+        for (var i = 1; i < times.Count; i++)
+            Assert.True(times[i] >= times[i - 1],
+                $"Control point {i} expectedPassingTime regressed: {times[i - 1]} → {times[i]}");
+    }
+
+    [Fact]
+    public void From_TorresStraitFixture_NonNavigableAreasParsed()
+    {
+        var typed = Project("12900MCTDS130TS.gml", out _);
+        Assert.NotEmpty(typed.NonNavigableAreas);
+
+        foreach (var area in typed.NonNavigableAreas)
+        {
+            Assert.Equal(S129GeometryKind.Surface, area.GeometryKind);
+            Assert.NotEmpty(area.Coordinates);
+            Assert.Equal(1, area.ScaleMinimum);
+        }
+    }
+
+    [Fact]
+    public void From_PreservesRawDatasetOnSource()
+    {
+        var dataset = LoadFixture("12900MCTDS130TS.gml");
+        var typed = S129UnderKeelClearancePlan.From(dataset, out _);
+        Assert.Same(dataset, typed.Source);
+    }
+
+    // ── Synthetic-fixture edge cases ────────────────────────────────
+
+    [Fact]
+    public void From_EmptyDataset_Throws()
+    {
+        var gml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dataset xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:S100="http://www.iho.int/s100gml/5.0"
+                 xmlns="http://www.iho.int/S129/2.0"
+                 gml:id="EMPTY">
+          <members />
+        </Dataset>
+        """;
+        var dataset = OpenGml(gml);
+        Assert.Throws<InvalidOperationException>(
+            () => S129UnderKeelClearancePlan.From(dataset, out _));
+    }
+
+    [Fact]
+    public void From_DuplicatePlan_ReportsDiagnostic()
+    {
+        var gml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dataset xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:S100="http://www.iho.int/s100gml/5.0"
+                 xmlns="http://www.iho.int/S129/2.0"
+                 gml:id="DUPE">
+          <members>
+            <UnderKeelClearancePlan gml:id="PLAN_A">
+              <vesselID>1</vesselID>
+            </UnderKeelClearancePlan>
+            <UnderKeelClearancePlan gml:id="PLAN_B">
+              <vesselID>2</vesselID>
+            </UnderKeelClearancePlan>
+          </members>
+        </Dataset>
+        """;
+        var typed = S129UnderKeelClearancePlan.From(OpenGml(gml), out var diagnostics);
+
+        Assert.Equal("PLAN_A", typed.Plan!.Id);
+        Assert.Contains(
+            diagnostics,
+            d => d.Code == "feature.duplicate" && d.RelatedId == "PLAN_B");
+    }
+
+    [Fact]
+    public void From_UnresolvedXlink_ReportsDiagnostic()
+    {
+        // A child element with an xlink:href to a non-existent target is
+        // captured by the reader as an S129Reference and surfaced by the
+        // typed projection through XlinkResolver.
+        var gml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dataset xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:S100="http://www.iho.int/s100gml/5.0"
+                 xmlns="http://www.iho.int/S129/2.0"
+                 gml:id="XLINK">
+          <members>
+            <UnderKeelClearancePlan gml:id="PLAN">
+              <vesselID>1</vesselID>
+              <sourceRoute xlink:href="#MISSING" />
+            </UnderKeelClearancePlan>
+          </members>
+        </Dataset>
+        """;
+        var typed = S129UnderKeelClearancePlan.From(OpenGml(gml), out var diagnostics);
+
+        Assert.NotNull(typed.Plan);
+        Assert.Contains(
+            diagnostics,
+            d => d.Code == "xlink.unresolved" && d.RelatedId == "PLAN");
+    }
+
+    [Fact]
+    public void From_AttributeParseFailure_ReportsDiagnostic()
+    {
+        var gml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dataset xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:S100="http://www.iho.int/s100gml/5.0"
+                 xmlns="http://www.iho.int/S129/2.0"
+                 gml:id="BAD">
+          <members>
+            <UnderKeelClearancePlan gml:id="PLAN">
+              <maximumDraught>not-a-number</maximumDraught>
+            </UnderKeelClearancePlan>
+          </members>
+        </Dataset>
+        """;
+        var typed = S129UnderKeelClearancePlan.From(OpenGml(gml), out var diagnostics);
+
+        Assert.Null(typed.Plan!.MaximumDraught);
+        Assert.Contains(
+            diagnostics,
+            d => d.Code == "attribute.parse.double"
+                && d.RelatedAttribute == "maximumDraught");
+    }
+
+    [Fact]
+    public void From_ExtraAttributes_PreservesUnmodelledKeys()
+    {
+        // A producer extension attribute not consumed by the typed model
+        // round-trips through ExtraAttributes for forward compatibility.
+        var gml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dataset xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:S100="http://www.iho.int/s100gml/5.0"
+                 xmlns="http://www.iho.int/S129/2.0"
+                 gml:id="EXTRA">
+          <members>
+            <UnderKeelClearancePlan gml:id="PLAN">
+              <vesselID>1234</vesselID>
+              <producerExtensionFooBar>baz</producerExtensionFooBar>
+            </UnderKeelClearancePlan>
+          </members>
+        </Dataset>
+        """;
+        var typed = S129UnderKeelClearancePlan.From(OpenGml(gml), out _);
+
+        Assert.True(
+            typed.Plan!.ExtraAttributes.TryGetValue("producerExtensionFooBar", out var v));
+        Assert.Equal("baz", v);
+        // VesselId is modelled; it should not also appear in ExtraAttributes.
+        Assert.False(typed.Plan.ExtraAttributes.ContainsKey("vesselID"));
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Tests/EncDotNet.S100.Datasets.S129.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S129.Tests/EncDotNet.S100.Datasets.S129.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\datasets\S129\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Datasets.S129.Tests/S129DatasetReaderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Tests/S129DatasetReaderTests.cs
@@ -1,0 +1,67 @@
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S129.Tests;
+
+/// <summary>
+/// Smoke tests for <see cref="S129Dataset"/> over the two bundled
+/// real-world S-129 fixtures.
+/// </summary>
+public class S129DatasetReaderTests
+{
+    private const string TestDataDir = "TestData";
+
+    [Theory]
+    [InlineData("12900MCTDS130TS.gml")]
+    [InlineData("12900MCTDS200TS.gml")]
+    public void Open_RealFixture_ParsesProductAndFeatures(string fileName)
+    {
+        var path = Path.Combine(TestDataDir, fileName);
+        var dataset = S129Dataset.Open(path);
+
+        Assert.Equal("S-129", dataset.ProductIdentifier);
+        Assert.False(dataset.Features.IsDefaultOrEmpty);
+
+        // The two bundled fixtures both carry exactly one plan and one
+        // plan-area feature plus many areas and control points.
+        Assert.Single(dataset.Features.Where(f =>
+            string.Equals(f.FeatureType, "UnderKeelClearancePlan", StringComparison.OrdinalIgnoreCase)));
+        Assert.Single(dataset.Features.Where(f =>
+            string.Equals(f.FeatureType, "UnderKeelClearancePlanArea", StringComparison.OrdinalIgnoreCase)));
+        Assert.NotEmpty(dataset.Features.Where(f =>
+            string.Equals(f.FeatureType, "UnderKeelClearanceNonNavigableArea", StringComparison.OrdinalIgnoreCase)));
+        Assert.NotEmpty(dataset.Features.Where(f =>
+            string.Equals(f.FeatureType, "UnderKeelClearanceControlPoint", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void Open_RealFixture_ControlPointGeometryParsesLatFirst()
+    {
+        // S-100 Part 10b §6.2: GML coordinate ordering for EPSG:4326 is
+        // (lat, lon). The Torres Strait fixture sits around lat ≈ -10.5,
+        // lon ≈ 142.x — verify the reader does not swap them.
+        var dataset = S129Dataset.Open(Path.Combine(TestDataDir, "12900MCTDS130TS.gml"));
+        var firstCp = dataset.Features
+            .First(f => string.Equals(
+                f.FeatureType, "UnderKeelClearanceControlPoint", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(GmlGeometryType.Point, firstCp.GeometryType);
+        Assert.Single(firstCp.Points);
+        var (lat, lon) = firstCp.Points[0];
+        Assert.InRange(lat, -11.0, -10.0);
+        Assert.InRange(lon, 142.0, 143.0);
+    }
+
+    [Fact]
+    public void Open_RealFixture_PlanAreaSurfaceRingClosed()
+    {
+        var dataset = S129Dataset.Open(Path.Combine(TestDataDir, "12900MCTDS130TS.gml"));
+        var planArea = dataset.Features.Single(f =>
+            string.Equals(f.FeatureType, "UnderKeelClearancePlanArea", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(GmlGeometryType.Surface, planArea.GeometryType);
+        Assert.False(planArea.ExteriorRing.IsDefaultOrEmpty);
+        Assert.True(planArea.ExteriorRing.Length >= 4);
+        // Ring closure: first ≡ last coordinate.
+        Assert.Equal(planArea.ExteriorRing[0], planArea.ExteriorRing[^1]);
+    }
+}


### PR DESCRIPTION
Adds a typed `DataModel` projection to S-129 (Under Keel Clearance Management), following the pattern established for S-124, S-125, S-128, and S-201 in #69 / #70 / #71 / #72.

## What this PR does

- Introduces `S129UnderKeelClearancePlan` as the root typed projection of an `S129Dataset`, built via `S129UnderKeelClearancePlan.From(dataset, out diagnostics)` and exposing the raw `S129Feature` bag on `.Source` (same shape as the peer specs).
- Adds typed per-feature records under `src/EncDotNet.S100.Datasets.S129/DataModel/`:
  - `S129UkcPlanMetadata` — typed plan metadata (vessel id, draught, fixed time range, generation time, source-route reference).
  - `S129UkcPlanArea`, `S129NonNavigableArea`, `S129AlmostNonNavigableArea` — typed surfaces.
  - `S129ControlPoint` — typed waypoint with per-CP UKC time-step measurement; control points are returned **stably sorted by `expectedPassingTime`** (gaps preserved — the projection never interpolates across explicit producer gaps, per the S-129 skill checklist).
- Adds shared sub-types `S129TimeRange`, `S129FeatureName`, `S129ExternalReference` and an `S129GeometryKind` enum.
- Reuses the shared `EncDotNet.S100.Core/DataModel/` abstractions introduced in #69 (`ProjectionContext`, `XlinkResolver`, `AttributeParser`, `ExtraAttributes`, `GeoPosition`, `ProjectionDiagnostic`).

## Cross-product references

In S-129 Edition 2.0.0, links to the source S-421 route / S-102 bathymetry / S-104 water level are **textual** (`sourceRouteName`, `sourceRouteVersion`, `vesselID`) — not `xlink:href`. The typed model surfaces these as `S129ExternalReference` values; resolving them against an actual S-421 / S-102 / S-104 dataset is the caller's responsibility, and the typed model never requires those datasets to be present.

To future-proof the projection, `S129DatasetReader` has been extended to capture `xlink:href` on child elements as `S129Reference` entries (matching the S-125 / S-128 pattern), and the projection runs them through an `XlinkResolver` so any future fixture emitting true xlinks gets the same `xlink.unresolved` diagnostic channel as peer specs.

## Tests

`tests/EncDotNet.S100.Datasets.S129.Tests/` (new): 16 passing tests covering
- the two bundled real-world fixtures (`12900MCTDS130TS.gml`, `…200TS.gml`),
- attribute / time-range / control-point-ordering parsing,
- synthetic edge cases: empty-dataset throws, duplicate-plan diagnostic, unresolved-xlink diagnostic, attribute parse failure, `ExtraAttributes` preservation.

## Out of scope

- Tier-1 fusion work (S-102/S-104 binding + S-421 route binding + timeline) — this is the prerequisite for that PR, which is now unblocked.
- Portrayal-rule changes in `content/S129/`.
- Viewer pick-panel migration — peer specs still consume the raw `S129Feature` bag in the viewer, so S-129 stays consistent with that.

## Verification

- `dotnet build` clean.
- `dotnet test --configuration Release` clean (S-129: 16 / 16 passing; peer specs + viewer + pipelines + visual-regression all green).

## Co-author

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;