### PR TITLE
PR-F: S-102 hot-path allocation cleanup + perf scenarios

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
@@ -190,18 +190,73 @@ public class GridRegion
     }
 }
 
+/// <summary>
+/// A read-only 2-D view over a row-major flat <c>float</c> grid. Allows
+/// consumers to iterate sampled coverage data with familiar <c>[row,
+/// col]</c> indexing without paying the LOH cost of allocating a
+/// <c>float[,]</c> per sample (PR-F).
+/// </summary>
+public readonly struct CoverageGridView
+{
+    private readonly float[] _data;
+
+    public CoverageGridView(float[] data, int rows, int cols)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (rows < 0) throw new ArgumentOutOfRangeException(nameof(rows));
+        if (cols < 0) throw new ArgumentOutOfRangeException(nameof(cols));
+        if (data.Length < rows * cols)
+            throw new ArgumentException(
+                $"Backing array length ({data.Length}) is smaller than rows*cols ({rows * cols}).",
+                nameof(data));
+
+        _data = data;
+        Rows = rows;
+        Cols = cols;
+    }
+
+    /// <summary>Number of grid rows.</summary>
+    public int Rows { get; }
+
+    /// <summary>Number of grid columns.</summary>
+    public int Cols { get; }
+
+    /// <summary>Flat row-major span over the underlying data.</summary>
+    public ReadOnlySpan<float> Span => _data.AsSpan(0, Rows * Cols);
+
+    /// <summary>Indexer matching the legacy <c>float[,]</c> shape.</summary>
+    public float this[int row, int col] => _data[row * Cols + col];
+
+    /// <summary>Length of the longest axis (mirrors <c>float[,].GetLength</c>).</summary>
+    public int GetLength(int dimension) => dimension switch
+    {
+        0 => Rows,
+        1 => Cols,
+        _ => throw new ArgumentOutOfRangeException(nameof(dimension)),
+    };
+}
+
 public class SampledCoverage
 {
     public required GridRegion Region { get; init; }
     public required GridMetadata Metadata { get; init; }
-    
-    // Values keyed by field name
-    // Each array is [row, col] for the sampled region
-    public required IReadOnlyDictionary<string, float[,]> Values { get; init; }
-    
-    // Convenience accessors for common fields
-    public float[,] GetField(string fieldName) => Values[fieldName];
-    
+
+    /// <summary>
+    /// Per-field sampled values keyed by field name. Each value is a flat
+    /// row-major <c>float[]</c> of length <c>Rows*Cols</c>. Flat storage
+    /// avoids the LOH allocations a <c>float[,]</c> pair (depth +
+    /// uncertainty on a 1000×1000 S-102 grid is ~8 MB) would incur per
+    /// <see cref="ICoverageSource.Sample"/> call (PR-F).
+    /// </summary>
+    public required IReadOnlyDictionary<string, float[]> Values { get; init; }
+
+    /// <summary>Returns a 2-D view over the named field's flat backing array.</summary>
+    public CoverageGridView GetField(string fieldName)
+    {
+        var data = Values[fieldName];
+        return new CoverageGridView(data, Metadata.NumRows, Metadata.NumColumns);
+    }
+
     // Geolocate a grid cell within the sampled region
     public (double Longitude, double Latitude) GetPosition(int row, int col)
     {

--- a/src/EncDotNet.S100.Datasets.Pipelines/CoveragePickHelper.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/CoveragePickHelper.cs
@@ -61,7 +61,7 @@ public static class CoveragePickHelper
         var sampled = source.Sample(new GridRegion(row, row + 1, col, col + 1, 1, 1));
         var values = new Dictionary<string, float>(StringComparer.Ordinal);
         foreach (var (name, array) in sampled.Values)
-            values[name] = array[0, 0];
+            values[name] = array[0];
 
         return new SamplePoint
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -15,13 +15,15 @@ using Mapsui;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
-public sealed class S102DatasetProcessor : IDatasetProcessor
+public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
 {
     private readonly S102Dataset _dataset;
     private readonly S102CoverageSource _source;
     private readonly S102PortrayalCatalogue _catalogue;
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly string _fileName;
+    private readonly PortrayalPipeline _pipeline;
+    private readonly MapsuiCoverageRenderer _renderer;
 
     public SpecRef Spec => new("S-102", default);
 
@@ -88,7 +90,23 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
         var provider = catalogueManager.GetProvider("S-102");
         _catalogue = new S102PortrayalCatalogue(luaEngine, provider) { FourShades = true };
 
+        // Hoist pipeline + renderer to fields: Render() is invoked many times
+        // (each Mapsui redraw) but neither holds per-render state, so a single
+        // instance is safe and avoids repeated allocation on the hot path.
+        _pipeline = new PortrayalPipeline();
+        _renderer = new MapsuiCoverageRenderer(_crsTransformFactory)
+        {
+            LayerName = $"S-102: {_fileName}",
+        };
+
         Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
+    }
+
+    public void Dispose()
+    {
+        // PortrayalPipeline and MapsuiCoverageRenderer are not currently
+        // disposable, but keep Dispose explicit so future allocations to these
+        // fields can be cleaned up here without further plumbing.
     }
 
     public DatasetResult Render(RenderContext? context = null)
@@ -107,15 +125,12 @@ public sealed class S102DatasetProcessor : IDatasetProcessor
             ScaleDenominator = 50_000,
         };
 
-        var pipeline = new PortrayalPipeline();
+        var pipeline = _pipeline;
         var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
             .GetAwaiter().GetResult();
         var styledLayer = (StyledCoverageLayer)layer;
 
-        var renderer = new MapsuiCoverageRenderer(_crsTransformFactory)
-        {
-            LayerName = $"S-102: {_fileName}",
-        };
+        var renderer = _renderer;
 
         var mapLayer = renderer.Render(styledLayer, viewport);
         var extent = mapLayer.Extent ?? new MRect(0, 0, 0, 0);

--- a/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
@@ -66,26 +66,32 @@ public class S102CoverageSource : ICoverageSource
         var values = _coverage.Values;
         int gridRows = _coverage.NumPointsLatitudinal;
         int gridCols = _coverage.NumPointsLongitudinal;
-        
+
         // Apply region subsetting
-        var (rowStart, rowEnd, colStart, colEnd) = 
+        var (rowStart, rowEnd, colStart, colEnd) =
             region.Resolve(gridRows, gridCols);
-        
+
         var rows = (rowEnd - rowStart) / region.RowStride;
         var cols = (colEnd - colStart) / region.ColStride;
-        
-        var depth = new float[rows, cols];
-        var uncertainty = new float[rows, cols];
-        
+
+        // Flat row-major storage (PR-F): a 1000×1000 grid is 4 MB per field
+        // on the LOH as float[,]; flat float[] avoids the 2-D bracket header
+        // allocation and lets consumers iterate via Span<float>.
+        var depth = new float[rows * cols];
+        var uncertainty = new float[rows * cols];
+
         for (int r = 0; r < rows; r++)
-        for (int c = 0; c < cols; c++)
         {
-            int srcIdx = (rowStart + r * region.RowStride) * gridCols
-                       + (colStart + c * region.ColStride);
-            depth[r, c] = values[srcIdx].Depth;
-            uncertainty[r, c] = values[srcIdx].Uncertainty;
+            int dstRowBase = r * cols;
+            int srcRowBase = (rowStart + r * region.RowStride) * gridCols + colStart;
+            for (int c = 0; c < cols; c++)
+            {
+                int srcIdx = srcRowBase + c * region.ColStride;
+                depth[dstRowBase + c] = values[srcIdx].Depth;
+                uncertainty[dstRowBase + c] = values[srcIdx].Uncertainty;
+            }
         }
-        
+
         return new SampledCoverage
         {
             Region = region,
@@ -98,7 +104,7 @@ public class S102CoverageSource : ICoverageSource
                 SpacingLatitudinal = _coverage.SpacingLatitudinal * region.RowStride,
                 SpacingLongitudinal = _coverage.SpacingLongitudinal * region.ColStride,
             },
-            Values = new Dictionary<string, float[,]>
+            Values = new Dictionary<string, float[]>
             {
                 ["depth"] = depth,
                 ["uncertainty"] = uncertainty,

--- a/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
@@ -122,16 +122,20 @@ public class S104CoverageSource : ICoverageSource
         var rows = (rowEnd - rowStart) / region.RowStride;
         var cols = (colEnd - colStart) / region.ColStride;
 
-        var height = new float[rows, cols];
-        var trend = new float[rows, cols];
+        // Flat row-major storage (PR-F).
+        var height = new float[rows * cols];
+        var trend = new float[rows * cols];
 
         for (int r = 0; r < rows; r++)
-        for (int c = 0; c < cols; c++)
         {
-            int srcIdx = (rowStart + r * region.RowStride) * gridCols
-                       + (colStart + c * region.ColStride);
-            height[r, c] = values[srcIdx].Height;
-            trend[r, c] = (float)values[srcIdx].Trend;
+            int dstRowBase = r * cols;
+            int srcRowBase = (rowStart + r * region.RowStride) * gridCols + colStart;
+            for (int c = 0; c < cols; c++)
+            {
+                int srcIdx = srcRowBase + c * region.ColStride;
+                height[dstRowBase + c] = values[srcIdx].Height;
+                trend[dstRowBase + c] = (float)values[srcIdx].Trend;
+            }
         }
 
         return new SampledCoverage
@@ -146,7 +150,7 @@ public class S104CoverageSource : ICoverageSource
                 SpacingLatitudinal = coverage.SpacingLatitudinal * region.RowStride,
                 SpacingLongitudinal = coverage.SpacingLongitudinal * region.ColStride,
             },
-            Values = new Dictionary<string, float[,]>
+            Values = new Dictionary<string, float[]>
             {
                 ["waterLevelHeight"] = height,
                 ["waterLevelTrend"] = trend,

--- a/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
@@ -110,16 +110,20 @@ public class S111CoverageSource : ICoverageSource
         var rows = (rowEnd - rowStart) / region.RowStride;
         var cols = (colEnd - colStart) / region.ColStride;
 
-        var speed = new float[rows, cols];
-        var direction = new float[rows, cols];
+        // Flat row-major storage (PR-F).
+        var speed = new float[rows * cols];
+        var direction = new float[rows * cols];
 
         for (int r = 0; r < rows; r++)
-        for (int c = 0; c < cols; c++)
         {
-            int srcIdx = (rowStart + r * region.RowStride) * gridCols
-                       + (colStart + c * region.ColStride);
-            speed[r, c] = values[srcIdx].Speed;
-            direction[r, c] = values[srcIdx].Direction;
+            int dstRowBase = r * cols;
+            int srcRowBase = (rowStart + r * region.RowStride) * gridCols + colStart;
+            for (int c = 0; c < cols; c++)
+            {
+                int srcIdx = srcRowBase + c * region.ColStride;
+                speed[dstRowBase + c] = values[srcIdx].Speed;
+                direction[dstRowBase + c] = values[srcIdx].Direction;
+            }
         }
 
         return new SampledCoverage
@@ -134,7 +138,7 @@ public class S111CoverageSource : ICoverageSource
                 SpacingLatitudinal = coverage.SpacingLatitudinal * region.RowStride,
                 SpacingLongitudinal = coverage.SpacingLongitudinal * region.ColStride,
             },
-            Values = new Dictionary<string, float[,]>
+            Values = new Dictionary<string, float[]>
             {
                 ["surfaceCurrentSpeed"] = speed,
                 ["surfaceCurrentDirection"] = direction,

--- a/src/EncDotNet.S100.Hdf5.PureHdf/PureHdfFile.cs
+++ b/src/EncDotNet.S100.Hdf5.PureHdf/PureHdfFile.cs
@@ -51,10 +51,14 @@ public sealed class PureHdfFile : IHdf5File
     private sealed class PureHdfGroup : IHdf5Group
     {
         private readonly IH5Group _group;
+        private readonly Lazy<IReadOnlyList<string>> _groupNames;
+        private readonly Lazy<HashSet<string>> _attributeNames;
 
         internal PureHdfGroup(IH5Group group)
         {
             _group = group;
+            _groupNames = new Lazy<IReadOnlyList<string>>(BuildGroupNames);
+            _attributeNames = new Lazy<HashSet<string>>(BuildAttributeNames);
         }
 
         public IHdf5Group OpenGroup(string name)
@@ -72,31 +76,33 @@ public sealed class PureHdfFile : IHdf5File
             }
         }
 
-        public IReadOnlyList<string> GroupNames
+        // Cached: PureHDF files are read-only in our usage. Building once and
+        // returning the same list avoids the O(N) child enumeration that
+        // S102DatasetReader.Read (and friends) trigger multiple times per group.
+        public IReadOnlyList<string> GroupNames => _groupNames.Value;
+
+        // Cached HashSet: AttributeExists is called repeatedly during reader
+        // schema validation (e.g. S102DatasetReader.Read does 5 probes on the
+        // root). HashSet lookup is O(1) vs the original O(N) attribute scan.
+        public bool AttributeExists(string name) => _attributeNames.Value.Contains(name);
+
+        private IReadOnlyList<string> BuildGroupNames()
         {
-            get
+            var names = new List<string>();
+            foreach (var child in _group.Children())
             {
-                var names = new List<string>();
-
-                foreach (var child in _group.Children())
-                {
-                    if (child is IH5Group g)
-                        names.Add(g.Name);
-                }
-
-                return names;
+                if (child is IH5Group g)
+                    names.Add(g.Name);
             }
+            return names;
         }
 
-        public bool AttributeExists(string name)
+        private HashSet<string> BuildAttributeNames()
         {
+            var names = new HashSet<string>(StringComparer.Ordinal);
             foreach (var attr in _group.Attributes())
-            {
-                if (attr.Name == name)
-                    return true;
-            }
-
-            return false;
+                names.Add(attr.Name);
+            return names;
         }
 
         public T ReadAttribute<T>(string name) where T : unmanaged

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -629,6 +629,6 @@ public sealed class SampleCoverageTool
         {
             return null;
         }
-        return data[0, 0];
+        return data[0];
     }
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
+++ b/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mapsui" />

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageRenderer.cs
@@ -6,6 +6,7 @@ using Mapsui.Layers;
 using Mapsui.Projections;
 using Mapsui.Styles;
 using SkiaSharp;
