### PR TITLE
PR-A: HDF5 reader hardening (numerics, compound names, nullpad)

### DIFF
--- a/src/EncDotNet.S100.Core/Hdf5/IHdf5Group.cs
+++ b/src/EncDotNet.S100.Core/Hdf5/IHdf5Group.cs
@@ -17,7 +17,29 @@ public interface IHdf5Group
     /// <summary>Reads a scalar unmanaged attribute value.</summary>
     T ReadAttribute<T>(string name) where T : unmanaged;
 
-    /// <summary>Reads a string attribute value.</summary>
+    /// <summary>
+    /// Reads a floating-point attribute as <see cref="double"/>, accepting
+    /// either <c>H5T_IEEE_F32*</c> or <c>H5T_IEEE_F64*</c> on disk. The
+    /// S-100 specs leave the on-disk width of many grid-georef attributes
+    /// (origin, spacing) to producer choice, so readers should not hard-code
+    /// the width.
+    /// </summary>
+    double ReadDoubleAttribute(string name);
+
+    /// <summary>
+    /// Reads a fixed-point attribute as <see cref="long"/>, accepting any
+    /// of the 8/16/32/64-bit signed or unsigned integer types on disk. The
+    /// S-100 specs leave the on-disk width of many count attributes
+    /// (<c>numPointsLatitudinal</c>, <c>numberOfTimes</c>, …) to producer
+    /// choice, so readers should not hard-code the width.
+    /// </summary>
+    long ReadInt64Attribute(string name);
+
+    /// <summary>
+    /// Reads a string attribute value. Trailing <c>NUL</c> characters from
+    /// fixed-length <c>H5T_STR_NULLPAD</c> strings are stripped so that the
+    /// returned value is suitable for direct parsing.
+    /// </summary>
     string ReadStringAttribute(string name);
 
     /// <summary>
@@ -25,4 +47,13 @@ public interface IHdf5Group
     /// For compound datasets the struct layout must match the HDF5 field offsets.
     /// </summary>
     T[] ReadDataset<T>(string name) where T : unmanaged;
+
+    /// <summary>
+    /// Reads a compound dataset as raw bytes plus member metadata. Callers
+    /// project rows into product-specific value types so that small
+    /// spec-conforming variations between producers (member renames,
+    /// numeric width changes) can be tolerated without changing public
+    /// value-struct layouts.
+    /// </summary>
+    RawCompoundDataset ReadRawCompoundDataset(string name);
 }

