### PR TITLE
PR-G: S-111 dcf8 (time series at fixed stations) support

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -13,22 +13,40 @@ using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using Mapsui;
 using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
+/// <summary>
+/// Pipeline processor for S-111 surface-currents datasets. Branches
+/// between dcf2 (regular grid → coverage + arrow layers, see existing
+/// portrayal catalogue) and dcf8 (time series at fixed stations →
+/// station-arrow point layer; see S-111 Edition 2.0.0 §10.2.3 /
+/// §10.2.7).
+/// </summary>
 public sealed class S111DatasetProcessor : IDatasetProcessor
 {
-    private readonly S111CoverageSource _source;
-    private readonly S111PortrayalCatalogue _catalogue;
+    // dcf2 only
+    private readonly S111CoverageSource? _source;
+    private readonly S111PortrayalCatalogue? _catalogue;
+    private readonly PortrayalCatalogueProvider? _provider;
+    private readonly S111Dataset? _dataset;
+
+    // dcf8 only
+    private readonly S111StationSeriesDataset? _stationSeries;
+    private readonly IReadOnlyList<DateTime> _stationTimes = Array.Empty<DateTime>();
+
     private readonly ICrsTransformFactory _crsTransformFactory;
-    private readonly PortrayalCatalogueProvider _provider;
-    private readonly S111Dataset _dataset;
+    private readonly S111DatasetData _data;
     private readonly string _fileName;
 
     public SpecRef Spec => new("S-111", default);
 
     /// <summary>Available forecast time steps in this dataset.</summary>
-    public IReadOnlyList<DateTime> AvailableTimes => _source.AvailableTimes;
+    public IReadOnlyList<DateTime> AvailableTimes =>
+        _source?.AvailableTimes ?? _stationTimes;
 
     public S111DatasetProcessor(
         string path,
@@ -71,7 +89,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         {
             try
             {
-                _dataset = S111DatasetReader.Read(hdf5);
+                _data = S111DatasetReader.ReadAny(hdf5);
             }
             catch (S100DatasetSchemaException ex) when (ex.File is null)
             {
@@ -82,36 +100,58 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                 throw ex.WithFile(_fileName);
             }
         }
-        _source = new S111CoverageSource(_dataset);
 
-        _provider = catalogueManager.HasCatalogue("S-111")
-            ? catalogueManager.GetProvider("S-111")
-            : throw new InvalidOperationException(
-                "S-111 portrayal catalogue is not registered. " +
-                "Ensure the S-111 portrayal catalogue is loaded before opening S-111 datasets.");
-        _catalogue = new S111PortrayalCatalogue(_provider);
-
-        Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
+        switch (_data)
+        {
+            case S111DatasetData.GriddedCoverage g:
+                _dataset = g.Dataset;
+                _source = new S111CoverageSource(g.Dataset);
+                _provider = catalogueManager.HasCatalogue("S-111")
+                    ? catalogueManager.GetProvider("S-111")
+                    : throw new InvalidOperationException(
+                        "S-111 portrayal catalogue is not registered. " +
+                        "Ensure the S-111 portrayal catalogue is loaded before opening S-111 datasets.");
+                _catalogue = new S111PortrayalCatalogue(_provider);
+                Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
+                break;
+            case S111DatasetData.StationSeries s:
+                _stationSeries = s.Dataset;
+                _stationTimes = ComputeStationUnionTimes(s.Dataset);
+                // dcf8 uses an inline arrow glyph — no portrayal
+                // catalogue required.
+                break;
+        }
     }
 
     public DatasetResult Render(RenderContext? context = null)
     {
-        _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        if (_stationSeries is not null)
+        {
+            return RenderStationSeries(_stationSeries, context);
+        }
+        return RenderGridded(context);
+    }
 
-        // Select the requested time step, defaulting to the first
+    private DatasetResult RenderGridded(RenderContext? context)
+    {
+        var source = _source!;
+        var catalogue = _catalogue!;
+        var provider = _provider!;
+        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+
         DateTime selectedTime;
         if (context is S111RenderContext { TimeStep: { } timeStep })
         {
-            _source.SelectTime(timeStep);
+            source.SelectTime(timeStep);
             selectedTime = timeStep;
         }
         else
         {
-            selectedTime = _source.AvailableTimes[0];
-            _source.SelectTime(selectedTime);
+            selectedTime = source.AvailableTimes[0];
+            source.SelectTime(selectedTime);
         }
 
-        var metadata = _source.Metadata;
+        var metadata = source.Metadata;
 
         var viewport = new EncDotNet.S100.Pipelines.Viewport
         {
@@ -125,11 +165,10 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
+        var layer = pipeline.ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default)
             .GetAwaiter().GetResult();
         var styledLayer = (StyledCoverageLayer)layer;
 
-        // Color raster layer
         var colorRenderer = new MapsuiCoverageRenderer(_crsTransformFactory)
         {
             LayerName = $"S-111: {_fileName}",
@@ -139,18 +178,17 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
 
         var layers = new List<ILayer> { colorLayer };
 
-        // Arrow overlay layer
         var arrowRenderer = new MapsuiCoverageArrowRenderer(_crsTransformFactory)
         {
             LayerName = $"S-111 Arrows: {_fileName}",
-            Palette = _catalogue.ActivePalette,
+            Palette = catalogue.ActivePalette,
             SymbolProvider = symbolName =>
             {
-                var item = _provider.Catalogue.Symbols
+                var item = provider.Catalogue.Symbols
                     .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase));
                 if (item is null) return null;
 
-                using var stream = _provider.FetchAssetAsync(item, "Symbols").GetAwaiter().GetResult();
+                using var stream = provider.FetchAssetAsync(item, "Symbols").GetAwaiter().GetResult();
                 using var reader = new StreamReader(stream);
                 return reader.ReadToEnd();
             },
@@ -161,10 +199,10 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             layers.Add(arrowLayer);
         }
 
-        int crs = _dataset.HorizontalCRS ?? 4326;
+        int crs = _dataset!.HorizontalCRS ?? 4326;
         var geoId = _dataset.GeographicIdentifier ?? _fileName;
-        var timeInfo = _source.AvailableTimes.Count > 1
-            ? $", time: {selectedTime:u} ({_source.AvailableTimes.Count} steps)"
+        var timeInfo = source.AvailableTimes.Count > 1
+            ? $", time: {selectedTime:u} ({source.AvailableTimes.Count} steps)"
             : "";
         var info = $"{geoId} — {metadata.GridMetadata.NumColumns}×{metadata.GridMetadata.NumRows} grid, CRS: EPSG:{crs}{timeInfo}";
 
@@ -174,13 +212,153 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             Extent = extent,
             Info = info,
             Spec = new SpecRef("S-111", default),
-            // Stable sub-layer keys; the viewer maps these to
-            // localized display names. The processor itself does not
-            // depend on UI string resources.
             LayerNames = arrowLayer is not null
                 ? new[] { "s111.color-band", "s111.arrows" }
                 : new[] { "s111.color-band" },
         };
