### PR TITLE
Add MCP describers for S-102/S-104/S-111 coverage instances

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -36,7 +36,7 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | Tool | Purpose |
 |---|---|
 | `list_datasets` | Summarises every dataset currently loaded in the viewer. |
-| `describe_feature` | Returns spec, feature type, and attributes for a feature id in a given dataset. |
+| `describe_feature` | Returns spec, feature type, and attributes for a feature id in a given dataset. Supported specs: S-101 (RCID), S-102 (`BathymetryCoverage[.01]`), S-104 / S-111 (`WaterLevel`/`SurfaceCurrent[.NN][.Group_KKK]` or bare station identifier), and S-124 (`gml:id`). |
 | `sample_coverage` | Samples a depth / water-level / current value at a lat/lon from an S-102 / S-104 / S-111 dataset. |
 
 ## Sample agent prompts

--- a/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
@@ -17,6 +17,12 @@ public class S102CoverageSource : ICoverageSource
         _dataset = dataset;
         _coverage = dataset.Coverages[coverageIndex];
     }
+
+    /// <summary>The underlying S-102 dataset wrapped by this source.</summary>
+    public S102Dataset Dataset => _dataset;
+
+    /// <summary>The single bathymetry coverage instance this source exposes.</summary>
+    public BathymetryCoverage Coverage => _coverage;
     
     public CoverageMetadata Metadata => new CoverageMetadata
     {

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -116,11 +116,22 @@ The five error variants implemented in this PR:
 `FeatureDescriberRegistry` keyed on `SpecRef.Name`. Each describer
 implements an internal `ISpecFeatureDescriber` strategy.
 
-This PR ships `S124FeatureDescriber` end-to-end (lookup, attribute
-serialisation, complex-attribute serialisation, xlink-reference
-projection across the catalog). Other specs fall through to a
-`SpecNotSupportedForTool` error until their describers are added in
-follow-up PRs.
+The registry currently wires five describers:
+
+| Spec   | Describer                  | Feature id convention                                                                                       |
+|--------|----------------------------|-------------------------------------------------------------------------------------------------------------|
+| S-101  | `S101FeatureDescriber`     | Record identifier (RCID), e.g. `42`.                                                                        |
+| S-102  | `S102FeatureDescriber`     | Coverage path `BathymetryCoverage[.01]` (bare `BathymetryCoverage` accepted).                               |
+| S-104  | `S104FeatureDescriber`     | Coverage path `WaterLevel[.NN][.Group_KKK]` (dcf2 grid / dcf8 station-series), or a bare station identifier. |
+| S-111  | `S111FeatureDescriber`     | Coverage path `SurfaceCurrent[.NN][.Group_KKK]` (dcf2 / dcf8), or a bare station identifier.                 |
+| S-124  | `S124FeatureDescriber`     | GML `gml:id` of the warning feature.                                                                        |
+
+For the coverage describers (S-102/S-104/S-111) the result returns
+instance-level metadata (origin, spacing, grid dimensions, CRS,
+bounding box, NoData value, value ranges, time-step counts, station
+counts, ...) — coverage instances do not xlink to each other, so
+`References` is always empty. Specs without a registered describer
+return `SpecNotSupportedForTool`.
 
 ## Usage
 

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
@@ -25,6 +25,9 @@ public sealed class FeatureDescriberRegistry
     public static FeatureDescriberRegistry Default { get; } = new FeatureDescriberRegistry(
     [
         new S101FeatureDescriber(),
+        new S102FeatureDescriber(),
+        new S104FeatureDescriber(),
+        new S111FeatureDescriber(),
         new S124FeatureDescriber(),
     ]);
 

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S102FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S102FeatureDescriber.cs
@@ -1,0 +1,166 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Describer strategy for S-102 Bathymetric Surface coverages.
+/// Resolves a feature by an HDF5-style group path
+/// (<c>BathymetryCoverage.01</c>, <c>BathymetryCoverage.1</c>, or bare
+/// <c>BathymetryCoverage</c>) and serialises the coverage instance's
+/// grid metadata, value-field schema, and depth statistics as JSON.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The catalog projects each S-102 dataset to a single
+/// <see cref="S102CoverageSource"/> wrapping coverage index 0
+/// (<see cref="EncDotNet.S100.Mcp.Tools.Catalog.S102CoverageData"/>),
+/// so this describer recognises only one instance id. Attribute paths
+/// follow S-102 Edition 2.1.0 §10 — origin/spacing/grid extents under
+/// <c>BathymetryCoverage.NN</c>, NoData fill value <c>1_000_000f</c>.
+/// </para>
+/// </remarks>
+internal sealed class S102FeatureDescriber : ISpecFeatureDescriber
+{
+    private const string FeatureType = "BathymetryCoverage";
+    private const float FillValue = S102CoverageSource.FillValue;
+
+    public string SpecName => "S-102";
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Dataset.Data is not S102CoverageData s102)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+        }
+
+        if (!TryParseFeatureId(context.FeatureId, out _))
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var dataset = s102.Source.Dataset;
+        var coverage = s102.Source.Coverage;
+        var metadata = s102.Source.Metadata;
+
+        var attributes = SerializeAttributes(dataset, coverage, metadata);
+
+        return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+            context.Dataset.Spec,
+            FeatureType,
+            attributes,
+            ImmutableArray<FeatureReference>.Empty));
+    }
+
+    /// <summary>
+    /// Accepts <c>"BathymetryCoverage"</c>, <c>"BathymetryCoverage.NN"</c>,
+    /// or <c>"BathymetryCoverage.N"</c>. Only instance 1 (the single
+    /// coverage exposed by the catalog) is recognised.
+    /// </summary>
+    internal static bool TryParseFeatureId(string id, out int instance)
+    {
+        instance = 1;
+        if (string.IsNullOrEmpty(id)) return false;
+
+        if (string.Equals(id, FeatureType, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!id.StartsWith(FeatureType + ".", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var suffix = id[(FeatureType.Length + 1)..];
+        if (!int.TryParse(suffix, NumberStyles.None, CultureInfo.InvariantCulture, out instance))
+        {
+            return false;
+        }
+
+        // The catalog only projects coverage index 0 (instance 1).
+        return instance == 1;
+    }
+
+    private static JsonElement SerializeAttributes(
+        S102Dataset dataset,
+        BathymetryCoverage coverage,
+        EncDotNet.S100.Pipelines.Coverage.CoverageMetadata metadata)
+    {
+        var (minDepth, maxDepth, noDataCount) = ComputeDepthRange(coverage.Values);
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{FeatureType}.01",
+            ["featureType"] = FeatureType,
+            ["gridMetadata"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["originLatitude"] = coverage.OriginLatitude,
+                ["originLongitude"] = coverage.OriginLongitude,
+                ["spacingLatitudinal"] = coverage.SpacingLatitudinal,
+                ["spacingLongitudinal"] = coverage.SpacingLongitudinal,
+                ["numPointsLatitudinal"] = coverage.NumPointsLatitudinal,
+                ["numPointsLongitudinal"] = coverage.NumPointsLongitudinal,
+                ["startSequence"] = coverage.StartSequence,
+            },
+            ["boundingBox"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["south"] = metadata.Extent.SouthLatitude,
+                ["west"] = metadata.Extent.WestLongitude,
+                ["north"] = metadata.Extent.NorthLatitude,
+                ["east"] = metadata.Extent.EastLongitude,
+            },
+            ["horizontalCRS"] = dataset.HorizontalCRS,
+            ["epoch"] = dataset.Epoch,
+            ["verticalDatum"] = metadata.VerticalDatum,
+            ["noDataValue"] = FillValue,
+            ["valueFields"] = metadata.ValueFields.Select(v => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["name"] = v.Name,
+                ["type"] = v.Type.ToString(),
+                ["units"] = v.Units,
+                ["fillValue"] = v.FillValue,
+            }).ToArray(),
+            ["depthRange"] = minDepth is null
+                ? null
+                : new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["min"] = minDepth,
+                    ["max"] = maxDepth,
+                    ["nodataCount"] = noDataCount,
+                },
+            ["geographicIdentifier"] = dataset.GeographicIdentifier,
+            ["issueDate"] = dataset.IssueDate,
+            ["metadata"] = dataset.Metadata,
+        };
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+
+    /// <summary>
+    /// Single pass over the depth field, skipping <see cref="FillValue"/>.
+    /// Returns <c>(null, null, count)</c> when every cell is NoData.
+    /// </summary>
+    private static (float? Min, float? Max, int NoDataCount) ComputeDepthRange(BathymetryValue[] values)
+    {
+        float? min = null;
+        float? max = null;
+        int nodata = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            var d = values[i].Depth;
+            if (d == FillValue) { nodata++; continue; }
+            if (min is null || d < min) min = d;
+            if (max is null || d > max) max = d;
+        }
+        return (min, max, nodata);
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S104FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S104FeatureDescriber.cs
@@ -1,0 +1,416 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Describer strategy for S-104 Water Level Information for Surface
+/// Navigation datasets. Dispatches on the catalog payload variant:
+/// <list type="bullet">
+/// <item><description><see cref="S104CoverageData"/> — data coding
+/// format 2 (regularly-gridded coverage). Accepts
+/// <c>WaterLevel[.NN]</c> for the instance and
+/// <c>WaterLevel[.NN].Group_KKK</c> for the K-th time-step group
+/// (S-104 Edition 2.0.0 §10.2.1).</description></item>
+/// <item><description><see cref="S104StationSeriesData"/> — data
+/// coding format 8 (time series at fixed stations; S-104
+/// Edition 2.0.0 §10.2.3 / §10.2.7). Accepts <c>WaterLevel[.NN]</c>
+/// for the instance, <c>WaterLevel[.NN].Group_KKK</c> for the K-th
+/// station, or the bare station identifier string.</description></item>
+/// </list>
+/// </summary>
+internal sealed class S104FeatureDescriber : ISpecFeatureDescriber
+{
+    private const string InstancePrefix = "WaterLevel";
+    private const string InstanceFeatureType = "WaterLevel";
+    private const string StationFeatureType = "WaterLevelStation";
+    private const float HeightFillValue = S104CoverageSource.FillValue;
+
+    public string SpecName => "S-104";
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return context.Dataset.Data switch
+        {
+            S104CoverageData gridded => DescribeGridded(context, gridded),
+            S104StationSeriesData stations => DescribeStations(context, stations),
+            _ => ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name)),
+        };
+    }
+
+    private static ToolResult<DescribeFeatureResult> DescribeGridded(
+        FeatureDescriberContext context,
+        S104CoverageData payload)
+    {
+        var dataset = payload.Source.Dataset;
+
+        if (!TryParseInstanceId(context.FeatureId, out var groupIndex))
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        if (groupIndex is null)
+        {
+            // Instance-level summary.
+            var attributes = SerializeGriddedInstance(dataset);
+            return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                context.Dataset.Spec,
+                InstanceFeatureType,
+                attributes,
+                ImmutableArray<FeatureReference>.Empty));
+        }
+
+        var idx = groupIndex.Value - 1;
+        if (idx < 0 || idx >= dataset.Coverages.Count)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var groupAttrs = SerializeGriddedGroup(dataset, groupIndex.Value, dataset.Coverages[idx]);
+        return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+            context.Dataset.Spec,
+            InstanceFeatureType,
+            groupAttrs,
+            ImmutableArray<FeatureReference>.Empty));
+    }
+
+    private static ToolResult<DescribeFeatureResult> DescribeStations(
+        FeatureDescriberContext context,
+        S104StationSeriesData payload)
+    {
+        var dataset = payload.Dataset;
+
+        // Try parsing as instance/Group_NNN first; otherwise fall back to a station identifier match.
+        if (TryParseInstanceId(context.FeatureId, out var groupIndex))
+        {
+            if (groupIndex is null)
+            {
+                var attributes = SerializeStationInstance(dataset);
+                return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                    context.Dataset.Spec,
+                    InstanceFeatureType,
+                    attributes,
+                    ImmutableArray<FeatureReference>.Empty));
+            }
+
+            var idx = groupIndex.Value - 1;
+            if (idx < 0 || idx >= dataset.Stations.Count)
+            {
+                return ToolResult<DescribeFeatureResult>.Err(
+                    new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+            }
+
+            var stationAttrs = SerializeStation(dataset.Stations[idx]);
+            return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                context.Dataset.Spec,
+                StationFeatureType,
+                stationAttrs,
+                ImmutableArray<FeatureReference>.Empty));
+        }
+
+        // Try station identifier.
+        foreach (var station in dataset.Stations)
+        {
+            if (string.Equals(station.Identifier, context.FeatureId, StringComparison.Ordinal))
+            {
+                var attrs = SerializeStation(station);
+                return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                    context.Dataset.Spec,
+                    StationFeatureType,
+                    attrs,
+                    ImmutableArray<FeatureReference>.Empty));
+            }
+        }
+
+        return ToolResult<DescribeFeatureResult>.Err(
+            new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+    }
+
+    /// <summary>
+    /// Parses ids of the form <c>WaterLevel</c>, <c>WaterLevel.NN</c>, or
+    /// <c>WaterLevel.NN.Group_KKK</c>. Returns <c>true</c> with
+    /// <paramref name="groupIndex"/> = <c>null</c> for the instance form
+    /// (instance number is always 1 in the current catalog projection);
+    /// <c>true</c> with <paramref name="groupIndex"/> = K for the group
+    /// form; <c>false</c> otherwise.
+    /// </summary>
+    internal static bool TryParseInstanceId(string id, out int? groupIndex)
+    {
+        groupIndex = null;
+        if (string.IsNullOrEmpty(id)) return false;
+
+        if (string.Equals(id, InstancePrefix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!id.StartsWith(InstancePrefix + ".", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var rest = id[(InstancePrefix.Length + 1)..];
+        var dot = rest.IndexOf('.');
+        var instancePart = dot < 0 ? rest : rest[..dot];
+
+        if (!int.TryParse(instancePart, NumberStyles.None, CultureInfo.InvariantCulture, out var instance))
+        {
+            return false;
+        }
+        if (instance != 1) return false;
+
+        if (dot < 0) return true;
+
+        var groupPart = rest[(dot + 1)..];
+        if (!groupPart.StartsWith("Group_", StringComparison.Ordinal)) return false;
+        var nPart = groupPart["Group_".Length..];
+        if (!int.TryParse(nPart, NumberStyles.None, CultureInfo.InvariantCulture, out var k)) return false;
+        if (k < 1) return false;
+
+        groupIndex = k;
+        return true;
+    }
+
+    private static JsonElement SerializeGriddedInstance(S104Dataset dataset)
+    {
+        var first = dataset.Coverages.Count > 0 ? dataset.Coverages[0] : null;
+
+        DateTime? firstTime = dataset.Coverages.Count > 0 ? dataset.Coverages[0].TimePoint : null;
+        DateTime? lastTime = dataset.Coverages.Count > 0 ? dataset.Coverages[^1].TimePoint : null;
+        double? intervalSeconds = null;
+        if (dataset.Coverages.Count >= 2)
+        {
+            var t0 = dataset.Coverages[0].TimePoint;
+            var t1 = dataset.Coverages[1].TimePoint;
+            var step = (t1 - t0).TotalSeconds;
+            var uniform = true;
+            for (int i = 2; i < dataset.Coverages.Count; i++)
+            {
+                if (Math.Abs((dataset.Coverages[i].TimePoint - dataset.Coverages[i - 1].TimePoint).TotalSeconds - step) > 1e-3)
+                {
+                    uniform = false;
+                    break;
+                }
+            }
+            if (uniform) intervalSeconds = step;
+        }
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{InstancePrefix}.01",
+            ["featureType"] = InstanceFeatureType,
+            ["dataCodingFormat"] = dataset.DataCodingFormat,
+            ["methodWaterLevelProduct"] = dataset.MethodWaterLevelProduct,
+            ["gridMetadata"] = first is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["originLatitude"] = first.OriginLatitude,
+                ["originLongitude"] = first.OriginLongitude,
+                ["spacingLatitudinal"] = first.SpacingLatitudinal,
+                ["spacingLongitudinal"] = first.SpacingLongitudinal,
+                ["numPointsLatitudinal"] = first.NumPointsLatitudinal,
+                ["numPointsLongitudinal"] = first.NumPointsLongitudinal,
+            },
+            ["boundingBox"] = first is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["south"] = first.OriginLatitude,
+                ["west"] = first.OriginLongitude,
+                ["north"] = first.OriginLatitude + first.SpacingLatitudinal * first.NumPointsLatitudinal,
+                ["east"] = first.OriginLongitude + first.SpacingLongitudinal * first.NumPointsLongitudinal,
+            },
+            ["horizontalCRS"] = dataset.HorizontalCRS,
+            ["epoch"] = dataset.Epoch,
+            ["timeSteps"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["count"] = dataset.Coverages.Count,
+                ["first"] = firstTime,
+                ["last"] = lastTime,
+                ["intervalSeconds"] = intervalSeconds,
+            },
+            ["noDataValue"] = HeightFillValue,
+            ["geographicIdentifier"] = dataset.GeographicIdentifier,
+            ["issueDate"] = dataset.IssueDate,
+            ["metadata"] = dataset.Metadata,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeGriddedGroup(S104Dataset dataset, int groupIndex, WaterLevelCoverage coverage)
+    {
+        var (minH, maxH, nodata) = ComputeHeightRange(coverage.Values);
+        var trends = ComputeTrendCounts(coverage.Values);
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{InstancePrefix}.01",
+            ["groupIndex"] = groupIndex,
+            ["groupId"] = $"Group_{groupIndex:D3}",
+            ["featureType"] = InstanceFeatureType,
+            ["dataCodingFormat"] = dataset.DataCodingFormat,
+            ["timePoint"] = coverage.TimePoint,
+            ["gridMetadata"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["originLatitude"] = coverage.OriginLatitude,
+                ["originLongitude"] = coverage.OriginLongitude,
+                ["spacingLatitudinal"] = coverage.SpacingLatitudinal,
+                ["spacingLongitudinal"] = coverage.SpacingLongitudinal,
+                ["numPointsLatitudinal"] = coverage.NumPointsLatitudinal,
+                ["numPointsLongitudinal"] = coverage.NumPointsLongitudinal,
+            },
+            ["heightRange"] = minH is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = minH,
+                ["max"] = maxH,
+                ["nodataCount"] = nodata,
+            },
+            ["trendCounts"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["unknown"] = trends.Unknown,
+                ["decreasing"] = trends.Decreasing,
+                ["increasing"] = trends.Increasing,
+                ["steady"] = trends.Steady,
+            },
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeStationInstance(S104StationSeriesDataset dataset)
+    {
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{InstancePrefix}.01",
+            ["featureType"] = InstanceFeatureType,
+            ["dataCodingFormat"] = dataset.DataCodingFormat,
+            ["methodWaterLevelProduct"] = dataset.MethodWaterLevelProduct,
+            ["waterLevelTrendThreshold"] = dataset.WaterLevelTrendThreshold,
+            ["horizontalCRS"] = dataset.HorizontalCRS,
+            ["epoch"] = dataset.Epoch,
+            ["stations"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["count"] = dataset.Stations.Count,
+            },
+            ["timeRange"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = dataset.MinTime,
+                ["max"] = dataset.MaxTime,
+            },
+            ["geographicIdentifier"] = dataset.GeographicIdentifier,
+            ["issueDate"] = dataset.IssueDate,
+            ["metadata"] = dataset.Metadata,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeStation(WaterLevelStation station)
+    {
+        var (minH, maxH, nodata) = ComputeHeightRange(station.Heights);
+        var trends = ComputeTrendCounts(station.Trends);
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["stationId"] = station.Identifier,
+            ["featureType"] = StationFeatureType,
+            ["position"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["latitude"] = station.Latitude,
+                ["longitude"] = station.Longitude,
+            },
+            ["timeRange"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["start"] = station.StartTime,
+                ["end"] = station.EndTime,
+                ["intervalSeconds"] = station.TimeRecordInterval.TotalSeconds,
+                ["count"] = station.NumberOfTimes,
+            },
+            ["heightRange"] = minH is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = minH,
+                ["max"] = maxH,
+                ["nodataCount"] = nodata,
+            },
+            ["trendCounts"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["unknown"] = trends.Unknown,
+                ["decreasing"] = trends.Decreasing,
+                ["increasing"] = trends.Increasing,
+                ["steady"] = trends.Steady,
+            },
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static (float? Min, float? Max, int NoDataCount) ComputeHeightRange(WaterLevelValue[] values)
+    {
+        float? min = null; float? max = null; int nodata = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            var h = values[i].Height;
+            if (h == HeightFillValue) { nodata++; continue; }
+            if (min is null || h < min) min = h;
+            if (max is null || h > max) max = h;
+        }
+        return (min, max, nodata);
+    }
+
+    private static (float? Min, float? Max, int NoDataCount) ComputeHeightRange(float[] heights)
+    {
+        float? min = null; float? max = null; int nodata = 0;
+        for (int i = 0; i < heights.Length; i++)
+        {
+            var h = heights[i];
+            if (h == HeightFillValue) { nodata++; continue; }
+            if (min is null || h < min) min = h;
+            if (max is null || h > max) max = h;
+        }
+        return (min, max, nodata);
+    }
+
+    private static (int Unknown, int Decreasing, int Increasing, int Steady) ComputeTrendCounts(WaterLevelValue[] values)
+    {
+        int u = 0, d = 0, inc = 0, s = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            switch (values[i].Trend)
+            {
+                case 1: d++; break;
+                case 2: inc++; break;
+                case 3: s++; break;
+                default: u++; break;
+            }
+        }
+        return (u, d, inc, s);
+    }
+
+    private static (int Unknown, int Decreasing, int Increasing, int Steady) ComputeTrendCounts(byte[] trends)
+    {
+        int u = 0, d = 0, inc = 0, st = 0;
+        for (int i = 0; i < trends.Length; i++)
+        {
+            switch (trends[i])
+            {
+                case 1: d++; break;
+                case 2: inc++; break;
+                case 3: st++; break;
+                default: u++; break;
+            }
+        }
+        return (u, d, inc, st);
+    }
+
+    private static JsonElement ToJsonElement(object payload)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S111FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S111FeatureDescriber.cs
@@ -1,0 +1,367 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Describer strategy for S-111 Surface Currents datasets. Dispatches
+/// on the catalog payload variant:
+/// <list type="bullet">
+/// <item><description><see cref="S111CoverageData"/> — data coding
+/// format 2 (regularly-gridded coverage). Accepts
+/// <c>SurfaceCurrent[.NN]</c> for the instance and
+/// <c>SurfaceCurrent[.NN].Group_KKK</c> for the K-th time-step group
+/// (S-111 Edition 2.0.0 §10.2).</description></item>
+/// <item><description><see cref="S111StationSeriesData"/> — data
+/// coding format 8 (time series at fixed stations; S-111
+/// Edition 2.0.0 §10.2.3 / §10.2.7). Accepts <c>SurfaceCurrent[.NN]</c>,
+/// <c>SurfaceCurrent[.NN].Group_KKK</c>, or the bare station
+/// identifier.</description></item>
+/// </list>
+/// </summary>
+internal sealed class S111FeatureDescriber : ISpecFeatureDescriber
+{
+    private const string InstancePrefix = "SurfaceCurrent";
+    private const string InstanceFeatureType = "SurfaceCurrent";
+    private const string StationFeatureType = "SurfaceCurrentStation";
+
+    public string SpecName => "S-111";
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return context.Dataset.Data switch
+        {
+            S111CoverageData gridded => DescribeGridded(context, gridded),
+            S111StationSeriesData stations => DescribeStations(context, stations),
+            _ => ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name)),
+        };
+    }
+
+    private static ToolResult<DescribeFeatureResult> DescribeGridded(
+        FeatureDescriberContext context,
+        S111CoverageData payload)
+    {
+        var dataset = payload.Source.Dataset;
+
+        if (!TryParseInstanceId(context.FeatureId, out var groupIndex))
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        if (groupIndex is null)
+        {
+            return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                context.Dataset.Spec,
+                InstanceFeatureType,
+                SerializeGriddedInstance(dataset),
+                ImmutableArray<FeatureReference>.Empty));
+        }
+
+        var idx = groupIndex.Value - 1;
+        if (idx < 0 || idx >= dataset.Coverages.Count)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+            context.Dataset.Spec,
+            InstanceFeatureType,
+            SerializeGriddedGroup(dataset, groupIndex.Value, dataset.Coverages[idx]),
+            ImmutableArray<FeatureReference>.Empty));
+    }
+
+    private static ToolResult<DescribeFeatureResult> DescribeStations(
+        FeatureDescriberContext context,
+        S111StationSeriesData payload)
+    {
+        var dataset = payload.Dataset;
+
+        if (TryParseInstanceId(context.FeatureId, out var groupIndex))
+        {
+            if (groupIndex is null)
+            {
+                return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                    context.Dataset.Spec,
+                    InstanceFeatureType,
+                    SerializeStationInstance(dataset),
+                    ImmutableArray<FeatureReference>.Empty));
+            }
+
+            var idx = groupIndex.Value - 1;
+            if (idx < 0 || idx >= dataset.Stations.Count)
+            {
+                return ToolResult<DescribeFeatureResult>.Err(
+                    new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+            }
+
+            return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                context.Dataset.Spec,
+                StationFeatureType,
+                SerializeStation(dataset.Stations[idx]),
+                ImmutableArray<FeatureReference>.Empty));
+        }
+
+        foreach (var station in dataset.Stations)
+        {
+            if (string.Equals(station.Identifier, context.FeatureId, StringComparison.Ordinal))
+            {
+                return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+                    context.Dataset.Spec,
+                    StationFeatureType,
+                    SerializeStation(station),
+                    ImmutableArray<FeatureReference>.Empty));
+            }
+        }
+
+        return ToolResult<DescribeFeatureResult>.Err(
+            new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+    }
+
+    /// <summary>
+    /// Parses ids of the form <c>SurfaceCurrent</c>,
+    /// <c>SurfaceCurrent.NN</c>, or
+    /// <c>SurfaceCurrent.NN.Group_KKK</c>.
+    /// </summary>
+    internal static bool TryParseInstanceId(string id, out int? groupIndex)
+    {
+        groupIndex = null;
+        if (string.IsNullOrEmpty(id)) return false;
+
+        if (string.Equals(id, InstancePrefix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!id.StartsWith(InstancePrefix + ".", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var rest = id[(InstancePrefix.Length + 1)..];
+        var dot = rest.IndexOf('.');
+        var instancePart = dot < 0 ? rest : rest[..dot];
+        if (!int.TryParse(instancePart, NumberStyles.None, CultureInfo.InvariantCulture, out var instance)) return false;
+        if (instance != 1) return false;
+
+        if (dot < 0) return true;
+
+        var groupPart = rest[(dot + 1)..];
+        if (!groupPart.StartsWith("Group_", StringComparison.Ordinal)) return false;
+        var nPart = groupPart["Group_".Length..];
+        if (!int.TryParse(nPart, NumberStyles.None, CultureInfo.InvariantCulture, out var k)) return false;
+        if (k < 1) return false;
+
+        groupIndex = k;
+        return true;
+    }
+
+    private static JsonElement SerializeGriddedInstance(S111Dataset dataset)
+    {
+        var first = dataset.Coverages.Count > 0 ? dataset.Coverages[0] : null;
+
+        DateTime? firstTime = dataset.Coverages.Count > 0 ? dataset.Coverages[0].TimePoint : null;
+        DateTime? lastTime = dataset.Coverages.Count > 0 ? dataset.Coverages[^1].TimePoint : null;
+        double? intervalSeconds = null;
+        if (dataset.Coverages.Count >= 2)
+        {
+            var t0 = dataset.Coverages[0].TimePoint;
+            var t1 = dataset.Coverages[1].TimePoint;
+            var step = (t1 - t0).TotalSeconds;
+            var uniform = true;
+            for (int i = 2; i < dataset.Coverages.Count; i++)
+            {
+                if (Math.Abs((dataset.Coverages[i].TimePoint - dataset.Coverages[i - 1].TimePoint).TotalSeconds - step) > 1e-3)
+                {
+                    uniform = false; break;
+                }
+            }
+            if (uniform) intervalSeconds = step;
+        }
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{InstancePrefix}.01",
+            ["featureType"] = InstanceFeatureType,
+            ["dataCodingFormat"] = dataset.DataCodingFormat,
+            ["typeOfCurrentData"] = dataset.TypeOfCurrentData,
+            ["surfaceCurrentDepth"] = dataset.SurfaceCurrentDepth,
+            ["gridMetadata"] = first is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["originLatitude"] = first.OriginLatitude,
+                ["originLongitude"] = first.OriginLongitude,
+                ["spacingLatitudinal"] = first.SpacingLatitudinal,
+                ["spacingLongitudinal"] = first.SpacingLongitudinal,
+                ["numPointsLatitudinal"] = first.NumPointsLatitudinal,
+                ["numPointsLongitudinal"] = first.NumPointsLongitudinal,
+            },
+            ["boundingBox"] = first is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["south"] = first.OriginLatitude,
+                ["west"] = first.OriginLongitude,
+                ["north"] = first.OriginLatitude + first.SpacingLatitudinal * first.NumPointsLatitudinal,
+                ["east"] = first.OriginLongitude + first.SpacingLongitudinal * first.NumPointsLongitudinal,
+            },
+            ["horizontalCRS"] = dataset.HorizontalCRS,
+            ["epoch"] = dataset.Epoch,
+            ["timeSteps"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["count"] = dataset.Coverages.Count,
+                ["first"] = firstTime,
+                ["last"] = lastTime,
+                ["intervalSeconds"] = intervalSeconds,
+            },
+            ["geographicIdentifier"] = dataset.GeographicIdentifier,
+            ["issueDate"] = dataset.IssueDate,
+            ["metadata"] = dataset.Metadata,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeGriddedGroup(S111Dataset dataset, int groupIndex, SurfaceCurrentCoverage coverage)
+    {
+        var (minS, maxS, minD, maxD) = ComputeSpeedDirectionRange(coverage.Values);
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{InstancePrefix}.01",
+            ["groupIndex"] = groupIndex,
+            ["groupId"] = $"Group_{groupIndex:D3}",
+            ["featureType"] = InstanceFeatureType,
+            ["dataCodingFormat"] = dataset.DataCodingFormat,
+            ["typeOfCurrentData"] = dataset.TypeOfCurrentData,
+            ["surfaceCurrentDepth"] = dataset.SurfaceCurrentDepth,
+            ["timePoint"] = coverage.TimePoint,
+            ["gridMetadata"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["originLatitude"] = coverage.OriginLatitude,
+                ["originLongitude"] = coverage.OriginLongitude,
+                ["spacingLatitudinal"] = coverage.SpacingLatitudinal,
+                ["spacingLongitudinal"] = coverage.SpacingLongitudinal,
+                ["numPointsLatitudinal"] = coverage.NumPointsLatitudinal,
+                ["numPointsLongitudinal"] = coverage.NumPointsLongitudinal,
+            },
+            ["speedRange"] = minS is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = minS,
+                ["max"] = maxS,
+                ["units"] = "knots",
+            },
+            ["directionRange"] = minD is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = minD,
+                ["max"] = maxD,
+                ["units"] = "degrees true",
+            },
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeStationInstance(S111StationSeriesDataset dataset)
+    {
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["instanceId"] = $"{InstancePrefix}.01",
+            ["featureType"] = InstanceFeatureType,
+            ["dataCodingFormat"] = dataset.DataCodingFormat,
+            ["typeOfCurrentData"] = dataset.TypeOfCurrentData,
+            ["surfaceCurrentDepth"] = dataset.SurfaceCurrentDepth,
+            ["horizontalCRS"] = dataset.HorizontalCRS,
+            ["epoch"] = dataset.Epoch,
+            ["stations"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["count"] = dataset.Stations.Count,
+            },
+            ["timeRange"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = dataset.MinTime,
+                ["max"] = dataset.MaxTime,
+            },
+            ["geographicIdentifier"] = dataset.GeographicIdentifier,
+            ["issueDate"] = dataset.IssueDate,
+            ["metadata"] = dataset.Metadata,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeStation(SurfaceCurrentStation station)
+    {
+        var (minS, maxS) = ComputeRange(station.SpeedsMetresPerSecond);
+        var (minD, maxD) = ComputeRange(station.DirectionsDegreesTrue);
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["stationId"] = station.Identifier,
+            ["featureType"] = StationFeatureType,
+            ["position"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["latitude"] = station.Latitude,
+                ["longitude"] = station.Longitude,
+            },
+            ["timeRange"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["start"] = station.StartTime,
+                ["end"] = station.EndTime,
+                ["intervalSeconds"] = station.TimeRecordInterval.TotalSeconds,
+                ["count"] = station.NumberOfTimes,
+            },
+            ["speedRange"] = minS is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = minS,
+                ["max"] = maxS,
+                ["units"] = "metres/second",
+            },
+            ["directionRange"] = minD is null ? null : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["min"] = minD,
+                ["max"] = maxD,
+                ["units"] = "degrees true",
+            },
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static (float? MinSpeed, float? MaxSpeed, float? MinDir, float? MaxDir) ComputeSpeedDirectionRange(SurfaceCurrentValue[] values)
+    {
+        float? minS = null, maxS = null, minD = null, maxD = null;
+        for (int i = 0; i < values.Length; i++)
+        {
+            var s = values[i].Speed;
+            var d = values[i].Direction;
+            if (minS is null || s < minS) minS = s;
+            if (maxS is null || s > maxS) maxS = s;
+            if (minD is null || d < minD) minD = d;
+            if (maxD is null || d > maxD) maxD = d;
+        }
+        return (minS, maxS, minD, maxD);
+    }
+
+    private static (float? Min, float? Max) ComputeRange(float[] xs)
+    {
+        float? min = null, max = null;
+        for (int i = 0; i < xs.Length; i++)
+        {
+            var v = xs[i];
+            if (min is null || v < min) min = v;
+            if (max is null || v > max) max = v;
+        }
+        return (min, max);
+    }
+
+    private static JsonElement ToJsonElement(object payload)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS102Tests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS102Tests.cs
@@ -1,0 +1,158 @@
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DescribeFeatureToolS102Tests
+{
+    [Fact]
+    public async Task Ok_DescribesCoverageInstance()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S102Synth.Dataset(
+            originLat: 47.0,
+            originLon: -122.0,
+            spacingLat: 0.01,
+            spacingLon: 0.01,
+            numRows: 3,
+            numCols: 4,
+            depth: 12.5f,
+            uncertainty: 0.25f);
+        catalog.Add(LoadedDatasetFactory.S102("s102-ds", source: new(dataset)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("s102-ds"), "BathymetryCoverage.01"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("S-102", value.Spec.Name);
+        Assert.Equal("BathymetryCoverage", value.FeatureTypeName);
+        Assert.Empty(value.References);
+
+        var attrs = value.Attributes;
+        Assert.Equal("BathymetryCoverage.01", attrs.GetProperty("instanceId").GetString());
+        var grid = attrs.GetProperty("gridMetadata");
+        Assert.Equal(47.0, grid.GetProperty("originLatitude").GetDouble());
+        Assert.Equal(-122.0, grid.GetProperty("originLongitude").GetDouble());
+        Assert.Equal(3, grid.GetProperty("numPointsLatitudinal").GetInt32());
+        Assert.Equal(4, grid.GetProperty("numPointsLongitudinal").GetInt32());
+
+        Assert.Equal(4326, attrs.GetProperty("horizontalCRS").GetInt32());
+        Assert.Equal(1_000_000f, attrs.GetProperty("noDataValue").GetSingle());
+
+        var depthRange = attrs.GetProperty("depthRange");
+        Assert.Equal(12.5f, depthRange.GetProperty("min").GetSingle());
+        Assert.Equal(12.5f, depthRange.GetProperty("max").GetSingle());
+        Assert.Equal(0, depthRange.GetProperty("nodataCount").GetInt32());
+
+        var fields = attrs.GetProperty("valueFields");
+        Assert.Equal(2, fields.GetArrayLength());
+        Assert.Equal("depth", fields[0].GetProperty("name").GetString());
+        Assert.Equal("uncertainty", fields[1].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task Ok_AcceptsBareBathymetryCoverageId()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "BathymetryCoverage"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("BathymetryCoverage", value.FeatureTypeName);
+    }
+
+    [Fact]
+    public async Task NotFound_UnknownInstanceId()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "BathymetryCoverage.99"));
+
+        Assert.True(result.TryGetError(out var err));
+        var nf = Assert.IsType<FeatureNotFound>(err);
+        Assert.Equal("BathymetryCoverage.99", nf.FeatureId);
+    }
+
+    [Fact]
+    public async Task NotFound_UnparseableId()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "NotARealId"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+
+    [Fact]
+    public async Task DepthRange_SkipsFillValues()
+    {
+        var dataset = new EncDotNet.S100.Datasets.S102.S102Dataset
+        {
+            HorizontalCRS = 4326,
+            Coverages =
+            [
+                new EncDotNet.S100.Datasets.S102.BathymetryCoverage
+                {
+                    OriginLatitude = 0, OriginLongitude = 0,
+                    SpacingLatitudinal = 1, SpacingLongitudinal = 1,
+                    NumPointsLatitudinal = 2, NumPointsLongitudinal = 2,
+                    Values =
+                    [
+                        new(5.0f, 0.1f),
+                        new(1_000_000f, 1_000_000f),
+                        new(10.0f, 0.2f),
+                        new(1_000_000f, 1_000_000f),
+                    ],
+                },
+            ],
+        };
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102("ds", source: new EncDotNet.S100.Datasets.S102.S102CoverageSource(dataset)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "BathymetryCoverage.01"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var dr = value.Attributes.GetProperty("depthRange");
+        Assert.Equal(5.0f, dr.GetProperty("min").GetSingle());
+        Assert.Equal(10.0f, dr.GetProperty("max").GetSingle());
+        Assert.Equal(2, dr.GetProperty("nodataCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task SpecMismatch_PayloadIsS101()
+    {
+        var catalog = new FakeDatasetCatalog();
+        // Inject an S-101 dataset but register it under the S-102 spec so
+        // the registry dispatches to S102FeatureDescriber.
+        var s101 = LoadedDatasetFactory.S101("ds");
+        var mismatched = new LoadedDataset(
+            s101.Id,
+            LoadedDatasetFactory.S102Spec,
+            s101.Bounds,
+            null,
+            s101.Data);
+        catalog.Add(mismatched);
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "BathymetryCoverage.01"));
+
+        Assert.True(result.TryGetError(out var err));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(err);
+        Assert.Equal("S-102", unsupported.Spec.Name);
+        Assert.Equal(DescribeFeatureTool.Name, unsupported.Tool);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS104Tests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS104Tests.cs
@@ -1,0 +1,147 @@
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DescribeFeatureToolS104Tests
+{
+    [Fact]
+    public async Task Dcf2_Ok_DescribesInstance()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "WaterLevel.01"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("WaterLevel", value.FeatureTypeName);
+        Assert.Equal("S-104", value.Spec.Name);
+        var attrs = value.Attributes;
+        Assert.Equal(2, attrs.GetProperty("dataCodingFormat").GetInt32());
+        var ts = attrs.GetProperty("timeSteps");
+        Assert.Equal(3, ts.GetProperty("count").GetInt32());
+        Assert.Equal(3600.0, ts.GetProperty("intervalSeconds").GetDouble());
+    }
+
+    [Fact]
+    public async Task Dcf2_Ok_DescribesGroup()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "WaterLevel.01.Group_002"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var attrs = value.Attributes;
+        Assert.Equal(2, attrs.GetProperty("groupIndex").GetInt32());
+        Assert.Equal("Group_002", attrs.GetProperty("groupId").GetString());
+        Assert.True(attrs.TryGetProperty("timePoint", out _));
+        var hr = attrs.GetProperty("heightRange");
+        Assert.True(hr.GetProperty("min").GetSingle() > 0);
+        var trends = attrs.GetProperty("trendCounts");
+        Assert.Equal(16, trends.GetProperty("steady").GetInt32());
+    }
+
+    [Fact]
+    public async Task Dcf2_NotFound_UnknownGroupIndex()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "WaterLevel.01.Group_099"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+
+    [Fact]
+    public async Task Dcf8_Ok_DescribesInstanceWithStationCount()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("ds", S104Synth.StationSeries(stationCount: 3)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "WaterLevel.01"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var attrs = value.Attributes;
+        Assert.Equal(8, attrs.GetProperty("dataCodingFormat").GetInt32());
+        Assert.Equal(3, attrs.GetProperty("stations").GetProperty("count").GetInt32());
+        Assert.Equal(0.1, attrs.GetProperty("waterLevelTrendThreshold").GetDouble());
+    }
+
+    [Fact]
+    public async Task Dcf8_Ok_DescribesStationByGroupIndex()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("ds", S104Synth.StationSeries(stationCount: 3)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "WaterLevel.01.Group_002"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("WaterLevelStation", value.FeatureTypeName);
+        var attrs = value.Attributes;
+        Assert.Equal("STN_002", attrs.GetProperty("stationId").GetString());
+        var pos = attrs.GetProperty("position");
+        Assert.Equal(47.1, pos.GetProperty("latitude").GetDouble(), 6);
+    }
+
+    [Fact]
+    public async Task Dcf8_Ok_DescribesStationByIdentifier()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("ds", S104Synth.StationSeries(stationCount: 3)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "STN_003"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("WaterLevelStation", value.FeatureTypeName);
+        Assert.Equal("STN_003", value.Attributes.GetProperty("stationId").GetString());
+    }
+
+    [Fact]
+    public async Task Dcf8_NotFound_UnknownStationIdentifier()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104Stations("ds", S104Synth.StationSeries()));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "NOT_A_STATION"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+
+    [Fact]
+    public async Task SpecMismatch_PayloadIsS101()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var s101 = LoadedDatasetFactory.S101("ds");
+        catalog.Add(new LoadedDataset(
+            s101.Id,
+            LoadedDatasetFactory.S104Spec,
+            s101.Bounds,
+            null,
+            s101.Data));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "WaterLevel.01"));
+
+        Assert.True(result.TryGetError(out var err));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(err);
+        Assert.Equal("S-104", unsupported.Spec.Name);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS111Tests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS111Tests.cs
@@ -1,0 +1,148 @@
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DescribeFeatureToolS111Tests
+{
+    [Fact]
+    public async Task Dcf2_Ok_DescribesInstance()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "SurfaceCurrent.01"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("SurfaceCurrent", value.FeatureTypeName);
+        Assert.Equal("S-111", value.Spec.Name);
+        var attrs = value.Attributes;
+        Assert.Equal(2, attrs.GetProperty("dataCodingFormat").GetInt32());
+        var ts = attrs.GetProperty("timeSteps");
+        Assert.Equal(3, ts.GetProperty("count").GetInt32());
+        Assert.Equal(3600.0, ts.GetProperty("intervalSeconds").GetDouble());
+    }
+
+    [Fact]
+    public async Task Dcf2_Ok_DescribesGroup()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "SurfaceCurrent.01.Group_001"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var attrs = value.Attributes;
+        Assert.Equal(1, attrs.GetProperty("groupIndex").GetInt32());
+        Assert.Equal("Group_001", attrs.GetProperty("groupId").GetString());
+        var sr = attrs.GetProperty("speedRange");
+        Assert.Equal(0.5f, sr.GetProperty("min").GetSingle());
+        var dr = attrs.GetProperty("directionRange");
+        Assert.Equal(90.0f, dr.GetProperty("min").GetSingle());
+    }
+
+    [Fact]
+    public async Task Dcf2_NotFound_UnknownGroupIndex()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111("ds"));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "SurfaceCurrent.01.Group_099"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+
+    [Fact]
+    public async Task Dcf8_Ok_DescribesInstanceWithStationCount()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("ds", S111Synth.StationSeries(stationCount: 4)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "SurfaceCurrent.01"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var attrs = value.Attributes;
+        Assert.Equal(8, attrs.GetProperty("dataCodingFormat").GetInt32());
+        Assert.Equal(4, attrs.GetProperty("stations").GetProperty("count").GetInt32());
+        Assert.Equal(6, attrs.GetProperty("typeOfCurrentData").GetInt32());
+        Assert.Equal(1.5f, attrs.GetProperty("surfaceCurrentDepth").GetSingle());
+    }
+
+    [Fact]
+    public async Task Dcf8_Ok_DescribesStationByGroupIndex()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("ds", S111Synth.StationSeries(stationCount: 3)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "SurfaceCurrent.01.Group_001"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("SurfaceCurrentStation", value.FeatureTypeName);
+        Assert.Equal("CUR_001", value.Attributes.GetProperty("stationId").GetString());
+    }
+
+    [Fact]
+    public async Task Dcf8_Ok_DescribesStationByIdentifier()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("ds", S111Synth.StationSeries(stationCount: 3)));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "CUR_002"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("SurfaceCurrentStation", value.FeatureTypeName);
+        var attrs = value.Attributes;
+        Assert.Equal("CUR_002", attrs.GetProperty("stationId").GetString());
+        var tr = attrs.GetProperty("timeRange");
+        Assert.Equal(4, tr.GetProperty("count").GetInt32());
+        Assert.Equal(3600.0, tr.GetProperty("intervalSeconds").GetDouble());
+    }
+
+    [Fact]
+    public async Task Dcf8_NotFound_UnknownStationIdentifier()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111Stations("ds", S111Synth.StationSeries()));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "BAD_ID"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+
+    [Fact]
+    public async Task SpecMismatch_PayloadIsS101()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var s101 = LoadedDatasetFactory.S101("ds");
+        catalog.Add(new LoadedDataset(
+            s101.Id,
+            LoadedDatasetFactory.S111Spec,
+            s101.Bounds,
+            null,
+            s101.Data));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("ds"), "SurfaceCurrent.01"));
+
+        Assert.True(result.TryGetError(out var err));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(err);
+        Assert.Equal("S-111", unsupported.Spec.Name);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S104Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S104Synth.cs
@@ -54,4 +54,59 @@ internal static class S104Synth
 
     public static S104CoverageSource Source(S104Dataset? dataset = null) =>
         new(dataset ?? Dataset());
