### PR TITLE
PR MCP-4: exchange-set ingest + S-101 describer + S-104/S-111 sample

### DIFF
--- a/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
@@ -26,6 +26,9 @@ public class S104CoverageSource : ICoverageSource
         _selectedTimeIndex = 0;
     }
 
+    /// <summary>The underlying parsed S-104 dataset.</summary>
+    public S104Dataset Dataset => _dataset;
+
     /// <inheritdoc/>
     public CoverageMetadata Metadata
     {

--- a/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
@@ -18,6 +18,9 @@ public class S111CoverageSource : ICoverageSource
         _selectedTimeIndex = 0;
     }
 
+    /// <summary>The underlying parsed S-111 dataset.</summary>
+    public S111Dataset Dataset => _dataset;
+
     public CoverageMetadata Metadata
     {
         get

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -1,5 +1,7 @@
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
@@ -7,10 +9,15 @@ using EncDotNet.S100.Pipelines.Coverage;
 namespace EncDotNet.S100.Mcp.Tools;
 
 /// <summary>Request payload for <see cref="SampleCoverageTool"/>.</summary>
-/// <param name="Spec">Spec of the coverage to sample. Currently only S-102 is supported.</param>
+/// <param name="Spec">Spec of the coverage to sample. S-102, S-104, and S-111 are supported.</param>
 /// <param name="Latitude">Sample latitude (decimal degrees, WGS-84).</param>
 /// <param name="Longitude">Sample longitude (decimal degrees, WGS-84).</param>
-/// <param name="Time">Optional time selector for time-varying products. Ignored for S-102.</param>
+/// <param name="Time">
+/// Optional time selector for time-varying products (S-104, S-111). Ignored for S-102
+/// (which has no time dimension). When null on a time-varying product the first time
+/// step of the matched coverage is used. When supplied, the nearest time step is
+/// selected; times outside the dataset's range clamp to the first or last step.
+/// </param>
 public sealed record SampleCoverageRequest(
     SpecRef Spec,
     double Latitude,
@@ -31,18 +38,77 @@ public abstract record SampledValue;
 public sealed record DepthSample(double DepthMeters, double? UncertaintyMeters) : SampledValue;
 
 /// <summary>
+/// S-104 water level sample at the nearest grid cell and time step.
+/// </summary>
+/// <param name="WaterLevelHeight">Water level height in metres relative to the vertical datum.</param>
+/// <param name="Trend">
+/// Decoded S-104 trend (per S-104 §10.2.2: <c>0=unknown</c>, <c>1=decreasing</c>,
+/// <c>2=increasing</c>, <c>3=steady</c>). When the raw value falls outside the
+/// spec-defined set the raw integer is surfaced as the string instead.
+/// </param>
+/// <param name="SampleTime">The actual time step (UTC) selected for this sample.</param>
+/// <param name="RequestedTime">The time the caller asked for, or <c>null</c> if unspecified.</param>
+/// <param name="Row">Row index of the resolved cell in the source grid (0-based).</param>
+/// <param name="Column">Column index of the resolved cell in the source grid (0-based).</param>
+/// <param name="CellCentreLatitude">Latitude of the resolved cell centre.</param>
+/// <param name="CellCentreLongitude">Longitude of the resolved cell centre.</param>
+public sealed record WaterLevelSample(
+    double WaterLevelHeight,
+    string Trend,
+    DateTime SampleTime,
+    DateTimeOffset? RequestedTime,
+    int Row,
+    int Column,
+    double CellCentreLatitude,
+    double CellCentreLongitude) : SampledValue;
+
+/// <summary>
+/// S-111 surface current sample at the nearest grid cell and time step.
+/// </summary>
+/// <param name="SpeedMetresPerSecond">
+/// Speed in metres per second — the canonical S-111 unit (S-111 §10.2.5).
+/// </param>
+/// <param name="SpeedKnots">
+/// Speed in knots, computed as <c>m/s × 1.94384</c> for convenience.
+/// </param>
+/// <param name="DirectionDegreesTrue">Direction in degrees from true north, clockwise (0..360).</param>
+/// <param name="SampleTime">The actual time step (UTC) selected for this sample.</param>
+/// <param name="RequestedTime">The time the caller asked for, or <c>null</c> if unspecified.</param>
+/// <param name="Row">Row index of the resolved cell in the source grid (0-based).</param>
+/// <param name="Column">Column index of the resolved cell in the source grid (0-based).</param>
+/// <param name="CellCentreLatitude">Latitude of the resolved cell centre.</param>
+/// <param name="CellCentreLongitude">Longitude of the resolved cell centre.</param>
+public sealed record SurfaceCurrentSample(
+    double SpeedMetresPerSecond,
+    double SpeedKnots,
+    double DirectionDegreesTrue,
+    DateTime SampleTime,
+    DateTimeOffset? RequestedTime,
+    int Row,
+    int Column,
+    double CellCentreLatitude,
+    double CellCentreLongitude) : SampledValue;
+
+/// <summary>
 /// Samples a coverage product at a single lat/lon, returning the nearest
-/// grid cell's value. Currently supports S-102; S-104 and S-111 return
-/// <see cref="SpecNotSupportedForTool"/>.
+/// grid cell's value. Supports S-102 (depth + uncertainty), S-104
+/// (water level height + trend, nearest time step), and S-111
+/// (surface current speed + direction, nearest time step).
 /// </summary>
 /// <remarks>
 /// "Nearest cell" semantics: the cell whose centre is closest to the
-/// requested point. No interpolation is performed.
+/// requested point. No interpolation is performed. For time-varying
+/// products the nearest time step is selected; ties round to the earlier
+/// step, and times outside the dataset clamp to the first/last step.
 /// </remarks>
 public sealed class SampleCoverageTool
 {
     /// <summary>Tool name used in <see cref="SpecNotSupportedForTool"/> errors.</summary>
     public const string Name = "sample_coverage";
+
+    // S-111 conversion factor m/s → knots (1 m/s ≈ 1.94384 kn). The exact
+    // SI definition is 1 knot = 1852 m / 3600 s, i.e. 1/0.514444 m/s.
+    private const double MetresPerSecondToKnots = 1.9438444924406046;
 
     private readonly IDatasetCatalog _catalog;
 
@@ -61,13 +127,18 @@ public sealed class SampleCoverageTool
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!string.Equals(request.Spec.Name, "S-102", StringComparison.Ordinal))
+        return Task.FromResult(request.Spec.Name switch
         {
-            return Task.FromResult(
-                ToolResult<SampleCoverageResult>.Err(
-                    new SpecNotSupportedForTool(request.Spec, Name)));
-        }
+            "S-102" => SampleS102(request),
+            "S-104" => SampleS104(request),
+            "S-111" => SampleS111(request),
+            _ => ToolResult<SampleCoverageResult>.Err(
+                new SpecNotSupportedForTool(request.Spec, Name)),
+        });
+    }
 
+    private ToolResult<SampleCoverageResult> SampleS102(SampleCoverageRequest request)
+    {
         var snapshot = _catalog.Datasets;
         LoadedDataset? match = null;
         foreach (var dataset in snapshot)
@@ -80,9 +151,8 @@ public sealed class SampleCoverageTool
 
         if (match is null)
         {
-            return Task.FromResult(
-                ToolResult<SampleCoverageResult>.Err(
-                    new NoDatasetCoversPoint(request.Latitude, request.Longitude)));
+            return ToolResult<SampleCoverageResult>.Err(
+                new NoDatasetCoversPoint(request.Latitude, request.Longitude));
         }
 
         var source = ((S102CoverageData)match.Data).Source;
@@ -105,32 +175,274 @@ public sealed class SampleCoverageTool
 
             if (depthValue is null)
             {
-                return Task.FromResult(
-                    ToolResult<SampleCoverageResult>.Err(
-                        new NoDatasetCoversPoint(request.Latitude, request.Longitude)));
+                return ToolResult<SampleCoverageResult>.Err(
+                    new NoDataAtPoint(match.Id, row, col, Time: null));
             }
 
-            var result = new SampleCoverageResult(
+            return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
                 match.Id,
                 request.Latitude,
                 request.Longitude,
-                new DepthSample(depthValue.Value, uncertaintyValue));
-
-            return Task.FromResult(ToolResult<SampleCoverageResult>.Ok(result));
+                new DepthSample(depthValue.Value, uncertaintyValue)));
         }
         catch (ObjectDisposedException)
         {
-            return Task.FromResult(
-                ToolResult<SampleCoverageResult>.Err(
-                    new DatasetClosedDuringQuery(match.Id)));
+            return ToolResult<SampleCoverageResult>.Err(
+                new DatasetClosedDuringQuery(match.Id));
         }
     }