+    }
+
+    // ---- dcf8 station series rendering ---------------------------------
+
+    /// <summary>
+    /// Projects each station to a single point feature with an arrow
+    /// glyph oriented along <c>DirectionsDegreesTrue</c> and scaled by
+    /// speed magnitude. Rebuilt per <see cref="S111RenderContext.TimeStep"/>.
+    /// </summary>
+    private DatasetResult RenderStationSeries(S111StationSeriesDataset ds, RenderContext? context)
+    {
+        DateTime selectedTime;
+        if (context is S111RenderContext { TimeStep: { } timeStep })
+        {
+            selectedTime = timeStep;
+        }
+        else
+        {
+            selectedTime = ds.MinTime ?? DateTime.UtcNow;
+        }
+
+        var nativeToMerc = _crsTransformFactory.Create($"EPSG:{ds.HorizontalCRS ?? 4326}", "EPSG:3857");
+
+        var features = new List<IFeature>(ds.Stations.Count);
+        double mercMinX = double.PositiveInfinity, mercMinY = double.PositiveInfinity;
+        double mercMaxX = double.NegativeInfinity, mercMaxY = double.NegativeInfinity;
+
+        foreach (var station in ds.Stations)
+        {
+            double mx, my;
+            if (nativeToMerc.IsIdentity)
+            {
+                mx = station.Longitude;
+                my = station.Latitude;
+            }
+            else
+            {
+                (mx, my) = nativeToMerc.Transform(station.Longitude, station.Latitude);
+            }
+
+            if (mx < mercMinX) mercMinX = mx;
+            if (mx > mercMaxX) mercMaxX = mx;
+            if (my < mercMinY) mercMinY = my;
+            if (my > mercMaxY) mercMaxY = my;
+
+            int idx = station.NearestTimeIndex(selectedTime);
+            var speed = station.SpeedsMetresPerSecond[idx];
+            var direction = station.DirectionsDegreesTrue[idx];
+
+            var feature = new GeometryFeature
+            {
+                Geometry = new Point(mx, my),
+            };
+            feature["StationId"] = station.Identifier;
+            feature["SpeedMetresPerSecond"] = speed;
+            feature["SpeedKnots"] = speed * 1.9438444924406046;
+            feature["DirectionDegreesTrue"] = direction;
+            feature["SampleTime"] = station.TimeAt(idx);
+            feature["Latitude"] = station.Latitude;
+            feature["Longitude"] = station.Longitude;
+
+            var arrowColour = ColorByMagnitude(speed);
+
+            // Symbol orientation in Mapsui follows screen rotation
+            // (counter-clockwise positive); compass bearing increases
+            // clockwise from north, so negate. Geographic north on
+            // screen is "up", which corresponds to a zero-rotation
+            // arrow whose default orientation we treat as pointing up.
+            feature.Styles.Add(new SymbolStyle
+            {
+                SymbolType = SymbolType.Triangle,
+                Fill = new Brush(arrowColour),
+                Outline = new Pen(arrowColour, 1.0),
+                SymbolScale = SymbolScaleForSpeed(speed),
+                SymbolRotation = -direction,
+            });
+
+            features.Add(feature);
+        }
+
+        var layer = new MemoryLayer
+        {
+            Name = $"S-111: {_fileName}",
+            Features = features,
+            Style = null,
+        };
+
+        var extent = ds.Stations.Count == 0
+            ? new MRect(0, 0, 0, 0)
+            : new MRect(mercMinX, mercMinY, mercMaxX, mercMaxY);
+
+        var info = $"{ds.GeographicIdentifier ?? _fileName} — {ds.Stations.Count} stations, " +
+                   $"time: {selectedTime:u}";
+
+        return new DatasetResult
+        {
+            Layers = [layer],
+            Extent = extent,
+            Info = info,
+            Spec = new SpecRef("S-111", default),
+        };
+    }
+
+    private static IReadOnlyList<DateTime> ComputeStationUnionTimes(S111StationSeriesDataset ds)
+    {
+        var set = new SortedSet<DateTime>();
+        foreach (var s in ds.Stations)
+        {
+            for (int i = 0; i < s.NumberOfTimes; i++)
+            {
+                set.Add(DateTime.SpecifyKind(s.TimeAt(i), DateTimeKind.Utc));
+            }
+        }
+        return set.ToArray();
+    }
+
+    /// <summary>
+    /// Graduated Beaufort-style palette across 0..2.0 m/s with a hot
+    /// overflow above 2.0 m/s.
+    /// </summary>
+    private static Color ColorByMagnitude(float speedMetresPerSecond)
+    {
+        if (float.IsNaN(speedMetresPerSecond) || speedMetresPerSecond < 0.25f)
+            return new Color(0xcf, 0xe2, 0xf3); // very pale blue
+        if (speedMetresPerSecond < 0.50f) return new Color(0x6f, 0xa8, 0xdc);
+        if (speedMetresPerSecond < 1.00f) return new Color(0x3d, 0x85, 0xc6);
+        if (speedMetresPerSecond < 1.50f) return new Color(0x1c, 0x45, 0x87);
+        if (speedMetresPerSecond < 2.00f) return new Color(0xa6, 0x4d, 0x79);
+        return new Color(0xc1, 0x12, 0x1f);
+    }
+
+    /// <summary>
+    /// Maps a current speed to a Mapsui <see cref="SymbolStyle.SymbolScale"/>
+    /// with a visible floor (~6 px) and ceiling (~24 px at 2 m/s).
+    /// </summary>
+    private static double SymbolScaleForSpeed(float speedMetresPerSecond)
+    {
+        const double minScale = 0.30; // ~6 px at default symbol size
+        const double maxScale = 1.20; // ~24 px
+        const double fastReference = 2.0;
+        if (float.IsNaN(speedMetresPerSecond) || speedMetresPerSecond <= 0) return minScale;
+        var t = Math.Clamp(speedMetresPerSecond / fastReference, 0.0, 1.0);
+        return minScale + (maxScale - minScale) * t;
     }
 
     public FeatureInfo? GetFeatureInfo(string featureRef) => null;
@@ -194,23 +372,26 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
     /// </summary>
     public FeatureInfo? GetCoverageInfo(double latitude, double longitude, DateTime? time)
     {
-        if (_source.AvailableTimes.Count == 0)
+        if (_stationSeries is not null)
+        {
+            return GetStationInfo(_stationSeries, latitude, longitude, time);
+        }
+
+        var source = _source!;
+        if (source.AvailableTimes.Count == 0)
             return null;
 
-        var selectedTime = time ?? _source.AvailableTimes[0];
-        _source.SelectTime(selectedTime);
+        var selectedTime = time ?? source.AvailableTimes[0];
+        source.SelectTime(selectedTime);
 
-        var sample = CoveragePickHelper.Sample(_source, _crsTransformFactory, latitude, longitude);
+        var sample = CoveragePickHelper.Sample(source, _crsTransformFactory, latitude, longitude);
         if (sample is null)
             return null;
 
         var speed = sample.Values.TryGetValue("surfaceCurrentSpeed", out var s) ? s : sample.NoDataValue;
         var direction = sample.Values.TryGetValue("surfaceCurrentDirection", out var dir) ? dir : sample.NoDataValue;
 
-        // S-111 Ed 2.0.0 §10.2.10: speed unit is published in
-        // surfaceCurrentSpeedUom on the dataset root. The bundled
-        // CoverageSource declares "knots" as the published unit.
-        var speedUnit = _source.Metadata.ValueFields
+        var speedUnit = source.Metadata.ValueFields
             .FirstOrDefault(f => string.Equals(f.Name, "surfaceCurrentSpeed", StringComparison.Ordinal))
             ?.Units ?? "knots";
 
@@ -252,6 +433,73 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             FeatureType = "SurfaceCurrent",
             FeatureTypeName = "Surface Current",
             Attributes = attrs,
+        };
+    }
+
+    private FeatureInfo? GetStationInfo(
+        S111StationSeriesDataset ds,
+        double latitude,
+        double longitude,
+        DateTime? time)
+    {
+        if (ds.Stations.Count == 0) return null;
+
+        SurfaceCurrentStation? best = null;
+        double bestSqDeg = double.PositiveInfinity;
+        foreach (var s in ds.Stations)
+        {
+            var dLat = s.Latitude - latitude;
+            var dLon = (s.Longitude - longitude) * Math.Cos(latitude * Math.PI / 180.0);
+            var d = dLat * dLat + dLon * dLon;
+            if (d < bestSqDeg)
+            {
+                bestSqDeg = d;
+                best = s;
+            }
+        }
+        if (best is null) return null;
+
+        var selectedTime = time ?? best.StartTime;
+        int idx = best.NearestTimeIndex(selectedTime);
+        var speed = best.SpeedsMetresPerSecond[idx];
+        var direction = best.DirectionsDegreesTrue[idx];
+        var sampleTime = best.TimeAt(idx);
+        var speedKnots = speed * 1.9438444924406046;
+
+        return new FeatureInfo
+        {
+            FeatureRef = best.Identifier,
+            FeatureType = "SurfaceCurrent",
+            FeatureTypeName = "Surface Current (Station)",
+            Attributes = new List<PickAttribute>
+            {
+                new()
+                {
+                    Code = "stationIdentification",
+                    Name = "Station",
+                    RawValue = best.Identifier,
+                },
+                new()
+                {
+                    Code = "surfaceCurrentSpeed",
+                    Name = "Current Speed",
+                    RawValue = speed.ToString("0.##########", CultureInfo.InvariantCulture),
+                    DisplayValue = $"{speed.ToString("0.##", CultureInfo.InvariantCulture)} m/s ({speedKnots.ToString("0.##", CultureInfo.InvariantCulture)} kn)",
+                },
+                new()
+                {
+                    Code = "surfaceCurrentDirection",
+                    Name = "Current Direction (going to)",
+                    RawValue = direction.ToString("0.##########", CultureInfo.InvariantCulture),
+                    DisplayValue = $"{direction.ToString("0.#", CultureInfo.InvariantCulture)}°",
+                },
+                new()
+                {
+                    Code = "timePoint",
+                    Name = "Time",
+                    RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                },
+            },
         };
     }
 }

--- a/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
@@ -6,15 +6,46 @@ namespace EncDotNet.S100.Datasets.S111;
 
 /// <summary>
 /// Reads an S-111 Surface Currents dataset from an HDF5 file via the