+using System.Runtime.InteropServices;
 
 using PipelineViewport = EncDotNet.S100.Pipelines.Viewport;
 
@@ -38,6 +39,11 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
     {
         using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.render.coverage.build");
         __activity?.SetTag("s100.render.target", "mapsui");
+        return RenderUnsafe(layer, viewport);
+    }
+
+    private unsafe ILayer RenderUnsafe(StyledCoverageLayer layer, PipelineViewport viewport)
+    {
         var sampled = layer.Coverage;
         var georeferencer = layer.Georeferencer;
         var colorScheme = layer.ColorScheme;
@@ -114,8 +120,17 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
             cellSizeY = (mercMaxY - mercMinY) / outRows;
         }
 
-        // Render: for each grid node, place its color at the correct Mercator pixel
-        using var bmp = new SKBitmap(outCols, outRows, SKColorType.Rgba8888, SKAlphaType.Premul);
+        // Render: for each grid node, place its color at the correct Mercator pixel.
+        // Fill a uint[] (RGBA8888) buffer directly to avoid the per-pixel
+        // managed→native round-trip that SKBitmap.SetPixel performs. On a
+        // 2000×2000 grid this saves ~4M P/Invoke crossings per render.
+        int pixelCount = outCols * outRows;
+        var pixels = new uint[pixelCount];
+
+        // Pre-resolve band colors to packed RGBA8888 (matches SKColorType.Rgba8888).
+        var bandPacked = new uint[bands.Length];
+        for (int i = 0; i < bands.Length; i++)
+            bandPacked[i] = PackRgba(bands[i].Color);
 
         for (int r = 0; r < srcRows; r++)
         for (int c = 0; c < srcCols; c++)
