### PR TITLE
PR-C: S-104 dcf8 (time series at fixed stations) support

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -12,21 +12,37 @@ using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Renderers.Mapsui;
 using Mapsui;
 using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
+/// <summary>
+/// Pipeline processor for S-104 water-level datasets. Branches between
+/// dcf2 (regular grid → coverage layer) and dcf8 (time series at fixed
+/// stations → station-glyph point layer; see S-104 Edition 2.0.0
+/// §10.2.3 / §10.2.7).
+/// </summary>
 public sealed class S104DatasetProcessor : IDatasetProcessor
 {
-    private readonly S104CoverageSource _source;
-    private readonly S104PortrayalCatalogue _catalogue;
+    // dcf2 only
+    private readonly S104CoverageSource? _source;
+    private readonly S104PortrayalCatalogue? _catalogue;
+
+    // dcf8 only
+    private readonly S104StationSeriesDataset? _stationSeries;
+    private readonly IReadOnlyList<DateTime> _stationTimes = Array.Empty<DateTime>();
+
     private readonly ICrsTransformFactory _crsTransformFactory;
-    private readonly S104Dataset _dataset;
+    private readonly S104DatasetData _data;
     private readonly string _fileName;
 
     public SpecRef Spec => new("S-104", default);
 
     /// <summary>Available forecast time steps in this dataset.</summary>
-    public IReadOnlyList<DateTime> AvailableTimes => _source.AvailableTimes;
+    public IReadOnlyList<DateTime> AvailableTimes =>
+        _source?.AvailableTimes ?? _stationTimes;
 
     public S104DatasetProcessor(
         string path,
@@ -35,11 +51,6 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     {
     }
 
-    /// <summary>
-    /// Initializes a new <see cref="S104DatasetProcessor"/> by reading
-    /// the HDF5 dataset <paramref name="relativePath"/> from
-    /// <paramref name="source"/>. Used by exchange-set bulk loading.
-    /// </summary>
     public S104DatasetProcessor(
         IAssetSource source,
         string relativePath,
@@ -65,7 +76,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         {
             try
             {
-                _dataset = S104DatasetReader.Read(hdf5);
+                _data = S104DatasetReader.ReadAny(hdf5);
             }
             catch (S100DatasetSchemaException ex) when (ex.File is null)
             {
@@ -76,28 +87,48 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
                 throw ex.WithFile(_fileName);
             }
         }
-        _source = new S104CoverageSource(_dataset);
-        _catalogue = new S104PortrayalCatalogue();
+
+        switch (_data)
+        {
+            case S104DatasetData.GriddedCoverage g:
+                _source = new S104CoverageSource(g.Dataset);
+                _catalogue = new S104PortrayalCatalogue();
+                break;
+            case S104DatasetData.StationSeries s:
+                _stationSeries = s.Dataset;
+                _stationTimes = ComputeStationUnionTimes(s.Dataset);
+                break;
+        }
     }
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        if (_stationSeries is not null)
+        {
+            return RenderStationSeries(_stationSeries, context);
+        }
+        return RenderGridded(context);
+    }
 
-        // Select the requested time step, defaulting to the first
+    private DatasetResult RenderGridded(RenderContext? context)
+    {
+        var source = _source!;
+        var catalogue = _catalogue!;
+        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+
         DateTime selectedTime;
         if (context is S104RenderContext { TimeStep: { } timeStep })
         {
-            _source.SelectTime(timeStep);
+            source.SelectTime(timeStep);
             selectedTime = timeStep;
         }
         else
         {
-            selectedTime = _source.AvailableTimes[0];
-            _source.SelectTime(selectedTime);
+            selectedTime = source.AvailableTimes[0];
+            source.SelectTime(selectedTime);
         }
 
-        var metadata = _source.Metadata;
+        var metadata = source.Metadata;
 
         var viewport = new EncDotNet.S100.Pipelines.Viewport
         {
@@ -111,7 +142,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
+        var layer = pipeline.ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default)
             .GetAwaiter().GetResult();
         var styledLayer = (StyledCoverageLayer)layer;
 
@@ -122,10 +153,11 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         var colorLayer = colorRenderer.Render(styledLayer, viewport);
         var extent = colorLayer.Extent ?? new MRect(0, 0, 0, 0);
 
-        int crs = _dataset.HorizontalCRS ?? 4326;
-        var geoId = _dataset.GeographicIdentifier ?? _fileName;
-        var timeInfo = _source.AvailableTimes.Count > 1
-            ? $", time: {selectedTime:u} ({_source.AvailableTimes.Count} steps)"
+        var griddedDataset = ((S104DatasetData.GriddedCoverage)_data).Dataset;
+        int crs = griddedDataset.HorizontalCRS ?? 4326;
+        var geoId = griddedDataset.GeographicIdentifier ?? _fileName;
+        var timeInfo = source.AvailableTimes.Count > 1
+            ? $", time: {selectedTime:u} ({source.AvailableTimes.Count} steps)"
             : "";
         var info = $"{geoId} — {metadata.GridMetadata.NumColumns}×{metadata.GridMetadata.NumRows} grid, CRS: EPSG:{crs}{timeInfo}";
 
@@ -138,29 +170,147 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         };
     }
 
-    public FeatureInfo? GetFeatureInfo(string featureRef) => null;
+    // ---- dcf8 station series rendering ---------------------------------
+
+    private DatasetResult RenderStationSeries(S104StationSeriesDataset ds, RenderContext? context)
+    {
+        DateTime selectedTime;
+        if (context is S104RenderContext { TimeStep: { } timeStep })
+        {
+            selectedTime = timeStep;
+        }
+        else
+        {
+            selectedTime = ds.MinTime ?? DateTime.UtcNow;
+        }
+
+        var nativeToMerc = _crsTransformFactory.Create($"EPSG:{ds.HorizontalCRS ?? 4326}", "EPSG:3857");
+
+        var features = new List<IFeature>(ds.Stations.Count);
+        double mercMinX = double.PositiveInfinity, mercMinY = double.PositiveInfinity;
+        double mercMaxX = double.NegativeInfinity, mercMaxY = double.NegativeInfinity;
+
+        foreach (var station in ds.Stations)
+        {
+            double mx, my;
+            if (nativeToMerc.IsIdentity)
+            {
+                mx = station.Longitude;
+                my = station.Latitude;
+            }
+            else
+            {
+                (mx, my) = nativeToMerc.Transform(station.Longitude, station.Latitude);
+            }
+
+            if (mx < mercMinX) mercMinX = mx;
+            if (mx > mercMaxX) mercMaxX = mx;
+            if (my < mercMinY) mercMinY = my;
+            if (my > mercMaxY) mercMaxY = my;
+
+            int idx = station.NearestTimeIndex(selectedTime);
+            var height = station.Heights[idx];
+            var trend = station.Trends[idx];
+
+            var fill = TrendFill(trend);
+            var stroke = ResolveStrokeColor(height, ds.WaterLevelTrendThreshold);
+
+            var feature = new GeometryFeature
+            {
+                Geometry = new Point(mx, my),
+            };
+            feature["StationId"] = station.Identifier;
+            feature["WaterLevelHeight"] = height;
+            feature["WaterLevelTrend"] = (int)trend;
+            feature["WaterLevelTrendLabel"] = DecodeTrend(trend);
+            feature["SampleTime"] = station.TimeAt(idx);
+            feature["Latitude"] = station.Latitude;
+            feature["Longitude"] = station.Longitude;
+
+            feature.Styles.Add(new SymbolStyle
+            {
+                SymbolType = SymbolType.Ellipse,
+                Fill = new Brush(fill),
+                Outline = new Pen(stroke, 1.5),
+                SymbolScale = 0.7,
+            });
+
+            features.Add(feature);
+        }
+
+        var layer = new MemoryLayer
+        {
+            Name = $"S-104: {_fileName}",
+            Features = features,
+            Style = null,
+        };
+
+        var extent = ds.Stations.Count == 0
+            ? new MRect(0, 0, 0, 0)
+            : new MRect(mercMinX, mercMinY, mercMaxX, mercMaxY);
+
+        var info = $"{ds.GeographicIdentifier ?? _fileName} — {ds.Stations.Count} stations, " +
+                   $"time: {selectedTime:u}";
+
+        return new DatasetResult
+        {
+            Layers = [layer],
+            Extent = extent,
+            Info = info,
+            Spec = new SpecRef("S-104", default),
+        };
+    }
+
+    private static IReadOnlyList<DateTime> ComputeStationUnionTimes(S104StationSeriesDataset ds)
+    {
+        var set = new SortedSet<DateTime>();
+        foreach (var s in ds.Stations)
+        {
+            for (int i = 0; i < s.NumberOfTimes; i++)
+            {
+                set.Add(DateTime.SpecifyKind(s.TimeAt(i), DateTimeKind.Utc));
+            }
+        }
+        return set.ToArray();
+    }
 
     /// <summary>
-    /// Samples the water-level grid at the supplied geographic
-    /// position and time. <paramref name="time"/> is matched to the
-    /// nearest available time step (see
-    /// <see cref="S104CoverageSource.SelectTime"/>); when <c>null</c>
-    /// the first available step is used.
+    /// Trend → fill colour table (S-104 Edition 2.0.0 §10.2.7 trend
+    /// enumeration: 0 unknown, 1 decreasing, 2 increasing, 3 steady).
     /// </summary>
