### PR TITLE
PR-B: actionable HDF5 reader errors (schema / not-supported)

### DIFF
--- a/src/EncDotNet.S100.Core/Hdf5/ExceptionMessageFormatter.cs
+++ b/src/EncDotNet.S100.Core/Hdf5/ExceptionMessageFormatter.cs
@@ -1,0 +1,55 @@
+namespace EncDotNet.S100.Hdf5;
+
+/// <summary>
+/// Shared message-text helpers used by
+/// <see cref="S100DatasetSchemaException"/>,
+/// <see cref="S100DatasetNotSupportedException"/>, and dataset readers
+/// that need to construct a "not yet supported" message with the
+/// canonical four-piece shape (product, file, feature, spec ref).
+/// </summary>
+public static class ExceptionMessageFormatter
+{
+    /// <summary>
+    /// Formats the standard "missing required attribute / group" message.
+    /// </summary>
+    public static string FormatSchema(
+        string product,
+        string? file,
+        string groupPath,
+        string? attributeOrDataset,
+        string? specReference)
+    {
+        string subject = string.IsNullOrEmpty(file)
+            ? $"{product} dataset"
+            : $"{product} dataset {file}";
+
+        string missing = attributeOrDataset is null
+            ? $"is missing required group '{groupPath}'"
+            : $"is missing required attribute '{attributeOrDataset}' on group '{groupPath}'";
+
+        string cite = specReference is null ? string.Empty : $" ({specReference})";
+
+        return $"{subject} {missing}{cite}. The file appears to be non-conforming.";
+    }
+
+    /// <summary>
+    /// Formats a "not yet supported" message with the canonical
+    /// four-piece shape used across S-100 readers.
+    /// </summary>
+    public static string FormatNotSupported(
+        string product,
+        string? file,
+        string feature,
+        string? specReference,
+        string? trailingHint)
+    {
+        string subject = string.IsNullOrEmpty(file)
+            ? $"{product} dataset"
+            : $"{product} dataset {file}";
+
+        string cite = specReference is null ? string.Empty : $" ({specReference})";
+        string hint = string.IsNullOrEmpty(trailingHint) ? string.Empty : $" {trailingHint}";
+
+        return $"{subject} uses {feature}, which is not yet supported{cite}.{hint}";
+    }
+}

--- a/src/EncDotNet.S100.Core/Hdf5/Hdf5RequiredAttributeExtensions.cs
+++ b/src/EncDotNet.S100.Core/Hdf5/Hdf5RequiredAttributeExtensions.cs
@@ -1,0 +1,123 @@
+namespace EncDotNet.S100.Hdf5;
+
+/// <summary>
+/// Extension methods that translate PureHDF's
+/// <c>Could not find attribute '{name}'</c> failure (and equivalent
+/// "missing" exceptions from other backends) into typed
+/// <see cref="S100DatasetSchemaException"/>s carrying spec context.
+/// Reader implementations call these for attributes that are required
+/// by the spec; optional attributes should still be guarded with
+/// <see cref="IHdf5Group.AttributeExists(string)"/>.
+/// </summary>
+public static class Hdf5RequiredAttributeExtensions
+{
+    /// <summary>
+    /// Reads a required floating-point attribute from
+    /// <paramref name="group"/>. Throws
+    /// <see cref="S100DatasetSchemaException"/> if the attribute is
+    /// missing, preserving the underlying exception as
+    /// <see cref="Exception.InnerException"/>.
+    /// </summary>
+    public static double ReadRequiredDoubleAttribute(
+        this IHdf5Group group,
+        string name,
+        string product,
+        string? file,
+        string groupPath,
+        string? specReference)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        try
+        {
+            return group.ReadDoubleAttribute(name);
+        }
+        catch (Exception ex) when (LooksLikeMissingAttribute(ex, name))
+        {
+            throw MakeSchemaException(product, file, groupPath, name, specReference, ex);
+        }
+    }
+
+    /// <summary>
+    /// Reads a required fixed-point attribute from
+    /// <paramref name="group"/>. Throws
+    /// <see cref="S100DatasetSchemaException"/> if the attribute is
+    /// missing.
+    /// </summary>
+    public static long ReadRequiredInt64Attribute(
+        this IHdf5Group group,
+        string name,
+        string product,
+        string? file,
+        string groupPath,
+        string? specReference)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        try
+        {
+            return group.ReadInt64Attribute(name);
+        }
+        catch (Exception ex) when (LooksLikeMissingAttribute(ex, name))
+        {
+            throw MakeSchemaException(product, file, groupPath, name, specReference, ex);
+        }
+    }
+
+    /// <summary>
+    /// Reads a required string attribute from <paramref name="group"/>.
+    /// Throws <see cref="S100DatasetSchemaException"/> if the attribute
+    /// is missing.
+    /// </summary>
+    public static string ReadRequiredStringAttribute(
+        this IHdf5Group group,
+        string name,
+        string product,
+        string? file,
+        string groupPath,
+        string? specReference)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        try
+        {
+            return group.ReadStringAttribute(name);
+        }
+        catch (Exception ex) when (LooksLikeMissingAttribute(ex, name))
+        {
+            throw MakeSchemaException(product, file, groupPath, name, specReference, ex);
+        }
+    }
+
+    /// <summary>
+    /// Pattern-matches the textual signature of a "missing HDF5
+    /// attribute" failure. We don't depend on a specific PureHDF
+    /// exception subclass (the backend is plug-replaceable), so we
+    /// match the message defensively. The signature observed in
+    /// PureHDF is <c>Could not find attribute '{name}'</c>; we require
+    /// both the <c>Could not find</c> prefix and the attribute name
+    /// itself to appear in the message so unrelated failures do not
+    /// get re-skinned as schema exceptions.
+    /// </summary>
+    internal static bool LooksLikeMissingAttribute(Exception ex, string name)
+    {
+        var message = ex.Message;
+        if (string.IsNullOrEmpty(message))
+            return false;
+
+        bool prefixMatches =
+            message.Contains("Could not find", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("not found", StringComparison.OrdinalIgnoreCase);
+
+        return prefixMatches && message.Contains(name, StringComparison.Ordinal);
+    }
+
+    private static S100DatasetSchemaException MakeSchemaException(
+        string product,
+        string? file,
+        string groupPath,
+        string name,
+        string? specReference,
+        Exception inner)
+    {
+        var message = ExceptionMessageFormatter.FormatSchema(product, file, groupPath, name, specReference);
+        return new S100DatasetSchemaException(product, file, groupPath, name, specReference, message, inner);
+    }
+}

