### PR TITLE
Add `find_at` MCP tool: list datasets containing a point

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -36,6 +36,7 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | Tool | Purpose |
 |---|---|
 | `list_datasets` | Summarises every dataset currently loaded in the viewer. |
+| `find_at` | Returns every loaded dataset whose declared bounding box contains a lat/lon point (decimal degrees, WGS-84). Bbox-only — does not check per-cell coverage or NoData masks. |
 | `describe_feature` | Returns spec, feature type, and attributes for a feature id in a given dataset. |
 | `sample_coverage` | Samples a depth / water-level / current value at a lat/lon from an S-102 / S-104 / S-111 dataset. |
 

--- a/src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>
+/// Request payload for <see cref="FindAtTool"/>.
+/// </summary>
+/// <param name="Latitude">Query latitude (decimal degrees, WGS-84). Must be in <c>[-90, 90]</c>.</param>
+/// <param name="Longitude">Query longitude (decimal degrees, WGS-84). Must be in <c>[-180, 180]</c>.</param>
+/// <param name="Spec">Optional spec filter; <c>null</c> matches every spec.</param>
+/// <param name="Page">Zero-based page index.</param>
+/// <param name="PageSize">Page size; clamped to 1..500.</param>
+public sealed record FindAtRequest(
+    double Latitude,
+    double Longitude,
+    SpecRef? Spec = null,
+    int Page = 0,
+    int PageSize = 50);
+
+/// <summary>Result of <see cref="FindAtTool"/>.</summary>
+/// <param name="Datasets">Datasets whose declared bounding box contains the query point, in catalog insertion order.</param>
+/// <param name="Page">Echoed (and floored) page index.</param>
+/// <param name="PageSize">Echoed (and clamped) page size.</param>
+/// <param name="TotalCount">Total number of matching datasets across all pages.</param>
+/// <param name="HasMore"><c>true</c> if additional pages remain.</param>
+public sealed record FindAtResult(
+    ImmutableArray<DatasetSummary> Datasets,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    bool HasMore);
+
+/// <summary>
+/// Returns every loaded dataset whose declared bounding box contains the
+/// supplied latitude/longitude point.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Containment is evaluated against the dataset's declared bounding box
+/// only — there is no per-cell coverage check, no NoData masking, and no
+/// vector geometry intersection. A positive result means the point lies
+/// within the rectangle <c>[SouthLatitude, NorthLatitude] × [WestLongitude,
+/// EastLongitude]</c>. Actual cell coverage may differ; callers that need
+/// the actual value at the point should follow up with
+/// <see cref="SampleCoverageTool"/>.
+/// </para>
+/// <para>
+/// Bounds are treated as inclusive on every edge, matching
+/// <see cref="SampleCoverageTool"/>'s contains check.
+/// </para>
+/// <para>
+/// The current implementation assumes <c>WestLongitude ≤ EastLongitude</c>,
+/// matching <see cref="ListDatasetsTool"/>'s intersection helper. Datasets
+/// whose bounding box crosses the antimeridian (stored with
+/// <c>West &gt; East</c>) will not match. See S-100 Part 10b §6.2.
+/// </para>
+/// </remarks>
+public sealed class FindAtTool
+{
+    private readonly IDatasetCatalog _catalog;
+
+    /// <summary>Creates a new <see cref="FindAtTool"/>.</summary>
+    public FindAtTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<FindAtResult>> InvokeAsync(
+        FindAtRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (double.IsNaN(request.Latitude) || request.Latitude < -90.0 || request.Latitude > 90.0)
+        {
+            return Task.FromResult(ToolResult<FindAtResult>.Err(
+                new InvalidArgument("latitude", $"value {request.Latitude} is outside the WGS-84 range [-90, 90]")));
+        }
+
+        if (double.IsNaN(request.Longitude) || request.Longitude < -180.0 || request.Longitude > 180.0)
+        {
+            return Task.FromResult(ToolResult<FindAtResult>.Err(
+                new InvalidArgument("longitude", $"value {request.Longitude} is outside the WGS-84 range [-180, 180]")));
+        }
+
+        var pageSize = Math.Clamp(request.PageSize, 1, 500);
+        var page = Math.Max(0, request.Page);
+
+        var snapshot = _catalog.Datasets;
+        var matched = ImmutableArray.CreateBuilder<DatasetSummary>();
+        foreach (var dataset in snapshot)
+        {
+            if (request.Spec is { } spec && !SpecMatches(dataset.Spec, spec))
+            {
+                continue;
+            }
+
+            if (!Contains(dataset.Bounds, request.Latitude, request.Longitude))
+            {
+                continue;
+            }
+
+            matched.Add(new DatasetSummary(dataset.Id, dataset.Spec, dataset.Bounds, dataset.TimeRange));
+        }
+
+        var totalCount = matched.Count;
+        var skip = page * pageSize;
+        var take = Math.Max(0, Math.Min(pageSize, totalCount - skip));
+        var pageBuilder = ImmutableArray.CreateBuilder<DatasetSummary>(take);
+        for (var i = 0; i < take; i++)
+        {
+            pageBuilder.Add(matched[skip + i]);
+        }
+
+        var hasMore = skip + take < totalCount;
+        var result = new FindAtResult(
+            pageBuilder.MoveToImmutable(),
+            page,
+            pageSize,
+            totalCount,
+            hasMore);
+
+        return Task.FromResult(ToolResult<FindAtResult>.Ok(result));
+    }
+
+    private static bool SpecMatches(SpecRef actual, SpecRef filter)
+    {
+        if (!string.Equals(actual.Name, filter.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return filter.Edition == default || actual.Edition == filter.Edition;
+    }
+
+    private static bool Contains(BoundingBox b, double lat, double lon) =>
+        lat >= b.SouthLatitude
+        && lat <= b.NorthLatitude
+        && lon >= b.WestLongitude
+        && lon <= b.EastLongitude;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -109,6 +109,7 @@ The five error variants implemented in this PR:
 | `no_dataset_covers_point`     | No loaded dataset's bounds contain the requested lat/lon.             |
 | `feature_not_found`           | The named feature is not present in the named dataset.                |
 | `spec_not_supported_for_tool` | The tool does not (yet) support the requested spec.                   |
+| `invalid_argument`            | A request property failed validation (e.g. latitude / longitude out of WGS-84 range). |
 
 ## Spec strategy pattern
 
@@ -135,6 +136,7 @@ IDatasetCatalog catalog = host.Catalog;
 var list = new ListDatasetsTool(catalog);
 var describe = new DescribeFeatureTool(catalog);
 var sample = new SampleCoverageTool(catalog);
+var findAt = new FindAtTool(catalog);
 
 var listed = await list.InvokeAsync(new ListDatasetsRequest());
 if (listed.TryGetValue(out var summary))
@@ -142,6 +144,19 @@ if (listed.TryGetValue(out var summary))
     foreach (var ds in summary.Datasets)
     {
         Console.WriteLine($"{ds.Id} ({ds.Spec})");
+    }
+}
+
+// Which loaded datasets cover this point? (bbox-only — does not check
+// per-cell coverage or NoData masks.)
+var hits = await findAt.InvokeAsync(new FindAtRequest(
+    Latitude: 50.77,
+    Longitude: -1.30));
+if (hits.TryGetValue(out var hit))
+{
+    foreach (var ds in hit.Datasets)
+    {
+        Console.WriteLine($"{ds.Id} ({ds.Spec}) covers the point.");
     }
 }
 

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -17,6 +17,16 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// </remarks>
 public abstract record ToolError(string Code, string Message);
 
+/// <summary>
+/// A tool argument failed validation (e.g. latitude or longitude
+/// outside the valid WGS-84 range). The <paramref name="Parameter"/>
+/// names the request property that was rejected and
+/// <paramref name="Reason"/> describes why.
+/// </summary>
+public sealed record InvalidArgument(string Parameter, string Reason) : ToolError(
+    "invalid_argument",
+    $"Invalid argument '{Parameter}': {Reason}.");
+
 /// <summary>The named dataset is not present in the catalog snapshot.</summary>
 public sealed record DatasetNotFound(DatasetId Id) : ToolError(
     "dataset_not_found",

--- a/src/EncDotNet.S100.Mcp/S100McpServer.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServer.cs
@@ -107,12 +107,13 @@ public sealed class S100McpServer : IAsyncDisposable
             k.Limits.KeepAliveTimeout = _options.IdleTimeout;
         });
 
-        // Register the three MCP-1 tools as in-process singletons.
+        // Register the MCP-1 tools as in-process singletons.
         var listDatasets = new ListDatasetsTool(_catalog);
         var describeFeature = new DescribeFeatureTool(_catalog);
         var sampleCoverage = new SampleCoverageTool(_catalog);
+        var findAt = new FindAtTool(_catalog);
         var tools = S100McpServerToolFactory
-            .CreateTools(listDatasets, describeFeature, sampleCoverage)
+            .CreateTools(listDatasets, describeFeature, sampleCoverage, findAt)
             .ToArray();
 
         builder.Services

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -11,9 +11,9 @@ using ModelContextProtocol.Server;
 namespace EncDotNet.S100.Mcp;
 
 /// <summary>
-/// Builds <see cref="McpServerTool"/> wrappers around the three
-/// MCP-1 tools (<see cref="ListDatasetsTool"/>,
-/// <see cref="DescribeFeatureTool"/>, <see cref="SampleCoverageTool"/>),
+/// Builds <see cref="McpServerTool"/> wrappers around the MCP-1 tools
+/// (<see cref="ListDatasetsTool"/>, <see cref="DescribeFeatureTool"/>,
+/// <see cref="SampleCoverageTool"/>, <see cref="FindAtTool"/>),
 /// translating <see cref="ToolResult{T}"/> outcomes into MCP
 /// <see cref="CallToolResult"/> payloads.
 /// </summary>
@@ -64,11 +64,13 @@ internal static class S100McpServerToolFactory
     public static IEnumerable<McpServerTool> CreateTools(
         ListDatasetsTool listDatasets,
         DescribeFeatureTool describeFeature,
-        SampleCoverageTool sampleCoverage)
+        SampleCoverageTool sampleCoverage,
+        FindAtTool findAt)
     {
         yield return CreateListDatasetsTool(listDatasets);
         yield return CreateDescribeFeatureTool(describeFeature);
         yield return CreateSampleCoverageTool(sampleCoverage);
+        yield return CreateFindAtTool(findAt);
     }
 
     private static McpServerTool CreateListDatasetsTool(ListDatasetsTool inner)