-    /// <remarks>
-    /// <see cref="S104.WaterLevelValue.Trend"/> is decoded against the
-    /// S-104 Edition 2.0.0 trend enumeration (0 nodata, 1 decreasing,
-    /// 2 increasing, 3 steady).
-    /// </remarks>
+    private static Color TrendFill(byte trend) => trend switch
+    {
+        1 => new Color(42, 111, 151),    // #2a6f97 descending blue
+        2 => new Color(193, 18, 31),     // #c1121f ascending red
+        3 => new Color(42, 157, 143),    // #2a9d8f neutral teal
+        _ => new Color(128, 128, 128),   // #808080 unknown grey
+    };
+
+    private static Color ResolveStrokeColor(float height, double? trendThreshold)
+    {
+        if (trendThreshold is null) return new Color(0, 0, 0);
+        return height >= trendThreshold.Value
+            ? new Color(255, 255, 255)
+            : new Color(0, 0, 0);
+    }
+
+    public FeatureInfo? GetFeatureInfo(string featureRef) => null;
+
     public FeatureInfo? GetCoverageInfo(double latitude, double longitude, DateTime? time)
     {
-        if (_source.AvailableTimes.Count == 0)
+        if (_stationSeries is not null)
+        {
+            return GetStationInfo(_stationSeries, latitude, longitude, time);
+        }
+
+        var source = _source!;
+        if (source.AvailableTimes.Count == 0)
             return null;
 
-        var selectedTime = time ?? _source.AvailableTimes[0];
-        _source.SelectTime(selectedTime);
+        var selectedTime = time ?? source.AvailableTimes[0];
+        source.SelectTime(selectedTime);
 
-        var sample = CoveragePickHelper.Sample(_source, _crsTransformFactory, latitude, longitude);
+        var sample = CoveragePickHelper.Sample(source, _crsTransformFactory, latitude, longitude);
         if (sample is null)
             return null;
 
@@ -204,6 +354,74 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         };
     }
 
+    private FeatureInfo? GetStationInfo(
+        S104StationSeriesDataset ds,
+        double latitude,
+        double longitude,
+        DateTime? time)
+    {
+        if (ds.Stations.Count == 0) return null;
+
+        // Nearest station via small-angle approximation; the viewer's
+        // PickService already supplies pixel-tolerant hit-testing.
+        WaterLevelStation? best = null;
+        double bestSqDeg = double.PositiveInfinity;
+        foreach (var s in ds.Stations)
+        {
+            var dLat = s.Latitude - latitude;
+            var dLon = (s.Longitude - longitude) * Math.Cos(latitude * Math.PI / 180.0);
+            var d = dLat * dLat + dLon * dLon;
+            if (d < bestSqDeg)
+            {
+                bestSqDeg = d;
+                best = s;
+            }
+        }
+        if (best is null) return null;
+
+        var selectedTime = time ?? best.StartTime;
+        int idx = best.NearestTimeIndex(selectedTime);
+        var height = best.Heights[idx];
+        var trend = best.Trends[idx];
+        var sampleTime = best.TimeAt(idx);
+
+        return new FeatureInfo
+        {
+            FeatureRef = best.Identifier,
+            FeatureType = "WaterLevel",
+            FeatureTypeName = "Water Level (Station)",
+            Attributes = new List<PickAttribute>
+            {
+                new()
+                {
+                    Code = "stationIdentification",
+                    Name = "Station",
+                    RawValue = best.Identifier,
+                },
+                new()
+                {
+                    Code = "waterLevelHeight",
+                    Name = "Water Level Height",
+                    RawValue = height.ToString("0.##########", CultureInfo.InvariantCulture),
+                    DisplayValue = $"{height.ToString("0.##", CultureInfo.InvariantCulture)} m",
+                },
+                new()
+                {
+                    Code = "waterLevelTrend",
+                    Name = "Water Level Trend",
+                    RawValue = ((int)trend).ToString(CultureInfo.InvariantCulture),
+                    DisplayValue = DecodeTrend(trend),
+                },
+                new()
+                {
+                    Code = "timePoint",
+                    Name = "Time",
+                    RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                },
+            },
+        };
+    }
+
     private static string DecodeTrend(int code) => code switch
     {
         1 => "Decreasing",
@@ -211,4 +429,6 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         3 => "Steady",
         _ => "Unknown",
     };
+
+    private static string DecodeTrend(byte code) => DecodeTrend((int)code);
 }

--- a/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
@@ -408,7 +408,7 @@ public static class S104DatasetReader
                 innerException: ex);
         }
 
-        var latMember = raw.FindMember("latitude", "Latitude")
+        var latMember = raw.FindMember("latitude", "Latitude", "lat", "Lat")
             ?? throw new S100DatasetSchemaException(
                 product: "S-104",
                 file: null,
@@ -419,7 +419,7 @@ public static class S104DatasetReader
                     "S-104", null, "/Positioning/geometryValues", "latitude",
                     "S-104 Edition 2.0.0 §10.2.3"));
 
-        var lonMember = raw.FindMember("longitude", "Longitude")
+        var lonMember = raw.FindMember("longitude", "Longitude", "long", "Long", "lon", "Lon")
             ?? throw new S100DatasetSchemaException(
                 product: "S-104",
                 file: null,

--- a/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
@@ -6,15 +6,46 @@ namespace EncDotNet.S100.Datasets.S104;
 
 /// <summary>
 /// Reads an S-104 Water Level dataset from an HDF5 file via the
-/// <see cref="IHdf5File"/> abstraction. Currently supports data coding format 2
-/// (regular grid) only.
+/// <see cref="IHdf5File"/> abstraction. Supports data coding format 2
+/// (regularly-gridded coverage) and data coding format 8 (time series at
+/// fixed stations).
 /// </summary>
 public static class S104DatasetReader
 {
     /// <summary>
-    /// Reads an <see cref="S104Dataset"/> from the given HDF5 file.
+    /// Reads an <see cref="S104Dataset"/> from the given HDF5 file. Throws
+    /// <see cref="S100DatasetNotSupportedException"/> if the dataset is
+    /// not dcf2 (regularly-gridded). Use <see cref="ReadAny"/> to handle
+    /// both dcf2 and dcf8.
     /// </summary>
     public static S104Dataset Read(IHdf5File file)
+    {
+        var any = ReadAny(file);
+        return any switch
+        {
+            S104DatasetData.GriddedCoverage g => g.Dataset,
+            S104DatasetData.StationSeries => throw new S100DatasetNotSupportedException(
+                product: "S-104",
+                file: null,
+                feature: "data coding format 8 (time series at fixed stations)",
+                specReference: "S-100 Part 10c §10.2.1",
+                message: ExceptionMessageFormatter.FormatNotSupported(
+                    "S-104", null,
+                    "data coding format 8 (time series at fixed stations)",
+                    "S-100 Part 10c §10.2.1",
+                    "Use S104DatasetReader.ReadAny to handle dcf8 station series.")),
+            _ => throw new InvalidOperationException("Unhandled S104DatasetData variant."),
+        };
+    }
+
+    /// <summary>
+    /// Reads either a dcf2 <see cref="S104Dataset"/> or a dcf8
+    /// <see cref="S104StationSeriesDataset"/> from the given HDF5 file,
+    /// dispatching on the <c>/WaterLevel/dataCodingFormat</c> attribute
+    /// (S-100 Part 10c §10.2.1). Other data coding formats raise
+    /// <see cref="S100DatasetNotSupportedException"/>.
+    /// </summary>
+    public static S104DatasetData ReadAny(IHdf5File file)
     {
         using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
         __activity?.SetTag("s100.product", "S-104");
@@ -42,6 +73,10 @@ public static class S104DatasetReader
             ? root.ReadStringAttribute("metadata")
             : null;
 
+        double? waterLevelTrendThreshold = root.AttributeExists("waterLevelTrendThreshold")
+            ? root.ReadDoubleAttribute("waterLevelTrendThreshold")
+            : null;
+
         var wlGroup = root.OpenGroup("WaterLevel");
         const string WaterLevelPath = "/WaterLevel";
 
@@ -60,9 +95,35 @@ public static class S104DatasetReader
             ? wlGroup.ReadStringAttribute("methodWaterLevelProduct")
             : null;
 
+        if (dataCodingFormat == 8)
+        {
+            var stations = ReadStationSeries(root, wlGroup);
+            DateTime? minTime = null, maxTime = null;
+            foreach (var s in stations)
+            {
+                if (minTime is null || s.StartTime < minTime) minTime = s.StartTime;
+                if (maxTime is null || s.EndTime > maxTime) maxTime = s.EndTime;
+            }
+
+            return new S104DatasetData.StationSeries(new S104StationSeriesDataset
+            {
+                HorizontalCRS = horizontalCRS,
+                Epoch = epoch,
+                GeographicIdentifier = geographicIdentifier,
+                IssueDate = issueDate,
+                Metadata = metadata,
+                DataCodingFormat = 8,
+                MethodWaterLevelProduct = methodWaterLevelProduct,
+                WaterLevelTrendThreshold = waterLevelTrendThreshold,
+                Stations = stations,
+                MinTime = minTime,
+                MaxTime = maxTime,
+            });
+        }
+
         var coverages = ReadCoverages(wlGroup, dataCodingFormat);
 
-        return new S104Dataset
+        return new S104DatasetData.GriddedCoverage(new S104Dataset
         {
             HorizontalCRS = horizontalCRS,
             Epoch = epoch,
@@ -72,7 +133,7 @@ public static class S104DatasetReader
             DataCodingFormat = dataCodingFormat,
             MethodWaterLevelProduct = methodWaterLevelProduct,
             Coverages = coverages,
-        };
+        });
     }
 
     private static List<WaterLevelCoverage> ReadCoverages(IHdf5Group wlGroup, int dataCodingFormat)
@@ -87,7 +148,7 @@ public static class S104DatasetReader
                 specReference: "S-100 Part 10c §10.2.1",
                 message: ExceptionMessageFormatter.FormatNotSupported(
                     "S-104", null, feature, "S-100 Part 10c §10.2.1",
-                    "Only format 2 (regular grid) is currently implemented."));
+                    "Only formats 2 (regular grid) and 8 (time series at fixed stations) are currently implemented."));
         }
 
         var coverages = new List<WaterLevelCoverage>();