-/// <see cref="IHdf5File"/> abstraction. Currently supports data coding format 2
-/// (regular grid) only.
+/// <see cref="IHdf5File"/> abstraction. Supports data coding format 2
+/// (regular grid) and data coding format 8 (time series at fixed
+/// stations; S-111 Edition 2.0.0 §10.2.3 / §10.2.7).
 /// </summary>
 public static class S111DatasetReader
 {
     /// <summary>
-    /// Reads an <see cref="S111Dataset"/> from the given HDF5 file.
+    /// Reads an <see cref="S111Dataset"/> from the given HDF5 file. Throws
+    /// <see cref="S100DatasetNotSupportedException"/> if the dataset is
+    /// not dcf2 (regularly-gridded). Use <see cref="ReadAny"/> to handle
+    /// both dcf2 and dcf8.
     /// </summary>
     public static S111Dataset Read(IHdf5File file)
+    {
+        var any = ReadAny(file);
+        return any switch
+        {
+            S111DatasetData.GriddedCoverage g => g.Dataset,
+            S111DatasetData.StationSeries => throw new S100DatasetNotSupportedException(
+                product: "S-111",
+                file: null,
+                feature: "data coding format 8 (time series at fixed stations)",
+                specReference: "S-100 Part 10c §10.2.1",
+                message: ExceptionMessageFormatter.FormatNotSupported(
+                    "S-111", null,
+                    "data coding format 8 (time series at fixed stations)",
+                    "S-100 Part 10c §10.2.1",
+                    "Use S111DatasetReader.ReadAny to handle dcf8 station series.")),
+            _ => throw new InvalidOperationException("Unhandled S111DatasetData variant."),
+        };
+    }
+
+    /// <summary>
+    /// Reads either a dcf2 <see cref="S111Dataset"/> or a dcf8
+    /// <see cref="S111StationSeriesDataset"/> from the given HDF5 file,
+    /// dispatching on the <c>/SurfaceCurrent/dataCodingFormat</c> attribute
+    /// (S-100 Part 10c §10.2.1). Other data coding formats raise
+    /// <see cref="S100DatasetNotSupportedException"/>.
+    /// </summary>
+    public static S111DatasetData ReadAny(IHdf5File file)
     {
         using var __activity = S100Diag.Telemetry.ActivitySource.StartActivity("s100.dataset.open");
         __activity?.SetTag("s100.product", "S-111");
@@ -65,9 +96,35 @@ public static class S111DatasetReader
             ? (int)scGroup.ReadInt64Attribute("typeOfCurrentData")
             : null;
 
+        if (dataCodingFormat == 8)
+        {
+            var stations = ReadStationSeries(root, scGroup);
+            DateTime? minTime = null, maxTime = null;
+            foreach (var s in stations)
+            {
+                if (minTime is null || s.StartTime < minTime) minTime = s.StartTime;
+                if (maxTime is null || s.EndTime > maxTime) maxTime = s.EndTime;
+            }
+
+            return new S111DatasetData.StationSeries(new S111StationSeriesDataset
+            {
+                HorizontalCRS = horizontalCRS,
+                Epoch = epoch,
+                GeographicIdentifier = geographicIdentifier,
+                IssueDate = issueDate,
+                Metadata = metadata,
+                SurfaceCurrentDepth = surfaceCurrentDepth,
+                DataCodingFormat = 8,
+                TypeOfCurrentData = typeOfCurrentData,
+                Stations = stations,
+                MinTime = minTime,
+                MaxTime = maxTime,
+            });
+        }
+
         var coverages = ReadCoverages(scGroup, dataCodingFormat);
 
-        return new S111Dataset
+        return new S111DatasetData.GriddedCoverage(new S111Dataset
         {
             HorizontalCRS = horizontalCRS,
             Epoch = epoch,
@@ -78,7 +135,7 @@ public static class S111DatasetReader
             DataCodingFormat = dataCodingFormat,
             TypeOfCurrentData = typeOfCurrentData,
             Coverages = coverages,
-        };
+        });
     }
 
     private static List<SurfaceCurrentCoverage> ReadCoverages(IHdf5Group scGroup, int dataCodingFormat)
@@ -227,4 +284,261 @@ public static class S111DatasetReader
         _ => throw new NotSupportedException(
             $"S-111 member '{member.Name}' has unsupported kind {member.Kind}."),
     };
+
+    // -------------------------------------------------------------------
+    // dcf8 — time series at fixed stations (S-111 Edition 2.0.0 §10.2.3 / §10.2.7)
+    // -------------------------------------------------------------------
+
+    /// <summary>
+    /// Reads every <c>SurfaceCurrent.NN</c> instance group's per-station
+    /// time-series payload and joins it against
+    /// <c>/Positioning/geometryValues</c> (S-111 Edition 2.0.0 §10.2.3,
+    /// mirroring S-104 §10.2.3 / S-100 Part 10c §10.2.6), returning one
+    /// <see cref="SurfaceCurrentStation"/> per <c>Group_NNN</c>.
+    /// </summary>
+    /// <remarks>
+    /// Per spec §10.2.3 the i-th row of <c>geometryValues</c> is the
+    /// position of the i-th station (Group_001 → row 0). Positions are
+    /// shared across every <c>SurfaceCurrent.NN</c> instance under
+    /// <c>/SurfaceCurrent/</c>.
+    /// </remarks>
+    private static IReadOnlyList<SurfaceCurrentStation> ReadStationSeries(IHdf5Group root, IHdf5Group scGroup)
+    {
+        var positions = ReadStationPositions(root);
+
+        var stations = new List<SurfaceCurrentStation>();
+
+        foreach (var instanceName in scGroup.GroupNames)
+        {
+            if (!instanceName.StartsWith("SurfaceCurrent.", StringComparison.Ordinal))
+                continue;
+
+            var instance = scGroup.OpenGroup(instanceName);
+            var instancePath = $"/SurfaceCurrent/{instanceName}";
+            ReadStationInstance(instance, instancePath, positions, stations);
+        }
+
+        return stations;
+    }
+
+    private static List<(double Lat, double Lon)> ReadStationPositions(IHdf5Group root)
+    {
+        // S-111 Edition 2.0.0 §10.2.3 — station positions live in a
+        // /Positioning group containing a compound 'geometryValues'
+        // dataset with members 'latitude' and 'longitude'. Some legacy
+        // tooling places the group under /SurfaceCurrent/SurfaceCurrent.NN;
+        // accept either.
+        IHdf5Group? positioningGroup = null;
+        if (root.GroupNames.Contains("Positioning"))
+        {
+            positioningGroup = root.OpenGroup("Positioning");
+        }
+        else if (root.GroupNames.Contains("SurfaceCurrent"))
+        {
+            var sc = root.OpenGroup("SurfaceCurrent");
+            foreach (var name in sc.GroupNames)
+            {
+                if (!name.StartsWith("SurfaceCurrent.", StringComparison.Ordinal)) continue;
+                var inst = sc.OpenGroup(name);
+                if (inst.GroupNames.Contains("Positioning"))
+                {
+                    positioningGroup = inst.OpenGroup("Positioning");
+                    break;
+                }
+            }
+        }
+
+        if (positioningGroup is null)
+        {
+            throw new S100DatasetSchemaException(
+                product: "S-111",
+                file: null,
+                groupPath: "/Positioning",
+                attributeOrDataset: "Positioning/geometryValues",
+                specReference: "S-111 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-111", null, "/Positioning", "Positioning/geometryValues",
+                    "S-111 Edition 2.0.0 §10.2.3"));
+        }
+
+        RawCompoundDataset raw;
+        try
+        {
+            raw = positioningGroup.ReadRawCompoundDataset("geometryValues");
+        }
+        catch (Exception ex)
+        {
+            throw new S100DatasetSchemaException(
+                product: "S-111",
+                file: null,
+                groupPath: "/Positioning",
+                attributeOrDataset: "Positioning/geometryValues",
+                specReference: "S-111 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-111", null, "/Positioning", "Positioning/geometryValues",
+                    "S-111 Edition 2.0.0 §10.2.3"),
+                innerException: ex);
+        }
+
+        var latMember = raw.FindMember("latitude", "Latitude", "lat", "Lat")
+            ?? throw new S100DatasetSchemaException(
+                product: "S-111",
+                file: null,
+                groupPath: "/Positioning/geometryValues",
+                attributeOrDataset: "latitude",
+                specReference: "S-111 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-111", null, "/Positioning/geometryValues", "latitude",
+                    "S-111 Edition 2.0.0 §10.2.3"));
+
+        var lonMember = raw.FindMember("longitude", "Longitude", "long", "Long", "lon", "Lon")
+            ?? throw new S100DatasetSchemaException(
+                product: "S-111",
+                file: null,
+                groupPath: "/Positioning/geometryValues",
+                attributeOrDataset: "longitude",
+                specReference: "S-111 Edition 2.0.0 §10.2.3",
+                message: ExceptionMessageFormatter.FormatSchema(
+                    "S-111", null, "/Positioning/geometryValues", "longitude",
+                    "S-111 Edition 2.0.0 §10.2.3"));
+
+        var positions = new List<(double Lat, double Lon)>(raw.RecordCount);
+        var span = raw.Data.AsSpan();
+        for (int i = 0; i < raw.RecordCount; i++)
+        {
+            var record = span.Slice(i * raw.RecordSize, raw.RecordSize);
+            double lat = ReadFloatingPointMember(record, latMember);
+            double lon = ReadFloatingPointMember(record, lonMember);
+            positions.Add((lat, lon));
+        }
+        return positions;
+    }
+
+    private static double ReadFloatingPointMember(ReadOnlySpan<byte> record, CompoundMemberInfo member) =>
+        member.Kind switch
+        {
+            CompoundMemberKind.Float32 => System.Buffers.Binary.BinaryPrimitives.ReadSingleLittleEndian(
+                record.Slice(member.Offset, 4)),
+            CompoundMemberKind.Float64 => System.Buffers.Binary.BinaryPrimitives.ReadDoubleLittleEndian(
+                record.Slice(member.Offset, 8)),
+            _ => throw new NotSupportedException(
+                $"S-111 Positioning member '{member.Name}' has unsupported kind {member.Kind}."),
+        };
+
+    private static void ReadStationInstance(
+        IHdf5Group instance,
+        string instancePath,
+        IReadOnlyList<(double Lat, double Lon)> positions,
+        List<SurfaceCurrentStation> stations)
+    {
+        const string Spec = "S-111 Edition 2.0.0 §10.2.7";
+
+        int numberOfStations = instance.AttributeExists("numberOfStations")
+            ? (int)instance.ReadInt64Attribute("numberOfStations")
+            : 0;
+
+        int stationIndex = 0;
+        foreach (var groupName in instance.GroupNames)
+        {
+            if (!groupName.StartsWith("Group_", StringComparison.Ordinal))
+                continue;
+
+            var groupPath = $"{instancePath}/{groupName}";
+            var group = instance.OpenGroup(groupName);
+
+            string stationId = group.AttributeExists("stationIdentification")
+                ? group.ReadStringAttribute("stationIdentification")
+                : groupName;
+
+            string startStr = group.ReadRequiredStringAttribute(
+                "startDateTime", "S-111", null, groupPath, Spec);
+            string endStr = group.ReadRequiredStringAttribute(
+                "endDateTime", "S-111", null, groupPath, Spec);
+
+            DateTime startTime = ParseTimestamp(startStr);
+            DateTime endTime = ParseTimestamp(endStr);
+
+            int numberOfTimes = (int)group.ReadRequiredInt64Attribute(
+                "numberOfTimes", "S-111", null, groupPath, Spec);
+            long intervalSeconds = group.ReadRequiredInt64Attribute(
+                "timeRecordInterval", "S-111", null, groupPath, Spec);
+            var interval = TimeSpan.FromSeconds(intervalSeconds);
+
+            var (speeds, directions) = ReadStationValues(group, numberOfTimes);
+
+            if (stationIndex >= positions.Count)
+            {
+                throw new S100DatasetSchemaException(
+                    product: "S-111",
+                    file: null,
+                    groupPath: "/Positioning/geometryValues",
+                    attributeOrDataset: "Positioning/geometryValues",
+                    specReference: "S-111 Edition 2.0.0 §10.2.3",
+                    message: ExceptionMessageFormatter.FormatSchema(
+                        "S-111", null, "/Positioning/geometryValues", "Positioning/geometryValues",
+                        "S-111 Edition 2.0.0 §10.2.3")
+                    + $" Position row {stationIndex} missing for station '{stationId}'.");
+            }
+            var (lat, lon) = positions[stationIndex];
+
+            stations.Add(new SurfaceCurrentStation
+            {
+                Identifier = stationId,
+                Latitude = lat,
+                Longitude = lon,
+                StartTime = startTime,
+                EndTime = endTime,
+                TimeRecordInterval = interval,
+                NumberOfTimes = numberOfTimes,
+                SpeedsMetresPerSecond = speeds,
+                DirectionsDegreesTrue = directions,
+            });
+
+            stationIndex++;
+        }
+
+        // numberOfStations is an authoritative spec-declared count; if a
+        // file claims more than it actually delivers, we tolerate the
+        // shortfall (consistent with the spec's allowance for trailing
+        // empty groups), but we don't try to invent stations.
+        _ = numberOfStations;
+    }
+
+    private static DateTime ParseTimestamp(string s)
+    {
+        return DateTime.ParseExact(
+            s,
+            ["yyyyMMdd'T'HHmmss'Z'", "yyyy-MM-dd'T'HH:mm:ss'Z'"],
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+    }
+
+    private static (float[] Speeds, float[] Directions) ReadStationValues(IHdf5Group group, int numberOfTimes)
+    {
+        var raw = group.ReadRawCompoundDataset("values");
+
+        var speedMember = raw.FindMember("surfaceCurrentSpeed", "speed", "Speed")
+            ?? throw new InvalidOperationException(
+                "S-111 dcf8 station 'values' compound is missing a speed member " +
+                "(expected 'surfaceCurrentSpeed', 'speed', or 'Speed').");
+
+        var directionMember = raw.FindMember("surfaceCurrentDirection", "direction", "Direction")
+            ?? throw new InvalidOperationException(
+                "S-111 dcf8 station 'values' compound is missing a direction member " +
+                "(expected 'surfaceCurrentDirection', 'direction', or 'Direction').");
+
+        int count = Math.Min(raw.RecordCount, numberOfTimes);
+        var speeds = new float[count];
+        var directions = new float[count];
+        var span = raw.Data.AsSpan();
+
+        for (int i = 0; i < count; i++)
+        {
+            var record = span.Slice(i * raw.RecordSize, raw.RecordSize);
+            speeds[i] = ReadFloat(record, speedMember);
+            directions[i] = ReadFloat(record, directionMember);
+        }
+
+        return (speeds, directions);
+    }
 }

