### PR TITLE
PR-E: MCP server sticky-port allocation

### DIFF
--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -328,6 +328,13 @@ internal static class Strings
     public static string Settings_McpEnabledTooltip => Get(nameof(Settings_McpEnabledTooltip));
     public static string Settings_McpPort => Get(nameof(Settings_McpPort));
     public static string Settings_McpPortTooltip => Get(nameof(Settings_McpPortTooltip));
+    public static string Settings_McpPort_ResetToAuto => Get(nameof(Settings_McpPort_ResetToAuto));
+    public static string Settings_McpPort_ResetToAutoTooltip => Get(nameof(Settings_McpPort_ResetToAutoTooltip));
+    public static string Toast_McpPortConflictTitle => Get(nameof(Toast_McpPortConflictTitle));
+    public static string Toast_McpPortConflictBody => Get(nameof(Toast_McpPortConflictBody));
+    public static string Toast_McpPortFindAnother => Get(nameof(Toast_McpPortFindAnother));
+    public static string Toast_McpPortReassignedTitle => Get(nameof(Toast_McpPortReassignedTitle));
+    public static string Toast_McpPortReassignedBody => Get(nameof(Toast_McpPortReassignedBody));
 
     // Load-failure toast
     public static string Toast_DatasetErrorTitle => Get(nameof(Toast_DatasetErrorTitle));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -845,6 +845,29 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   <data name="Settings_McpPortTooltip" xml:space="preserve">
     <value>TCP port to bind on 127.0.0.1. Use 0 to let the OS pick an ephemeral port.</value>
   </data>
+  <data name="Settings_McpPort_ResetToAuto" xml:space="preserve">
+    <value>Reset to auto</value>
+  </data>
+  <data name="Settings_McpPort_ResetToAutoTooltip" xml:space="preserve">
+    <value>Forget the saved port and let the system pick a free one on next start.</value>
+  </data>
+  <data name="Toast_McpPortConflictTitle" xml:space="preserve">
+    <value>MCP server port unavailable</value>
+  </data>
+  <data name="Toast_McpPortConflictBody" xml:space="preserve">
+    <value>Port {0} is already in use. The MCP server is offline until a free port is chosen.</value>
+    <comment>{0} = conflicting port number.</comment>
+  </data>
+  <data name="Toast_McpPortFindAnother" xml:space="preserve">
+    <value>Find another port</value>
+  </data>
+  <data name="Toast_McpPortReassignedTitle" xml:space="preserve">
+    <value>MCP server moved</value>
+  </data>
+  <data name="Toast_McpPortReassignedBody" xml:space="preserve">
+    <value>MCP server is now on port {0}. Update your MCP client configuration.</value>
+    <comment>{0} = newly-assigned port.</comment>
+  </data>
 
   <!-- Load-failure toast -->
   <data name="Toast_DatasetErrorTitle" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Mcp;