@@ -246,5 +307,292 @@ public static class S104DatasetReader
         }
 
         return result;
+    }
+
+    // -------------------------------------------------------------------
+    // dcf8 — time series at fixed stations (S-104 Edition 2.0.0 §10.2.3 / §10.2.7)
+    // -------------------------------------------------------------------
+
+    /// <summary>
+    /// Reads every <c>WaterLevel.NN</c> instance group's per-station
+    /// time-series payload and joins it against
+    /// <c>/Positioning/geometryValues</c> (S-104 Edition 2.0.0 §10.2.3),
+    /// returning one <see cref="WaterLevelStation"/> per <c>Group_NNN</c>.
+    /// </summary>
+    /// <remarks>
+    /// Per spec §10.2.3 the i-th row of <c>geometryValues</c> is the
+    /// position of the i-th station (Group_001 → row 0). Positions are
+    /// shared across every <c>WaterLevel.NN</c> instance under
+    /// <c>/WaterLevel/</c>.
+    /// </remarks>
+    private static IReadOnlyList<WaterLevelStation> ReadStationSeries(IHdf5Group root, IHdf5Group wlGroup)
+    {
+        var positions = ReadStationPositions(root);
+
+        var stations = new List<WaterLevelStation>();
+
+        foreach (var instanceName in wlGroup.GroupNames)
+        {
+            if (!instanceName.StartsWith("WaterLevel.", StringComparison.Ordinal))
+                continue;
+
+            var instance = wlGroup.OpenGroup(instanceName);
+            var instancePath = $"/WaterLevel/{instanceName}";
+            ReadStationInstance(instance, instancePath, positions, stations);
+        }
+
+        return stations;
+    }
+
+    private static List<(double Lat, double Lon)> ReadStationPositions(IHdf5Group root)
+    {
+        // S-104 Edition 2.0.0 §10.2.3 — station positions live in a
+        // /Positioning group containing a compound 'geometryValues'
+        // dataset with members 'latitude' and 'longitude'. Some legacy
+        // tooling places the group under /WaterLevel/Positioning;
+        // accept either.
+        IHdf5Group? positioningGroup = null;
+        if (root.GroupNames.Contains("Positioning"))
+        {
+            positioningGroup = root.OpenGroup("Positioning");
+        }
+        else
+        {
+            // Look one level deeper, under any WaterLevel.NN instance.
+            // (Strictly out-of-spec but worth a tolerant fallback.)
+            if (root.GroupNames.Contains("WaterLevel"))
+            {
+                var wl = root.OpenGroup("WaterLevel");
+                foreach (var name in wl.GroupNames)
+                {
+                    if (!name.StartsWith("WaterLevel.", StringComparison.Ordinal)) continue;
+                    var inst = wl.OpenGroup(name);
+                    if (inst.GroupNames.Contains("Positioning"))
+                    {
+                        positioningGroup = inst.OpenGroup("Positioning");
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (positioningGroup is null)
+        {
+            throw new S100DatasetSchemaException(
+                product: "S-104",
+                file: null,
+                groupPath: "/Positioning",
+                attributeOrDataset: "Positioning/geometryValues",
+                specReference: "S-104 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-104", null, "/Positioning", "Positioning/geometryValues",
+                    "S-104 Edition 2.0.0 §10.2.3"));
+        }
+
+        RawCompoundDataset raw;
+        try
+        {
+            raw = positioningGroup.ReadRawCompoundDataset("geometryValues");
+        }
+        catch (Exception ex)
+        {
+            throw new S100DatasetSchemaException(
+                product: "S-104",
+                file: null,
+                groupPath: "/Positioning",
+                attributeOrDataset: "Positioning/geometryValues",
+                specReference: "S-104 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-104", null, "/Positioning", "Positioning/geometryValues",
+                    "S-104 Edition 2.0.0 §10.2.3"),
+                innerException: ex);
+        }
+
+        var latMember = raw.FindMember("latitude", "Latitude")
+            ?? throw new S100DatasetSchemaException(
+                product: "S-104",
+                file: null,
+                groupPath: "/Positioning/geometryValues",
+                attributeOrDataset: "latitude",
+                specReference: "S-104 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-104", null, "/Positioning/geometryValues", "latitude",
+                    "S-104 Edition 2.0.0 §10.2.3"));
+
+        var lonMember = raw.FindMember("longitude", "Longitude")
+            ?? throw new S100DatasetSchemaException(
+                product: "S-104",
+                file: null,
+                groupPath: "/Positioning/geometryValues",
+                attributeOrDataset: "longitude",
+                specReference: "S-104 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-104", null, "/Positioning/geometryValues", "longitude",
+                    "S-104 Edition 2.0.0 §10.2.3"));
+
+        var positions = new List<(double Lat, double Lon)>(raw.RecordCount);
+        var span = raw.Data.AsSpan();
+        for (int i = 0; i < raw.RecordCount; i++)
+        {
+            var record = span.Slice(i * raw.RecordSize, raw.RecordSize);
+            double lat = ReadFloatingPointMember(record, latMember);
+            double lon = ReadFloatingPointMember(record, lonMember);
+            positions.Add((lat, lon));
+        }
+        return positions;
+    }
+
+    private static double ReadFloatingPointMember(ReadOnlySpan<byte> record, CompoundMemberInfo member) =>
+        member.Kind switch
+        {
+            CompoundMemberKind.Float32 => System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+                record.Slice(member.Offset, 4)),
+            CompoundMemberKind.Float64 => System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+                record.Slice(member.Offset, 8)),
+            _ => throw new NotSupportedException(
+                $"S-104 Positioning member '{member.Name}' has unsupported kind {member.Kind}."),
+        };
+
+    private static void ReadStationInstance(
+        IHdf5Group instance,
+        string instancePath,
+        IReadOnlyList<(double Lat, double Lon)> positions,
+        List<WaterLevelStation> stations)
+    {
+        const string Spec = "S-104 Edition 2.0.0 §10.2.7";
+
+        int numberOfStations = instance.AttributeExists("numberOfStations")
+            ? (int)instance.ReadInt64Attribute("numberOfStations")
+            : 0;
+
+        // Walk each Group_NNN station group in declaration order — the
+        // i-th group's position is positions[i].
+        int stationIndex = 0;
+        foreach (var groupName in instance.GroupNames)
+        {
+            if (!groupName.StartsWith("Group_", StringComparison.Ordinal))
+                continue;
+
+            var groupPath = $"{instancePath}/{groupName}";
+            var group = instance.OpenGroup(groupName);
+
+            string stationId = group.AttributeExists("stationIdentification")
+                ? group.ReadStringAttribute("stationIdentification")
+                : groupName;
+
+            string startStr = group.ReadRequiredStringAttribute(
+                "startDateTime", "S-104", null, groupPath, Spec);
+            string endStr = group.ReadRequiredStringAttribute(
+                "endDateTime", "S-104", null, groupPath, Spec);
+
+            DateTime startTime = ParseTimestamp(startStr);
+            DateTime endTime = ParseTimestamp(endStr);
+
+            int numberOfTimes = (int)group.ReadRequiredInt64Attribute(
+                "numberOfTimes", "S-104", null, groupPath, Spec);
+            long intervalSeconds = group.ReadRequiredInt64Attribute(
+                "timeRecordInterval", "S-104", null, groupPath, Spec);
+            var interval = TimeSpan.FromSeconds(intervalSeconds);
+
+            var (heights, trends) = ReadStationValues(group, numberOfTimes);
+
+            if (stationIndex >= positions.Count)
+            {
+                throw new S100DatasetSchemaException(
+                    product: "S-104",
+                    file: null,
+                    groupPath: "/Positioning/geometryValues",
+                    attributeOrDataset: "Positioning/geometryValues",
+                    specReference: "S-104 Edition 2.0.0 §10.2.3",
+                    message: ExceptionMessageFormatter.FormatSchema(
+                        "S-104", null, "/Positioning/geometryValues", "Positioning/geometryValues",
+                        "S-104 Edition 2.0.0 §10.2.3")
+                    + $" Position row {stationIndex} missing for station '{stationId}'.");
+            }
+            var (lat, lon) = positions[stationIndex];
+
+            stations.Add(new WaterLevelStation
+            {
+                Identifier = stationId,
+                Latitude = lat,
+                Longitude = lon,
+                StartTime = startTime,
+                EndTime = endTime,
+                TimeRecordInterval = interval,
+                NumberOfTimes = numberOfTimes,
+                Heights = heights,
+                Trends = trends,
+            });
+
+            stationIndex++;
+        }
+
+        // numberOfStations is an authoritative spec-declared count; if a
+        // file claims more than it actually delivers, we tolerate the
+        // shortfall (consistent with the spec's allowance for trailing
+        // empty groups), but we don't try to invent stations.
+        _ = numberOfStations;
+    }
+
+    private static DateTime ParseTimestamp(string s)
+    {
+        return DateTime.ParseExact(
+            s,
+            ["yyyyMMdd'T'HHmmss'Z'", "yyyy-MM-dd'T'HH:mm:ss'Z'"],
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+    }
+
+    private static (float[] Heights, byte[] Trends) ReadStationValues(IHdf5Group group, int numberOfTimes)
+    {
+        var raw = group.ReadRawCompoundDataset("values");
+
+        var heightMember = raw.FindMember("waterLevelHeight", "surfaceHeight", "Height")
+            ?? throw new InvalidOperationException(
+                "S-104 dcf8 station 'values' compound is missing a height member " +
+                "(expected 'waterLevelHeight', 'surfaceHeight', or 'Height').");
+
+        var trendMember = raw.FindMember("waterLevelTrend", "trend", "Trend");
+
+        int count = Math.Min(raw.RecordCount, numberOfTimes);
+        var heights = new float[count];
+        var trends = new byte[count];
+        var span = raw.Data.AsSpan();
+
+        for (int i = 0; i < count; i++)
+        {
+            var record = span.Slice(i * raw.RecordSize, raw.RecordSize);
+
+            heights[i] = heightMember.Kind switch
+            {
+                CompoundMemberKind.Float32 => System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+                    record.Slice(heightMember.Offset, 4)),
+                CompoundMemberKind.Float64 => (float)System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+                    record.Slice(heightMember.Offset, 8)),
+                _ => throw new NotSupportedException(
+                    $"S-104 height member '{heightMember.Name}' has unsupported kind {heightMember.Kind}."),
+            };
+
+            trends[i] = trendMember is null ? (byte)0 : trendMember.Kind switch
+            {
+                CompoundMemberKind.UInt8 or CompoundMemberKind.Int8 => record[trendMember.Offset],
+                CompoundMemberKind.Float32 => (byte)Math.Clamp(
+                    (int)Math.Round(System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+                        record.Slice(trendMember.Offset, 4))),
+                    0, 255),
+                CompoundMemberKind.Float64 => (byte)Math.Clamp(
+                    (int)Math.Round(System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+                        record.Slice(trendMember.Offset, 8))),
+                    0, 255),
+                CompoundMemberKind.UInt16 => (byte)Math.Clamp(
+                    (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(
+                        record.Slice(trendMember.Offset, 2)),
+                    0, 255),
+                _ => throw new NotSupportedException(
+                    $"S-104 trend member '{trendMember.Name}' has unsupported kind {trendMember.Kind}."),
+            };
+        }
+
+        return (heights, trends);
     }
 }