@@ -150,6 +152,40 @@ internal static class S100McpServerToolFactory
         return McpServerTool.Create(del, new McpServerToolCreateOptions
         {
             Name = SampleCoverageTool.Name,
+            Description = description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static McpServerTool CreateFindAtTool(FindAtTool inner)
+    {
+        var description =
+            "Returns every dataset currently loaded in the host (viewer or CLI) whose declared " +
+            "bounding box contains the supplied lat/lon point. Coordinates are decimal degrees, " +
+            "WGS-84. Containment is bbox-only — a positive result means the point lies inside the " +
+            "dataset's declared rectangle, not that the point has actual cell coverage (call " +
+            "sample_coverage to read a value). Optionally filtered by spec. Returns dataset IDs, " +
+            "spec, bounds, and time range, with pagination.";
+
+        var del = ([Description("Query latitude in decimal degrees, WGS-84. Must be in [-90, 90].")] double latitude,
+                   [Description("Query longitude in decimal degrees, WGS-84. Must be in [-180, 180].")] double longitude,
+                   [Description("Optional spec filter (e.g. \"S-101/1.2.0\"); null matches every spec.")] string? spec = null,
+                   [Description("Zero-based page index.")] int page = 0,
+                   [Description("Page size (clamped to 1..500).")] int pageSize = 50,
+                   CancellationToken ct = default) =>
+            DispatchAsync(() =>
+                inner.InvokeAsync(
+                    new FindAtRequest(
+                        latitude,
+                        longitude,
+                        ParseSpec(spec),
+                        page,
+                        pageSize),
+                    ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = "find_at",
             Description = description,
             SerializerOptions = JsonOptions,
         });

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
@@ -10,7 +10,7 @@ namespace EncDotNet.S100.Mcp.Tests;
 public class S100McpServerRoundTripTests
 {
     [Fact]
-    public async Task ListTools_returns_three_tools_with_schemas()
+    public async Task ListTools_returns_four_tools_with_schemas()
     {
         var catalog = McpTestHelpers.NewCatalog();
         await using var server = await McpTestHelpers.StartServerAsync(catalog);
@@ -19,7 +19,7 @@ public class S100McpServerRoundTripTests
         var tools = await client.ListToolsAsync();
         var names = tools.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
 
-        Assert.Equal(new[] { "describe_feature", "list_datasets", "sample_coverage" }, names);
+        Assert.Equal(new[] { "describe_feature", "find_at", "list_datasets", "sample_coverage" }, names);
         foreach (var tool in tools)
         {
             // ProtocolTool exposes the JSON schema; ensure it is non-empty.
@@ -127,6 +127,49 @@ public class S100McpServerRoundTripTests
         var payload = ParseSingleJson(result);
         Assert.Equal("dataset_not_found", payload["code"]!.GetValue<string>());
         Assert.False(string.IsNullOrEmpty(payload["message"]?.GetValue<string>()));
+    }
+
+    [Fact]
+    public async Task FindAt_round_trip_returns_matching_datasets()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S124("warn-here", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)),
+            LoadedDatasetFactory.S124("warn-elsewhere", bounds: LoadedDatasetFactory.Box(50, 50, 60, 60)));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("find_at", new Dictionary<string, object?>
+        {
+            ["latitude"] = 5.0,
+            ["longitude"] = 5.0,
+        });
+
+        Assert.False(result.IsError ?? false, $"find_at returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var datasets = payload["datasets"]!.AsArray();
+        Assert.Single(datasets);
+        Assert.Equal("warn-here", datasets[0]!["id"]!["value"]!.GetValue<string>());
+        Assert.Equal(1, payload["totalCount"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public async Task FindAt_invalid_latitude_returns_structured_error()
+    {
+        var catalog = McpTestHelpers.NewCatalog();
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("find_at", new Dictionary<string, object?>
+        {
+            ["latitude"] = 95.0,
+            ["longitude"] = 0.0,
+        });
+
+        Assert.True(result.IsError ?? false, "Expected isError=true for out-of-range latitude.");
+        var payload = ParseSingleJson(result);
+        Assert.Equal("invalid_argument", payload["code"]!.GetValue<string>());
+        Assert.Equal("latitude", payload["details"]!["parameter"]!.GetValue<string>());
     }
 
     private static JsonObject ParseSingleJson(CallToolResult result)

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/FindAtToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/FindAtToolTests.cs
@@ -1,0 +1,198 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class FindAtToolTests
+{
+    [Fact]
+    public async Task Returns_empty_for_empty_catalog()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(0, 0));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Datasets);
+        Assert.Equal(0, value.TotalCount);
+        Assert.False(value.HasMore);
+    }
+
+    [Fact]
+    public async Task Returns_only_datasets_containing_point()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("inside", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        catalog.Add(LoadedDatasetFactory.S124("outside", bounds: LoadedDatasetFactory.Box(20, 20, 30, 30)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(Latitude: 5, Longitude: 5));
+
+        Assert.True(result.TryGetValue(out var value));
+        var single = Assert.Single(value.Datasets);
+        Assert.Equal(new DatasetId("inside"), single.Id);
+        Assert.Equal(1, value.TotalCount);
+    }
+
+    [Fact]
+    public async Task Returns_all_overlapping_datasets_in_insertion_order()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        catalog.Add(LoadedDatasetFactory.S122("b", bounds: LoadedDatasetFactory.Box(4, 4, 8, 8)));
+        catalog.Add(LoadedDatasetFactory.S102("c", bounds: LoadedDatasetFactory.Box(5, 5, 6, 6)));
+        catalog.Add(LoadedDatasetFactory.S124("disjoint", bounds: LoadedDatasetFactory.Box(50, 50, 51, 51)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(Latitude: 5.5, Longitude: 5.5));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.Datasets.Length);
+        Assert.Equal(new[] { "a", "b", "c" }, value.Datasets.Select(d => d.Id.Value).ToArray());
+    }
+
+    [Fact]
+    public async Task Spec_filter_narrows_result_set()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("warn", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        catalog.Add(LoadedDatasetFactory.S122("mpa", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            Latitude: 5,
+            Longitude: 5,
+            Spec: LoadedDatasetFactory.S124Spec));
+
+        Assert.True(result.TryGetValue(out var value));
+        var single = Assert.Single(value.Datasets);
+        Assert.Equal("S-124", single.Spec.Name);
+    }
+
+    [Fact]
+    public async Task Spec_filter_with_default_edition_matches_any_edition()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        var tool = new FindAtTool(catalog);
+
+        var filter = new SpecRef("S-124", default);
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            Latitude: 5, Longitude: 5, Spec: filter));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Datasets);
+    }
+
+    [Fact]
+    public async Task Point_on_bbox_edge_is_inside()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("edge", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        var tool = new FindAtTool(catalog);
+
+        var southWest = await tool.InvokeAsync(new FindAtRequest(0, 0));
+        var northEast = await tool.InvokeAsync(new FindAtRequest(10, 10));
+
+        Assert.True(southWest.TryGetValue(out var sw));
+        Assert.Single(sw.Datasets);
+        Assert.True(northEast.TryGetValue(out var ne));
+        Assert.Single(ne.Datasets);
+    }
+
+    [Theory]
+    [InlineData(91.0)]
+    [InlineData(-90.01)]
+    [InlineData(double.NaN)]
+    public async Task Latitude_out_of_range_returns_invalid_argument(double lat)
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(lat, 0));
+
+        Assert.True(result.TryGetError(out var err));
+        var invalid = Assert.IsType<InvalidArgument>(err);
+        Assert.Equal("latitude", invalid.Parameter);
+    }
+
+    [Theory]
+    [InlineData(180.01)]
+    [InlineData(-181.0)]
+    [InlineData(double.NaN)]
+    public async Task Longitude_out_of_range_returns_invalid_argument(double lon)
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(0, lon));
+
+        Assert.True(result.TryGetError(out var err));
+        var invalid = Assert.IsType<InvalidArgument>(err);
+        Assert.Equal("longitude", invalid.Parameter);
+    }
+
+    [Fact]
+    public async Task Paging_returns_requested_page_with_HasMore_flag()
+    {
+        var catalog = new FakeDatasetCatalog();
+        for (var i = 0; i < 7; i++)
+        {
+            catalog.Add(LoadedDatasetFactory.S124($"ds{i}", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        }
+        var tool = new FindAtTool(catalog);
+
+        var page0 = await tool.InvokeAsync(new FindAtRequest(5, 5, Page: 0, PageSize: 3));
+        Assert.True(page0.TryGetValue(out var v0));
+        Assert.Equal(3, v0.Datasets.Length);
+        Assert.True(v0.HasMore);
+        Assert.Equal(7, v0.TotalCount);
+
+        var page2 = await tool.InvokeAsync(new FindAtRequest(5, 5, Page: 2, PageSize: 3));
+        Assert.True(page2.TryGetValue(out var v2));
+        Assert.Single(v2.Datasets);
+        Assert.False(v2.HasMore);
+
+        var page5 = await tool.InvokeAsync(new FindAtRequest(5, 5, Page: 5, PageSize: 3));
+        Assert.True(page5.TryGetValue(out var v5));
+        Assert.Empty(v5.Datasets);
+        Assert.False(v5.HasMore);
+        Assert.Equal(7, v5.TotalCount);
+    }
+
+    [Fact]
+    public async Task Point_outside_all_bboxes_returns_empty_success()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a", bounds: LoadedDatasetFactory.Box(0, 0, 1, 1)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(50, 50));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Datasets);
+        Assert.Equal(0, value.TotalCount);
+    }
+
+    // S-100 Part 10b §6.2 allows bounding boxes that cross the antimeridian
+    // (stored with WestLongitude > EastLongitude). The current containment
+    // check assumes West ≤ East and matches ListDatasetsTool.Intersects;
+    // wrap-around handling would need a coordinated change across all three
+    // bbox helpers (FindAtTool.Contains, ListDatasetsTool.Intersects,
+    // SampleCoverageTool.Contains). TODO: enable once those are unified.
+    [Fact(Skip = "Antimeridian-crossing bbox support is a codebase-wide change; see S-100 Part 10b §6.2.")]
+    public async Task Antimeridian_crossing_bbox_contains_point()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("dateline",
+            bounds: new EncDotNet.S100.Pipelines.BoundingBox(0, 170, 10, -170)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(5, 175));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Datasets);
+    }
+}