@@ -21,7 +23,7 @@ namespace EncDotNet.S100.Viewer.Services;
 /// </remarks>
 internal sealed class McpServerHost : IAsyncDisposable
 {
-    private readonly ViewerDatasetCatalog _catalog;
+    private readonly EncDotNet.S100.Mcp.Tools.Catalog.IDatasetCatalog _catalog;
     private readonly ViewerSettings _settings;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
@@ -30,7 +32,7 @@ internal sealed class McpServerHost : IAsyncDisposable
     private bool _disposed;
 
     public McpServerHost(
-        ViewerDatasetCatalog catalog,
+        EncDotNet.S100.Mcp.Tools.Catalog.IDatasetCatalog catalog,
         ViewerSettings settings,
         ILoggerFactory? loggers = null)
     {
@@ -54,6 +56,15 @@ internal sealed class McpServerHost : IAsyncDisposable
     /// new server's events after handling this signal.
     /// </summary>
     public event EventHandler<EventArgs>? ServerChanged;
+
+    /// <summary>
+    /// Raised when an attempt to bind the MCP server failed because the
+    /// configured <see cref="ViewerSettings.McpPort"/> was already in
+    /// use by another process. The event argument carries the port the
+    /// bind was attempted on. Subscribers (e.g. the main view-model)
+    /// typically surface a sticky toast offering to re-allocate.
+    /// </summary>
+    public event EventHandler<McpPortConflictEventArgs>? McpPortConflict;
 
     /// <summary>
     /// Reconciles the running server with the current
@@ -106,6 +117,18 @@ internal sealed class McpServerHost : IAsyncDisposable
         {
             await next.StartAsync(cancellationToken).ConfigureAwait(false);
         }
+        catch (Exception ex) when (IsPortInUse(ex))
+        {
+            await next.DisposeAsync().ConfigureAwait(false);
+            // Bind failed because the requested port is taken by another
+            // process. Leave the server torn down and notify subscribers
+            // so the UI can offer a recovery action. We never silently
+            // fall back to an ephemeral port — the user explicitly
+            // persisted this port (or it was persisted previously) and
+            // must opt in to changing it.
+            McpPortConflict?.Invoke(this, new McpPortConflictEventArgs(port));
+            return;
+        }
         catch
         {
             await next.DisposeAsync().ConfigureAwait(false);
@@ -113,7 +136,85 @@ internal sealed class McpServerHost : IAsyncDisposable
         }
 
         _server = next;
+
+        // Persist the bound port so subsequent launches reuse it. When
+        // the user asked for an ephemeral port (McpPort == 0) Kestrel
+        // selected a concrete port for us; writing it back makes the
+        // assignment "sticky". This trade-off does silently convert a
+        // user who set McpPort == 0 ("pick any port each time") to a
+        // persisted port, but ephemeral has no advantage for MCP
+        // tooling and the user can clear it via the "Reset to auto"
+        // button in Settings.
+        if (next.Port is { } boundPort && boundPort != _settings.McpPort)
+        {
+            _settings.McpPort = boundPort;
+            TrySaveSettings();
+        }
+
         ServerChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Re-allocates the MCP server's port by clearing
+    /// <see cref="ViewerSettings.McpPort"/> back to 0 (ephemeral) and
+    /// re-running <see cref="Apply"/>. The newly-bound port is
+    /// persisted to settings as part of the normal apply flow.
+    /// </summary>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// The port the server is now listening on, or <see langword="null"/>
+    /// if the re-bind itself failed (e.g. an ephemeral assignment hit
+    /// a transient conflict).
+    /// </returns>
+    public async Task<int?> ResetPortAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed) return null;
+
+        _settings.McpPort = 0;
+        TrySaveSettings();
+
+        await Apply(cancellationToken).ConfigureAwait(false);
+        return _server?.Port;
+    }
+
+    private void TrySaveSettings()
+    {
+        try
+        {
+            _settings.Save();
+        }
+        catch
+        {
+            // Settings persistence is best-effort; a failure here must
+            // not take down the MCP server. The next successful save
+            // (e.g. via the Settings UI) will re-persist the port.
+        }
+    }
+
+    /// <summary>
+    /// Detects the various ways Kestrel surfaces an "address in use"
+    /// error. Kestrel typically wraps the underlying
+    /// <see cref="SocketException"/> (errno <c>EADDRINUSE</c> = 48 on
+    /// macOS / 98 on Linux / 10048 on Windows) in an
+    /// <see cref="IOException"/>. We walk the inner-exception chain
+    /// and match on the platform-portable
+    /// <see cref="SocketError.AddressAlreadyInUse"/> as well as the
+    /// .NET 10 <c>AddressInUseException</c> wrapper.
+    /// </summary>
+    private static bool IsPortInUse(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException!)
+        {
+            if (e is SocketException sx && sx.SocketErrorCode == SocketError.AddressAlreadyInUse)
+                return true;
+            if (e.GetType().Name == "AddressInUseException")
+                return true;
+            if (e is IOException io
+                && io.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (e.InnerException is null) break;
+        }
+        return false;
     }
 
     private static IPAddress ParseBindAddress(string? raw)
@@ -161,4 +262,20 @@ internal sealed class McpServerHost : IAsyncDisposable
         }
         _gate.Dispose();
     }
+}
+
+/// <summary>
+/// Event payload for <see cref="McpServerHost.McpPortConflict"/>.
+/// Carries the port the bind failed on so the UI can mention it in
+/// the resulting error toast.
+/// </summary>
+internal sealed class McpPortConflictEventArgs : EventArgs
+{
+    public McpPortConflictEventArgs(int port)
+    {
+        Port = port;
+    }
+
+    /// <summary>The port that was already in use.</summary>
+    public int Port { get; }
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -466,6 +466,51 @@ internal sealed class MainViewModel : ViewModelBase
         });
     }
 