--- a/src/EncDotNet.S100.Datasets.S104/S104StationSeriesDataset.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104StationSeriesDataset.cs
@@ -1,0 +1,82 @@
+namespace EncDotNet.S100.Datasets.S104;
+
+/// <summary>
+/// Root data model for an S-104 Water Level dataset encoded in
+/// <em>data coding format 8 — time series at fixed stations</em>
+/// (S-104 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+/// <remarks>
+/// dcf8 is structurally different from the regularly-gridded dcf2 path
+/// modelled by <see cref="S104Dataset"/>: instead of a 2-D grid of
+/// values per time-step, each station carries an independent 1-D series
+/// of <c>(height, trend)</c> samples plus its own start/end timestamps
+/// and sampling interval. The two shapes share the S-104 Feature
+/// Catalogue's <c>WaterLevel</c> feature; the distinction is encoding,
+/// not taxonomy.
+/// </remarks>
+public sealed class S104StationSeriesDataset
+{
+    /// <summary>EPSG code of the horizontal coordinate reference system.</summary>
+    public int? HorizontalCRS { get; init; }
+
+    /// <summary>Epoch of the coordinate reference system (e.g. "G1762").</summary>
+    public string? Epoch { get; init; }
+
+    /// <summary>A geographic description of the dataset coverage area.</summary>
+    public string? GeographicIdentifier { get; init; }
+
+    /// <summary>Issue date of the dataset (ISO 8601).</summary>
+    public string? IssueDate { get; init; }
+
+    /// <summary>Reference to an associated metadata file.</summary>
+    public string? Metadata { get; init; }
+
+    /// <summary>
+    /// Data coding format — always <c>8</c> for this dataset type
+    /// (S-100 Part 10c §10.2.1 Table).
+    /// </summary>
+    public int DataCodingFormat { get; init; } = 8;
+
+    /// <summary>
+    /// Method or source used to compute water level values (e.g. model
+    /// name or "astronomical prediction").
+    /// </summary>
+    public string? MethodWaterLevelProduct { get; init; }
+
+    /// <summary>
+    /// Threshold (in metres) used by viewer portrayal to distinguish
+    /// "above" vs. "below" water-level reference. Read from the root-level
+    /// <c>waterLevelTrendThreshold</c> attribute when present (UKHO
+    /// astronomical-prediction files supply it); <c>null</c> when absent.
+    /// </summary>
+    public double? WaterLevelTrendThreshold { get; init; }
+
+    /// <summary>Time-series stations contained in the dataset.</summary>
+    public required IReadOnlyList<WaterLevelStation> Stations { get; init; }
+
+    /// <summary>
+    /// Earliest sample timestamp across all stations, or <c>null</c>
+    /// when <see cref="Stations"/> is empty.
+    /// </summary>
+    public DateTime? MinTime { get; init; }
+
+    /// <summary>
+    /// Latest sample timestamp across all stations, or <c>null</c>
+    /// when <see cref="Stations"/> is empty.
+    /// </summary>
+    public DateTime? MaxTime { get; init; }
+}
+
+/// <summary>
+/// Discriminated union over the two structurally different S-104
+/// dataset shapes the reader emits — gridded coverage (dcf2) and
+/// per-station time series (dcf8). See <see cref="S104DatasetReader.ReadAny"/>.
+/// </summary>
+public abstract record S104DatasetData
+{
+    /// <summary>S-104 dcf2 — regularly-gridded water-level coverage.</summary>
+    public sealed record GriddedCoverage(S104Dataset Dataset) : S104DatasetData;
+
+    /// <summary>S-104 dcf8 — time series at fixed stations.</summary>
+    public sealed record StationSeries(S104StationSeriesDataset Dataset) : S104DatasetData;
+}

--- a/src/EncDotNet.S100.Datasets.S104/WaterLevelStation.cs
+++ b/src/EncDotNet.S100.Datasets.S104/WaterLevelStation.cs
@@ -1,0 +1,82 @@
+namespace EncDotNet.S100.Datasets.S104;
+
+/// <summary>
+/// A single water-level time series at a fixed station, as encoded by an
+/// S-104 data-coding-format-8 ("time series at fixed stations") instance
+/// (S-104 Edition 2.0.0 §10.2.3 and §10.2.7).
+/// </summary>
+/// <remarks>
+/// Each <c>Group_NNN</c> under the dcf8 <c>WaterLevel.NN</c> instance
+/// corresponds to one station; the i-th station's position is read from
+/// the i-th row of the <c>Positioning/geometryValues</c> compound
+/// dataset (S-104 Edition 2.0.0 §10.2.3).
+/// </remarks>
+public sealed class WaterLevelStation
+{
+    /// <summary>Identifier of the station (S-104 <c>stationIdentification</c>).</summary>
+    public required string Identifier { get; init; }
+
+    /// <summary>Station latitude in decimal degrees (WGS-84).</summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>Station longitude in decimal degrees (WGS-84).</summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>UTC timestamp of the first sample.</summary>
+    public required DateTime StartTime { get; init; }
+
+    /// <summary>UTC timestamp of the last sample.</summary>
+    public required DateTime EndTime { get; init; }
+
+    /// <summary>
+    /// Interval between consecutive samples. Parsed from the S-104
+    /// <c>timeRecordInterval</c> integer (seconds).
+    /// </summary>
+    public required TimeSpan TimeRecordInterval { get; init; }
+
+    /// <summary>
+    /// Number of samples in this station's time series — equal to
+    /// <see cref="Heights"/> and <see cref="Trends"/> length.
+    /// </summary>
+    public required int NumberOfTimes { get; init; }
+
+    /// <summary>
+    /// Water-level heights in metres, one per time step, in ascending
+    /// chronological order starting at <see cref="StartTime"/>.
+    /// </summary>
+    public required float[] Heights { get; init; }
+
+    /// <summary>
+    /// Decoded S-104 <c>waterLevelTrend</c> enumeration per time step
+    /// (0=unknown, 1=decreasing, 2=increasing, 3=steady — see
+    /// S-104 Edition 2.0.0 §10.2.2 Table 10-3).
+    /// </summary>
+    public required byte[] Trends { get; init; }
+
+    /// <summary>
+    /// Returns the index of the sample whose timestamp is closest to
+    /// <paramref name="time"/>, clamped to <c>[0, NumberOfTimes - 1]</c>.
+    /// Nearest-neighbour rounding; no interpolation.
+    /// </summary>
+    public int NearestTimeIndex(DateTime time)
+    {
+        if (NumberOfTimes <= 1) return 0;
+        if (TimeRecordInterval <= TimeSpan.Zero) return 0;
+        var delta = (time - StartTime).TotalSeconds / TimeRecordInterval.TotalSeconds;
+        var idx = (int)Math.Round(delta, MidpointRounding.AwayFromZero);
+        if (idx < 0) return 0;
+        if (idx >= NumberOfTimes) return NumberOfTimes - 1;
+        return idx;
+    }
+
+    /// <summary>
+    /// Returns the timestamp of the i-th sample, computed from
+    /// <see cref="StartTime"/> and <see cref="TimeRecordInterval"/>.
+    /// </summary>
+    public DateTime TimeAt(int index)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, NumberOfTimes);
+        return StartTime + TimeSpan.FromTicks(TimeRecordInterval.Ticks * index);
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
@@ -76,8 +76,14 @@ public sealed record S421DatasetData(S421Dataset Model) : LoadedDatasetData;
 /// </remarks>
 public sealed record S102CoverageData(S102CoverageSource Source) : LoadedDatasetData;
 
-/// <summary>S-104 Water Level coverage handle.</summary>
+/// <summary>S-104 Water Level coverage handle (dcf2 — regular grid).</summary>
 public sealed record S104CoverageData(S104CoverageSource Source) : LoadedDatasetData;
+
+/// <summary>
+/// S-104 Water Level station-series dataset (dcf8 — time series at fixed
+/// stations; see S-104 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+public sealed record S104StationSeriesData(S104StationSeriesDataset Dataset) : LoadedDatasetData;
 
 /// <summary>S-111 Surface Currents coverage handle.</summary>
 public sealed record S111CoverageData(S111CoverageSource Source) : LoadedDatasetData;

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -38,6 +38,29 @@ public abstract record SampledValue;
 public sealed record DepthSample(double DepthMeters, double? UncertaintyMeters) : SampledValue;
 
 /// <summary>