--- a/src/EncDotNet.S100.Core/Hdf5/RawCompoundDataset.cs
+++ b/src/EncDotNet.S100.Core/Hdf5/RawCompoundDataset.cs
@@ -1,0 +1,105 @@
+namespace EncDotNet.S100.Hdf5;
+
+/// <summary>
+/// Classifies a compound member's on-disk numeric kind so callers can
+/// project it into a target .NET type without recompiling against
+/// PureHDF types.
+/// </summary>
+public enum CompoundMemberKind
+{
+    /// <summary>The member is not a primitive numeric type recognised here (e.g. string, opaque, compound).</summary>
+    Other = 0,
+
+    /// <summary><c>H5T_IEEE_F32LE</c> / <c>H5T_IEEE_F32BE</c>.</summary>
+    Float32,
+
+    /// <summary><c>H5T_IEEE_F64LE</c> / <c>H5T_IEEE_F64BE</c>.</summary>
+    Float64,
+
+    /// <summary>Signed 8-bit fixed-point integer.</summary>
+    Int8,
+
+    /// <summary>Unsigned 8-bit fixed-point integer.</summary>
+    UInt8,
+
+    /// <summary>Signed 16-bit fixed-point integer.</summary>
+    Int16,
+
+    /// <summary>Unsigned 16-bit fixed-point integer.</summary>
+    UInt16,
+
+    /// <summary>Signed 32-bit fixed-point integer.</summary>
+    Int32,
+
+    /// <summary>Unsigned 32-bit fixed-point integer.</summary>
+    UInt32,
+
+    /// <summary>Signed 64-bit fixed-point integer.</summary>
+    Int64,
+
+    /// <summary>Unsigned 64-bit fixed-point integer.</summary>
+    UInt64,
+}
+
+/// <summary>
+/// Describes a single member of a compound HDF5 datatype as observed
+/// on disk. Used to project <see cref="RawCompoundDataset"/> rows
+/// into product-specific value types when member naming or numeric
+/// width varies between producers.
+/// </summary>
+public sealed record CompoundMemberInfo(string Name, int Offset, int Size, CompoundMemberKind Kind);
+
+/// <summary>
+/// A compound dataset returned in raw form: the bytes are laid out
+/// exactly as on disk (record-major), and the members describe where
+/// each field lives within a record. Callers project rows into their
+/// own value types so that small spec-conforming variations (member
+/// renames, numeric width changes) can be tolerated without changing
+/// public value-struct layouts.
+/// </summary>
+public sealed class RawCompoundDataset
+{
+    /// <summary>Initializes a new instance.</summary>
+    public RawCompoundDataset(byte[] data, int recordSize, IReadOnlyList<CompoundMemberInfo> members)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(members);
+        if (recordSize <= 0) throw new ArgumentOutOfRangeException(nameof(recordSize));
+        if (data.Length % recordSize != 0)
+            throw new ArgumentException(
+                $"Raw compound data length {data.Length} is not a multiple of record size {recordSize}.",
+                nameof(data));
+
+        Data = data;
+        RecordSize = recordSize;
+        Members = members;
+        RecordCount = data.Length / recordSize;
+    }
+
+    /// <summary>Raw record-major payload.</summary>
+    public byte[] Data { get; }
+
+    /// <summary>Size of one record in bytes.</summary>
+    public int RecordSize { get; }
+
+    /// <summary>Number of records in <see cref="Data"/>.</summary>
+    public int RecordCount { get; }
+
+    /// <summary>Compound member descriptors, in the order declared on disk.</summary>
+    public IReadOnlyList<CompoundMemberInfo> Members { get; }
+
+    /// <summary>Looks up a member by name (case-insensitive), trying each candidate in turn.</summary>
+    public CompoundMemberInfo? FindMember(params string[] candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            foreach (var member in Members)
+            {
+                if (string.Equals(member.Name, candidate, StringComparison.OrdinalIgnoreCase))
+                    return member;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
@@ -21,7 +21,7 @@ public static class S102DatasetReader
         var root = file.Root;
 
         int? horizontalCRS = root.AttributeExists("horizontalCRS")
-            ? root.ReadAttribute<int>("horizontalCRS")
+            ? (int)root.ReadInt64Attribute("horizontalCRS")
             : null;
 
         string? epoch = root.AttributeExists("epoch")
@@ -72,12 +72,12 @@ public static class S102DatasetReader
 
     private static BathymetryCoverage ReadCoverage(IHdf5Group instance)
     {
-        double originLat = instance.ReadAttribute<double>("gridOriginLatitude");
-        double originLon = instance.ReadAttribute<double>("gridOriginLongitude");
-        double spacingLat = instance.ReadAttribute<double>("gridSpacingLatitudinal");
-        double spacingLon = instance.ReadAttribute<double>("gridSpacingLongitudinal");
-        int numLat = instance.ReadAttribute<int>("numPointsLatitudinal");
-        int numLon = instance.ReadAttribute<int>("numPointsLongitudinal");
+        double originLat = instance.ReadDoubleAttribute("gridOriginLatitude");
+        double originLon = instance.ReadDoubleAttribute("gridOriginLongitude");
+        double spacingLat = instance.ReadDoubleAttribute("gridSpacingLatitudinal");
+        double spacingLon = instance.ReadDoubleAttribute("gridSpacingLongitudinal");
+        int numLat = (int)instance.ReadInt64Attribute("numPointsLatitudinal");
+        int numLon = (int)instance.ReadInt64Attribute("numPointsLongitudinal");
 
         string? startSequence = instance.AttributeExists("startSequence")
             ? instance.ReadStringAttribute("startSequence")

--- a/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
@@ -23,7 +23,7 @@ public static class S104DatasetReader
         var root = file.Root;
 
         int? horizontalCRS = root.AttributeExists("horizontalCRS")
-            ? root.ReadAttribute<int>("horizontalCRS")
+            ? (int)root.ReadInt64Attribute("horizontalCRS")
             : null;
 
         string? epoch = root.AttributeExists("epoch")
@@ -45,7 +45,7 @@ public static class S104DatasetReader
         var wlGroup = root.OpenGroup("WaterLevel");
 
         int dataCodingFormat = wlGroup.AttributeExists("dataCodingFormat")
-            ? wlGroup.ReadAttribute<byte>("dataCodingFormat")
+            ? (int)wlGroup.ReadInt64Attribute("dataCodingFormat")
             : 2;
 
         string? methodWaterLevelProduct = wlGroup.AttributeExists("methodWaterLevelProduct")
@@ -91,12 +91,12 @@ public static class S104DatasetReader
 
     private static void ReadInstance(IHdf5Group instance, List<WaterLevelCoverage> coverages)
     {
-        double originLat = instance.ReadAttribute<double>("gridOriginLatitude");
-        double originLon = instance.ReadAttribute<double>("gridOriginLongitude");
-        double spacingLat = instance.ReadAttribute<double>("gridSpacingLatitudinal");
-        double spacingLon = instance.ReadAttribute<double>("gridSpacingLongitudinal");
-        int numLat = (int)instance.ReadAttribute<uint>("numPointsLatitudinal");
-        int numLon = (int)instance.ReadAttribute<uint>("numPointsLongitudinal");
+        double originLat = instance.ReadDoubleAttribute("gridOriginLatitude");
+        double originLon = instance.ReadDoubleAttribute("gridOriginLongitude");
+        double spacingLat = instance.ReadDoubleAttribute("gridSpacingLatitudinal");
+        double spacingLon = instance.ReadDoubleAttribute("gridSpacingLongitudinal");
+        int numLat = (int)instance.ReadInt64Attribute("numPointsLatitudinal");
+        int numLon = (int)instance.ReadInt64Attribute("numPointsLongitudinal");
 
         string? startSequence = instance.AttributeExists("startSequence")
             ? instance.ReadStringAttribute("startSequence")
@@ -117,7 +117,7 @@ public static class S104DatasetReader
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
 
-            var values = group.ReadDataset<WaterLevelValue>("values");
+            var values = ReadValues(group);
 
             coverages.Add(new WaterLevelCoverage
             {
@@ -132,5 +132,82 @@ public static class S104DatasetReader
                 Values = values,
             });
         }
+    }
+
+    /// <summary>
+    /// Reads the per-time-step <c>values</c> compound dataset and projects it
+    /// into <see cref="WaterLevelValue"/>s, tolerating producer variation in
+    /// member naming and trend encoding.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The S-104 Feature Catalogue names the compound members
+    /// <c>waterLevelHeight</c> and <c>waterLevelTrend</c>; observed UKHO
+    /// production files use <c>surfaceHeight</c> and <c>trend</c>; some
+    /// in-tree synthetic fixtures use the C# field names <c>Height</c> and
+    /// <c>Trend</c>. All three are accepted (case-insensitive).
+    /// </para>
+    /// <para>
+    /// <c>waterLevelTrend</c> is spec-encoded as a uint8 enumeration but UKHO
+    /// dcf2 files store it as <c>f32</c>; both are decoded.
+    /// </para>
+    /// </remarks>
+    private static WaterLevelValue[] ReadValues(IHdf5Group group)
+    {
+        var raw = group.ReadRawCompoundDataset("values");
+
+        var heightMember = raw.FindMember("waterLevelHeight", "surfaceHeight", "Height")
+            ?? throw new InvalidOperationException(
+                "S-104 'values' compound is missing a height member " +
+                "(expected 'waterLevelHeight', 'surfaceHeight', or 'Height').");
+
+        var trendMember = raw.FindMember("waterLevelTrend", "trend", "Trend");
+
+        var result = new WaterLevelValue[raw.RecordCount];
+        var span = raw.Data.AsSpan();
+
+        for (int i = 0; i < raw.RecordCount; i++)
+        {
+            var record = span.Slice(i * raw.RecordSize, raw.RecordSize);
+
+            float height = heightMember.Kind switch
+            {
+                CompoundMemberKind.Float32 => System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+                    record.Slice(heightMember.Offset, 4)),
+                CompoundMemberKind.Float64 => (float)System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+                    record.Slice(heightMember.Offset, 8)),
+                _ => throw new NotSupportedException(
+                    $"S-104 height member '{heightMember.Name}' has unsupported kind {heightMember.Kind}."),
+            };
+
+            byte trend = 0;
+            if (trendMember is not null)
+            {
+                trend = trendMember.Kind switch
+                {
+                    CompoundMemberKind.UInt8 or CompoundMemberKind.Int8 =>
+                        record[trendMember.Offset],
+                    // UKHO dcf2 stores trend as f32 — round to nearest valid enum byte.
+                    CompoundMemberKind.Float32 => (byte)Math.Clamp(
+                        (int)Math.Round(System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+                            record.Slice(trendMember.Offset, 4))),
+                        0, 255),
+                    CompoundMemberKind.Float64 => (byte)Math.Clamp(
+                        (int)Math.Round(System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+                            record.Slice(trendMember.Offset, 8))),
+                        0, 255),
+                    CompoundMemberKind.UInt16 => (byte)Math.Clamp(
+                        (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(
+                            record.Slice(trendMember.Offset, 2)),
+                        0, 255),
+                    _ => throw new NotSupportedException(
+                        $"S-104 trend member '{trendMember.Name}' has unsupported kind {trendMember.Kind}."),
+                };
+            }
+
+            result[i] = new WaterLevelValue(height, trend);
+        }
+
+        return result;
     }
 }