--- a/src/EncDotNet.S100.Core/Hdf5/S100DatasetNotSupportedException.cs
+++ b/src/EncDotNet.S100.Core/Hdf5/S100DatasetNotSupportedException.cs
@@ -1,0 +1,76 @@
+namespace EncDotNet.S100.Hdf5;
+
+/// <summary>
+/// Thrown when an S-100 dataset uses an optional spec feature
+/// (data-coding format, CRS variant, attribute encoding, etc.) that
+/// the current reader does not yet implement. Distinct from
+/// <see cref="S100DatasetSchemaException"/>: the file is conforming;
+/// it just exercises a region of the spec we haven't built yet.
+/// </summary>
+public sealed class S100DatasetNotSupportedException : Exception
+{
+    /// <summary>Product code, e.g. <c>"S-104"</c>.</summary>
+    public string Product { get; }
+
+    /// <summary>
+    /// File name (without path) the failure relates to, or <c>null</c>
+    /// when the dataset was opened from a stream and the caller hasn't
+    /// yet attached the source name (see <see cref="WithFile"/>).
+    /// </summary>
+    public string? File { get; }
+
+    /// <summary>
+    /// Human-readable description of the unsupported feature, e.g.
+    /// <c>"data coding format 8 (time series at fixed stations)"</c>.
+    /// </summary>
+    public string Feature { get; }
+
+    /// <summary>
+    /// Citation into the relevant S-100 spec, e.g.
+    /// <c>"S-100 Part 10c §10.2.1"</c>. <c>null</c> when no
+    /// authoritative section number is known.
+    /// </summary>
+    public string? SpecReference { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="S100DatasetNotSupportedException"/>.
+    /// </summary>
+    public S100DatasetNotSupportedException(
+        string product,
+        string? file,
+        string feature,
+        string? specReference,
+        string message,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        ArgumentNullException.ThrowIfNull(product);
+        ArgumentNullException.ThrowIfNull(feature);
+        ArgumentNullException.ThrowIfNull(message);
+
+        Product = product;
+        File = file;
+        Feature = feature;
+        SpecReference = specReference;
+    }
+
+    /// <summary>
+    /// Returns a copy of this exception with <see cref="File"/> set to
+    /// <paramref name="file"/>. Used by dataset processors to attach the
+    /// source file name to an exception thrown by a reader that only had
+    /// a stream.
+    /// </summary>
+    public S100DatasetNotSupportedException WithFile(string? file)
+    {
+        if (string.Equals(File, file, StringComparison.Ordinal))
+            return this;
+
+        return new S100DatasetNotSupportedException(
+            Product,
+            file,
+            Feature,
+            SpecReference,
+            ExceptionMessageFormatter.FormatNotSupported(Product, file, Feature, SpecReference, trailingHint: null),
+            InnerException);
+    }
+}

--- a/src/EncDotNet.S100.Core/Hdf5/S100DatasetSchemaException.cs
+++ b/src/EncDotNet.S100.Core/Hdf5/S100DatasetSchemaException.cs
@@ -1,0 +1,84 @@
+namespace EncDotNet.S100.Hdf5;
+
+/// <summary>
+/// Thrown when a required HDF5 attribute, dataset, or group is missing
+/// from a location that the S-100 spec requires it on, or is present
+/// but malformed in a way that cannot be reasonably tolerated. The
+/// exception carries the product, file (when known), the HDF5 group
+/// path that was being read, the offending attribute/dataset name (when
+/// applicable), and a citation into the relevant spec section so that
+/// callers can produce actionable diagnostics.
+/// </summary>
+public sealed class S100DatasetSchemaException : Exception
+{
+    /// <summary>Product code, e.g. <c>"S-104"</c>.</summary>
+    public string Product { get; }
+
+    /// <summary>
+    /// File name (without path) the failure relates to, or <c>null</c>
+    /// when the dataset was opened from a stream and the caller hasn't
+    /// yet attached the source name (see <see cref="WithFile"/>).
+    /// </summary>
+    public string? File { get; }
+
+    /// <summary>HDF5 group path, e.g. <c>"/WaterLevel/WaterLevel.03"</c>.</summary>
+    public string GroupPath { get; }
+
+    /// <summary>
+    /// Name of the missing or malformed attribute or dataset; <c>null</c>
+    /// when the failure is the absence of the group itself.
+    /// </summary>
+    public string? AttributeOrDataset { get; }
+
+    /// <summary>
+    /// Citation into the relevant S-100 spec, e.g.
+    /// <c>"S-100 Part 10c §10.2.1.2"</c>. <c>null</c> when no
+    /// authoritative section number is known.
+    /// </summary>
+    public string? SpecReference { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="S100DatasetSchemaException"/>.
+    /// </summary>
+    public S100DatasetSchemaException(
+        string product,
+        string? file,
+        string groupPath,
+        string? attributeOrDataset,
+        string? specReference,
+        string message,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        ArgumentNullException.ThrowIfNull(product);
+        ArgumentNullException.ThrowIfNull(groupPath);
+        ArgumentNullException.ThrowIfNull(message);
+
+        Product = product;
+        File = file;
+        GroupPath = groupPath;
+        AttributeOrDataset = attributeOrDataset;
+        SpecReference = specReference;
+    }
+
+    /// <summary>
+    /// Returns a copy of this exception with <see cref="File"/> set to
+    /// <paramref name="file"/>. Used by dataset processors to attach the
+    /// source file name to an exception thrown by a reader that only had
+    /// a stream.
+    /// </summary>
+    public S100DatasetSchemaException WithFile(string? file)
+    {
+        if (string.Equals(File, file, StringComparison.Ordinal))
+            return this;
+
+        return new S100DatasetSchemaException(
+            Product,
+            file,
+            GroupPath,
+            AttributeOrDataset,
+            SpecReference,
+            ExceptionMessageFormatter.FormatSchema(Product, file, GroupPath, AttributeOrDataset, SpecReference),
+            InnerException);
+    }
+}

--- a/src/EncDotNet.S100.Core/README.md
+++ b/src/EncDotNet.S100.Core/README.md
@@ -8,6 +8,7 @@ This library provides the foundational types used across the EncDotNet.S100 libr
 
 - **Asset sources** — `IAssetSource` abstraction for reading files from directories (`FileSystemAssetSource`) or ZIP archives (`ZipAssetSource`).
 - **HDF5 abstractions** — `IHdf5File` and `IHdf5Group` interfaces for reading HDF5 data without binding to a specific HDF5 library.
+- **HDF5 reader exceptions** — `S100DatasetSchemaException` (a required attribute/group is missing or malformed) and `S100DatasetNotSupportedException` (the file uses an optional spec feature the reader doesn't yet implement). Both carry product, file, group path, spec reference, and a `.WithFile(...)` helper used by processor layers to attach the source file name. `Hdf5RequiredAttributeExtensions` provides `ReadRequiredDoubleAttribute` / `ReadRequiredInt64Attribute` / `ReadRequiredStringAttribute` that translate backend "missing attribute" failures into these typed exceptions.
 - **Lua scripting abstractions** — `ILuaEngine` and `ILuaContext` interfaces for running sandboxed Lua portrayal scripts, plus the `S100LuaHost` host API.
 - **Coverage pipeline** — `ICoverageSource`, `ICoverageRenderer<T>`, `CoveragePipeline`, and supporting types (`GridGeoreferencer`, `CoverageColorScheme`, `StyledCoverageLayer`) for rendering gridded data.
 - **Vector pipeline** — `IVectorSource`, `IVectorPortrayalCatalogue`, `VectorPipeline`, and the `DrawingInstruction` hierarchy (`AreaInstruction`, `LineInstruction`, `PointInstruction`, `TextInstruction`) modelled directly on the S-100 Part 9 display list.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
@@ -69,7 +70,18 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
         using (datasetStream)
         using (var hdf5 = PureHdfFile.Open(datasetStream))
         {
-            _dataset = S102DatasetReader.Read(hdf5);
+            try
+            {
+                _dataset = S102DatasetReader.Read(hdf5);
+            }
+            catch (S100DatasetSchemaException ex) when (ex.File is null)
+            {
+                throw ex.WithFile(_fileName);
+            }
+            catch (S100DatasetNotSupportedException ex) when (ex.File is null)
+            {
+                throw ex.WithFile(_fileName);
+            }
         }
         _source = new S102CoverageSource(_dataset);
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
@@ -62,7 +63,18 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         using (datasetStream)
         using (var hdf5 = PureHdfFile.Open(datasetStream))
         {
-            _dataset = S104DatasetReader.Read(hdf5);
+            try
+            {
+                _dataset = S104DatasetReader.Read(hdf5);
+            }
+            catch (S100DatasetSchemaException ex) when (ex.File is null)
+            {
+                throw ex.WithFile(_fileName);
+            }
+            catch (S100DatasetNotSupportedException ex) when (ex.File is null)
+            {
+                throw ex.WithFile(_fileName);
+            }
         }
         _source = new S104CoverageSource(_dataset);
         _catalogue = new S104PortrayalCatalogue();

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
@@ -68,7 +69,18 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         using (datasetStream)
         using (var hdf5 = PureHdfFile.Open(datasetStream))
         {
-            _dataset = S111DatasetReader.Read(hdf5);
+            try
+            {
+                _dataset = S111DatasetReader.Read(hdf5);
+            }
+            catch (S100DatasetSchemaException ex) when (ex.File is null)
+            {
+                throw ex.WithFile(_fileName);
+            }
+            catch (S100DatasetNotSupportedException ex) when (ex.File is null)
+            {
+                throw ex.WithFile(_fileName);
+            }
         }
         _source = new S111CoverageSource(_dataset);
 

--- a/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
@@ -64,20 +64,24 @@ public static class S102DatasetReader
                 continue;
 
             var instance = bcGroup.OpenGroup(instanceName);
-            coverages.Add(ReadCoverage(instance));
+            coverages.Add(ReadCoverage(instance, $"/BathymetryCoverage/{instanceName}"));
         }
 
         return coverages;
     }
 
-    private static BathymetryCoverage ReadCoverage(IHdf5Group instance)
+    private static BathymetryCoverage ReadCoverage(IHdf5Group instance, string instancePath)
     {
-        double originLat = instance.ReadDoubleAttribute("gridOriginLatitude");
-        double originLon = instance.ReadDoubleAttribute("gridOriginLongitude");
-        double spacingLat = instance.ReadDoubleAttribute("gridSpacingLatitudinal");
-        double spacingLon = instance.ReadDoubleAttribute("gridSpacingLongitudinal");
-        int numLat = (int)instance.ReadInt64Attribute("numPointsLatitudinal");
-        int numLon = (int)instance.ReadInt64Attribute("numPointsLongitudinal");
+        // S-102 Edition 3.0.0 §12.6 — BathymetryCoverage.NN groups carry
+        // the mandatory grid-georef attributes inherited from the S-100
+        // gridded-coverage profile (S-100 Part 10c §10.2.1.2).
+        const string Spec = "S-100 Part 10c §10.2.1.2";
+        double originLat = instance.ReadRequiredDoubleAttribute("gridOriginLatitude", "S-102", null, instancePath, Spec);
+        double originLon = instance.ReadRequiredDoubleAttribute("gridOriginLongitude", "S-102", null, instancePath, Spec);
+        double spacingLat = instance.ReadRequiredDoubleAttribute("gridSpacingLatitudinal", "S-102", null, instancePath, Spec);
+        double spacingLon = instance.ReadRequiredDoubleAttribute("gridSpacingLongitudinal", "S-102", null, instancePath, Spec);
+        int numLat = (int)instance.ReadRequiredInt64Attribute("numPointsLatitudinal", "S-102", null, instancePath, Spec);
+        int numLon = (int)instance.ReadRequiredInt64Attribute("numPointsLongitudinal", "S-102", null, instancePath, Spec);
 
         string? startSequence = instance.AttributeExists("startSequence")
             ? instance.ReadStringAttribute("startSequence")

--- a/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
@@ -43,9 +43,17 @@ public static class S104DatasetReader
             : null;
 
         var wlGroup = root.OpenGroup("WaterLevel");
+        const string WaterLevelPath = "/WaterLevel";
 
+        // S-104 Edition 2.0.0 §10.2 — every WaterLevel container carries
+        // a dataCodingFormat enum that selects the per-instance layout.
         int dataCodingFormat = wlGroup.AttributeExists("dataCodingFormat")
-            ? (int)wlGroup.ReadInt64Attribute("dataCodingFormat")
+            ? (int)wlGroup.ReadRequiredInt64Attribute(
+                "dataCodingFormat",
+                product: "S-104",
+                file: null,
+                groupPath: WaterLevelPath,
+                specReference: "S-100 Part 10c §10.2.1")
             : 2;
 
         string? methodWaterLevelProduct = wlGroup.AttributeExists("methodWaterLevelProduct")
@@ -71,8 +79,15 @@ public static class S104DatasetReader
     {
         if (dataCodingFormat != 2)
         {
-            throw new NotSupportedException(
-                $"Data coding format {dataCodingFormat} is not yet supported. Only format 2 (regular grid) is implemented.");
+            string feature = $"data coding format {dataCodingFormat} ({DataCodingFormatName(dataCodingFormat)})";
+            throw new S100DatasetNotSupportedException(
+                product: "S-104",
+                file: null,
+                feature: feature,
+                specReference: "S-100 Part 10c §10.2.1",
+                message: ExceptionMessageFormatter.FormatNotSupported(
+                    "S-104", null, feature, "S-100 Part 10c §10.2.1",
+                    "Only format 2 (regular grid) is currently implemented."));
         }
 
         var coverages = new List<WaterLevelCoverage>();
@@ -83,20 +98,42 @@ public static class S104DatasetReader
                 continue;
 
             var instance = wlGroup.OpenGroup(instanceName);
-            ReadInstance(instance, coverages);
+            ReadInstance(instance, coverages, $"/WaterLevel/{instanceName}");
         }
 
         return coverages;
     }
 
-    private static void ReadInstance(IHdf5Group instance, List<WaterLevelCoverage> coverages)
+    /// <summary>
+    /// Human-readable label for the S-100 data coding format enumeration
+    /// (S-100 Part 10c §10.2.1 Table). Used only in error messages, not
+    /// in dispatch logic.
+    /// </summary>
+    private static string DataCodingFormatName(int dcf) => dcf switch
     {
-        double originLat = instance.ReadDoubleAttribute("gridOriginLatitude");
-        double originLon = instance.ReadDoubleAttribute("gridOriginLongitude");
-        double spacingLat = instance.ReadDoubleAttribute("gridSpacingLatitudinal");
-        double spacingLon = instance.ReadDoubleAttribute("gridSpacingLongitudinal");
-        int numLat = (int)instance.ReadInt64Attribute("numPointsLatitudinal");
-        int numLon = (int)instance.ReadInt64Attribute("numPointsLongitudinal");
+        1 => "time series at fixed stations (irregular)",
+        2 => "regularly-gridded arrays",
+        3 => "ungeorectified grid",
+        4 => "moving platform",
+        5 => "irregular grid",
+        6 => "variable cell size",
+        7 => "TIN",
+        8 => "time series at fixed stations",
+        9 => "stationwise arrays",
+        _ => "unknown",
+    };
+
+    private static void ReadInstance(IHdf5Group instance, List<WaterLevelCoverage> coverages, string instancePath)
+    {
+        // S-100 Part 10c §10.2.1.2 — the grid-georef attributes are
+        // required on every dcf2 WaterLevel.NN instance group.
+        const string Spec = "S-100 Part 10c §10.2.1.2";
+        double originLat = instance.ReadRequiredDoubleAttribute("gridOriginLatitude", "S-104", null, instancePath, Spec);
+        double originLon = instance.ReadRequiredDoubleAttribute("gridOriginLongitude", "S-104", null, instancePath, Spec);
+        double spacingLat = instance.ReadRequiredDoubleAttribute("gridSpacingLatitudinal", "S-104", null, instancePath, Spec);
+        double spacingLon = instance.ReadRequiredDoubleAttribute("gridSpacingLongitudinal", "S-104", null, instancePath, Spec);
+        int numLat = (int)instance.ReadRequiredInt64Attribute("numPointsLatitudinal", "S-104", null, instancePath, Spec);
+        int numLon = (int)instance.ReadRequiredInt64Attribute("numPointsLongitudinal", "S-104", null, instancePath, Spec);
 
         string? startSequence = instance.AttributeExists("startSequence")
             ? instance.ReadStringAttribute("startSequence")

--- a/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
@@ -47,9 +47,18 @@ public static class S111DatasetReader
             : null;
 
         var scGroup = root.OpenGroup("SurfaceCurrent");
+        const string SurfaceCurrentPath = "/SurfaceCurrent";
 
+        // S-111 Edition 2.0.0 §12.2 — every SurfaceCurrent container
+        // carries a dataCodingFormat enum that selects the per-instance
+        // layout.
         int dataCodingFormat = scGroup.AttributeExists("dataCodingFormat")
-            ? (int)scGroup.ReadInt64Attribute("dataCodingFormat")
+            ? (int)scGroup.ReadRequiredInt64Attribute(
+                "dataCodingFormat",
+                product: "S-111",
+                file: null,
+                groupPath: SurfaceCurrentPath,
+                specReference: "S-100 Part 10c §10.2.1")
             : 2;
 
         int? typeOfCurrentData = scGroup.AttributeExists("typeOfCurrentData")
@@ -76,8 +85,15 @@ public static class S111DatasetReader
     {
         if (dataCodingFormat != 2)
         {
-            throw new NotSupportedException(
-                $"Data coding format {dataCodingFormat} is not yet supported. Only format 2 (regular grid) is implemented.");
+            string feature = $"data coding format {dataCodingFormat} ({DataCodingFormatName(dataCodingFormat)})";
+            throw new S100DatasetNotSupportedException(
+                product: "S-111",
+                file: null,
+                feature: feature,
+                specReference: "S-100 Part 10c §10.2.1",
+                message: ExceptionMessageFormatter.FormatNotSupported(
+                    "S-111", null, feature, "S-100 Part 10c §10.2.1",
+                    "Only format 2 (regular grid) is currently implemented."));
         }
 
         var coverages = new List<SurfaceCurrentCoverage>();
@@ -88,20 +104,42 @@ public static class S111DatasetReader
                 continue;
 
             var instance = scGroup.OpenGroup(instanceName);
-            ReadInstance(instance, coverages);
+            ReadInstance(instance, coverages, $"/SurfaceCurrent/{instanceName}");
         }
 
         return coverages;
     }
 
-    private static void ReadInstance(IHdf5Group instance, List<SurfaceCurrentCoverage> coverages)
+    /// <summary>
+    /// Human-readable label for the S-100 data coding format enumeration
+    /// (S-100 Part 10c §10.2.1 Table). Used only in error messages, not
+    /// in dispatch logic.
+    /// </summary>
+    private static string DataCodingFormatName(int dcf) => dcf switch
     {
-        double originLat = instance.ReadDoubleAttribute("gridOriginLatitude");
-        double originLon = instance.ReadDoubleAttribute("gridOriginLongitude");
-        double spacingLat = instance.ReadDoubleAttribute("gridSpacingLatitudinal");
-        double spacingLon = instance.ReadDoubleAttribute("gridSpacingLongitudinal");
-        int numLat = (int)instance.ReadInt64Attribute("numPointsLatitudinal");
-        int numLon = (int)instance.ReadInt64Attribute("numPointsLongitudinal");
+        1 => "time series at fixed stations (irregular)",
+        2 => "regularly-gridded arrays",
+        3 => "ungeorectified grid",
+        4 => "moving platform",
+        5 => "irregular grid",
+        6 => "variable cell size",
+        7 => "TIN",
+        8 => "time series at fixed stations",
+        9 => "stationwise arrays",
+        _ => "unknown",
+    };
+
+    private static void ReadInstance(IHdf5Group instance, List<SurfaceCurrentCoverage> coverages, string instancePath)
+    {
+        // S-100 Part 10c §10.2.1.2 — the grid-georef attributes are
+        // required on every dcf2 SurfaceCurrent.NN instance group.
+        const string Spec = "S-100 Part 10c §10.2.1.2";
+        double originLat = instance.ReadRequiredDoubleAttribute("gridOriginLatitude", "S-111", null, instancePath, Spec);
+        double originLon = instance.ReadRequiredDoubleAttribute("gridOriginLongitude", "S-111", null, instancePath, Spec);
+        double spacingLat = instance.ReadRequiredDoubleAttribute("gridSpacingLatitudinal", "S-111", null, instancePath, Spec);
+        double spacingLon = instance.ReadRequiredDoubleAttribute("gridSpacingLongitudinal", "S-111", null, instancePath, Spec);
+        int numLat = (int)instance.ReadRequiredInt64Attribute("numPointsLatitudinal", "S-111", null, instancePath, Spec);
+        int numLon = (int)instance.ReadRequiredInt64Attribute("numPointsLongitudinal", "S-111", null, instancePath, Spec);
 
         string? startSequence = instance.AttributeExists("startSequence")
             ? instance.ReadStringAttribute("startSequence")

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/S104DatasetReaderErrorTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/S104DatasetReaderErrorTests.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using EncDotNet.S100.Datasets.S104.Tests.Fixtures;
+using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Hdf5.PureHdf;
+using PureHDF;
+
+namespace EncDotNet.S100.Datasets.S104.Tests;
+
+/// <summary>
+/// PR-B: verifies that the S-104 reader translates HDF5-backend
+/// "missing attribute" failures and the data-coding-format guard
+/// into typed, contextual exceptions.
+/// </summary>
+public class S104DatasetReaderErrorTests
+{
+    [Fact]
+    public void Read_MissingGridOriginLatitude_ThrowsSchemaExceptionWithContext()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            WriteFileMissingAttribute(path, omit: "gridOriginLatitude");
+
+            using var file = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetSchemaException>(() => S104DatasetReader.Read(file));
+
+            Assert.Equal("S-104", ex.Product);
+            Assert.EndsWith("/WaterLevel/WaterLevel.01", ex.GroupPath, StringComparison.Ordinal);
+            Assert.Equal("gridOriginLatitude", ex.AttributeOrDataset);
+            Assert.NotNull(ex.SpecReference);
+            Assert.NotNull(ex.InnerException);
+
+            Assert.Contains("S-104", ex.Message);
+            Assert.Contains("gridOriginLatitude", ex.Message);
+            Assert.Contains("/WaterLevel/WaterLevel.01", ex.Message);
+            Assert.Contains(ex.SpecReference!, ex.Message);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_UnsupportedDataCodingFormat_ThrowsNotSupportedException()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            WriteFileWithDcf(path, dcf: 8);
+
+            using var file = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetNotSupportedException>(() => S104DatasetReader.Read(file));
+
+            Assert.Equal("S-104", ex.Product);
+            Assert.Contains("8", ex.Feature);
+            Assert.Contains("time series at fixed stations", ex.Feature);
+            Assert.Contains("not yet supported", ex.Message);
+        }
+        finally { File.Delete(path); }
+    }
+
+    private static void WriteFileMissingAttribute(string path, string omit)
+    {
+        var attrs = new Dictionary<string, object>
+        {
+            ["gridOriginLatitude"] = 50.0,
+            ["gridOriginLongitude"] = -1.0,
+            ["gridSpacingLatitudinal"] = 0.01,
+            ["gridSpacingLongitudinal"] = 0.01,
+            ["numPointsLatitudinal"] = 1,
+            ["numPointsLongitudinal"] = 1,
+        };
+        attrs.Remove(omit);
+
+        var instance = new H5Group
+        {
+            Attributes = attrs,
+            ["Group_001"] = new H5Group
+            {
+                Attributes = new() { ["timePoint"] = "20210401T000000Z" },
+                ["values"] = new[] { new S104FixtureBuilder.SpecRow { WaterLevelHeight = 1.5f, WaterLevelTrend = 2 } },
+            },
+        };
+
+        var file = new H5File
+        {
+            Attributes = new() { ["horizontalCRS"] = 4326 },
+            ["WaterLevel"] = new H5Group
+            {
+                Attributes = new() { ["dataCodingFormat"] = (byte)2 },
+                ["WaterLevel.01"] = instance,
+            },
+        };
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+        file.Write(path, options);
+    }
+
+    private static void WriteFileWithDcf(string path, byte dcf)
+    {
+        var file = new H5File
+        {
+            Attributes = new() { ["horizontalCRS"] = 4326 },
+            ["WaterLevel"] = new H5Group
+            {
+                Attributes = new() { ["dataCodingFormat"] = dcf },
+            },
+        };
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+        file.Write(path, options);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111DatasetReaderErrorTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111DatasetReaderErrorTests.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+using EncDotNet.S100.Datasets.S111.Tests.Fixtures;
+using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Hdf5.PureHdf;
+using PureHDF;
+
+namespace EncDotNet.S100.Datasets.S111.Tests;
+
+/// <summary>
+/// PR-B: verifies that the S-111 reader translates HDF5-backend
+/// "missing attribute" failures and the data-coding-format guard
+/// into typed, contextual exceptions.
+/// </summary>
+public class S111DatasetReaderErrorTests
+{
+    [Fact]
+    public void Read_MissingGridOriginLatitude_ThrowsSchemaExceptionWithContext()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var attrs = new Dictionary<string, object>
+            {
+                ["gridOriginLongitude"] = -1.0,
+                ["gridSpacingLatitudinal"] = 0.01,
+                ["gridSpacingLongitudinal"] = 0.01,
+                ["numPointsLatitudinal"] = 1,
+                ["numPointsLongitudinal"] = 1,
+            };
+
+            var instance = new H5Group
+            {
+                Attributes = attrs,
+                ["Group_001"] = new H5Group
+                {
+                    Attributes = new() { ["timePoint"] = "20210401T000000Z" },
+                    ["values"] = new[] { new S111FixtureBuilder.SpecRow { SurfaceCurrentSpeed = 1.0f, SurfaceCurrentDirection = 45f } },
+                },
+            };
+
+            var file = new H5File
+            {
+                Attributes = new() { ["horizontalDatumValue"] = 4326 },
+                ["SurfaceCurrent"] = new H5Group
+                {
+                    Attributes = new() { ["dataCodingFormat"] = (byte)2 },
+                    ["SurfaceCurrent.01"] = instance,
+                },
+            };
+            var options = new H5WriteOptions(
+                FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+            file.Write(path, options);
+
+            using var f = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetSchemaException>(() => S111DatasetReader.Read(f));
+
+            Assert.Equal("S-111", ex.Product);
+            Assert.EndsWith("/SurfaceCurrent/SurfaceCurrent.01", ex.GroupPath, StringComparison.Ordinal);
+            Assert.Equal("gridOriginLatitude", ex.AttributeOrDataset);
+            Assert.NotNull(ex.InnerException);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_UnsupportedDataCodingFormat_ThrowsNotSupportedException()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var file = new H5File
+            {
+                Attributes = new() { ["horizontalDatumValue"] = 4326 },
+                ["SurfaceCurrent"] = new H5Group
+                {
+                    Attributes = new() { ["dataCodingFormat"] = (byte)7 },
+                },
+            };
+            var options = new H5WriteOptions(
+                FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+            file.Write(path, options);
+
+            using var f = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetNotSupportedException>(() => S111DatasetReader.Read(f));
+
+            Assert.Equal("S-111", ex.Product);
+            Assert.Contains("7", ex.Feature);
+            Assert.Contains("not yet supported", ex.Message);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/Hdf5DatasetExceptionWithFileTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/Hdf5DatasetExceptionWithFileTests.cs
@@ -1,0 +1,77 @@
+using EncDotNet.S100.Hdf5;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// PR-B: verifies the .WithFile(...) processor-layer attachment used
+/// by S-102/S-104/S-111 dataset processors when the underlying reader
+/// threw a typed exception with File == null (because the reader only
+/// had a Stream). Processors catch and rethrow via .WithFile() to
+/// attach the source file name.
+/// </summary>
+public class Hdf5DatasetExceptionWithFileTests
+{
+    [Fact]
+    public void SchemaException_WithFile_AttachesFileNameAndPreservesContext()
+    {
+        var inner = new InvalidOperationException("Could not find attribute 'gridOriginLatitude'.");
+        var original = new S100DatasetSchemaException(
+            product: "S-104",
+            file: null,
+            groupPath: "/WaterLevel/WaterLevel.01",
+            attributeOrDataset: "gridOriginLatitude",
+            specReference: "S-100 Part 10c §10.2.1.2",
+            message: "S-104 dataset is missing required attribute 'gridOriginLatitude' on group '/WaterLevel/WaterLevel.01' (S-100 Part 10c §10.2.1.2). The file appears to be non-conforming.",
+            innerException: inner);
+
+        Assert.Null(original.File);
+
+        var wrapped = original.WithFile("104UK_TEST.h5");
+
+        Assert.Equal("104UK_TEST.h5", wrapped.File);
+        Assert.Equal(original.Product, wrapped.Product);
+        Assert.Equal(original.GroupPath, wrapped.GroupPath);
+        Assert.Equal(original.AttributeOrDataset, wrapped.AttributeOrDataset);
+        Assert.Equal(original.SpecReference, wrapped.SpecReference);
+        Assert.Same(original.InnerException, wrapped.InnerException);
+
+        Assert.Contains("104UK_TEST.h5", wrapped.Message);
+        Assert.Contains("gridOriginLatitude", wrapped.Message);
+        Assert.Contains("/WaterLevel/WaterLevel.01", wrapped.Message);
+        Assert.Contains("S-100 Part 10c §10.2.1.2", wrapped.Message);
+    }
+
+    [Fact]
+    public void NotSupportedException_WithFile_AttachesFileNameAndPreservesContext()
+    {
+        var original = new S100DatasetNotSupportedException(
+            product: "S-104",
+            file: null,
+            feature: "data coding format 8 (time series at fixed stations)",
+            specReference: "S-100 Part 10c §10.2.1",
+            message: "S-104 dataset uses data coding format 8 (time series at fixed stations), which is not yet supported (S-100 Part 10c §10.2.1).");
+
+        var wrapped = original.WithFile("104UK_DCF8.h5");
+
+        Assert.Equal("104UK_DCF8.h5", wrapped.File);
+        Assert.Equal(original.Product, wrapped.Product);
+        Assert.Equal(original.Feature, wrapped.Feature);
+        Assert.Equal(original.SpecReference, wrapped.SpecReference);
+
+        Assert.Contains("104UK_DCF8.h5", wrapped.Message);
+        Assert.Contains("data coding format 8", wrapped.Message);
+        Assert.Contains("not yet supported", wrapped.Message);
+    }
+
+    [Fact]
+    public void WithFile_NullArgument_ReturnsEquivalentExceptionWhenAlreadyNull()
+    {
+        var original = new S100DatasetSchemaException(
+            "S-104", null, "/WaterLevel", "dataCodingFormat", null,
+            "S-104 dataset is missing required attribute 'dataCodingFormat' on group '/WaterLevel'. The file appears to be non-conforming.");
+
+        var same = original.WithFile(null);
+
+        Assert.Same(original, same);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102DatasetReaderErrorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102DatasetReaderErrorTests.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Hdf5.PureHdf;
+using PureHDF;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// PR-B: verifies that the S-102 reader translates HDF5-backend
+/// "missing attribute" failures into typed, contextual exceptions.
+/// </summary>
+public class S102DatasetReaderErrorTests
+{
+    [Fact]
+    public void Read_MissingGridOriginLatitude_ThrowsSchemaExceptionWithContext()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var instance = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["gridOriginLongitude"] = -1.0,
+                    ["gridSpacingLatitudinal"] = 0.01,
+                    ["gridSpacingLongitudinal"] = 0.01,
+                    ["numPointsLatitudinal"] = 1,
+                    ["numPointsLongitudinal"] = 1,
+                },
+                ["Group_001"] = new H5Group
+                {
+                    ["values"] = new[] { new SpecBathyRow { Depth = 12.5f, Uncertainty = 0.1f } },
+                },
+            };
+
+            var file = new H5File
+            {
+                Attributes = new() { ["horizontalCRS"] = 4326 },
+                ["BathymetryCoverage"] = new H5Group
+                {
+                    ["BathymetryCoverage.01"] = instance,
+                },
+            };
+
+            var options = new H5WriteOptions(
+                FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+            file.Write(path, options);
+
+            using var hdf = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetSchemaException>(() => S102DatasetReader.Read(hdf));
+
+            Assert.Equal("S-102", ex.Product);
+            Assert.EndsWith("/BathymetryCoverage/BathymetryCoverage.01", ex.GroupPath, StringComparison.Ordinal);
+            Assert.Equal("gridOriginLatitude", ex.AttributeOrDataset);
+            Assert.NotNull(ex.InnerException);
+            Assert.Contains("S-102", ex.Message);
+        }
+        finally { File.Delete(path); }
+    }
+
+    private struct SpecBathyRow
+    {
+        [H5Name("depth")] public float Depth;
+        [H5Name("uncertainty")] public float Uncertainty;
+    }
+}


### PR DESCRIPTION
## Motivation

When the viewer loads non-conforming UKHO trial cells, the S-104 reader fails with a raw `PureHDF.Selections.PureHdfException: Could not find attribute 'gridOriginLatitude'` and the S-104/S-111 dcf guards throw `NotSupportedException("Data coding format 8 is not yet supported.")`. Neither message tells the user **which file**, **which group**, or **which spec section** the failure refers to — even though every piece of context is sitting on the call stack at the throw site.

This PR turns those raw failures into typed, contextual exceptions in the **readers' presentation layer**. It does **not** add capability, change behaviour on conforming files, or modify the viewer's error dialog (that's a separate follow-up).

## What changed

### New in `EncDotNet.S100.Core/Hdf5/`

- **`S100DatasetSchemaException`** — a required HDF5 attribute or group is missing / malformed. Carries:
  - `Product` (e.g. `"S-104"`)
  - `File` (e.g. `"104UK_….h5"`, or `null` until processor attaches it)
  - `GroupPath` (e.g. `"/WaterLevel/WaterLevel.03"`)
  - `AttributeOrDataset` (e.g. `"gridOriginLatitude"`)
  - `SpecReference` (e.g. `"S-100 Part 10c §10.2.1.2"`)
  - `.WithFile(...)` helper that returns a copy with `File` set.

- **`S100DatasetNotSupportedException`** — file uses an optional spec feature this reader doesn't yet implement. Carries `Product`, `File`, `Feature`, `SpecReference`, plus `.WithFile(...)`.

- **`Hdf5RequiredAttributeExtensions`** — `ReadRequiredDoubleAttribute` / `ReadRequiredInt64Attribute` / `ReadRequiredStringAttribute`. Each wraps a backend read and translates the PureHDF `Could not find attribute '{name}'` failure into a `S100DatasetSchemaException` with full spec context. Pattern-matches the message defensively (no PureHDF type dependency).

- **`ExceptionMessageFormatter`** — shared text builder for the canonical messages.

### Reader changes

- `S104DatasetReader` — required grid-georef attrs and the dcf guard now throw the typed exceptions. Cites `S-100 Part 10c §10.2.1.2` (grid attrs) and `§10.2.1` (dcf). `DataCodingFormatName()` maps the dcf integer to its spec label for error messages only.
- `S111DatasetReader` — same treatment.
- `S102DatasetReader` — required grid-georef attrs on `BathymetryCoverage.NN` now throw schema exceptions citing `S-100 Part 10c §10.2.1.2`.

### Processor changes

- `S102DatasetProcessor`, `S104DatasetProcessor`, `S111DatasetProcessor` wrap the reader call with a `catch (S100Dataset* ex) when (ex.File is null) → throw ex.WithFile(_fileName)` so the exchange-set / stream-opened paths still get the source filename in error messages.

### Message templates

- Schema: `"S-104 dataset 104UK_….h5 is missing required attribute 'gridOriginLatitude' on group '/WaterLevel/WaterLevel.03' (S-100 Part 10c §10.2.1.2). The file appears to be non-conforming."`
- NotSupported: `"S-104 dataset 104UK_….h5 uses data coding format 8 (time series at fixed stations), which is not yet supported (S-100 Part 10c §10.2.1). Only format 2 (regular grid) is currently implemented."`

The `{file}` fragment drops gracefully when `File` is `null`.

## Tests

- `S104DatasetReaderErrorTests` — synthetic HDF5 file missing `gridOriginLatitude`; synthetic file with `dataCodingFormat = 8`.
- `S111DatasetReaderErrorTests` — same pattern with dcf=7.
- `S102DatasetReaderErrorTests` — missing `gridOriginLatitude` on `BathymetryCoverage.01`.
- `Hdf5DatasetExceptionWithFileTests` — `.WithFile(...)` preserves Product / GroupPath / AttributeOrDataset / SpecReference / InnerException and reformats the message with the file name.

All existing reader-hardening / pipeline tests continue to pass unchanged.

## Verification gates

- `dotnet build EncDotNet.S100.slnx --configuration Release` — clean (0 errors, 4 pre-existing warnings).
- `dotnet test --configuration Release` — all suites green.

## Audit notes

- `grep -r "catch.*PureHDF" src tests --include "*.cs"` → no matches. No caller depends on the old PureHDF exception type.
- `IHdf5File` does not expose a file name property, which is why the readers pass `file: null` and the processors attach the filename via `.WithFile(...)`. No interface change.

## Non-goals (out of scope, deferred to follow-ups)

- Viewer error-dialog refinement (still routes through the existing `catch (Exception ex)` path on `DatasetLoaderService.LoadAsync` — the dialog content improvement is the next PR).
- Adding dcf=8 support (PR-C).
- Touching GML / ISO-8211 readers.

## Commits

Rebased onto current `main` (PR-A merged as `c2834a0`).