+    private void OnMcpPortConflict(object? sender, McpPortConflictEventArgs e)
+    {
+        var conflictPort = e.Port;
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            _toasts.ShowError(
+                title: Strings.Toast_McpPortConflictTitle,
+                content: string.Format(
+                    System.Globalization.CultureInfo.CurrentCulture,
+                    Strings.Toast_McpPortConflictBody,
+                    conflictPort),
+                actionLabel: Strings.Toast_McpPortFindAnother,
+                action: () => _ = FindAnotherMcpPortAsync(),
+                sticky: true);
+        });
+    }
+
+    private async Task FindAnotherMcpPortAsync()
+    {
+        if (_mcpServerHost is not { } host) return;
+
+        int? newPort;
+        try
+        {
+            newPort = await host.ResetPortAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            newPort = null;
+        }
+
+        if (newPort is { } port)
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                _toasts.ShowInfo(
+                    title: Strings.Toast_McpPortReassignedTitle,
+                    content: string.Format(
+                        System.Globalization.CultureInfo.CurrentCulture,
+                        Strings.Toast_McpPortReassignedBody,
+                        port));
+            });
+        }
+    }
+
     public MainViewModel(
         ViewerSettings settings,
         FeatureCataloguesViewModel featureCatalogues,
@@ -513,6 +558,7 @@ internal sealed class MainViewModel : ViewModelBase
         if (_mcpServerHost is { } host)
         {
             host.ServerChanged += (_, _) => AttachToMcpServer();
+            host.McpPortConflict += OnMcpPortConflict;
             AttachToMcpServer();
         }
         if (_statusPresenter is { } presenter)

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Windows.Input;
 using Avalonia.Media;
+using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Viewer.Resources;
 
@@ -424,7 +426,15 @@ internal sealed class SettingsViewModel : ViewModelBase
 
         _mcpEnabled = settings.McpEnabled;
         _mcpPort = settings.McpPort;
+        ResetMcpPortCommand = new RelayCommand(() => McpPort = 0);
     }
+
+    /// <summary>
+    /// Command bound to the "Reset to auto" button in Settings.
+    /// Clears the persisted MCP port so the next bind picks an
+    /// ephemeral port (which the host then persists back).
+    /// </summary>
+    public ICommand ResetMcpPortCommand { get; }
 
     /// <summary>
     /// Raised when an MCP-related setting changes so the

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -246,14 +246,19 @@
                 <TextBlock Text="{x:Static loc:Strings.Settings_McpPort}"
                            FontSize="12"
                            FontWeight="SemiBold" />