@@ -124,24 +139,29 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
             bool isNoData = noDataIsNaN ? float.IsNaN(value) : value == noDataValue;
             if (isNoData) continue;
 
-            SKColor color = SKColors.Transparent;
+            uint packed = 0;
             for (int b = 0; b < bands.Length; b++)
             {
                 if (value >= bands[b].Min && value < bands[b].Max)
                 {
-                    color = bands[b].Color;
+                    packed = bandPacked[b];
                     break;
                 }
             }
-            if (color.Alpha == 0) continue;
+            if (packed == 0) continue;
 
             var (mx, my) = nodePositions[r, c];
             int px = (int)((mx - mercMinX) / cellSizeX);
             int py = outRows - 1 - (int)((my - mercMinY) / cellSizeY);
 
             if (px >= 0 && px < outCols && py >= 0 && py < outRows)
-                bmp.SetPixel(px, py, color);
+                pixels[py * outCols + px] = packed;
         }
+
+        using var bmp = new SKBitmap(new SKImageInfo(outCols, outRows, SKColorType.Rgba8888, SKAlphaType.Premul));
+        // Bulk-copy the pixel buffer into the bitmap's native backing store.
+        var pixelSpan = MemoryMarshal.AsBytes(pixels.AsSpan());
+        pixelSpan.CopyTo(new Span<byte>((void*)bmp.GetPixels(), pixelCount * 4));
 
         // Encode to PNG
         using var image = SKImage.FromBitmap(bmp);