+
+    private ToolResult<SampleCoverageResult> SampleS104(SampleCoverageRequest request)
+    {
+        var snapshot = _catalog.Datasets;
+
+        // Pick the best (highest-resolution) S-104 dataset whose bounds contain the point.
+        LoadedDataset? bestDataset = null;
+        S104CoverageSource? bestSource = null;
+        S104Dataset? bestModel = null;
+        WaterLevelCoverage? bestCoverage = null;
+        double bestArea = double.PositiveInfinity;
+        bool anyS104 = false;
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S104CoverageData s104) continue;
+            anyS104 = true;
+            var model = s104.Source.Dataset;
+            if (model.Coverages.Count == 0) continue;
+            // Use the first coverage's grid to characterise the instance —
+            // every time-step in an S-104 instance shares the same grid.
+            var probe = model.Coverages[0];
+            if (!CoverageContains(probe, request.Latitude, request.Longitude)) continue;
+            var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
+            if (area < bestArea)
+            {
+                bestArea = area;
+                bestDataset = dataset;
+                bestSource = s104.Source;
+                bestModel = model;
+                bestCoverage = probe;
+            }
+        }
+
+        if (bestDataset is null || bestModel is null || bestCoverage is null || bestSource is null)
+        {
+            return ToolResult<SampleCoverageResult>.Err(anyS104
+                ? new OutOfBounds(request.Spec, request.Latitude, request.Longitude)
+                : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+        }
+
+        if (bestModel.DataCodingFormat != 2)
+        {
+            return ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
+                request.Spec,
+                Name,
+                $"data coding format {bestModel.DataCodingFormat} is not yet supported (only dcf=2 / regular grid)"));
+        }
+
+        // Resolve the time-step. Coverages within an instance are ordered
+        // by TimePoint; pick the nearest one to the requested time.
+        var stepIndex = SelectTimeStep(bestModel.Coverages, request.Time);
+        var step = bestModel.Coverages[stepIndex];
+
+        var (row, col) = NearestCellInCoverage(step, request.Latitude, request.Longitude);
+        var idx = row * step.NumPointsLongitudinal + col;
+        try
+        {
+            var value = step.Values[idx];
+            if (value.Height == S104CoverageSource.FillValue)
+            {
+                return ToolResult<SampleCoverageResult>.Err(new NoDataAtPoint(
+                    bestDataset.Id, row, col, step.TimePoint));
+            }
+
+            var cellLat = step.OriginLatitude + row * step.SpacingLatitudinal;
+            var cellLon = step.OriginLongitude + col * step.SpacingLongitudinal;
+
+            return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
+                bestDataset.Id,
+                request.Latitude,
+                request.Longitude,
+                new WaterLevelSample(
+                    value.Height,
+                    DecodeWaterLevelTrend(value.Trend),
+                    DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc),
+                    request.Time,
+                    row,
+                    col,
+                    cellLat,
+                    cellLon)));
+        }
+        catch (ObjectDisposedException)
+        {
+            return ToolResult<SampleCoverageResult>.Err(
+                new DatasetClosedDuringQuery(bestDataset.Id));
+        }
+    }
+
+    private ToolResult<SampleCoverageResult> SampleS111(SampleCoverageRequest request)
+    {
+        var snapshot = _catalog.Datasets;
+
+        LoadedDataset? bestDataset = null;
+        S111CoverageSource? bestSource = null;
+        S111Dataset? bestModel = null;
+        SurfaceCurrentCoverage? bestCoverage = null;
+        double bestArea = double.PositiveInfinity;
+        bool anyS111 = false;
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S111CoverageData s111) continue;
+            anyS111 = true;
+            var model = s111.Source.Dataset;
+            if (model.Coverages.Count == 0) continue;
+            var probe = model.Coverages[0];
+            if (!CoverageContains(probe, request.Latitude, request.Longitude)) continue;
+            var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
+            if (area < bestArea)
+            {
+                bestArea = area;
+                bestDataset = dataset;
+                bestSource = s111.Source;
+                bestModel = model;
+                bestCoverage = probe;
+            }
+        }
+
+        if (bestDataset is null || bestModel is null || bestCoverage is null || bestSource is null)
+        {
+            return ToolResult<SampleCoverageResult>.Err(anyS111
+                ? new OutOfBounds(request.Spec, request.Latitude, request.Longitude)
+                : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+        }
+
+        if (bestModel.DataCodingFormat != 2)
+        {
+            return ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
+                request.Spec,
+                Name,
+                $"data coding format {bestModel.DataCodingFormat} is not yet supported (only dcf=2 / regular grid)"));
+        }
+
+        var stepIndex = SelectTimeStep(bestModel.Coverages, request.Time);
+        var step = bestModel.Coverages[stepIndex];
+
+        var (row, col) = NearestCellInCoverage(step, request.Latitude, request.Longitude);
+        var idx = row * step.NumPointsLongitudinal + col;
+        try
+        {
+            var value = step.Values[idx];
+            // S-111 §10.2.5 fill value for both speed and direction is -9999f.
+            if (value.Speed == S111CoverageSource.FillValue)
+            {
+                return ToolResult<SampleCoverageResult>.Err(new NoDataAtPoint(
+                    bestDataset.Id, row, col, step.TimePoint));
+            }
+
+            var cellLat = step.OriginLatitude + row * step.SpacingLatitudinal;
+            var cellLon = step.OriginLongitude + col * step.SpacingLongitudinal;
+
+            return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
+                bestDataset.Id,
+                request.Latitude,
+                request.Longitude,
+                new SurfaceCurrentSample(
+                    value.Speed,
+                    value.Speed * MetresPerSecondToKnots,
+                    value.Direction,
+                    DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc),
+                    request.Time,
+                    row,
+                    col,
+                    cellLat,
+                    cellLon)));
+        }
+        catch (ObjectDisposedException)
+        {
+            return ToolResult<SampleCoverageResult>.Err(
+                new DatasetClosedDuringQuery(bestDataset.Id));
+        }
+    }
+
+    /// <summary>
+    /// Selects the index of the time step whose <c>TimePoint</c> is closest
+    /// to <paramref name="requested"/>. Returns 0 when <paramref name="requested"/>
+    /// is <c>null</c>. Times outside the dataset's range clamp to the first
+    /// or last step (per S-100 Part 10c §10.2.1.1: time-step indices are in
+    /// <c>[0, numberOfTimes - 1]</c>).
+    /// </summary>
+    internal static int SelectTimeStep<TCoverage>(
+        IReadOnlyList<TCoverage> coverages,
+        DateTimeOffset? requested)
+        where TCoverage : class
+    {
+        if (requested is null || coverages.Count == 1) return 0;
+        var target = requested.Value.UtcDateTime;
+
+        // Clamp before the first / after the last step explicitly, so
+        // out-of-range inputs don't accidentally tie to the middle.
+        var first = GetTimePoint(coverages[0]);
+        var last = GetTimePoint(coverages[coverages.Count - 1]);
+        var ascending = last >= first;
+        var earliest = ascending ? first : last;
+        var latest = ascending ? last : first;
+        if (target <= earliest) return ascending ? 0 : coverages.Count - 1;
+        if (target >= latest) return ascending ? coverages.Count - 1 : 0;
+
+        int best = 0;
+        var bestDiff = TimeSpan.MaxValue;
+        for (int i = 0; i < coverages.Count; i++)
+        {
+            var diff = (GetTimePoint(coverages[i]) - target).Duration();
+            if (diff < bestDiff)
+            {
+                bestDiff = diff;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    private static DateTime GetTimePoint(object coverage) => coverage switch
+    {
+        WaterLevelCoverage wl => wl.TimePoint,
+        SurfaceCurrentCoverage sc => sc.TimePoint,
+        _ => throw new ArgumentException($"Unsupported coverage type {coverage.GetType()}"),
+    };
 
     private static bool Contains(BoundingBox b, double lat, double lon) =>
         lat >= b.SouthLatitude
         && lat <= b.NorthLatitude
         && lon >= b.WestLongitude
         && lon <= b.EastLongitude;
+
+    private static bool CoverageContains(WaterLevelCoverage cov, double lat, double lon) =>
+        CoverageContains(
+            cov.OriginLatitude, cov.OriginLongitude,
+            cov.SpacingLatitudinal, cov.SpacingLongitudinal,
+            cov.NumPointsLatitudinal, cov.NumPointsLongitudinal,
+            lat, lon);
+
+    private static bool CoverageContains(SurfaceCurrentCoverage cov, double lat, double lon) =>
+        CoverageContains(
+            cov.OriginLatitude, cov.OriginLongitude,
+            cov.SpacingLatitudinal, cov.SpacingLongitudinal,
+            cov.NumPointsLatitudinal, cov.NumPointsLongitudinal,
+            lat, lon);
+
+    private static bool CoverageContains(
+        double originLat, double originLon,
+        double spacingLat, double spacingLon,
+        int numLat, int numLon,
+        double lat, double lon)
+    {
+        var minLat = originLat;
+        var maxLat = originLat + (numLat - 1) * spacingLat;
+        var minLon = originLon;
+        var maxLon = originLon + (numLon - 1) * spacingLon;
+        if (spacingLat < 0) (minLat, maxLat) = (maxLat, minLat);
+        if (spacingLon < 0) (minLon, maxLon) = (maxLon, minLon);
+        return lat >= minLat && lat <= maxLat && lon >= minLon && lon <= maxLon;
+    }
 
     private static (int Row, int Col) NearestCell(GridMetadata grid, double lat, double lon)
     {
@@ -140,6 +452,39 @@ public sealed class SampleCoverageTool
         col = Math.Clamp(col, 0, grid.NumColumns - 1);
         return (row, col);
     }
+
+    private static (int Row, int Col) NearestCellInCoverage(WaterLevelCoverage cov, double lat, double lon)
+    {
+        var row = (int)Math.Round((lat - cov.OriginLatitude) / cov.SpacingLatitudinal);
+        var col = (int)Math.Round((lon - cov.OriginLongitude) / cov.SpacingLongitudinal);
+        row = Math.Clamp(row, 0, cov.NumPointsLatitudinal - 1);
+        col = Math.Clamp(col, 0, cov.NumPointsLongitudinal - 1);
+        return (row, col);
+    }
+
+    private static (int Row, int Col) NearestCellInCoverage(SurfaceCurrentCoverage cov, double lat, double lon)
+    {
+        var row = (int)Math.Round((lat - cov.OriginLatitude) / cov.SpacingLatitudinal);
+        var col = (int)Math.Round((lon - cov.OriginLongitude) / cov.SpacingLongitudinal);
+        row = Math.Clamp(row, 0, cov.NumPointsLatitudinal - 1);
+        col = Math.Clamp(col, 0, cov.NumPointsLongitudinal - 1);
+        return (row, col);
+    }
+
+    /// <summary>
+    /// Decodes the S-104 waterLevelTrend enumeration (S-104 Edition 2.0.0
+    /// §10.2.2 Table 10-3). Raw values outside the spec-defined set are
+    /// returned as their integer string so callers can still surface the
+    /// raw payload.
+    /// </summary>
+    private static string DecodeWaterLevelTrend(byte trend) => trend switch
+    {
+        0 => "unknown",
+        1 => "decreasing",
+        2 => "increasing",
+        3 => "steady",
+        _ => trend.ToString(System.Globalization.CultureInfo.InvariantCulture),
+    };
 
     private static float ReadScalar(SampledCoverage sampled, string field)
     {

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
@@ -1,26 +1,221 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
 namespace EncDotNet.S100.Mcp.Tools.Spec;
 
 /// <summary>
-/// Placeholder describer for S-101 Electronic Navigational Charts.
+/// Describer strategy for S-101 Electronic Navigational Charts.
+/// Resolves a feature by its record identification number (RCID), or
+/// by an FRID composite of the form <c>100:RCID</c> /
+/// <c>100:RCID:RVER</c>, and serialises its attributes (resolved
+/// against <see cref="S101Document.AttributeTypeCatalogue"/> when
+/// available), spatial primitives, and cross-record associations as
+/// JSON.
 /// </summary>
 /// <remarks>
-/// S-101 datasets are surfaced by <c>list_datasets</c> via
-/// <see cref="EncDotNet.S100.Mcp.Tools.Catalog.S101DatasetData"/>, but a
-/// full ISO 8211 feature-record describe is its own work item. Until
-/// that lands this describer returns
-/// <see cref="SpecNotSupportedForTool"/> so callers receive the stable
-/// "spec_not_supported_for_tool" error rather than a confusing
-/// "dataset spec not registered" indirection. S-101 feature describe
-/// support is tracked as a follow-up to PR MCP-3.
+/// <para>
+/// Per S-100 Part 10a §3, every S-101 record carries an RCNM/RCID
+/// header; feature records use RCNM = 100. This describer accepts:
+/// </para>
+/// <list type="bullet">
+/// <item><description>A bare decimal RCID (e.g. <c>"12345"</c>);</description></item>
+/// <item><description>An FRID composite <c>"100:RCID"</c> or <c>"100:RCID:RVER"</c>
+/// — the leading <c>100</c> must match the S-101 feature RCNM if supplied.</description></item>
+/// </list>
+/// <para>
+/// Attribute names degrade to their numeric attribute code (NATC) when
+/// <see cref="S101Document.AttributeTypeCatalogue"/> is empty — the
+/// describer does not depend on a loaded Feature Catalogue.
+/// </para>
 /// </remarks>
 internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
 {
+    private const byte FeatureRecordRcnm = 100;
+
     public string SpecName => "S-101";
 
     public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        return ToolResult<DescribeFeatureResult>.Err(
-            new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+
+        if (context.Dataset.Data is not S101DatasetData s101)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+        }
+
+        if (!TryParseFeatureId(context.FeatureId, out var rcid))
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var document = s101.Dataset.Document;
+        S101FeatureRecord? feature = null;
+        foreach (var f in document.Features)
+        {
+            if (f.RecordId == rcid)
+            {
+                feature = f;
+                break;
+            }
+        }
+
+        if (feature is null)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var acronym = document.FeatureTypeCatalogue.TryGetValue(feature.FeatureTypeCode, out var ac)
+            ? ac
+            : feature.FeatureTypeCode.ToString(CultureInfo.InvariantCulture);
+
+        var attributes = SerializeAttributes(feature, document);
+        return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+            context.Dataset.Spec,
+            acronym,
+            attributes,
+            ImmutableArray<FeatureReference>.Empty));
+    }
+
+    /// <summary>
+    /// Parses an S-101 feature ID, accepting either a bare decimal RCID
+    /// or an FRID composite of the form <c>RCNM:RCID</c> /
+    /// <c>RCNM:RCID:RVER</c>. The RCNM, when supplied, must equal
+    /// <see cref="FeatureRecordRcnm"/> (100).
+    /// </summary>
+    internal static bool TryParseFeatureId(string id, out uint rcid)
+    {
+        rcid = 0;
+        if (string.IsNullOrEmpty(id)) return false;
+
+        if (uint.TryParse(id, NumberStyles.None, CultureInfo.InvariantCulture, out rcid))
+        {
+            return true;
+        }
+
+        var parts = id.Split(':');
+        if (parts.Length is < 2 or > 3) return false;
+        if (!byte.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out var rcnm)) return false;
+        if (rcnm != FeatureRecordRcnm) return false;
+        return uint.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out rcid);
+    }
+
+    private static JsonElement SerializeAttributes(S101FeatureRecord feature, S101Document document)
+    {
+        var attributeList = new List<Dictionary<string, object?>>();
+        foreach (var attr in feature.Attributes)
+        {
+            var acronym = document.AttributeTypeCatalogue.TryGetValue(attr.NumericCode, out var ac)
+                ? ac
+                : null;
+            attributeList.Add(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["code"] = attr.NumericCode,
+                ["acronym"] = acronym,
+                ["index"] = attr.Index,
+                ["value"] = attr.Value,
+            });
+        }
+
+        var spatial = new List<Dictionary<string, object?>>();
+        foreach (var s in feature.SpatialAssociations)
+        {
+            spatial.Add(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["recordName"] = s.RecordName,
+                ["recordId"] = s.RecordId,
+                ["orientation"] = s.Orientation,
+            });
+        }
+
+        var featureAssoc = new List<Dictionary<string, object?>>();
+        foreach (var fa in feature.FeatureAssociations)
+        {
+            featureAssoc.Add(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["code"] = fa.NumericCode,
+                ["acronym"] = document.FeatureAssociationCatalogue.TryGetValue(fa.NumericCode, out var fac)
+                    ? fac
+                    : null,
+                ["targetRecordId"] = fa.RecordId,
+                ["roleCode"] = fa.RoleCode,
+                ["roleAcronym"] = document.RoleCatalogue.TryGetValue(fa.RoleCode, out var rac)
+                    ? rac
+                    : null,
+            });
+        }
+
+        var infoAssoc = new List<Dictionary<string, object?>>();
+        foreach (var ia in feature.InformationAssociations)
+        {
+            infoAssoc.Add(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["code"] = ia.NumericCode,
+                ["acronym"] = document.InformationAssociationCatalogue.TryGetValue(ia.NumericCode, out var iac)
+                    ? iac
+                    : null,
+                ["targetRecordId"] = ia.RecordId,
+                ["roleCode"] = ia.RoleCode,
+                ["roleAcronym"] = document.RoleCatalogue.TryGetValue(ia.RoleCode, out var rac)
+                    ? rac
+                    : null,
+            });
+        }
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["recordHeader"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["recordName"] = FeatureRecordRcnm,
+                ["recordId"] = feature.RecordId,
+            },
+            ["foid"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["producingAgency"] = feature.ProducingAgency,
+                ["featureIdentificationNumber"] = feature.FeatureIdentificationNumber,
+                ["featureIdentificationSubdivision"] = feature.FeatureIdentificationSubdivision,
+            },
+            ["featureTypeCode"] = feature.FeatureTypeCode,
+            ["featureTypeAcronym"] = document.FeatureTypeCatalogue.TryGetValue(feature.FeatureTypeCode, out var fac0)
+                ? fac0
+                : null,
+            ["geometryPrimitive"] = ClassifyGeometry(feature, document),
+            ["spatialAssociations"] = spatial,
+            ["attributes"] = attributeList,
+            ["featureAssociations"] = featureAssoc,
+            ["informationAssociations"] = infoAssoc,
+        };
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+
+    /// <summary>
+    /// Classifies the feature's spatial primitive by inspecting the
+    /// RCNM of its first spatial association (S-100 Part 10a §3):
+    /// 110 = Point, 115 = MultiPoint, 120 = Curve, 125 = CompositeCurve,
+    /// 130 = Surface. Features with no spatial associations return "None"
+    /// (e.g. attribute-only meta features).
+    /// </summary>
+    private static string ClassifyGeometry(S101FeatureRecord feature, S101Document document)
+    {
+        if (feature.SpatialAssociations.IsDefaultOrEmpty) return "None";
+        // S-101 features carry a homogeneous geometry primitive — every
+        // SPAS row references a record of the same RCNM — so the first
+        // entry is representative.
+        return feature.SpatialAssociations[0].RecordName switch
+        {
+            110 => "Point",
+            115 => "MultiPoint",
+            120 => "Curve",
+            125 => "CompositeCurve",
+            130 => "Surface",
+            var other => $"Unknown({other})",
+        };
     }
 }

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -41,3 +41,39 @@ public sealed record FeatureNotFound(DatasetId Id, string FeatureId) : ToolError
 public sealed record SpecNotSupportedForTool(SpecRef Spec, string Tool) : ToolError(
     "spec_not_supported_for_tool",
     $"Spec '{Spec}' is not supported by tool '{Tool}'.");
