### PR TITLE
PR MCP-3: wire S-101 / S-104 / S-111 / S-131 + fix bounds in catalog

### DIFF
--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
@@ -1,3 +1,4 @@
+using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Datasets.S102;
 using EncDotNet.S100.Datasets.S104;
 using EncDotNet.S100.Datasets.S111;
@@ -7,6 +8,7 @@ using EncDotNet.S100.Datasets.S125;
 using EncDotNet.S100.Datasets.S127;
 using EncDotNet.S100.Datasets.S128;
 using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S131;
 using EncDotNet.S100.Datasets.S201;
 using EncDotNet.S100.Datasets.S411;
 using EncDotNet.S100.Datasets.S421;
@@ -20,6 +22,18 @@ namespace EncDotNet.S100.Mcp.Tools.Catalog;
 /// (HDF5-encoded coverage products).
 /// </summary>
 public abstract record LoadedDatasetData;
+
+/// <summary>
+/// S-101 Electronic Navigational Chart typed dataset.
+/// </summary>
+/// <remarks>
+/// Carries the parsed <see cref="S101Dataset"/> handle. The MCP
+/// <c>describe_feature</c> tool returns
+/// <see cref="EncDotNet.S100.Mcp.Tools.SpecNotSupportedForTool"/> for
+/// S-101 today (see <c>S101FeatureDescriber</c>); the variant exists so
+/// <c>list_datasets</c> can surface ENCs loaded into the viewer.
+/// </remarks>
+public sealed record S101DatasetData(S101Dataset Dataset) : LoadedDatasetData;
 
 /// <summary>S-122 Marine Protected Areas typed model.</summary>
 public sealed record S122DatasetData(S122Dataset Model) : LoadedDatasetData;
@@ -38,6 +52,9 @@ public sealed record S128DatasetData(S128Dataset Model) : LoadedDatasetData;
 
 /// <summary>S-129 Under Keel Clearance typed model.</summary>
 public sealed record S129DatasetData(S129Dataset Model) : LoadedDatasetData;
+
+/// <summary>S-131 Marine Harbour Infrastructure typed model.</summary>
+public sealed record S131DatasetData(S131Dataset Model) : LoadedDatasetData;
 
 /// <summary>S-201 Aids to Navigation Information typed model.</summary>
 public sealed record S201DatasetData(S201Dataset Model) : LoadedDatasetData;