+
+    /// <summary>
+    /// Creates a synthetic <see cref="S104StationSeriesDataset"/> (dcf8)
+    /// containing <paramref name="stationCount"/> stations, each with
+    /// <paramref name="samplesPerStation"/> samples at one-hour cadence
+    /// starting at <c>2024-01-01T00:00:00Z</c>.
+    /// </summary>
+    public static S104StationSeriesDataset StationSeries(
+        int stationCount = 2,
+        int samplesPerStation = 4,
+        string idPrefix = "STN_",
+        float baseHeight = 1.0f)
+    {
+        var stations = new List<WaterLevelStation>(stationCount);
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var interval = TimeSpan.FromHours(1);
+
+        DateTime? min = null, max = null;
+        for (int s = 0; s < stationCount; s++)
+        {
+            var heights = new float[samplesPerStation];
+            var trends = new byte[samplesPerStation];
+            for (int i = 0; i < samplesPerStation; i++)
+            {
+                heights[i] = baseHeight + s * 0.5f + i * 0.1f;
+                trends[i] = (byte)((i % 3) + 1);
+            }
+            var end = start + TimeSpan.FromTicks(interval.Ticks * (samplesPerStation - 1));
+            stations.Add(new WaterLevelStation
+            {
+                Identifier = $"{idPrefix}{s + 1:D3}",
+                Latitude = 47.0 + s * 0.1,
+                Longitude = -122.0 - s * 0.1,
+                StartTime = start,
+                EndTime = end,
+                TimeRecordInterval = interval,
+                NumberOfTimes = samplesPerStation,
+                Heights = heights,
+                Trends = trends,
+            });
+            min = min is null || start < min ? start : min;
+            max = max is null || end > max ? end : max;
+        }
+
+        return new S104StationSeriesDataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = 8,
+            MethodWaterLevelProduct = "astronomical prediction",
+            WaterLevelTrendThreshold = 0.1,
+            Stations = stations,
+            MinTime = min,
+            MaxTime = max,
+        };
+    }
 }

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S111Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S111Synth.cs
@@ -54,4 +54,57 @@ internal static class S111Synth
 
     public static S111CoverageSource Source(S111Dataset? dataset = null) =>
         new(dataset ?? Dataset());