-                <NumericUpDown Value="{Binding McpPort}"
-                               Minimum="0"
-                               Maximum="65535"
-                               Increment="1"
-                               FormatString="0"
-                               ToolTip.Tip="{x:Static loc:Strings.Settings_McpPortTooltip}"
-                               MinWidth="120"
-                               HorizontalAlignment="Left" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <NumericUpDown Value="{Binding McpPort}"
+                                   Minimum="0"
+                                   Maximum="65535"
+                                   Increment="1"
+                                   FormatString="0"
+                                   ToolTip.Tip="{x:Static loc:Strings.Settings_McpPortTooltip}"
+                                   MinWidth="120" />
+                    <Button Content="{x:Static loc:Strings.Settings_McpPort_ResetToAuto}"
+                            Command="{Binding ResetMcpPortCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.Settings_McpPort_ResetToAutoTooltip}"
+                            VerticalAlignment="Center" />
+                </StackPanel>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerPortConflictTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerPortConflictTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Sockets;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tests;
+
+/// <summary>
+/// Exercises bind-time port-conflict surfacing for
+/// <see cref="S100McpServer"/>. These tests are the empirical basis for
+/// the exception-detection logic in <c>McpServerHost.IsPortInUse</c>:
+/// they pre-bind a <see cref="TcpListener"/> on a chosen loopback port
+/// and confirm that <see cref="S100McpServer.StartAsync"/> surfaces a
+/// distinguishable exception whose chain contains the underlying
+/// <see cref="SocketException"/> with
+/// <see cref="SocketError.AddressAlreadyInUse"/>.
+/// </summary>
+public class S100McpServerPortConflictTests
+{
+    [Fact]
+    public async Task StartAsync_throws_when_port_is_in_use()
+    {
+        // Pick a free port up-front by binding-then-releasing a listener.
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        // Now occupy that port for the duration of the test.
+        var squatter = new TcpListener(IPAddress.Loopback, port);
+        squatter.Start();
+        try
+        {
+            await using var server = new S100McpServer(
+                new FakeDatasetCatalog(),
+                new S100McpServerOptions { BindAddress = IPAddress.Loopback, Port = port });
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(() => server.StartAsync());
+
+            // The exception chain must contain a SocketException with
+            // AddressAlreadyInUse — this is the signal McpServerHost
+            // relies on to distinguish "port taken" from other faults.
+            bool foundAddressInUse = false;
+            for (var e = (Exception?)ex; e is not null; e = e.InnerException)
+            {
+                if (e is SocketException sx && sx.SocketErrorCode == SocketError.AddressAlreadyInUse)
+                {
+                    foundAddressInUse = true;
+                    break;
+                }
+            }
+            Assert.True(foundAddressInUse,
+                $"Expected AddressAlreadyInUse SocketException in chain. Got: {ex}");
+
+            Assert.False(server.IsRunning);
+        }
+        finally
+        {
+            squatter.Stop();
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/McpServerHostStickyPortTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/McpServerHostStickyPortTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Sticky-port behaviour for <see cref="McpServerHost"/>:
+/// auto-allocates-and-persists when <c>McpPort == 0</c>, surfaces a
+/// conflict event when a persisted port is squatted, and rebinds
+/// via <see cref="McpServerHost.ResetPortAsync"/> on user opt-in.
+/// </summary>
+public class McpServerHostStickyPortTests
+{
+    private sealed class EmptyCatalog : IDatasetCatalog
+    {
+        public ImmutableArray<LoadedDataset> Datasets => ImmutableArray<LoadedDataset>.Empty;
+        public event EventHandler<DatasetCatalogChangedEventArgs>? Changed { add { } remove { } }
+    }
+
+    private static ViewerSettings NewSettings()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(),
+            "EncDotNet.S100.Viewer.Tests",
+            $"mcp-{Guid.NewGuid():N}",
+            "settings.json");
+        return new ViewerSettings
+        {
+            SettingsFilePath = tmp,
+            McpEnabled = true,
+            McpPort = 0,
+        };
+    }
+
+    [Fact]
+    public async Task Apply_with_port_zero_binds_and_persists_concrete_port()
+    {
+        var settings = NewSettings();
+        await using var host = new McpServerHost(new EmptyCatalog(), settings);
+
+        await host.Apply();
+
+        Assert.NotNull(host.Server);
+        Assert.True(host.Server!.IsRunning);
+        Assert.NotNull(host.Server.Port);
+        Assert.True(host.Server.Port > 0);
+
+        // The bound port must have been written back to settings.
+        Assert.Equal(host.Server.Port!.Value, settings.McpPort);
+
+        // And persisted to disk.
+        Assert.True(File.Exists(settings.SettingsFilePath));
+        var reloaded = ViewerSettings.Load(settings.SettingsFilePath);
+        Assert.Equal(host.Server.Port!.Value, reloaded.McpPort);
+    }
+
+    [Fact]
+    public async Task Apply_raises_McpPortConflict_when_persisted_port_is_in_use()
+    {
+        // Reserve a free port, then squat on it.
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        var squatter = new TcpListener(IPAddress.Loopback, port);
+        squatter.Start();
+        try
+        {
+            var settings = NewSettings();
+            settings.McpPort = port;
+
+            await using var host = new McpServerHost(new EmptyCatalog(), settings);
+
+            int? conflictPort = null;
+            host.McpPortConflict += (_, e) => conflictPort = e.Port;
+
+            await host.Apply();
+
+            Assert.Equal(port, conflictPort);
+            // Server must NOT come up — the user has to opt in to recovery.
+            Assert.Null(host.Server);
+            // Persisted port is unchanged — the user might want to
+            // resolve the conflict externally and try again.
+            Assert.Equal(port, settings.McpPort);
+        }
+        finally
+        {
+            squatter.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task ResetPortAsync_rebinds_and_persists_new_port_after_conflict()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        var squatter = new TcpListener(IPAddress.Loopback, port);
+        squatter.Start();
+        try
+        {
+            var settings = NewSettings();
+            settings.McpPort = port;
+
+            await using var host = new McpServerHost(new EmptyCatalog(), settings);
+            await host.Apply(); // conflict, no server
+            Assert.Null(host.Server);
+
+            var newPort = await host.ResetPortAsync();
+
+            Assert.NotNull(newPort);
+            Assert.NotEqual(port, newPort);
+            Assert.NotNull(host.Server);
+            Assert.True(host.Server!.IsRunning);
+            Assert.Equal(newPort, host.Server.Port);
+            // Persisted to settings.
+            Assert.Equal(newPort, settings.McpPort);
+            var reloaded = ViewerSettings.Load(settings.SettingsFilePath);
+            Assert.Equal(newPort, reloaded.McpPort);
+        }
+        finally
+        {
+            squatter.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Apply_with_already_running_matching_port_is_idempotent()
+    {
+        var settings = NewSettings();
+        await using var host = new McpServerHost(new EmptyCatalog(), settings);
+
+        await host.Apply();
+        var firstPort = host.Server?.Port;
+        var firstServer = host.Server;
+
+        await host.Apply();
+
+        Assert.Same(firstServer, host.Server);
+        Assert.Equal(firstPort, host.Server?.Port);
+    }
+}


### PR DESCRIPTION
Make the viewer's embedded MCP server port "sticky": on first launch (or whenever `McpPort = 0`), let Kestrel pick a free port and persist it back to settings; on subsequent launches reuse the persisted port. If the persisted port is in use, surface a sticky error toast with a single "Find another port" action.

## Behaviour matrix

| State at startup | Action |
|---|---|
| `McpPort = 0` (or unset) | Bind with `Port=0`; on success, write `server.Port` back to settings + save. No toast. |
| `McpPort = N` (persisted) | Try to bind `N`. On success: silent. On `SocketException(AddressAlreadyInUse)`: sticky error toast with "Find another port" action. |
| User clicks "Find another port" | `ResetPortAsync()` sets `McpPort=0`, saves, rebinds (which then persists the new port), shows info toast. |
| `McpPort = N` set explicitly via Settings | Same persist-on-bind path (no-op when port already matches). Collision toast still appears on conflict. |

A "Reset to auto" button has also been added next to the port field in Settings — clears `McpPort` to 0 on demand.

## Implementation

- **`McpServerHost.cs`** — wraps `StartAsync` in a try/catch matching the `SocketException`/`IOException`/`AddressInUseException` chain Kestrel actually throws (verified by the new `S100McpServerPortConflictTests`). On port-in-use, raises a new `McpPortConflict` event instead of throwing. On successful bind, writes `Server.Port` back to settings and saves. New `ResetPortAsync()` drives the user-opt-in recovery flow.
- **`MainViewModel.cs`** — subscribes to `McpPortConflict`, surfaces a sticky error toast via the PR-D `ShowError` overload with a "Find another port" action that calls `ResetPortAsync` and shows an info toast on success.
- **`SettingsViewModel.cs` / `SettingsView.axaml`** — adds `ResetMcpPortCommand` and a "Reset to auto" button (with required tooltip) next to the port input.
- **`Resources/Strings.{cs,resx}`** — 7 new localized strings; zero hardcoded UI text.

## Tests

- `S100McpServerPortConflictTests` (Mcp.Tests): pre-binds a `TcpListener` on a port, confirms `S100McpServer.StartAsync` surfaces an exception whose chain contains `SocketError.AddressAlreadyInUse` — pinning the contract `McpServerHost.IsPortInUse` matches against.
- `McpServerHostStickyPortTests` (Viewer.Tests):
  - `Apply` with `McpPort=0` binds and persists the bound port to settings (including to disk).
  - `Apply` with a squatted persisted port raises `McpPortConflict` without throwing or starting the server, and leaves the persisted port unchanged.
  - `ResetPortAsync` rebinds successfully and persists the new port after a conflict.
  - `Apply` is idempotent when already running on the matching port.

All 234 Viewer.Tests + 12 Mcp.Tests pass; full solution builds clean.

## Manual smoke test

1. Delete `~/Library/Application Support/EncDotNet.S100.Viewer/settings.json` (or set `McpPort = 0` in it).
2. Start the viewer, enable MCP. Observe a port in the status bar.
3. Inspect `settings.json` — `McpPort` is now the concrete bound port.
4. Restart the viewer. Status bar shows the same port (sticky).
5. Quit the viewer; run `nc -l <that-port>` in a terminal; start the viewer again. Sticky error toast appears: "MCP server port unavailable — Port N is already in use. The MCP server is offline until a free port is chosen." with a "Find another port" button.
6. Click "Find another port". Info toast confirms a new port was chosen and `settings.json` is updated.

## Out of scope

- Custom port ranges, IPv6 / non-loopback binds, automatic re-notification of MCP clients.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>