--- a/src/EncDotNet.S100.Datasets.S111/S111StationSeriesDataset.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111StationSeriesDataset.cs
@@ -1,0 +1,77 @@
+namespace EncDotNet.S100.Datasets.S111;
+
+/// <summary>
+/// Root data model for an S-111 Surface Currents dataset encoded in
+/// <em>data coding format 8 — time series at fixed stations</em>
+/// (S-111 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+/// <remarks>
+/// dcf8 is structurally different from the regularly-gridded dcf2 path
+/// modelled by <see cref="S111Dataset"/>: instead of a 2-D grid of values
+/// per time step, each station carries an independent 1-D series of
+/// <c>(speed, direction)</c> samples plus its own start/end timestamps
+/// and sampling interval. The two shapes share the S-111 Feature
+/// Catalogue's <c>SurfaceCurrent</c> feature; the distinction is
+/// encoding, not taxonomy.
+/// </remarks>
+public sealed class S111StationSeriesDataset
+{
+    /// <summary>EPSG code of the horizontal coordinate reference system.</summary>
+    public int? HorizontalCRS { get; init; }
+
+    /// <summary>Epoch of the coordinate reference system (e.g. "G1762").</summary>
+    public string? Epoch { get; init; }
+
+    /// <summary>A geographic description of the dataset coverage area.</summary>
+    public string? GeographicIdentifier { get; init; }
+
+    /// <summary>Issue date of the dataset (ISO 8601).</summary>
+    public string? IssueDate { get; init; }
+
+    /// <summary>Reference to an associated metadata file.</summary>
+    public string? Metadata { get; init; }
+
+    /// <summary>Depth below the water surface at which currents apply, in metres.</summary>
+    public float? SurfaceCurrentDepth { get; init; }
+
+    /// <summary>
+    /// Data coding format — always <c>8</c> for this dataset type
+    /// (S-100 Part 10c §10.2.1 Table).
+    /// </summary>
+    public int DataCodingFormat { get; init; } = 8;
+
+    /// <summary>
+    /// Type of current data (e.g. <c>6</c> = forecast model output). See
+    /// S-111 Edition 2.0.0 §10.2 for the enumeration.
+    /// </summary>
+    public int? TypeOfCurrentData { get; init; }
+
+    /// <summary>Time-series stations contained in the dataset.</summary>
+    public required IReadOnlyList<SurfaceCurrentStation> Stations { get; init; }
+
+    /// <summary>
+    /// Earliest sample timestamp across all stations, or <c>null</c>
+    /// when <see cref="Stations"/> is empty.
+    /// </summary>
+    public DateTime? MinTime { get; init; }
+
+    /// <summary>
+    /// Latest sample timestamp across all stations, or <c>null</c>
+    /// when <see cref="Stations"/> is empty.
+    /// </summary>
+    public DateTime? MaxTime { get; init; }
+}
+
+/// <summary>
+/// Discriminated union over the two structurally different S-111
+/// dataset shapes the reader emits — gridded coverage (dcf2) and
+/// per-station time series (dcf8). See <see cref="S111DatasetReader.ReadAny"/>.
+/// </summary>
+public abstract record S111DatasetData
+{
+    /// <summary>S-111 dcf2 — regularly-gridded surface-current coverage.</summary>
+    public sealed record GriddedCoverage(S111Dataset Dataset) : S111DatasetData;
+
+    /// <summary>S-111 dcf8 — time series at fixed stations.</summary>
+    public sealed record StationSeries(S111StationSeriesDataset Dataset) : S111DatasetData;
+}

