### PR TITLE
S-122: add strongly-typed DataModel projection

### DIFF
--- a/docs/typed-data-models.md
+++ b/docs/typed-data-models.md
@@ -84,8 +84,9 @@ When adding a typed model for a new product spec:
 |---|---|---|
 | S-421 | `S421RoutePlan` | Original precedent; refactored in Pass 1 to consume the shared abstractions. |
 | S-124 | `S124NavigationalWarning` | Pass 1 second consumer. |
+| S-122 | `S122MarineProtectedAreaDataset` | Pass 2 — catalogue of MPAs / restricted areas / VTS areas with typed information-type bindings. |
 
-Other GML-encoded specs (S-122, S-125, S-127, S-128, S-129, S-131,
+Other GML-encoded specs (S-125, S-127, S-128, S-129, S-131,
 S-201, S-411) are intentionally deferred to a future *Pass 2* —
 the shared abstractions are validated against the first two
 consumers before being rolled out further.

--- a/src/EncDotNet.S100.Datasets.S122/DataModel/S122Features.cs
+++ b/src/EncDotNet.S100.Datasets.S122/DataModel/S122Features.cs
@@ -1,0 +1,225 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S122.DataModel;
+
+/// <summary>
+/// Common base for every concrete S-122 feature projection. Carries
+/// the FC-abstract <c>FeatureType</c> inherited attributes (S-122 FC
+/// 2.0.0 §FeatureType) plus the shared identity / geometry / reference
+/// fields required by <see cref="IS122Feature"/>.
+/// </summary>
+public abstract class S122FeatureBase : IS122Feature
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+
+    /// <inheritdoc/>
+    public abstract string FeatureType { get; }
+
+    /// <inheritdoc/>
+    public S122GeometryKind GeometryKind { get; init; }
+
+    /// <inheritdoc/>
+    public ImmutableArray<GeoPosition> Coordinates { get; init; } = ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>The interoperability identifier (S-122 FC §interoperabilityIdentifier), when present.</summary>
+    public string? InteroperabilityIdentifier { get; init; }
+
+    /// <summary>The feature name (S-122 FC §featureName), when present.</summary>
+    public string? FeatureName { get; init; }
+
+    /// <summary>The minimum display scale (S-122 FC §scaleMinimum), when present.</summary>
+    public int? ScaleMinimum { get; init; }
+
+    /// <summary>The graphic reference (S-122 FC §graphic), when present.</summary>
+    public string? Graphic { get; init; }
+
+    /// <summary>The source indication (S-122 FC §sourceIndication), when present.</summary>
+    public string? SourceIndication { get; init; }
+
+    /// <summary>The text content payload (S-122 FC §textContent), when present.</summary>
+    public string? TextContent { get; init; }
+
+    /// <summary>The fixed date range (S-122 FC §fixedDateRange), when present (raw text).</summary>
+    public string? FixedDateRange { get; init; }
+
+    /// <summary>The periodic date range (S-122 FC §periodicDateRange), when present (raw text).</summary>
+    public string? PeriodicDateRange { get; init; }
+
+    /// <inheritdoc/>
+    public ImmutableArray<GmlReference> References { get; init; } = ImmutableArray<GmlReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableArray<S122InformationReference> InformationReferences { get; internal set; } =
+        ImmutableArray<S122InformationReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableArray<S122FeatureReference> FeatureReferences { get; internal set; } =
+        ImmutableArray<S122FeatureReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>MarineProtectedArea</c> feature
+/// (S-122 FC 2.0.0 §MarineProtectedArea): a zoned area carrying
+/// protection / restriction categorisation and designation metadata.
+/// </summary>
+public sealed class S122MarineProtectedArea : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "MarineProtectedArea";
+
+    /// <summary>The category-of-marine-protected-area code (S-122 FC §categoryOfMarineProtectedArea), when present.</summary>
+    public int? CategoryOfMarineProtectedArea { get; init; }
+
+    /// <summary>The category-of-restricted-area code (S-122 FC §categoryOfRestrictedArea), when present.</summary>
+    public int? CategoryOfRestrictedArea { get; init; }
+
+    /// <summary>The jurisdiction (S-122 FC §jurisdiction), when present.</summary>
+    public string? Jurisdiction { get; init; }
+
+    /// <summary>The restriction code (S-122 FC §restriction), when present.</summary>
+    public int? Restriction { get; init; }
+
+    /// <summary>The status code (S-122 FC §status), when present.</summary>
+    public int? Status { get; init; }
+
+    /// <summary>The designation (S-122 FC §designation), when present.</summary>
+    public string? Designation { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>RestrictedArea</c> feature (S-122
+/// FC 2.0.0 §RestrictedArea).
+/// </summary>
+public sealed class S122RestrictedArea : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "RestrictedArea";
+
+    /// <summary>The category-of-restricted-area code (S-122 FC §categoryOfRestrictedArea), when present.</summary>
+    public int? CategoryOfRestrictedArea { get; init; }
+
+    /// <summary>The restriction code (S-122 FC §restriction), when present.</summary>
+    public int? Restriction { get; init; }
+
+    /// <summary>The status code (S-122 FC §status), when present.</summary>
+    public int? Status { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>VesselTrafficServiceArea</c>
+/// feature (S-122 FC 2.0.0 §VesselTrafficServiceArea).
+/// </summary>
+public sealed class S122VesselTrafficServiceArea : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "VesselTrafficServiceArea";
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>InformationArea</c> feature (S-122
+/// FC 2.0.0 §InformationArea).
+/// </summary>
+public sealed class S122InformationArea : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "InformationArea";
+
+    /// <summary>The category-of-relationship code (S-122 FC §categoryOfRelationship), when present.</summary>
+    public int? CategoryOfRelationship { get; init; }
+
+    /// <summary>The action-or-activity descriptor (S-122 FC §actionOrActivity), when present.</summary>
+    public string? ActionOrActivity { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>DataCoverage</c> feature (S-122 FC
+/// 2.0.0 §DataCoverage): dataset-extent / scale-band metadata polygon.
+/// </summary>
+public sealed class S122DataCoverage : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "DataCoverage";
+
+    /// <summary>The maximum display scale (S-122 FC §maximumDisplayScale), when present.</summary>
+    public int? MaximumDisplayScale { get; init; }
+
+    /// <summary>The minimum display scale (S-122 FC §minimumDisplayScale), when present.</summary>
+    public int? MinimumDisplayScale { get; init; }
+
+    /// <summary>The optimum display scale (S-122 FC §optimumDisplayScale), when present.</summary>
+    public int? OptimumDisplayScale { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>QualityOfNonBathymetricData</c>
+/// feature (S-122 FC 2.0.0 §QualityOfNonBathymetricData).
+/// </summary>
+public sealed class S122QualityOfNonBathymetricData : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "QualityOfNonBathymetricData";
+
+    /// <summary>The category-of-temporal-variation code (S-122 FC §categoryOfTemporalVariation), when present.</summary>
+    public int? CategoryOfTemporalVariation { get; init; }
+
+    /// <summary>The horizontal distance uncertainty (S-122 FC §horizontalDistanceUncertainty), when present.</summary>
+    public double? HorizontalDistanceUncertainty { get; init; }
+
+    /// <summary>The horizontal position uncertainty (S-122 FC §horizontalPositionUncertainty), when present.</summary>
+    public double? HorizontalPositionUncertainty { get; init; }
+
+    /// <summary>The orientation uncertainty (S-122 FC §orientationUncertainty), when present.</summary>
+    public double? OrientationUncertainty { get; init; }
+
+    /// <summary>The survey date range (S-122 FC §surveyDateRange), when present (raw text).</summary>
+    public string? SurveyDateRange { get; init; }
+
+    /// <summary>The information text (S-122 FC §information), when present.</summary>
+    public string? Information { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>TextPlacement</c> feature (S-122
+/// FC 2.0.0 §TextPlacement): a cartographic-text positioning anchor.
+/// </summary>
+public sealed class S122TextPlacement : S122FeatureBase
+{
+    /// <inheritdoc/>
+    public override string FeatureType => "TextPlacement";
+
+    /// <summary>The text offset bearing in degrees (S-122 FC §textOffsetBearing), when present.</summary>
+    public double? TextOffsetBearing { get; init; }
+
+    /// <summary>The text offset distance (S-122 FC §textOffsetDistance), when present.</summary>
+    public double? TextOffsetDistance { get; init; }
+
+    /// <summary>The text rotation in degrees (S-122 FC §textRotation), when present.</summary>
+    public double? TextRotation { get; init; }
+
+    /// <summary>The text type code (S-122 FC §textType), when present.</summary>
+    public int? TextType { get; init; }
+}
+
+/// <summary>
+/// Catch-all typed projection for any future S-122 feature class not
+/// individually broken out above. All source attributes survive on
+/// <see cref="S122FeatureBase.ExtraAttributes"/>.
+/// </summary>
+public sealed class S122OtherFeature : S122FeatureBase
+{
+    private readonly string _featureType;
+
+    /// <summary>Creates an <see cref="S122OtherFeature"/> tagged with the supplied feature-type code.</summary>
+    /// <param name="featureType">The S-122 feature type code (GML element local name).</param>
+    public S122OtherFeature(string featureType) => _featureType = featureType;
+
+    /// <inheritdoc/>
+    public override string FeatureType => _featureType;
+}

--- a/src/EncDotNet.S100.Datasets.S122/DataModel/S122InformationTypes.cs
+++ b/src/EncDotNet.S100.Datasets.S122/DataModel/S122InformationTypes.cs
@@ -1,0 +1,240 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S122.DataModel;
+
+/// <summary>
+/// Common base for every concrete S-122 information-type projection.
+/// Carries the FC-abstract <c>InformationType</c> inherited attributes
+/// (S-122 FC 2.0.0 §InformationType) plus the shared identity /
+/// reference fields required by <see cref="IS122InformationType"/>.
+/// </summary>
+public abstract class S122InformationTypeBase : IS122InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+
+    /// <inheritdoc/>
+    public abstract string TypeCode { get; }
+
+    /// <summary>The feature name (S-122 FC §featureName), when present.</summary>
+    public string? FeatureName { get; init; }
+
+    /// <summary>The fixed date range (S-122 FC §fixedDateRange), when present (raw text).</summary>
+    public string? FixedDateRange { get; init; }
+
+    /// <summary>The periodic date range (S-122 FC §periodicDateRange), when present (raw text).</summary>
+    public string? PeriodicDateRange { get; init; }
+
+    /// <summary>The graphic reference (S-122 FC §graphic), when present.</summary>
+    public string? Graphic { get; init; }
+
+    /// <summary>The source indication (S-122 FC §sourceIndication), when present.</summary>
+    public string? SourceIndication { get; init; }
+
+    /// <inheritdoc/>
+    public ImmutableArray<GmlReference> References { get; init; } = ImmutableArray<GmlReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableArray<S122InformationReference> InformationReferences { get; internal set; } =
+        ImmutableArray<S122InformationReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>Authority</c> information type
+/// (S-122 FC 2.0.0 §Authority): the protected-area-managing /
+/// regulatory body for the related feature.
+/// </summary>
+public sealed class S122Authority : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "Authority";
+
+    /// <summary>The category-of-authority code (S-122 FC §categoryOfAuthority), when present.</summary>
+    public int? CategoryOfAuthority { get; init; }
+
+    /// <summary>The text content payload (S-122 FC §textContent), when present.</summary>
+    public string? TextContent { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>ContactDetails</c> information
+/// type (S-122 FC 2.0.0 §ContactDetails).
+/// </summary>
+public sealed class S122ContactDetails : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "ContactDetails";
+
+    /// <summary>The call name (S-122 FC §callName), when present.</summary>
+    public string? CallName { get; init; }
+
+    /// <summary>The radio call sign (S-122 FC §callSign), when present.</summary>
+    public string? CallSign { get; init; }
+
+    /// <summary>The category-of-communication-preference code (S-122 FC §categoryOfCommunicationPreference), when present.</summary>
+    public int? CategoryOfCommunicationPreference { get; init; }
+
+    /// <summary>The communication channel (S-122 FC §communicationChannel), when present.</summary>
+    public string? CommunicationChannel { get; init; }
+
+    /// <summary>The contact instructions (S-122 FC §contactInstructions), when present.</summary>
+    public string? ContactInstructions { get; init; }
+
+    /// <summary>The contact language (S-122 FC §language), when present.</summary>
+    public string? Language { get; init; }
+
+    /// <summary>The MMSI code (S-122 FC §mMSICode), when present.</summary>
+    public string? MMSICode { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>Applicability</c> information type
+/// (S-122 FC 2.0.0 §Applicability): a vessel / cargo / route /
+/// performance filter that scopes a restriction or recommendation.
+/// </summary>
+public sealed class S122Applicability : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "Applicability";
+
+    /// <summary>The in-ballast flag (S-122 FC §inBallast), when present.</summary>
+    public bool? InBallast { get; init; }
+
+    /// <summary>The category-of-cargo code (S-122 FC §categoryOfCargo), when present.</summary>
+    public int? CategoryOfCargo { get; init; }
+
+    /// <summary>The category-of-dangerous-or-hazardous-cargo code (S-122 FC §categoryOfDangerousOrHazardousCargo), when present.</summary>
+    public int? CategoryOfDangerousOrHazardousCargo { get; init; }
+
+    /// <summary>The category-of-vessel code (S-122 FC §categoryOfVessel), when present.</summary>
+    public int? CategoryOfVessel { get; init; }
+
+    /// <summary>The category-of-vessel-registry code (S-122 FC §categoryOfVesselRegistry), when present.</summary>
+    public int? CategoryOfVesselRegistry { get; init; }
+
+    /// <summary>The logical connective (S-122 FC §logicalConnectives), when present.</summary>
+    public string? LogicalConnectives { get; init; }
+
+    /// <summary>The thickness-of-ice capability (S-122 FC §thicknessOfIceCapability), when present.</summary>
+    public double? ThicknessOfIceCapability { get; init; }
+
+    /// <summary>The vessel performance (S-122 FC §vesselPerformance), when present.</summary>
+    public string? VesselPerformance { get; init; }
+
+    /// <summary>The destination (S-122 FC §destination), when present.</summary>
+    public string? Destination { get; init; }
+
+    /// <summary>The information text (S-122 FC §information), when present.</summary>
+    public string? Information { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>NauticalInformation</c> information
+/// type (S-122 FC 2.0.0 §NauticalInformation): inherits all attributes
+/// from the FC-abstract base.
+/// </summary>
+public sealed class S122NauticalInformation : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "NauticalInformation";
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>NonStandardWorkingDay</c>
+/// information type (S-122 FC 2.0.0 §NonStandardWorkingDay).
+/// </summary>
+public sealed class S122NonStandardWorkingDay : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "NonStandardWorkingDay";
+
+    /// <summary>The fixed date (S-122 FC §dateFixed), when present (raw text).</summary>
+    public string? DateFixed { get; init; }
+
+    /// <summary>The variable date (S-122 FC §dateVariable), when present.</summary>
+    public string? DateVariable { get; init; }
+
+    /// <summary>The information text (S-122 FC §information), when present.</summary>
+    public string? Information { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>Recommendations</c> information
+/// type (S-122 FC 2.0.0 §Recommendations).
+/// </summary>
+public sealed class S122Recommendations : S122AbstractRxN
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "Recommendations";
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>Regulations</c> information type
+/// (S-122 FC 2.0.0 §Regulations).
+/// </summary>
+public sealed class S122Regulations : S122AbstractRxN
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "Regulations";
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>Restrictions</c> information type
+/// (S-122 FC 2.0.0 §Restrictions).
+/// </summary>
+public sealed class S122Restrictions : S122AbstractRxN
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "Restrictions";
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>ServiceHours</c> information type
+/// (S-122 FC 2.0.0 §ServiceHours).
+/// </summary>
+public sealed class S122ServiceHours : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "ServiceHours";
+
+    /// <summary>The information text (S-122 FC §information), when present.</summary>
+    public string? Information { get; init; }
+}
+
+/// <summary>
+/// Typed projection of the S-122 <c>SpatialQuality</c> information
+/// type (S-122 FC 2.0.0 §SpatialQuality).
+/// </summary>
+public sealed class S122SpatialQuality : S122InformationTypeBase
+{
+    /// <inheritdoc/>
+    public override string TypeCode => "SpatialQuality";
+
+    /// <summary>The quality-of-horizontal-measurement code (S-122 FC §qualityOfHorizontalMeasurement), when present.</summary>
+    public int? QualityOfHorizontalMeasurement { get; init; }
+
+    /// <summary>The spatial accuracy (S-122 FC §spatialAccuracy), when present.</summary>
+    public double? SpatialAccuracy { get; init; }
+}
+
+/// <summary>
+/// Catch-all typed projection for any future S-122 information-type
+/// class not individually broken out above. All source attributes
+/// survive on <see cref="S122InformationTypeBase.ExtraAttributes"/>.
+/// </summary>
+public sealed class S122OtherInformationType : S122InformationTypeBase
+{
+    private readonly string _typeCode;
+
+    /// <summary>Creates an <see cref="S122OtherInformationType"/> tagged with the supplied type code.</summary>
+    /// <param name="typeCode">The S-122 information-type code (GML element local name).</param>
+    public S122OtherInformationType(string typeCode) => _typeCode = typeCode;
+
+    /// <inheritdoc/>
+    public override string TypeCode => _typeCode;
+}

--- a/src/EncDotNet.S100.Datasets.S122/DataModel/S122MarineProtectedAreaDataset.cs
+++ b/src/EncDotNet.S100.Datasets.S122/DataModel/S122MarineProtectedAreaDataset.cs
@@ -1,0 +1,595 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S122.DataModel;
+
+/// <summary>
+/// Strongly-typed projection of an <see cref="S122Dataset"/> as a
+/// catalogue of Marine Protected Areas and related zoned features
+/// (S-122 FC 2.0.0 § Marine Protected Area Product Specification).
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-122 datasets carry a heterogeneous collection of zoned
+/// features (<see cref="S122MarineProtectedArea"/>,
+/// <see cref="S122RestrictedArea"/>,
+/// <see cref="S122VesselTrafficServiceArea"/>, …) plus a set of
+/// non-geographic information types (<see cref="S122Authority"/>,
+/// <see cref="S122Regulations"/>, <see cref="S122ContactDetails"/>,
+/// <see cref="S122SpatialQuality"/>, …) which features bind to via
+/// <c>xlink:href</c> associations such as <c>theAuthority</c>,
+/// <c>theInformation</c>, <c>theCartographicText</c>.
+/// </para>
+/// <para>
+/// The projection mirrors the S-125 / S-201 pattern: a static
+/// <see cref="From"/> factory walks the source feature bag and produces
+/// a graph of typed shapes. Each typed feature exposes both the raw
+/// <see cref="IS122Feature.References"/> collection and the resolved
+/// <see cref="IS122Feature.InformationReferences"/> /
+/// <see cref="IS122Feature.FeatureReferences"/> bindings.
+/// </para>
+/// <para>
+/// Projection issues — unresolved xlinks, attribute parse failures —
+/// surface as <see cref="ProjectionDiagnostic"/> entries rather than
+/// exceptions. The projection only throws when the source dataset has
+/// no features and no information types (i.e. is fully empty).
+/// </para>
+/// </remarks>
+public sealed class S122MarineProtectedAreaDataset
+{
+    /// <summary>The dataset identifier carried by the source GML <c>Dataset</c> element.</summary>
+    public string? DatasetIdentifier { get; init; }
+
+    /// <summary>The S-122 product identifier (typically <c>"S-122"</c> or <c>"INT.IHO.S-122…"</c>).</summary>
+    public string? ProductIdentifier { get; init; }
+
+    /// <summary>All typed features in the dataset (every concrete S-122 feature type).</summary>
+    public required ImmutableArray<IS122Feature> Features { get; init; }
+
+    /// <summary>All typed information types in the dataset.</summary>
+    public required ImmutableArray<IS122InformationType> InformationTypes { get; init; }
+
+    /// <summary>Typed Marine Protected Area features (S-122 FC §MarineProtectedArea).</summary>
+    public ImmutableArray<S122MarineProtectedArea> MarineProtectedAreas =>
+        Features.OfType<S122MarineProtectedArea>().ToImmutableArray();
+
+    /// <summary>Typed Restricted Area features (S-122 FC §RestrictedArea).</summary>
+    public ImmutableArray<S122RestrictedArea> RestrictedAreas =>
+        Features.OfType<S122RestrictedArea>().ToImmutableArray();
+
+    /// <summary>Typed Vessel Traffic Service Area features (S-122 FC §VesselTrafficServiceArea).</summary>
+    public ImmutableArray<S122VesselTrafficServiceArea> VesselTrafficServiceAreas =>
+        Features.OfType<S122VesselTrafficServiceArea>().ToImmutableArray();
+
+    /// <summary>The originating feature-bag dataset.</summary>
+    public required S122Dataset Source { get; init; }
+
+    /// <summary>
+    /// Projects a feature-bag <see cref="S122Dataset"/> into the typed
+    /// data model. Issues encountered during projection are reported via
+    /// <paramref name="diagnostics"/>; the projection only throws for a
+    /// fully empty source.
+    /// </summary>
+    /// <param name="dataset">The source dataset to project.</param>
+    /// <param name="diagnostics">
+    /// Receives the accumulated projection diagnostics (unresolved xlinks,
+    /// parse failures, etc.) as an immutable snapshot.
+    /// </param>
+    /// <exception cref="ArgumentNullException">If <paramref name="dataset"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the dataset contains neither features nor information types.
+    /// </exception>
+    public static S122MarineProtectedAreaDataset From(
+        S122Dataset dataset,
+        out IReadOnlyList<ProjectionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        if (dataset.Features.IsDefaultOrEmpty && dataset.InformationTypes.IsDefaultOrEmpty)
+            throw new InvalidOperationException("Dataset contains no features and no information types.");
+
+        // Project information types first (without resolved references) so the
+        // xlink index can hand back fully-typed targets when features /
+        // info-types resolve their bindings in the second pass.
+        var emptyResolver = XlinkResolver.Build(Array.Empty<KeyValuePair<string, object>>());
+        var preCtx = new ProjectionContext(emptyResolver);
+
+        var infoTypes = ImmutableArray.CreateBuilder<IS122InformationType>();
+        var infoTypesById = new Dictionary<string, IS122InformationType>(StringComparer.OrdinalIgnoreCase);
+        foreach (var i in dataset.InformationTypes.IsDefault ? ImmutableArray<S122InformationType>.Empty : dataset.InformationTypes)
+        {
+            var typed = ProjectInformationType(i, preCtx);
+            infoTypes.Add(typed);
+            if (!string.IsNullOrEmpty(typed.Id))
+                infoTypesById[typed.Id] = typed;
+        }
+
+        // Project features (without resolved references) so feature ⇄ feature
+        // bindings can be resolved in pass 2.
+        var features = ImmutableArray.CreateBuilder<IS122Feature>();
+        var featuresById = new Dictionary<string, IS122Feature>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in dataset.Features.IsDefault ? ImmutableArray<S122Feature>.Empty : dataset.Features)
+        {
+            var typed = ProjectFeature(f, preCtx);
+            features.Add(typed);
+            if (!string.IsNullOrEmpty(typed.Id))
+                featuresById[typed.Id] = typed;
+        }
+
+        // Build the xlink resolver over everything addressable by gml:id.
+        var resolver = BuildXlinkResolver(featuresById, infoTypesById);
+        var ctx = new ProjectionContext(resolver);
+        foreach (var d in preCtx.Diagnostics) ctx.Report(d);
+
+        // Pass 2: resolve references on every projected feature / info type.
+        foreach (var typed in features)
+        {
+            var (infoRefs, featRefs) = ResolveReferences(typed.Id, typed.References, ctx);
+            ((S122FeatureBase)typed).InformationReferences = infoRefs;
+            ((S122FeatureBase)typed).FeatureReferences = featRefs;
+        }
+
+        foreach (var typed in infoTypes)
+        {
+            var (infoRefs, _) = ResolveReferences(typed.Id, typed.References, ctx);
+            switch (typed)
+            {
+                case S122InformationTypeBase b: b.InformationReferences = infoRefs; break;
+                case S122AbstractRxN r: r.InformationReferences = infoRefs; break;
+            }
+        }
+
+        diagnostics = ctx.ToImmutableDiagnostics();
+        return new S122MarineProtectedAreaDataset
+        {
+            DatasetIdentifier = dataset.DatasetIdentifier,
+            ProductIdentifier = dataset.ProductIdentifier,
+            Features = features.ToImmutable(),
+            InformationTypes = infoTypes.ToImmutable(),
+            Source = dataset,
+        };
+    }
+
+    private static XlinkResolver BuildXlinkResolver(
+        IReadOnlyDictionary<string, IS122Feature> features,
+        IReadOnlyDictionary<string, IS122InformationType> infoTypes)
+    {
+        IEnumerable<KeyValuePair<string, object>> All()
+        {
+            foreach (var (id, f) in features)
+                yield return new KeyValuePair<string, object>(id, f);
+            foreach (var (id, i) in infoTypes)
+                yield return new KeyValuePair<string, object>(id, i);
+        }
+        return XlinkResolver.Build(All());
+    }
+
+    private static (ImmutableArray<S122InformationReference> infoRefs,
+                    ImmutableArray<S122FeatureReference> featRefs)
+        ResolveReferences(string referrerId, ImmutableArray<GmlReference> refs, ProjectionContext ctx)
+    {
+        if (refs.IsDefaultOrEmpty)
+            return (ImmutableArray<S122InformationReference>.Empty,
+                    ImmutableArray<S122FeatureReference>.Empty);
+
+        var infos = ImmutableArray.CreateBuilder<S122InformationReference>();
+        var feats = ImmutableArray.CreateBuilder<S122FeatureReference>();
+        foreach (var r in refs)
+        {
+            var target = ctx.Xlinks.ResolveAny(r.Href, r.Role, ctx, referrerId);
+            switch (target)
+            {
+                case IS122InformationType info:
+                    infos.Add(new S122InformationReference(r.Role, r.ArcRole, info));
+                    break;
+                case IS122Feature feat:
+                    feats.Add(new S122FeatureReference(r.Role, r.ArcRole, feat));
+                    break;
+            }
+        }
+        return (infos.ToImmutable(), feats.ToImmutable());
+    }
+
+    private static IS122Feature ProjectFeature(S122Feature f, ProjectionContext ctx)
+    {
+        var (kind, coords) = ProjectGeometry(f);
+
+        // Inherited (FC-abstract) attribute keys consumed by the typed base.
+        // Every concrete projection adds its own keys via WithBaseInit below.
+        static (string?, string?, int?, string?, string?, string?, string?, string?)
+            ReadBase(S122Feature feat, ProjectionContext c)
+        {
+            var attrs = feat.Attributes;
+            var interop = attrs.GetValueOrDefault("interoperabilityIdentifier");
+            var featName = attrs.GetValueOrDefault("featureName");
+            var scaleMin = AttributeParser.TryParseInt(attrs.GetValueOrDefault("scaleMinimum"), c, feat.Id, "scaleMinimum");
+            var graphic = attrs.GetValueOrDefault("graphic");
+            var srcInd = attrs.GetValueOrDefault("sourceIndication");
+            var textC = attrs.GetValueOrDefault("textContent");
+            var fixedDr = attrs.GetValueOrDefault("fixedDateRange");
+            var perDr = attrs.GetValueOrDefault("periodicDateRange");
+            return (interop, featName, scaleMin, graphic, srcInd, textC, fixedDr, perDr);
+        }
+
+        var (interopId, featureName, scaleMinimum, graphic, sourceIndication, textContent, fixedDr, periodicDr) =
+            ReadBase(f, ctx);
+
+        var baseKeys = new[] {
+            "interoperabilityIdentifier", "featureName", "scaleMinimum", "graphic",
+            "sourceIndication", "textContent", "fixedDateRange", "periodicDateRange"
+        };
+
+        IS122Feature typed = f.FeatureType switch
+        {
+            "MarineProtectedArea" => new S122MarineProtectedArea
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                CategoryOfMarineProtectedArea = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("categoryOfMarineProtectedArea"), ctx, f.Id, "categoryOfMarineProtectedArea"),
+                CategoryOfRestrictedArea = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("categoryOfRestrictedArea"), ctx, f.Id, "categoryOfRestrictedArea"),
+                Jurisdiction = f.Attributes.GetValueOrDefault("jurisdiction"),
+                Restriction = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("restriction"), ctx, f.Id, "restriction"),
+                Status = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("status"), ctx, f.Id, "status"),
+                Designation = f.Attributes.GetValueOrDefault("designation"),
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    [..baseKeys, "categoryOfMarineProtectedArea", "categoryOfRestrictedArea",
+                     "jurisdiction", "restriction", "status", "designation"]),
+            },
+            "RestrictedArea" => new S122RestrictedArea
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                CategoryOfRestrictedArea = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("categoryOfRestrictedArea"), ctx, f.Id, "categoryOfRestrictedArea"),
+                Restriction = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("restriction"), ctx, f.Id, "restriction"),
+                Status = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("status"), ctx, f.Id, "status"),
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    [..baseKeys, "categoryOfRestrictedArea", "restriction", "status"]),
+            },
+            "VesselTrafficServiceArea" => new S122VesselTrafficServiceArea
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, baseKeys),
+            },
+            "InformationArea" => new S122InformationArea
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                CategoryOfRelationship = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("categoryOfRelationship"), ctx, f.Id, "categoryOfRelationship"),
+                ActionOrActivity = f.Attributes.GetValueOrDefault("actionOrActivity"),
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    [..baseKeys, "categoryOfRelationship", "actionOrActivity"]),
+            },
+            "DataCoverage" => new S122DataCoverage
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                MaximumDisplayScale = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("maximumDisplayScale"), ctx, f.Id, "maximumDisplayScale"),
+                MinimumDisplayScale = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("minimumDisplayScale"), ctx, f.Id, "minimumDisplayScale"),
+                OptimumDisplayScale = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("optimumDisplayScale"), ctx, f.Id, "optimumDisplayScale"),
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    [..baseKeys, "maximumDisplayScale", "minimumDisplayScale", "optimumDisplayScale"]),
+            },
+            "QualityOfNonBathymetricData" => new S122QualityOfNonBathymetricData
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                CategoryOfTemporalVariation = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("categoryOfTemporalVariation"), ctx, f.Id, "categoryOfTemporalVariation"),
+                HorizontalDistanceUncertainty = AttributeParser.TryParseDouble(f.Attributes.GetValueOrDefault("horizontalDistanceUncertainty"), ctx, f.Id, "horizontalDistanceUncertainty"),
+                HorizontalPositionUncertainty = AttributeParser.TryParseDouble(f.Attributes.GetValueOrDefault("horizontalPositionUncertainty"), ctx, f.Id, "horizontalPositionUncertainty"),
+                OrientationUncertainty = AttributeParser.TryParseDouble(f.Attributes.GetValueOrDefault("orientationUncertainty"), ctx, f.Id, "orientationUncertainty"),
+                SurveyDateRange = f.Attributes.GetValueOrDefault("surveyDateRange"),
+                Information = f.Attributes.GetValueOrDefault("information"),
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    [..baseKeys, "categoryOfTemporalVariation", "horizontalDistanceUncertainty",
+                     "horizontalPositionUncertainty", "orientationUncertainty",
+                     "surveyDateRange", "information"]),
+            },
+            "TextPlacement" => new S122TextPlacement
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                TextOffsetBearing = AttributeParser.TryParseDouble(f.Attributes.GetValueOrDefault("textOffsetBearing"), ctx, f.Id, "textOffsetBearing"),
+                TextOffsetDistance = AttributeParser.TryParseDouble(f.Attributes.GetValueOrDefault("textOffsetDistance"), ctx, f.Id, "textOffsetDistance"),
+                TextRotation = AttributeParser.TryParseDouble(f.Attributes.GetValueOrDefault("textRotation"), ctx, f.Id, "textRotation"),
+                TextType = AttributeParser.TryParseInt(f.Attributes.GetValueOrDefault("textType"), ctx, f.Id, "textType"),
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes,
+                    [..baseKeys, "textOffsetBearing", "textOffsetDistance", "textRotation", "textType"]),
+            },
+            _ => new S122OtherFeature(f.FeatureType)
+            {
+                Id = f.Id,
+                GeometryKind = kind,
+                Coordinates = coords,
+                InteroperabilityIdentifier = interopId,
+                FeatureName = featureName,
+                ScaleMinimum = scaleMinimum,
+                Graphic = graphic,
+                SourceIndication = sourceIndication,
+                TextContent = textContent,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = periodicDr,
+                References = f.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(f.Attributes, baseKeys),
+            },
+        };
+
+        return typed;
+    }
+
+    private static IS122InformationType ProjectInformationType(S122InformationType i, ProjectionContext ctx)
+    {
+        var baseKeys = new[] {
+            "featureName", "fixedDateRange", "periodicDateRange", "graphic", "sourceIndication"
+        };
+        var featureName = i.Attributes.GetValueOrDefault("featureName");
+        var fixedDr = i.Attributes.GetValueOrDefault("fixedDateRange");
+        var perDr = i.Attributes.GetValueOrDefault("periodicDateRange");
+        var graphic = i.Attributes.GetValueOrDefault("graphic");
+        var srcInd = i.Attributes.GetValueOrDefault("sourceIndication");
+
+        IS122InformationType typed = i.TypeCode switch
+        {
+            "Authority" => new S122Authority
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                CategoryOfAuthority = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfAuthority"), ctx, i.Id, "categoryOfAuthority"),
+                TextContent = i.Attributes.GetValueOrDefault("textContent"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "categoryOfAuthority", "textContent"]),
+            },
+            "ContactDetails" => new S122ContactDetails
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                CallName = i.Attributes.GetValueOrDefault("callName"),
+                CallSign = i.Attributes.GetValueOrDefault("callSign"),
+                CategoryOfCommunicationPreference = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfCommunicationPreference"), ctx, i.Id, "categoryOfCommunicationPreference"),
+                CommunicationChannel = i.Attributes.GetValueOrDefault("communicationChannel"),
+                ContactInstructions = i.Attributes.GetValueOrDefault("contactInstructions"),
+                Language = i.Attributes.GetValueOrDefault("language"),
+                MMSICode = i.Attributes.GetValueOrDefault("mMSICode"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "callName", "callSign", "categoryOfCommunicationPreference",
+                     "communicationChannel", "contactInstructions", "language", "mMSICode"]),
+            },
+            "Applicability" => new S122Applicability
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                InBallast = AttributeParser.TryParseBool(i.Attributes.GetValueOrDefault("inBallast"), ctx, i.Id, "inBallast"),
+                CategoryOfCargo = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfCargo"), ctx, i.Id, "categoryOfCargo"),
+                CategoryOfDangerousOrHazardousCargo = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfDangerousOrHazardousCargo"), ctx, i.Id, "categoryOfDangerousOrHazardousCargo"),
+                CategoryOfVessel = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfVessel"), ctx, i.Id, "categoryOfVessel"),
+                CategoryOfVesselRegistry = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfVesselRegistry"), ctx, i.Id, "categoryOfVesselRegistry"),
+                LogicalConnectives = i.Attributes.GetValueOrDefault("logicalConnectives"),
+                ThicknessOfIceCapability = AttributeParser.TryParseDouble(i.Attributes.GetValueOrDefault("thicknessOfIceCapability"), ctx, i.Id, "thicknessOfIceCapability"),
+                VesselPerformance = i.Attributes.GetValueOrDefault("vesselPerformance"),
+                Destination = i.Attributes.GetValueOrDefault("destination"),
+                Information = i.Attributes.GetValueOrDefault("information"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "inBallast", "categoryOfCargo", "categoryOfDangerousOrHazardousCargo",
+                     "categoryOfVessel", "categoryOfVesselRegistry", "logicalConnectives",
+                     "thicknessOfIceCapability", "vesselPerformance", "destination", "information"]),
+            },
+            "NauticalInformation" => new S122NauticalInformation
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes, baseKeys),
+            },
+            "NonStandardWorkingDay" => new S122NonStandardWorkingDay
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                DateFixed = i.Attributes.GetValueOrDefault("dateFixed"),
+                DateVariable = i.Attributes.GetValueOrDefault("dateVariable"),
+                Information = i.Attributes.GetValueOrDefault("information"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "dateFixed", "dateVariable", "information"]),
+            },
+            "Recommendations" => ProjectRxN(new S122Recommendations { Id = i.Id }, i, ctx, baseKeys),
+            "Regulations" => ProjectRxN(new S122Regulations { Id = i.Id }, i, ctx, baseKeys),
+            "Restrictions" => ProjectRxN(new S122Restrictions { Id = i.Id }, i, ctx, baseKeys),
+            "ServiceHours" => new S122ServiceHours
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                Information = i.Attributes.GetValueOrDefault("information"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "information"]),
+            },
+            "SpatialQuality" => new S122SpatialQuality
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                QualityOfHorizontalMeasurement = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("qualityOfHorizontalMeasurement"), ctx, i.Id, "qualityOfHorizontalMeasurement"),
+                SpatialAccuracy = AttributeParser.TryParseDouble(i.Attributes.GetValueOrDefault("spatialAccuracy"), ctx, i.Id, "spatialAccuracy"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "qualityOfHorizontalMeasurement", "spatialAccuracy"]),
+            },
+            _ => new S122OtherInformationType(i.TypeCode)
+            {
+                Id = i.Id,
+                FeatureName = featureName,
+                FixedDateRange = fixedDr,
+                PeriodicDateRange = perDr,
+                Graphic = graphic,
+                SourceIndication = srcInd,
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes, baseKeys),
+            },
+        };
+
+        return typed;
+    }
+
+    private static T ProjectRxN<T>(T seed, S122InformationType i, ProjectionContext ctx, string[] baseKeys)
+        where T : S122AbstractRxN
+    {
+        // The RxN concrete types share the same attribute shape; only the
+        // TypeCode discriminator differs.
+        return (T)(object)(seed switch
+        {
+            S122Recommendations => new S122Recommendations
+            {
+                Id = i.Id,
+                CategoryOfAuthority = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfAuthority"), ctx, i.Id, "categoryOfAuthority"),
+                RxNCode = i.Attributes.GetValueOrDefault("rxNCode"),
+                TextContent = i.Attributes.GetValueOrDefault("textContent"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "categoryOfAuthority", "rxNCode", "textContent"]),
+            },
+            S122Regulations => new S122Regulations
+            {
+                Id = i.Id,
+                CategoryOfAuthority = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfAuthority"), ctx, i.Id, "categoryOfAuthority"),
+                RxNCode = i.Attributes.GetValueOrDefault("rxNCode"),
+                TextContent = i.Attributes.GetValueOrDefault("textContent"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "categoryOfAuthority", "rxNCode", "textContent"]),
+            },
+            S122Restrictions => new S122Restrictions
+            {
+                Id = i.Id,
+                CategoryOfAuthority = AttributeParser.TryParseInt(i.Attributes.GetValueOrDefault("categoryOfAuthority"), ctx, i.Id, "categoryOfAuthority"),
+                RxNCode = i.Attributes.GetValueOrDefault("rxNCode"),
+                TextContent = i.Attributes.GetValueOrDefault("textContent"),
+                References = i.References,
+                ExtraAttributes = ExtraAttributes.ExcludeKnown(i.Attributes,
+                    [..baseKeys, "categoryOfAuthority", "rxNCode", "textContent"]),
+            },
+            _ => throw new InvalidOperationException("Unexpected RxN concrete type."),
+        });
+    }
+
+    private static (S122GeometryKind, ImmutableArray<GeoPosition>) ProjectGeometry(S122Feature f)
+    {
+        switch (f.GeometryType)
+        {
+            case GmlGeometryType.Point:
+                return (S122GeometryKind.Point, f.Points.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.Points.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            case GmlGeometryType.Curve:
+                return (S122GeometryKind.Curve, f.Curves.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.Curves.SelectMany(c => c).Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            case GmlGeometryType.Surface:
+                return (S122GeometryKind.Surface, f.ExteriorRing.IsDefaultOrEmpty
+                    ? ImmutableArray<GeoPosition>.Empty
+                    : f.ExteriorRing.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray());
+            default:
+                return (S122GeometryKind.None, ImmutableArray<GeoPosition>.Empty);
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S122/DataModel/S122Types.cs
+++ b/src/EncDotNet.S100.Datasets.S122/DataModel/S122Types.cs
@@ -1,0 +1,140 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S122.DataModel;
+
+/// <summary>The geometry primitive kind of an S-122 feature.</summary>
+/// <remarks>
+/// Geometry-less feature instances are allowed by the S-122 Feature
+/// Catalogue (e.g. an area that delegates its boundary to an associated
+/// <c>InformationArea</c>); renderers and consumers must tolerate
+/// <see cref="None"/>.
+/// </remarks>
+public enum S122GeometryKind
+{
+    /// <summary>No geometry.</summary>
+    None,
+    /// <summary>Single point (<see cref="GeoPosition"/>).</summary>
+    Point,
+    /// <summary>Curve (ordered sequence of <see cref="GeoPosition"/>).</summary>
+    Curve,
+    /// <summary>Surface exterior ring (closed sequence of <see cref="GeoPosition"/>).</summary>
+    Surface,
+}
+
+/// <summary>
+/// Common shape implemented by every typed S-122 feature projection
+/// (S-122 FC 2.0.0 § Feature Types). Allows generic consumers to walk
+/// <see cref="S122MarineProtectedAreaDataset.Features"/> without
+/// switching on concrete type.
+/// </summary>
+public interface IS122Feature
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    string Id { get; }
+
+    /// <summary>The S-122 feature type code (the GML element local name).</summary>
+    string FeatureType { get; }
+
+    /// <summary>Geometry primitive kind of the source feature.</summary>
+    S122GeometryKind GeometryKind { get; }
+
+    /// <summary>Coordinates whose semantics depend on <see cref="GeometryKind"/>.</summary>
+    ImmutableArray<GeoPosition> Coordinates { get; }
+
+    /// <summary>The raw <c>xlink:href</c> cross-references from the source feature.</summary>
+    ImmutableArray<GmlReference> References { get; }
+
+    /// <summary>Information-type bindings resolved from <see cref="References"/>.</summary>
+    ImmutableArray<S122InformationReference> InformationReferences { get; }
+
+    /// <summary>Feature-to-feature bindings resolved from <see cref="References"/>.</summary>
+    ImmutableArray<S122FeatureReference> FeatureReferences { get; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    ImmutableDictionary<string, string> ExtraAttributes { get; }
+}
+
+/// <summary>
+/// Common shape implemented by every typed S-122 information-type
+/// projection (S-122 FC 2.0.0 § Information Types).
+/// </summary>
+public interface IS122InformationType
+{
+    /// <summary>The GML identifier.</summary>
+    string Id { get; }
+
+    /// <summary>The S-122 information-type code (the GML element local name).</summary>
+    string TypeCode { get; }
+
+    /// <summary>The raw <c>xlink:href</c> cross-references.</summary>
+    ImmutableArray<GmlReference> References { get; }
+
+    /// <summary>Information-type bindings resolved from <see cref="References"/>.</summary>
+    ImmutableArray<S122InformationReference> InformationReferences { get; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    ImmutableDictionary<string, string> ExtraAttributes { get; }
+}
+
+/// <summary>
+/// A typed binding from a referring object to an information-type
+/// target, resolved from an <c>xlink:href</c> by
+/// <see cref="S122MarineProtectedAreaDataset.From"/>.
+/// </summary>
+/// <param name="Role">The GML role (containing element local name, e.g. <c>theAuthority</c>).</param>
+/// <param name="ArcRole">The optional <c>xlink:arcrole</c>.</param>
+/// <param name="Target">The resolved typed information type.</param>
+public sealed record S122InformationReference(
+    string Role,
+    string? ArcRole,
+    IS122InformationType Target);
+
+/// <summary>
+/// A typed binding from a referring object to a feature target,
+/// resolved from an <c>xlink:href</c> by
+/// <see cref="S122MarineProtectedAreaDataset.From"/>.
+/// </summary>
+/// <param name="Role">The GML role (containing element local name, e.g. <c>theCartographicText</c>).</param>
+/// <param name="ArcRole">The optional <c>xlink:arcrole</c>.</param>
+/// <param name="Target">The resolved typed feature.</param>
+public sealed record S122FeatureReference(
+    string Role,
+    string? ArcRole,
+    IS122Feature Target);
+
+/// <summary>
+/// Common base for the three S-122 RxN (Recommendations / Regulations /
+/// Restrictions) concrete information-type projections, which all
+/// derive from the FC-abstract <c>AbstractRxN</c> (S-122 FC 2.0.0
+/// §AbstractRxN).
+/// </summary>
+public abstract class S122AbstractRxN : IS122InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+
+    /// <inheritdoc/>
+    public abstract string TypeCode { get; }
+
+    /// <summary>The category-of-authority code (S-122 FC §categoryOfAuthority), when present.</summary>
+    public int? CategoryOfAuthority { get; init; }
+
+    /// <summary>The RxN code (S-122 FC §rxNCode), when present.</summary>
+    public string? RxNCode { get; init; }
+
+    /// <summary>The text content payload (S-122 FC §textContent), when present.</summary>
+    public string? TextContent { get; init; }
+
+    /// <inheritdoc/>
+    public ImmutableArray<GmlReference> References { get; init; } = ImmutableArray<GmlReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableArray<S122InformationReference> InformationReferences { get; internal set; } =
+        ImmutableArray<S122InformationReference>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+}

--- a/src/EncDotNet.S100.Datasets.S122/README.md
+++ b/src/EncDotNet.S100.Datasets.S122/README.md
@@ -56,3 +56,49 @@ Key types include:
 ```sh
 dotnet add package EncDotNet.S100.Datasets.S122
 ```
+
+## Strongly-typed data model
+
+In addition to the feature-bag `S122Dataset`, the library exposes a
+strongly-typed projection rooted at `S122MarineProtectedAreaDataset`
+under `EncDotNet.S100.Datasets.S122.DataModel`. It uses the shared
+typed-model abstractions in `EncDotNet.S100.Core.DataModel`
+(`XlinkResolver`, `ProjectionContext`, `GeoPosition`,
+`AttributeParser`, `ExtraAttributes`) and follows the same pattern
+as the S-124 / S-125 / S-128 / S-201 projections.
+
+```csharp
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S122.DataModel;
+
+var dataset = S122Dataset.Open("122TESTDATASET.gml");
+var typed = S122MarineProtectedAreaDataset.From(dataset, out var diagnostics);
+
+foreach (var mpa in typed.MarineProtectedAreas)
+{
+    Console.WriteLine($"{mpa.Id}: cat={mpa.CategoryOfMarineProtectedArea}, designation={mpa.Designation}");
+
+    foreach (var infoRef in mpa.InformationReferences)
+        Console.WriteLine($"  -> {infoRef.Role}: {infoRef.Target.TypeCode} #{infoRef.Target.Id}");
+}
+
+foreach (var diag in diagnostics)
+    Console.WriteLine($"[{diag.Severity}] {diag.Code}: {diag.Message}");
+```
+
+Notes:
+
+- Typed projection is purely **additive** — the portrayal pipeline
+  continues to run off the feature-bag dataset and is unchanged.
+- `From()` throws only when the source dataset has no features and no
+  information types; everything else surfaces as a
+  `ProjectionDiagnostic` (unresolved xlinks, attribute parse
+  failures, etc.).
+- `xlink:href` associations (e.g. `theAuthority`, `theInformation`,
+  `theCartographicText`) are resolved into typed
+  `S122InformationReference` / `S122FeatureReference` records.
+  The raw `GmlReference` list is also preserved on every typed
+  object for callers that need role / arcrole / href verbatim.
+- Unrecognised feature / information types are preserved as
+  `S122OtherFeature` / `S122OtherInformationType` so future-edition
+  catalogues round-trip without information loss.

--- a/src/EncDotNet.S100.Datasets.S122/S122Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S122/S122Dataset.cs
@@ -69,6 +69,15 @@ public sealed class S122Feature : IGmlFeature
     /// <summary>Complex attribute groups keyed by code, each containing sub-attribute dictionaries.</summary>
     public required ImmutableArray<S122ComplexAttribute> ComplexAttributes { get; init; }
 
+    /// <summary>
+    /// References to other features and information types resolved via
+    /// <c>xlink:href</c>. The role of each reference is the local name of
+    /// the GML element that carried the <c>xlink:href</c> attribute
+    /// (e.g. <c>theAuthority</c>, <c>theContactDetails</c>,
+    /// <c>theCartographicText</c>; see S-122 FC 2.0.0 §Roles).
+    /// </summary>
+    public ImmutableArray<GmlReference> References { get; init; } = ImmutableArray<GmlReference>.Empty;
+
     /// <inheritdoc/>
     IEnumerable<IGmlComplexAttribute> IGmlFeature.GmlComplexAttributes => ComplexAttributes.Cast<IGmlComplexAttribute>();
 }
@@ -89,6 +98,15 @@ public sealed class S122InformationType : IGmlInformationType
 
     /// <summary>Complex attribute groups.</summary>
     public required ImmutableArray<S122ComplexAttribute> ComplexAttributes { get; init; }
+
+    /// <summary>
+    /// References to other features and information types resolved via
+    /// <c>xlink:href</c>. The role of each reference is the local name of
+    /// the GML element that carried the <c>xlink:href</c> attribute
+    /// (e.g. <c>theAuthority</c>, <c>theContactDetails</c>; see S-122 FC
+    /// 2.0.0 §Roles).
+    /// </summary>
+    public ImmutableArray<GmlReference> References { get; init; } = ImmutableArray<GmlReference>.Empty;
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.S122/S122DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S122/S122DatasetReader.cs
@@ -22,6 +22,8 @@ internal static class S122DatasetReader
         "http://www.iho.int/s100gml/5.0",
     ];
 
+    private static readonly XNamespace XLinkNs = "http://www.w3.org/1999/xlink";
+
     // S-122 feature type codes (per FC 2.0.0, S-122 § Feature Catalogue).
     private static readonly HashSet<string> FeatureTypeCodes = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -252,7 +254,7 @@ internal static class S122DatasetReader
         var featureType = element.Name.LocalName;
 
         var (geometryType, points, curves, exteriorRing, interiorRings) = ParseGeometry(element, s100Ns);
-        var (simpleAttrs, complexAttrs) = ParseAttributes(element, s100Ns);
+        var (simpleAttrs, complexAttrs, references) = ParseAttributes(element, s100Ns);
 
         return new S122Feature
         {
@@ -265,6 +267,7 @@ internal static class S122DatasetReader
             InteriorRings = interiorRings,
             Attributes = simpleAttrs,
             ComplexAttributes = complexAttrs,
+            References = references,
         };
     }
 
@@ -273,7 +276,7 @@ internal static class S122DatasetReader
         var id = element.Attribute(GmlNamespaces.Gml + "id")?.Value ?? "";
         var typeCode = element.Name.LocalName;
 
-        var (simpleAttrs, complexAttrs) = ParseAttributes(element, s100Ns);
+        var (simpleAttrs, complexAttrs, references) = ParseAttributes(element, s100Ns);
 
         return new S122InformationType
         {
@@ -281,6 +284,7 @@ internal static class S122DatasetReader
             TypeCode = typeCode,
             Attributes = simpleAttrs,
             ComplexAttributes = complexAttrs,
+            References = references,
         };
     }
 