+/// S-104 water level sample read from a dcf8 ("time series at fixed
+/// stations") dataset — picks the nearest station to the requested
+/// position and the nearest time step within that station's series.
+/// </summary>
+/// <param name="StationId">Reporting station identifier (S-104 <c>stationIdentification</c>).</param>
+/// <param name="StationDistanceMetres">Great-circle distance from requested point to the station, metres.</param>
+/// <param name="WaterLevelHeight">Water level height in metres relative to the vertical datum.</param>
+/// <param name="Trend">Decoded S-104 trend (see <see cref="WaterLevelSample"/>).</param>
+/// <param name="SampleTime">Actual time step (UTC) selected for this sample.</param>
+/// <param name="RequestedTime">The time the caller asked for, or <c>null</c> if unspecified.</param>
+/// <param name="StationLatitude">Latitude of the matched station.</param>
+/// <param name="StationLongitude">Longitude of the matched station.</param>
+public sealed record WaterLevelStationSample(
+    string StationId,
+    double StationDistanceMetres,
+    double WaterLevelHeight,
+    string Trend,
+    DateTime SampleTime,
+    DateTimeOffset? RequestedTime,
+    double StationLatitude,
+    double StationLongitude) : SampledValue;
+
+/// <summary>
 /// S-104 water level sample at the nearest grid cell and time step.
 /// </summary>
 /// <param name="WaterLevelHeight">Water level height in metres relative to the vertical datum.</param>
@@ -196,41 +219,68 @@ public sealed class SampleCoverageTool
     {
         var snapshot = _catalog.Datasets;
 
-        // Pick the best (highest-resolution) S-104 dataset whose bounds contain the point.
+        // First: prefer dcf2 gridded coverage whose bounds contain the
+        // point. This preserves existing behaviour where a colocated
+        // gridded forecast wins over a sparse station file.
         LoadedDataset? bestDataset = null;
         S104CoverageSource? bestSource = null;
         S104Dataset? bestModel = null;
         WaterLevelCoverage? bestCoverage = null;
         double bestArea = double.PositiveInfinity;
-        bool anyS104 = false;
+        bool anyS104Gridded = false;
+        bool anyS104StationSeries = false;
         foreach (var dataset in snapshot)
         {
-            if (dataset.Data is not S104CoverageData s104) continue;
-            anyS104 = true;
-            var model = s104.Source.Dataset;
-            if (model.Coverages.Count == 0) continue;
-            // Use the first coverage's grid to characterise the instance —
-            // every time-step in an S-104 instance shares the same grid.
-            var probe = model.Coverages[0];
-            if (!CoverageContains(probe, request.Latitude, request.Longitude)) continue;
-            var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
-            if (area < bestArea)
+            switch (dataset.Data)
             {
-                bestArea = area;
-                bestDataset = dataset;
-                bestSource = s104.Source;
-                bestModel = model;
-                bestCoverage = probe;
+                case S104CoverageData s104:
+                {
+                    anyS104Gridded = true;
+                    var model = s104.Source.Dataset;
+                    if (model.Coverages.Count == 0) break;
+                    var probe = model.Coverages[0];
+                    if (!CoverageContains(probe, request.Latitude, request.Longitude)) break;
+                    var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
+                    if (area < bestArea)
+                    {
+                        bestArea = area;
+                        bestDataset = dataset;
+                        bestSource = s104.Source;
+                        bestModel = model;
+                        bestCoverage = probe;
+                    }
+                    break;
+                }
+                case S104StationSeriesData:
+                    anyS104StationSeries = true;
+                    break;
             }
         }
 
-        if (bestDataset is null || bestModel is null || bestCoverage is null || bestSource is null)
+        if (bestDataset is not null && bestModel is not null && bestCoverage is not null && bestSource is not null)
         {
-            return ToolResult<SampleCoverageResult>.Err(anyS104
-                ? new OutOfBounds(request.Spec, request.Latitude, request.Longitude)
-                : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+            return SampleS104Gridded(request, bestDataset, bestSource, bestModel, bestCoverage);
         }
 
+        // No gridded match. Fall back to nearest-station across all
+        // loaded dcf8 station-series datasets (no max-distance cap).
+        if (anyS104StationSeries)
+        {
+            return SampleS104StationSeries(request, snapshot);
+        }
+
+        return ToolResult<SampleCoverageResult>.Err(anyS104Gridded
+            ? new OutOfBounds(request.Spec, request.Latitude, request.Longitude)
+            : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+    }
+
+    private static ToolResult<SampleCoverageResult> SampleS104Gridded(
+        SampleCoverageRequest request,
+        LoadedDataset bestDataset,
+        S104CoverageSource bestSource,
+        S104Dataset bestModel,
+        WaterLevelCoverage bestCoverage)
+    {
         if (bestModel.DataCodingFormat != 2)
         {
             return ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
@@ -277,6 +327,87 @@ public sealed class SampleCoverageTool
             return ToolResult<SampleCoverageResult>.Err(
                 new DatasetClosedDuringQuery(bestDataset.Id));
         }
+    }
+
+    /// <summary>
+    /// Sample a loaded dcf8 station-series dataset (S-104 Edition 2.0.0
+    /// §10.2.3 / §10.2.7). Finds the nearest station across every loaded
+    /// dcf8 dataset by great-circle distance with no max-distance cap,
+    /// then picks the nearest time step within that station's series.
+    /// </summary>
+    private static ToolResult<SampleCoverageResult> SampleS104StationSeries(
+        SampleCoverageRequest request,
+        System.Collections.Immutable.ImmutableArray<LoadedDataset> snapshot)
+    {
+        LoadedDataset? bestDataset = null;
+        WaterLevelStation? bestStation = null;
+        double bestDistance = double.PositiveInfinity;
+
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S104StationSeriesData ss) continue;
+            foreach (var station in ss.Dataset.Stations)
+            {
+                var d = GreatCircleMetres(request.Latitude, request.Longitude, station.Latitude, station.Longitude);
+                if (d < bestDistance)
+                {
+                    bestDistance = d;
+                    bestStation = station;
+                    bestDataset = dataset;
+                }
+            }
+        }
+
+        if (bestDataset is null || bestStation is null)
+        {
+            return ToolResult<SampleCoverageResult>.Err(
+                new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+        }
+
+        var requestedAsUtc = request.Time?.UtcDateTime;
+        DateTime sampleTime;
+        int idx;
+        if (requestedAsUtc is null)
+        {
+            idx = 0;
+            sampleTime = bestStation.StartTime;
+        }
+        else
+        {
+            idx = bestStation.NearestTimeIndex(requestedAsUtc.Value);
+            sampleTime = bestStation.TimeAt(idx);
+        }
+
+        return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
+            bestDataset.Id,
+            request.Latitude,
+            request.Longitude,
+            new WaterLevelStationSample(
+                bestStation.Identifier,
+                bestDistance,
+                bestStation.Heights[idx],
+                DecodeWaterLevelTrend(bestStation.Trends[idx]),
+                DateTime.SpecifyKind(sampleTime, DateTimeKind.Utc),
+                request.Time,
+                bestStation.Latitude,
+                bestStation.Longitude)));
+    }
+
+    // Spherical-earth great-circle distance, matching the accuracy bar
+    // of other catalog tools.
+    private const double EarthRadiusMetres = 6_371_000.0;
+
+    private static double GreatCircleMetres(double lat1, double lon1, double lat2, double lon2)
+    {
+        var phi1 = lat1 * Math.PI / 180.0;
+        var phi2 = lat2 * Math.PI / 180.0;
+        var dPhi = (lat2 - lat1) * Math.PI / 180.0;
+        var dLambda = (lon2 - lon1) * Math.PI / 180.0;
+        var a = Math.Sin(dPhi / 2) * Math.Sin(dPhi / 2)
+              + Math.Cos(phi1) * Math.Cos(phi2)
+              * Math.Sin(dLambda / 2) * Math.Sin(dLambda / 2);
+        var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        return EarthRadiusMetres * c;
     }
 
     private ToolResult<SampleCoverageResult> SampleS111(SampleCoverageRequest request)

--- a/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
@@ -297,20 +297,29 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
 
     private static LoadedDataset ProjectS104(DatasetId id, DatasetEntry entry)
     {
-        // S104DatasetReader.Read materialises every time-step's value
-        // grid into a managed WaterLevelValue[] before returning, so
-        // the file handle (and its stream) can be disposed eagerly.
+        // S104DatasetReader.ReadAny materialises every time-step's value
+        // grid (or per-station series) into managed arrays before
+        // returning, so the file handle can be disposed eagerly.
         using var stream = OpenEntryStream(entry);
         using var file = PureHdfFile.Open(stream);
-        var dataset = S104DatasetReader.Read(file);
-        var source = new S104CoverageSource(dataset);
-        var bounds = ComputeS104Bounds(dataset) ?? WorldBounds;
-        return new LoadedDataset(
-            id,
-            new SpecRef("S-104", default),
-            bounds,
-            null,
-            new S104CoverageData(source));
+        var data = S104DatasetReader.ReadAny(file);
+        return data switch
+        {
+            S104DatasetData.GriddedCoverage g => new LoadedDataset(
+                id,
+                new SpecRef("S-104", default),
+                ComputeS104Bounds(g.Dataset) ?? WorldBounds,
+                null,
+                new S104CoverageData(new S104CoverageSource(g.Dataset))),
+            S104DatasetData.StationSeries s => new LoadedDataset(
+                id,
+                new SpecRef("S-104", default),
+                ComputeS104StationSeriesBounds(s.Dataset) ?? WorldBounds,
+                ComputeS104StationSeriesTimeRange(s.Dataset),
+                new S104StationSeriesData(s.Dataset)),
+            _ => throw new InvalidOperationException(
+                $"Unexpected S-104 dataset variant {data.GetType().Name}."),
+        };
     }
 
     private static LoadedDataset ProjectS111(DatasetId id, DatasetEntry entry)