--- a/src/EncDotNet.S100.Datasets.S111/SurfaceCurrentStation.cs
+++ b/src/EncDotNet.S100.Datasets.S111/SurfaceCurrentStation.cs
@@ -1,0 +1,85 @@
+namespace EncDotNet.S100.Datasets.S111;
+
+/// <summary>
+/// A single surface-current time series at a fixed station, as encoded by
+/// an S-111 data-coding-format-8 ("time series at fixed stations") instance
+/// (S-111 Edition 2.0.0 §10.2.3 — Positioning — and §10.2.7).
+/// </summary>
+/// <remarks>
+/// Each <c>Group_NNN</c> under the dcf8 <c>SurfaceCurrent.NN</c> instance
+/// corresponds to one station; the i-th station's position is read from
+/// the i-th row of the <c>Positioning/geometryValues</c> compound
+/// dataset (S-111 Edition 2.0.0 §10.2.3, mirroring S-104 §10.2.3 / S-100
+/// Part 10c §10.2.6).
+/// </remarks>
+public sealed class SurfaceCurrentStation
+{
+    /// <summary>Identifier of the station (S-111 <c>stationIdentification</c>).</summary>
+    public required string Identifier { get; init; }
+
+    /// <summary>Station latitude in decimal degrees (WGS-84).</summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>Station longitude in decimal degrees (WGS-84).</summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>UTC timestamp of the first sample.</summary>
+    public required DateTime StartTime { get; init; }
+
+    /// <summary>UTC timestamp of the last sample.</summary>
+    public required DateTime EndTime { get; init; }
+
+    /// <summary>
+    /// Interval between consecutive samples. Parsed from the S-111
+    /// <c>timeRecordInterval</c> integer (seconds).
+    /// </summary>
+    public required TimeSpan TimeRecordInterval { get; init; }
+
+    /// <summary>
+    /// Number of samples in this station's time series — equal to the
+    /// length of <see cref="SpeedsMetresPerSecond"/> and
+    /// <see cref="DirectionsDegreesTrue"/>.
+    /// </summary>
+    public required int NumberOfTimes { get; init; }
+
+    /// <summary>
+    /// Surface-current speeds in metres per second, one per time step,
+    /// in ascending chronological order starting at <see cref="StartTime"/>.
+    /// (S-111 Edition 2.0.0 §10.2.5 — canonical unit is m/s.)
+    /// </summary>
+    public required float[] SpeedsMetresPerSecond { get; init; }
+
+    /// <summary>
+    /// Surface-current directions in degrees from true north (clockwise,
+    /// "going to" convention; S-111 Edition 2.0.0 §10.2), one per time
+    /// step in the same order as <see cref="SpeedsMetresPerSecond"/>.
+    /// </summary>
+    public required float[] DirectionsDegreesTrue { get; init; }
+
+    /// <summary>
+    /// Returns the index of the sample whose timestamp is closest to
+    /// <paramref name="time"/>, clamped to <c>[0, NumberOfTimes - 1]</c>.
+    /// Nearest-neighbour rounding; no interpolation.
+    /// </summary>
+    public int NearestTimeIndex(DateTime time)
+    {
+        if (NumberOfTimes <= 1) return 0;
+        if (TimeRecordInterval <= TimeSpan.Zero) return 0;
+        var delta = (time - StartTime).TotalSeconds / TimeRecordInterval.TotalSeconds;
+        var idx = (int)Math.Round(delta, MidpointRounding.AwayFromZero);
+        if (idx < 0) return 0;
+        if (idx >= NumberOfTimes) return NumberOfTimes - 1;
+        return idx;
+    }
+
+    /// <summary>
+    /// Returns the timestamp of the i-th sample, computed from
+    /// <see cref="StartTime"/> and <see cref="TimeRecordInterval"/>.
+    /// </summary>
+    public DateTime TimeAt(int index)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, NumberOfTimes);
+        return StartTime + TimeSpan.FromTicks(TimeRecordInterval.Ticks * index);
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDatasetData.cs
@@ -87,3 +87,9 @@ public sealed record S104StationSeriesData(S104StationSeriesDataset Dataset) : L
 
 /// <summary>S-111 Surface Currents coverage handle.</summary>
 public sealed record S111CoverageData(S111CoverageSource Source) : LoadedDatasetData;
+
+/// <summary>
+/// S-111 Surface Currents station-series dataset (dcf8 — time series at
+/// fixed stations; see S-111 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+public sealed record S111StationSeriesData(S111StationSeriesDataset Dataset) : LoadedDatasetData;

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -113,6 +113,32 @@ public sealed record SurfaceCurrentSample(
     double CellCentreLongitude) : SampledValue;
 
 /// <summary>
+/// S-111 surface current sample read from a dcf8 ("time series at
+/// fixed stations") dataset — picks the nearest station to the
+/// requested position and the nearest time step within that station's
+/// series (S-111 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+/// <param name="StationId">Reporting station identifier (S-111 <c>stationIdentification</c>).</param>
+/// <param name="StationDistanceMetres">Great-circle distance from requested point to the station, metres.</param>
+/// <param name="SpeedMetresPerSecond">Speed in metres per second — canonical S-111 unit (§10.2.5).</param>
+/// <param name="SpeedKnots">Speed in knots, computed as <c>m/s × 1.94384</c> for convenience.</param>
+/// <param name="DirectionDegreesTrue">Direction in degrees from true north, clockwise (0..360).</param>
+/// <param name="SampleTime">Actual time step (UTC) selected for this sample.</param>
+/// <param name="RequestedTime">The time the caller asked for, or <c>null</c> if unspecified.</param>
+/// <param name="StationLatitude">Latitude of the matched station.</param>
+/// <param name="StationLongitude">Longitude of the matched station.</param>
+public sealed record SurfaceCurrentStationSample(
+    string StationId,
+    double StationDistanceMetres,
+    double SpeedMetresPerSecond,
+    double SpeedKnots,
+    double DirectionDegreesTrue,
+    DateTime SampleTime,
+    DateTimeOffset? RequestedTime,
+    double StationLatitude,
+    double StationLongitude) : SampledValue;
+
+/// <summary>
 /// Samples a coverage product at a single lat/lon, returning the nearest
 /// grid cell's value. Supports S-102 (depth + uncertainty), S-104
 /// (water level height + trend, nearest time step), and S-111
@@ -419,33 +445,58 @@ public sealed class SampleCoverageTool
         S111Dataset? bestModel = null;
         SurfaceCurrentCoverage? bestCoverage = null;
         double bestArea = double.PositiveInfinity;
-        bool anyS111 = false;
+        bool anyS111Gridded = false;
+        bool anyS111StationSeries = false;
         foreach (var dataset in snapshot)
         {
-            if (dataset.Data is not S111CoverageData s111) continue;
-            anyS111 = true;
-            var model = s111.Source.Dataset;
-            if (model.Coverages.Count == 0) continue;
-            var probe = model.Coverages[0];
-            if (!CoverageContains(probe, request.Latitude, request.Longitude)) continue;
-            var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
-            if (area < bestArea)
+            switch (dataset.Data)
             {
-                bestArea = area;
-                bestDataset = dataset;
-                bestSource = s111.Source;
-                bestModel = model;
-                bestCoverage = probe;
+                case S111CoverageData s111:
+                {
+                    anyS111Gridded = true;
+                    var model = s111.Source.Dataset;
+                    if (model.Coverages.Count == 0) break;
+                    var probe = model.Coverages[0];
+                    if (!CoverageContains(probe, request.Latitude, request.Longitude)) break;
+                    var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
+                    if (area < bestArea)
+                    {
+                        bestArea = area;
+                        bestDataset = dataset;
+                        bestSource = s111.Source;
+                        bestModel = model;
+                        bestCoverage = probe;
+                    }
+                    break;
+                }
+                case S111StationSeriesData:
+                    anyS111StationSeries = true;
+                    break;
             }
         }
 
-        if (bestDataset is null || bestModel is null || bestCoverage is null || bestSource is null)
+        if (bestDataset is not null && bestModel is not null && bestCoverage is not null && bestSource is not null)
         {
-            return ToolResult<SampleCoverageResult>.Err(anyS111
-                ? new OutOfBounds(request.Spec, request.Latitude, request.Longitude)
-                : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+            return SampleS111Gridded(request, bestDataset, bestSource, bestModel, bestCoverage);
         }
 
+        if (anyS111StationSeries)
+        {
+            return SampleS111StationSeries(request, snapshot);
+        }
+
+        return ToolResult<SampleCoverageResult>.Err(anyS111Gridded
+            ? new OutOfBounds(request.Spec, request.Latitude, request.Longitude)
+            : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+    }
+
+    private static ToolResult<SampleCoverageResult> SampleS111Gridded(
+        SampleCoverageRequest request,
+        LoadedDataset bestDataset,
+        S111CoverageSource bestSource,
+        S111Dataset bestModel,
+        SurfaceCurrentCoverage bestCoverage)
+    {
         if (bestModel.DataCodingFormat != 2)
         {
             return ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
@@ -492,6 +543,72 @@ public sealed class SampleCoverageTool
             return ToolResult<SampleCoverageResult>.Err(
                 new DatasetClosedDuringQuery(bestDataset.Id));
         }
+    }
+
+    /// <summary>
+    /// Sample a loaded dcf8 S-111 station-series dataset (S-111 Edition
+    /// 2.0.0 §10.2.3 / §10.2.7). Finds the nearest station across every
+    /// loaded dcf8 dataset by great-circle distance with no max-distance
+    /// cap, then picks the nearest time step within that station's series.
+    /// </summary>
+    private static ToolResult<SampleCoverageResult> SampleS111StationSeries(
+        SampleCoverageRequest request,
+        System.Collections.Immutable.ImmutableArray<LoadedDataset> snapshot)
+    {
+        LoadedDataset? bestDataset = null;
+        SurfaceCurrentStation? bestStation = null;
+        double bestDistance = double.PositiveInfinity;
+
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S111StationSeriesData ss) continue;
+            foreach (var station in ss.Dataset.Stations)
+            {
+                var d = GreatCircleMetres(request.Latitude, request.Longitude, station.Latitude, station.Longitude);
+                if (d < bestDistance)
+                {
+                    bestDistance = d;
+                    bestStation = station;
+                    bestDataset = dataset;
+                }
+            }
+        }
+
+        if (bestDataset is null || bestStation is null)
+        {
+            return ToolResult<SampleCoverageResult>.Err(
+                new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+        }
+
+        var requestedAsUtc = request.Time?.UtcDateTime;
+        DateTime sampleTime;
+        int idx;
+        if (requestedAsUtc is null)
+        {
+            idx = 0;
+            sampleTime = bestStation.StartTime;
+        }
+        else
+        {
+            idx = bestStation.NearestTimeIndex(requestedAsUtc.Value);
+            sampleTime = bestStation.TimeAt(idx);
+        }
+
+        var speed = bestStation.SpeedsMetresPerSecond[idx];
+        return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
+            bestDataset.Id,
+            request.Latitude,
+            request.Longitude,
+            new SurfaceCurrentStationSample(
+                bestStation.Identifier,
+                bestDistance,
+                speed,
+                speed * MetresPerSecondToKnots,
+                bestStation.DirectionsDegreesTrue[idx],
+                DateTime.SpecifyKind(sampleTime, DateTimeKind.Utc),
+                request.Time,
+                bestStation.Latitude,
+                bestStation.Longitude)));
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
@@ -324,20 +324,29 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
 
     private static LoadedDataset ProjectS111(DatasetId id, DatasetEntry entry)
     {
-        // S111DatasetReader.Read materialises every time-step's value
-        // grid into managed arrays before returning, so the file
-        // handle (and its stream) can be disposed eagerly.
+        // S111DatasetReader.ReadAny materialises every time-step's value
+        // grid (or per-station series) into managed arrays before
+        // returning, so the file handle can be disposed eagerly.
         using var stream = OpenEntryStream(entry);
         using var file = PureHdfFile.Open(stream);
-        var dataset = S111DatasetReader.Read(file);
-        var source = new S111CoverageSource(dataset);
-        var bounds = ComputeS111Bounds(dataset) ?? WorldBounds;
-        return new LoadedDataset(
-            id,
-            new SpecRef("S-111", default),
-            bounds,
-            null,
-            new S111CoverageData(source));
+        var data = S111DatasetReader.ReadAny(file);
+        return data switch
+        {
+            S111DatasetData.GriddedCoverage g => new LoadedDataset(
+                id,
+                new SpecRef("S-111", default),
+                ComputeS111Bounds(g.Dataset) ?? WorldBounds,
+                null,
+                new S111CoverageData(new S111CoverageSource(g.Dataset))),
+            S111DatasetData.StationSeries s => new LoadedDataset(
+                id,
+                new SpecRef("S-111", default),
+                ComputeS111StationSeriesBounds(s.Dataset) ?? WorldBounds,
+                ComputeS111StationSeriesTimeRange(s.Dataset),
+                new S111StationSeriesData(s.Dataset)),
+            _ => throw new InvalidOperationException(
+                $"Unexpected S-111 dataset variant {data.GetType().Name}."),
+        };
     }
 
     private static BoundingBox? ComputeS102Bounds(S102Dataset dataset)