@@ -349,10 +353,11 @@ internal static class S122DatasetReader
         }
 
         return (geometryType, points, curves, exteriorRing, interiorRings);
-    }    private static (ImmutableDictionary<string, string>, ImmutableArray<S122ComplexAttribute>) ParseAttributes(XElement element, XNamespace s100Ns)
+    }    private static (ImmutableDictionary<string, string>, ImmutableArray<S122ComplexAttribute>, ImmutableArray<GmlReference>) ParseAttributes(XElement element, XNamespace s100Ns)
     {
         var simple = ImmutableDictionary.CreateBuilder<string, string>();
         var complex = ImmutableArray.CreateBuilder<S122ComplexAttribute>();
+        var refs = ImmutableArray.CreateBuilder<GmlReference>();
 
         foreach (var child in element.Elements())
         {
@@ -364,12 +369,27 @@ internal static class S122DatasetReader
                 child.Name.Namespace == s100Ns)
                 continue;
 
+            // xlink:href cross-reference — surface as a typed reference rather
+            // than an attribute. The element's local name is the association
+            // role (e.g. "theAuthority", "theContactDetails"; S-122 FC 2.0.0 §Roles).
+            var href = child.Attribute(XLinkNs + "href")?.Value;
+            if (href is not null)
+            {
+                refs.Add(new GmlReference
+                {
+                    Role = localName,
+                    Href = href,
+                    ArcRole = child.Attribute(XLinkNs + "arcrole")?.Value,
+                });
+                continue;
+            }
+
             if (child.HasElements)
             {
                 var subAttrs = ImmutableDictionary.CreateBuilder<string, string>();
                 foreach (var sub in child.Elements())
                 {
-                    if (!sub.HasElements)
+                    if (!sub.HasElements && sub.Attribute(XLinkNs + "href") is null)
                     {
                         subAttrs[sub.Name.LocalName] = sub.Value;
                     }
@@ -390,7 +410,7 @@ internal static class S122DatasetReader
             }
         }
 
-        return (simple.ToImmutable(), complex.ToImmutable());
+        return (simple.ToImmutable(), complex.ToImmutable(), refs.ToImmutable());
     }
 
     private static bool IsFeatureType(XName name, XNamespace datasetNs)