--- a/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
@@ -23,7 +23,7 @@ public static class S111DatasetReader
         var root = file.Root;
 
         int? horizontalCRS = root.AttributeExists("horizontalDatumValue")
-            ? root.ReadAttribute<int>("horizontalDatumValue")
+            ? (int)root.ReadInt64Attribute("horizontalDatumValue")
             : null;
 
         string? epoch = root.AttributeExists("epoch")
@@ -43,17 +43,17 @@ public static class S111DatasetReader
             : null;
 
         float? surfaceCurrentDepth = root.AttributeExists("surfaceCurrentDepth")
-            ? root.ReadAttribute<float>("surfaceCurrentDepth")
+            ? (float)root.ReadDoubleAttribute("surfaceCurrentDepth")
             : null;
 
         var scGroup = root.OpenGroup("SurfaceCurrent");
 
         int dataCodingFormat = scGroup.AttributeExists("dataCodingFormat")
-            ? scGroup.ReadAttribute<byte>("dataCodingFormat")
+            ? (int)scGroup.ReadInt64Attribute("dataCodingFormat")
             : 2;
 
         int? typeOfCurrentData = scGroup.AttributeExists("typeOfCurrentData")
-            ? scGroup.ReadAttribute<byte>("typeOfCurrentData")
+            ? (int)scGroup.ReadInt64Attribute("typeOfCurrentData")
             : null;
 
         var coverages = ReadCoverages(scGroup, dataCodingFormat);
@@ -96,12 +96,12 @@ public static class S111DatasetReader
 
     private static void ReadInstance(IHdf5Group instance, List<SurfaceCurrentCoverage> coverages)
     {
-        double originLat = instance.ReadAttribute<float>("gridOriginLatitude");
-        double originLon = instance.ReadAttribute<float>("gridOriginLongitude");
-        double spacingLat = instance.ReadAttribute<float>("gridSpacingLatitudinal");
-        double spacingLon = instance.ReadAttribute<float>("gridSpacingLongitudinal");
-        int numLat = instance.ReadAttribute<int>("numPointsLatitudinal");
-        int numLon = instance.ReadAttribute<int>("numPointsLongitudinal");
+        double originLat = instance.ReadDoubleAttribute("gridOriginLatitude");
+        double originLon = instance.ReadDoubleAttribute("gridOriginLongitude");
+        double spacingLat = instance.ReadDoubleAttribute("gridSpacingLatitudinal");
+        double spacingLon = instance.ReadDoubleAttribute("gridSpacingLongitudinal");
+        int numLat = (int)instance.ReadInt64Attribute("numPointsLatitudinal");
+        int numLon = (int)instance.ReadInt64Attribute("numPointsLongitudinal");
 
         string? startSequence = instance.AttributeExists("startSequence")
             ? instance.ReadStringAttribute("startSequence")
@@ -122,7 +122,7 @@ public static class S111DatasetReader
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
 
-            var values = group.ReadDataset<SurfaceCurrentValue>("values");
+            var values = ReadValues(group);
 
             coverages.Add(new SurfaceCurrentCoverage
             {
@@ -138,4 +138,55 @@ public static class S111DatasetReader
             });
         }
     }
+
+    /// <summary>
+    /// Reads the per-time-step <c>values</c> compound dataset and projects it
+    /// into <see cref="SurfaceCurrentValue"/>s, tolerating producer variation
+    /// in member naming and numeric width.
+    /// </summary>
+    /// <remarks>
+    /// The S-111 Feature Catalogue names the compound members
+    /// <c>surfaceCurrentSpeed</c> and <c>surfaceCurrentDirection</c>; some
+    /// in-tree synthetic fixtures use the C# field names <c>Speed</c> and
+    /// <c>Direction</c>. Both are accepted (case-insensitive).
+    /// </remarks>
+    private static SurfaceCurrentValue[] ReadValues(IHdf5Group group)
+    {
+        var raw = group.ReadRawCompoundDataset("values");
+
+        var speedMember = raw.FindMember("surfaceCurrentSpeed", "Speed")
+            ?? throw new InvalidOperationException(
+                "S-111 'values' compound is missing a speed member " +
+                "(expected 'surfaceCurrentSpeed' or 'Speed').");
+
+        var directionMember = raw.FindMember("surfaceCurrentDirection", "Direction")
+            ?? throw new InvalidOperationException(
+                "S-111 'values' compound is missing a direction member " +
+                "(expected 'surfaceCurrentDirection' or 'Direction').");
+
+        var result = new SurfaceCurrentValue[raw.RecordCount];
+        var span = raw.Data.AsSpan();
+
+        for (int i = 0; i < raw.RecordCount; i++)
+        {
+            var record = span.Slice(i * raw.RecordSize, raw.RecordSize);
+
+            float speed = ReadFloat(record, speedMember);
+            float direction = ReadFloat(record, directionMember);
+
+            result[i] = new SurfaceCurrentValue(speed, direction);
+        }
+
+        return result;
+    }
+
+    private static float ReadFloat(ReadOnlySpan<byte> record, CompoundMemberInfo member) => member.Kind switch
+    {
+        CompoundMemberKind.Float32 => System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+            record.Slice(member.Offset, 4)),
+        CompoundMemberKind.Float64 => (float)System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+            record.Slice(member.Offset, 8)),
+        _ => throw new NotSupportedException(
+            $"S-111 member '{member.Name}' has unsupported kind {member.Kind}."),
+    };
 }

