### PR TITLE
MCP-1: IDatasetCatalog + tool library

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -23,6 +23,7 @@
     <Project Path="src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj" />
     <Project Path="src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj" />
     <Project Path="src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj" />
+    <Project Path="src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj" />
     <Project Path="src/EncDotNet.S100.Portrayals/EncDotNet.S100.Portrayals.csproj" />
     <Project Path="src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj" />
     <Project Path="src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj" />
@@ -52,6 +53,7 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Features.Tests/EncDotNet.S100.Features.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.PerfReport.Tests/EncDotNet.S100.PerfReport.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ into focused packages:
 | **EncDotNet.S100.Renderers.Skia** | Coverage and vector rendering to [SkiaSharp](https://github.com/mono/SkiaSharp) bitmaps. |
 | **EncDotNet.S100.Renderers.Mapsui** | Rendering of S-100 data into [Mapsui](https://mapsui.com/) map layers with CRS projection. |
 
+### MCP server (in development)
+
+| Package | Description |
+|---|---|
+| **EncDotNet.S100.Mcp.Tools** | Foundation for a Model Context Protocol server: `IDatasetCatalog` abstraction and the tool surface (`list_datasets`, `describe_feature`, `sample_coverage`). Contains no MCP protocol code or transport — the protocol layer and viewer wiring land in PR MCP-2. See [its README](src/EncDotNet.S100.Mcp.Tools/README.md). |
+
 ## Building
 
 ```sh

--- a/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
@@ -61,7 +61,7 @@ public class S102CoverageSource : ICoverageSource
     public IReadOnlyList<DateTime> AvailableTimes => [];
     public void SelectTime(DateTime time) { }  // no-op
     
-    public SampledCoverage Sample(GridRegion region)
+    public virtual SampledCoverage Sample(GridRegion region)
     {
         var values = _coverage.Values;
         int gridRows = _coverage.NumPointsLatitudinal;

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetCatalogChangedEventArgs.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetCatalogChangedEventArgs.cs
@@ -1,0 +1,32 @@
+namespace EncDotNet.S100.Mcp.Tools.Catalog;
+
+/// <summary>
+/// The kind of change reported by an <see cref="IDatasetCatalog"/>.
+/// </summary>
+public enum DatasetCatalogChangeKind
+{
+    /// <summary>A single dataset was added.</summary>
+    Added,
+
+    /// <summary>A single dataset was removed.</summary>
+    Removed,
+
+    /// <summary>A single dataset was replaced (same ID, different payload).</summary>
+    Replaced,
+
+    /// <summary>Multiple datasets changed atomically; <see cref="DatasetCatalogChangedEventArgs.DatasetId"/> is <c>null</c>.</summary>
+    Batch,
+}
+
+/// <summary>Event payload for <see cref="IDatasetCatalog.Changed"/>.</summary>
+public sealed class DatasetCatalogChangedEventArgs : EventArgs
+{
+    /// <summary>The kind of change.</summary>
+    public required DatasetCatalogChangeKind Kind { get; init; }
+
+    /// <summary>
+    /// The dataset that changed, or <c>null</c> when
+    /// <see cref="Kind"/> is <see cref="DatasetCatalogChangeKind.Batch"/>.
+    /// </summary>
+    public DatasetId? DatasetId { get; init; }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetId.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetId.cs
@@ -1,0 +1,27 @@
+namespace EncDotNet.S100.Mcp.Tools.Catalog;
+
+/// <summary>
+/// Stable identifier for a dataset within an <see cref="IDatasetCatalog"/>.
+/// </summary>
+/// <remarks>
+/// IDs are opaque strings minted by the catalog implementation. They must
+/// be stable for the lifetime of a host session (e.g. while a viewer is
+/// running) so that tool callers can hold onto an ID across multiple
+/// invocations.
+/// </remarks>
+public readonly record struct DatasetId
+{
+    /// <summary>The underlying opaque identifier value.</summary>
+    public string Value { get; }
+
+    /// <summary>Creates a new <see cref="DatasetId"/>.</summary>
+    /// <exception cref="ArgumentException">The value is null or empty.</exception>
+    public DatasetId(string value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(value);
+        Value = value;
+    }
+
+    /// <summary>Returns the underlying string value.</summary>
+    public override string ToString() => Value;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/IDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/IDatasetCatalog.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Mcp.Tools.Catalog;
+
+/// <summary>
+/// Read-only view onto the set of datasets currently loaded by a host
+/// (e.g. a viewer, CLI, or headless service).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The catalog exposes state as a property — <see cref="Datasets"/> — rather
+/// than as a method, because "what is loaded right now" reads more
+/// naturally as state than as an operation. Implementations must publish
+/// a fresh <see cref="ImmutableArray{T}"/> on every change so that
+/// consumers can capture the reference once and use it for the duration
+/// of a single tool invocation without taking any lock.
+/// </para>
+/// <para>
+/// Coverage payloads (S-102, S-104, S-111) carry live handles whose
+/// lifetime is owned by the host, not the catalog. Tools must therefore
+/// treat coverage reads as best-effort: a dataset may be unloaded between
+/// the catalog snapshot and the actual read. Tool implementations catch
+/// <see cref="ObjectDisposedException"/> and surface
+/// <see cref="DatasetClosedDuringQuery"/>.
+/// </para>
+/// </remarks>
+public interface IDatasetCatalog
+{
+    /// <summary>
+    /// Atomic, immutable snapshot of all datasets currently loaded.
+    /// Implementations publish a fresh array on every change; consumers
+    /// may capture the reference for the duration of an operation
+    /// without locking.
+    /// </summary>
+    ImmutableArray<LoadedDataset> Datasets { get; }
+
+    /// <summary>
+    /// Raised after <see cref="Datasets"/> has been updated. The event
+    /// reports what changed; consumers needing the new state read
+    /// <see cref="Datasets"/> directly.
+    /// </summary>
+    event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDataset.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDataset.cs
@@ -1,0 +1,19 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Catalog;
+
+/// <summary>
+/// A single dataset currently loaded into an <see cref="IDatasetCatalog"/>.
+/// </summary>
+/// <param name="Id">Stable identifier for the dataset within the catalog session.</param>
+/// <param name="Spec">The product specification (and edition) the dataset declares.</param>
+/// <param name="Bounds">Geographic extent of the dataset.</param>
+/// <param name="TimeRange">Time interval covered by the dataset, or <c>null</c> for static products.</param>
+/// <param name="Data">Typed payload — see <see cref="LoadedDatasetData"/> variants.</param>
+public sealed record LoadedDataset(
+    DatasetId Id,
+    SpecRef Spec,
+    BoundingBox Bounds,
+    TimeRange? TimeRange,
+    LoadedDatasetData Data);

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
@@ -1,0 +1,66 @@
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S125;
+using EncDotNet.S100.Datasets.S127;
+using EncDotNet.S100.Datasets.S128;
+using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S201;
+using EncDotNet.S100.Datasets.S411;
+using EncDotNet.S100.Datasets.S421;
+
+namespace EncDotNet.S100.Mcp.Tools.Catalog;
+
+/// <summary>
+/// Discriminated union over the typed payloads that a
+/// <see cref="LoadedDataset"/> may carry. Each spec contributes either a
+/// typed DataModel projection (vector products) or a coverage source
+/// (HDF5-encoded coverage products).
+/// </summary>
+public abstract record LoadedDatasetData;
+
+/// <summary>S-122 Marine Protected Areas typed model.</summary>
+public sealed record S122DatasetData(S122Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-124 Navigational Warnings typed model.</summary>
+public sealed record S124DatasetData(S124Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-125 Marine Aids to Navigation typed model.</summary>
+public sealed record S125DatasetData(S125Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-127 Marine Resources and Services typed model.</summary>
+public sealed record S127DatasetData(S127Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-128 Catalogue of Nautical Products typed model.</summary>
+public sealed record S128DatasetData(S128Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-129 Under Keel Clearance typed model.</summary>
+public sealed record S129DatasetData(S129Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-201 Aids to Navigation Information typed model.</summary>
+public sealed record S201DatasetData(S201Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-411 Sea Ice Information typed model.</summary>
+public sealed record S411DatasetData(S411Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-421 Route Plans typed model.</summary>
+public sealed record S421DatasetData(S421Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-102 Bathymetric Surface coverage handle.</summary>
+/// <remarks>
+/// Coverage variants carry a live handle (the <see cref="ICoverageSource"/>
+/// or its concrete equivalent). Tool implementations must treat the handle
+/// as best-effort: it may be disposed between catalog capture and the
+/// actual sample call. Wrap reads in
+/// <c>try / catch (ObjectDisposedException)</c> and surface the failure as
+/// <see cref="EncDotNet.S100.Mcp.Tools.DatasetClosedDuringQuery"/>.
+/// </remarks>
+public sealed record S102CoverageData(S102CoverageSource Source) : LoadedDatasetData;
+
+/// <summary>S-104 Water Level coverage handle.</summary>
+public sealed record S104CoverageData(S104CoverageSource Source) : LoadedDatasetData;
+
+/// <summary>S-111 Surface Currents coverage handle.</summary>
+public sealed record S111CoverageData(S111CoverageSource Source) : LoadedDatasetData;

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/TimeRange.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/TimeRange.cs
@@ -1,0 +1,14 @@
+namespace EncDotNet.S100.Mcp.Tools.Catalog;
+
+/// <summary>
+/// An optional time interval associated with a loaded dataset.
+/// </summary>
+/// <remarks>
+/// Used for time-varying products such as S-104 water levels and
+/// S-111 surface currents. Static products (S-102) report no time range.
+/// </remarks>
+public readonly record struct TimeRange(DateTimeOffset Start, DateTimeOffset End)
+{
+    /// <summary>Returns <c>true</c> when the range contains <paramref name="instant"/> (inclusive).</summary>
+    public bool Contains(DateTimeOffset instant) => instant >= Start && instant <= End;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/DescribeFeatureTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/DescribeFeatureTool.cs
@@ -1,0 +1,104 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Spec;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>Request payload for <see cref="DescribeFeatureTool"/>.</summary>
+public sealed record DescribeFeatureRequest(DatasetId DatasetId, string FeatureId);
+
+/// <summary>Result of <see cref="DescribeFeatureTool"/>.</summary>
+/// <param name="Spec">The spec the feature was parsed from.</param>
+/// <param name="FeatureTypeName">The spec-defined feature type code (e.g. <c>"NavwarnPart"</c>).</param>
+/// <param name="Attributes">Serialised attribute payload as JSON.</param>
+/// <param name="References">xlink-style cross references resolved against the catalog snapshot.</param>
+public sealed record DescribeFeatureResult(
+    Core.SpecRef Spec,
+    string FeatureTypeName,
+    JsonElement Attributes,
+    ImmutableArray<FeatureReference> References);
+
+/// <summary>
+/// A cross-reference from one feature to another, projected from the
+/// underlying <c>xlink:href</c> attribute.
+/// </summary>
+/// <param name="Role">The association role name (the local element name carrying <c>xlink:href</c>).</param>
+/// <param name="Href">The raw <c>xlink:href</c> value.</param>
+/// <param name="TargetDatasetId">The dataset containing the target, if it could be resolved within the catalog snapshot.</param>
+/// <param name="TargetFeatureId">The target feature ID, if extractable from the href.</param>
+/// <param name="Resolved"><c>true</c> when both target dataset and feature ID were located in the snapshot.</param>
+public sealed record FeatureReference(
+    string Role,
+    string Href,
+    DatasetId? TargetDatasetId,
+    string? TargetFeatureId,
+    bool Resolved);
+
+/// <summary>
+/// Describes a single feature in a loaded dataset. Dispatches to a
+/// per-spec strategy (<see cref="ISpecFeatureDescriber"/>); specs without
+/// an end-to-end implementation in this PR return
+/// <see cref="SpecNotSupportedForTool"/>.
+/// </summary>
+public sealed class DescribeFeatureTool
+{
+    /// <summary>Tool name used in <see cref="SpecNotSupportedForTool"/> errors.</summary>
+    public const string Name = "describe_feature";
+
+    private readonly IDatasetCatalog _catalog;
+    private readonly FeatureDescriberRegistry _registry;
+
+    /// <summary>Creates a new <see cref="DescribeFeatureTool"/> with the default registry.</summary>
+    public DescribeFeatureTool(IDatasetCatalog catalog)
+        : this(catalog, FeatureDescriberRegistry.Default)
+    {
+    }
+
+    /// <summary>Creates a new <see cref="DescribeFeatureTool"/> with a custom registry.</summary>
+    public DescribeFeatureTool(IDatasetCatalog catalog, FeatureDescriberRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(registry);
+        _catalog = catalog;
+        _registry = registry;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<DescribeFeatureResult>> InvokeAsync(
+        DescribeFeatureRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var snapshot = _catalog.Datasets;
+        LoadedDataset? target = null;
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Id == request.DatasetId)
+            {
+                target = dataset;
+                break;
+            }
+        }
+
+        if (target is null)
+        {
+            return Task.FromResult(
+                ToolResult<DescribeFeatureResult>.Err(
+                    new DatasetNotFound(request.DatasetId)));
+        }
+
+        var describer = _registry.Get(target.Spec.Name);
+        if (describer is null)
+        {
+            return Task.FromResult(
+                ToolResult<DescribeFeatureResult>.Err(
+                    new SpecNotSupportedForTool(target.Spec, Name)));
+        }
+
+        var context = new FeatureDescriberContext(target, request.FeatureId, snapshot);
+        return Task.FromResult(describer.Describe(context));
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj
+++ b/src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S125\EncDotNet.S100.Datasets.S125.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S127\EncDotNet.S100.Datasets.S127.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S128\EncDotNet.S100.Datasets.S128.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S201\EncDotNet.S100.Datasets.S201.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S411\EncDotNet.S100.Datasets.S411.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EncDotNet.S100.Mcp.Tools/ListDatasetsTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ListDatasetsTool.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>
+/// Request payload for <see cref="ListDatasetsTool"/>.
+/// </summary>
+/// <param name="Spec">Optional spec filter; <c>null</c> matches all specs.</param>
+/// <param name="IntersectsBounds">Optional bbox filter; only datasets whose bounds overlap are returned.</param>
+/// <param name="Page">Zero-based page index.</param>
+/// <param name="PageSize">Page size; clamped to 1..500.</param>
+public sealed record ListDatasetsRequest(
+    SpecRef? Spec = null,
+    BoundingBox? IntersectsBounds = null,
+    int Page = 0,
+    int PageSize = 50);
+
+/// <summary>Per-dataset summary returned by <see cref="ListDatasetsTool"/>.</summary>
+public sealed record DatasetSummary(
+    DatasetId Id,
+    SpecRef Spec,
+    BoundingBox Bounds,
+    TimeRange? TimeRange);
+
+/// <summary>Result of <see cref="ListDatasetsTool"/>.</summary>
+public sealed record ListDatasetsResult(
+    ImmutableArray<DatasetSummary> Datasets,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    bool HasMore);
+
+/// <summary>
+/// Lists datasets currently loaded in an <see cref="IDatasetCatalog"/>,
+/// optionally filtered by spec and bounding-box intersection.
+/// </summary>
+public sealed class ListDatasetsTool
+{
+    private readonly IDatasetCatalog _catalog;
+
+    /// <summary>Creates a new <see cref="ListDatasetsTool"/>.</summary>
+    public ListDatasetsTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<ListDatasetsResult>> InvokeAsync(
+        ListDatasetsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var pageSize = Math.Clamp(request.PageSize, 1, 500);
+        var page = Math.Max(0, request.Page);
+
+        var snapshot = _catalog.Datasets;
+        var filtered = ImmutableArray.CreateBuilder<DatasetSummary>();
+        foreach (var dataset in snapshot)
+        {
+            if (request.Spec is { } spec && !SpecMatches(dataset.Spec, spec))
+            {
+                continue;
+            }
+
+            if (request.IntersectsBounds is { } bbox && !Intersects(dataset.Bounds, bbox))
+            {
+                continue;
+            }
+
+            filtered.Add(new DatasetSummary(dataset.Id, dataset.Spec, dataset.Bounds, dataset.TimeRange));
+        }
+
+        var totalCount = filtered.Count;
+        var skip = page * pageSize;
+        var take = Math.Max(0, Math.Min(pageSize, totalCount - skip));
+        var pageBuilder = ImmutableArray.CreateBuilder<DatasetSummary>(take);
+        for (var i = 0; i < take; i++)
+        {
+            pageBuilder.Add(filtered[skip + i]);
+        }
+
+        var hasMore = skip + take < totalCount;
+        var result = new ListDatasetsResult(
+            pageBuilder.MoveToImmutable(),
+            page,
+            pageSize,
+            totalCount,
+            hasMore);
+
+        return Task.FromResult(ToolResult<ListDatasetsResult>.Ok(result));
+    }
+
+    private static bool SpecMatches(SpecRef actual, SpecRef filter)
+    {
+        // Match on name; treat a default (unset) edition in the filter as
+        // "any edition of this spec".
+        if (!string.Equals(actual.Name, filter.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return filter.Edition == default || actual.Edition == filter.Edition;
+    }
+
+    private static bool Intersects(BoundingBox a, BoundingBox b) =>
+        a.WestLongitude <= b.EastLongitude
+        && a.EastLongitude >= b.WestLongitude
+        && a.SouthLatitude <= b.NorthLatitude
+        && a.NorthLatitude >= b.SouthLatitude;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -1,0 +1,167 @@
+# EncDotNet.S100.Mcp.Tools
+
+Foundation for a Model Context Protocol (MCP) server that exposes
+S-100 datasets to LLM-driven tooling. This project ships **the
+abstraction and the tool surface only** — no MCP protocol code, no
+viewer code, no transport. PR MCP-2 will layer the wire protocol on
+top of this.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────┐
+│ EncDotNet.S100.Viewer                          │
+│  (PR MCP-2: hosts MCP server,                  │
+│   implements IDatasetCatalog)                  │
+└──────────────────────┬─────────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────────┐
+│ EncDotNet.S100.Mcp                             │
+│  (PR MCP-2: MCP server + transports)           │
+└──────────────────────┬─────────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────────┐
+│ EncDotNet.S100.Mcp.Tools         ← THIS PROJ   │
+│  - IDatasetCatalog + LoadedDataset             │
+│  - ToolResult<T> + ToolError                   │
+│  - ListDatasetsTool / DescribeFeatureTool /    │
+│    SampleCoverageTool                          │
+└──────────────────────┬─────────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────────┐
+│ EncDotNet.S100.Core + EncDotNet.S100.Datasets.*│
+└────────────────────────────────────────────────┘
+```
+
+The project intentionally has **no MCP SDK, no Avalonia, and no viewer
+reference**. The same tool surface can therefore be hosted by a CLI, a
+headless service, or a different viewer in the future.
+
+## `IDatasetCatalog`
+
+The abstraction is in `EncDotNet.S100.Mcp.Tools.Catalog` and exposes a
+single property + an event:
+
+```csharp
+public interface IDatasetCatalog
+{
+    ImmutableArray<LoadedDataset> Datasets { get; }
+    event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+}
+```
+
+**Why a property, not a method?** "What is loaded right now" reads more
+naturally as state than as an operation. The catalog implementation
+publishes a fresh `ImmutableArray<LoadedDataset>` on every change.
+Consumers capture the reference once and use it for the duration of an
+operation without taking any lock.
+
+**Why `LoadedDatasetData` is a discriminated union.** Each spec
+contributes either a typed DataModel (vector products — S-122, S-124,
+S-125, S-127, S-128, S-129, S-201, S-411, S-421) or a coverage source
+(HDF5-encoded coverage products — S-102, S-104, S-111). Tool code
+pattern-matches on the variants:
+
+```csharp
+return dataset.Data switch
+{
+    S124DatasetData s124 => DescribeS124(s124.Model, ...),
+    S102CoverageData cov => SampleS102(cov.Source, ...),
+    _ => ToolResult<T>.Err(new SpecNotSupportedForTool(dataset.Spec, name)),
+};
+```
+
+**Best-effort coverage handles.** Coverage variants carry live handles
+whose lifetime is owned by the host (e.g. the viewer). A dataset can be
+unloaded between the catalog snapshot and the actual read. Tool
+implementations wrap reads in `try / catch (ObjectDisposedException)`
+and surface `DatasetClosedDuringQuery`. The host is responsible for
+publishing the next snapshot before disposing the handle.
+
+## Tool contract
+
+Every tool exposes a single async method that returns
+`Task<ToolResult<T>>` where `T` is the result record:
+
+```csharp
+public sealed class ListDatasetsTool
+{
+    public ListDatasetsTool(IDatasetCatalog catalog);
+    public Task<ToolResult<ListDatasetsResult>> InvokeAsync(
+        ListDatasetsRequest request,
+        CancellationToken cancellationToken = default);
+}
+```
+
+`ToolResult<T>` is a small local discriminated union (`OkResult` /
+`ErrResult`) — there is no NuGet dependency on
+`OneOf` / `LanguageExt`. Tools never throw into the calling code; every
+failure case is reified as a typed `ToolError`. This keeps the eventual
+MCP-error wire format flexible while giving in-process callers a typed
+surface to match on.
+
+The five error variants implemented in this PR:
+
+| Code                          | When                                                                  |
+|-------------------------------|-----------------------------------------------------------------------|
+| `dataset_not_found`           | The requested `DatasetId` is not in the snapshot.                     |
+| `dataset_closed_during_query` | The coverage handle threw `ObjectDisposedException` mid-read.         |
+| `no_dataset_covers_point`     | No loaded dataset's bounds contain the requested lat/lon.             |
+| `feature_not_found`           | The named feature is not present in the named dataset.                |
+| `spec_not_supported_for_tool` | The tool does not (yet) support the requested spec.                   |
+
+## Spec strategy pattern
+
+`DescribeFeatureTool` dispatches per-spec through
+`FeatureDescriberRegistry` keyed on `SpecRef.Name`. Each describer
+implements an internal `ISpecFeatureDescriber` strategy.
+
+This PR ships `S124FeatureDescriber` end-to-end (lookup, attribute
+serialisation, complex-attribute serialisation, xlink-reference
+projection across the catalog). Other specs fall through to a
+`SpecNotSupportedForTool` error until their describers are added in
+follow-up PRs.
+
+## Usage
+
+```csharp
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+// A host (e.g. the viewer) implements IDatasetCatalog and publishes
+// LoadedDataset instances whenever its loaded set changes.
+IDatasetCatalog catalog = host.Catalog;
+
+var list = new ListDatasetsTool(catalog);
+var describe = new DescribeFeatureTool(catalog);
+var sample = new SampleCoverageTool(catalog);
+
+var listed = await list.InvokeAsync(new ListDatasetsRequest());
+if (listed.TryGetValue(out var summary))
+{
+    foreach (var ds in summary.Datasets)
+    {
+        Console.WriteLine($"{ds.Id} ({ds.Spec})");
+    }
+}
+
+var depth = await sample.InvokeAsync(new SampleCoverageRequest(
+    new SpecRef("S-102", new SpecVersion(2, 1, 0)),
+    Latitude: 47.6,
+    Longitude: -122.3));
+
+if (depth.TryGetValue(out var ok) && ok.Value is DepthSample d)
+{
+    Console.WriteLine($"Depth at point: {d.DepthMeters} m");
+}
+```
+
+## Out of scope (PR MCP-1)
+
+- MCP protocol / server / transports — PR MCP-2.
+- Viewer changes — PR MCP-2.
+- Pan/zoom/screenshot tools.
+- Search / NL tools.
+- Write-back tools.
+- Comprehensive feature describer coverage for every spec.
+- S-104 / S-111 sampling (only S-102 is wired end-to-end).

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -1,0 +1,158 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Coverage;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>Request payload for <see cref="SampleCoverageTool"/>.</summary>
+/// <param name="Spec">Spec of the coverage to sample. Currently only S-102 is supported.</param>
+/// <param name="Latitude">Sample latitude (decimal degrees, WGS-84).</param>
+/// <param name="Longitude">Sample longitude (decimal degrees, WGS-84).</param>
+/// <param name="Time">Optional time selector for time-varying products. Ignored for S-102.</param>
+public sealed record SampleCoverageRequest(
+    SpecRef Spec,
+    double Latitude,
+    double Longitude,
+    DateTimeOffset? Time = null);
+
+/// <summary>Result of <see cref="SampleCoverageTool"/>.</summary>
+public sealed record SampleCoverageResult(
+    DatasetId DatasetId,
+    double Latitude,
+    double Longitude,
+    SampledValue Value);
+
+/// <summary>Discriminated payload returned by <see cref="SampleCoverageTool"/>.</summary>
+public abstract record SampledValue;
+
+/// <summary>S-102 depth sample (metres below the vertical datum, positive down).</summary>
+public sealed record DepthSample(double DepthMeters, double? UncertaintyMeters) : SampledValue;
+
+/// <summary>
+/// Samples a coverage product at a single lat/lon, returning the nearest
+/// grid cell's value. Currently supports S-102; S-104 and S-111 return
+/// <see cref="SpecNotSupportedForTool"/>.
+/// </summary>
+/// <remarks>
+/// "Nearest cell" semantics: the cell whose centre is closest to the
+/// requested point. No interpolation is performed.
+/// </remarks>
+public sealed class SampleCoverageTool
+{
+    /// <summary>Tool name used in <see cref="SpecNotSupportedForTool"/> errors.</summary>
+    public const string Name = "sample_coverage";
+
+    private readonly IDatasetCatalog _catalog;
+
+    /// <summary>Creates a new <see cref="SampleCoverageTool"/>.</summary>
+    public SampleCoverageTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<SampleCoverageResult>> InvokeAsync(
+        SampleCoverageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!string.Equals(request.Spec.Name, "S-102", StringComparison.Ordinal))
+        {
+            return Task.FromResult(
+                ToolResult<SampleCoverageResult>.Err(
+                    new SpecNotSupportedForTool(request.Spec, Name)));
+        }
+
+        var snapshot = _catalog.Datasets;
+        LoadedDataset? match = null;
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S102CoverageData) continue;
+            if (!Contains(dataset.Bounds, request.Latitude, request.Longitude)) continue;
+            match = dataset;
+            break;
+        }
+
+        if (match is null)
+        {
+            return Task.FromResult(
+                ToolResult<SampleCoverageResult>.Err(
+                    new NoDatasetCoversPoint(request.Latitude, request.Longitude)));
+        }
+
+        var source = ((S102CoverageData)match.Data).Source;
+
+        try
+        {
+            var metadata = source.Metadata;
+            var grid = metadata.GridMetadata;
+            var (row, col) = NearestCell(grid, request.Latitude, request.Longitude);
+
+            var region = new GridRegion(row, row + 1, col, col + 1, 1, 1);
+            var sampled = source.Sample(region);
+
+            var depth = ReadScalar(sampled, "depth");
+            var uncertainty = TryReadScalar(sampled, "uncertainty");
+
+            var noData = metadata.NoDataValue;
+            double? depthValue = depth == noData ? null : depth;
+            double? uncertaintyValue = uncertainty is { } u && u != noData ? u : null;
+
+            if (depthValue is null)
+            {
+                return Task.FromResult(
+                    ToolResult<SampleCoverageResult>.Err(
+                        new NoDatasetCoversPoint(request.Latitude, request.Longitude)));
+            }
+
+            var result = new SampleCoverageResult(
+                match.Id,
+                request.Latitude,
+                request.Longitude,
+                new DepthSample(depthValue.Value, uncertaintyValue));
+
+            return Task.FromResult(ToolResult<SampleCoverageResult>.Ok(result));
+        }
+        catch (ObjectDisposedException)
+        {
+            return Task.FromResult(
+                ToolResult<SampleCoverageResult>.Err(
+                    new DatasetClosedDuringQuery(match.Id)));
+        }
+    }
+
+    private static bool Contains(BoundingBox b, double lat, double lon) =>
+        lat >= b.SouthLatitude
+        && lat <= b.NorthLatitude
+        && lon >= b.WestLongitude
+        && lon <= b.EastLongitude;
+
+    private static (int Row, int Col) NearestCell(GridMetadata grid, double lat, double lon)
+    {
+        var row = (int)Math.Round((lat - grid.OriginLatitude) / grid.SpacingLatitudinal);
+        var col = (int)Math.Round((lon - grid.OriginLongitude) / grid.SpacingLongitudinal);
+        row = Math.Clamp(row, 0, grid.NumRows - 1);
+        col = Math.Clamp(col, 0, grid.NumColumns - 1);
+        return (row, col);
+    }
+
+    private static float ReadScalar(SampledCoverage sampled, string field)
+    {
+        var data = sampled.GetField(field);
+        return data[0, 0];
+    }
+
+    private static float? TryReadScalar(SampledCoverage sampled, string field)
+    {
+        if (!sampled.Values.TryGetValue(field, out var data))
+        {
+            return null;
+        }
+        return data[0, 0];
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Lookup table from spec name (canonical <c>"S-NNN"</c>) to the
+/// describer that handles it. <see cref="Default"/> is populated with
+/// every describer this assembly ships with.
+/// </summary>
+public sealed class FeatureDescriberRegistry
+{
+    private readonly ConcurrentDictionary<string, ISpecFeatureDescriber> _byName;
+
+    internal FeatureDescriberRegistry(IEnumerable<ISpecFeatureDescriber> describers)
+    {
+        ArgumentNullException.ThrowIfNull(describers);
+        _byName = new ConcurrentDictionary<string, ISpecFeatureDescriber>(StringComparer.Ordinal);
+        foreach (var d in describers)
+        {
+            _byName[d.SpecName] = d;
+        }
+    }
+
+    /// <summary>Default registry, containing the describers shipped with this assembly.</summary>
+    public static FeatureDescriberRegistry Default { get; } = new FeatureDescriberRegistry(
+    [
+        new S124FeatureDescriber(),
+    ]);
+
+    internal ISpecFeatureDescriber? Get(string specName) =>
+        _byName.TryGetValue(specName, out var d) ? d : null;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/ISpecFeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/ISpecFeatureDescriber.cs
@@ -1,0 +1,29 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Context handed to an <see cref="ISpecFeatureDescriber"/>.
+/// </summary>
+/// <param name="Dataset">The dataset being inspected.</param>
+/// <param name="FeatureId">The feature ID requested by the caller.</param>
+/// <param name="Snapshot">
+/// The catalog snapshot captured at tool entry; describers use it to
+/// resolve <c>xlink:href</c> references against currently-loaded
+/// datasets.
+/// </param>
+internal sealed record FeatureDescriberContext(
+    LoadedDataset Dataset,
+    string FeatureId,
+    ImmutableArray<LoadedDataset> Snapshot);
+
+/// <summary>Per-spec describer strategy.</summary>
+internal interface ISpecFeatureDescriber
+{
+    /// <summary>Spec name (canonical "S-NNN") this describer handles.</summary>
+    string SpecName { get; }
+
+    /// <summary>Builds a <see cref="DescribeFeatureResult"/> or returns a typed error.</summary>
+    ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context);
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S124FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S124FeatureDescriber.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Describer strategy for S-124 Navigational Warnings. Looks up the
+/// feature by ID, serialises its attributes and complex attributes as
+/// JSON, and projects each <see cref="GmlReference"/> against the
+/// catalog snapshot to flag whether the target was loaded.
+/// </summary>
+internal sealed class S124FeatureDescriber : ISpecFeatureDescriber
+{
+    public string SpecName => "S-124";
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        if (context.Dataset.Data is not S124DatasetData s124)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+        }
+
+        var model = s124.Model;
+
+        S124Feature? feature = null;
+        foreach (var f in model.Features)
+        {
+            if (string.Equals(f.Id, context.FeatureId, StringComparison.Ordinal))
+            {
+                feature = f;
+                break;
+            }
+        }
+
+        if (feature is null)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var attributesJson = SerializeAttributes(feature);
+        var references = ProjectReferences(feature.References, context);
+
+        return ToolResult<DescribeFeatureResult>.Ok(
+            new DescribeFeatureResult(
+                context.Dataset.Spec,
+                feature.FeatureType,
+                attributesJson,
+                references));
+    }
+
+    private static JsonElement SerializeAttributes(S124Feature feature)
+    {
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = feature.Id,
+            ["featureType"] = feature.FeatureType,
+            ["geometryType"] = feature.GeometryType.ToString(),
+            ["attributes"] = feature.Attributes,
+            ["complexAttributes"] = feature.ComplexAttributes.Select(c => new
+            {
+                code = c.Code,
+                subAttributes = c.SubAttributes,
+            }).ToArray(),
+        };
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+
+    private static ImmutableArray<FeatureReference> ProjectReferences(
+        ImmutableArray<GmlReference> references,
+        FeatureDescriberContext context)
+    {
+        if (references.IsDefaultOrEmpty)
+        {
+            return ImmutableArray<FeatureReference>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<FeatureReference>(references.Length);
+        foreach (var reference in references)
+        {
+            var targetId = ExtractFragment(reference.Href);
+            var (datasetId, resolved) = ResolveTarget(targetId, context);
+            builder.Add(new FeatureReference(
+                reference.Role,
+                reference.Href,
+                datasetId,
+                targetId,
+                resolved));
+        }
+        return builder.MoveToImmutable();
+    }
+
+    private static string? ExtractFragment(string href)
+    {
+        if (string.IsNullOrEmpty(href)) return null;
+        var hash = href.IndexOf('#');
+        if (hash < 0)
+        {
+            // Some encoders omit the leading '#'; treat the whole href as the ID.
+            return href;
+        }
+        var fragment = href[(hash + 1)..];
+        return fragment.Length == 0 ? null : fragment;
+    }
+
+    private static (DatasetId? DatasetId, bool Resolved) ResolveTarget(
+        string? targetId,
+        FeatureDescriberContext context)
+    {
+        if (targetId is null)
+        {
+            return (null, false);
+        }
+
+        // Look in the originating dataset first.
+        if (TargetExistsInDataset(context.Dataset, targetId))
+        {
+            return (context.Dataset.Id, true);
+        }
+
+        // Fall back to other loaded datasets in the snapshot.
+        foreach (var dataset in context.Snapshot)
+        {
+            if (dataset.Id == context.Dataset.Id) continue;
+            if (TargetExistsInDataset(dataset, targetId))
+            {
+                return (dataset.Id, true);
+            }
+        }
+
+        return (null, false);
+    }
+
+    private static bool TargetExistsInDataset(LoadedDataset dataset, string targetId)
+    {
+        if (dataset.Data is not S124DatasetData s124) return false;
+
+        foreach (var f in s124.Model.Features)
+        {
+            if (string.Equals(f.Id, targetId, StringComparison.Ordinal)) return true;
+        }
+        foreach (var info in s124.Model.InformationTypes)
+        {
+            if (string.Equals(info.Id, targetId, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -1,0 +1,43 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>
+/// Base type for typed tool errors.
+/// </summary>
+/// <param name="Code">Stable error code; safe to switch on.</param>
+/// <param name="Message">Human-readable message; not localised.</param>
+/// <remarks>
+/// Tool implementations never throw into their callers. Every failure
+/// case is reified as a concrete <see cref="ToolError"/> wrapped in
+/// <see cref="ToolResult{T}.Err"/>. This keeps the eventual MCP-error
+/// wire format flexible while giving in-process callers a typed
+/// surface they can match on.
+/// </remarks>
+public abstract record ToolError(string Code, string Message);
+
+/// <summary>The named dataset is not present in the catalog snapshot.</summary>
+public sealed record DatasetNotFound(DatasetId Id) : ToolError(
+    "dataset_not_found",
+    $"Dataset '{Id}' is not present in the catalog.");
+
+/// <summary>The dataset was unloaded after the catalog snapshot was taken but before the read completed.</summary>
+public sealed record DatasetClosedDuringQuery(DatasetId Id) : ToolError(
+    "dataset_closed_during_query",
+    $"Dataset '{Id}' was closed while the query was in flight; retry once the dataset is reopened.");
+
+/// <summary>No loaded dataset of the requested spec covers the supplied lat/lon.</summary>
+public sealed record NoDatasetCoversPoint(double Latitude, double Longitude) : ToolError(
+    "no_dataset_covers_point",
+    $"No loaded dataset's bounds contain the point ({Latitude}, {Longitude}).");
+
+/// <summary>The named feature is not present in the named dataset.</summary>
+public sealed record FeatureNotFound(DatasetId Id, string FeatureId) : ToolError(
+    "feature_not_found",
+    $"Feature '{FeatureId}' is not present in dataset '{Id}'.");
+
+/// <summary>The tool does not (yet) support the requested spec.</summary>
+public sealed record SpecNotSupportedForTool(SpecRef Spec, string Tool) : ToolError(
+    "spec_not_supported_for_tool",
+    $"Spec '{Spec}' is not supported by tool '{Tool}'.");

--- a/src/EncDotNet.S100.Mcp.Tools/ToolResult.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolResult.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>
+/// Discriminated union over a successful tool result of type
+/// <typeparamref name="T"/> and a typed <see cref="ToolError"/>.
+/// </summary>
+/// <remarks>
+/// This is a deliberately small, local implementation (no
+/// <c>OneOf</c>/<c>Result</c> NuGet dependency). Use
+/// <see cref="Ok(T)"/> / <see cref="Err(ToolError)"/> to construct,
+/// pattern-match on <see cref="ToolResult{T}.OkResult"/> /
+/// <see cref="ToolResult{T}.ErrResult"/> to consume, or call
+/// <see cref="TryGetValue"/> / <see cref="TryGetError"/>.
+/// </remarks>
+public abstract record ToolResult<T>
+{
+    private ToolResult() { }
+
+    /// <summary>Constructs a successful result.</summary>
+    public static ToolResult<T> Ok(T value) => new OkResult(value);
+
+    /// <summary>Constructs a failed result.</summary>
+    public static ToolResult<T> Err(ToolError error) => new ErrResult(error);
+
+    /// <summary>Tries to extract the success value.</summary>
+    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    {
+        if (this is OkResult ok)
+        {
+            value = ok.Value;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    /// <summary>Tries to extract the error.</summary>
+    public bool TryGetError([MaybeNullWhen(false)] out ToolError error)
+    {
+        if (this is ErrResult err)
+        {
+            error = err.Error;
+            return true;
+        }
+        error = default;
+        return false;
+    }
+
+    /// <summary>Successful variant.</summary>
+    public sealed record OkResult(T Value) : ToolResult<T>;
+
+    /// <summary>Failed variant.</summary>
+    public sealed record ErrResult(ToolError Error) : ToolResult<T>;
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DatasetCatalogTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DatasetCatalogTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DatasetCatalogTests
+{
+    [Fact]
+    public void Replace_raises_Changed_with_specified_kind_and_id()
+    {
+        var catalog = new FakeDatasetCatalog();
+        DatasetCatalogChangedEventArgs? captured = null;
+        catalog.Changed += (_, e) => captured = e;
+
+        var dataset = LoadedDatasetFactory.S124("a");
+        catalog.Add(dataset);
+
+        Assert.NotNull(captured);
+        Assert.Equal(DatasetCatalogChangeKind.Added, captured!.Kind);
+        Assert.Equal(dataset.Id, captured.DatasetId);
+        Assert.Single(catalog.Datasets);
+    }
+
+    [Fact]
+    public void Snapshot_captured_before_replace_is_stable()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a"));
+        var before = catalog.Datasets;
+
+        catalog.Replace(ImmutableArray<LoadedDataset>.Empty);
+
+        Assert.Single(before);
+        Assert.Empty(catalog.Datasets);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DescribeFeatureToolTests
+{
+    [Fact]
+    public async Task Returns_DatasetNotFound_for_unknown_dataset_id()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("missing"), "f1"));
+
+        Assert.True(result.TryGetError(out var error));
+        var notFound = Assert.IsType<DatasetNotFound>(error);
+        Assert.Equal(new DatasetId("missing"), notFound.Id);
+    }
+
+    [Fact]
+    public async Task Returns_SpecNotSupported_for_unsupported_spec()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S122("s122-ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("s122-ds"), "x"));
+
+        Assert.True(result.TryGetError(out var error));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(error);
+        Assert.Equal("S-122", unsupported.Spec.Name);
+        Assert.Equal(DescribeFeatureTool.Name, unsupported.Tool);
+    }
+
+    [Fact]
+    public async Task Returns_FeatureNotFound_for_unknown_feature_id()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var model = S124Synth.Dataset(S124Synth.Feature("known"));
+        catalog.Add(LoadedDatasetFactory.S124("ds", model));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "absent"));
+
+        Assert.True(result.TryGetError(out var error));
+        var notFound = Assert.IsType<FeatureNotFound>(error);
+        Assert.Equal("absent", notFound.FeatureId);
+    }
+
+    [Fact]
+    public async Task Returns_basic_feature_with_attributes_and_type_name()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var feature = S124Synth.Feature(
+            id: "warn-1",
+            featureType: "NavwarnPart",
+            attributes: new Dictionary<string, string> { ["status"] = "in force" });
+        catalog.Add(LoadedDatasetFactory.S124("ds", S124Synth.Dataset(feature)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "warn-1"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("NavwarnPart", value.FeatureTypeName);
+        Assert.Equal("S-124", value.Spec.Name);
+
+        var attrs = value.Attributes.GetProperty("attributes");
+        Assert.Equal("in force", attrs.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task Serializes_complex_attributes()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var feature = S124Synth.Feature(
+            id: "f",
+            complex: [S124Synth.Complex("fixedDateRange", new Dictionary<string, string>
+            {
+                ["dateStart"] = "2025-01-01",
+                ["dateEnd"] = "2025-01-31",
+            })]);
+        catalog.Add(LoadedDatasetFactory.S124("ds", S124Synth.Dataset(feature)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "f"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var complex = value.Attributes.GetProperty("complexAttributes");
+        Assert.Equal(JsonValueKind.Array, complex.ValueKind);
+        var first = complex[0];
+        Assert.Equal("fixedDateRange", first.GetProperty("code").GetString());
+        Assert.Equal("2025-01-01", first.GetProperty("subAttributes").GetProperty("dateStart").GetString());
+    }
+
+    [Fact]
+    public async Task Projects_reference_with_resolved_target_in_same_dataset()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var target = S124Synth.Feature("target");
+        var source = S124Synth.Feature(
+            id: "source",
+            references: [S124Synth.Ref("theWarningPart", "#target")]);
+        catalog.Add(LoadedDatasetFactory.S124("ds", S124Synth.Dataset(target, source)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "source"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var reference = Assert.Single(value.References);
+        Assert.Equal("theWarningPart", reference.Role);
+        Assert.True(reference.Resolved);
+        Assert.Equal(new DatasetId("ds"), reference.TargetDatasetId);
+        Assert.Equal("target", reference.TargetFeatureId);
+    }
+
+    [Fact]
+    public async Task Projects_reference_unresolved_when_target_missing()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var source = S124Synth.Feature(
+            id: "source",
+            references: [S124Synth.Ref("theWarningPart", "#nope")]);
+        catalog.Add(LoadedDatasetFactory.S124("ds", S124Synth.Dataset(source)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "source"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var reference = Assert.Single(value.References);
+        Assert.False(reference.Resolved);
+        Assert.Null(reference.TargetDatasetId);
+        Assert.Equal("nope", reference.TargetFeatureId);
+    }
+
+    [Fact]
+    public async Task Resolves_reference_against_information_type_in_same_dataset()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var info = S124Synth.Info("preamble-1");
+        var source = S124Synth.Feature(
+            id: "source",
+            references: [S124Synth.Ref("preamble", "#preamble-1")]);
+        catalog.Add(LoadedDatasetFactory.S124("ds",
+            S124Synth.Dataset([source], [info])));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "source"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var reference = Assert.Single(value.References);
+        Assert.True(reference.Resolved);
+        Assert.Equal("preamble-1", reference.TargetFeatureId);
+    }
+
+    [Fact]
+    public async Task Resolves_reference_across_loaded_datasets()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var target = S124Synth.Feature("cross-target");
+        var source = S124Synth.Feature(
+            id: "source",
+            references: [S124Synth.Ref("xref", "#cross-target")]);
+        catalog.Add(LoadedDatasetFactory.S124("ds-a", S124Synth.Dataset(target)));
+        catalog.Add(LoadedDatasetFactory.S124("ds-b", S124Synth.Dataset(source)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds-b"), "source"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var reference = Assert.Single(value.References);
+        Assert.True(reference.Resolved);
+        Assert.Equal(new DatasetId("ds-a"), reference.TargetDatasetId);
+    }
+
+    [Fact]
+    public async Task Empty_references_collection_returns_no_references()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("ds", S124Synth.Dataset(S124Synth.Feature("f"))));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "f"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.References);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp.Tools\EncDotNet.S100.Mcp.Tools.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/FakeDatasetCatalog.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/FakeDatasetCatalog.cs
@@ -1,0 +1,22 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal sealed class FakeDatasetCatalog : IDatasetCatalog
+{
+    public ImmutableArray<LoadedDataset> Datasets { get; private set; } = ImmutableArray<LoadedDataset>.Empty;
+
+    public event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+
+    public void Replace(ImmutableArray<LoadedDataset> next, DatasetCatalogChangeKind kind = DatasetCatalogChangeKind.Batch, DatasetId? id = null)
+    {
+        Datasets = next;
+        Changed?.Invoke(this, new DatasetCatalogChangedEventArgs { Kind = kind, DatasetId = id });
+    }
+
+    public void Add(LoadedDataset dataset)
+    {
+        Replace(Datasets.Add(dataset), DatasetCatalogChangeKind.Added, dataset.Id);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
@@ -1,0 +1,61 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class LoadedDatasetFactory
+{
+    public static SpecRef S124Spec => new("S-124", new SpecVersion(1, 1, 0));
+    public static SpecRef S122Spec => new("S-122", new SpecVersion(1, 0, 0));
+    public static SpecRef S102Spec => new("S-102", new SpecVersion(2, 1, 0));
+    public static SpecRef S104Spec => new("S-104", new SpecVersion(1, 0, 0));
+
+    public static BoundingBox Box(double s = -1, double w = -1, double n = 1, double e = 1) =>
+        new(s, w, n, e);
+
+    public static LoadedDataset S124(
+        string id,
+        S124Dataset? model = null,
+        BoundingBox? bounds = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S124Spec,
+            bounds ?? Box(),
+            null,
+            new S124DatasetData(model ?? S124Synth.Dataset()));
+    }
+
+    public static LoadedDataset S122(string id, BoundingBox? bounds = null)
+    {
+        var model = new S122Dataset
+        {
+            Features = ImmutableArray<S122Feature>.Empty,
+            InformationTypes = ImmutableArray<S122InformationType>.Empty,
+        };
+        return new LoadedDataset(
+            new DatasetId(id),
+            S122Spec,
+            bounds ?? Box(),
+            null,
+            new S122DatasetData(model));
+    }
+
+    public static LoadedDataset S102(
+        string id,
+        BoundingBox? bounds = null,
+        S102CoverageSource? source = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S102Spec,
+            bounds ?? Box(0, 0, 0.04, 0.04),
+            null,
+            new S102CoverageData(source ?? S102Synth.Source()));
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S102Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S102Synth.cs
@@ -1,0 +1,57 @@
+using EncDotNet.S100.Datasets.S102;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class S102Synth
+{
+    public static S102Dataset Dataset(
+        double originLat = 0.0,
+        double originLon = 0.0,
+        double spacingLat = 0.01,
+        double spacingLon = 0.01,
+        int numRows = 4,
+        int numCols = 4,
+        float depth = 12.5f,
+        float uncertainty = 0.25f)
+    {
+        var values = new BathymetryValue[numRows * numCols];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = new BathymetryValue(depth, uncertainty);
+        }
+
+        var coverage = new BathymetryCoverage
+        {
+            OriginLatitude = originLat,
+            OriginLongitude = originLon,
+            SpacingLatitudinal = spacingLat,
+            SpacingLongitudinal = spacingLon,
+            NumPointsLatitudinal = numRows,
+            NumPointsLongitudinal = numCols,
+            Values = values,
+        };
+
+        return new S102Dataset
+        {
+            HorizontalCRS = 4326,
+            Coverages = [coverage],
+        };
+    }
+
+    public static S102CoverageSource Source(S102Dataset? dataset = null) =>
+        new(dataset ?? Dataset());
+}
+
+/// <summary>S-102 coverage source that throws <see cref="ObjectDisposedException"/> from <c>Sample</c> after being disposed.</summary>
+internal sealed class DisposableS102CoverageSource(S102Dataset dataset) : S102CoverageSource(dataset), IDisposable
+{
+    private bool _disposed;
+
+    public override EncDotNet.S100.Pipelines.Coverage.SampledCoverage Sample(EncDotNet.S100.Pipelines.Coverage.GridRegion region)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return base.Sample(region);
+    }
+
+    public void Dispose() => _disposed = true;
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S124Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S124Synth.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class S124Synth
+{
+    public static S124Dataset Dataset(params S124Feature[] features) => new()
+    {
+        Features = features.ToImmutableArray(),
+        InformationTypes = ImmutableArray<S124InformationType>.Empty,
+    };
+
+    public static S124Dataset Dataset(IEnumerable<S124Feature> features, IEnumerable<S124InformationType> infos) => new()
+    {
+        Features = features.ToImmutableArray(),
+        InformationTypes = infos.ToImmutableArray(),
+    };
+
+    public static S124Feature Feature(
+        string id,
+        string featureType = "NavwarnPart",
+        IDictionary<string, string>? attributes = null,
+        IEnumerable<S124ComplexAttribute>? complex = null,
+        IEnumerable<GmlReference>? references = null)
+    {
+        return new S124Feature
+        {
+            Id = id,
+            FeatureType = featureType,
+            GeometryType = GmlGeometryType.Point,
+            Attributes = (attributes ?? new Dictionary<string, string>()).ToImmutableDictionary(),
+            ComplexAttributes = (complex ?? []).ToImmutableArray(),
+            References = (references ?? []).ToImmutableArray(),
+        };
+    }
+
+    public static S124InformationType Info(string id, string typeCode = "NavwarnPreamble") => new()
+    {
+        Id = id,
+        TypeCode = typeCode,
+        Attributes = ImmutableDictionary<string, string>.Empty,
+        ComplexAttributes = ImmutableArray<S124ComplexAttribute>.Empty,
+    };
+
+    public static GmlReference Ref(string role, string href) => new()
+    {
+        Role = role,
+        Href = href,
+    };
+
+    public static S124ComplexAttribute Complex(string code, IDictionary<string, string> sub) => new()
+    {
+        Code = code,
+        SubAttributes = sub.ToImmutableDictionary(),
+    };
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/ListDatasetsToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/ListDatasetsToolTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class ListDatasetsToolTests
+{
+    [Fact]
+    public async Task Returns_empty_for_empty_catalog()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Datasets);
+        Assert.Equal(0, value.TotalCount);
+        Assert.False(value.HasMore);
+    }
+
+    [Fact]
+    public async Task Returns_single_dataset_summary()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("alpha"));
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        var summary = Assert.Single(value.Datasets);
+        Assert.Equal(new DatasetId("alpha"), summary.Id);
+        Assert.Equal("S-124", summary.Spec.Name);
+    }
+
+    [Fact]
+    public async Task Returns_all_specs_when_no_filter()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a"));
+        catalog.Add(LoadedDatasetFactory.S122("b"));
+        catalog.Add(LoadedDatasetFactory.S102("c"));
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.Datasets.Length);
+    }
+
+    [Fact]
+    public async Task Filter_by_spec_returns_only_matching_spec()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a"));
+        catalog.Add(LoadedDatasetFactory.S122("b"));
+        catalog.Add(LoadedDatasetFactory.S124("c"));
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest(Spec: LoadedDatasetFactory.S124Spec));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(2, value.Datasets.Length);
+        Assert.All(value.Datasets, s => Assert.Equal("S-124", s.Spec.Name));
+    }
+
+    [Fact]
+    public async Task Filter_by_spec_with_default_edition_matches_any_edition()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a"));
+        var tool = new ListDatasetsTool(catalog);
+
+        var filter = new SpecRef("S-124", default);
+        var result = await tool.InvokeAsync(new ListDatasetsRequest(Spec: filter));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Datasets);
+    }
+
+    [Fact]
+    public async Task Bbox_inside_includes_dataset()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("inside", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest(
+            IntersectsBounds: LoadedDatasetFactory.Box(5, 5, 6, 6)));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Datasets);
+    }
+
+    [Fact]
+    public async Task Bbox_disjoint_excludes_dataset()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a", bounds: LoadedDatasetFactory.Box(0, 0, 1, 1)));
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest(
+            IntersectsBounds: LoadedDatasetFactory.Box(10, 10, 11, 11)));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Datasets);
+    }
+
+    [Fact]
+    public async Task Paging_returns_requested_page_with_HasMore_flag()
+    {
+        var catalog = new FakeDatasetCatalog();
+        for (var i = 0; i < 7; i++)
+        {
+            catalog.Add(LoadedDatasetFactory.S124($"ds{i}"));
+        }
+        var tool = new ListDatasetsTool(catalog);
+
+        var page0 = await tool.InvokeAsync(new ListDatasetsRequest(Page: 0, PageSize: 3));
+        Assert.True(page0.TryGetValue(out var v0));
+        Assert.Equal(3, v0.Datasets.Length);
+        Assert.True(v0.HasMore);
+        Assert.Equal(7, v0.TotalCount);
+
+        var page2 = await tool.InvokeAsync(new ListDatasetsRequest(Page: 2, PageSize: 3));
+        Assert.True(page2.TryGetValue(out var v2));
+        Assert.Single(v2.Datasets);
+        Assert.False(v2.HasMore);
+    }
+
+    [Fact]
+    public async Task Paging_past_end_returns_empty_with_HasMore_false()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("only"));
+        var tool = new ListDatasetsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListDatasetsRequest(Page: 5, PageSize: 10));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Datasets);
+        Assert.False(value.HasMore);
+        Assert.Equal(1, value.TotalCount);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolTests.cs
@@ -1,0 +1,114 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class SampleCoverageToolTests
+{
+    [Fact]
+    public async Task Returns_depth_sample_inside_bounds()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S102Synth.Dataset(originLat: 0, originLon: 0, spacingLat: 0.01, spacingLon: 0.01,
+            numRows: 4, numCols: 4, depth: 25.0f, uncertainty: 0.5f);
+        catalog.Add(LoadedDatasetFactory.S102(
+            "s102-1",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S102CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S102Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(new DatasetId("s102-1"), value.DatasetId);
+        var depth = Assert.IsType<DepthSample>(value.Value);
+        Assert.Equal(25.0, depth.DepthMeters);
+        Assert.Equal(0.5, depth.UncertaintyMeters);
+    }
+
+    [Fact]
+    public async Task Returns_NoDatasetCoversPoint_when_point_outside_bounds()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102("s102-1", bounds: LoadedDatasetFactory.Box(0, 0, 1, 1)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S102Spec, Latitude: 50, Longitude: 50));
+
+        Assert.True(result.TryGetError(out var error));
+        var miss = Assert.IsType<NoDatasetCoversPoint>(error);
+        Assert.Equal(50, miss.Latitude);
+        Assert.Equal(50, miss.Longitude);
+    }
+
+    [Fact]
+    public async Task Returns_NoDatasetCoversPoint_when_no_S102_loaded()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("vector-only"));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S102Spec, Latitude: 0, Longitude: 0));
+
+        Assert.True(result.TryGetError(out var error));
+        Assert.IsType<NoDatasetCoversPoint>(error);
+    }
+
+    [Fact]
+    public async Task Returns_SpecNotSupported_for_S104()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 0, Longitude: 0));
+
+        Assert.True(result.TryGetError(out var error));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(error);
+        Assert.Equal("S-104", unsupported.Spec.Name);
+        Assert.Equal(SampleCoverageTool.Name, unsupported.Tool);
+    }
+
+    [Fact]
+    public async Task Returns_DatasetClosedDuringQuery_when_handle_disposed()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S102Synth.Dataset();
+        var source = new DisposableS102CoverageSource(dataset);
+        catalog.Add(LoadedDatasetFactory.S102("ds", bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04), source: source));
+        var tool = new SampleCoverageTool(catalog);
+        source.Dispose();
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S102Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetError(out var error));
+        var closed = Assert.IsType<DatasetClosedDuringQuery>(error);
+        Assert.Equal(new DatasetId("ds"), closed.Id);
+    }
+
+    [Fact]
+    public async Task Nearest_cell_clamps_to_grid_when_point_on_boundary()
+    {
+        var catalog = new FakeDatasetCatalog();
+        // Cell-centred grid where the bounds include the grid origin corner exactly.
+        var dataset = S102Synth.Dataset(originLat: 10, originLon: 20, depth: 7.0f, uncertainty: 0.0f);
+        catalog.Add(LoadedDatasetFactory.S102(
+            "edge",
+            bounds: LoadedDatasetFactory.Box(10, 20, 10.04, 20.04),
+            source: new S102CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S102Spec, Latitude: 10.0, Longitude: 20.0));
+
+        Assert.True(result.TryGetValue(out var value));
+        var depth = Assert.IsType<DepthSample>(value.Value);
+        Assert.Equal(7.0, depth.DepthMeters);
+    }
+}