--- a/tests/EncDotNet.S100.Datasets.S122.Tests/DataModelTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S122.Tests/DataModelTests.cs
@@ -1,0 +1,258 @@
+using System.Collections.Immutable;
+using System.Text;
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S122.DataModel;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S122.Tests;
+
+/// <summary>
+/// Tests for the strongly-typed
+/// <see cref="S122MarineProtectedAreaDataset"/> projection that sits
+/// alongside the feature-bag <see cref="S122Dataset"/>. Mirrors the
+/// shape of the typed-model tests for S-124 / S-125 / S-128 / S-201.
+/// </summary>
+public class DataModelTests
+{
+    private const string TestDataDir = "TestData";
+    private const string SampleFile = "122TESTDATASET.gml";
+
+    private static S122Dataset Parse(string gml)
+    {
+        var bytes = Encoding.UTF8.GetBytes(gml);
+        using var stream = new MemoryStream(bytes);
+        return S122Dataset.Open(stream);
+    }
+
+    private static string Wrap(string memberFragments) => $$"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <S122:Dataset gml:id="ds1"
+            xmlns:S122="http://www.iho.int/S122/1.0"
+            xmlns:S100="http://www.iho.int/s100gml/5.0"
+            xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:xlink="http://www.w3.org/1999/xlink">
+            <gml:boundedBy>
+                <gml:Envelope srsName="EPSG:4326">
+                    <gml:lowerCorner>-90 -180</gml:lowerCorner>
+                    <gml:upperCorner>90 180</gml:upperCorner>
+                </gml:Envelope>
+            </gml:boundedBy>
+            <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>INT.IHO.S-122.1.0.0</S100:productIdentifier>
+            </S100:DatasetIdentificationInformation>
+            <S122:members>
+                {{memberFragments}}
+            </S122:members>
+        </S122:Dataset>
+        """;
+
+    private const string MpaWithAuthorityRef = """
+        <S122:MarineProtectedArea gml:id="MPA1">
+            <S122:categoryOfMarineProtectedArea>1</S122:categoryOfMarineProtectedArea>
+            <S122:restriction>3</S122:restriction>
+            <S122:status>5</S122:status>
+            <S122:jurisdiction>National</S122:jurisdiction>
+            <S122:designation>RAMSAR</S122:designation>
+            <S122:geometry>
+                <S100:surfaceProperty>
+                    <gml:Polygon srsName="EPSG:4326">
+                        <gml:exterior>
+                            <gml:LinearRing>
+                                <gml:posList>0 0 0 1 1 1 1 0 0 0</gml:posList>
+                            </gml:LinearRing>
+                        </gml:exterior>
+                    </gml:Polygon>
+                </S100:surfaceProperty>
+            </S122:geometry>
+            <S122:theAuthority xlink:href="#AUTH1"/>
+        </S122:MarineProtectedArea>
+        <S122:Authority gml:id="AUTH1">
+            <S122:categoryOfAuthority>2</S122:categoryOfAuthority>
+            <S122:textContent>Port Authority</S122:textContent>
+        </S122:Authority>
+        """;
+
+    [Fact]
+    public void From_ProjectsMpaAttributes()
+    {
+        var ds = Parse(Wrap(MpaWithAuthorityRef));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out var diags);
+
+        var mpa = Assert.Single(typed.MarineProtectedAreas);
+        Assert.Equal("MPA1", mpa.Id);
+        Assert.Equal(1, mpa.CategoryOfMarineProtectedArea);
+        Assert.Equal(3, mpa.Restriction);
+        Assert.Equal(5, mpa.Status);
+        Assert.Equal("National", mpa.Jurisdiction);
+        Assert.Equal("RAMSAR", mpa.Designation);
+        Assert.Equal(S122GeometryKind.Surface, mpa.GeometryKind);
+        Assert.NotEmpty(mpa.Coordinates);
+        Assert.DoesNotContain(diags, d => d.Severity == DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public void From_ResolvesAuthorityXlink()
+    {
+        var ds = Parse(Wrap(MpaWithAuthorityRef));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out _);
+
+        var mpa = Assert.Single(typed.MarineProtectedAreas);
+        var infoRef = Assert.Single(mpa.InformationReferences);
+        Assert.Equal("theAuthority", infoRef.Role);
+        var auth = Assert.IsType<S122Authority>(infoRef.Target);
+        Assert.Equal("AUTH1", auth.Id);
+        Assert.Equal(2, auth.CategoryOfAuthority);
+        Assert.Equal("Port Authority", auth.TextContent);
+    }
+
+    [Fact]
+    public void From_UnresolvedXlink_ReportsDiagnostic()
+    {
+        const string gml = """
+            <S122:RestrictedArea gml:id="RA1">
+                <S122:categoryOfRestrictedArea>4</S122:categoryOfRestrictedArea>
+                <S122:geometry>
+                    <S100:surfaceProperty>
+                        <gml:Polygon srsName="EPSG:4326">
+                            <gml:exterior>
+                                <gml:LinearRing>
+                                    <gml:posList>0 0 0 1 1 1 1 0 0 0</gml:posList>
+                                </gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </S100:surfaceProperty>
+                </S122:geometry>
+                <S122:theAuthority xlink:href="#MISSING"/>
+            </S122:RestrictedArea>
+            """;
+        var ds = Parse(Wrap(gml));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out var diags);
+
+        var ra = Assert.Single(typed.RestrictedAreas);
+        Assert.Empty(ra.InformationReferences);
+        Assert.Contains(diags, d => d.Code == "xlink.unresolved" && d.RelatedId == "RA1");
+    }
+
+    [Fact]
+    public void From_UnparseableInt_ReportsDiagnosticAndPreservesRawInExtra()
+    {
+        const string gml = """
+            <S122:RestrictedArea gml:id="RA2">
+                <S122:restriction>not-a-number</S122:restriction>
+            </S122:RestrictedArea>
+            """;
+        var ds = Parse(Wrap(gml));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out var diags);
+
+        var ra = Assert.Single(typed.RestrictedAreas);
+        Assert.Null(ra.Restriction);
+        Assert.Contains(diags, d =>
+            d.Code == "attribute.parse.int" &&
+            d.RelatedId == "RA2" &&
+            d.RelatedAttribute == "restriction");
+    }
+
+    [Fact]
+    public void From_EmptyDataset_Throws()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S122:Dataset gml:id="ds_empty"
+                xmlns:S122="http://www.iho.int/S122/1.0"
+                xmlns:S100="http://www.iho.int/s100gml/5.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:xlink="http://www.w3.org/1999/xlink">
+                <S100:DatasetIdentificationInformation>
+                    <S100:productIdentifier>INT.IHO.S-122.1.0.0</S100:productIdentifier>
+                </S100:DatasetIdentificationInformation>
+                <S122:members/>
+            </S122:Dataset>
+            """;
+        var ds = Parse(gml);
+        Assert.Throws<InvalidOperationException>(() =>
+            S122MarineProtectedAreaDataset.From(ds, out _));
+    }
+
+    [Fact]
+    public void From_ProjectsTextPlacementAttributes()
+    {
+        const string gml = """
+            <S122:TextPlacement gml:id="TP1">
+                <S122:textOffsetBearing>45.5</S122:textOffsetBearing>
+                <S122:textOffsetDistance>10.0</S122:textOffsetDistance>
+                <S122:textRotation>90</S122:textRotation>
+                <S122:textType>1</S122:textType>
+                <S122:geometry>
+                    <S100:pointProperty>
+                        <gml:Point srsName="EPSG:4326">
+                            <gml:pos>10 20</gml:pos>
+                        </gml:Point>
+                    </S100:pointProperty>
+                </S122:geometry>
+            </S122:TextPlacement>
+            """;
+        var ds = Parse(Wrap(gml));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out _);
+
+        var tp = Assert.Single(typed.Features.OfType<S122TextPlacement>());
+        Assert.Equal(45.5, tp.TextOffsetBearing);
+        Assert.Equal(10.0, tp.TextOffsetDistance);
+        Assert.Equal(90.0, tp.TextRotation);
+        Assert.Equal(1, tp.TextType);
+        Assert.Equal(S122GeometryKind.Point, tp.GeometryKind);
+    }
+
+    [Fact]
+    public void From_ProjectsRegulationInformationType()
+    {
+        const string gml = """
+            <S122:Regulations gml:id="REG1">
+                <S122:categoryOfAuthority>3</S122:categoryOfAuthority>
+                <S122:rxNCode>R-42</S122:rxNCode>
+                <S122:textContent>No anchoring</S122:textContent>
+            </S122:Regulations>
+            """;
+        var ds = Parse(Wrap(gml));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out _);
+
+        var reg = Assert.Single(typed.InformationTypes.OfType<S122Regulations>());
+        Assert.Equal(3, reg.CategoryOfAuthority);
+        Assert.Equal("R-42", reg.RxNCode);
+        Assert.Equal("No anchoring", reg.TextContent);
+        Assert.Equal("Regulations", reg.TypeCode);
+    }
+
+    [Fact]
+    public void From_UnknownAttributesPreservedInExtraAttributes()
+    {
+        const string gml = """
+            <S122:RestrictedArea gml:id="RA3">
+                <S122:restriction>3</S122:restriction>
+                <S122:someFutureAttribute>future-value</S122:someFutureAttribute>
+            </S122:RestrictedArea>
+            """;
+        var ds = Parse(Wrap(gml));
+        var typed = S122MarineProtectedAreaDataset.From(ds, out _);
+
+        var ra = Assert.Single(typed.RestrictedAreas);
+        Assert.Equal(3, ra.Restriction);
+        Assert.True(ra.ExtraAttributes.ContainsKey("someFutureAttribute"));
+        Assert.Equal("future-value", ra.ExtraAttributes["someFutureAttribute"]);
+    }
+
+    [Fact]
+    public void From_OfficialSample_RoundTrips()
+    {
+        var path = Path.Combine(TestDataDir, SampleFile);
+        Assert.True(File.Exists(path), $"Test data file not found: {path}");
+
+        var ds = S122Dataset.Open(path);
+        var typed = S122MarineProtectedAreaDataset.From(ds, out var diags);
+
+        Assert.Equal(ds.Features.Length, typed.Features.Length);
+        Assert.Equal(ds.InformationTypes.Length, typed.InformationTypes.Length);
+        Assert.NotNull(typed.ProductIdentifier);
+        // Sample is xlink-free, so no unresolved-reference diagnostics.
+        Assert.DoesNotContain(diags, d => d.Code == "xlink.unresolved");
+    }
+}