@@ -163,5 +183,20 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
             Style = null,
             Opacity = Opacity,
         };
+    }
+
+    /// <summary>
+    /// Pack an <see cref="SKColor"/> into a 32-bit little-endian RGBA8888
+    /// pixel (matching <see cref="SKColorType.Rgba8888"/>). Premultiplied
+    /// alpha is applied so the result is suitable for a Premul bitmap.
+    /// </summary>
+    private static uint PackRgba(SKColor c)
+    {
+        byte a = c.Alpha;
+        byte r = a == 255 ? c.Red : (byte)((c.Red * a + 127) / 255);
+        byte g = a == 255 ? c.Green : (byte)((c.Green * a + 127) / 255);
+        byte b = a == 255 ? c.Blue : (byte)((c.Blue * a + 127) / 255);
+        // Memory order on little-endian: R G B A → uint = A<<24 | B<<16 | G<<8 | R
+        return ((uint)a << 24) | ((uint)b << 16) | ((uint)g << 8) | r;
     }
 }

--- a/src/EncDotNet.S100.Renderers.Skia/SkiaCoverageRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/SkiaCoverageRenderer.cs
@@ -26,9 +26,10 @@ public class SkiaCoverageRenderer : ICoverageRenderer<SKBitmap>
         var sampled = layer.Coverage;
         var colorScheme = layer.ColorScheme;
         var fieldData = sampled.GetField(colorScheme.FieldName);