### PR DESCRIPTION
First step toward a viewer-hosted MCP server. This PR delivers the
**foundation only** — the abstraction the viewer will eventually publish,
the tool library that consumes it, and tests proving the tools work
end-to-end against synthetic datasets.

**No MCP protocol code, no viewer changes.** That is PR MCP-2.

## Architecture

```
EncDotNet.S100.Viewer                (later: hosts MCP server)
        │
EncDotNet.S100.Mcp                   (later: protocol + transports)
        │
EncDotNet.S100.Mcp.Tools     ◄── NEW (this PR)
  ├─ IDatasetCatalog + LoadedDataset union
  ├─ ToolResult<T> + ToolError hierarchy
  └─ ListDatasetsTool / DescribeFeatureTool / SampleCoverageTool
        │
EncDotNet.S100.Core          (untouched)
EncDotNet.S100.Datasets.*    (unchanged)
```

The abstraction lives in `Mcp.Tools` rather than Core because putting
per-spec variants in Core would force Core to reference every
`Datasets.S*` project, inverting the established dependency direction.
The viewer (PR MCP-2) and any other host (CLI, headless service) will
reference `Mcp.Tools` directly.

## What landed

- **`IDatasetCatalog`** — property-based, snapshot-immutable
  (`ImmutableArray<LoadedDataset>`), with a `Changed` event.