@@ -409,6 +418,36 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
         var north = cov.OriginLatitude + (cov.NumPointsLatitudinal - 1) * cov.SpacingLatitudinal;
         var east = cov.OriginLongitude + (cov.NumPointsLongitudinal - 1) * cov.SpacingLongitudinal;
         return new BoundingBox(south, west, north, east);
+    }
+
+    /// <summary>
+    /// Bounding box covering all stations in an S-111 dcf8 dataset.
+    /// Returns <c>null</c> for an empty station set (caller falls back to
+    /// <see cref="WorldBounds"/>). See S-111 Edition 2.0.0 §10.2.3.
+    /// </summary>
+    private static BoundingBox? ComputeS111StationSeriesBounds(S111StationSeriesDataset dataset)
+    {
+        if (dataset.Stations.Count == 0) return null;
+        double south = double.PositiveInfinity, west = double.PositiveInfinity;
+        double north = double.NegativeInfinity, east = double.NegativeInfinity;
+        foreach (var s in dataset.Stations)
+        {
+            if (s.Latitude < south) south = s.Latitude;
+            if (s.Latitude > north) north = s.Latitude;
+            if (s.Longitude < west) west = s.Longitude;
+            if (s.Longitude > east) east = s.Longitude;
+        }
+        if (Math.Abs(north - south) < 1e-9) { south -= 0.01; north += 0.01; }
+        if (Math.Abs(east - west) < 1e-9) { west -= 0.01; east += 0.01; }
+        return new BoundingBox(south, west, north, east);
+    }
+
+    private static TimeRange? ComputeS111StationSeriesTimeRange(S111StationSeriesDataset dataset)
+    {
+        if (dataset.Stations.Count == 0 || dataset.MinTime is null || dataset.MaxTime is null) return null;
+        var start = new DateTimeOffset(DateTime.SpecifyKind(dataset.MinTime.Value, DateTimeKind.Utc));
+        var end = new DateTimeOffset(DateTime.SpecifyKind(dataset.MaxTime.Value, DateTimeKind.Utc));
+        return new TimeRange(start, end);
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/Fixtures/S111Dcf8FixtureBuilder.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/Fixtures/S111Dcf8FixtureBuilder.cs
@@ -1,0 +1,199 @@
+using System.Reflection;
+using PureHDF;
+
+namespace EncDotNet.S100.Datasets.S111.Tests.Fixtures;
+
+/// <summary>
+/// Helpers that author small synthetic S-111 dcf8 ("time series at fixed
+/// stations") HDF5 files for reader tests. Mirrors the S-104 dcf8 fixture
+/// builder used by PR-C.
+/// </summary>
+internal static class S111Dcf8FixtureBuilder
+{
+    // ---- Compound row variants --------------------------------------------------
+
+    public struct SpecValueRow
+    {
+        [H5Name("surfaceCurrentSpeed")] public float SurfaceCurrentSpeed;
+        [H5Name("surfaceCurrentDirection")] public float SurfaceCurrentDirection;
+    }
+
+    /// <summary>
+    /// Short member names <c>speed</c>/<c>direction</c> seen on legacy /
+    /// pre-Edition-2 fixtures.
+    /// </summary>
+    public struct LegacyValueRow
+    {
+        [H5Name("speed")] public float Speed;
+        [H5Name("direction")] public float Direction;
+    }
+
+    public struct GeometryRow
+    {
+        [H5Name("latitude")] public float Latitude;
+        [H5Name("longitude")] public float Longitude;
+    }
+
+    /// <summary>
+    /// UKHO-style short member names <c>lat</c>/<c>long</c>.
+    /// </summary>
+    public struct GeometryRowShort
+    {
+        [H5Name("lat")] public float Lat;
+        [H5Name("long")] public float Long;
+    }
+
+    public sealed class Station<TRow> where TRow : struct
+    {
+        public required string Identifier { get; init; }
+        public required float Latitude { get; init; }
+        public required float Longitude { get; init; }
+        public required string StartDateTime { get; init; }
+        public required string EndDateTime { get; init; }
+        public required long TimeRecordInterval { get; init; }
+        public required TRow[] Values { get; init; }
+    }
+
+    /// <summary>
+    /// Writes a minimal S-111 dcf8 file with one <c>SurfaceCurrent.01</c>
+    /// instance containing the supplied stations. Position rows match
+    /// station declaration order per S-111 Edition 2.0.0 §10.2.3.
+    /// </summary>
+    public static string WriteFile<TRow>(
+        string path,
+        IReadOnlyList<Station<TRow>> stations,
+        bool includePositioning = true,
+        bool useShortGeometryNames = false,
+        bool positioningUnderInstance = false)
+        where TRow : struct
+    {
+        var instanceGroups = new Dictionary<string, object>();
+        for (int i = 0; i < stations.Count; i++)
+        {
+            var s = stations[i];
+            instanceGroups[$"Group_{i + 1:000}"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["stationIdentification"] = s.Identifier,
+                    ["startDateTime"] = s.StartDateTime,
+                    ["endDateTime"] = s.EndDateTime,
+                    ["numberOfTimes"] = (long)s.Values.Length,
+                    ["timeRecordInterval"] = s.TimeRecordInterval,
+                },
+                ["values"] = s.Values,
+            };
+        }
+
+        long firstInterval = stations.Count > 0 ? stations[0].TimeRecordInterval : 0L;
+        int firstNumberOfTimes = stations.Count > 0 ? stations[0].Values.Length : 0;
+
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["numberOfStations"] = (long)stations.Count,
+                ["numberOfTimes"] = (long)firstNumberOfTimes,
+                ["timeRecordInterval"] = firstInterval,
+            },
+        };
+        foreach (var (k, v) in instanceGroups)
+            instance[k] = v;
+
+        var rootAttrs = new Dictionary<string, object>
+        {
+            ["horizontalDatumValue"] = 4326,
+            ["geographicIdentifier"] = "Test",
+            ["issueDate"] = "2024-01-01",
+        };
+
+        var file = new H5File
+        {
+            Attributes = rootAttrs,
+            ["SurfaceCurrent"] = new H5Group
+            {
+                Attributes = new()
+                {
+                    ["dataCodingFormat"] = (byte)8,
+                    ["typeOfCurrentData"] = (long)6,
+                },
+                ["SurfaceCurrent.01"] = instance,
+            },
+        };
+
+        if (includePositioning)
+        {
+            object geom;
+            if (useShortGeometryNames)
+            {
+                var arr = new GeometryRowShort[stations.Count];
+                for (int i = 0; i < stations.Count; i++)
+                    arr[i] = new GeometryRowShort { Lat = stations[i].Latitude, Long = stations[i].Longitude };
+                geom = arr;
+            }
+            else
+            {
+                var arr = new GeometryRow[stations.Count];
+                for (int i = 0; i < stations.Count; i++)
+                    arr[i] = new GeometryRow { Latitude = stations[i].Latitude, Longitude = stations[i].Longitude };
+                geom = arr;
+            }
+
+            var positioningGroup = new H5Group { ["geometryValues"] = geom };
+            if (positioningUnderInstance)
+            {
+                instance["Positioning"] = positioningGroup;
+            }
+            else
+            {
+                file["Positioning"] = positioningGroup;
+            }
+        }
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+
+        file.Write(path, options);
+        return path;
+    }
+
+    /// <summary>
+    /// Writes an empty S-111 dcf8 file with <c>numberOfStations=0</c> and
+    /// no <c>Group_NNN</c> children (still includes a Positioning group
+    /// with an empty <c>geometryValues</c> dataset).
+    /// </summary>
+    public static string WriteEmptyFile(string path)
+    {
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["numberOfStations"] = 0L,
+                ["numberOfTimes"] = 0L,
+                ["timeRecordInterval"] = 0L,
+            },
+        };
+
+        var file = new H5File
+        {
+            Attributes = new()
+            {
+                ["horizontalDatumValue"] = 4326,
+            },
+            ["SurfaceCurrent"] = new H5Group
+            {
+                Attributes = new() { ["dataCodingFormat"] = (byte)8 },
+                ["SurfaceCurrent.01"] = instance,
+            },
+            ["Positioning"] = new H5Group
+            {
+                ["geometryValues"] = Array.Empty<GeometryRow>(),
+            },
+        };
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+        file.Write(path, options);
+        return path;
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111Dcf8ReaderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111Dcf8ReaderTests.cs
@@ -1,0 +1,243 @@
+using EncDotNet.S100.Datasets.S111.Tests.Fixtures;
+using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Hdf5.PureHdf;
+
+namespace EncDotNet.S100.Datasets.S111.Tests;
+
+/// <summary>
+/// Tests for the S-111 dcf8 (time series at fixed stations) reader path
+/// (S-111 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+public class S111Dcf8ReaderTests
+{
+    private static S111Dcf8FixtureBuilder.Station<T> Station<T>(
+        string id, float lat, float lon, T[] values,
+        string start = "20240101T000000Z",
+        string end = "20240101T030000Z",
+        long interval = 3600)
+        where T : struct =>
+        new()
+        {
+            Identifier = id,
+            Latitude = lat,
+            Longitude = lon,
+            StartDateTime = start,
+            EndDateTime = end,
+            TimeRecordInterval = interval,
+            Values = values,
+        };
+
+    [Fact]
+    public void ReadAny_HappyPath_ThreeStationsFourTimeSteps_RoundTrips()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 51.5f, -0.1f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.3f, SurfaceCurrentDirection = 45f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.5f, SurfaceCurrentDirection = 50f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.8f, SurfaceCurrentDirection = 55f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.6f, SurfaceCurrentDirection = 60f },
+                }),
+                Station("B", 51.6f, -0.2f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 1.0f, SurfaceCurrentDirection = 90f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 1.2f, SurfaceCurrentDirection = 95f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 1.1f, SurfaceCurrentDirection = 100f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.9f, SurfaceCurrentDirection = 105f },
+                }),
+                Station("C", 51.7f, -0.3f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.1f, SurfaceCurrentDirection = 180f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.2f, SurfaceCurrentDirection = 180f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.3f, SurfaceCurrentDirection = 180f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.4f, SurfaceCurrentDirection = 180f },
+                }),
+            };
+            S111Dcf8FixtureBuilder.WriteFile(path, stations);
+
+            using var file = PureHdfFile.Open(path);
+            var any = S111DatasetReader.ReadAny(file);
+
+            var stationSeries = Assert.IsType<S111DatasetData.StationSeries>(any);
+            var model = stationSeries.Dataset;
+
+            Assert.Equal(8, model.DataCodingFormat);
+            Assert.Equal(4326, model.HorizontalCRS);
+            Assert.Equal(3, model.Stations.Count);
+
+            Assert.Equal("A", model.Stations[0].Identifier);
+            Assert.Equal(51.5, model.Stations[0].Latitude, precision: 4);
+            Assert.Equal(-0.1, model.Stations[0].Longitude, precision: 4);
+            Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), model.Stations[0].StartTime);
+            Assert.Equal(new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc), model.Stations[0].EndTime);
+            Assert.Equal(TimeSpan.FromHours(1), model.Stations[0].TimeRecordInterval);
+            Assert.Equal(4, model.Stations[0].NumberOfTimes);
+            Assert.Equal(0.5f, model.Stations[0].SpeedsMetresPerSecond[1]);
+            Assert.Equal(50f, model.Stations[0].DirectionsDegreesTrue[1]);
+
+            Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), model.MinTime);
+            Assert.Equal(new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc), model.MaxTime);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_MissingPositioning_ThrowsSchemaException()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 1f, 1f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.5f, SurfaceCurrentDirection = 90f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.5f, SurfaceCurrentDirection = 90f },
+                }),
+            };
+            S111Dcf8FixtureBuilder.WriteFile(path, stations, includePositioning: false);
+
+            using var file = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetSchemaException>(() => S111DatasetReader.ReadAny(file));
+
+            Assert.Equal("S-111", ex.Product);
+            Assert.Equal("Positioning/geometryValues", ex.AttributeOrDataset);
+            Assert.Contains("§10.2.3", ex.SpecReference ?? "");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_SpecMemberNames_RoundTrips()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 51.5f, -0.1f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.75f, SurfaceCurrentDirection = 270f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.85f, SurfaceCurrentDirection = 275f },
+                }),
+            };
+            S111Dcf8FixtureBuilder.WriteFile(path, stations);
+
+            using var file = PureHdfFile.Open(path);
+            var model = ((S111DatasetData.StationSeries)S111DatasetReader.ReadAny(file)).Dataset;
+
+            Assert.Single(model.Stations);
+            Assert.Equal(0.75f, model.Stations[0].SpeedsMetresPerSecond[0]);
+            Assert.Equal(270f, model.Stations[0].DirectionsDegreesTrue[0]);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_LegacyShortMemberNames_RoundTrips()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 50.75f, -1.5f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.LegacyValueRow { Speed = 1.1f, Direction = 30f },
+                    new S111Dcf8FixtureBuilder.LegacyValueRow { Speed = 1.3f, Direction = 35f },
+                }),
+                Station("B", 50.80f, -1.4f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.LegacyValueRow { Speed = 0.9f, Direction = 200f },
+                    new S111Dcf8FixtureBuilder.LegacyValueRow { Speed = 0.7f, Direction = 205f },
+                }),
+            };
+            S111Dcf8FixtureBuilder.WriteFile(
+                path, stations,
+                useShortGeometryNames: true,
+                positioningUnderInstance: true);
+
+            using var file = PureHdfFile.Open(path);
+            var model = ((S111DatasetData.StationSeries)S111DatasetReader.ReadAny(file)).Dataset;
+
+            Assert.Equal(2, model.Stations.Count);
+            Assert.Equal("A", model.Stations[0].Identifier);
+            Assert.Equal(50.75, model.Stations[0].Latitude, 3);
+            Assert.Equal(-1.5, model.Stations[0].Longitude, 3);
+            Assert.Equal(1.1f, model.Stations[0].SpeedsMetresPerSecond[0]);
+            Assert.Equal(30f, model.Stations[0].DirectionsDegreesTrue[0]);
+            Assert.Equal("B", model.Stations[1].Identifier);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAny_EmptyStations_ReturnsEmptyList()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            S111Dcf8FixtureBuilder.WriteEmptyFile(path);
+
+            using var file = PureHdfFile.Open(path);
+            var any = S111DatasetReader.ReadAny(file);
+            var model = ((S111DatasetData.StationSeries)any).Dataset;
+
+            Assert.Empty(model.Stations);
+            Assert.Null(model.MinTime);
+            Assert.Null(model.MaxTime);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_OnDcf8_ThrowsNotSupportedForGriddedCallers()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        try
+        {
+            var stations = new[]
+            {
+                Station("A", 1f, 1f, new[]
+                {
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.5f, SurfaceCurrentDirection = 90f },
+                    new S111Dcf8FixtureBuilder.SpecValueRow { SurfaceCurrentSpeed = 0.5f, SurfaceCurrentDirection = 90f },
+                }),
+            };
+            S111Dcf8FixtureBuilder.WriteFile(path, stations);
+
+            using var file = PureHdfFile.Open(path);
+            var ex = Assert.Throws<S100DatasetNotSupportedException>(() => S111DatasetReader.Read(file));
+
+            Assert.Equal("S-111", ex.Product);
+            Assert.Contains("8", ex.Feature);
+            Assert.Contains("time series", ex.Feature);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void SurfaceCurrentStation_NearestTimeIndex_ClampsToBounds()
+    {
+        var s = new SurfaceCurrentStation
+        {
+            Identifier = "X",
+            Latitude = 0, Longitude = 0,
+            StartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc),
+            TimeRecordInterval = TimeSpan.FromHours(1),
+            NumberOfTimes = 4,
+            SpeedsMetresPerSecond = new[] { 0f, 1f, 2f, 3f },
+            DirectionsDegreesTrue = new[] { 0f, 0f, 0f, 0f },
+        };
+
+        Assert.Equal(0, s.NearestTimeIndex(new DateTime(2023, 12, 31, 23, 0, 0, DateTimeKind.Utc)));
+        Assert.Equal(0, s.NearestTimeIndex(new DateTime(2024, 1, 1, 0, 20, 0, DateTimeKind.Utc)));
+        Assert.Equal(1, s.NearestTimeIndex(new DateTime(2024, 1, 1, 0, 40, 0, DateTimeKind.Utc)));
+        Assert.Equal(3, s.NearestTimeIndex(new DateTime(2024, 1, 1, 5, 0, 0, DateTimeKind.Utc)));
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
@@ -130,4 +130,17 @@ internal static class LoadedDatasetFactory
             null,
             new S111CoverageData(source ?? S111Synth.Source()));
     }