--- a/src/EncDotNet.S100.Hdf5.PureHdf/PureHdfFile.cs
+++ b/src/EncDotNet.S100.Hdf5.PureHdf/PureHdfFile.cs
@@ -112,12 +112,99 @@ public sealed class PureHdfFile : IHdf5File
             }
         }
 
+        public double ReadDoubleAttribute(string name)
+        {
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                var attr = _group.Attribute(name);
+                var type = attr.Type;
+
+                if (type.Class == H5DataTypeClass.FloatingPoint)
+                {
+                    return type.Size switch
+                    {
+                        4 => attr.Read<float>(),
+                        8 => attr.Read<double>(),
+                        _ => throw new NotSupportedException(
+                            $"Unsupported floating-point size {type.Size} bytes for attribute '{name}'."),
+                    };
+                }
+
+                // Tolerate integers that happen to be used where the spec
+                // allows either; widening to double never loses precision
+                // for 32-bit-or-smaller integers and is what callers want.
+                if (type.Class == H5DataTypeClass.FixedPoint)
+                {
+                    return ReadInt64Attribute(name);
+                }
+
+                throw new NotSupportedException(
+                    $"Attribute '{name}' has class {type.Class}; expected FloatingPoint or FixedPoint.");
+            }
+            finally
+            {
+                Telemetry.ReadDuration.Record(GetElapsedMs(start), new KeyValuePair<string, object?>("kind", "attribute"));
+            }
+        }
+
+        public long ReadInt64Attribute(string name)
+        {
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                var attr = _group.Attribute(name);
+                var type = attr.Type;
+
+                // Accept both raw fixed-point integers and enumerations
+                // (which are fixed-point integers with a name table) since
+                // S-100 attributes like dataCodingFormat are spec-defined
+                // enums but treated as integer values by callers.
+                bool signed;
+                if (type.Class == H5DataTypeClass.FixedPoint)
+                {
+                    signed = type.FixedPoint.IsSigned;
+                }
+                else if (type.Class == H5DataTypeClass.Enumerated)
+                {
+                    // S-100 enumerations are spec-defined as unsigned 8-bit
+                    // values (and PureHDF does not expose the underlying
+                    // base-type signedness through IH5DataType).
+                    signed = false;
+                }
+                else
+                {
+                    throw new NotSupportedException(
+                        $"Attribute '{name}' has class {type.Class}; expected FixedPoint or Enumerated.");
+                }
+
+                return (type.Size, signed) switch
+                {
+                    (1, true) => attr.Read<sbyte>(),
+                    (1, false) => attr.Read<byte>(),
+                    (2, true) => attr.Read<short>(),
+                    (2, false) => attr.Read<ushort>(),
+                    (4, true) => attr.Read<int>(),
+                    (4, false) => attr.Read<uint>(),
+                    (8, true) => attr.Read<long>(),
+                    (8, false) => checked((long)attr.Read<ulong>()),
+                    _ => throw new NotSupportedException(
+                        $"Unsupported fixed-point size {type.Size} bytes (signed={signed}) for attribute '{name}'."),
+                };
+            }
+            finally
+            {
+                Telemetry.ReadDuration.Record(GetElapsedMs(start), new KeyValuePair<string, object?>("kind", "attribute"));
+            }
+        }
+
         public string ReadStringAttribute(string name)
         {
             var start = Stopwatch.GetTimestamp();
             try
             {
-                return _group.Attribute(name).Read<string>();
+                var raw = _group.Attribute(name).Read<string>();
+                return TrimNullPadding(raw);
             }
             finally
             {
@@ -144,6 +231,100 @@ public sealed class PureHdfFile : IHdf5File
             activity?.SetTag("s100.hdf5.read.bytes", bytes);
             activity?.SetTag("s100.hdf5.element.count", result.Length);
             return result;
+        }
+
+        public RawCompoundDataset ReadRawCompoundDataset(string name)
+        {
+            using var activity = Telemetry.ActivitySource.StartActivity("s100.hdf5.dataset.read");
+            activity?.SetTag("s100.hdf5.dataset", name);
+            activity?.SetTag("s100.hdf5.dataset.kind", "compound.raw");
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                var dataset = _group.Dataset(name);
+                var type = dataset.Type;
+
+                if (type.Class != H5DataTypeClass.Compound)
+                {
+                    throw new InvalidOperationException(
+                        $"Dataset '{name}' has class {type.Class}; expected Compound.");
+                }
+
+                int recordSize = (int)type.Size;
+                var rawMembers = type.Compound.Members;
+                var members = new List<CompoundMemberInfo>(rawMembers.Length);
+                foreach (var m in rawMembers)
+                {
+                    members.Add(new CompoundMemberInfo(
+                        m.Name,
+                        m.Offset,
+                        (int)m.Type.Size,
+                        ClassifyMember(m.Type)));
+                }
+
+                var bytes = dataset.Read<byte[]>();
+                Telemetry.ReadBytes.Add(bytes.LongLength);
+                activity?.SetTag("s100.hdf5.read.bytes", bytes.LongLength);
+                activity?.SetTag("s100.hdf5.element.count", bytes.Length / Math.Max(1, recordSize));
+
+                return new RawCompoundDataset(bytes, recordSize, members);
+            }
+            finally
+            {
+                Telemetry.ReadDuration.Record(GetElapsedMs(start), new KeyValuePair<string, object?>("kind", "dataset"));
+            }
+        }
+
+        private static CompoundMemberKind ClassifyMember(IH5DataType type)
+        {
+            // S-104 stores waterLevelTrend as an enumeration over uint8 in
+            // conforming files, and as a plain f32 in some UKHO files; we
+            // classify the underlying base type so callers can decode either.
+            if (type.Class == H5DataTypeClass.FloatingPoint)
+            {
+                return type.Size switch
+                {
+                    4 => CompoundMemberKind.Float32,
+                    8 => CompoundMemberKind.Float64,
+                    _ => CompoundMemberKind.Other,
+                };
+            }
+
+            if (type.Class == H5DataTypeClass.FixedPoint || type.Class == H5DataTypeClass.Enumerated)
+            {
+                bool signed = type.Class == H5DataTypeClass.FixedPoint
+                    ? type.FixedPoint.IsSigned
+                    // Enumerated types in S-100 (trend, etc.) are always
+                    // backed by unsigned fixed-point integers per the spec.
+                    : false;
+
+                return (type.Size, signed) switch
+                {
+                    (1, true) => CompoundMemberKind.Int8,
+                    (1, false) => CompoundMemberKind.UInt8,
+                    (2, true) => CompoundMemberKind.Int16,
+                    (2, false) => CompoundMemberKind.UInt16,
+                    (4, true) => CompoundMemberKind.Int32,
+                    (4, false) => CompoundMemberKind.UInt32,
+                    (8, true) => CompoundMemberKind.Int64,
+                    (8, false) => CompoundMemberKind.UInt64,
+                    _ => CompoundMemberKind.Other,
+                };
+            }
+
+            return CompoundMemberKind.Other;
+        }
+
+        private static string TrimNullPadding(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value ?? string.Empty;
+
+            int end = value.Length;
+            while (end > 0 && value[end - 1] == '\0')
+                end--;
+
+            return end == value.Length ? value : value[..end];
         }
 
         private static double GetElapsedMs(long startTimestamp) =>

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/EncDotNet.S100.Datasets.S104.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/EncDotNet.S100.Datasets.S104.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="PureHDF" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.SkippableFact" />

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/S104FixtureBuilder.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/S104FixtureBuilder.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using PureHDF;
+
+namespace EncDotNet.S100.Datasets.S104.Tests.Fixtures;
+
+/// <summary>
+/// Helpers that author small synthetic S-104 HDF5 files for reader-hardening
+/// tests. Each builder method writes to a temp <c>.h5</c> path and returns
+/// it; the caller is responsible for deletion.
+/// </summary>
+internal static class S104FixtureBuilder
+{
+    // ---- Compound row variants --------------------------------------------------
+
+    // Spec member names — height as F32, trend as uint8.
+    public struct SpecRow
+    {
+        [H5Name("waterLevelHeight")] public float WaterLevelHeight;
+        [H5Name("waterLevelTrend")] public byte WaterLevelTrend;
+    }
+
+    // UKHO dcf2 shape — height as F32, trend as F32.
+    public struct UkhoRow
+    {
+        [H5Name("surfaceHeight")] public float SurfaceHeight;
+        [H5Name("trend")] public float Trend;
+    }
+
+    // Legacy synthetic-fixture shape — C# names that happen to match struct fields.
+    public struct LegacyRow
+    {
+        public float Height;
+        public byte Trend;
+    }
+
+    /// <summary>
+    /// Writes a minimal S-104 file using the supplied compound-row type and
+    /// the requested numeric width for grid-georef attributes.
+    /// </summary>
+    public static string WriteFile<TRow>(
+        string path,
+        TRow[] values,
+        int numLat,
+        int numLon,
+        bool useF64GridAttrs,
+        bool useUnsignedCounts,
+        string timePoint = "20210401T000000Z")
+        where TRow : struct
+    {
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["gridOriginLatitude"] = useF64GridAttrs ? 50.0 : (object)50.0f,
+                ["gridOriginLongitude"] = useF64GridAttrs ? -1.0 : (object)-1.0f,
+                ["gridSpacingLatitudinal"] = useF64GridAttrs ? 0.01 : (object)0.01f,
+                ["gridSpacingLongitudinal"] = useF64GridAttrs ? 0.01 : (object)0.01f,
+                ["numPointsLatitudinal"] = useUnsignedCounts ? (object)(uint)numLat : numLat,
+                ["numPointsLongitudinal"] = useUnsignedCounts ? (object)(uint)numLon : numLon,
+            },
+            ["Group_001"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["timePoint"] = timePoint,
+                },
+                ["values"] = values,
+            },
+        };
+
+        var file = new H5File
+        {
+            Attributes = new()
+            {
+                ["horizontalCRS"] = 4326,
+                ["geographicIdentifier"] = "Test",
+                ["issueDate"] = "2021-04-01",
+            },
+            ["WaterLevel"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["dataCodingFormat"] = (byte)2,
+                },
+                ["WaterLevel.01"] = instance,
+            },
+        };
+
+        // Map [H5Name(...)] on row fields → HDF5 compound member names.
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+
+        file.Write(path, options);
+        return path;
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/S104DatasetReaderHardeningTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/S104DatasetReaderHardeningTests.cs
@@ -1,0 +1,188 @@
+using EncDotNet.S100.Datasets.S104.Tests.Fixtures;
+using EncDotNet.S100.Hdf5.PureHdf;
+
+namespace EncDotNet.S100.Datasets.S104.Tests;
+
+/// <summary>
+/// Reader-hardening tests (PR-A): tolerant numeric attribute reads,
+/// compound-member name mapping, and NULLPAD string handling. The
+/// fixtures are synthetic and built on the fly so the test suite has
+/// no dependency on real producer files.
+/// </summary>
+public class S104DatasetReaderHardeningTests
+{
+    /// <summary>
+    /// Grid-georef attributes are spec-allowed to be either F32 or F64.
+    /// The reader must accept both and return identical double values.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Read_AcceptsBothF32AndF64GridAttrs(bool useF64)
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[] { new S104FixtureBuilder.SpecRow { WaterLevelHeight = 1.5f, WaterLevelTrend = 2 } };
+            S104FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: useF64, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S104DatasetReader.Read(file);
+
+            var coverage = Assert.Single(dataset.Coverages);
+            Assert.Equal(50.0, coverage.OriginLatitude, precision: 6);
+            Assert.Equal(-1.0, coverage.OriginLongitude, precision: 6);
+            Assert.Equal(0.01, coverage.SpacingLatitudinal, precision: 6);
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Count attributes (numPointsLatitudinal / numPointsLongitudinal) are
+    /// spec-allowed to be either signed or unsigned. The reader must accept
+    /// both widths.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Read_AcceptsBothSignedAndUnsignedCountAttrs(bool unsigned)
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[] { new S104FixtureBuilder.SpecRow { WaterLevelHeight = 1.5f, WaterLevelTrend = 2 } };
+            S104FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: false, useUnsignedCounts: unsigned);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S104DatasetReader.Read(file);
+
+            var coverage = Assert.Single(dataset.Coverages);
+            Assert.Equal(1, coverage.NumPointsLatitudinal);
+            Assert.Equal(1, coverage.NumPointsLongitudinal);
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// The S-104 Feature Catalogue names compound members
+    /// <c>waterLevelHeight</c> and <c>waterLevelTrend</c>. The reader
+    /// must accept those exact names (no positional fallback required).
+    /// </summary>
+    [Fact]
+    public void Read_AcceptsSpecMemberNames()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[]
+            {
+                new S104FixtureBuilder.SpecRow { WaterLevelHeight = 2.5f, WaterLevelTrend = 1 },
+                new S104FixtureBuilder.SpecRow { WaterLevelHeight = -1.25f, WaterLevelTrend = 3 },
+            };
+            S104FixtureBuilder.WriteFile(path, values, 1, 2, useF64GridAttrs: true, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S104DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(2, coverage.Values.Length);
+            Assert.Equal(2.5f, coverage.Values[0].Height);
+            Assert.Equal((byte)1, coverage.Values[0].Trend);
+            Assert.Equal(-1.25f, coverage.Values[1].Height);
+            Assert.Equal((byte)3, coverage.Values[1].Trend);
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// UKHO production dcf2 files use <c>surfaceHeight</c> and <c>trend</c>
+    /// as the compound member names. The reader must accept that variant.
+    /// </summary>
+    [Fact]
+    public void Read_AcceptsUkhoMemberNames()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[]
+            {
+                new S104FixtureBuilder.UkhoRow { SurfaceHeight = 3.25f, Trend = 2.0f },
+            };
+            S104FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: true, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S104DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Single(coverage.Values);
+            Assert.Equal(3.25f, coverage.Values[0].Height);
+            // UKHO stores trend as f32; the reader rounds to the nearest enum byte.
+            Assert.Equal((byte)2, coverage.Values[0].Trend);
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Existing in-tree synthetic fixtures (and the real NOAA file via
+    /// PureHDF's positional fallback) use the C# names <c>Height</c> and
+    /// <c>Trend</c>. The reader must continue to accept them.
+    /// </summary>
+    [Fact]
+    public void Read_AcceptsLegacyMemberNames()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[]
+            {
+                new S104FixtureBuilder.LegacyRow { Height = 1.0f, Trend = 1 },
+            };
+            S104FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: false, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S104DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Single(coverage.Values);
+            Assert.Equal(1.0f, coverage.Values[0].Height);
+            Assert.Equal((byte)1, coverage.Values[0].Trend);
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Near-UKHO end-to-end fixture combining F64 grid attrs, the
+    /// <c>surfaceHeight</c> / <c>trend</c> compound shape with trend as
+    /// f32, and a fixed-length nullpad timePoint. The reader must open it
+    /// cleanly and round-trip values.
+    /// </summary>
+    [Fact]
+    public void Read_NearUkhoFixture_RoundTripsCleanly()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[]
+            {
+                new S104FixtureBuilder.UkhoRow { SurfaceHeight = 0.75f, Trend = 3.0f },
+                new S104FixtureBuilder.UkhoRow { SurfaceHeight = -0.5f, Trend = 1.0f },
+            };
+            S104FixtureBuilder.WriteFile(path, values, 1, 2,
+                useF64GridAttrs: true,
+                useUnsignedCounts: false,
+                timePoint: "20210401T000000Z");
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S104DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(new DateTime(2021, 4, 1, 0, 0, 0, DateTimeKind.Utc), coverage.TimePoint);
+            Assert.Equal(2, coverage.Values.Length);
+            Assert.Equal(0.75f, coverage.Values[0].Height);
+            Assert.Equal((byte)3, coverage.Values[0].Trend);
+            Assert.Equal(-0.5f, coverage.Values[1].Height);
+            Assert.Equal((byte)1, coverage.Values[1].Trend);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/EncDotNet.S100.Datasets.S111.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/EncDotNet.S100.Datasets.S111.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="PureHDF" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.SkippableFact" />

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/Fixtures/S111FixtureBuilder.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/Fixtures/S111FixtureBuilder.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using PureHDF;
+
+namespace EncDotNet.S100.Datasets.S111.Tests.Fixtures;
+
+internal static class S111FixtureBuilder
+{
+    public struct SpecRow
+    {
+        [H5Name("surfaceCurrentSpeed")] public float SurfaceCurrentSpeed;
+        [H5Name("surfaceCurrentDirection")] public float SurfaceCurrentDirection;
+    }
+
+    public struct LegacyRow
+    {
+        public float Speed;
+        public float Direction;
+    }
+
+    public static string WriteFile<TRow>(
+        string path,
+        TRow[] values,
+        int numLat,
+        int numLon,
+        bool useF64GridAttrs,
+        bool useUnsignedCounts,
+        string timePoint = "20210401T000000Z")
+        where TRow : struct
+    {
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["gridOriginLatitude"] = useF64GridAttrs ? 50.0 : (object)50.0f,
+                ["gridOriginLongitude"] = useF64GridAttrs ? -1.0 : (object)-1.0f,
+                ["gridSpacingLatitudinal"] = useF64GridAttrs ? 0.01 : (object)0.01f,
+                ["gridSpacingLongitudinal"] = useF64GridAttrs ? 0.01 : (object)0.01f,
+                ["numPointsLatitudinal"] = useUnsignedCounts ? (object)(uint)numLat : numLat,
+                ["numPointsLongitudinal"] = useUnsignedCounts ? (object)(uint)numLon : numLon,
+            },
+            ["Group_001"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["timePoint"] = timePoint,
+                },
+                ["values"] = values,
+            },
+        };
+
+        var file = new H5File
+        {
+            Attributes = new()
+            {
+                ["horizontalDatumValue"] = 4326,
+                ["geographicIdentifier"] = "Test",
+                ["issueDate"] = "2021-04-01",
+            },
+            ["SurfaceCurrent"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["dataCodingFormat"] = (byte)2,
+                    ["typeOfCurrentData"] = (byte)6,
+                },
+                ["SurfaceCurrent.01"] = instance,
+            },
+        };
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+
+        file.Write(path, options);
+        return path;
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111DatasetReaderHardeningTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111DatasetReaderHardeningTests.cs
@@ -1,0 +1,126 @@
+using EncDotNet.S100.Datasets.S111.Tests.Fixtures;
+using EncDotNet.S100.Hdf5.PureHdf;
+
+namespace EncDotNet.S100.Datasets.S111.Tests;
+
+public class S111DatasetReaderHardeningTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Read_AcceptsBothF32AndF64GridAttrs(bool useF64)
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[] { new S111FixtureBuilder.SpecRow { SurfaceCurrentSpeed = 1.5f, SurfaceCurrentDirection = 90f } };
+            S111FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: useF64, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S111DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(50.0, coverage.OriginLatitude, precision: 6);
+            Assert.Equal(-1.0, coverage.OriginLongitude, precision: 6);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Read_AcceptsBothSignedAndUnsignedCountAttrs(bool unsigned)
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[] { new S111FixtureBuilder.SpecRow { SurfaceCurrentSpeed = 1f, SurfaceCurrentDirection = 0f } };
+            S111FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: false, useUnsignedCounts: unsigned);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S111DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(1, coverage.NumPointsLatitudinal);
+            Assert.Equal(1, coverage.NumPointsLongitudinal);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_AcceptsSpecMemberNames()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[]
+            {
+                new S111FixtureBuilder.SpecRow { SurfaceCurrentSpeed = 2.5f, SurfaceCurrentDirection = 45f },
+                new S111FixtureBuilder.SpecRow { SurfaceCurrentSpeed = 1.0f, SurfaceCurrentDirection = 180f },
+            };
+            S111FixtureBuilder.WriteFile(path, values, 1, 2, useF64GridAttrs: true, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S111DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(2, coverage.Values.Length);
+            Assert.Equal(2.5f, coverage.Values[0].Speed);
+            Assert.Equal(45f, coverage.Values[0].Direction);
+            Assert.Equal(1.0f, coverage.Values[1].Speed);
+            Assert.Equal(180f, coverage.Values[1].Direction);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_AcceptsLegacyMemberNames()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[] { new S111FixtureBuilder.LegacyRow { Speed = 0.5f, Direction = 270f } };
+            S111FixtureBuilder.WriteFile(path, values, 1, 1, useF64GridAttrs: false, useUnsignedCounts: false);
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S111DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Single(coverage.Values);
+            Assert.Equal(0.5f, coverage.Values[0].Speed);
+            Assert.Equal(270f, coverage.Values[0].Direction);
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Near-UKHO end-to-end fixture combining F64 grid attrs, spec compound
+    /// member names, and the canonical timePoint format. The reader must
+    /// open it cleanly and round-trip values.
+    /// </summary>
+    [Fact]
+    public void Read_NearUkhoFixture_RoundTripsCleanly()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[]
+            {
+                new S111FixtureBuilder.SpecRow { SurfaceCurrentSpeed = 0.75f, SurfaceCurrentDirection = 120f },
+            };
+            S111FixtureBuilder.WriteFile(path, values, 1, 1,
+                useF64GridAttrs: true,
+                useUnsignedCounts: false,
+                timePoint: "20210401T000000Z");
+
+            using var file = PureHdfFile.Open(path);
+            var dataset = S111DatasetReader.Read(file);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(new DateTime(2021, 4, 1, 0, 0, 0, DateTimeKind.Utc), coverage.TimePoint);
+            Assert.Equal(0.75f, coverage.Values[0].Speed);
+            Assert.Equal(120f, coverage.Values[0].Direction);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
+++ b/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="PureHDF" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.SkippableFact" />

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102DatasetReaderHardeningTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102DatasetReaderHardeningTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Hdf5.PureHdf;
+using PureHDF;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Reader-hardening tests for S-102: verifies tolerant numeric attribute
+/// reads accept both F32 and F64 grid attributes (PR-A).
+/// </summary>
+public class S102DatasetReaderHardeningTests
+{
+    /// <summary>
+    /// S-102 spec mandates F32 depth/uncertainty in the BathymetryCoverage
+    /// compound (so the row schema is fixed) but the grid-georef attributes
+    /// can be either F32 or F64 in practice. Verify both succeed.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Read_AcceptsBothF32AndF64GridAttrs(bool useF64)
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var values = new[] { new SpecBathyRow { Depth = 12.5f, Uncertainty = 0.1f } };
+
+            var instance = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["gridOriginLatitude"] = useF64 ? 50.0 : (object)50.0f,
+                    ["gridOriginLongitude"] = useF64 ? -1.0 : (object)-1.0f,
+                    ["gridSpacingLatitudinal"] = useF64 ? 0.01 : (object)0.01f,
+                    ["gridSpacingLongitudinal"] = useF64 ? 0.01 : (object)0.01f,
+                    ["numPointsLatitudinal"] = 1,
+                    ["numPointsLongitudinal"] = 1,
+                },
+                ["Group_001"] = new H5Group { ["values"] = values },
+            };
+
+            var file = new H5File
+            {
+                Attributes = new()
+                {
+                    ["horizontalCRS"] = 4326,
+                },
+                ["BathymetryCoverage"] = new H5Group
+                {
+                    ["BathymetryCoverage.01"] = instance,
+                },
+            };
+
+            var options = new H5WriteOptions(
+                FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+            file.Write(path, options);
+
+            using var hdf = PureHdfFile.Open(path);
+            var dataset = S102DatasetReader.Read(hdf);
+            var coverage = Assert.Single(dataset.Coverages);
+
+            Assert.Equal(50.0, coverage.OriginLatitude, precision: 6);
+            Assert.Equal(-1.0, coverage.OriginLongitude, precision: 6);
+        }
+        finally { File.Delete(path); }
+    }
+
+    private struct SpecBathyRow
+    {
+        [H5Name("depth")] public float Depth;
+        [H5Name("uncertainty")] public float Uncertainty;
+    }
+}