@@ -355,6 +364,38 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
         var north = cov.OriginLatitude + (cov.NumPointsLatitudinal - 1) * cov.SpacingLatitudinal;
         var east = cov.OriginLongitude + (cov.NumPointsLongitudinal - 1) * cov.SpacingLongitudinal;
         return new BoundingBox(south, west, north, east);
+    }
+
+    /// <summary>
+    /// Bounding box covering all stations in an S-104 dcf8 dataset.
+    /// Returns <c>null</c> for an empty station set (caller falls back to
+    /// <see cref="WorldBounds"/>). See S-104 Edition 2.0.0 §10.2.3.
+    /// </summary>
+    private static BoundingBox? ComputeS104StationSeriesBounds(S104StationSeriesDataset dataset)
+    {
+        if (dataset.Stations.Count == 0) return null;
+        double south = double.PositiveInfinity, west = double.PositiveInfinity;
+        double north = double.NegativeInfinity, east = double.NegativeInfinity;
+        foreach (var s in dataset.Stations)
+        {
+            if (s.Latitude < south) south = s.Latitude;
+            if (s.Latitude > north) north = s.Latitude;
+            if (s.Longitude < west) west = s.Longitude;
+            if (s.Longitude > east) east = s.Longitude;
+        }
+        // A single station yields a zero-extent box; pad slightly so the
+        // viewer can zoom to it.
+        if (Math.Abs(north - south) < 1e-9) { south -= 0.01; north += 0.01; }
+        if (Math.Abs(east - west) < 1e-9) { west -= 0.01; east += 0.01; }
+        return new BoundingBox(south, west, north, east);
+    }
+
+    private static TimeRange? ComputeS104StationSeriesTimeRange(S104StationSeriesDataset dataset)
+    {
+        if (dataset.Stations.Count == 0 || dataset.MinTime is null || dataset.MaxTime is null) return null;
+        var start = new DateTimeOffset(DateTime.SpecifyKind(dataset.MinTime.Value, DateTimeKind.Utc));
+        var end = new DateTimeOffset(DateTime.SpecifyKind(dataset.MaxTime.Value, DateTimeKind.Utc));
+        return new TimeRange(start, end);
     }
 
     private static BoundingBox? ComputeS111Bounds(S111Dataset dataset)

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/S104Dcf8FixtureBuilder.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/S104Dcf8FixtureBuilder.cs
@@ -35,6 +35,16 @@ internal static class S104Dcf8FixtureBuilder
         [H5Name("longitude")] public float Longitude;
     }
 
+    /// <summary>
+    /// UKHO-style short member names <c>lat</c>/<c>long</c> seen in the
+    /// real <c>104UK_..._dcf8.hdf5</c> astronomical-prediction trial cells.
+    /// </summary>
+    public struct GeometryRowShort
+    {
+        [H5Name("lat")] public float Lat;
+        [H5Name("long")] public float Long;
+    }
+
     public sealed class Station<TRow> where TRow : struct
     {
         public required string Identifier { get; init; }
@@ -55,7 +65,9 @@ internal static class S104Dcf8FixtureBuilder
         string path,
         IReadOnlyList<Station<TRow>> stations,
         bool includePositioning = true,
-        double? waterLevelTrendThreshold = null)
+        double? waterLevelTrendThreshold = null,
+        bool useShortGeometryNames = false,
+        bool positioningUnderInstance = false)
         where TRow : struct
     {
         var instanceGroups = new Dictionary<string, object>();
@@ -116,14 +128,31 @@ internal static class S104Dcf8FixtureBuilder
 
         if (includePositioning)
         {
-            var geom = new GeometryRow[stations.Count];
-            for (int i = 0; i < stations.Count; i++)
-                geom[i] = new GeometryRow { Latitude = stations[i].Latitude, Longitude = stations[i].Longitude };
-
-            file["Positioning"] = new H5Group
+            object geom;
+            if (useShortGeometryNames)
             {
-                ["geometryValues"] = geom,
-            };
+                var arr = new GeometryRowShort[stations.Count];
+                for (int i = 0; i < stations.Count; i++)
+                    arr[i] = new GeometryRowShort { Lat = stations[i].Latitude, Long = stations[i].Longitude };
+                geom = arr;
+            }
+            else
+            {
+                var arr = new GeometryRow[stations.Count];
+                for (int i = 0; i < stations.Count; i++)
+                    arr[i] = new GeometryRow { Latitude = stations[i].Latitude, Longitude = stations[i].Longitude };
+                geom = arr;
+            }
+
+            var positioningGroup = new H5Group { ["geometryValues"] = geom };
+            if (positioningUnderInstance)
+            {
+                instance["Positioning"] = positioningGroup;
+            }
+            else
+            {
+                file["Positioning"] = positioningGroup;
+            }
         }
 
         var options = new H5WriteOptions(

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/S104Dcf8FixtureBuilder.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/Fixtures/S104Dcf8FixtureBuilder.cs
@@ -1,0 +1,135 @@
+using System.Reflection;
+using PureHDF;
+
+namespace EncDotNet.S100.Datasets.S104.Tests.Fixtures;
+
+/// <summary>
+/// Helpers that author small synthetic S-104 dcf8 ("time series at fixed
+/// stations") HDF5 files for reader tests.
+/// </summary>
+internal static class S104Dcf8FixtureBuilder
+{
+    // ---- Compound row variants --------------------------------------------------
+
+    public struct SpecValueRow
+    {
+        [H5Name("waterLevelHeight")] public float WaterLevelHeight;
+        [H5Name("waterLevelTrend")] public byte WaterLevelTrend;
+    }
+
+    public struct UkhoValueRow
+    {
+        [H5Name("surfaceHeight")] public float SurfaceHeight;
+        [H5Name("trend")] public sbyte Trend;
+    }
+
+    public struct UkhoValueRowF32Trend
+    {
+        [H5Name("surfaceHeight")] public float SurfaceHeight;
+        [H5Name("trend")] public float Trend;
+    }
+
+    public struct GeometryRow
+    {
+        [H5Name("latitude")] public float Latitude;
+        [H5Name("longitude")] public float Longitude;
+    }
+
+    public sealed class Station<TRow> where TRow : struct
+    {
+        public required string Identifier { get; init; }
+        public required float Latitude { get; init; }
+        public required float Longitude { get; init; }
+        public required string StartDateTime { get; init; }
+        public required string EndDateTime { get; init; }
+        public required long TimeRecordInterval { get; init; }
+        public required TRow[] Values { get; init; }
+    }
+
+    /// <summary>
+    /// Writes a minimal S-104 dcf8 file with one <c>WaterLevel.01</c>
+    /// instance containing the supplied stations. Position rows match
+    /// station declaration order per S-104 §10.2.3.
+    /// </summary>
+    public static string WriteFile<TRow>(
+        string path,
+        IReadOnlyList<Station<TRow>> stations,
+        bool includePositioning = true,
+        double? waterLevelTrendThreshold = null)
+        where TRow : struct
+    {
+        var instanceGroups = new Dictionary<string, object>();
+        for (int i = 0; i < stations.Count; i++)
+        {
+            var s = stations[i];
+            instanceGroups[$"Group_{i + 1:000}"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["stationIdentification"] = s.Identifier,
+                    ["startDateTime"] = s.StartDateTime,
+                    ["endDateTime"] = s.EndDateTime,
+                    ["numberOfTimes"] = (long)s.Values.Length,
+                    ["timeRecordInterval"] = s.TimeRecordInterval,
+                },
+                ["values"] = s.Values,
+            };
+        }
+
+        long firstInterval = stations.Count > 0 ? stations[0].TimeRecordInterval : 0L;
+        int firstNumberOfTimes = stations.Count > 0 ? stations[0].Values.Length : 0;
+
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["numberOfStations"] = (long)stations.Count,
+                ["numberOfTimes"] = (long)firstNumberOfTimes,
+                ["timeRecordInterval"] = firstInterval,
+            },
+        };
+        foreach (var (k, v) in instanceGroups)
+            instance[k] = v;
+
+        var rootAttrs = new Dictionary<string, object>
+        {
+            ["horizontalCRS"] = 4326,
+            ["geographicIdentifier"] = "Test",
+            ["issueDate"] = "2024-01-01",
+        };
+        if (waterLevelTrendThreshold is not null)
+            rootAttrs["waterLevelTrendThreshold"] = waterLevelTrendThreshold.Value;
+
+        var file = new H5File
+        {
+            Attributes = rootAttrs,
+            ["WaterLevel"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["dataCodingFormat"] = (byte)8,
+                    ["methodWaterLevelProduct"] = "astronomical prediction",
+                },
+                ["WaterLevel.01"] = instance,
+            },
+        };
+
+        if (includePositioning)
+        {
+            var geom = new GeometryRow[stations.Count];
+            for (int i = 0; i < stations.Count; i++)
+                geom[i] = new GeometryRow { Latitude = stations[i].Latitude, Longitude = stations[i].Longitude };
+
+            file["Positioning"] = new H5Group
+            {
+                ["geometryValues"] = geom,
+            };
+        }
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+
+        file.Write(path, options);
+        return path;
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/S104DatasetReaderErrorTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/S104DatasetReaderErrorTests.cs
@@ -44,14 +44,15 @@ public class S104DatasetReaderErrorTests
         var path = Path.GetTempFileName() + ".h5";
         try
         {
-            WriteFileWithDcf(path, dcf: 8);
+            // dcf=3 (ungeorectified grid) is not yet implemented.
+            WriteFileWithDcf(path, dcf: 3);
 
             using var file = PureHdfFile.Open(path);
             var ex = Assert.Throws<S100DatasetNotSupportedException>(() => S104DatasetReader.Read(file));
 
             Assert.Equal("S-104", ex.Product);
-            Assert.Contains("8", ex.Feature);
-            Assert.Contains("time series at fixed stations", ex.Feature);
+            Assert.Contains("3", ex.Feature);
+            Assert.Contains("ungeorectified", ex.Feature);
             Assert.Contains("not yet supported", ex.Message);
         }
         finally { File.Delete(path); }

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/S104Dcf8ReaderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/S104Dcf8ReaderTests.cs
@@ -144,6 +144,51 @@ public class S104Dcf8ReaderTests
         finally { File.Delete(path); }
     }
 