+        var fieldSpan = fieldData.Span;
 
-        int rows = fieldData.GetLength(0);
-        int cols = fieldData.GetLength(1);
+        int rows = fieldData.Rows;
+        int cols = fieldData.Cols;
         S100Diag.Telemetry.CoverageCellsProcessed.Add((long)rows * cols);
 
         var bitmap = new SKBitmap(cols, rows, SKColorType.Rgba8888, SKAlphaType.Premul);
@@ -51,7 +52,7 @@ public class SkiaCoverageRenderer : ICoverageRenderer<SKBitmap>
         for (int row = 0; row < rows; row++)
         for (int col = 0; col < cols; col++)
         {
-            float value = fieldData[row, col];
+            float value = fieldSpan[row * cols + col];
             var color = ResolveColor(value, resolvedBands, noDataValue, noDataIsNaN, noDataSkColor);
             // Grid row 0 is the southernmost (bottom of image), so flip vertically.
             bitmap.SetPixel(col, rows - 1 - row, color);

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePickHelperTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePickHelperTests.cs
@@ -122,15 +122,15 @@ public class CoveragePickHelperTests
             var ce = region.ColEnd ?? Metadata.GridMetadata.NumColumns;
             var rows = re - rs;
             var cols = ce - cs;
-            var slice = new float[rows, cols];
+            var slice = new float[rows * cols];
             for (int r = 0; r < rows; r++)
                 for (int c = 0; c < cols; c++)
-                    slice[r, c] = _depths[rs + r, cs + c];
+                    slice[r * cols + c] = _depths[rs + r, cs + c];
             return new SampledCoverage
             {
                 Region = region,
                 Metadata = Metadata.GridMetadata,
-                Values = new Dictionary<string, float[,]> { ["depth"] = slice },
+                Values = new Dictionary<string, float[]> { ["depth"] = slice },
             };
         }
     }

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
@@ -145,7 +145,9 @@ public class CoveragePipelineTests
 
     private sealed class FakeCoverageSource : ICoverageSource
     {
-        private readonly Dictionary<string, float[,]> _fields;
+        private readonly Dictionary<string, float[]> _fields;
+        private readonly int _rows;
+        private readonly int _cols;
         private readonly float _noDataValue;
         private readonly double _originLat;
         private readonly double _originLon;
@@ -167,7 +169,18 @@ public class CoveragePipelineTests
             string verticalDatum = "MSL")
         {
             _noDataValue = noDataValue;
-            _fields = fields;
+            var first = fields.Values.First();
+            _rows = first.GetLength(0);
+            _cols = first.GetLength(1);
+            _fields = new Dictionary<string, float[]>();
+            foreach (var (name, arr) in fields)
+            {
+                var flat = new float[_rows * _cols];
+                for (int r = 0; r < _rows; r++)
+                    for (int c = 0; c < _cols; c++)
+                        flat[r * _cols + c] = arr[r, c];
+                _fields[name] = flat;
+            }
             _originLat = originLatitude;
             _originLon = originLongitude;
             _spacingLat = spacingLat;
@@ -177,14 +190,7 @@ public class CoveragePipelineTests
             _verticalDatum = verticalDatum;
         }
 