### PR DESCRIPTION
## Summary

Three narrow sub-fixes so `S102DatasetReader`, `S104DatasetReader`, and `S111DatasetReader` tolerate the schema variants the S-100 specs legitimately permit but real producer files actually exercise. Strictly infrastructure — no new features, no portrayal/renderer/pipeline/viewer changes, no PureHDF version bump.

Builds on the diagnosis from `philliphoff/diagnose-s104-s111-ukho-load`.

## Sub-fixes

### 1. Tolerant numeric attribute reads

New methods on `IHdf5Group` (implemented in `PureHdfGroup`):

- `ReadDoubleAttribute(name)` — accepts `H5T_IEEE_F32LE` or `H5T_IEEE_F64LE`, falls back to integer widening when the attribute is stored as an integer.
- `ReadInt64Attribute(name)` — accepts any width of signed or unsigned integer, plus `H5T_ENUM` (treated as unsigned per S-100 §10c).
- `ReadStringAttribute(name)` — now trims trailing `\0` so fixed-length `H5T_STR_NULLPAD` strings (e.g. UKHO `timePoint`) parse via `DateTime.ParseExact`.

Every numeric `ReadAttribute<T>` call in the three readers was replaced with the tolerant helper, harmonising the (previously inconsistent) hard-coded widths between S-104 and S-111.