+
+    /// <summary>
+    /// Creates a synthetic <see cref="S111StationSeriesDataset"/> (dcf8).
+    /// </summary>
+    public static S111StationSeriesDataset StationSeries(
+        int stationCount = 2,
+        int samplesPerStation = 4,
+        string idPrefix = "CUR_",
+        float baseSpeed = 0.3f,
+        float baseDirection = 45.0f)
+    {
+        var stations = new List<SurfaceCurrentStation>(stationCount);
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var interval = TimeSpan.FromHours(1);
+
+        DateTime? min = null, max = null;
+        for (int s = 0; s < stationCount; s++)
+        {
+            var speeds = new float[samplesPerStation];
+            var dirs = new float[samplesPerStation];
+            for (int i = 0; i < samplesPerStation; i++)
+            {
+                speeds[i] = baseSpeed + s * 0.05f + i * 0.01f;
+                dirs[i] = (baseDirection + s * 10f + i * 5f) % 360f;
+            }
+            var end = start + TimeSpan.FromTicks(interval.Ticks * (samplesPerStation - 1));
+            stations.Add(new SurfaceCurrentStation
+            {
+                Identifier = $"{idPrefix}{s + 1:D3}",
+                Latitude = 47.0 + s * 0.1,
+                Longitude = -122.0 - s * 0.1,
+                StartTime = start,
+                EndTime = end,
+                TimeRecordInterval = interval,
+                NumberOfTimes = samplesPerStation,
+                SpeedsMetresPerSecond = speeds,
+                DirectionsDegreesTrue = dirs,
+            });
+            min = min is null || start < min ? start : min;
+            max = max is null || end > max ? end : max;
+        }
+
+        return new S111StationSeriesDataset
+        {
+            HorizontalCRS = 4326,
+            DataCodingFormat = 8,
+            TypeOfCurrentData = 6,
+            SurfaceCurrentDepth = 1.5f,
+            Stations = stations,
+            MinTime = min,
+            MaxTime = max,
+        };
+    }
 }