+
+    public static LoadedDataset S111Stations(
+        string id,
+        S111StationSeriesDataset dataset,
+        BoundingBox? bounds = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S111Spec,
+            bounds ?? Box(),
+            null,
+            new S111StationSeriesData(dataset));
+    }
 }

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolS111StationSeriesTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolS111StationSeriesTests.cs
@@ -1,0 +1,147 @@
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+/// <summary>
+/// Sample-coverage tests for the S-111 dcf8 (time series at fixed
+/// stations) path (S-111 Edition 2.0.0 §10.2.3 / §10.2.7).
+/// </summary>
+public class SampleCoverageToolS111StationSeriesTests
+{
+    private static SurfaceCurrentStation Station(
+        string id, double lat, double lon,
+        float[] speeds, float[] directions)
+    {
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new SurfaceCurrentStation
+        {
+            Identifier = id,
+            Latitude = lat,
+            Longitude = lon,
+            StartTime = start,
+            EndTime = start.AddHours(speeds.Length - 1),
+            TimeRecordInterval = TimeSpan.FromHours(1),
+            NumberOfTimes = speeds.Length,
+            SpeedsMetresPerSecond = speeds,
+            DirectionsDegreesTrue = directions,
+        };
+    }
+
+    private static S111StationSeriesDataset Synth()
+    {
+        var stations = new[]
+        {
+            Station("A", 51.5, -0.1,
+                new[] { 0.5f, 1.0f, 1.5f, 1.0f },
+                new[] { 45f, 50f, 55f, 60f }),
+            Station("B", 51.6, -0.2,
+                new[] { 0.3f, 0.7f, 0.4f, 0.2f },
+                new[] { 90f, 95f, 100f, 105f }),
+            Station("C", 60.0, 10.0,
+                new[] { 2.0f, 2.1f, 2.2f, 2.3f },
+                new[] { 180f, 180f, 180f, 180f }),
+        };
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new S111StationSeriesDataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = 8,
+            Stations = stations,
+            MinTime = start,
+            MaxTime = start.AddHours(3),
+        };
+    }
+
+    [Fact]
+    public async Task SelectsNearestStation_AndFirstSampleByDefault()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 51.5, Longitude: -0.1));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<SurfaceCurrentStationSample>(value.Value);
+        Assert.Equal("A", sample.StationId);
+        Assert.Equal(0.5, sample.SpeedMetresPerSecond, 5);
+        Assert.Equal(0.5 * 1.9438444924406046, sample.SpeedKnots, 5);
+        Assert.Equal(45.0, sample.DirectionDegreesTrue, 5);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+        Assert.True(sample.StationDistanceMetres < 1.0);
+        Assert.Null(sample.RequestedTime);
+    }
+
+    [Fact]
+    public async Task ClampsTimeBeforeStart_ToFirstStep()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        var requested = new DateTimeOffset(2023, 12, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 51.5, Longitude: -0.1, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<SurfaceCurrentStationSample>(value.Value);
+        Assert.Equal(0.5, sample.SpeedMetresPerSecond, 5);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+        Assert.Equal(requested, sample.RequestedTime);
+    }
+
+    [Fact]
+    public async Task ClampsTimeAfterEnd_ToLastStep()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        var requested = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 51.5, Longitude: -0.1, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<SurfaceCurrentStationSample>(value.Value);
+        Assert.Equal(1.0, sample.SpeedMetresPerSecond, 5);
+        Assert.Equal(60.0, sample.DirectionDegreesTrue, 5);
+        Assert.Equal(new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+    }
+
+    [Fact]
+    public async Task NearestTime_RoundsToClosestStep()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        // 01:40 → rounds to 02:00 (index 2).
+        var requested = new DateTimeOffset(2024, 1, 1, 1, 40, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: 51.5, Longitude: -0.1, Time: requested));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<SurfaceCurrentStationSample>(value.Value);
+        Assert.Equal("A", sample.StationId);
+        Assert.Equal(1.5, sample.SpeedMetresPerSecond, 5);
+        Assert.Equal(55.0, sample.DirectionDegreesTrue, 5);
+        Assert.Equal(new DateTime(2024, 1, 1, 2, 0, 0, DateTimeKind.Utc), sample.SampleTime);
+    }
+
+    [Fact]
+    public async Task NoMaxDistanceCap_FarPointStillReturnsNearestStation()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("dcf8", Synth()));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec, Latitude: -80.0, Longitude: 0.0));
+
+        Assert.True(result.TryGetValue(out var value));
+        var sample = Assert.IsType<SurfaceCurrentStationSample>(value.Value);
+        Assert.True(sample.StationDistanceMetres > 10_000_000);
+    }
+}