- **`LoadedDatasetData`** — 12-variant discriminated union: nine typed
  vector models (S-122/124/125/127/128/129/201/411/421) and three
  coverage sources (S-102/104/111).
- **`ToolResult<T>`** — local `Ok`/`Err` discriminated union; no
  external dependency.
- **`ToolError`** — five concrete variants: `DatasetNotFound`,
  `FeatureNotFound`, `NoDatasetCoversPoint`, `SpecNotSupportedForTool`,
  `DatasetClosedDuringQuery`.
- **`ListDatasetsTool`** — spec + bbox filtering, paging.
- **`DescribeFeatureTool`** — `S124FeatureDescriber` end-to-end (typed
  attributes → `JsonElement`, xlink reference resolution). Other specs
  return a structured "not yet supported" error; describers can be
  added incrementally.
- **`SampleCoverageTool`** — S-102 depth + uncertainty sampling.
  S-104/S-111 return `SpecNotSupportedForTool` until extended.

## Tests

27 tests in `tests/EncDotNet.S100.Mcp.Tools.Tests/`, all `Fact`/`Theory`,
no `SkippableFact` needed (synthetic data throughout). Covers all
three tools and the catalog event surface.

```
Passed!  - Failed: 0, Passed: 27, Skipped: 0, Total: 27
```