### 2. Compound-member name mapping by spec field name

New `ReadRawCompoundDataset(name)` API plus `RawCompoundDataset` / `CompoundMemberInfo` / `CompoundMemberKind` in `EncDotNet.S100.Core/Hdf5/`. Reads the dataset as a raw byte buffer, probes the on-disk compound layout, and exposes a `FindMember(params string[] candidates)` lookup that lets the reader project rows by spec member name.

The S-104 and S-111 readers now build their value structs via raw projection:

- **S-104** — height candidates: `waterLevelHeight`, `surfaceHeight`, `Height`; trend candidates: `waterLevelTrend`, `trend`, `Trend`. Trend decoder handles `u8` (spec enum), `i8`, `u16`, **and `f32` (UKHO dcf2)** with `Math.Round` → byte.
- **S-111** — speed candidates: `surfaceCurrentSpeed`, `Speed`; direction candidates: `surfaceCurrentDirection`, `Direction`. Both fields read as F32 or F64.

**S-102** `BathymetryValue` is deliberately *not* migrated — the spec mandates F32/F32 for its compound members and no observed producer deviates. Only S-102's attribute reads were tolerantised.

The public layouts of `WaterLevelValue`, `SurfaceCurrentValue`, and `BathymetryValue` are unchanged (kept stable for downstream consumers).