### PR DESCRIPTION
Adds a strongly-typed `DataModel` projection to S-122, following the
pattern established for S-124, S-125, S-128, and S-201 in
#69 / #70 / #71 / #72.

The typed projection (`S122MarineProtectedAreaDataset`) sits
alongside the existing `S122Dataset` feature bag. Portrayal continues
to flow through the feature bag — the typed projection is purely
additive (per `docs/typed-data-models.md` rule 8).

## Changes

### Reader

- `S122Feature` / `S122InformationType`: capture `xlink:href`
  associations into `ImmutableArray<GmlReference> References`.
- `S122DatasetReader.ParseAttributes`: parse `xlink:href` child
  elements as `GmlReference` entries (mirroring `S124DatasetReader`).

### Typed model

Under `src/EncDotNet.S100.Datasets.S122/DataModel/`:

- `S122Types.cs` — `IS122Feature` / `IS122InformationType`
  interfaces, `S122GeometryKind` enum, `S122InformationReference`
  / `S122FeatureReference` records, `S122AbstractRxN` base.
- `S122Features.cs` — seven concrete feature classes
  (`S122MarineProtectedArea`, `S122RestrictedArea`,
  `S122VesselTrafficServiceArea`, `S122InformationArea`,
  `S122DataCoverage`, `S122QualityOfNonBathymetricData`,
  `S122TextPlacement`) plus `S122OtherFeature` catch-all.