+    /// <summary>
+    /// UKHO <c>104UK_..._dcf8.hdf5</c> astronomical-prediction trial cells
+    /// use the short geometry member names <c>lat</c>/<c>long</c> and place
+    /// the <c>Positioning</c> group under <c>/WaterLevel/WaterLevel.NN</c>
+    /// instead of at the file root. The reader must tolerate both
+    /// variations (S-104 Ed 2.0.0 §10.2.3).
+    /// </summary>
+    [Fact]
+    public void ReadAny_UkhoShortGeometryNames_PositioningUnderInstance_RoundTrips()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("0031", 50.75f, -1.5f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 1.1f, Trend = 2 },
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 1.3f, Trend = 2 },
+                }),
+                Station("0033", 50.80f, -1.4f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 0.9f, Trend = 1 },
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 0.7f, Trend = 1 },
+                }),
+            };
+            S104Dcf8FixtureBuilder.WriteFile(
+                path, stations,
+                useShortGeometryNames: true,
+                positioningUnderInstance: true);
+
+            using var file = PureHdfFile.Open(path);
+            var any = S104DatasetReader.ReadAny(file);
+            var model = ((S104DatasetData.StationSeries)any).Dataset;
+
+            Assert.Equal(2, model.Stations.Count);
+            Assert.Equal("0031", model.Stations[0].Identifier);
+            Assert.Equal(50.75, model.Stations[0].Latitude, 3);
+            Assert.Equal(-1.5, model.Stations[0].Longitude, 3);
+            Assert.Equal("0033", model.Stations[1].Identifier);
+            Assert.Equal(50.80, model.Stations[1].Latitude, 3);
+        }
+        finally { File.Delete(path); }
+    }
+
     [Fact]
     public void ReadAny_F32Trend_RoundsAndClamps()
     {

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/S104Dcf8ReaderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/S104Dcf8ReaderTests.cs
@@ -1,0 +1,226 @@
+using EncDotNet.S100.Datasets.S104.Tests.Fixtures;
+using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Hdf5.PureHdf;
+
+namespace EncDotNet.S100.Datasets.S104.Tests;
+
+/// <summary>
+/// Tests for the S-104 dcf8 (time series at fixed stations) reader path
+/// (S-104 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+public class S104Dcf8ReaderTests
+{
+    private static S104Dcf8FixtureBuilder.Station<T> Station<T>(
+        string id, float lat, float lon, T[] values,
+        string start = "20240101T000000Z",
+        string end = "20240101T030000Z",
+        long interval = 3600)
+        where T : struct =>
+        new()
+        {
+            Identifier = id,
+            Latitude = lat,
+            Longitude = lon,
+            StartDateTime = start,
+            EndDateTime = end,
+            TimeRecordInterval = interval,
+            Values = values,
+        };
+
+    [Fact]
+    public void ReadAny_HappyPath_ThreeStationsFourTimeSteps_RoundTrips()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 51.5f, -0.1f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1.0f, WaterLevelTrend = 1 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1.5f, WaterLevelTrend = 2 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1.2f, WaterLevelTrend = 1 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.8f, WaterLevelTrend = 3 },
+                }),
+                Station("B", 51.6f, -0.2f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = -0.5f, WaterLevelTrend = 2 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.0f, WaterLevelTrend = 2 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.6f, WaterLevelTrend = 2 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.4f, WaterLevelTrend = 1 },
+                }),
+                Station("C", 51.7f, -0.3f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.1f, WaterLevelTrend = 0 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.2f, WaterLevelTrend = 0 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.3f, WaterLevelTrend = 0 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 0.4f, WaterLevelTrend = 0 },
+                }),
+            };
+            S104Dcf8FixtureBuilder.WriteFile(path, stations, waterLevelTrendThreshold: 0.5);
+
+            using var file = PureHdfFile.Open(path);
+            var any = S104DatasetReader.ReadAny(file);
+
+            var stationSeries = Assert.IsType<S104DatasetData.StationSeries>(any);
+            var model = stationSeries.Dataset;
+
+            Assert.Equal(8, model.DataCodingFormat);
+            Assert.Equal(4326, model.HorizontalCRS);
+            Assert.Equal(0.5, model.WaterLevelTrendThreshold);
+            Assert.Equal(3, model.Stations.Count);
+
+            Assert.Equal("A", model.Stations[0].Identifier);
+            Assert.Equal(51.5, model.Stations[0].Latitude, precision: 4);
+            Assert.Equal(-0.1, model.Stations[0].Longitude, precision: 4);
+            Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), model.Stations[0].StartTime);
+            Assert.Equal(new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc), model.Stations[0].EndTime);
+            Assert.Equal(TimeSpan.FromHours(1), model.Stations[0].TimeRecordInterval);
+            Assert.Equal(4, model.Stations[0].NumberOfTimes);
+            Assert.Equal(1.5f, model.Stations[0].Heights[1]);
+            Assert.Equal((byte)2, model.Stations[0].Trends[1]);
+
+            Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), model.MinTime);
+            Assert.Equal(new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc), model.MaxTime);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_MissingPositioning_ThrowsSchemaException()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 1f, 1f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1f, WaterLevelTrend = 1 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 2f, WaterLevelTrend = 2 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 3f, WaterLevelTrend = 3 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 4f, WaterLevelTrend = 0 },
+                }),
+            };
+            S104Dcf8FixtureBuilder.WriteFile(path, stations, includePositioning: false);
+
+            using var file = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetSchemaException>(() => S104DatasetReader.ReadAny(file));
+
+            Assert.Equal("S-104", ex.Product);
+            Assert.Equal("Positioning/geometryValues", ex.AttributeOrDataset);
+            Assert.Contains("§10.2.3", ex.SpecReference ?? "");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_UkhoMemberNames_RoundTrips()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 51.5f, -0.1f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 2.5f, Trend = 2 },
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 3.0f, Trend = 2 },
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 2.8f, Trend = 1 },
+                    new S104Dcf8FixtureBuilder.UkhoValueRow { SurfaceHeight = 2.2f, Trend = 1 },
+                }),
+            };
+            S104Dcf8FixtureBuilder.WriteFile(path, stations);
+
+            using var file = PureHdfFile.Open(path);
+            var any = S104DatasetReader.ReadAny(file);
+            var model = ((S104DatasetData.StationSeries)any).Dataset;
+
+            Assert.Single(model.Stations);
+            Assert.Equal(2.5f, model.Stations[0].Heights[0]);
+            Assert.Equal((byte)2, model.Stations[0].Trends[0]);
+            Assert.Equal((byte)1, model.Stations[0].Trends[3]);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_F32Trend_RoundsAndClamps()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 1f, 1f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.UkhoValueRowF32Trend { SurfaceHeight = 1.0f, Trend = 1.6f },
+                    new S104Dcf8FixtureBuilder.UkhoValueRowF32Trend { SurfaceHeight = 1.0f, Trend = 0.4f },
+                    new S104Dcf8FixtureBuilder.UkhoValueRowF32Trend { SurfaceHeight = 1.0f, Trend = 3.0f },
+                    new S104Dcf8FixtureBuilder.UkhoValueRowF32Trend { SurfaceHeight = 1.0f, Trend = -5.0f },
+                }),
+            };
+            S104Dcf8FixtureBuilder.WriteFile(path, stations);
+
+            using var file = PureHdfFile.Open(path);
+            var model = ((S104DatasetData.StationSeries)S104DatasetReader.ReadAny(file)).Dataset;
+            var trends = model.Stations[0].Trends;
+
+            // 1.6 rounds to 2; 0.4 to 0; 3.0 stays 3; -5.0 clamps to 0.
+            Assert.Equal((byte)2, trends[0]);
+            Assert.Equal((byte)0, trends[1]);
+            Assert.Equal((byte)3, trends[2]);
+            Assert.Equal((byte)0, trends[3]);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_OnDcf8_ThrowsNotSupportedForGriddedCallers()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 1f, 1f, new[]
+                {
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1f, WaterLevelTrend = 1 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1f, WaterLevelTrend = 1 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1f, WaterLevelTrend = 1 },
+                    new S104Dcf8FixtureBuilder.SpecValueRow { WaterLevelHeight = 1f, WaterLevelTrend = 1 },
+                }),
+            };
+            S104Dcf8FixtureBuilder.WriteFile(path, stations);
+
+            using var file = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetNotSupportedException>(() => S104DatasetReader.Read(file));
+
+            Assert.Equal("S-104", ex.Product);
+            Assert.Contains("8", ex.Feature);
+            Assert.Contains("time series", ex.Feature);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void WaterLevelStation_NearestTimeIndex_ClampsToBounds()
+    {
+        var s = new WaterLevelStation
+        {
+            Identifier = "X",
+            Latitude = 0, Longitude = 0,
+            StartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc),
+            TimeRecordInterval = TimeSpan.FromHours(1),
+            NumberOfTimes = 4,
+            Heights = new[] { 0f, 1f, 2f, 3f },
+            Trends = new byte[] { 0, 0, 0, 0 },
+        };
+
+        Assert.Equal(0, s.NearestTimeIndex(new DateTime(2023, 12, 31, 23, 0, 0, DateTimeKind.Utc)));
+        Assert.Equal(0, s.NearestTimeIndex(new DateTime(2024, 1, 1, 0, 20, 0, DateTimeKind.Utc)));
+        Assert.Equal(1, s.NearestTimeIndex(new DateTime(2024, 1, 1, 0, 40, 0, DateTimeKind.Utc)));
+        Assert.Equal(3, s.NearestTimeIndex(new DateTime(2024, 1, 1, 5, 0, 0, DateTimeKind.Utc)));
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
@@ -105,6 +105,19 @@ internal static class LoadedDatasetFactory
             new S104CoverageData(source ?? S104Synth.Source()));
     }
 