### 3. NULLPAD string trimming

Folded into `ReadStringAttribute` (above). Variable-length string reads are unaffected.

## Tests

- **All baseline tests pass unchanged.** Full solution `dotnet test -c Release` is green; existing in-tree S-104 / S-111 / pipeline fixtures continue to round-trip.
- **New synthetic-fixture authoring helpers** in `tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/` and `tests/EncDotNet.S100.Datasets.S111.Tests/Fixtures/` use PureHDF's writer API to build minimal `.h5` files on the fly. No real producer file is committed.
- **New hardening tests** for each spec covering:
  - F32 vs F64 grid-georef attrs (S-102 / S-104 / S-111).
  - Signed vs unsigned `numPoints*` (S-104 / S-111).
  - Compound member names — spec, UKHO, legacy variants (S-104 / S-111).
  - `trend` stored as f32 (S-104, the UKHO dcf2 shape).
  - Near-UKHO end-to-end fixture combining F64 grid attrs + spec/UKHO compound shape + canonical timePoint (S-104 / S-111).

`PureHDF` was added as a test-project package reference (the runtime dep was already present transitively).

## Verification gates

| Gate | Status |
| --- | --- |
| `dotnet build` | clean |
| `dotnet test -c Release` (full suite) | all green; new tests included |

## Manual smoke (per the spec — UKHO files are not in the repo)