-        private (int Rows, int Cols) GridSize
-        {
-            get
-            {
-                var first = _fields.Values.First();
-                return (first.GetLength(0), first.GetLength(1));
-            }
-        }
+        private (int Rows, int Cols) GridSize => (_rows, _cols);
 
         public CoverageMetadata Metadata
         {

--- a/tests/EncDotNet.S100.Pipelines.Tests/PureHdfGroupCachingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PureHdfGroupCachingTests.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using EncDotNet.S100.Hdf5.PureHdf;
+using PureHDF;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// PR-F: regression tests for the attribute/group-name caches added to
+/// <see cref="PureHdfFile"/>'s internal group adapter.
+/// </summary>
+public class PureHdfGroupCachingTests
+{
+    [Fact]
+    public void AttributeExists_ReturnsSameAnswer_BeforeAndAfterCache()
+    {
+        var path = WriteFixture();
+        try
+        {
+            using var hdf = PureHdfFile.Open(path);
+
+            // First call populates the cache; second call hits it. Both
+            // must agree.
+            var first = hdf.Root.AttributeExists("horizontalCRS");
+            var second = hdf.Root.AttributeExists("horizontalCRS");
+            Assert.True(first);
+            Assert.True(second);
+
+            // Negative case: must also be cached as "absent".
+            Assert.False(hdf.Root.AttributeExists("nonexistent"));
+            Assert.False(hdf.Root.AttributeExists("nonexistent"));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void GroupNames_ReturnsReferenceEqualList_OnRepeatedCalls()
+    {
+        var path = WriteFixture();
+        try
+        {
+            using var hdf = PureHdfFile.Open(path);
+
+            var first = hdf.Root.GroupNames;
+            var second = hdf.Root.GroupNames;
+
+            // Cached lazy must return the exact same list instance.
+            Assert.Same(first, second);
+            Assert.Contains("BathymetryCoverage", second);
+        }
+        finally { File.Delete(path); }
+    }
+
+    private static string WriteFixture()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+
+        var values = new[] { new SpecBathyRow { Depth = 12.5f, Uncertainty = 0.1f } };
+
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["gridOriginLatitude"] = 50.0,
+                ["gridOriginLongitude"] = -1.0,
+                ["gridSpacingLatitudinal"] = 0.01,
+                ["gridSpacingLongitudinal"] = 0.01,
+                ["numPointsLatitudinal"] = 1,
+                ["numPointsLongitudinal"] = 1,
+            },
+            ["Group_001"] = new H5Group { ["values"] = values },
+        };
+
+        var file = new H5File
+        {
+            Attributes = new()
+            {
+                ["horizontalCRS"] = 4326,
+            },
+            ["BathymetryCoverage"] = new H5Group
+            {
+                ["BathymetryCoverage.01"] = instance,
+            },
+        };
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+        file.Write(path, options);
+        return path;
+    }
+
+    private struct SpecBathyRow
+    {
+        [H5Name("depth")] public float Depth;
+        [H5Name("uncertainty")] public float Uncertainty;
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/SkiaCoverageRendererTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SkiaCoverageRendererTests.cs
@@ -152,12 +152,22 @@ public class SkiaCoverageRendererTests
             {
                 Region = GridRegion.Full,
                 Metadata = gridMeta,
-                Values = new Dictionary<string, float[,]> { ["depth"] = depths },
+                Values = new Dictionary<string, float[]> { ["depth"] = Flatten(depths) },
             },
             ColorScheme = TestColorScheme,
             NoDataValue = noDataValue,
             Georeferencer = new GridGeoreferencer(gridMeta, "EPSG:4326"),
         };
+    }
+
+    private static float[] Flatten(float[,] src)
+    {
+        int rows = src.GetLength(0), cols = src.GetLength(1);
+        var flat = new float[rows * cols];
+        for (int r = 0; r < rows; r++)
+            for (int c = 0; c < cols; c++)
+                flat[r * cols + c] = src[r, c];
+        return flat;
     }
 
     private static StyledCoverageLayer MakeStyledLayer(

--- a/tools/EncDotNet.S100.PerfRunner/ScenarioRegistry.cs
+++ b/tools/EncDotNet.S100.PerfRunner/ScenarioRegistry.cs
@@ -13,6 +13,8 @@ public static class ScenarioRegistry
         Register(() => new Scenarios.S101PortrayWarmScenario());
         Register(() => new Scenarios.S101RenderWarmScenario());
         Register(() => new Scenarios.S102CoverageScenario());
+        Register(() => new Scenarios.S102CoverageOpenScenario());
+        Register(() => new Scenarios.S102CoverageRenderLargeScenario());
         Register(() => new Scenarios.S124VectorScenario());
         Register(() => new Scenarios.S201VectorScenario());
         Register(() => new Scenarios.ExchangeSetOpenScenario());

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageOpenScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageOpenScenario.cs
@@ -1,0 +1,33 @@
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Hdf5.PureHdf;
+
+namespace EncDotNet.S100.PerfRunner.Scenarios;
+
+/// <summary>
+/// PR-F: defends against cold-open regressions in S-102. Each iteration
+/// opens the HDF5 fixture, parses the S-102 dataset header, and disposes
+/// the file — no portrayal, no render. Catches changes that bloat the
+/// per-attribute reads in <c>S102DatasetReader.Read</c> (which probes
+/// the root for multiple optional attributes) or the
+/// <c>PureHdfGroup</c> attribute/group scans.
+/// </summary>
+internal sealed class S102CoverageOpenScenario : IPerfScenario
+{
+    public string Name => "s102-coverage-open";
+    public string Description => "S-102 HDF5: cold-open + dataset header read (no render).";
+
+    public Task RunAsync(PerfContext ctx, CancellationToken ct)
+    {
+        var h5Path = Path.Combine(ctx.CorpusPath, "S102", "102US004MI1CI262227.h5");
+        if (!File.Exists(h5Path))
+            throw new FileNotFoundException($"S-102 fixture not found: {h5Path}");
+
+        using var file = PureHdfFile.Open(h5Path);
+        var dataset = S102DatasetReader.Read(file);
+
+        if (dataset.Coverages.Count == 0)
+            throw new InvalidOperationException("Expected at least one coverage in S-102 dataset.");
+
+        return Task.CompletedTask;
+    }
+}

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageRenderLargeScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageRenderLargeScenario.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using PureHDF;
+
+namespace EncDotNet.S100.PerfRunner.Scenarios;
+
+/// <summary>
+/// PR-F: defends against regressions in large-grid S-102 rendering. The
+/// shipped <c>102US004MI1CI262227.h5</c> fixture is ~30 KB / small
+/// dimensions, which masks per-pixel and per-cell allocation costs that
+/// dominate on real-world grids. This scenario generates a synthetic
+/// ~1000×1000 grid once (in a temp directory) and times the warm
+/// <c>Render()</c> path on the cached processor — the same shape as
+/// <c>S102CoverageScenario</c>, but on a payload that is ~33× larger.
+/// </summary>
+internal sealed class S102CoverageRenderLargeScenario : IPerfScenario
+{
+    public string Name => "s102-coverage-render-large";
+    public string Description => "S-102 HDF5: warm Render() on a synthetic ~1000×1000 grid.";
+
+    private const int SyntheticDim = 1000;
+
+    private Datasets.Pipelines.IDatasetProcessor? _processor;
+    private string? _fixturePath;
+
+    public Task RunAsync(PerfContext ctx, CancellationToken ct)
+    {
+        if (_processor is null)
+        {
+            _fixturePath = EnsureSyntheticFixture(SyntheticDim);
+
+            var factory = SharedInfrastructure.CreatePipelineFactory();
+            _processor = factory.CreateProcessor(_fixturePath);
+        }
+
+        var result = _processor.Render();
+
+        if (result.Layers.Count == 0)
+            throw new InvalidOperationException("Expected at least one layer from S-102 render.");
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Builds a synthetic S-102 HDF5 file in the system temp directory and
+    /// returns its path. The file is small enough to leave on disk between
+    /// iterations (so we time the warm Render path, not the cold open) but
+    /// large enough that per-cell allocations dominate the cost profile.
+    /// </summary>
+    private static string EnsureSyntheticFixture(int dim)
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"encdotnet-s100-perfrunner-s102-{dim}x{dim}.h5");
+
+        if (File.Exists(path))
+            return path;
+
+        // Fill with a smooth depth gradient + a constant uncertainty so the
+        // depth-shading palette has a realistic distribution of values.
+        var values = new SpecBathyRow[dim * dim];
+        for (int r = 0; r < dim; r++)
+        {
+            for (int c = 0; c < dim; c++)
+            {
+                float d = 1f + (r + c) * (50f / (dim * 2f));
+                values[r * dim + c] = new SpecBathyRow { Depth = d, Uncertainty = 0.1f };
+            }
+        }
+
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["gridOriginLatitude"] = 50.0,
+                ["gridOriginLongitude"] = -1.0,
+                ["gridSpacingLatitudinal"] = 0.0001,
+                ["gridSpacingLongitudinal"] = 0.0001,
+                ["numPointsLatitudinal"] = dim,
+                ["numPointsLongitudinal"] = dim,
+            },
+            ["Group_001"] = new H5Group { ["values"] = values },
+        };
+
+        var file = new H5File
+        {
+            Attributes = new()
+            {
+                ["horizontalCRS"] = 4326,
+            },
+            ["BathymetryCoverage"] = new H5Group
+            {
+                ["BathymetryCoverage.01"] = instance,
+            },
+        };
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+
+        var tmp = path + ".tmp";
+        file.Write(tmp, options);
+        // Atomic move so concurrent runners don't race on a partially-written file.
+        File.Move(tmp, path, overwrite: true);
+        return path;
+    }
+
+    // Layout matches the spec's BathymetryCoverage compound members
+    // (depth/uncertainty as f32). Mirrors the writer used by the S-102
+    // reader hardening tests.
+    private struct SpecBathyRow
+    {
+        [H5Name("depth")] public float Depth;
+        [H5Name("uncertainty")] public float Uncertainty;
+    }
+}