- `S122InformationTypes.cs` — ten concrete info-type classes
  (`S122Authority`, `S122ContactDetails`, `S122Applicability`,
  `S122NauticalInformation`, `S122NonStandardWorkingDay`,
  `S122Recommendations`, `S122Regulations`, `S122Restrictions`,
  `S122ServiceHours`, `S122SpatialQuality`) plus
  `S122OtherInformationType` catch-all.
- `S122MarineProtectedAreaDataset.cs` —
  `From(dataset, out diagnostics)` factory using `XlinkResolver`,
  `ProjectionContext`, `AttributeParser`, `ExtraAttributes` from
  `EncDotNet.S100.Core.DataModel`. Throws only for fully-empty
  datasets; everything else surfaces as a `ProjectionDiagnostic`.
  Two-pass projection so feature ↔ info-type and feature ↔ feature
  xlinks resolve into typed references.

### Tests

- `tests/EncDotNet.S100.Datasets.S122.Tests/DataModelTests.cs` —
  eight new tests over synthetic inline GML fixtures covering: MPA
  attribute round-trip, `theAuthority` xlink resolution,
  unresolved-xlink diagnostic, unparseable-int diagnostic,
  extra-attribute preservation, empty-dataset throw, text-placement
  projection, regulation info-type, and round-trip of the official
  `122TESTDATASET.gml` sample.

### Docs

- `src/EncDotNet.S100.Datasets.S122/README.md`: new
  **Strongly-typed data model** section with usage snippet.
- `docs/typed-data-models.md`: adds the S-122 row to *Current
  consumers* and drops S-122 from the deferred list.

## Verification

- `dotnet build --configuration Release` — clean.
- `dotnet test --configuration Release` — all tests pass
  (27 S-122 tests = 19 existing + 8 new; no regressions across the
  full suite).

## References

Pattern: #69 / #70 / #71 / #72.