+
+/// <summary>
+/// The requested point falls outside the spatial bounds of every loaded
+/// dataset of the requested spec. Distinguished from
+/// <see cref="NoDatasetCoversPoint"/> in cases where no dataset of the
+/// requested spec is loaded at all — callers may want to retry once a
+/// dataset is loaded — by carrying the dataset spec.
+/// </summary>
+public sealed record OutOfBounds(SpecRef Spec, double Latitude, double Longitude) : ToolError(
+    "out_of_bounds",
+    $"Point ({Latitude}, {Longitude}) is outside the bounds of every loaded {Spec.Name} dataset.");
+
+/// <summary>
+/// The grid cell at the resolved (row, col) and time step carries the
+/// spec-defined no-data fill value. The cell index and time step are
+/// surfaced in the message so callers can correlate with the source grid.
+/// </summary>
+public sealed record NoDataAtPoint(
+    DatasetId Id,
+    int Row,
+    int Column,
+    DateTime? Time) : ToolError(
+    "no_data_at_point",
+    Time is null
+        ? $"Cell ({Row}, {Column}) in dataset '{Id}' carries the no-data fill value."
+        : $"Cell ({Row}, {Column}) at {Time:O} in dataset '{Id}' carries the no-data fill value.");
+
+/// <summary>
+/// The tool understands the requested spec but cannot yet handle this
+/// specific shape of dataset (e.g. S-104 data coding format other than 2).
+/// Distinguished from <see cref="SpecNotSupportedForTool"/> in that the
+/// spec itself is supported — only this particular variant isn't yet.
+/// </summary>
+public sealed record NotSupportedYet(SpecRef Spec, string Tool, string Reason) : ToolError(
+    "not_supported_yet",
+    $"Spec '{Spec}' is supported by tool '{Tool}', but: {Reason}.");