+    public static LoadedDataset S104Stations(
+        string id,
+        S104StationSeriesDataset dataset,
+        BoundingBox? bounds = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S104Spec,
+            bounds ?? Box(),
+            null,
+            new S104StationSeriesData(dataset));
+    }
+
     public static LoadedDataset S111(
         string id,
         BoundingBox? bounds = null,

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolS104StationSeriesTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolS104StationSeriesTests.cs
@@ -1,0 +1,145 @@
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+/// <summary>
+/// Sample-coverage tests for the S-104 dcf8 (time series at fixed
+/// stations) path (S-104 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+public class SampleCoverageToolS104StationSeriesTests
+{
+    private static WaterLevelStation Station(
+        string id, double lat, double lon,
+        float[] heights, byte[] trends)
+    {
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new WaterLevelStation
+        {
+            Identifier = id,
+            Latitude = lat,
+            Longitude = lon,
+            StartTime = start,
+            EndTime = start.AddHours(heights.Length - 1),
+            TimeRecordInterval = TimeSpan.FromHours(1),
+            NumberOfTimes = heights.Length,
+            Heights = heights,
+            Trends = trends,
+        };
+    }
+
+    private static S104StationSeriesDataset Synth()
+    {
+        var stations = new[]
+        {
+            Station("A", 51.5, -0.1, new[] { 1.0f, 1.5f, 2.0f, 1.5f }, new byte[] { 2, 2, 3, 1 }),
+            Station("B", 51.6, -0.2, new[] { 0.5f, 1.0f, 0.7f, 0.4f }, new byte[] { 2, 3, 1, 1 }),
+            Station("C", 60.0, 10.0, new[] { 3.0f, 3.1f, 3.2f, 3.3f }, new byte[] { 2, 2, 2, 2 }),
+        };
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new S104StationSeriesDataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = 8,
+            Stations = stations,
+            MinTime = start,
+            MaxTime = start.AddHours(3),
+        };
+    }
+
+    [Fact]
+    public async Task SelectsNearestStation_AndFirstSampleByDefault()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        // Request very close to station A (51.5, -0.1).
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 51.5, Longitude: -0.1));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelStationSample>(value.Value);
+        Assert.Equal("A", sample.StationId);
+        Assert.Equal(1.0, sample.WaterLevelHeight, 5);
+        Assert.Equal("increasing", sample.Trend);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+        Assert.True(sample.StationDistanceMetres < 1.0);
+        Assert.Null(sample.RequestedTime);
+    }
+
+    [Fact]
+    public async Task ClampsTimeBeforeStart_ToFirstStep()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        var requested = new DateTimeOffset(2023, 12, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 51.5, Longitude: -0.1, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelStationSample>(value.Value);
+        Assert.Equal(1.0, sample.WaterLevelHeight, 5);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+        Assert.Equal(requested, sample.RequestedTime);
+    }
+
+    [Fact]
+    public async Task ClampsTimeAfterEnd_ToLastStep()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        var requested = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 51.5, Longitude: -0.1, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelStationSample>(value.Value);
+        Assert.Equal(1.5, sample.WaterLevelHeight, 5);
+        Assert.Equal("decreasing", sample.Trend);
+        Assert.Equal(new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+    }
+
+    [Fact]
+    public async Task NearestTime_RoundsToClosestStep()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        // 01:40 → rounds to 02:00 (index 2).
+        var requested = new DateTimeOffset(2024, 1, 1, 1, 40, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: 51.5, Longitude: -0.1, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelStationSample>(value.Value);
+        Assert.Equal("A", sample.StationId);
+        Assert.Equal(2.0, sample.WaterLevelHeight, 5);
+        Assert.Equal("steady", sample.Trend);
+        Assert.Equal(new DateTime(2024, 1, 1, 2, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+    }
+
+    [Fact]
+    public async Task NoMaxDistanceCap_FarPointStillReturnsNearestStation()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        // Far away from every station — should still pick the closest
+        // (no max-distance cap).
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec, Latitude: -80.0, Longitude: 0.0));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<WaterLevelStationSample>(value.Value);
+        // Stations A and B are at ~51-52 N; C is at 60 N. All are very
+        // far from -80 N — accept any but verify a distance is reported.
+        Assert.True(sample.StationDistanceMetres > 10_000_000);
+    }
+}


### PR DESCRIPTION
## Summary

Adds full S-104 dcf8 (`dataCodingFormat = 8` — "Time series at fixed stations") support: reader, data model, MCP `sample_coverage` extension, viewer catalog/processor wiring, and station-glyph portrayal driven by the existing global timeline.

Spec reference: S-104 Edition 2.0.0 §10.2.3 (Positioning), §10.2.7 (time series at fixed stations).

After this PR the UKHO `104UK_…_dcf8.hdf5` astronomical-prediction trial cell loads end-to-end: stations render at their charted positions and glyph colours change as the timeline scrubs.

## What changed

**Reader + data model** (`EncDotNet.S100.Datasets.S104`)
- New `WaterLevelStation` and `S104StationSeriesDataset` POCOs (the dcf2 `S104Dataset` / `WaterLevelCoverage` shape is **unchanged**).
- New `S104DatasetData` discriminated union (`GriddedCoverage` | `StationSeries`).
- `S104DatasetReader.ReadAny` dispatches by `dataCodingFormat`; `Read()` retains its dcf2-only contract and now throws on dcf8 (back-compat).
- dcf8 path: walks `/WaterLevel/WaterLevel.NN/Group_NNN` for per-station metadata + `values` compound, resolves station positions from `/Positioning/geometryValues` (case-insensitive `latitude`/`longitude`, tolerant fallback to `/WaterLevel/WaterLevel.NN/Positioning`). Missing positioning → `S100DatasetSchemaException` with `AttributeOrDataset = Positioning/geometryValues`.
- Member-name tolerance: `surfaceHeight`/`waterLevelHeight`, `trend`/`waterLevelTrend` (i8 enum, u8, or f32 — f32 rounds and clamps to byte).
- Surfaces `waterLevelTrendThreshold` root attribute.

**MCP `sample_coverage`**
- New `WaterLevelStationSample` result variant: `StationId`, `StationDistanceMetres`, `WaterLevelHeight`, `Trend`, `SampleTime`, `RequestedTime`, station lat/lon.
- New `S104StationSeriesData` variant on `LoadedDatasetData`.
- Dispatches: gridded match (with bounds containment) wins over a station match; otherwise picks the nearest station across loaded dcf8 datasets by great-circle distance, with **no max-distance cap** as specified. Nearest-time via `WaterLevelStation.NearestTimeIndex` with clamping at both ends. Default time → first sample.

**Viewer integration**
- `ViewerDatasetCatalog.ProjectS104` switches to `ReadAny` and branches; station series gets per-station bounds and a non-null `LoadedDataset.TimeRange`.
- `S104DatasetProcessor` now owns the variant: for station series it builds a Mapsui `MemoryLayer` of point features styled with the trend-colour table at the current `S104RenderContext.TimeStep`. Stroke colour encodes height-vs-`waterLevelTrendThreshold` when present.
- `AvailableTimes` for stations = sorted union of every station's time steps.
- `GetCoverageInfo` picks the nearest station and emits a tooltip with station id + height + trend + sample time.

**Tests**
- 6 new S-104 dcf8 reader tests (happy path, missing positioning, UKHO `surfaceHeight`/`trend` names, legacy `waterLevelHeight`/`waterLevelTrend` names, f32-trend round/clamp, `Read()` back-compat, `NearestTimeIndex`).
- 5 new MCP sample-coverage station-series tests (nearest station, default = first step, clamp before/after, nearest-time rounding, far-point unbounded sampling).
- Existing "unsupported dcf" test switched from dcf=8 to dcf=3.
- Synthetic fixtures only; no real UKHO data committed.

## Deviation — time-aware vector pipeline (plan §4)

The plan explicitly authorized a fallback to rebuilding the display list on each global-time change instead of introducing a new `IVectorFeatureTimeSeries` interface plus `TimeAwarePointInstruction` in `Core/Vector`. **Took the fallback.** The viewer already calls `DatasetLoaderService.CreateRenderContext` with a fresh `S104RenderContext.TimeStep` whenever the global clock scrubs, so station-glyph re-colouring happens by rebuilding the `MemoryLayer` each frame inside `RenderStationSeries`. This keeps Core/Vector abstractions untouched.

If anyone hits performance limits with very dense station files we can revisit the resolver-delegate design then.

## Manual smoke instructions

1. Open the UKHO `104UK_…_dcf8.hdf5` astronomical-prediction trial cell in the viewer.
2. Expect stations to appear at their charted positions.
3. Scrub the timeline — glyph fill colour should change per the trend table:
   - unknown (0) → grey `#808080`
   - decreasing (1) → blue `#2a6f97`
   - increasing (2) → red `#c1121f`
   - steady (3) → teal `#2a9d8f`
4. Hover/click a glyph — tooltip should report station id, current height (m), trend label, and the selected time step.
5. With MCP up, call `sample_coverage` with `spec: S-104` at a position near a station — should return a `WaterLevelStationSample` with the station id, distance in metres, height, and trend.

## Build + tests

- `dotnet build --configuration Release` — clean.
- `dotnet test --configuration Release` — zero failures across the solution (only the pre-existing single S-201 skip).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>