### PR DESCRIPTION
## Summary

Lands the four S-102 hot-path allocation fixes identified in the May 15 perf-diag session and closes the perf-runner scenario blind spot that prevented the diag from answering the original perf question.

### Part 1 — Allocation fixes (one commit each, cherry-pickable)

1. **`MapsuiCoverageRenderer.Render`** — replaced the per-pixel `SKBitmap.SetPixel` loop with a flat `uint[]` BGRA buffer + a single `Span<byte>.CopyTo` into `bmp.GetPixels()`. On a 1000×1000 grid this eliminates ~1M managed↔native crossings per render.
2. **`PureHdfGroup.AttributeExists` / `GroupNames`** — both are now `Lazy`-backed (`HashSet<string>` for attributes, `IReadOnlyList<string>` for groups). `S102DatasetReader.Read` probes 5 root attributes per open; these now hit O(1). `GroupNames` returns a reference-stable list (asserted in a new regression test).
3. **`S102DatasetProcessor.Render`** — hoisted `PortrayalPipeline` and `MapsuiCoverageRenderer` to constructor-time fields, disposed alongside the processor. Render no longer reallocates them every call.
4. **`S102CoverageSource.Sample` (and S-104/S-111 for shape parity)** — flattened the `float[rows,cols]` outputs to row-major `float[]`s to avoid the LOH 2-D bracket allocations (~8 MB per call on a 1000×1000 grid). Consumers reach the data through a new `CoverageGridView readonly struct` exposing `Rows/Cols/Span` and a `[row,col]` indexer so the existing call sites stay ergonomic. Skia/Mapsui renderers, the coverage pick helper, the MCP `sample-coverage` tool, and the pipelines tests are all updated.