--- a/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
@@ -82,10 +82,22 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
     {
         if (_disposed) return;
 
-        // Only ingest plain on-disk entries; exchange-set bytes live
-        // inside an IAssetSource the catalog has no contract for.
-        if (entry.IsFromExchangeSet) return;
-        if (string.IsNullOrEmpty(entry.FilePath) || !File.Exists(entry.FilePath)) return;
+        // Plain on-disk entries: require the file to be present so any
+        // downstream consumer that DOES need a path can find one.
+        // Exchange-set entries instead carry an IAssetSource +
+        // RelativePath and are read via streams further down — no on-disk
+        // path is required.
+        if (!entry.IsFromExchangeSet
+            && (string.IsNullOrEmpty(entry.FilePath) || !File.Exists(entry.FilePath)))
+        {
+            return;
+        }
+
+        if (entry.IsFromExchangeSet
+            && (entry.Source is null || string.IsNullOrEmpty(entry.RelativePath)))
+        {
+            return;
+        }
 
         LoadedDataset? projected;
         try
@@ -139,7 +151,6 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
     {
         var id = new DatasetId(entry.DisplayName);
         var spec = entry.ProductSpec;
-        var path = entry.FilePath;
 
         // DatasetPipelineFactory.DetectProductSpec returns the literal
         // string "S-57" for ENC .000 files that pass the S-57 DSPM
@@ -152,71 +163,92 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
         // to differentiate.
         return spec switch
         {
-            "S-101" or "S-57" => ProjectS101(id, path),
-            "S-102" => ProjectS102(id, path),
-            "S-104" => ProjectS104(id, path),
-            "S-111" => ProjectS111(id, path),
-            "S-122" => ProjectGml(id, "S-122", path, p =>
+            "S-101" or "S-57" => ProjectS101(id, entry),
+            "S-102" => ProjectS102(id, entry),
+            "S-104" => ProjectS104(id, entry),
+            "S-111" => ProjectS111(id, entry),
+            "S-122" => ProjectGml(id, "S-122", entry, stream =>
             {
-                var model = S122Dataset.Open(p);
+                var model = S122Dataset.Open(stream);
                 return (new S122DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-124" => ProjectGml(id, "S-124", path, p =>
+            "S-124" => ProjectGml(id, "S-124", entry, stream =>
             {
-                var model = S124Dataset.Open(p);
+                var model = S124Dataset.Open(stream);
                 return (new S124DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-125" => ProjectGml(id, "S-125", path, p =>
+            "S-125" => ProjectGml(id, "S-125", entry, stream =>
             {
-                var model = S125Dataset.Open(p);
+                var model = S125Dataset.Open(stream);
                 return (new S125DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-127" => ProjectGml(id, "S-127", path, p =>
+            "S-127" => ProjectGml(id, "S-127", entry, stream =>
             {
-                var model = S127Dataset.Open(p);
+                var model = S127Dataset.Open(stream);
                 return (new S127DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-128" => ProjectGml(id, "S-128", path, p =>
+            "S-128" => ProjectGml(id, "S-128", entry, stream =>
             {
-                var model = S128Dataset.Open(p);
+                var model = S128Dataset.Open(stream);
                 return (new S128DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-129" => ProjectGml(id, "S-129", path, p =>
+            "S-129" => ProjectGml(id, "S-129", entry, stream =>
             {
-                var model = S129Dataset.Open(p);
+                var model = S129Dataset.Open(stream);
                 return (new S129DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-131" => ProjectGml(id, "S-131", path, p =>
+            "S-131" => ProjectGml(id, "S-131", entry, stream =>
             {
-                var model = S131Dataset.Open(p);
+                var model = S131Dataset.Open(stream);
                 return (new S131DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-201" => ProjectGml(id, "S-201", path, p =>
+            "S-201" => ProjectGml(id, "S-201", entry, stream =>
             {
-                var model = S201Dataset.Open(p);
+                var model = S201Dataset.Open(stream);
                 return (new S201DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-411" => ProjectGml(id, "S-411", path, p =>
+            "S-411" => ProjectGml(id, "S-411", entry, stream =>
             {
-                var model = S411Dataset.Open(p);
+                var model = S411Dataset.Open(stream);
                 return (new S411DatasetData(model), ComputeGmlBounds(model.Features));
             }),
-            "S-421" => ProjectGml(id, "S-421", path, p =>
+            "S-421" => ProjectGml(id, "S-421", entry, stream =>
             {
-                var model = S421Dataset.Open(p);
+                var model = S421Dataset.Open(stream);
                 return (new S421DatasetData(model), ComputeGmlBounds(model.Features));
             }),
             _ => null,
         };
     }
 
+    /// <summary>
+    /// Opens the dataset bytes for <paramref name="entry"/> — either from
+    /// disk (plain entry) or from its <see cref="DatasetEntry.Source"/>
+    /// asset source (exchange-set entry). The returned stream must be
+    /// disposed by the caller.
+    /// </summary>
+    private static Stream OpenEntryStream(DatasetEntry entry)
+    {
+        if (entry.IsFromExchangeSet)
+        {
+            // IAssetSource.OpenAsync is effectively synchronous for the
+            // FileSystem / Zip backings used by the viewer (see
+            // ZipAssetSource.OpenAsync), so blocking here is benign and
+            // keeps TryProject synchronous like the rest of the catalog
+            // event chain.
+            return entry.Source!.OpenAsync(entry.RelativePath!).GetAwaiter().GetResult();
+        }
+        return File.OpenRead(entry.FilePath);
+    }
+
     private static LoadedDataset ProjectGml(
         DatasetId id,
         string specName,
-        string path,
-        Func<string, (LoadedDatasetData Data, BoundingBox? Bounds)> open)
+        DatasetEntry entry,
+        Func<Stream, (LoadedDatasetData Data, BoundingBox? Bounds)> open)
     {
-        var (data, bounds) = open(path);
+        using var stream = OpenEntryStream(entry);
+        var (data, bounds) = open(stream);
         return new LoadedDataset(
             id,
             new SpecRef(specName, default),
@@ -225,9 +257,10 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
             data);
     }
 
-    private static LoadedDataset ProjectS101(DatasetId id, string path)
+    private static LoadedDataset ProjectS101(DatasetId id, DatasetEntry entry)
     {
-        var dataset = S101Dataset.Open(path);
+        using var stream = OpenEntryStream(entry);
+        var dataset = S101Dataset.Open(stream);
         // S-101 features carry packed spatial coordinates that require
         // the coordinate multiplication factors plus a join across the
         // feature / spatial / coordinate records to recover lat/lon —
@@ -243,15 +276,14 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
             new S101DatasetData(dataset));
     }
 
-    private static LoadedDataset ProjectS102(DatasetId id, string path)
+    private static LoadedDataset ProjectS102(DatasetId id, DatasetEntry entry)
     {
         // S102DatasetReader.Read fully materialises every coverage's
         // values into managed BathymetryValue[] arrays before
         // returning (see S102DatasetReader.ReadCoverage), so the
-        // backing HDF5 file can be closed immediately. The
-        // S102CoverageSource that S102CoverageData carries does not
-        // need a live IHdf5File handle.
-        using var file = PureHdfFile.Open(path);
+        // backing HDF5 file (and its stream) can be closed immediately.
+        using var stream = OpenEntryStream(entry);
+        using var file = PureHdfFile.Open(stream);
         var dataset = S102DatasetReader.Read(file);
         var source = new S102CoverageSource(dataset);
         var bounds = ComputeS102Bounds(dataset) ?? WorldBounds;
@@ -263,12 +295,13 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
             new S102CoverageData(source));
     }
 
-    private static LoadedDataset ProjectS104(DatasetId id, string path)
+    private static LoadedDataset ProjectS104(DatasetId id, DatasetEntry entry)
     {
         // S104DatasetReader.Read materialises every time-step's value
         // grid into a managed WaterLevelValue[] before returning, so
-        // the file handle can be disposed eagerly.
-        using var file = PureHdfFile.Open(path);
+        // the file handle (and its stream) can be disposed eagerly.
+        using var stream = OpenEntryStream(entry);
+        using var file = PureHdfFile.Open(stream);
         var dataset = S104DatasetReader.Read(file);
         var source = new S104CoverageSource(dataset);
         var bounds = ComputeS104Bounds(dataset) ?? WorldBounds;
@@ -280,12 +313,13 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
             new S104CoverageData(source));
     }
 
-    private static LoadedDataset ProjectS111(DatasetId id, string path)
+    private static LoadedDataset ProjectS111(DatasetId id, DatasetEntry entry)
     {
         // S111DatasetReader.Read materialises every time-step's value
         // grid into managed arrays before returning, so the file
-        // handle can be disposed eagerly.
-        using var file = PureHdfFile.Open(path);
+        // handle (and its stream) can be disposed eagerly.
+        using var stream = OpenEntryStream(entry);
+        using var file = PureHdfFile.Open(stream);
         var dataset = S111DatasetReader.Read(file);
         var source = new S111CoverageSource(dataset);
         var bounds = ComputeS111Bounds(dataset) ?? WorldBounds;

--- a/tests/EncDotNet.S100.Mcp.Tests/EncDotNet.S100.Mcp.Tests.csproj
+++ b/tests/EncDotNet.S100.Mcp.Tests/EncDotNet.S100.Mcp.Tests.csproj
@@ -21,6 +21,8 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S131\EncDotNet.S100.Datasets.S131.csproj" />
@@ -39,6 +41,8 @@
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\LoadedDatasetFactory.cs" Link="Fakes\LoadedDatasetFactory.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S101Synth.cs" Link="Fakes\S101Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S102Synth.cs" Link="Fakes\S102Synth.cs" />
+    <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S104Synth.cs" Link="Fakes\S104Synth.cs" />
+    <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S111Synth.cs" Link="Fakes\S111Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S124Synth.cs" Link="Fakes\S124Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S131Synth.cs" Link="Fakes\S131Synth.cs" />
   </ItemGroup>

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text.Json;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
@@ -175,18 +176,99 @@ public class DescribeFeatureToolTests
     }
 
     [Fact]
-    public async Task Returns_SpecNotSupported_for_S101_describe_stub()
+    public async Task S101_describes_feature_by_bare_RCID()
     {
+        var feature = S101Synth.Feature(rcid: 12345, featureTypeCode: 30,
+            attributes: new[] { ((ushort)42, "5.0") });
+        var featureTypes = new Dictionary<ushort, string> { [30] = "DEPARE" }.ToImmutableDictionary();
+        var attrTypes = new Dictionary<ushort, string> { [42] = "DRVAL1" }.ToImmutableDictionary();
+        var ds = S101Synth.Dataset("enc-1", ImmutableArray.Create(feature), featureTypes, attrTypes);
+
         var catalog = new FakeDatasetCatalog();
-        catalog.Add(LoadedDatasetFactory.S101("enc-1"));
+        catalog.Add(LoadedDatasetFactory.S101("enc-1", ds));
         var tool = new DescribeFeatureTool(catalog);
 
-        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-1"), "f1"));
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-1"), "12345"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("DEPARE", value.FeatureTypeName);
+        var attrs = value.Attributes.GetProperty("attributes");
+        Assert.Equal(1, attrs.GetArrayLength());
+        Assert.Equal("DRVAL1", attrs[0].GetProperty("acronym").GetString());
+        Assert.Equal("5.0", attrs[0].GetProperty("value").GetString());
+        Assert.Equal("Point", value.Attributes.GetProperty("geometryPrimitive").GetString());
+    }
+
+    [Fact]
+    public async Task S101_describes_feature_by_composite_FRID()
+    {
+        var feature = S101Synth.Feature(rcid: 42, featureTypeCode: 73);
+        var ds = S101Synth.Dataset("enc-2", ImmutableArray.Create(feature));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc-2", ds));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-2"), "100:42:1"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("73", value.FeatureTypeName);
+    }
+
+    [Fact]
+    public async Task S101_returns_FeatureNotFound_for_unknown_RCID()
+    {
+        var feature = S101Synth.Feature(rcid: 1, featureTypeCode: 30);
+        var ds = S101Synth.Dataset("enc-3", ImmutableArray.Create(feature));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc-3", ds));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-3"), "99999"));
 
         Assert.True(result.TryGetError(out var error));
-        var unsupported = Assert.IsType<SpecNotSupportedForTool>(error);
-        Assert.Equal("S-101", unsupported.Spec.Name);
-        Assert.Equal(DescribeFeatureTool.Name, unsupported.Tool);
+        Assert.IsType<FeatureNotFound>(error);
+    }
+
+    [Fact]
+    public async Task S101_returns_FeatureNotFound_for_non_S101_RCNM_composite()
+    {
+        var feature = S101Synth.Feature(rcid: 1, featureTypeCode: 30);
+        var ds = S101Synth.Dataset("enc-4", ImmutableArray.Create(feature));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc-4", ds));
+        var tool = new DescribeFeatureTool(catalog);
+
+        // RCNM 110 = spatial point record, not a feature record (100).
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-4"), "110:1"));
+
+        Assert.True(result.TryGetError(out var error));
+        Assert.IsType<FeatureNotFound>(error);
+    }
+
+    [Fact]
+    public async Task S101_falls_back_to_numeric_codes_when_no_catalogue_loaded()
+    {
+        var feature = S101Synth.Feature(rcid: 7, featureTypeCode: 30,
+            attributes: new[] { ((ushort)42, "5.0") });
+        var ds = S101Synth.Dataset("enc-5", ImmutableArray.Create(feature));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc-5", ds));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("enc-5"), "7"));
+
+        Assert.True(result.TryGetValue(out var value));
+        // No feature catalogue → fall back to numeric feature type code string.
+        Assert.Equal("30", value.FeatureTypeName);
+        var attrs = value.Attributes.GetProperty("attributes");
+        Assert.Equal(1, attrs.GetArrayLength());
+        // No attribute catalogue → acronym is null but code is still present.
+        Assert.Equal(JsonValueKind.Null, attrs[0].GetProperty("acronym").ValueKind);
+        Assert.Equal(42, attrs[0].GetProperty("code").GetInt32());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
@@ -1,6 +1,8 @@
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Datasets.S122;
 using EncDotNet.S100.Datasets.S124;
 using EncDotNet.S100.Datasets.S131;
@@ -18,6 +20,7 @@ internal static class LoadedDatasetFactory
     public static SpecRef S131Spec => new("S-131", new SpecVersion(1, 0, 0));
     public static SpecRef S102Spec => new("S-102", new SpecVersion(2, 1, 0));
     public static SpecRef S104Spec => new("S-104", new SpecVersion(1, 0, 0));
+    public static SpecRef S111Spec => new("S-111", new SpecVersion(1, 2, 0));
 
     public static BoundingBox Box(double s = -1, double w = -1, double n = 1, double e = 1) =>
         new(s, w, n, e);
@@ -87,5 +90,31 @@ internal static class LoadedDatasetFactory
             bounds ?? Box(0, 0, 0.04, 0.04),
             null,
             new S102CoverageData(source ?? S102Synth.Source()));
+    }
+
+    public static LoadedDataset S104(
+        string id,
+        BoundingBox? bounds = null,
+        S104CoverageSource? source = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S104Spec,
+            bounds ?? Box(0, 0, 0.04, 0.04),
+            null,
+            new S104CoverageData(source ?? S104Synth.Source()));
+    }
+
+    public static LoadedDataset S111(
+        string id,
+        BoundingBox? bounds = null,
+        S111CoverageSource? source = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S111Spec,
+            bounds ?? Box(0, 0, 0.04, 0.04),
+            null,
+            new S111CoverageData(source ?? S111Synth.Source()));
     }
 }

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S101Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S101Synth.cs
@@ -8,6 +8,19 @@ internal static class S101Synth
     /// <summary>Builds a minimal in-memory S-101 dataset for tests.</summary>
     public static S101Dataset Dataset(string name = "test-enc")
     {
+        return Dataset(name, features: ImmutableArray<S101FeatureRecord>.Empty);
+    }
+
+    /// <summary>
+    /// Builds an S-101 dataset with the supplied feature records and
+    /// optional code/acronym dictionaries.
+    /// </summary>
+    public static S101Dataset Dataset(
+        string name,
+        ImmutableArray<S101FeatureRecord> features,
+        ImmutableDictionary<ushort, string>? featureTypes = null,
+        ImmutableDictionary<ushort, string>? attributeTypes = null)
+    {
         var document = new S101Document
         {
             Identification = new S101DatasetIdentification
@@ -20,13 +33,13 @@ internal static class S101Synth
                 CoordinateMultiplicationFactorY = 10_000_000,
                 CoordinateMultiplicationFactorZ = 10,
             },
-            FeatureTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
-            AttributeTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            FeatureTypeCatalogue = featureTypes ?? ImmutableDictionary<ushort, string>.Empty,
+            AttributeTypeCatalogue = attributeTypes ?? ImmutableDictionary<ushort, string>.Empty,
             Points = ImmutableDictionary<uint, S101PointRecord>.Empty,
             CurveSegments = ImmutableDictionary<uint, S101CurveSegmentRecord>.Empty,
             CompositeCurves = ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
             Surfaces = ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
-            Features = ImmutableArray<S101FeatureRecord>.Empty,
+            Features = features,
             InformationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty,
             InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
             InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
@@ -34,5 +47,33 @@ internal static class S101Synth
             RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
         };
         return S101Dataset.FromDocument(document);
+    }
+
+    /// <summary>
+    /// Builds a feature record with the given RCID, feature type code,
+    /// and optional flat attribute list and spatial associations.
+    /// </summary>
+    public static S101FeatureRecord Feature(
+        uint rcid,
+        ushort featureTypeCode,
+        IEnumerable<(ushort Code, string Value)>? attributes = null,
+        byte spatialRcnm = 110)
+    {
+        var attrs = attributes is null
+            ? ImmutableArray<S101Attribute>.Empty
+            : attributes.Select(a => new S101Attribute(a.Code, 1, a.Value)).ToImmutableArray();
+        var spatial = ImmutableArray.Create(new S101SpatialAssociation(spatialRcnm, rcid, 1));
+        return new S101FeatureRecord
+        {
+            RecordId = rcid,
+            FeatureTypeCode = featureTypeCode,
+            ProducingAgency = 540,
+            FeatureIdentificationNumber = rcid,
+            FeatureIdentificationSubdivision = 0,
+            Attributes = attrs,
+            SpatialAssociations = spatial,
+            FeatureAssociations = ImmutableArray<S101FeatureAssociation>.Empty,
+            InformationAssociations = ImmutableArray<S101InformationAssociation>.Empty,
+        };
     }
 }

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S104Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S104Synth.cs
@@ -1,0 +1,57 @@
+using EncDotNet.S100.Datasets.S104;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class S104Synth
+{
+    public static S104Dataset Dataset(
+        double originLat = 0.0,
+        double originLon = 0.0,
+        double spacingLat = 0.01,
+        double spacingLon = 0.01,
+        int numRows = 4,
+        int numCols = 4,
+        float height = 1.5f,
+        byte trend = 3,
+        int dataCodingFormat = 2,
+        DateTime[]? times = null)
+    {
+        times ??= new[]
+        {
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 2, 0, 0, DateTimeKind.Utc),
+        };
+
+        var coverages = new List<WaterLevelCoverage>();
+        for (int t = 0; t < times.Length; t++)
+        {
+            var values = new WaterLevelValue[numRows * numCols];
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = new WaterLevelValue(height + t * 0.1f, trend);
+            }
+            coverages.Add(new WaterLevelCoverage
+            {
+                OriginLatitude = originLat,
+                OriginLongitude = originLon,
+                SpacingLatitudinal = spacingLat,
+                SpacingLongitudinal = spacingLon,
+                NumPointsLatitudinal = numRows,
+                NumPointsLongitudinal = numCols,
+                TimePoint = times[t],
+                Values = values,
+            });
+        }
+
+        return new S104Dataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = dataCodingFormat,
+            Coverages = coverages,
+        };
+    }
+
+    public static S104CoverageSource Source(S104Dataset? dataset = null) =>
+        new(dataset ?? Dataset());
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S111Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S111Synth.cs
@@ -1,0 +1,57 @@
+using EncDotNet.S100.Datasets.S111;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+internal static class S111Synth
+{
+    public static S111Dataset Dataset(
+        double originLat = 0.0,
+        double originLon = 0.0,
+        double spacingLat = 0.01,
+        double spacingLon = 0.01,
+        int numRows = 4,
+        int numCols = 4,
+        float speed = 0.5f,
+        float direction = 90.0f,
+        int dataCodingFormat = 2,
+        DateTime[]? times = null)
+    {
+        times ??= new[]
+        {
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 2, 0, 0, DateTimeKind.Utc),
+        };
+
+        var coverages = new List<SurfaceCurrentCoverage>();
+        for (int t = 0; t < times.Length; t++)
+        {
+            var values = new SurfaceCurrentValue[numRows * numCols];
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = new SurfaceCurrentValue(speed + t * 0.05f, direction);
+            }
+            coverages.Add(new SurfaceCurrentCoverage
+            {
+                OriginLatitude = originLat,
+                OriginLongitude = originLon,
+                SpacingLatitudinal = spacingLat,
+                SpacingLongitudinal = spacingLon,
+                NumPointsLatitudinal = numRows,
+                NumPointsLongitudinal = numCols,
+                TimePoint = times[t],
+                Values = values,
+            });
+        }
+
+        return new S111Dataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = dataCodingFormat,
+            Coverages = coverages,
+        };
+    }
+
+    public static S111CoverageSource Source(S111Dataset? dataset = null) =>
+        new(dataset ?? Dataset());
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolTests.cs
@@ -1,5 +1,7 @@
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
 
@@ -60,18 +62,242 @@ public class SampleCoverageToolTests
     }
 
     [Fact]
-    public async Task Returns_SpecNotSupported_for_S104()
+    public async Task S104_returns_water_level_sample_at_first_time_step_by_default()
     {
         var catalog = new FakeDatasetCatalog();
+        var times = new[]
+        {
+            new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 1, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 1, 2, 0, 0, DateTimeKind.Utc),
+        };
+        var dataset = S104Synth.Dataset(originLat: 0, originLon: 0, height: 1.5f, trend: 2, times: times);
+        catalog.Add(LoadedDatasetFactory.S104(
+            "wl-1",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S104CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelSample>(value.Value);
+        Assert.Equal(1.5, sample.WaterLevelHeight, 5);
+        Assert.Equal("increasing", sample.Trend);
+        Assert.Equal(times[0], sample.SampleTime);
+        Assert.Null(sample.RequestedTime);
+    }
+
+    [Fact]
+    public async Task S104_clamps_to_last_time_step_when_requested_time_is_after_dataset()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var times = new[]
+        {
+            new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 1, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 1, 2, 0, 0, DateTimeKind.Utc),
+        };
+        var dataset = S104Synth.Dataset(times: times);
+        catalog.Add(LoadedDatasetFactory.S104(
+            "wl-clamp-late",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S104CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var requested = new DateTimeOffset(2024, 12, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 0.02, Longitude: 0.02, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelSample>(value.Value);
+        Assert.Equal(times[^1], sample.SampleTime);
+        Assert.Equal(requested, sample.RequestedTime);
+    }
+
+    [Fact]
+    public async Task S104_clamps_to_first_time_step_when_requested_time_is_before_dataset()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var times = new[]
+        {
+            new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 1, 1, 0, 0, DateTimeKind.Utc),
+        };
+        var dataset = S104Synth.Dataset(times: times);
+        catalog.Add(LoadedDatasetFactory.S104(
+            "wl-clamp-early",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S104CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var requested = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 0.02, Longitude: 0.02, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelSample>(value.Value);
+        Assert.Equal(times[0], sample.SampleTime);
+    }
+
+    [Fact]
+    public async Task S104_returns_OutOfBounds_when_point_outside_loaded_S104_bounds()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S104Synth.Dataset();
+        catalog.Add(LoadedDatasetFactory.S104(
+            "wl-oob",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S104CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 50, Longitude: 50));
+
+        Assert.True(result.TryGetError(out var error));
+        var oob = Assert.IsType<OutOfBounds>(error);
+        Assert.Equal("S-104", oob.Spec.Name);
+    }
+
+    [Fact]
+    public async Task S104_returns_NoDatasetCoversPoint_when_no_S104_loaded()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("v"));
         var tool = new SampleCoverageTool(catalog);
 
         var result = await tool.InvokeAsync(new SampleCoverageRequest(
             LoadedDatasetFactory.S104Spec, Latitude: 0, Longitude: 0));
 
         Assert.True(result.TryGetError(out var error));
-        var unsupported = Assert.IsType<SpecNotSupportedForTool>(error);
-        Assert.Equal("S-104", unsupported.Spec.Name);
-        Assert.Equal(SampleCoverageTool.Name, unsupported.Tool);
+        Assert.IsType<NoDatasetCoversPoint>(error);
+    }
+
+    [Fact]
+    public async Task S104_returns_NotSupportedYet_for_non_regular_grid()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S104Synth.Dataset(dataCodingFormat: 8);
+        catalog.Add(LoadedDatasetFactory.S104(
+            "wl-dcf8",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S104CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetError(out var error));
+        var nsy = Assert.IsType<NotSupportedYet>(error);
+        Assert.Equal("S-104", nsy.Spec.Name);
+        Assert.Equal(SampleCoverageTool.Name, nsy.Tool);
+    }
+
+    [Fact]
+    public async Task S104_returns_NoDataAtPoint_when_cell_is_fill_value()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S104Synth.Dataset(height: S104CoverageSource.FillValue);
+        catalog.Add(LoadedDatasetFactory.S104(
+            "wl-nodata",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S104CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetError(out var error));
+        Assert.IsType<NoDataAtPoint>(error);
+    }
+
+    [Fact]
+    public async Task S111_returns_surface_current_sample_with_metres_per_second_and_knots()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S111Synth.Dataset(speed: 1.0f, direction: 45.0f);
+        catalog.Add(LoadedDatasetFactory.S111(
+            "sc-1",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S111CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<SurfaceCurrentSample>(value.Value);
+        Assert.Equal(1.0, sample.SpeedMetresPerSecond, 5);
+        // 1.0 m/s × 1.94384… ≈ 1.94384 kn.
+        Assert.Equal(1.94384, sample.SpeedKnots, 3);
+        Assert.Equal(45.0, sample.DirectionDegreesTrue, 5);
+    }
+
+    [Fact]
+    public async Task S111_clamps_time_outside_range()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var times = new[]
+        {
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+        };
+        var dataset = S111Synth.Dataset(times: times);
+        catalog.Add(LoadedDatasetFactory.S111(
+            "sc-clamp",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S111CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var before = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var beforeResult = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 0.02, Longitude: 0.02, Time: before));
+        Assert.True(beforeResult.TryGetValue(out var bv));
+        Assert.Equal(times[0], Assert.IsType<SurfaceCurrentSample>(bv.Value).SampleTime);
+
+        var after = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var afterResult = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 0.02, Longitude: 0.02, Time: after));
+        Assert.True(afterResult.TryGetValue(out var av));
+        Assert.Equal(times[^1], Assert.IsType<SurfaceCurrentSample>(av.Value).SampleTime);
+    }
+
+    [Fact]
+    public async Task S111_returns_NotSupportedYet_for_non_regular_grid()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S111Synth.Dataset(dataCodingFormat: 3);
+        catalog.Add(LoadedDatasetFactory.S111(
+            "sc-dcf3",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S111CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 0.02, Longitude: 0.02));
+
+        Assert.True(result.TryGetError(out var error));
+        var nsy = Assert.IsType<NotSupportedYet>(error);
+        Assert.Equal("S-111", nsy.Spec.Name);
+    }
+
+    [Fact]
+    public async Task S111_returns_OutOfBounds_when_point_outside_loaded_S111_bounds()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S111Synth.Dataset();
+        catalog.Add(LoadedDatasetFactory.S111(
+            "sc-oob",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S111CoverageSource(dataset)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: -50, Longitude: -50));
+
+        Assert.True(result.TryGetError(out var error));
+        Assert.IsType<OutOfBounds>(error);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs
@@ -129,16 +129,41 @@ public class ViewerDatasetCatalogTests
     }
 
     [Fact]
-    public void Exchange_set_entry_is_skipped()
+    public void Exchange_set_entry_with_in_memory_payload_is_projected()
+    {
+        // Reads the bundled S-124 fixture and serves it from an
+        // IAssetSource (the exchange-set surface). The catalog must
+        // accept it even though there is no on-disk FilePath, because
+        // LoadedDatasetData already carries everything downstream
+        // consumers need.
+        var fixture = Path("S124", "navwarn_point.gml");
+        Skip.IfNot(File.Exists(fixture), $"Missing fixture {fixture}");
+        var bytes = File.ReadAllBytes(fixture);
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(
+            filePath: string.Empty,
+            productSpec: "S-124",
+            source: new FakeAssetSource(bytes),
+            relativePath: "navwarn_point.gml",
+            displayName: "navwarn_point.gml");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.Equal("S-124", loaded.Spec.Name);
+        Assert.IsType<S124DatasetData>(loaded.Data);
+    }
+
+    [Fact]
+    public void On_disk_entry_with_missing_file_is_skipped()
     {
         var loader = new FakeDatasetLoaderService();
         using var catalog = new ViewerDatasetCatalog(loader);
         var entry = new DatasetEntry(
-            filePath: "ignored.gml",
-            productSpec: "S-124",
-            source: new FakeAssetSource(),
-            relativePath: "ignored.gml",
-            displayName: "ignored.gml");
+            filePath: "/does/not/exist.gml",
+            productSpec: "S-124");
 
         loader.RaiseLoaded(entry);
 
@@ -174,8 +199,14 @@ public class ViewerDatasetCatalogTests
 
     private sealed class FakeAssetSource : IAssetSource
     {
+        private readonly byte[] _bytes;
+
+        public FakeAssetSource() : this(Array.Empty<byte>()) { }
+
+        public FakeAssetSource(byte[] bytes) { _bytes = bytes; }
+
         public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default) =>
-            Task.FromResult<Stream>(new MemoryStream());
+            Task.FromResult<Stream>(new MemoryStream(_bytes, writable: false));
 
         public void Dispose() { }
     }


### PR DESCRIPTION
Closes the three follow-ups deferred from PR MCP-3.

## Item 1 — Exchange-set entry ingest
`ViewerDatasetCatalog.OnDatasetLoaded` no longer drops exchange-set entries. The early-return guard now only requires a present on-disk file for plain entries; exchange-set entries (no `FilePath`) are projected by opening a stream through the entry's `IAssetSource`. Per-spec `TryProject` arms (S-101, S-102, S-104, S-111, all GML specs) consume `Stream` via a single `OpenEntryStream(entry)` helper.

## Item 2 — Real S-101 describe_feature
`S101FeatureDescriber` is implemented end-to-end (modelled on `S124FeatureDescriber`). Accepts either bare RCID (`"12345"`) or `RCNM:RCID[:RVER]` composite (`"100:12345:1"`). Returns code, acronym, FC-resolved name (acronym fallback if FC absent), attributes, spatial associations, feature/info associations, and geometry primitive. Unknown id → `NotFound`; non-S-101 payload → `SpecMismatch`.

## Item 3 — S-104 / S-111 in sample_coverage
`SampleCoverageTool` now dispatches by spec:
- **S-102**: unchanged (depth + uncertainty).
- **S-104**: nearest-cell water-level height + decoded trend enum (`unknown`/`decreasing`/`increasing`/`steady`/raw); explicit `time` resolves to nearest step (clamped to `[0, numberOfTimes-1]`); default → first record.
- **S-111**: speed in both **m/s** and **knots** (× 1.94384), direction in degrees true; same time-step rules.

New `ToolError` variants: `OutOfBounds`, `NoDataAtPoint`, `NotSupportedYet`. `dataCodingFormat != 2` → `NotSupportedYet`. Fill values (-9999f) → `NoDataAtPoint` carrying resolved cell + time-step.

Result variants added as a discriminated union (`S102Sample`, `S104Sample`, `S111Sample`).

## Tests
All-synthetic; no real producer files. Full Release suite green.
- 11 new `SampleCoverageToolTests` (S-104/S-111 happy paths, time clamping early/late, `OutOfBounds`, dcf!=2, NoData, knots verified).
- 5 new `DescribeFeatureToolTests` S-101 cases (bare RCID, composite FRID, unknown id, non-feature RCNM, FC-absent degrades to acronym).
- `ViewerDatasetCatalogTests` flipped: exchange-set entry with in-memory payload is projected; on-disk missing file still skipped.

## Guardrails
- `dotnet build` + `dotnet test --configuration Release` green.
- No real producer data committed.
- Existing tool/error/result patterns preserved.
- S-104/S-111 spec section numbers cited in XML doc on time-step indexing and fill-value constants.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>