The implementer cannot run these locally without UKHO files. Expected post-PR state, per the in-spec analysis:

- `111UK_…_SolentAndAppr_dcf2.h5` — should now open without error (was failing on F32 attrs + `surfaceCurrentSpeed` member name + NUL-padded timePoint; all three are fixed here).
- `104UK_…_SolentAndAppr_dcf2.hdf5` — F32/compound/string issues resolved, but the file is genuinely missing required `gridOriginLatitude` etc. — expected failure mode is now `cannot find attribute 'gridOriginLatitude'` (a real conformance error to be surfaced more clearly by PR-B).
- `104UK_…_dcf8.hdf5` — continues to throw `NotSupportedException: Data coding format 8 is not yet supported` (PR-C scope, not regressed).

## Out of scope

Explicitly deferred to follow-up PRs:

- **PR-B**: friendlier error messages on non-conforming files.
- **PR-C**: S-104 dcf8 (time-series-at-stations) support.
- New attributes surfaced for portrayal (`verticalDatum`, `waterLevelTrendThreshold`, `pickPriorityType`, …).
- `Group_F` validation.
- Viewer-side error dialogs.

## Notes

- **Branch name quirk**: the workspace `rename_branch` tool auto-prefixed the branch with the user namespace, producing `philliphoff/philliphoff-hdf5-reader-hardening` instead of the requested `philliphoff/hdf5-reader-hardening`. Per the repo rules I avoided raw `git branch -m`; happy to rename via GitHub UI on merge if preferred.
- Diagnosis branch reference: `philliphoff/diagnose-s104-s111-ukho-load`.