### PR DESCRIPTION
## What

Adds a new MCP tool, `find_at(latitude, longitude, [spec])`, that returns every loaded dataset whose declared bounding box contains the supplied point. Collapses what used to be N manual bbox checks (one per dataset) into a single declarative call — the case that bit us during the Solent dogfooding incident.

## Request / result

```csharp
public sealed record FindAtRequest(
    double Latitude,
    double Longitude,
    SpecRef? Spec = null,
    int Page = 0,
    int PageSize = 50);

public sealed record FindAtResult(
    ImmutableArray<DatasetSummary> Datasets,   // reused from ListDatasetsTool
    int Page,
    int PageSize,
    int TotalCount,
    bool HasMore);
```

Insertion order from the catalog snapshot is preserved, matching `list_datasets`. Spec filter behaves identically to `list_datasets` (default-edition matches any edition).

## Containment semantics

- **Bbox-only.** A positive result means the point lies within `[SouthLatitude, NorthLatitude] × [WestLongitude, EastLongitude]`. No per-cell coverage check, no NoData masking, no vector geometry intersection. The tool description tells agents this explicitly and points them at `sample_coverage` for actual values.
- **Inclusive on every edge**, matching `SampleCoverageTool.Contains`.

## Antimeridian decision

The current implementation assumes `WestLongitude ≤ EastLongitude` — same convention used by `ListDatasetsTool.Intersects` and `SampleCoverageTool.Contains`. Datasets whose bbox crosses the antimeridian (stored with `West > East`) will not match here.