### Part 2 — Two new perf-runner scenarios

- `s102-coverage-open` — fresh `PureHdfFile.Open` + `S102DatasetReader.Read` per iteration on the existing 30 KB fixture (no Render). Defends against regressions in the cold-open path, including the new attribute caches.
- `s102-coverage-render-large` — synthesizes a ~1000×1000 S-102 fixture in the system temp directory on first iteration, then times warm `Render()` on the cached processor. Defends against `SetPixel`/LOH-style regressions that the 30 KB fixture cannot surface.

Both scenarios touch only `PureHdfFile.Open`, `S102DatasetReader.Read`, `DatasetPipelineFactory.CreateProcessor`, and `IDatasetProcessor.Render` — APIs whose shape is identical on the base SHA and on this PR — so the perf-CI overlay that builds the base PerfRunner against PR tooling compiles either way.

## Local perf numbers (Apple Silicon, Release)

| Scenario | Result |
| --- | --- |
| `s102-coverage` (existing, 30 KB fixture, warm render) | ~0.5–1.1 ms/iter |
| `s102-coverage-open` (new, cold open) | ~1.2–1.8 ms/iter |
| `s102-coverage-render-large` (new, synthetic 1000×1000) | ~61–69 ms/iter |

The perf-CI gate will use these scenarios to detect future regressions on the same fixtures.

## Verification

- `dotnet build EncDotNet.S100.slnx` — succeeded.
- `dotnet test --configuration Release` — all suites pass (Pipelines.Tests 262/262, Viewer 234/234, all spec test projects green).
- Perf-runner exercised locally for all three S-102 scenarios.

## Deviations from the plan

- Plan suggested replacing the `Dictionary<string, float[,]>` on `SampledCoverage` with a named-fields record on the S-102 path. I kept the dictionary shape (now `Dictionary<string, float[]>`) for cross-spec consistency — S-104, S-111, and MCP consumers all use the `TryGetValue` pattern, so collapsing only S-102 would have introduced a divergent shape. The dominant win (eliminating the `float[,]` LOH allocations) still lands.
- Branch name landed as `philliphoff/s102-hotpath-perf` without a double prefix.
- All other parts implemented verbatim.