### PR TITLE
Add S-129 Tier 1 data layer (Fusion library)

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -13,6 +13,7 @@
     <Project Path="src/EncDotNet.S100.Datasets.S127/EncDotNet.S100.Datasets.S127.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S128/EncDotNet.S100.Datasets.S128.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S129/EncDotNet.S100.Datasets.S129.csproj" />
+    <Project Path="src/EncDotNet.S100.Datasets.S129.Fusion/EncDotNet.S100.Datasets.S129.Fusion.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S131/EncDotNet.S100.Datasets.S131.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S201/EncDotNet.S100.Datasets.S201.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S411/EncDotNet.S100.Datasets.S411.csproj" />
@@ -43,6 +44,7 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S127.Tests/EncDotNet.S100.Datasets.S127.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S128.Tests/EncDotNet.S100.Datasets.S128.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S129.Tests/EncDotNet.S100.Datasets.S129.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/EncDotNet.S100.Datasets.S129.Fusion.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S131.Tests/EncDotNet.S100.Datasets.S131.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S201.Tests/EncDotNet.S100.Datasets.S201.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S411.Tests/EncDotNet.S100.Datasets.S411.Tests.csproj" />

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/EncDotNet.S100.Datasets.S129.Fusion.csproj
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/EncDotNet.S100.Datasets.S129.Fusion.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129BathymetryFusion.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129BathymetryFusion.cs
@@ -1,0 +1,66 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Pipelines.Coverage;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// Pure-data helpers for sampling an
+/// <see cref="S102CoverageSource"/> at a geographic position.
+/// </summary>
+/// <remarks>
+/// Sampling is nearest-cell — no bilinear / bicubic interpolation. The
+/// helpers never produce drawing instructions and never assume any
+/// rendering library is present.
+/// </remarks>
+public static class S129BathymetryFusion
+{
+    /// <summary>
+    /// Samples the bathymetric coverage at the supplied
+    /// <paramref name="position"/>.
+    /// </summary>
+    /// <param name="coverage">The S-102 coverage source.</param>
+    /// <param name="position">The position to sample (WGS-84 lat/lon).</param>
+    /// <returns>
+    /// The depth + uncertainty at the nearest cell, or <c>null</c> when
+    /// <paramref name="position"/> falls outside the coverage extent
+    /// (or the sampled cell carries the S-102 fill value).
+    /// </returns>
+    public static S129BathymetrySample? Sample(
+        S102CoverageSource coverage,
+        GeoPosition position)
+    {
+        ArgumentNullException.ThrowIfNull(coverage);
+
+        if (!TryLocateCell(coverage.Metadata.GridMetadata, position, out int row, out int col))
+            return null;
+
+        var region = new GridRegion(row, row + 1, col, col + 1, 1, 1);
+        var sampled = coverage.Sample(region);
+        var depth = sampled.GetField("depth")[0, 0];
+        var uncertainty = sampled.GetField("uncertainty")[0, 0];
+
+        if (depth == S102CoverageSource.FillValue)
+            return null;
+
+        return new S129BathymetrySample(depth, uncertainty, row, col);
+    }
+
+    internal static bool TryLocateCell(
+        GridMetadata grid,
+        GeoPosition position,
+        out int row,
+        out int col)
+    {
+        double rowFractional = (position.Latitude - grid.OriginLatitude) / grid.SpacingLatitudinal;
+        double colFractional = (position.Longitude - grid.OriginLongitude) / grid.SpacingLongitudinal;
+
+        row = (int)Math.Round(rowFractional, MidpointRounding.AwayFromZero);
+        col = (int)Math.Round(colFractional, MidpointRounding.AwayFromZero);
+
+        if (row < 0 || row >= grid.NumRows || col < 0 || col >= grid.NumColumns)
+            return false;
+
+        return true;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129BathymetrySample.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129BathymetrySample.cs
@@ -1,0 +1,19 @@
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// A single bathymetric sample at a control-point position, taken from
+/// the resolved S-102 dataset.
+/// </summary>
+/// <param name="Depth">
+/// The depth at the sampled cell, in metres, positive-down per S-102.
+/// </param>
+/// <param name="Uncertainty">
+/// The uncertainty (1-σ) at the sampled cell, in metres per S-102.
+/// </param>
+/// <param name="Row">The row of the sampled cell in the underlying grid.</param>
+/// <param name="Column">The column of the sampled cell in the underlying grid.</param>
+public sealed record S129BathymetrySample(
+    float Depth,
+    float Uncertainty,
+    int Row,
+    int Column);

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129CrossProductResolver.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129CrossProductResolver.cs
@@ -1,0 +1,210 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Datasets.S421.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// Resolves the textual cross-product references carried by an
+/// <see cref="S129UnderKeelClearancePlan"/> (S-129 Edition 2.0.0) against
+/// candidate strongly-typed datasets supplied by the caller.
+/// </summary>
+/// <remarks>
+/// <para>
+/// In S-129 Edition 2.0.0 the links to the source S-421 route, S-102
+/// bathymetry, and S-104 water-level products are carried as textual
+/// producer identifiers — not GML <c>xlink:href</c> URLs — and are
+/// preserved verbatim on the typed plan as
+/// <see cref="S129ExternalReference"/> values. This resolver turns
+/// those textual handles into typed
+/// <see cref="S129ResolvedReference{T}"/> values when matching datasets
+/// are supplied, or into <see cref="S129UnresolvedReference"/> entries
+/// when they are not.
+/// </para>
+/// <para>
+/// Resolution is best-effort and never throws. Callers are expected to
+/// open the candidate datasets themselves (no implicit catalogue is
+/// consulted; no I/O is performed) and may supply <c>null</c> for any
+/// dataset they have not opened.
+/// </para>
+/// <para>
+/// For the route: a candidate <see cref="S421Route"/> is considered a
+/// match for the plan's
+/// <see cref="S129UkcPlanMetadata.SourceRoute"/> when its
+/// <see cref="S421Route.RouteId"/> or
+/// <see cref="S421RouteInfo.Name"/> (or, failing those, its
+/// <see cref="S421Route.Id"/>) equals the reference's
+/// <see cref="S129ExternalReference.Identifier"/> (case-insensitive,
+/// trimmed). When the reference carries a
+/// <see cref="S129ExternalReference.Version"/>, the candidate's
+/// <see cref="S421Route.EditionNumber"/> (rendered as a decimal
+/// string) must also match.
+/// </para>
+/// <para>
+/// For S-102 and S-104: S-129 Edition 2.0.0 does not declare textual
+/// references to those products in any field of the current FC. If a
+/// candidate <see cref="S102Dataset"/> / <see cref="S104Dataset"/> is
+/// supplied alongside an S-129 plan, the resolver binds it as the
+/// resolved bathymetry / water-level surface for the plan (the caller
+/// is asserting "use this dataset"); when no candidate is supplied no
+/// resolved reference is produced and an
+/// <see cref="S129UnresolvedReference"/> with
+/// <see cref="S129ReferenceResolutionReason.DatasetNotProvided"/> is
+/// emitted.
+/// </para>
+/// </remarks>
+public static class S129CrossProductResolver
+{
+    /// <summary>
+    /// Resolves cross-product references for <paramref name="plan"/>
+    /// against the supplied candidate datasets.
+    /// </summary>
+    /// <param name="plan">The S-129 UKC plan whose references to resolve.</param>
+    /// <param name="bathymetry">
+    /// The candidate S-102 dataset, or <c>null</c> if none is open.
+    /// </param>
+    /// <param name="waterLevel">
+    /// The candidate S-104 dataset, or <c>null</c> if none is open.
+    /// </param>
+    /// <param name="route">
+    /// The candidate S-421 route, or <c>null</c> if none is open.
+    /// </param>
+    /// <returns>
+    /// A bag of resolved / unresolved references. The returned value is
+    /// independent of <paramref name="plan"/>'s lifetime — it holds
+    /// references back to the supplied dataset objects rather than
+    /// copying them.
+    /// </returns>
+    public static S129ResolvedReferences Resolve(
+        S129UnderKeelClearancePlan plan,
+        S102Dataset? bathymetry = null,
+        S104Dataset? waterLevel = null,
+        S421Route? route = null)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var unresolved = ImmutableArray.CreateBuilder<S129UnresolvedReference>();
+
+        S129ResolvedReference<S421Route>? resolvedRoute = ResolveRoute(plan, route, unresolved);
+        S129ResolvedReference<S102Dataset>? resolvedBathymetry = ResolveBathymetry(plan, bathymetry, unresolved);
+        S129ResolvedReference<S104Dataset>? resolvedWaterLevel = ResolveWaterLevel(plan, waterLevel, unresolved);
+
+        return new S129ResolvedReferences(
+            Bathymetry: resolvedBathymetry,
+            WaterLevel: resolvedWaterLevel,
+            Route: resolvedRoute,
+            Unresolved: unresolved.ToImmutable());
+    }
+
+    private static S129ResolvedReference<S421Route>? ResolveRoute(
+        S129UnderKeelClearancePlan plan,
+        S421Route? candidate,
+        ImmutableArray<S129UnresolvedReference>.Builder unresolved)
+    {
+        const string kind = "S-421 route";
+        var reference = plan.Plan?.SourceRoute;
+
+        if (candidate is null)
+        {
+            if (reference is not null)
+                unresolved.Add(new S129UnresolvedReference(
+                    reference, kind, S129ReferenceResolutionReason.DatasetNotProvided));
+            return null;
+        }
+
+        if (reference is null)
+        {
+            // The plan does not name a source route; treat the supplied
+            // candidate as an authoritative binding (caller is asserting
+            // "use this route for this plan").
+            var synthetic = new S129ExternalReference
+            {
+                Kind = kind,
+                Identifier = candidate.RouteId ?? candidate.Info?.Name ?? candidate.Id,
+                Version = candidate.EditionNumber?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            };
+            return new S129ResolvedReference<S421Route>(synthetic, candidate);
+        }
+
+        if (!RouteMatches(candidate, reference))
+        {
+            unresolved.Add(new S129UnresolvedReference(
+                reference, kind, S129ReferenceResolutionReason.IdentifierMismatch));
+            return null;
+        }
+
+        return new S129ResolvedReference<S421Route>(reference, candidate);
+    }
+
+    private static bool RouteMatches(S421Route candidate, S129ExternalReference reference)
+    {
+        var id = reference.Identifier;
+        if (string.IsNullOrWhiteSpace(id)) return false;
+
+        bool idHit =
+            Eq(candidate.RouteId, id) ||
+            Eq(candidate.Info?.Name, id) ||
+            Eq(candidate.Id, id);
+
+        if (!idHit) return false;
+
+        if (string.IsNullOrWhiteSpace(reference.Version)) return true;
+
+        var candidateVersion = candidate.EditionNumber?.ToString(
+            System.Globalization.CultureInfo.InvariantCulture);
+        return Eq(candidateVersion, reference.Version);
+    }
+
+    private static bool Eq(string? a, string? b) =>
+        a is not null && b is not null &&
+        string.Equals(a.Trim(), b.Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static S129ResolvedReference<S102Dataset>? ResolveBathymetry(
+        S129UnderKeelClearancePlan plan,
+        S102Dataset? candidate,
+        ImmutableArray<S129UnresolvedReference>.Builder unresolved)
+    {
+        const string kind = "S-102 bathymetry";
+        if (candidate is null)
+        {
+            unresolved.Add(new S129UnresolvedReference(
+                ExternalReference: null, kind, S129ReferenceResolutionReason.DatasetNotProvided));
+            return null;
+        }
+
+        // S-129 Edition 2.0.0 has no textual S-102 reference field; the
+        // caller is asserting that this dataset is the bathymetric input
+        // for the plan. Surface a synthetic external reference for
+        // round-trip traceability.
+        var synthetic = new S129ExternalReference
+        {
+            Kind = kind,
+            Identifier = plan.DatasetIdentifier ?? plan.Plan?.Id ?? "(unspecified)",
+        };
+        _ = plan;
+        return new S129ResolvedReference<S102Dataset>(synthetic, candidate);
+    }
+
+    private static S129ResolvedReference<S104Dataset>? ResolveWaterLevel(
+        S129UnderKeelClearancePlan plan,
+        S104Dataset? candidate,
+        ImmutableArray<S129UnresolvedReference>.Builder unresolved)
+    {
+        const string kind = "S-104 water level";
+        if (candidate is null)
+        {
+            unresolved.Add(new S129UnresolvedReference(
+                ExternalReference: null, kind, S129ReferenceResolutionReason.DatasetNotProvided));
+            return null;
+        }
+
+        var synthetic = new S129ExternalReference
+        {
+            Kind = kind,
+            Identifier = plan.DatasetIdentifier ?? plan.Plan?.Id ?? "(unspecified)",
+        };
+        return new S129ResolvedReference<S104Dataset>(synthetic, candidate);
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129PlanFusion.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129PlanFusion.cs
@@ -1,0 +1,72 @@
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S129.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// Convenience helpers that fuse an <see cref="S129ControlPoint"/> with
+/// a resolved S-102 or S-104 coverage in a single call.
+/// </summary>
+/// <remarks>
+/// All helpers are pure data accessors built on top of
+/// <see cref="S129BathymetryFusion"/> and
+/// <see cref="S129WaterLevelFusion"/>. They never produce drawing
+/// instructions and never depend on any rendering library.
+/// </remarks>
+public static class S129PlanFusion
+{
+    /// <summary>
+    /// Samples the supplied S-102 coverage at the control point's
+    /// position. Returns <c>null</c> when the control point has no
+    /// position or the position falls outside the coverage.
+    /// </summary>
+    public static S129BathymetrySample? SampleBathymetryAt(
+        S129ControlPoint controlPoint,
+        S102CoverageSource bathymetry)
+    {
+        ArgumentNullException.ThrowIfNull(controlPoint);
+        ArgumentNullException.ThrowIfNull(bathymetry);
+
+        if (controlPoint.Position is not { } pos) return null;
+        return S129BathymetryFusion.Sample(bathymetry, pos);
+    }
+
+    /// <summary>
+    /// Samples the supplied S-104 coverage at the control point's
+    /// position and <see cref="S129ControlPoint.ExpectedPassingTime"/>.
+    /// Returns <c>null</c> when the control point has no position, no
+    /// expected-passing-time, or the position falls outside the
+    /// coverage.
+    /// </summary>
+    public static S129WaterLevelSample? SampleWaterLevelAt(
+        S129ControlPoint controlPoint,
+        S104CoverageSource waterLevel)
+    {
+        ArgumentNullException.ThrowIfNull(controlPoint);
+        ArgumentNullException.ThrowIfNull(waterLevel);
+
+        if (controlPoint.Position is not { } pos) return null;
+        if (controlPoint.ExpectedPassingTime is not { } t) return null;
+        return S129WaterLevelFusion.Sample(waterLevel, pos, t);
+    }
+
+    /// <summary>
+    /// Samples the supplied S-104 coverage at the control point's
+    /// position and an explicit <paramref name="time"/>. Use this
+    /// overload to query a control point's location at a time other
+    /// than its expected passing time (e.g. when querying a timeline
+    /// snapshot).
+    /// </summary>
+    public static S129WaterLevelSample? SampleWaterLevelAt(
+        S129ControlPoint controlPoint,
+        S104CoverageSource waterLevel,
+        DateTimeOffset time)
+    {
+        ArgumentNullException.ThrowIfNull(controlPoint);
+        ArgumentNullException.ThrowIfNull(waterLevel);
+
+        if (controlPoint.Position is not { } pos) return null;
+        return S129WaterLevelFusion.Sample(waterLevel, pos, time);
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129ReferenceResolutionReason.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129ReferenceResolutionReason.cs
@@ -1,0 +1,35 @@
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// The reason an <see cref="EncDotNet.S100.Datasets.S129.DataModel.S129ExternalReference"/>
+/// could not be resolved against an in-process dataset.
+/// </summary>
+public enum S129ReferenceResolutionReason
+{
+    /// <summary>
+    /// No candidate dataset of the expected product was supplied to
+    /// <see cref="S129CrossProductResolver.Resolve"/>. The reference is
+    /// preserved verbatim.
+    /// </summary>
+    DatasetNotProvided,
+
+    /// <summary>
+    /// A candidate dataset was supplied but its product did not match
+    /// the kind expected by the reference.
+    /// </summary>
+    WrongProduct,
+
+    /// <summary>
+    /// A candidate dataset was supplied but its producer identifier
+    /// (and optional version) did not match the textual identifier
+    /// carried by the S-129 reference.
+    /// </summary>
+    IdentifierMismatch,
+
+    /// <summary>
+    /// The candidate dataset was structurally sound but lacked the
+    /// referenced entity (e.g. an <c>xlink:href</c> targeting a
+    /// <c>gml:id</c> not present in the candidate).
+    /// </summary>
+    ReferentMissing,
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129ResolvedReference.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129ResolvedReference.cs
@@ -1,0 +1,40 @@
+using EncDotNet.S100.Datasets.S129.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// A successfully-resolved cross-product reference: the original
+/// textual <see cref="S129ExternalReference"/> paired with the
+/// strongly-typed dataset the resolver matched it to.
+/// </summary>
+/// <typeparam name="T">
+/// The resolved dataset / feature type (typically
+/// <c>S102Dataset</c>, <c>S104Dataset</c>, or <c>S421Route</c>).
+/// </typeparam>
+/// <param name="ExternalReference">The textual S-129 reference being resolved.</param>
+/// <param name="Value">The typed referent.</param>
+public sealed record S129ResolvedReference<T>(
+    S129ExternalReference ExternalReference,
+    T Value)
+    where T : class;
+
+/// <summary>
+/// A cross-product reference that could not be resolved against the
+/// candidate datasets supplied to
+/// <see cref="S129CrossProductResolver.Resolve"/>.
+/// </summary>
+/// <param name="ExternalReference">
+/// The textual S-129 reference that failed to resolve. When the
+/// reference is implicit (e.g. an S-129 plan that does not name a
+/// source S-102 dataset but a candidate was nonetheless supplied),
+/// this is <c>null</c>.
+/// </param>
+/// <param name="ExpectedKind">
+/// The product kind the resolver was attempting to bind (e.g.
+/// <c>"S-421 route"</c>, <c>"S-102 bathymetry"</c>).
+/// </param>
+/// <param name="Reason">Why the reference could not be resolved.</param>
+public sealed record S129UnresolvedReference(
+    S129ExternalReference? ExternalReference,
+    string ExpectedKind,
+    S129ReferenceResolutionReason Reason);

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129ResolvedReferences.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129ResolvedReferences.cs
@@ -1,0 +1,24 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S421.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// The typed output of <see cref="S129CrossProductResolver.Resolve"/>:
+/// resolved / unresolved cross-product references for an
+/// <see cref="EncDotNet.S100.Datasets.S129.DataModel.S129UnderKeelClearancePlan"/>.
+/// </summary>
+/// <remarks>
+/// Resolution is best-effort. A plan with all references unresolved is
+/// surfaced as a fully-formed value with every typed slot <c>null</c>
+/// and the corresponding <see cref="S129UnresolvedReference"/> entries
+/// in <see cref="Unresolved"/>. The resolver never throws for missing
+/// or mismatched references.
+/// </remarks>
+public sealed record S129ResolvedReferences(
+    S129ResolvedReference<S102Dataset>? Bathymetry,
+    S129ResolvedReference<S104Dataset>? WaterLevel,
+    S129ResolvedReference<S421Route>? Route,
+    ImmutableArray<S129UnresolvedReference> Unresolved);

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129WaterLevelFusion.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129WaterLevelFusion.cs
@@ -1,0 +1,79 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Pipelines.Coverage;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// Pure-data helpers for sampling an
+/// <see cref="S104CoverageSource"/> at a geographic position and time.
+/// </summary>
+/// <remarks>
+/// Sampling is nearest-cell in space and nearest-time-slice in time —
+/// no interpolation. The helpers never produce drawing instructions
+/// and never assume any rendering library is present.
+/// </remarks>
+public static class S129WaterLevelFusion
+{
+    /// <summary>
+    /// Samples the water-level coverage at the supplied
+    /// <paramref name="position"/> and <paramref name="time"/>.
+    /// </summary>
+    /// <param name="coverage">The S-104 coverage source.</param>
+    /// <param name="position">The position to sample (WGS-84 lat/lon).</param>
+    /// <param name="time">
+    /// The requested time. The coverage selects the nearest available
+    /// time slice; the actual selected time is returned on the sample.
+    /// </param>
+    /// <returns>
+    /// The height + trend at the nearest cell of the nearest time
+    /// slice, or <c>null</c> when <paramref name="position"/> falls
+    /// outside the coverage extent (or the sampled cell carries the
+    /// S-104 fill value).
+    /// </returns>
+    public static S129WaterLevelSample? Sample(
+        S104CoverageSource coverage,
+        GeoPosition position,
+        DateTimeOffset time)
+    {
+        ArgumentNullException.ThrowIfNull(coverage);
+
+        var availableTimes = coverage.AvailableTimes;
+        if (availableTimes.Count == 0) return null;
+
+        // S104CoverageSource.SelectTime is in unspecified-kind DateTime
+        // (parsed from HDF5 timePoint); convert via UTC to keep ordering
+        // deterministic.
+        coverage.SelectTime(time.UtcDateTime);
+
+        // Capture the actually-selected time slice. SelectTime mutates
+        // internal state; the next Sample() call uses the new slice.
+        DateTime selected = FindNearestSelected(availableTimes, time.UtcDateTime);
+
+        if (!S129BathymetryFusion.TryLocateCell(
+                coverage.Metadata.GridMetadata, position, out int row, out int col))
+            return null;
+
+        var region = new GridRegion(row, row + 1, col, col + 1, 1, 1);
+        var sampled = coverage.Sample(region);
+        var height = sampled.GetField("waterLevelHeight")[0, 0];
+        var trend = sampled.GetField("waterLevelTrend")[0, 0];
+
+        if (height == S104CoverageSource.FillValue)
+            return null;
+
+        return new S129WaterLevelSample(height, trend, selected, row, col);
+    }
+
+    private static DateTime FindNearestSelected(IReadOnlyList<DateTime> times, DateTime target)
+    {
+        DateTime best = times[0];
+        TimeSpan bestDelta = (best - target).Duration();
+        for (int i = 1; i < times.Count; i++)
+        {
+            var delta = (times[i] - target).Duration();
+            if (delta < bestDelta) { best = times[i]; bestDelta = delta; }
+        }
+        return best;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129WaterLevelSample.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Fusion/S129WaterLevelSample.cs
@@ -1,0 +1,26 @@
+namespace EncDotNet.S100.Datasets.S129.Fusion;
+
+/// <summary>
+/// A single water-level sample at a control-point position and time,
+/// taken from the resolved S-104 dataset.
+/// </summary>
+/// <param name="Height">
+/// The water-level height at the sampled cell, in metres above the
+/// vertical datum, per S-104.
+/// </param>
+/// <param name="Trend">
+/// The water-level trend flag at the sampled cell (S-104 listed value).
+/// </param>
+/// <param name="TimeSelected">
+/// The actual time slice selected from the dataset's
+/// <c>AvailableTimes</c>; this may differ from the requested time when
+/// the dataset has no exact match (nearest-time semantics).
+/// </param>
+/// <param name="Row">The row of the sampled cell in the selected time slice's grid.</param>
+/// <param name="Column">The column of the sampled cell in the selected time slice's grid.</param>
+public sealed record S129WaterLevelSample(
+    float Height,
+    float Trend,
+    DateTime TimeSelected,
+    int Row,
+    int Column);

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/README.md
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/README.md
@@ -1,0 +1,157 @@
+# EncDotNet.S100.Datasets.S129.Fusion
+
+Cross-product data-layer helpers for IHO S-129 Under Keel Clearance
+Management plans. Fuses an `S129UnderKeelClearancePlan` with the
+strongly-typed datasets it references (S-102 bathymetry, S-104 water
+level, S-421 route) and surfaces a time-indexed view over the plan
+itself.
+
+This library is **purely additive** on top of the existing typed
+projections in `EncDotNet.S100.Datasets.S129`,
+`EncDotNet.S100.Datasets.S102`, `EncDotNet.S100.Datasets.S104`, and
+`EncDotNet.S100.Datasets.S421`. It does not modify them.
+
+## Three capabilities
+
+### 1. Timeline (`Timeline/`)
+
+`S129TimelineView` exposes the ordered sequence of distinct control-point
+expected-passing-times in an S-129 plan and lets callers query the UKC
+state at an arbitrary time:
+
+```csharp
+var view = new S129TimelineView(plan);
+foreach (var snap in view.EnumerateTimeline())
+    Console.WriteLine($"{snap.Time:o}  UKC margin = {snap.ControlPoint.DistanceAboveUkcLimit:F2} m");
+
+// Between-grid lookup with the default semantic:
+var nowSnap = view.GetSnapshotAt(DateTimeOffset.UtcNow); // NearestEarlier
+```
+
+`S129TimelineSamplingMode` chooses how off-grid times are resolved:
+
+| Mode | Behaviour |
+|---|---|
+| `NearestEarlier` *(default)* | greatest sample time ≤ `t`; null if before the first sample |
+| `NearestLater` | least sample time ≥ `t`; null if after the last sample |
+| `Nearest` | absolute closest sample time; ties resolve to the earlier sample |
+| `Exact` | only an exact-match sample; null otherwise |
+
+The library deliberately does **not** interpolate between control-point
+UKC values — interpolation across explicit producer gaps would change
+the semantics of S-129 §`UnderKeelClearanceControlPoint`. If
+interpolation is needed it can be layered on top later.
+
+### 2. Cross-product resolution + S-102 / S-104 fusion (`Fusion/`)
+
+In S-129 Edition 2.0.0 the links to the source S-421 route, S-102
+bathymetry, and S-104 water level are *textual* producer identifiers,
+preserved verbatim on the typed plan as `S129ExternalReference` values.
+`S129CrossProductResolver.Resolve(plan, bathymetry?, waterLevel?, route?)`
+turns those textual handles into typed `S129ResolvedReference<T>` values
+when matching datasets are supplied, or `S129UnresolvedReference`
+entries with a reason when they are not. Resolution is best-effort and
+never throws.
+
+```csharp
+var resolved = S129CrossProductResolver.Resolve(plan, route: openRoute);
+if (resolved.Route is { } r)
+    Console.WriteLine($"Matched route {r.Value.RouteId} edition {r.Value.EditionNumber}");
+foreach (var u in resolved.Unresolved)
+    Console.WriteLine($"  unresolved: {u.ExpectedKind} ({u.Reason})");
+```
+
+Once a coverage is resolved, the static fusion helpers sample it at a
+control point's geographic position:
+
+```csharp
+var bathy = new S102CoverageSource(openBathymetry);
+var depth = S129BathymetryFusion.Sample(bathy, controlPoint.Position!.Value);
+
+var wl = new S104CoverageSource(openWaterLevel);
+var level = S129WaterLevelFusion.Sample(wl, controlPoint.Position!.Value, controlPoint.ExpectedPassingTime!.Value);
+```
+
+`S129PlanFusion` adds CP-aware overloads:
+
+```csharp
+var depth  = S129PlanFusion.SampleBathymetryAt(cp, bathy);
+var level  = S129PlanFusion.SampleWaterLevelAt(cp, wl);   // uses cp.ExpectedPassingTime
+```
+
+Sampling is nearest-cell in space and nearest-time-slice in time — no
+interpolation. The helpers never produce drawing instructions and never
+depend on a rendering library.
+
+### 3. S-421 route binding (`Routing/`)
+
+`S129RouteBinder.Bind(plan, route, options?)` correlates each control
+point with the supplied route by spatial proximity:
+
+```csharp
+var binding = S129RouteBinder.Bind(plan, route);
+foreach (var (cp, mapping) in binding.Mappings)
+{
+    var label = mapping.Kind switch
+    {
+        S129RouteMappingKind.OnWaypoint => $"@ WP {mapping.Waypoint!.Id} ({mapping.DistanceMeters:F1} m)",
+        S129RouteMappingKind.OnLeg      => $"along {mapping.Leg!.Id} t={mapping.LegPositionFraction:F2}",
+        _                               => "unmapped",
+    };
+    Console.WriteLine($"{cp.Id}: {label}");
+}
+```
+
+For each control point the binder first tests every waypoint and keeps
+the closest within `WaypointToleranceMeters` (default **200 m**); if
+none qualifies it falls back to the closest projection onto a leg's
+polyline within `LegToleranceMeters` (default **100 m**); otherwise the
+control point is marked `Unmapped`. Distances use the haversine
+great-circle formula.
+
+## End-to-end example
+
+```csharp
+// Open the typed plan + auxiliary datasets.
+var rawPlan = S129Dataset.Open("12900MCTDS130TS.gml");
+var plan    = S129UnderKeelClearancePlan.From(rawPlan, out _);
+var bathy   = new S102CoverageSource(S102DatasetReader.Read("bathy.h5"));
+var route   = ... ; // S421RoutePlan.From(...).Routes[0]
+
+// Resolve cross-product references.
+var resolved = S129CrossProductResolver.Resolve(plan, bathymetry: bathyDs, route: route);
+
+// Sample fused bathymetry at each CP.
+foreach (var cp in plan.ControlPoints)
+{
+    var depth = S129PlanFusion.SampleBathymetryAt(cp, bathy);
+    Console.WriteLine($"{cp.Id} UKC margin {cp.DistanceAboveUkcLimit:F2} m  depth {depth?.Depth:F1} m");
+}
+
+// Correlate CPs with the route.
+var binding = S129RouteBinder.Bind(plan, route);
+```
+
+## Explicit non-goals
+
+This library is the **data-access half** of S-129 Tier 1. It does not:
+
+- Modify any portrayal pipeline.
+- Produce drawing instructions, XSLT, Lua rules, or any portrayal output.
+- Touch `MapsuiDisplayListRenderer`, `SkiaCoverageRenderer`, or any other renderer.
+- Add viewer UI (panels, timeline sliders, toolbars).
+- Introduce a new caching layer beyond what the underlying coverage / projection caches already do.
+- Provide a CLI tool or sample executable.
+- Change the existing typed `DataModel` shapes from PR #74 / PR #76.
+
+The visualisation half (drawing fused output, timeline scrub UI, route
+overlay) is a separate, larger problem that lives in subsequent PRs.
+
+## Installation
+
+```sh
+dotnet add package EncDotNet.S100.Datasets.S129.Fusion
+```
+
+Depends on `EncDotNet.S100.Datasets.S129`, `EncDotNet.S100.Datasets.S102`,
+`EncDotNet.S100.Datasets.S104`, and `EncDotNet.S100.Datasets.S421`.

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129ControlPointRouteMapping.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129ControlPointRouteMapping.cs
@@ -1,0 +1,53 @@
+using EncDotNet.S100.Datasets.S421.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Routing;
+
+/// <summary>
+/// The mapping of a single <c>S129ControlPoint</c> onto an S-421
+/// <see cref="S421Route"/>.
+/// </summary>
+/// <remarks>
+/// Implemented as a single record with a discriminator
+/// (<see cref="Kind"/>) plus nullable per-variant fields. This mirrors
+/// the discriminated-union shape used elsewhere in the codebase and
+/// keeps the type cheap to enumerate over.
+/// </remarks>
+/// <param name="Kind">Which variant this mapping is.</param>
+/// <param name="Waypoint">
+/// The matched waypoint when <see cref="Kind"/> is
+/// <see cref="S129RouteMappingKind.OnWaypoint"/>; otherwise <c>null</c>.
+/// </param>
+/// <param name="Leg">
+/// The matched leg when <see cref="Kind"/> is
+/// <see cref="S129RouteMappingKind.OnLeg"/>; otherwise <c>null</c>.
+/// </param>
+/// <param name="LegPositionFraction">
+/// The fractional position (0..1) along <see cref="Leg"/>'s polyline
+/// at which the control point projects, when <see cref="Kind"/> is
+/// <see cref="S129RouteMappingKind.OnLeg"/>; otherwise <c>null</c>.
+/// <c>0</c> is the leg's start, <c>1</c> is the leg's end.
+/// </param>
+/// <param name="DistanceMeters">
+/// The great-circle (waypoint) or perpendicular-to-polyline (leg)
+/// distance, in metres. <c>null</c> for
+/// <see cref="S129RouteMappingKind.Unmapped"/>.
+/// </param>
+public sealed record S129ControlPointRouteMapping(
+    S129RouteMappingKind Kind,
+    S421Waypoint? Waypoint,
+    S421Leg? Leg,
+    double? LegPositionFraction,
+    double? DistanceMeters)
+{
+    /// <summary>The canonical "unmapped" instance.</summary>
+    public static S129ControlPointRouteMapping Unmapped { get; } =
+        new(S129RouteMappingKind.Unmapped, null, null, null, null);
+
+    /// <summary>Constructs an <see cref="S129RouteMappingKind.OnWaypoint"/> mapping.</summary>
+    public static S129ControlPointRouteMapping OnWaypoint(S421Waypoint waypoint, double distanceMeters) =>
+        new(S129RouteMappingKind.OnWaypoint, waypoint, null, null, distanceMeters);
+
+    /// <summary>Constructs an <see cref="S129RouteMappingKind.OnLeg"/> mapping.</summary>
+    public static S129ControlPointRouteMapping OnLeg(S421Leg leg, double positionFraction, double distanceMeters) =>
+        new(S129RouteMappingKind.OnLeg, null, leg, positionFraction, distanceMeters);
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteBinder.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteBinder.cs
@@ -1,0 +1,213 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Datasets.S421.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Routing;
+
+/// <summary>
+/// Correlates the control points of an
+/// <see cref="S129UnderKeelClearancePlan"/> with the waypoints and legs
+/// of an S-421 <see cref="S421Route"/> via spatial proximity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-129 Edition 2.0.0 does not carry explicit waypoint cross-references
+/// from control points back to the source S-421 route; the binder is
+/// purely geometric.
+/// </para>
+/// <para>
+/// For each control point, the binder first tests every waypoint and
+/// keeps the closest within
+/// <see cref="S129RouteBindingOptions.WaypointToleranceMeters"/>. If no
+/// waypoint is close enough, it tests every leg's polyline (constructed
+/// from the leg's <see cref="S421Leg.Coordinates"/> if present, falling
+/// back to the leg's start/end waypoint positions) and keeps the
+/// closest within
+/// <see cref="S129RouteBindingOptions.LegToleranceMeters"/>. If neither
+/// passes, the control point is recorded as <see cref="S129RouteMappingKind.Unmapped"/>.
+/// </para>
+/// <para>
+/// Distances are computed using the haversine great-circle formula
+/// (Earth radius 6371008.8 m, the WGS-84 mean radius). At S-129
+/// chart-plan scales this is accurate to the small fractions of a
+/// metre that matter for tolerance comparisons.
+/// </para>
+/// </remarks>
+public static class S129RouteBinder
+{
+    private const double EarthRadiusMeters = 6_371_008.8;
+
+    /// <summary>
+    /// Correlates the supplied plan's control points with the supplied
+    /// route. Pure data accessor; never throws for missing or sparse
+    /// inputs.
+    /// </summary>
+    /// <param name="plan">The S-129 UKC plan.</param>
+    /// <param name="route">The S-421 route.</param>
+    /// <param name="options">
+    /// Tolerance parameters; defaults to
+    /// <see cref="S129RouteBindingOptions.Default"/>.
+    /// </param>
+    public static S129RouteBinding Bind(
+        S129UnderKeelClearancePlan plan,
+        S421Route route,
+        S129RouteBindingOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(route);
+
+        var opts = options ?? S129RouteBindingOptions.Default;
+        var mappings = ImmutableArray.CreateBuilder<(S129ControlPoint, S129ControlPointRouteMapping)>(plan.ControlPoints.Length);
+
+        foreach (var cp in plan.ControlPoints)
+        {
+            mappings.Add((cp, MapOne(cp, route, opts)));
+        }
+
+        return new S129RouteBinding(plan, route, mappings.ToImmutable());
+    }
+
+    private static S129ControlPointRouteMapping MapOne(
+        S129ControlPoint cp,
+        S421Route route,
+        S129RouteBindingOptions opts)
+    {
+        if (cp.Position is not { } cpPos) return S129ControlPointRouteMapping.Unmapped;
+
+        // Waypoint pass.
+        S421Waypoint? bestWp = null;
+        double bestWpDistance = double.PositiveInfinity;
+        foreach (var wp in route.Waypoints)
+        {
+            double d = Haversine(cpPos, wp.Position);
+            if (d < bestWpDistance)
+            {
+                bestWpDistance = d;
+                bestWp = wp;
+            }
+        }
+
+        if (bestWp is not null && bestWpDistance <= opts.WaypointToleranceMeters)
+            return S129ControlPointRouteMapping.OnWaypoint(bestWp, bestWpDistance);
+
+        // Leg pass.
+        S421Leg? bestLeg = null;
+        double bestLegDistance = double.PositiveInfinity;
+        double bestLegFraction = 0;
+        foreach (var leg in route.Legs)
+        {
+            var polyline = BuildLegPolyline(leg);
+            if (polyline.Count < 2) continue;
+
+            var (distance, fraction) = NearestPointOnPolyline(cpPos, polyline);
+            if (distance < bestLegDistance)
+            {
+                bestLegDistance = distance;
+                bestLegFraction = fraction;
+                bestLeg = leg;
+            }
+        }
+
+        if (bestLeg is not null && bestLegDistance <= opts.LegToleranceMeters)
+            return S129ControlPointRouteMapping.OnLeg(bestLeg, bestLegFraction, bestLegDistance);
+
+        return S129ControlPointRouteMapping.Unmapped;
+    }
+
+    private static IReadOnlyList<GeoPosition> BuildLegPolyline(S421Leg leg)
+    {
+        if (!leg.Coordinates.IsDefaultOrEmpty && leg.Coordinates.Length >= 2)
+            return leg.Coordinates;
+
+        if (leg.StartWaypoint is not null && leg.EndWaypoint is not null)
+            return [leg.StartWaypoint.Position, leg.EndWaypoint.Position];
+
+        return Array.Empty<GeoPosition>();
+    }
+
+    /// <summary>
+    /// Returns the minimum distance (m) from <paramref name="point"/> to
+    /// the polyline plus the fractional position (0..1) along the
+    /// polyline's total arc length where the projection lands.
+    /// Approximates each segment as planar on the equirectangular plane
+    /// scaled to the segment's mean latitude — accurate to well under a
+    /// metre across an S-129-sized chart.
+    /// </summary>
+    private static (double Distance, double Fraction) NearestPointOnPolyline(
+        GeoPosition point,
+        IReadOnlyList<GeoPosition> polyline)
+    {
+        double bestDistance = double.PositiveInfinity;
+        double bestArcSoFar = 0;
+        double accumulated = 0;
+        var segmentLengths = new double[polyline.Count - 1];
+        double total = 0;
+        for (int i = 0; i < polyline.Count - 1; i++)
+        {
+            segmentLengths[i] = Haversine(polyline[i], polyline[i + 1]);
+            total += segmentLengths[i];
+        }
+        if (total == 0)
+        {
+            // Degenerate polyline — fall back to the first vertex.
+            return (Haversine(point, polyline[0]), 0);
+        }
+
+        for (int i = 0; i < polyline.Count - 1; i++)
+        {
+            var a = polyline[i];
+            var b = polyline[i + 1];
+            var (segDistance, segFraction) = NearestPointOnSegment(point, a, b);
+            if (segDistance < bestDistance)
+            {
+                bestDistance = segDistance;
+                bestArcSoFar = accumulated + segFraction * segmentLengths[i];
+            }
+            accumulated += segmentLengths[i];
+        }
+
+        return (bestDistance, bestArcSoFar / total);
+    }
+
+    private static (double Distance, double Fraction) NearestPointOnSegment(
+        GeoPosition point, GeoPosition a, GeoPosition b)
+    {
+        // Equirectangular projection around the segment's mean latitude.
+        double midLat = (a.Latitude + b.Latitude) * 0.5;
+        double cosMidLat = Math.Cos(midLat * Math.PI / 180.0);
+        const double metersPerDegreeLat = Math.PI * EarthRadiusMeters / 180.0;
+
+        double ax = a.Longitude * cosMidLat * metersPerDegreeLat;
+        double ay = a.Latitude * metersPerDegreeLat;
+        double bx = b.Longitude * cosMidLat * metersPerDegreeLat;
+        double by = b.Latitude * metersPerDegreeLat;
+        double px = point.Longitude * cosMidLat * metersPerDegreeLat;
+        double py = point.Latitude * metersPerDegreeLat;
+
+        double dx = bx - ax;
+        double dy = by - ay;
+        double lenSq = dx * dx + dy * dy;
+        double t = lenSq > 0 ? ((px - ax) * dx + (py - ay) * dy) / lenSq : 0;
+        if (t < 0) t = 0;
+        else if (t > 1) t = 1;
+
+        double closestX = ax + t * dx;
+        double closestY = ay + t * dy;
+        double distance = Math.Sqrt((px - closestX) * (px - closestX) + (py - closestY) * (py - closestY));
+        return (distance, t);
+    }
+
+    private static double Haversine(GeoPosition a, GeoPosition b)
+    {
+        double lat1 = a.Latitude * Math.PI / 180.0;
+        double lat2 = b.Latitude * Math.PI / 180.0;
+        double dLat = (b.Latitude - a.Latitude) * Math.PI / 180.0;
+        double dLon = (b.Longitude - a.Longitude) * Math.PI / 180.0;
+
+        double s = Math.Sin(dLat / 2);
+        double c = Math.Sin(dLon / 2);
+        double h = s * s + Math.Cos(lat1) * Math.Cos(lat2) * c * c;
+        return 2 * EarthRadiusMeters * Math.Asin(Math.Min(1, Math.Sqrt(h)));
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteBinding.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteBinding.cs
@@ -1,0 +1,23 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Datasets.S421.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Routing;
+
+/// <summary>
+/// The typed correlation between an
+/// <see cref="S129UnderKeelClearancePlan"/>'s control points and an
+/// S-421 <see cref="S421Route"/>, produced by
+/// <see cref="S129RouteBinder.Bind"/>.
+/// </summary>
+/// <param name="Plan">The source UKC plan.</param>
+/// <param name="Route">The source S-421 route.</param>
+/// <param name="Mappings">
+/// Per-control-point mappings, in the same order as
+/// <see cref="S129UnderKeelClearancePlan.ControlPoints"/>. Each entry
+/// pairs a control point with its <see cref="S129ControlPointRouteMapping"/>.
+/// </param>
+public sealed record S129RouteBinding(
+    S129UnderKeelClearancePlan Plan,
+    S421Route Route,
+    ImmutableArray<(S129ControlPoint ControlPoint, S129ControlPointRouteMapping Mapping)> Mappings);

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteBindingOptions.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteBindingOptions.cs
@@ -1,0 +1,30 @@
+namespace EncDotNet.S100.Datasets.S129.Fusion.Routing;
+
+/// <summary>
+/// Tunable parameters for <see cref="S129RouteBinder.Bind"/>.
+/// </summary>
+/// <param name="WaypointToleranceMeters">
+/// Maximum great-circle distance (metres) between a control point and a
+/// waypoint for which the binder will record an
+/// <see cref="S129RouteMappingKind.OnWaypoint"/> mapping. Default 200 m.
+/// </param>
+/// <param name="LegToleranceMeters">
+/// Maximum perpendicular distance (metres) between a control point and
+/// the nearest point on a leg's polyline for which the binder will
+/// record an <see cref="S129RouteMappingKind.OnLeg"/> mapping. Default
+/// 100 m.
+/// </param>
+/// <remarks>
+/// S-129 Edition 2.0.0 does not require explicit waypoint cross-refs
+/// from control points to the source S-421 route. The binder therefore
+/// matches by spatial proximity; the defaults are tuned for typical
+/// pilotage / harbour-approach UKC plans and may be loosened for
+/// open-water plans.
+/// </remarks>
+public sealed record S129RouteBindingOptions(
+    double WaypointToleranceMeters = 200.0,
+    double LegToleranceMeters = 100.0)
+{
+    /// <summary>Default options.</summary>
+    public static S129RouteBindingOptions Default { get; } = new();
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteMappingKind.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Routing/S129RouteMappingKind.cs
@@ -1,0 +1,20 @@
+namespace EncDotNet.S100.Datasets.S129.Fusion.Routing;
+
+/// <summary>
+/// The kind of mapping <see cref="S129RouteBinder"/> produced for a
+/// particular control point.
+/// </summary>
+public enum S129RouteMappingKind
+{
+    /// <summary>The control point snapped to a specific S-421 waypoint.</summary>
+    OnWaypoint,
+
+    /// <summary>The control point fell along a specific S-421 leg.</summary>
+    OnLeg,
+
+    /// <summary>
+    /// The control point had no S-421 waypoint or leg within the
+    /// configured tolerances.
+    /// </summary>
+    Unmapped,
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Timeline/S129TimelineSamplingMode.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Timeline/S129TimelineSamplingMode.cs
@@ -1,0 +1,42 @@
+namespace EncDotNet.S100.Datasets.S129.Fusion.Timeline;
+
+/// <summary>
+/// Strategy for selecting an <see cref="S129TimelineSnapshot"/> when a
+/// requested time falls between two control-point time-stamps in an
+/// <see cref="S129TimelineView"/>.
+/// </summary>
+/// <remarks>
+/// S-129 Edition 2.0.0 does not prescribe a behaviour for off-grid time
+/// queries — control points are discrete samples along the planned voyage.
+/// <see cref="NearestEarlier"/> is the documented default for this
+/// library because it matches a "most recent UKC observation as of T"
+/// reading: a navigator querying time T sees the UKC reported at the
+/// last control point already passed.
+/// </remarks>
+public enum S129TimelineSamplingMode
+{
+    /// <summary>
+    /// Return the snapshot whose time is the greatest value ≤ <c>t</c>.
+    /// When <c>t</c> precedes the first sample, returns <c>null</c>.
+    /// This is the library default.
+    /// </summary>
+    NearestEarlier,
+
+    /// <summary>
+    /// Return the snapshot whose time is the least value ≥ <c>t</c>.
+    /// When <c>t</c> follows the last sample, returns <c>null</c>.
+    /// </summary>
+    NearestLater,
+
+    /// <summary>
+    /// Return the snapshot whose time is the absolute-closest value to
+    /// <c>t</c>. Ties resolve to the earlier sample.
+    /// </summary>
+    Nearest,
+
+    /// <summary>
+    /// Return only a snapshot whose time equals <c>t</c> exactly;
+    /// otherwise <c>null</c>.
+    /// </summary>
+    Exact,
+}

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Timeline/S129TimelineSnapshot.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Timeline/S129TimelineSnapshot.cs
@@ -1,0 +1,34 @@
+using EncDotNet.S100.Datasets.S129.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Timeline;
+
+/// <summary>
+/// A single timeline sample: the under-keel-clearance state at a
+/// specific instant along an <see cref="S129UnderKeelClearancePlan"/>.
+/// </summary>
+/// <param name="Time">
+/// The sample time. For <see cref="S129TimelineSamplingMode.Exact"/> /
+/// on-grid lookups this equals the source control point's
+/// <see cref="S129ControlPoint.ExpectedPassingTime"/>; for off-grid
+/// lookups it is the time of the selected neighbour.
+/// </param>
+/// <param name="ControlPoint">
+/// The control point whose UKC measurement applies at <see cref="Time"/>.
+/// </param>
+/// <param name="IsExact">
+/// <c>true</c> when the snapshot was taken at the control point's own
+/// time; <c>false</c> when it was selected via a sampling strategy that
+/// rounded toward a neighbour.
+/// </param>
+/// <param name="HasOverlappingControlPoints">
+/// <c>true</c> when more than one control point in the timeline shares
+/// the same <see cref="Time"/>. <see cref="ControlPoint"/> is the
+/// earliest such CP in source-document order; the remaining overlapping
+/// CPs are still present in <see cref="S129UnderKeelClearancePlan.ControlPoints"/>
+/// and can be inspected by the caller.
+/// </param>
+public sealed record S129TimelineSnapshot(
+    DateTimeOffset Time,
+    S129ControlPoint ControlPoint,
+    bool IsExact,
+    bool HasOverlappingControlPoints);

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/Timeline/S129TimelineView.cs
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/Timeline/S129TimelineView.cs
@@ -1,0 +1,219 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S129.DataModel;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Timeline;
+
+/// <summary>
+/// A time-indexed view over an <see cref="S129UnderKeelClearancePlan"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each <see cref="S129ControlPoint"/> in the source plan carries a
+/// single <see cref="S129ControlPoint.ExpectedPassingTime"/>. The
+/// timeline view surfaces these as ordered, deduplicated samples and
+/// lets callers query "the UKC state at time T" via
+/// <see cref="GetSnapshotAt"/>.
+/// </para>
+/// <para>
+/// Control points whose <c>ExpectedPassingTime</c> is <c>null</c> are
+/// excluded from the timeline (the underlying typed projection sorts
+/// them to the tail of the plan's control-point list in source-document
+/// order — see S-129 Edition 2.0.0 §<c>UnderKeelClearanceControlPoint</c>).
+/// </para>
+/// <para>
+/// This type is purely a data accessor: it returns typed values and
+/// never produces drawing instructions, never depends on a renderer,
+/// and never assumes a UI is present.
+/// </para>
+/// </remarks>
+public sealed class S129TimelineView
+{
+    private readonly ImmutableArray<S129ControlPoint> _timedControlPoints;
+    private readonly ImmutableArray<DateTimeOffset> _times;
+    private readonly ImmutableArray<int> _firstIndexByTime;
+
+    /// <summary>The source plan.</summary>
+    public S129UnderKeelClearancePlan Plan { get; }
+
+    /// <summary>
+    /// Distinct sample times in strictly ascending order. Identical to
+    /// the set of <see cref="S129ControlPoint.ExpectedPassingTime"/>
+    /// values present in <see cref="Plan"/>, deduplicated.
+    /// </summary>
+    public ImmutableArray<DateTimeOffset> Times => _times;
+
+    /// <summary>The earliest sample time, or <c>null</c> when the timeline is empty.</summary>
+    public DateTimeOffset? Start => _times.IsDefaultOrEmpty ? null : _times[0];
+
+    /// <summary>The latest sample time, or <c>null</c> when the timeline is empty.</summary>
+    public DateTimeOffset? End => _times.IsDefaultOrEmpty ? null : _times[^1];
+
+    /// <summary>
+    /// <c>true</c> when the source plan has no control points with an
+    /// <see cref="S129ControlPoint.ExpectedPassingTime"/>.
+    /// </summary>
+    public bool IsEmpty => _times.IsDefaultOrEmpty;
+
+    /// <summary>
+    /// Builds a timeline view from an
+    /// <see cref="S129UnderKeelClearancePlan"/>.
+    /// </summary>
+    /// <param name="plan">The source plan.</param>
+    public S129TimelineView(S129UnderKeelClearancePlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        Plan = plan;
+
+        var timed = plan.ControlPoints
+            .Where(cp => cp.ExpectedPassingTime.HasValue)
+            .ToImmutableArray();
+        _timedControlPoints = timed;
+
+        if (timed.IsDefaultOrEmpty)
+        {
+            _times = ImmutableArray<DateTimeOffset>.Empty;
+            _firstIndexByTime = ImmutableArray<int>.Empty;
+            return;
+        }
+
+        // The projection already sorts CPs by ExpectedPassingTime
+        // (stable); just collect distinct times and record the index of
+        // the first CP at each time so overlap detection is O(1).
+        var times = ImmutableArray.CreateBuilder<DateTimeOffset>();
+        var firstIndex = ImmutableArray.CreateBuilder<int>();
+        DateTimeOffset? previous = null;
+        for (int i = 0; i < timed.Length; i++)
+        {
+            var t = timed[i].ExpectedPassingTime!.Value;
+            if (previous.HasValue && t == previous.Value) continue;
+            times.Add(t);
+            firstIndex.Add(i);
+            previous = t;
+        }
+        _times = times.ToImmutable();
+        _firstIndexByTime = firstIndex.ToImmutable();
+    }
+
+    /// <summary>
+    /// Enumerates one <see cref="S129TimelineSnapshot"/> per distinct
+    /// sample time in chronological order.
+    /// </summary>
+    public IEnumerable<S129TimelineSnapshot> EnumerateTimeline()
+    {
+        for (int i = 0; i < _times.Length; i++)
+        {
+            int cpIndex = _firstIndexByTime[i];
+            bool overlap = HasOverlapAt(i, cpIndex);
+            yield return new S129TimelineSnapshot(
+                _times[i],
+                _timedControlPoints[cpIndex],
+                IsExact: true,
+                HasOverlappingControlPoints: overlap);
+        }
+    }
+
+    /// <summary>
+    /// Returns the snapshot at the given <paramref name="time"/>
+    /// according to the supplied sampling <paramref name="mode"/>, or
+    /// <c>null</c> when no snapshot can be returned (e.g. the timeline
+    /// is empty, or <paramref name="mode"/> is
+    /// <see cref="S129TimelineSamplingMode.NearestEarlier"/> and
+    /// <paramref name="time"/> precedes the first sample).
+    /// </summary>
+    /// <param name="time">The query time.</param>
+    /// <param name="mode">
+    /// The sampling strategy. Defaults to
+    /// <see cref="S129TimelineSamplingMode.NearestEarlier"/>, which
+    /// matches the "most recent UKC observation as of <paramref name="time"/>"
+    /// reading.
+    /// </param>
+    public S129TimelineSnapshot? GetSnapshotAt(
+        DateTimeOffset time,
+        S129TimelineSamplingMode mode = S129TimelineSamplingMode.NearestEarlier)
+    {
+        if (_times.IsDefaultOrEmpty) return null;
+
+        // Binary search for the time. ImmutableArray<T>.BinarySearch is
+        // not directly exposed on the struct; use Array.BinarySearch over
+        // the underlying segment via ToArray() once is fine for the
+        // small sizes typical of an S-129 plan, but we keep an in-place
+        // loop to avoid allocations.
+        int lo = 0, hi = _times.Length - 1;
+        int exact = -1;
+        while (lo <= hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            int cmp = _times[mid].CompareTo(time);
+            if (cmp == 0) { exact = mid; break; }
+            if (cmp < 0) lo = mid + 1;
+            else hi = mid - 1;
+        }
+        // After the loop (no exact match), lo = insertion point.
+
+        int chosen;
+        bool isExact;
+        switch (mode)
+        {
+            case S129TimelineSamplingMode.Exact:
+                if (exact < 0) return null;
+                chosen = exact;
+                isExact = true;
+                break;
+
+            case S129TimelineSamplingMode.NearestEarlier:
+                if (exact >= 0) { chosen = exact; isExact = true; }
+                else
+                {
+                    int prev = lo - 1;
+                    if (prev < 0) return null;
+                    chosen = prev;
+                    isExact = false;
+                }
+                break;
+
+            case S129TimelineSamplingMode.NearestLater:
+                if (exact >= 0) { chosen = exact; isExact = true; }
+                else
+                {
+                    if (lo >= _times.Length) return null;
+                    chosen = lo;
+                    isExact = false;
+                }
+                break;
+
+            case S129TimelineSamplingMode.Nearest:
+                if (exact >= 0) { chosen = exact; isExact = true; }
+                else
+                {
+                    int prev = lo - 1;
+                    int next = lo;
+                    if (prev < 0) { chosen = next; isExact = false; break; }
+                    if (next >= _times.Length) { chosen = prev; isExact = false; break; }
+                    var dPrev = time - _times[prev];
+                    var dNext = _times[next] - time;
+                    // Ties resolve to the earlier sample.
+                    chosen = dPrev <= dNext ? prev : next;
+                    isExact = false;
+                }
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+        }
+
+        int firstCp = _firstIndexByTime[chosen];
+        return new S129TimelineSnapshot(
+            _times[chosen],
+            _timedControlPoints[firstCp],
+            IsExact: isExact,
+            HasOverlappingControlPoints: HasOverlapAt(chosen, firstCp));
+    }
+
+    private bool HasOverlapAt(int timeIndex, int firstCpIndex)
+    {
+        int nextCpIndex = timeIndex + 1 < _firstIndexByTime.Length
+            ? _firstIndexByTime[timeIndex + 1]
+            : _timedControlPoints.Length;
+        return (nextCpIndex - firstCpIndex) > 1;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S129/README.md
+++ b/src/EncDotNet.S100.Datasets.S129/README.md
@@ -54,3 +54,11 @@ foreach (var cp in typed.ControlPoints)
 dotnet add package EncDotNet.S100.Datasets.S129
 ```
 
+## See also
+
+- [`EncDotNet.S100.Datasets.S129.Fusion`](../EncDotNet.S100.Datasets.S129.Fusion/README.md)
+  — cross-product data-layer helpers that fuse an
+  `S129UnderKeelClearancePlan` with the S-102 / S-104 / S-421 datasets
+  it references (timeline iteration, reference resolution, route
+  binding). Strictly additive on top of the types in this library.
+

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/BathymetryFusionTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/BathymetryFusionTests.cs
@@ -1,0 +1,46 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S129.Fusion.Tests.Helpers;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Tests;
+
+public class BathymetryFusionTests
+{
+    [Fact]
+    public void Sample_AtSentinelCell_ReturnsDistinctValue()
+    {
+        var bathy = SyntheticDatasets.MakeBathymetry();
+        var coverage = new S102CoverageSource(bathy);
+
+        // Cell (5,5) — origin (50.0, 5.0) + 5 * 0.001 in each axis.
+        var sample = S129BathymetryFusion.Sample(coverage, new GeoPosition(50.005, 5.005));
+
+        Assert.NotNull(sample);
+        Assert.Equal(20f, sample!.Depth);
+        Assert.Equal(0.5f, sample.Uncertainty);
+        Assert.Equal(5, sample.Row);
+        Assert.Equal(5, sample.Column);
+    }
+
+    [Fact]
+    public void Sample_AtNonSentinelCell_ReturnsBaseValue()
+    {
+        var bathy = SyntheticDatasets.MakeBathymetry();
+        var coverage = new S102CoverageSource(bathy);
+
+        var sample = S129BathymetryFusion.Sample(coverage, new GeoPosition(50.001, 5.001));
+
+        Assert.NotNull(sample);
+        Assert.Equal(10f, sample!.Depth);
+    }
+
+    [Fact]
+    public void Sample_OutOfExtent_ReturnsNull()
+    {
+        var bathy = SyntheticDatasets.MakeBathymetry();
+        var coverage = new S102CoverageSource(bathy);
+
+        Assert.Null(S129BathymetryFusion.Sample(coverage, new GeoPosition(51.0, 6.0)));
+        Assert.Null(S129BathymetryFusion.Sample(coverage, new GeoPosition(49.99, 4.99)));
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/CrossProductResolverTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/CrossProductResolverTests.cs
@@ -1,0 +1,96 @@
+using EncDotNet.S100.Datasets.S129.Fusion.Tests.Helpers;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Tests;
+
+public class CrossProductResolverTests
+{
+    [Fact]
+    public void Resolve_NoCandidates_ProducesUnresolvedForEachExpectedKind()
+    {
+        var plan = SyntheticDatasets.MakePlan();
+        var result = S129CrossProductResolver.Resolve(plan);
+
+        Assert.Null(result.Bathymetry);
+        Assert.Null(result.WaterLevel);
+        Assert.Null(result.Route);
+        Assert.Equal(3, result.Unresolved.Length);
+        Assert.All(result.Unresolved,
+            u => Assert.Equal(S129ReferenceResolutionReason.DatasetNotProvided, u.Reason));
+    }
+
+    [Fact]
+    public void Resolve_MatchingRoute_BindsByRouteId()
+    {
+        var plan = SyntheticDatasets.MakePlan(sourceRouteName: "ROUTE_A", sourceRouteVersion: "1");
+        var route = SyntheticDatasets.MakeRoute(routeId: "ROUTE_A", editionNumber: 1);
+
+        var result = S129CrossProductResolver.Resolve(plan, route: route);
+
+        Assert.NotNull(result.Route);
+        Assert.Same(route, result.Route!.Value);
+        Assert.DoesNotContain(result.Unresolved, u => u.ExpectedKind == "S-421 route");
+    }
+
+    [Fact]
+    public void Resolve_RouteIdentifierMismatch_LeavesRouteUnresolved()
+    {
+        var plan = SyntheticDatasets.MakePlan(sourceRouteName: "ROUTE_A");
+        var route = SyntheticDatasets.MakeRoute(routeId: "ROUTE_B");
+
+        var result = S129CrossProductResolver.Resolve(plan, route: route);
+
+        Assert.Null(result.Route);
+        Assert.Contains(result.Unresolved,
+            u => u.ExpectedKind == "S-421 route" &&
+                 u.Reason == S129ReferenceResolutionReason.IdentifierMismatch);
+    }
+
+    [Fact]
+    public void Resolve_RouteVersionMismatch_LeavesRouteUnresolved()
+    {
+        var plan = SyntheticDatasets.MakePlan(sourceRouteName: "ROUTE_A", sourceRouteVersion: "2");
+        var route = SyntheticDatasets.MakeRoute(routeId: "ROUTE_A", editionNumber: 1);
+
+        var result = S129CrossProductResolver.Resolve(plan, route: route);
+
+        Assert.Null(result.Route);
+        Assert.Contains(result.Unresolved,
+            u => u.Reason == S129ReferenceResolutionReason.IdentifierMismatch);
+    }
+
+    [Fact]
+    public void Resolve_PlanWithoutSourceRoute_BindsCandidateRouteSynthetically()
+    {
+        var plan = SyntheticDatasets.MakePlan(sourceRouteName: null, sourceRouteVersion: null);
+        var route = SyntheticDatasets.MakeRoute();
+
+        var result = S129CrossProductResolver.Resolve(plan, route: route);
+
+        Assert.NotNull(result.Route);
+        Assert.Equal("ROUTE_A", result.Route!.ExternalReference.Identifier);
+    }
+
+    [Fact]
+    public void Resolve_BathymetryProvided_AlwaysResolves()
+    {
+        var plan = SyntheticDatasets.MakePlan();
+        var bathy = SyntheticDatasets.MakeBathymetry();
+
+        var result = S129CrossProductResolver.Resolve(plan, bathymetry: bathy);
+
+        Assert.NotNull(result.Bathymetry);
+        Assert.Same(bathy, result.Bathymetry!.Value);
+    }
+
+    [Fact]
+    public void Resolve_WaterLevelProvided_AlwaysResolves()
+    {
+        var plan = SyntheticDatasets.MakePlan();
+        var wl = SyntheticDatasets.MakeWaterLevel();
+
+        var result = S129CrossProductResolver.Resolve(plan, waterLevel: wl);
+
+        Assert.NotNull(result.WaterLevel);
+        Assert.Same(wl, result.WaterLevel!.Value);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/EncDotNet.S100.Datasets.S129.Fusion.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/EncDotNet.S100.Datasets.S129.Fusion.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S129.Fusion\EncDotNet.S100.Datasets.S129.Fusion.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/Helpers/SyntheticDatasets.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/Helpers/SyntheticDatasets.cs
@@ -1,0 +1,223 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Datasets.S421.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Tests.Helpers;
+
+/// <summary>
+/// Builders for in-memory synthetic S-129, S-102, S-104, and S-421
+/// datasets used by the Fusion tests. No on-disk fixtures required.
+/// </summary>
+internal static class SyntheticDatasets
+{
+    public static readonly DateTimeOffset T0 = new(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+    public static S129Feature MakeControlPoint(
+        string id, double lat, double lon, DateTimeOffset? time, double? ukcMargin = 1.5)
+    {
+        var attrs = ImmutableDictionary.CreateBuilder<string, string>();
+        if (time.HasValue)
+            attrs["expectedPassingTime"] = time.Value.ToString("o");
+        if (ukcMargin.HasValue)
+            attrs["distanceAboveUKCLimit"] = ukcMargin.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearanceControlPoint",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((lat, lon)),
+            ExteriorRing = ImmutableArray<(double, double)>.Empty,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Attributes = attrs.ToImmutable(),
+            ComplexAttributes = ImmutableArray<S129ComplexAttribute>.Empty,
+        };
+    }
+
+    public static S129Feature MakePlanMetadata(
+        string id = "PLAN_1",
+        string? sourceRouteName = "ROUTE_A",
+        string? sourceRouteVersion = "1")
+    {
+        var attrs = ImmutableDictionary.CreateBuilder<string, string>();
+        attrs["vesselID"] = "123456789";
+        if (sourceRouteName is not null) attrs["sourceRouteName"] = sourceRouteName;
+        if (sourceRouteVersion is not null) attrs["sourceRouteVersion"] = sourceRouteVersion;
+
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearancePlan",
+            GeometryType = GmlGeometryType.None,
+            Points = ImmutableArray<(double, double)>.Empty,
+            ExteriorRing = ImmutableArray<(double, double)>.Empty,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Attributes = attrs.ToImmutable(),
+            ComplexAttributes = ImmutableArray<S129ComplexAttribute>.Empty,
+        };
+    }
+
+    public static S129UnderKeelClearancePlan MakePlan(
+        IEnumerable<S129Feature>? extraFeatures = null,
+        string? sourceRouteName = "ROUTE_A",
+        string? sourceRouteVersion = "1")
+    {
+        var features = ImmutableArray.CreateBuilder<S129Feature>();
+        features.Add(MakePlanMetadata("PLAN_1", sourceRouteName, sourceRouteVersion));
+        if (extraFeatures is not null) features.AddRange(extraFeatures);
+
+        var dataset = new S129Dataset
+        {
+            ProductIdentifier = "S-129",
+            DatasetIdentifier = "TEST_DS_1",
+            Features = features.ToImmutable(),
+        };
+        return S129UnderKeelClearancePlan.From(dataset, out _);
+    }
+
+    /// <summary>
+    /// Builds a tiny S-102 dataset: a 10×10 grid with cells of 0.001°
+    /// spacing centred near (50.0, 5.0). Cell (5,5) has depth=20m,
+    /// uncertainty=0.5m; all other cells have depth=10m, uncertainty=0.2m.
+    /// </summary>
+    public static S102Dataset MakeBathymetry()
+    {
+        const int n = 10;
+        var values = new BathymetryValue[n * n];
+        for (int r = 0; r < n; r++)
+        for (int c = 0; c < n; c++)
+        {
+            bool sentinel = (r == 5 && c == 5);
+            values[r * n + c] = new BathymetryValue(
+                depth: sentinel ? 20f : 10f,
+                uncertainty: sentinel ? 0.5f : 0.2f);
+        }
+        var coverage = new BathymetryCoverage
+        {
+            OriginLatitude = 50.0,
+            OriginLongitude = 5.0,
+            SpacingLatitudinal = 0.001,
+            SpacingLongitudinal = 0.001,
+            NumPointsLatitudinal = n,
+            NumPointsLongitudinal = n,
+            Values = values,
+        };
+        return new S102Dataset
+        {
+            HorizontalCRS = 4326,
+            Coverages = new[] { coverage },
+        };
+    }
+
+    /// <summary>
+    /// Builds a tiny S-104 dataset with two time slices (T0 and T0+1h).
+    /// Cell (5,5) has height = 1.5m at T0 and 2.5m at T0+1h. Other cells: 0.5m / 1.0m.
+    /// </summary>
+    public static S104Dataset MakeWaterLevel()
+    {
+        const int n = 10;
+
+        WaterLevelCoverage MakeSlice(DateTime t, float sentinelHeight, float baseHeight)
+        {
+            var values = new WaterLevelValue[n * n];
+            for (int r = 0; r < n; r++)
+            for (int c = 0; c < n; c++)
+            {
+                bool sentinel = (r == 5 && c == 5);
+                values[r * n + c] = new WaterLevelValue(
+                    height: sentinel ? sentinelHeight : baseHeight,
+                    trend: 0);
+            }
+            return new WaterLevelCoverage
+            {
+                OriginLatitude = 50.0,
+                OriginLongitude = 5.0,
+                SpacingLatitudinal = 0.001,
+                SpacingLongitudinal = 0.001,
+                NumPointsLatitudinal = n,
+                NumPointsLongitudinal = n,
+                TimePoint = t,
+                Values = values,
+            };
+        }
+
+        var slices = new List<WaterLevelCoverage>
+        {
+            MakeSlice(T0.UtcDateTime, sentinelHeight: 1.5f, baseHeight: 0.5f),
+            MakeSlice(T0.AddHours(1).UtcDateTime, sentinelHeight: 2.5f, baseHeight: 1.0f),
+        };
+        return new S104Dataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = 2,
+            Coverages = slices,
+        };
+    }
+
+    /// <summary>
+    /// Builds an S-421 route with three waypoints WP1..WP3 along an
+    /// east-going line and two legs WP1→WP2, WP2→WP3.
+    /// </summary>
+    public static S421Route MakeRoute(
+        string routeId = "ROUTE_A",
+        int editionNumber = 1)
+    {
+        var wp1 = new S421Waypoint
+        {
+            Id = "WP1",
+            WaypointNumber = 1,
+            Position = new GeoPosition(50.005, 5.001),
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+        var wp2 = new S421Waypoint
+        {
+            Id = "WP2",
+            WaypointNumber = 2,
+            Position = new GeoPosition(50.005, 5.005),
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+        var wp3 = new S421Waypoint
+        {
+            Id = "WP3",
+            WaypointNumber = 3,
+            Position = new GeoPosition(50.005, 5.009),
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+        var leg12 = new S421Leg
+        {
+            Id = "LEG12",
+            Coordinates = ImmutableArray.Create(wp1.Position, wp2.Position),
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+        var leg23 = new S421Leg
+        {
+            Id = "LEG23",
+            Coordinates = ImmutableArray.Create(wp2.Position, wp3.Position),
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+        // StartWaypoint / EndWaypoint use internal setters on S421Leg;
+        // S129RouteBinder.BuildLegPolyline prefers leg.Coordinates so
+        // these are not required for the fusion tests.
+
+        return new S421Route
+        {
+            Id = routeId,
+            RouteId = routeId,
+            EditionNumber = editionNumber,
+            Waypoints = ImmutableArray.Create(wp1, wp2, wp3),
+            Legs = ImmutableArray.Create(leg12, leg23),
+            ActionPoints = ImmutableArray<S421ActionPoint>.Empty,
+            Schedules = ImmutableArray<S421Schedule>.Empty,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/RouteBinderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/RouteBinderTests.cs
@@ -1,0 +1,105 @@
+using EncDotNet.S100.Datasets.S129.Fusion.Routing;
+using EncDotNet.S100.Datasets.S129.Fusion.Tests.Helpers;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Tests;
+
+public class RouteBinderTests
+{
+    [Fact]
+    public void Bind_ControlPointAtWaypoint_MapsOnWaypoint()
+    {
+        // WP1 sits at (50.005, 5.001). Place a CP right on top.
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, SyntheticDatasets.T0),
+        });
+        var route = SyntheticDatasets.MakeRoute();
+
+        var binding = S129RouteBinder.Bind(plan, route);
+        var mapping = binding.Mappings[0].Mapping;
+
+        Assert.Equal(S129RouteMappingKind.OnWaypoint, mapping.Kind);
+        Assert.Equal("WP1", mapping.Waypoint!.Id);
+        Assert.True(mapping.DistanceMeters < 1.0);
+    }
+
+    [Fact]
+    public void Bind_ControlPointAlongLeg_MapsOnLeg()
+    {
+        // WP1 (5.001) → WP2 (5.005); place CP at (50.005, 5.003), mid-leg.
+        // Use a tiny waypoint tolerance so the leg branch is exercised.
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.003, SyntheticDatasets.T0),
+        });
+        var route = SyntheticDatasets.MakeRoute();
+        var opts = new S129RouteBindingOptions(
+            WaypointToleranceMeters: 10,
+            LegToleranceMeters: 100);
+
+        var binding = S129RouteBinder.Bind(plan, route, opts);
+        var mapping = binding.Mappings[0].Mapping;
+
+        Assert.Equal(S129RouteMappingKind.OnLeg, mapping.Kind);
+        Assert.Equal("LEG12", mapping.Leg!.Id);
+        Assert.NotNull(mapping.LegPositionFraction);
+        Assert.InRange(mapping.LegPositionFraction!.Value, 0.4, 0.6);
+    }
+
+    [Fact]
+    public void Bind_ControlPointFarFromRoute_IsUnmapped()
+    {
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.5, 5.5, SyntheticDatasets.T0),
+        });
+        var route = SyntheticDatasets.MakeRoute();
+
+        var binding = S129RouteBinder.Bind(plan, route);
+        var mapping = binding.Mappings[0].Mapping;
+
+        Assert.Equal(S129RouteMappingKind.Unmapped, mapping.Kind);
+        Assert.Null(mapping.Waypoint);
+        Assert.Null(mapping.Leg);
+    }
+
+    [Fact]
+    public void Bind_ControlPointWithoutPosition_IsUnmapped()
+    {
+        // The synthetic helper always emits a position for control
+        // points; verify the same outcome by binding against an
+        // unreachable route (waypoints far from the CPs).
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.005, SyntheticDatasets.T0),
+        });
+        var route = SyntheticDatasets.MakeRoute(); // Route is at 5.001..5.009; CP at 5.005 is ~0m from leg.
+
+        // Force a tiny leg tolerance — CP is ON the leg so still under 1m.
+        // Use coordinates well off-route instead:
+        var farPlan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 60.0, 10.0, SyntheticDatasets.T0),
+        });
+        var binding = S129RouteBinder.Bind(farPlan, route);
+        Assert.Equal(S129RouteMappingKind.Unmapped, binding.Mappings[0].Mapping.Kind);
+    }
+
+    [Fact]
+    public void Bind_PreservesControlPointOrdering()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP2", 50.005, 5.005, t0.AddMinutes(10)),
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+        });
+        var route = SyntheticDatasets.MakeRoute();
+
+        var binding = S129RouteBinder.Bind(plan, route);
+
+        // Plan ordering puts CP1 first (earlier time) per typed-projection sorting.
+        Assert.Equal("CP1", binding.Mappings[0].ControlPoint.Id);
+        Assert.Equal("CP2", binding.Mappings[1].ControlPoint.Id);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/TimelineTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/TimelineTests.cs
@@ -1,0 +1,134 @@
+using EncDotNet.S100.Datasets.S129.Fusion.Timeline;
+using EncDotNet.S100.Datasets.S129.Fusion.Tests.Helpers;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Tests;
+
+public class TimelineTests
+{
+    [Fact]
+    public void Times_AreSortedAndDeduplicated()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP2", 50.005, 5.002, t0.AddMinutes(10)),
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+            SyntheticDatasets.MakeControlPoint("CP3", 50.005, 5.003, t0.AddMinutes(20)),
+            SyntheticDatasets.MakeControlPoint("CP4", 50.005, 5.004, t0.AddMinutes(20)), // duplicate time
+            SyntheticDatasets.MakeControlPoint("CPx", 50.005, 5.005, null),               // no time
+        });
+
+        var view = new S129TimelineView(plan);
+
+        Assert.Equal(3, view.Times.Length);
+        Assert.Equal(t0, view.Times[0]);
+        Assert.Equal(t0.AddMinutes(10), view.Times[1]);
+        Assert.Equal(t0.AddMinutes(20), view.Times[2]);
+        Assert.Equal(t0, view.Start);
+        Assert.Equal(t0.AddMinutes(20), view.End);
+    }
+
+    [Fact]
+    public void EnumerateTimeline_ReturnsOneSnapshotPerDistinctTime()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+            SyntheticDatasets.MakeControlPoint("CP2", 50.005, 5.002, t0.AddMinutes(10)),
+            SyntheticDatasets.MakeControlPoint("CP3", 50.005, 5.003, t0.AddMinutes(10)),
+        });
+
+        var view = new S129TimelineView(plan);
+        var snapshots = view.EnumerateTimeline().ToList();
+
+        Assert.Equal(2, snapshots.Count);
+        Assert.True(snapshots[0].IsExact);
+        Assert.False(snapshots[0].HasOverlappingControlPoints);
+        Assert.True(snapshots[1].HasOverlappingControlPoints);
+    }
+
+    [Fact]
+    public void GetSnapshotAt_OnGridTime_ReturnsExact()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+            SyntheticDatasets.MakeControlPoint("CP2", 50.005, 5.002, t0.AddMinutes(30)),
+        });
+        var view = new S129TimelineView(plan);
+
+        var snap = view.GetSnapshotAt(t0.AddMinutes(30));
+
+        Assert.NotNull(snap);
+        Assert.True(snap!.IsExact);
+        Assert.Equal("CP2", snap.ControlPoint.Id);
+    }
+
+    [Fact]
+    public void GetSnapshotAt_BetweenGrid_NearestEarlier_PicksPrior()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+            SyntheticDatasets.MakeControlPoint("CP2", 50.005, 5.002, t0.AddMinutes(30)),
+        });
+        var view = new S129TimelineView(plan);
+
+        var snap = view.GetSnapshotAt(t0.AddMinutes(10));
+
+        Assert.NotNull(snap);
+        Assert.False(snap!.IsExact);
+        Assert.Equal("CP1", snap.ControlPoint.Id);
+    }
+
+    [Fact]
+    public void GetSnapshotAt_BeforeFirst_NearestEarlier_ReturnsNull()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+        });
+        var view = new S129TimelineView(plan);
+
+        Assert.Null(view.GetSnapshotAt(t0.AddMinutes(-5)));
+    }
+
+    [Fact]
+    public void GetSnapshotAt_Modes_BehaveAsDocumented()
+    {
+        var t0 = SyntheticDatasets.T0;
+        var plan = SyntheticDatasets.MakePlan(extraFeatures: new[]
+        {
+            SyntheticDatasets.MakeControlPoint("CP1", 50.005, 5.001, t0),
+            SyntheticDatasets.MakeControlPoint("CP2", 50.005, 5.002, t0.AddMinutes(30)),
+        });
+        var view = new S129TimelineView(plan);
+
+        // Between samples — Nearest picks the closer
+        var nearest = view.GetSnapshotAt(t0.AddMinutes(20), S129TimelineSamplingMode.Nearest);
+        Assert.Equal("CP2", nearest!.ControlPoint.Id);
+
+        var later = view.GetSnapshotAt(t0.AddMinutes(5), S129TimelineSamplingMode.NearestLater);
+        Assert.Equal("CP2", later!.ControlPoint.Id);
+
+        Assert.Null(view.GetSnapshotAt(t0.AddMinutes(40), S129TimelineSamplingMode.NearestLater));
+        Assert.Null(view.GetSnapshotAt(t0.AddMinutes(20), S129TimelineSamplingMode.Exact));
+        Assert.NotNull(view.GetSnapshotAt(t0, S129TimelineSamplingMode.Exact));
+    }
+
+    [Fact]
+    public void EmptyPlan_TimelineIsEmpty()
+    {
+        var plan = SyntheticDatasets.MakePlan(); // metadata only
+        var view = new S129TimelineView(plan);
+
+        Assert.True(view.IsEmpty);
+        Assert.Null(view.Start);
+        Assert.Null(view.End);
+        Assert.Null(view.GetSnapshotAt(SyntheticDatasets.T0));
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/WaterLevelFusionTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/WaterLevelFusionTests.cs
@@ -1,0 +1,69 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S129.Fusion.Tests.Helpers;
+
+namespace EncDotNet.S100.Datasets.S129.Fusion.Tests;
+
+public class WaterLevelFusionTests
+{
+    [Fact]
+    public void Sample_AtT0AndSentinelCell_PicksT0Slice()
+    {
+        var wl = SyntheticDatasets.MakeWaterLevel();
+        var coverage = new S104CoverageSource(wl);
+
+        var sample = S129WaterLevelFusion.Sample(
+            coverage,
+            new GeoPosition(50.005, 5.005),
+            SyntheticDatasets.T0);
+
+        Assert.NotNull(sample);
+        Assert.Equal(1.5f, sample!.Height);
+        Assert.Equal(SyntheticDatasets.T0.UtcDateTime, sample.TimeSelected);
+    }
+
+    [Fact]
+    public void Sample_AtT0PlusOneHour_PicksLaterSlice()
+    {
+        var wl = SyntheticDatasets.MakeWaterLevel();
+        var coverage = new S104CoverageSource(wl);
+
+        var sample = S129WaterLevelFusion.Sample(
+            coverage,
+            new GeoPosition(50.005, 5.005),
+            SyntheticDatasets.T0.AddHours(1));
+
+        Assert.NotNull(sample);
+        Assert.Equal(2.5f, sample!.Height);
+    }
+
+    [Fact]
+    public void Sample_AtBetweenSlicesTime_PicksNearestTimeSlice()
+    {
+        var wl = SyntheticDatasets.MakeWaterLevel();
+        var coverage = new S104CoverageSource(wl);
+
+        // 50min in: nearest is T0+1h
+        var sample = S129WaterLevelFusion.Sample(
+            coverage,
+            new GeoPosition(50.005, 5.005),
+            SyntheticDatasets.T0.AddMinutes(50));
+
+        Assert.NotNull(sample);
+        Assert.Equal(SyntheticDatasets.T0.AddHours(1).UtcDateTime, sample!.TimeSelected);
+    }
+
+    [Fact]
+    public void Sample_OutOfExtent_ReturnsNull()
+    {
+        var wl = SyntheticDatasets.MakeWaterLevel();
+        var coverage = new S104CoverageSource(wl);
+
+        var sample = S129WaterLevelFusion.Sample(
+            coverage,
+            new GeoPosition(51.0, 6.0),
+            SyntheticDatasets.T0);
+
+        Assert.Null(sample);
+    }
+}


### PR DESCRIPTION
Adds a new `EncDotNet.S100.Datasets.S129.Fusion` library — the **data-access half** of S-129 Tier 1. Three additive capabilities; no portrayal, renderer, viewer, or `DataModel` changes.

## Three capabilities

1. **Timeline (`Timeline/`)** — `S129TimelineView` over an `S129UnderKeelClearancePlan`, with explicit `S129TimelineSamplingMode` for between-grid lookups (default `NearestEarlier`; also `NearestLater`, `Nearest`, `Exact`). No interpolation.
2. **Cross-product resolution + fusion (`Fusion/`)** — `S129CrossProductResolver.Resolve(plan, bathymetry?, waterLevel?, route?)` returns typed `S129ResolvedReference<T>` / `S129UnresolvedReference` records. Static `S129BathymetryFusion` / `S129WaterLevelFusion` / `S129PlanFusion` sample S-102 / S-104 coverages at control-point positions.
3. **S-421 route binding (`Routing/`)** — `S129RouteBinder.Bind(plan, route, options?)` correlates each control point with the route by spatial proximity (default 200 m to a waypoint, 100 m to a leg); discriminated `S129ControlPointRouteMapping` with `OnWaypoint` / `OnLeg` / `Unmapped` kinds.

## Code example

```csharp
var view = new S129TimelineView(plan);
foreach (var snap in view.EnumerateTimeline())
    Console.WriteLine($"{snap.Time:o}  margin={snap.ControlPoint.DistanceAboveUkcLimit:F2} m");

var resolved = S129CrossProductResolver.Resolve(plan, bathymetry: bathyDs, route: route);

var bathy = new S102CoverageSource(bathyDs);
foreach (var cp in plan.ControlPoints)
{
    var depth = S129PlanFusion.SampleBathymetryAt(cp, bathy);
    Console.WriteLine($"{cp.Id}: depth={depth?.Depth:F1} m, uncertainty={depth?.Uncertainty:F2} m");
}

var binding = S129RouteBinder.Bind(plan, route);
```

## Layout

- New project `src/EncDotNet.S100.Datasets.S129.Fusion/` (Option A from the brief — separate library so the spec-pure `Datasets.S129` stays free of cross-product references).
- New tests `tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/` — 26 xunit tests with in-code synthetic S-129/S-102/S-104/S-421 fixtures. No external data.
- Library `README.md` and a "See also" section in the existing `src/EncDotNet.S100.Datasets.S129/README.md`.

## Explicit non-goals

- No portrayal pipeline / renderer / viewer UI changes.
- No edits to typed `DataModel` shapes from #74 / #76.
- No new caching layer; reuses existing coverage caches.
- No CLI tool / sample app.

## Test results

`dotnet test tests/EncDotNet.S100.Datasets.S129.Fusion.Tests/` — **26/26 passed**. Full Release suite clean apart from a flaky pre-existing telemetry test (`Pipelines.Tests.TelemetrySmokeTests.VectorPipeline_emits_xslt_transform_span`) that passes in isolation; unrelated to this change.

## Skills consulted

`s129-ukc` (primary), `s102-bathymetry`, `s104-water-level`, `s421-route-plans`.