Adding wrap-around handling in `FindAtTool` alone would create an inconsistency with the other two bbox helpers, so I left it as a TODO — captured in a skipped test (`Antimeridian_crossing_bbox_contains_point`) that references **S-100 Part 10b §6.2**. Unifying all three callers is the right scope for a follow-up PR.

## Validation

Lat outside `[-90, 90]`, lon outside `[-180, 180]`, or `NaN` → new typed error `InvalidArgument(Parameter, Reason)` with code `invalid_argument`. Added to `ToolError.cs`; surfaced in the standard MCP error envelope as `{ "code": "invalid_argument", "details": { "parameter": "latitude", "reason": "..." } }`.

## Files

- `src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs` — new
- `src/EncDotNet.S100.Mcp.Tools/ToolError.cs` — `+InvalidArgument`
- `src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs` — `+find_at` registration with agent-facing description (decimal degrees, WGS-84, bbox-only)
- `src/EncDotNet.S100.Mcp/S100McpServer.cs` — wire `FindAtTool` into `CreateTools`
- `tests/EncDotNet.S100.Mcp.Tools.Tests/FindAtToolTests.cs` — new
- `tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs` — bumped tool count to 4, added round-trip and invalid-arg round-trip
- `src/EncDotNet.S100.Mcp.Tools/README.md`, `docs/mcp-server.md` — inventory + example