Full pipeline suite (254 tests, includes S-102) still passes.

## Usage example

```csharp
var catalog = new MyDatasetCatalog();   // viewer or test implements this
var list = new ListDatasetsTool(catalog);

var result = await list.InvokeAsync(new ListDatasetsRequest(
    Spec: new SpecRef("S-124"),
    Page: 0,
    PageSize: 50));

switch (result)
{
    case ToolResult<ListDatasetsResult>.Ok ok:
        foreach (var summary in ok.Value.Datasets)
            Console.WriteLine($"{summary.Id} – {summary.Spec}");
        break;
    case ToolResult<ListDatasetsResult>.Err err:
        Console.WriteLine($"{err.Error.Code}: {err.Error.Message}");
        break;
}
```

No MCP plumbing required — the same API is consumable from any host.

## Dependency hygiene

- `dotnet list package` on **Core**: unchanged (no new packages, no new
  project references).
- `dotnet list package` on **Mcp.Tools**: zero NuGet packages; only
  project references to `Core` + the twelve `Datasets.S*` projects.

## Out of scope (per brief)

- MCP protocol code, server, transports — PR MCP-2.
- Viewer changes — PR MCP-2.
- Pan/zoom/screenshot tools, search/NL tools, write-back tools.
- Comprehensive feature describers for every spec (extend incrementally).
- S-104/S-111 sampling (extend `SampleCoverageTool` once exercised).

See `src/EncDotNet.S100.Mcp.Tools/README.md` for the full architecture
diagram, tool contract, and strategy pattern guidance.