### PR DESCRIPTION
Extends the MCP `describe_feature` tool with three new
`ISpecFeatureDescriber` implementations covering the HDF5 coverage
products. Mirrors the existing `S101FeatureDescriber` /
`S124FeatureDescriber` pattern — typed downcast on
`LoadedDatasetData`, dictionary-based JSON attribute serialisation,
empty `References` (coverage instances don't xlink).

## New describers

| Spec  | Describer                 | Feature id convention |
|-------|---------------------------|------------------------|
| S-102 | `S102FeatureDescriber`    | `BathymetryCoverage[.01]` (bare `BathymetryCoverage` also accepted) |
| S-104 | `S104FeatureDescriber`    | `WaterLevel[.NN][.Group_KKK]` or bare station identifier |
| S-111 | `S111FeatureDescriber`    | `SurfaceCurrent[.NN][.Group_KKK]` or bare station identifier |

S-104 and S-111 dispatch dcf2 (gridded coverage) vs dcf8 (station
series) based on the `LoadedDatasetData` variant
(`S10{4,1}CoverageData` vs `S10{4,1}StationSeriesData`). The dcf8
variants resolve a station by either a structured `Group_KKK` (1-based)
index or a bare station identifier string.

Returned attributes include grid metadata (origin/spacing/dims/CRS),
bounding box, NoData value, value-range histograms (depth /
height+trend / speed+direction), time-step counts and uniform
interval detection, plus dcf8-specific station positions and time
ranges. Spec section references are cited in XML doc comments
(S-102 §10.x, S-104 §10.2.3/§10.2.7, S-111 §10.2.x).

## Other changes

- `S102CoverageSource` now exposes `public S102Dataset Dataset` and
  `public BathymetryCoverage Coverage` accessors, so the describer
  can read geometry/values without an HDF5 round-trip. (S-104 and
  S-111 sources already exposed equivalent properties — this is the
  symmetric addition for S-102.) Additive, non-breaking.
- `FeatureDescriberRegistry.Default` registers the three new entries
  (registry now has 5 specs).
- `Fakes/S104Synth.cs` and `Fakes/S111Synth.cs` gain `StationSeries(...)`
  factory helpers producing multi-station dcf8 fixtures.

## Tests

22 new xunit tests, all passing:

- **`DescribeFeatureToolS102Tests`** (6): instance, bare id, unknown
  id, unparseable id, NoData-skipping depth range, SpecMismatch.
- **`DescribeFeatureToolS104Tests`** (8): dcf2 instance/group/NotFound,
  dcf8 instance/by-group-index/by-identifier/NotFound, SpecMismatch.
- **`DescribeFeatureToolS111Tests`** (8): symmetric to S-104.

Full `tests/EncDotNet.S100.Mcp.Tools.Tests` suite: 76/76 pass.
Full solution build: clean (only pre-existing warnings).

## Note for reviewers

S-111 surfaces a `units` field on speed ranges that reflects the
underlying type docs: `"knots"` for dcf2 grid values
(`SurfaceCurrentValue.Speed`) and `"metres/second"` for dcf8 station
series (`SurfaceCurrentStation.SpeedsMetresPerSecond`). This is
pre-existing and not introduced by this PR, but worth flagging.

## Out of scope

- Render-to-image, `find_at`, schema annotations on
  `BoundingBox`/`TimeRange` — parallel sessions.
- Per-cell sampling (already in `sample_coverage`).
- Multi-coverage S-102 datasets (catalog projects only index 0).