## Tests

| Project | Pass | Skip |
|---|---|---|
| `EncDotNet.S100.Mcp.Tools.Tests` (full project) | 68 | 1 |
| `EncDotNet.S100.Mcp.Tests` (round-trip) | 14 | 0 |

`FindAtToolTests` contributes 14 passing cases + 1 intentionally skipped antimeridian case:

- single-match / multi-overlap (insertion order) / no-match
- spec filter (with-edition and default-edition)
- inclusive edges (SW, NE corners)
- 3 × invalid latitude (theory: 91, -90.01, NaN)
- 3 × invalid longitude (theory: 180.01, -181, NaN)
- empty catalog
- paging (page 0 + HasMore, last page + !HasMore, past-end empty)
- skipped antimeridian case with S-100 Part 10b §6.2 reference

Plus 2 new round-trip cases in `S100McpServerRoundTripTests`:

- `FindAt_round_trip_returns_matching_datasets`
- `FindAt_invalid_latitude_returns_structured_error`

## Out of scope (explicit, per the issue)

- Polygon / multi-point `find_in_region` (later).
- Time filter (defer until a real caller asks).
- Per-cell / NoData containment (use `sample_coverage`).
- Sorting (insertion order, same as `list_datasets`).

## Coordination

Sibling sessions are touching `S100McpServerToolFactory.cs` (schema annotations on shared types) and possibly `README.md`. Both surfaces are additive here; should merge cleanly. Bumping the expected tool count in `ListTools_returns_..._tools_with_schemas` is the most likely conflict point — if either sibling adds another tool, the assertion will need a re-bump.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>