--- a/src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj
+++ b/src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
@@ -16,6 +17,7 @@
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S127\EncDotNet.S100.Datasets.S127.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S128\EncDotNet.S100.Datasets.S128.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S131\EncDotNet.S100.Datasets.S131.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S201\EncDotNet.S100.Datasets.S201.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S411\EncDotNet.S100.Datasets.S411.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
@@ -24,6 +24,7 @@ public sealed class FeatureDescriberRegistry
     /// <summary>Default registry, containing the describers shipped with this assembly.</summary>
     public static FeatureDescriberRegistry Default { get; } = new FeatureDescriberRegistry(
     [
+        new S101FeatureDescriber(),
         new S124FeatureDescriber(),
     ]);
 

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
@@ -1,0 +1,26 @@
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Placeholder describer for S-101 Electronic Navigational Charts.
+/// </summary>
+/// <remarks>
+/// S-101 datasets are surfaced by <c>list_datasets</c> via
+/// <see cref="EncDotNet.S100.Mcp.Tools.Catalog.S101DatasetData"/>, but a
+/// full ISO 8211 feature-record describe is its own work item. Until
+/// that lands this describer returns
+/// <see cref="SpecNotSupportedForTool"/> so callers receive the stable
+/// "spec_not_supported_for_tool" error rather than a confusing
+/// "dataset spec not registered" indirection. S-101 feature describe
+/// support is tracked as a follow-up to PR MCP-3.
+/// </remarks>
+internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
+{
+    public string SpecName => "S-101";
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return ToolResult<DescribeFeatureResult>.Err(
+            new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
@@ -3,16 +3,21 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Datasets.S122;
 using EncDotNet.S100.Datasets.S124;
 using EncDotNet.S100.Datasets.S125;
 using EncDotNet.S100.Datasets.S127;
 using EncDotNet.S100.Datasets.S128;
 using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S131;
 using EncDotNet.S100.Datasets.S201;
 using EncDotNet.S100.Datasets.S411;
 using EncDotNet.S100.Datasets.S421;
+using EncDotNet.S100.Gml;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
@@ -136,39 +141,116 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
         var spec = entry.ProductSpec;
         var path = entry.FilePath;
 
+        // DatasetPipelineFactory.DetectProductSpec returns the literal
+        // string "S-57" for ENC .000 files that pass the S-57 DSPM
+        // discriminator (see DatasetPipelineFactory.cs:94) and "S-101"
+        // for everything else with that extension. The MCP surface
+        // treats both as S-101 — the S-57 → S-101 adapter is what the
+        // viewer's render pipeline ultimately uses for portrayal, so
+        // exposing them under a single canonical spec name keeps the
+        // tool surface predictable. The catalog itself does not need
+        // to differentiate.
         return spec switch
         {
+            "S-101" or "S-57" => ProjectS101(id, path),
             "S-102" => ProjectS102(id, path),
-            "S-122" => Project(id, "S-122", path, p => new S122DatasetData(S122Dataset.Open(p))),
-            "S-124" => Project(id, "S-124", path, p => new S124DatasetData(S124Dataset.Open(p))),
-            "S-125" => Project(id, "S-125", path, p => new S125DatasetData(S125Dataset.Open(p))),
-            "S-127" => Project(id, "S-127", path, p => new S127DatasetData(S127Dataset.Open(p))),
-            "S-128" => Project(id, "S-128", path, p => new S128DatasetData(S128Dataset.Open(p))),
-            "S-129" => Project(id, "S-129", path, p => new S129DatasetData(S129Dataset.Open(p))),
-            "S-201" => Project(id, "S-201", path, p => new S201DatasetData(S201Dataset.Open(p))),
-            "S-411" => Project(id, "S-411", path, p => new S411DatasetData(S411Dataset.Open(p))),
-            "S-421" => Project(id, "S-421", path, p => new S421DatasetData(S421Dataset.Open(p))),
+            "S-104" => ProjectS104(id, path),
+            "S-111" => ProjectS111(id, path),
+            "S-122" => ProjectGml(id, "S-122", path, p =>
+            {
+                var model = S122Dataset.Open(p);
+                return (new S122DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-124" => ProjectGml(id, "S-124", path, p =>
+            {
+                var model = S124Dataset.Open(p);
+                return (new S124DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-125" => ProjectGml(id, "S-125", path, p =>
+            {
+                var model = S125Dataset.Open(p);
+                return (new S125DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-127" => ProjectGml(id, "S-127", path, p =>
+            {
+                var model = S127Dataset.Open(p);
+                return (new S127DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-128" => ProjectGml(id, "S-128", path, p =>
+            {
+                var model = S128Dataset.Open(p);
+                return (new S128DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-129" => ProjectGml(id, "S-129", path, p =>
+            {
+                var model = S129Dataset.Open(p);
+                return (new S129DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-131" => ProjectGml(id, "S-131", path, p =>
+            {
+                var model = S131Dataset.Open(p);
+                return (new S131DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-201" => ProjectGml(id, "S-201", path, p =>
+            {
+                var model = S201Dataset.Open(p);
+                return (new S201DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-411" => ProjectGml(id, "S-411", path, p =>
+            {
+                var model = S411Dataset.Open(p);
+                return (new S411DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
+            "S-421" => ProjectGml(id, "S-421", path, p =>
+            {
+                var model = S421Dataset.Open(p);
+                return (new S421DatasetData(model), ComputeGmlBounds(model.Features));
+            }),
             _ => null,
         };
     }
 
-    private static LoadedDataset Project(
+    private static LoadedDataset ProjectGml(
         DatasetId id,
         string specName,
         string path,
-        Func<string, LoadedDatasetData> openData)
+        Func<string, (LoadedDatasetData Data, BoundingBox? Bounds)> open)
     {
-        var data = openData(path);
+        var (data, bounds) = open(path);
         return new LoadedDataset(
             id,
             new SpecRef(specName, default),
-            WorldBounds,
+            bounds ?? WorldBounds,
             null,
             data);
     }
 
-    private static LoadedDataset? ProjectS102(DatasetId id, string path)
+    private static LoadedDataset ProjectS101(DatasetId id, string path)
     {
+        var dataset = S101Dataset.Open(path);
+        // S-101 features carry packed spatial coordinates that require
+        // the coordinate multiplication factors plus a join across the
+        // feature / spatial / coordinate records to recover lat/lon —
+        // see S-100 Part 10a §3. That work belongs with the S-101
+        // describe implementation, so we fall back to world bounds for
+        // now; the MCP tool surface still lists the dataset and other
+        // tools can dispatch on it.
+        return new LoadedDataset(
+            id,
+            new SpecRef("S-101", default),
+            WorldBounds,
+            null,
+            new S101DatasetData(dataset));
+    }
+
+    private static LoadedDataset ProjectS102(DatasetId id, string path)
+    {
+        // S102DatasetReader.Read fully materialises every coverage's
+        // values into managed BathymetryValue[] arrays before
+        // returning (see S102DatasetReader.ReadCoverage), so the
+        // backing HDF5 file can be closed immediately. The
+        // S102CoverageSource that S102CoverageData carries does not
+        // need a live IHdf5File handle.
         using var file = PureHdfFile.Open(path);
         var dataset = S102DatasetReader.Read(file);
         var source = new S102CoverageSource(dataset);
@@ -179,6 +261,40 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
             bounds,
             null,
             new S102CoverageData(source));
+    }
+
+    private static LoadedDataset ProjectS104(DatasetId id, string path)
+    {
+        // S104DatasetReader.Read materialises every time-step's value
+        // grid into a managed WaterLevelValue[] before returning, so
+        // the file handle can be disposed eagerly.
+        using var file = PureHdfFile.Open(path);
+        var dataset = S104DatasetReader.Read(file);
+        var source = new S104CoverageSource(dataset);
+        var bounds = ComputeS104Bounds(dataset) ?? WorldBounds;
+        return new LoadedDataset(
+            id,
+            new SpecRef("S-104", default),
+            bounds,
+            null,
+            new S104CoverageData(source));
+    }
+
+    private static LoadedDataset ProjectS111(DatasetId id, string path)
+    {
+        // S111DatasetReader.Read materialises every time-step's value
+        // grid into managed arrays before returning, so the file
+        // handle can be disposed eagerly.
+        using var file = PureHdfFile.Open(path);
+        var dataset = S111DatasetReader.Read(file);
+        var source = new S111CoverageSource(dataset);
+        var bounds = ComputeS111Bounds(dataset) ?? WorldBounds;
+        return new LoadedDataset(
+            id,
+            new SpecRef("S-111", default),
+            bounds,
+            null,
+            new S111CoverageData(source));
     }
 
     private static BoundingBox? ComputeS102Bounds(S102Dataset dataset)
@@ -192,6 +308,84 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
         var north = cov.OriginLatitude + (cov.NumPointsLatitudinal - 1) * cov.SpacingLatitudinal;
         var east = cov.OriginLongitude + (cov.NumPointsLongitudinal - 1) * cov.SpacingLongitudinal;
         return new BoundingBox(south, west, north, east);
+    }
+
+    private static BoundingBox? ComputeS104Bounds(S104Dataset dataset)
+    {
+        if (dataset.Coverages is null || dataset.Coverages.Count == 0) return null;
+        var cov = dataset.Coverages[0];
+        if (cov.NumPointsLatitudinal <= 0 || cov.NumPointsLongitudinal <= 0) return null;
+
+        var south = cov.OriginLatitude;
+        var west = cov.OriginLongitude;
+        var north = cov.OriginLatitude + (cov.NumPointsLatitudinal - 1) * cov.SpacingLatitudinal;
+        var east = cov.OriginLongitude + (cov.NumPointsLongitudinal - 1) * cov.SpacingLongitudinal;
+        return new BoundingBox(south, west, north, east);
+    }
+
+    private static BoundingBox? ComputeS111Bounds(S111Dataset dataset)
+    {
+        if (dataset.Coverages is null || dataset.Coverages.Count == 0) return null;
+        var cov = dataset.Coverages[0];
+        if (cov.NumPointsLatitudinal <= 0 || cov.NumPointsLongitudinal <= 0) return null;
+
+        var south = cov.OriginLatitude;
+        var west = cov.OriginLongitude;
+        var north = cov.OriginLatitude + (cov.NumPointsLatitudinal - 1) * cov.SpacingLatitudinal;
+        var east = cov.OriginLongitude + (cov.NumPointsLongitudinal - 1) * cov.SpacingLongitudinal;
+        return new BoundingBox(south, west, north, east);
+    }
+
+    /// <summary>
+    /// Computes a lat/lon bounding box covering every coordinate
+    /// referenced by the supplied GML features (points, curves, ring
+    /// vertices). Returns <c>null</c> when no feature carries any
+    /// geometry — container-style features such as S-131
+    /// <c>Authority</c> or S-127 <c>Authority</c> are valid in their
+    /// respective product specs but produce no bounds, in which case
+    /// callers fall back to <see cref="WorldBounds"/>.
+    /// </summary>
+    private static BoundingBox? ComputeGmlBounds<TFeature>(IEnumerable<TFeature> features)
+        where TFeature : IGmlFeature
+    {
+        if (features is null) return null;
+
+        double minLat = double.PositiveInfinity, maxLat = double.NegativeInfinity;
+        double minLon = double.PositiveInfinity, maxLon = double.NegativeInfinity;
+        bool any = false;
+
+        void Expand(double lat, double lon)
+        {
+            any = true;
+            if (lat < minLat) minLat = lat;
+            if (lat > maxLat) maxLat = lat;
+            if (lon < minLon) minLon = lon;
+            if (lon > maxLon) maxLon = lon;
+        }
+
+        foreach (var feature in features)
+        {
+            if (feature is null) continue;
+            if (!feature.Points.IsDefaultOrEmpty)
+            {
+                foreach (var (lat, lon) in feature.Points) Expand(lat, lon);
+            }
+            if (!feature.Curves.IsDefaultOrEmpty)
+            {
+                foreach (var curve in feature.Curves)
+                {
+                    if (curve.IsDefaultOrEmpty) continue;
+                    foreach (var (lat, lon) in curve) Expand(lat, lon);
+                }
+            }
+            if (!feature.ExteriorRing.IsDefaultOrEmpty)
+            {
+                foreach (var (lat, lon) in feature.ExteriorRing) Expand(lat, lon);
+            }
+        }
+
+        if (!any) return null;
+        return new BoundingBox(minLat, minLon, maxLat, maxLon);
     }
 
     /// <inheritdoc />

--- a/tests/EncDotNet.S100.Mcp.Tests/EncDotNet.S100.Mcp.Tests.csproj
+++ b/tests/EncDotNet.S100.Mcp.Tests/EncDotNet.S100.Mcp.Tests.csproj
@@ -19,9 +19,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S131\EncDotNet.S100.Datasets.S131.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp\EncDotNet.S100.Mcp.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp.Tools\EncDotNet.S100.Mcp.Tools.csproj" />
   </ItemGroup>
@@ -35,8 +37,10 @@
   <ItemGroup>
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\FakeDatasetCatalog.cs" Link="Fakes\FakeDatasetCatalog.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\LoadedDatasetFactory.cs" Link="Fakes\LoadedDatasetFactory.cs" />
+    <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S101Synth.cs" Link="Fakes\S101Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S102Synth.cs" Link="Fakes\S102Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S124Synth.cs" Link="Fakes\S124Synth.cs" />
+    <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S131Synth.cs" Link="Fakes\S131Synth.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
@@ -175,6 +175,21 @@ public class DescribeFeatureToolTests
     }
 
     [Fact]
+    public async Task Returns_SpecNotSupported_for_S101_describe_stub()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc-1"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-1"), "f1"));
+
+        Assert.True(result.TryGetError(out var error));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(error);
+        Assert.Equal("S-101", unsupported.Spec.Name);
+        Assert.Equal(DescribeFeatureTool.Name, unsupported.Tool);
+    }
+
+    [Fact]
     public async Task Empty_references_collection_returns_no_references()
     {
         var catalog = new FakeDatasetCatalog();

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj
@@ -17,9 +17,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S131\EncDotNet.S100.Datasets.S131.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp.Tools\EncDotNet.S100.Mcp.Tools.csproj" />
   </ItemGroup>
 

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
@@ -1,7 +1,9 @@
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Datasets.S102;
 using EncDotNet.S100.Datasets.S122;
 using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S131;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
 using System.Collections.Immutable;
@@ -10,13 +12,28 @@ namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
 
 internal static class LoadedDatasetFactory
 {
+    public static SpecRef S101Spec => new("S-101", new SpecVersion(1, 0, 0));
     public static SpecRef S124Spec => new("S-124", new SpecVersion(1, 1, 0));
     public static SpecRef S122Spec => new("S-122", new SpecVersion(1, 0, 0));
+    public static SpecRef S131Spec => new("S-131", new SpecVersion(1, 0, 0));
     public static SpecRef S102Spec => new("S-102", new SpecVersion(2, 1, 0));
     public static SpecRef S104Spec => new("S-104", new SpecVersion(1, 0, 0));
 
     public static BoundingBox Box(double s = -1, double w = -1, double n = 1, double e = 1) =>
         new(s, w, n, e);
+
+    public static LoadedDataset S101(
+        string id,
+        S101Dataset? dataset = null,
+        BoundingBox? bounds = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S101Spec,
+            bounds ?? Box(),
+            null,
+            new S101DatasetData(dataset ?? S101Synth.Dataset()));
+    }
 
     public static LoadedDataset S124(
         string id,
@@ -44,6 +61,19 @@ internal static class LoadedDatasetFactory
             bounds ?? Box(),
             null,
             new S122DatasetData(model));
+    }
+
+    public static LoadedDataset S131(
+        string id,
+        S131Dataset? model = null,
+        BoundingBox? bounds = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S131Spec,
+            bounds ?? Box(),
+            null,
+            new S131DatasetData(model ?? S131Synth.Dataset()));
     }
 
     public static LoadedDataset S102(

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S101Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S101Synth.cs
@@ -1,0 +1,38 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S101;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class S101Synth
+{
+    /// <summary>Builds a minimal in-memory S-101 dataset for tests.</summary>
+    public static S101Dataset Dataset(string name = "test-enc")
+    {
+        var document = new S101Document
+        {
+            Identification = new S101DatasetIdentification
+            {
+                DatasetName = name,
+            },
+            StructureInfo = new S101DatasetStructureInfo
+            {
+                CoordinateMultiplicationFactorX = 10_000_000,
+                CoordinateMultiplicationFactorY = 10_000_000,
+                CoordinateMultiplicationFactorZ = 10,
+            },
+            FeatureTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            AttributeTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            Points = ImmutableDictionary<uint, S101PointRecord>.Empty,
+            CurveSegments = ImmutableDictionary<uint, S101CurveSegmentRecord>.Empty,
+            CompositeCurves = ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
+            Surfaces = ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
+            Features = ImmutableArray<S101FeatureRecord>.Empty,
+            InformationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty,
+            InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            FeatureAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
+        };
+        return S101Dataset.FromDocument(document);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S131Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S131Synth.cs
@@ -1,0 +1,14 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S131;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class S131Synth
+{
+    /// <summary>Builds a minimal in-memory S-131 dataset for tests.</summary>
+    public static S131Dataset Dataset(params S131Feature[] features) => new()
+    {
+        Features = features.ToImmutableArray(),
+        InformationTypes = ImmutableArray<S131InformationType>.Empty,
+    };
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/LoadedDatasetDataTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/LoadedDatasetDataTests.cs
@@ -1,0 +1,34 @@
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S131;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+/// <summary>
+/// Compile-time + shape assertions for the <see cref="LoadedDatasetData"/>
+/// discriminated union, ensuring every variant introduced by PR MCP-3
+/// constructs cleanly and exposes its underlying typed handle.
+/// </summary>
+public class LoadedDatasetDataTests
+{
+    [Fact]
+    public void S101_variant_carries_dataset_handle()
+    {
+        var dataset = S101Synth.Dataset();
+        LoadedDatasetData data = new S101DatasetData(dataset);
+
+        var typed = Assert.IsType<S101DatasetData>(data);
+        Assert.Same(dataset, typed.Dataset);
+    }
+
+    [Fact]
+    public void S131_variant_carries_model_handle()
+    {
+        var model = S131Synth.Dataset();
+        LoadedDatasetData data = new S131DatasetData(model);
+
+        var typed = Assert.IsType<S131DatasetData>(data);
+        Assert.Same(model, typed.Model);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj
+++ b/tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,12 +26,19 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S125\EncDotNet.S100.Datasets.S125.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S128\EncDotNet.S100.Datasets.S128.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp.Tools\EncDotNet.S100.Mcp.Tools.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="..\datasets\S125\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S125\%(Filename)%(Extension)" />
     <Content Include="..\datasets\S128\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\%(Filename)%(Extension)" />
     <Content Include="..\datasets\S421\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S421\%(Filename)%(Extension)" />
+    <Content Include="..\datasets\S124\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S124\%(Filename)%(Extension)" />
+    <Content Include="..\datasets\S131\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S131\%(Filename)%(Extension)" />
+    <Content Include="..\datasets\S104\*.h5" CopyToOutputDirectory="PreserveNewest" Link="TestData\S104\%(Filename)%(Extension)" />
+    <Content Include="..\datasets\S111\*.h5" CopyToOutputDirectory="PreserveNewest" Link="TestData\S111\%(Filename)%(Extension)" />
+    <Content Include="..\datasets\S101\S-101\DATASET_FILES\*.000" CopyToOutputDirectory="PreserveNewest" Link="TestData\S101\DATASET_FILES\%(Filename)%(Extension)" />
+    <Content Include="..\datasets\S57\US5MA1BO\*.000" CopyToOutputDirectory="PreserveNewest" Link="TestData\S57\US5MA1BO\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Minimal <see cref="IDatasetLoaderService"/> stand-in that lets tests
+/// drive <see cref="ViewerDatasetCatalog"/> by firing the
+/// <see cref="IDatasetLoaderService.DatasetLoaded"/> and
+/// <see cref="IDatasetLoaderService.DatasetRemoved"/> events directly.
+/// </summary>
+internal sealed class FakeDatasetLoaderService : IDatasetLoaderService
+{
+    public void RaiseLoaded(DatasetEntry entry) => DatasetLoaded?.Invoke(entry);
+    public void RaiseRemoved(DatasetEntry entry) => DatasetRemoved?.Invoke(entry);
+
+    public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+    public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task ReRenderAtTimeAsync(DateTime t, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task ReRenderAllAsync() => Task.CompletedTask;
+    public void RemoveEntry(DatasetEntry entry) => DatasetRemoved?.Invoke(entry);
+    public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries) { }
+
+    public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; } =
+        new Dictionary<DatasetEntry, IDatasetProcessor>();
+
+    public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; } =
+        new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+
+    public event Action<DatasetEntry>? DatasetLoaded;
+    public event Action<string?>? StatusChanged;
+    public event Action<DatasetEntry>? DatasetRemoved;
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests for <see cref="ViewerDatasetCatalog"/> covering the
+/// per-spec wiring added by PR MCP-3 (S-101, S-104, S-111, S-131)
+/// and the bounds correctness fix that replaced the world-bounds
+/// fallback for GML specs.
+/// </summary>
+public class ViewerDatasetCatalogTests
+{
+    private const string DatasetsDir = "TestData";
+
+    private static string Path(string spec, string fileName) =>
+        System.IO.Path.Combine(DatasetsDir, spec, fileName);
+
+    [SkippableFact]
+    public void S57_entry_is_projected_as_S101()
+    {
+        var path = Path("S57", System.IO.Path.Combine("US5MA1BO", "US5MA1BO.000"));
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-57");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.Equal("S-101", loaded.Spec.Name);
+        Assert.IsType<S101DatasetData>(loaded.Data);
+    }
+
+    [SkippableFact]
+    public void S101_entry_is_projected_as_S101()
+    {
+        var path = Path("S101", System.IO.Path.Combine("DATASET_FILES", "101AA00DS0003.000"));
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-101");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.Equal("S-101", loaded.Spec.Name);
+        Assert.IsType<S101DatasetData>(loaded.Data);
+    }
+
+    [SkippableFact]
+    public void S104_entry_is_projected_with_real_bounds()
+    {
+        var path = Path("S104", "104US004SC1CP_20251217T12Z.h5");
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-104");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.Equal("S-104", loaded.Spec.Name);
+        Assert.IsType<S104CoverageData>(loaded.Data);
+        AssertBoundsAreNotWorld(loaded.Bounds);
+    }
+
+    [SkippableFact]
+    public void S111_entry_is_projected_with_real_bounds()
+    {
+        var path = Path("S111", "111US00_DBOFS_20260320T18Z_US4DE1BB.h5");
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-111");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.Equal("S-111", loaded.Spec.Name);
+        Assert.IsType<S111CoverageData>(loaded.Data);
+        AssertBoundsAreNotWorld(loaded.Bounds);
+    }
+
+    [SkippableFact]
+    public void S131_entry_is_projected_as_S131()
+    {
+        var path = Path("S131", "harbour_point.gml");
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-131");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.Equal("S-131", loaded.Spec.Name);
+        Assert.IsType<S131DatasetData>(loaded.Data);
+    }
+
+    [SkippableFact]
+    public void S124_entry_has_computed_bounds_not_world()
+    {
+        var path = Path("S124", "navwarn_point.gml");
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-124");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.IsType<S124DatasetData>(loaded.Data);
+        AssertBoundsAreNotWorld(loaded.Bounds);
+    }
+
+    [Fact]
+    public void Exchange_set_entry_is_skipped()
+    {
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(
+            filePath: "ignored.gml",
+            productSpec: "S-124",
+            source: new FakeAssetSource(),
+            relativePath: "ignored.gml",
+            displayName: "ignored.gml");
+
+        loader.RaiseLoaded(entry);
+
+        Assert.Empty(catalog.Datasets);
+    }
+
+    [Fact]
+    public void Removed_entry_drops_from_snapshot()
+    {
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+
+        var path = Path("S124", "navwarn_point.gml");
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var entry = new DatasetEntry(path, "S-124");
+        loader.RaiseLoaded(entry);
+        Assert.Single(catalog.Datasets);
+
+        loader.RaiseRemoved(entry);
+        Assert.Empty(catalog.Datasets);
+    }
+
+    private static void AssertBoundsAreNotWorld(BoundingBox bounds)
+    {
+        Assert.False(
+            bounds.SouthLatitude == -90
+                && bounds.WestLongitude == -180
+                && bounds.NorthLatitude == 90
+                && bounds.EastLongitude == 180,
+            "Expected dataset-specific bounds; got the world fallback.");
+    }
+
+    private sealed class FakeAssetSource : IAssetSource
+    {
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default) =>
+            Task.FromResult<Stream>(new MemoryStream());
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Fixes `ViewerDatasetCatalog` so `list_datasets` actually returns the datasets loaded in the viewer. Addresses the five defects flagged by the `mcp-catalog-empty` MCP catalog diag (minus exchange-set ingest, which is deferred).

Stacked on PR MCP-1 (`philliphoff/mcp-1-catalog-tools`) and PR MCP-2 (`philliphoff/mcp-2-server`).

## Defects fixed

1. **S-101 / S-104 / S-111 / S-131 silently dropped.** `TryProject` previously had no arm for these specs, so every chart loaded into the viewer disappeared from `list_datasets`. Now each spec is opened with its dataset reader and wrapped in a `LoadedDatasetData` variant.
2. **`"S-57"` not mapped to S-101.** `DatasetPipelineFactory.DetectProductSpec` returns `"S-57"` for legacy ENC `.000` files (the viewer pipeline runs them through an S-57→S-101 adapter). The catalog now maps `"S-57"` to S-101 inline; comment explains why.
3. **`BoundingBox.World` fallback for every GML spec.** Each GML arm now walks its features' `IGmlFeature` geometry (Points / Curves / ExteriorRing / InteriorRings) and emits a real envelope. S-104 / S-111 bounds come from each coverage's georef attributes. World fallback is retained only when no envelope is computable.
4. **HDF5 dispose-after-Read concern.** Verified `S102/S104/S111DatasetReader.Read` fully materialize values to managed arrays, so `using var file` is safe. Documented inline.
5. **`describe_feature` against S-101 returned an opaque error.** Added a minimal `S101FeatureDescriber` stub that returns `spec_not_supported_for_tool` with a clear message and registered it in `FeatureDescriberRegistry.Default`.

## Additive contract

New `LoadedDatasetData` variants:

- `S101DatasetData(S101Dataset Dataset)`
- `S131DatasetData(S131Dataset Model)`

S-104 / S-111 use the pre-existing `S104CoverageData` / `S111CoverageData` variants.

No tool signature changes. No portrayal / renderer / dataset-pipeline changes.

## Deferred (explicitly out of scope)

- **Exchange-set entry ingest** — `if (entry.IsFromExchangeSet) return;` early-return preserved.
- **Real S-101 `describe_feature` implementation** — stub only; full ISO-8211 feature describe is its own PR.
- **`sample_coverage` for S-104 / S-111** — catalog now lists them, but the tool still rejects non-S-102 coverage with `spec_not_supported_for_tool`.

## Tests

- `tests/EncDotNet.S100.Mcp.Tools.Tests/LoadedDatasetDataTests.cs` — shape assertion for new variants.
- `tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs` — S-101 stub returns `spec_not_supported_for_tool` with `Tool = "describe_feature"`.
- `tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs` — 8 tests: S-57→S-101 mapping, S-101, S-104 (real bounds), S-111 (real bounds), S-131, S-124 bounds-not-world, exchange-set skip, remove-from-snapshot.

## Verification gates

1. ✅ `dotnet build` — clean.
2. ✅ `dotnet test --configuration Release` — full suite green (1300+ tests across 25 projects; 1 pre-existing skip in S-201 tests unrelated to this PR).
3. **Manual smoke** (perform after merge):
   - Run the viewer, load an S-101 chart from the UKHO Trial Cells.
   - Enable MCP, connect with `mcp-inspector`, call `list_datasets` → one S-101 entry returned.
   - Call `describe_feature` against an S-101 feature → returns `spec_not_supported_for_tool` (this is the stub working).