### PR DESCRIPTION
Mirrors the just-merged S-104 PR-C (#88) on the S-111 surface-currents side. After this PR, S-111 datasets encoded in `dataCodingFormat == 8` load, project as per-station current-arrow glyphs, animate against the global timeline, and are queryable via MCP `sample_coverage`.

## Highlights

**Reader (`EncDotNet.S100.Datasets.S111`)**
- New `SurfaceCurrentStation` POCO and `S111StationSeriesDataset` root POCO.
- Public `S111DatasetData` discriminated union (`GriddedCoverage` / `StationSeries`).
- `S111DatasetReader.ReadAny` dispatches by `dataCodingFormat`. The pre-existing `Read()` stays dcf2-only and throws `S100DatasetNotSupportedException` on dcf8.
- dcf8 path reads `/Positioning/geometryValues` (with `/SurfaceCurrent/SurfaceCurrent.NN/Positioning` fallback) and per-station `Group_NNN/values`. Tolerates `surfaceCurrentSpeed`/`speed`, `surfaceCurrentDirection`/`direction`, and `latitude`/`longitude`/`lat`/`long` member names.

**MCP `sample_coverage`**
- New `SurfaceCurrentStationSample` variant on `SampledValue` (station id, distance, m/s + knots, direction, sample time, station position).
- New `S111StationSeriesData` variant on `LoadedDatasetData`.
- `SampleS111` now branches dcf2 (gridded) vs dcf8 (nearest-station, no max-distance cap), mirroring PR-C's S-104 dual-path.

**Viewer pipeline**
- `ViewerDatasetCatalog.ProjectS111` calls `ReadAny` and branches; new bounds + time-range helpers.
- `S111DatasetProcessor` branches on the data variant. dcf8 emits a `MemoryLayer` of `SymbolType.Triangle` arrows rebuilt per `S111RenderContext.TimeStep`. Rotation = `-direction` (Mapsui CCW vs compass CW). Scale floors at 0.30 and ceilings at 1.20 across 0..2.0 m/s.

**Portrayal**
- Inline `ColorByMagnitude` graduates 0..2.5+ m/s across `#cfe2f3` → `#c1121f` (Beaufort-style cool-to-warm).
- Tooltip carries station ID, speed in m/s + knots, direction in degrees true, and the resolved time-step timestamp.

## Tests (all green)

- 7 new reader tests in `S111Dcf8ReaderTests.cs` (happy-path, missing positioning, spec vs legacy member names, empty stations, `Read()`-on-dcf8 guard, `NearestTimeIndex` clamping).
- 5 new MCP tests in `SampleCoverageToolS111StationSeriesTests.cs` (nearest-station, clamp before/after, nearest-time rounding, no-max-distance fallback).
- Full `dotnet test -c Release` green; S-111 (30), MCP Tools (54), Pipelines (260), Viewer (234), S-104 (27 — untouched dcf2 path).

## Out of scope / deferred (per plan)

- Bilinear time interpolation, S-111 dcf3 (ungeorectified grid), per-station chart UI, global timeline restyling, bundled S-111 PC content.
- **Time-aware vector pipeline** (`IVectorFeatureTimeSeries` / `TimeAwarePointInstruction`) — still deferred. Layer rebuild per time-step matches PR-C.

## Manual smoke (user-side)

Load a hypothetical UKHO S-111 dcf8 file (none committed): arrows should appear at station positions, colours should change as the timeline scrubs (cool → warm with speed), lengths should reflect speed magnitude. The dcf2 path is fully untouched.

## Deviations from the plan

- The plan suggested a `S111StationSeriesVectorSource` IVectorSource adapter, but the plan also said "do NOT introduce a new Core/Vector abstraction"; followed the authorised PR-C fallback of building a `MemoryLayer` directly inside the processor.
- Branch name carries an extra `philliphoff/` prefix (`philliphoff/philliphoff-s111-dcf8-stationwise`) — the `rename_branch` tool doubled it; accepted per the plan.