### PR TITLE
Annotate MCP tool surface with units, CRS, and field descriptions

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -35,6 +35,23 @@ subtype carries a `[System.ComponentModel.Description]` attribute with
 a single sentence stating the unit / CRS / semantics. A reflection
 contract test (`AnnotationContractTests`) enforces this.
 
+### Known unit warts
+
+These are pre-existing inconsistencies in the underlying dataset
+libraries that the MCP layer does **not** currently normalise. Agents
+should consult the `units` field on a per-payload basis rather than
+assume canonical units for these cases.
+
+- **S-111 current speed.** S-111 grids encoded as data coding format 2
+  (regularly-gridded time-series) surface speeds with `units = "knots"`,
+  while data coding format 8 (time series at fixed stations) surface
+  speeds with `units = "metres/second"`. The two values come from
+  different paths in `EncDotNet.S100.Datasets.S111` and have not yet
+  been normalised. TODO: pick one canonical unit at the MCP boundary
+  (almost certainly metres/second, matching the strongly-typed
+  `speedMetresPerSecond` field on `SurfaceCurrentSample` /
+  `SurfaceCurrentStationSample`) and rescale the other path.
+
 ## Enable it
 
 1. Open the viewer.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -8,6 +8,33 @@ The server is **off by default** and **listens on the loopback
 address only**. There is no authentication; the loopback isolation is
 the only protection in v1.
 
+## Field conventions
+
+Every MCP tool in this server follows the same conventions for the
+JSON it returns, so agents do not need to look up units, axes, or
+casing per-field. Anything that deviates is called out in the
+individual field's `[Description]`.
+
+| Concern | Convention |
+|---|---|
+| Coordinate reference system | WGS-84 (EPSG:4326). |
+| Coordinate values | Decimal degrees. Latitude range `-90..+90`; longitude range `-180..+180`. |
+| Bounding boxes | Four scalars labelled `southLatitude`, `westLongitude`, `northLatitude`, `eastLongitude` — never a bare pair. |
+| Times | UTC, ISO-8601. Time intervals are inclusive at both ends. |
+| Distances | Metres. |
+| Depths | Metres, positive down (matches S-102's vertical-datum convention). |
+| Water levels | Metres, positive up (matches S-104's vertical-datum convention). |
+| Current speeds | Canonical unit is metres per second (S-111 §10.2.5). Knots are provided alongside as a convenience (`speedKnots = m/s × 1.94384`). |
+| Bearings | Degrees from true north, clockwise, range `0..360`. |
+| JSON property naming | lower camelCase across every tool (driven by `JsonSerializerDefaults.Web`). |
+| Discriminated unions | Variant carries a `$kind` discriminator string (e.g. `"depth"`, `"waterLevel"`, `"surfaceCurrent"`). |
+| Errors | `isError = true` with payload `{ code, message, details }` — `code` is the stable switch key, `message` is human-readable, `details` carries the typed members of the error. |
+
+Every public property on a tool request, tool result, or `ToolError`
+subtype carries a `[System.ComponentModel.Description]` attribute with
+a single sentence stating the unit / CRS / semantics. A reflection
+contract test (`AnnotationContractTests`) enforces this.
+
 ## Enable it
 
 1. Open the viewer.

--- a/src/EncDotNet.S100.Core/Pipelines/BoundingBox.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/BoundingBox.cs
@@ -1,15 +1,37 @@
+using System.ComponentModel;
+
 namespace EncDotNet.S100.Pipelines;
 
 /// <summary>
-/// A geographic bounding rectangle.
+/// A geographic bounding rectangle in decimal degrees, WGS-84
+/// (EPSG:4326). Edges are stored independently as south / west / north
+/// / east so that JSON consumers cannot confuse the latitude and
+/// longitude ordering.
 /// </summary>
+[Description("Axis-aligned geographic bounding rectangle in decimal degrees, WGS-84.")]
 public sealed class BoundingBox
 {
+    /// <summary>South edge of the rectangle.</summary>
+    [Description("South edge in decimal degrees, WGS-84, range -90..+90.")]
     public double SouthLatitude { get; }
+
+    /// <summary>West edge of the rectangle.</summary>
+    [Description("West edge in decimal degrees, WGS-84, range -180..+180.")]
     public double WestLongitude { get; }
+
+    /// <summary>North edge of the rectangle.</summary>
+    [Description("North edge in decimal degrees, WGS-84, range -90..+90.")]
     public double NorthLatitude { get; }
+
+    /// <summary>East edge of the rectangle.</summary>
+    [Description("East edge in decimal degrees, WGS-84, range -180..+180.")]
     public double EastLongitude { get; }
 
+    /// <summary>Creates a new <see cref="BoundingBox"/>.</summary>
+    /// <param name="southLatitude">South edge (decimal degrees, WGS-84).</param>
+    /// <param name="westLongitude">West edge (decimal degrees, WGS-84).</param>
+    /// <param name="northLatitude">North edge (decimal degrees, WGS-84).</param>
+    /// <param name="eastLongitude">East edge (decimal degrees, WGS-84).</param>
     public BoundingBox(double southLatitude, double westLongitude, double northLatitude, double eastLongitude)
     {
         SouthLatitude = southLatitude;

--- a/src/EncDotNet.S100.Core/SpecRef.cs
+++ b/src/EncDotNet.S100.Core/SpecRef.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace EncDotNet.S100.Core;
 
 /// <summary>
@@ -29,9 +31,11 @@ public readonly record struct SpecRef
     /// The product specification short name in canonical <c>"S-NNN"</c> form
     /// (e.g. <c>"S-101"</c>, <c>"S-102"</c>).
     /// </summary>
+    [Description("Canonical product specification short name (e.g. \"S-101\").")]
     public string Name { get; }
 
     /// <summary>The product specification edition.</summary>
+    [Description("Product specification edition as a semantic version (major.minor.patch).")]
     public SpecVersion Edition { get; }
 
     /// <summary>

--- a/src/EncDotNet.S100.Core/SpecVersion.cs
+++ b/src/EncDotNet.S100.Core/SpecVersion.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Globalization;
 
 namespace EncDotNet.S100.Core;
@@ -21,12 +22,15 @@ namespace EncDotNet.S100.Core;
 public readonly record struct SpecVersion : IComparable<SpecVersion>
 {
     /// <summary>Major component (backward-incompatible change boundary).</summary>
+    [Description("Major component (backward-incompatible change boundary).")]
     public int Major { get; }
 
     /// <summary>Minor component (backward-compatible additions).</summary>
+    [Description("Minor component (backward-compatible additions).")]
     public int Minor { get; }
 
     /// <summary>Clarification component (editorial-only changes).</summary>
+    [Description("Clarification component (editorial-only changes).")]
     public int Clarification { get; }
 
     /// <summary>

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetCatalogChangedEventArgs.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetCatalogChangedEventArgs.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace EncDotNet.S100.Mcp.Tools.Catalog;
 
 /// <summary>
@@ -6,15 +8,19 @@ namespace EncDotNet.S100.Mcp.Tools.Catalog;
 public enum DatasetCatalogChangeKind
 {
     /// <summary>A single dataset was added.</summary>
+    [Description("A single dataset was added.")]
     Added,
 
     /// <summary>A single dataset was removed.</summary>
+    [Description("A single dataset was removed.")]
     Removed,
 
     /// <summary>A single dataset was replaced (same ID, different payload).</summary>
+    [Description("A single dataset was replaced (same ID, different payload).")]
     Replaced,
 
     /// <summary>Multiple datasets changed atomically; <see cref="DatasetCatalogChangedEventArgs.DatasetId"/> is <c>null</c>.</summary>
+    [Description("Multiple datasets changed atomically; DatasetId is null.")]
     Batch,
 }
 
@@ -22,11 +28,13 @@ public enum DatasetCatalogChangeKind
 public sealed class DatasetCatalogChangedEventArgs : EventArgs
 {
     /// <summary>The kind of change.</summary>
+    [Description("The kind of change reported (added, removed, replaced, batch).")]
     public required DatasetCatalogChangeKind Kind { get; init; }
 
     /// <summary>
     /// The dataset that changed, or <c>null</c> when
     /// <see cref="Kind"/> is <see cref="DatasetCatalogChangeKind.Batch"/>.
     /// </summary>
+    [Description("Identifier of the dataset that changed, or null when Kind is Batch.")]
     public DatasetId? DatasetId { get; init; }
 }

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetId.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/DatasetId.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace EncDotNet.S100.Mcp.Tools.Catalog;
 
 /// <summary>
@@ -12,6 +14,7 @@ namespace EncDotNet.S100.Mcp.Tools.Catalog;
 public readonly record struct DatasetId
 {
     /// <summary>The underlying opaque identifier value.</summary>
+    [Description("Opaque catalog-scoped identifier; stable for the lifetime of the host session.")]
     public string Value { get; }
 
     /// <summary>Creates a new <see cref="DatasetId"/>.</summary>

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDataset.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/LoadedDataset.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Pipelines;
+using System.ComponentModel;
 
 namespace EncDotNet.S100.Mcp.Tools.Catalog;
 
@@ -12,8 +13,8 @@ namespace EncDotNet.S100.Mcp.Tools.Catalog;
 /// <param name="TimeRange">Time interval covered by the dataset, or <c>null</c> for static products.</param>
 /// <param name="Data">Typed payload — see <see cref="LoadedDatasetData"/> variants.</param>
 public sealed record LoadedDataset(
-    DatasetId Id,
-    SpecRef Spec,
-    BoundingBox Bounds,
-    TimeRange? TimeRange,
-    LoadedDatasetData Data);
+    [property: Description("Stable identifier for the dataset within the catalog session.")] DatasetId Id,
+    [property: Description("Product specification (name and edition) the dataset declares conformance to.")] SpecRef Spec,
+    [property: Description("Geographic extent of the dataset (decimal degrees, WGS-84).")] BoundingBox Bounds,
+    [property: Description("Time interval covered by the dataset (UTC); null for static products such as S-102.")] TimeRange? TimeRange,
+    [property: Description("Typed payload carrying the parsed model or coverage handle.")] LoadedDatasetData Data);

--- a/src/EncDotNet.S100.Mcp.Tools/Catalog/TimeRange.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Catalog/TimeRange.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace EncDotNet.S100.Mcp.Tools.Catalog;
 
 /// <summary>
@@ -7,7 +9,11 @@ namespace EncDotNet.S100.Mcp.Tools.Catalog;
 /// Used for time-varying products such as S-104 water levels and
 /// S-111 surface currents. Static products (S-102) report no time range.
 /// </remarks>
-public readonly record struct TimeRange(DateTimeOffset Start, DateTimeOffset End)
+/// <param name="Start">Inclusive start of the dataset's declared time range (UTC).</param>
+/// <param name="End">Inclusive end of the dataset's declared time range (UTC).</param>
+public readonly record struct TimeRange(
+    [property: Description("Inclusive start of the dataset's declared time range, UTC ISO-8601.")] DateTimeOffset Start,
+    [property: Description("Inclusive end of the dataset's declared time range, UTC ISO-8601.")] DateTimeOffset End)
 {
     /// <summary>Returns <c>true</c> when the range contains <paramref name="instant"/> (inclusive).</summary>
     public bool Contains(DateTimeOffset instant) => instant >= Start && instant <= End;

--- a/src/EncDotNet.S100.Mcp.Tools/DescribeFeatureTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/DescribeFeatureTool.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Text.Json;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Spec;
@@ -6,7 +7,11 @@ using EncDotNet.S100.Mcp.Tools.Spec;
 namespace EncDotNet.S100.Mcp.Tools;
 
 /// <summary>Request payload for <see cref="DescribeFeatureTool"/>.</summary>
-public sealed record DescribeFeatureRequest(DatasetId DatasetId, string FeatureId);
+/// <param name="DatasetId">Stable dataset identifier returned by list_datasets.</param>
+/// <param name="FeatureId">GML id of the feature within the dataset.</param>
+public sealed record DescribeFeatureRequest(
+    [property: Description("Stable dataset identifier returned by list_datasets.")] DatasetId DatasetId,
+    [property: Description("GML id of the feature within the dataset.")] string FeatureId);
 
 /// <summary>Result of <see cref="DescribeFeatureTool"/>.</summary>
 /// <param name="Spec">The spec the feature was parsed from.</param>
@@ -14,10 +19,10 @@ public sealed record DescribeFeatureRequest(DatasetId DatasetId, string FeatureI
 /// <param name="Attributes">Serialised attribute payload as JSON.</param>
 /// <param name="References">xlink-style cross references resolved against the catalog snapshot.</param>
 public sealed record DescribeFeatureResult(
-    Core.SpecRef Spec,
-    string FeatureTypeName,
-    JsonElement Attributes,
-    ImmutableArray<FeatureReference> References);
+    [property: Description("Product specification and edition the feature was parsed from.")] Core.SpecRef Spec,
+    [property: Description("Spec-defined feature type code (e.g. \"NavwarnPart\").")] string FeatureTypeName,
+    [property: Description("Serialised attribute payload as a JSON object; structure follows the spec's Feature Catalogue.")] JsonElement Attributes,
+    [property: Description("xlink-style cross references projected against the catalog snapshot.")] ImmutableArray<FeatureReference> References);
 
 /// <summary>
 /// A cross-reference from one feature to another, projected from the
@@ -29,11 +34,11 @@ public sealed record DescribeFeatureResult(
 /// <param name="TargetFeatureId">The target feature ID, if extractable from the href.</param>
 /// <param name="Resolved"><c>true</c> when both target dataset and feature ID were located in the snapshot.</param>
 public sealed record FeatureReference(
-    string Role,
-    string Href,
-    DatasetId? TargetDatasetId,
-    string? TargetFeatureId,
-    bool Resolved);
+    [property: Description("Association role name (the local element name carrying xlink:href).")] string Role,
+    [property: Description("Raw xlink:href value as it appeared in the source GML.")] string Href,
+    [property: Description("Identifier of the dataset containing the target, if locatable in the catalog snapshot; null otherwise.")] DatasetId? TargetDatasetId,
+    [property: Description("Target feature id if extractable from the href; null otherwise.")] string? TargetFeatureId,
+    [property: Description("True when both the target dataset and feature id were located in the catalog snapshot.")] bool Resolved);
 
 /// <summary>
 /// Describes a single feature in a loaded dataset. Dispatches to a

--- a/src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.ComponentModel;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
@@ -14,11 +15,11 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// <param name="Page">Zero-based page index.</param>
 /// <param name="PageSize">Page size; clamped to 1..500.</param>
 public sealed record FindAtRequest(
-    double Latitude,
-    double Longitude,
-    SpecRef? Spec = null,
-    int Page = 0,
-    int PageSize = 50);
+    [property: Description("Query latitude in decimal degrees on WGS-84 (EPSG:4326). Must be in [-90, 90].")] double Latitude,
+    [property: Description("Query longitude in decimal degrees on WGS-84 (EPSG:4326). Must be in [-180, 180].")] double Longitude,
+    [property: Description("Optional spec filter; null matches every spec.")] SpecRef? Spec = null,
+    [property: Description("Zero-based page index into the result set.")] int Page = 0,
+    [property: Description("Maximum datasets per page; clamped to the range 1..500.")] int PageSize = 50);
 
 /// <summary>Result of <see cref="FindAtTool"/>.</summary>
 /// <param name="Datasets">Datasets whose declared bounding box contains the query point, in catalog insertion order.</param>
@@ -27,11 +28,11 @@ public sealed record FindAtRequest(
 /// <param name="TotalCount">Total number of matching datasets across all pages.</param>
 /// <param name="HasMore"><c>true</c> if additional pages remain.</param>
 public sealed record FindAtResult(
-    ImmutableArray<DatasetSummary> Datasets,
-    int Page,
-    int PageSize,
-    int TotalCount,
-    bool HasMore);
+    [property: Description("Datasets whose declared bounding box contains the query point, in catalog insertion order.")] ImmutableArray<DatasetSummary> Datasets,
+    [property: Description("Echoed (and floored) zero-based page index.")] int Page,
+    [property: Description("Echoed (and clamped) page size.")] int PageSize,
+    [property: Description("Total number of matching datasets across all pages.")] int TotalCount,
+    [property: Description("True if additional pages of matches remain after this one.")] bool HasMore);
 
 /// <summary>
 /// Returns every loaded dataset whose declared bounding box contains the

--- a/src/EncDotNet.S100.Mcp.Tools/ListDatasetsTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ListDatasetsTool.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.ComponentModel;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
@@ -13,25 +14,34 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// <param name="Page">Zero-based page index.</param>
 /// <param name="PageSize">Page size; clamped to 1..500.</param>
 public sealed record ListDatasetsRequest(
-    SpecRef? Spec = null,
-    BoundingBox? IntersectsBounds = null,
-    int Page = 0,
-    int PageSize = 50);
+    [property: Description("Optional spec filter (e.g. \"S-101/1.2.0\"); null matches every spec.")] SpecRef? Spec = null,
+    [property: Description("Optional WGS-84 bounding box; only datasets whose bounds intersect this rectangle are returned.")] BoundingBox? IntersectsBounds = null,
+    [property: Description("Zero-based page index.")] int Page = 0,
+    [property: Description("Page size; the tool clamps the effective value to the range 1..500.")] int PageSize = 50);
 
 /// <summary>Per-dataset summary returned by <see cref="ListDatasetsTool"/>.</summary>
+/// <param name="Id">Stable dataset identifier; pass back into other tools.</param>
+/// <param name="Spec">Product specification (name and edition) the dataset declares.</param>
+/// <param name="Bounds">Geographic extent of the dataset (decimal degrees, WGS-84).</param>
+/// <param name="TimeRange">UTC time interval covered by the dataset; null for static products such as S-102.</param>
 public sealed record DatasetSummary(
-    DatasetId Id,
-    SpecRef Spec,
-    BoundingBox Bounds,
-    TimeRange? TimeRange);
+    [property: Description("Stable dataset identifier; pass back into other tools.")] DatasetId Id,
+    [property: Description("Product specification (name and edition) the dataset declares.")] SpecRef Spec,
+    [property: Description("Geographic extent of the dataset in decimal degrees, WGS-84.")] BoundingBox Bounds,
+    [property: Description("UTC time interval covered by the dataset; null for static products such as S-102.")] TimeRange? TimeRange);
 
 /// <summary>Result of <see cref="ListDatasetsTool"/>.</summary>
+/// <param name="Datasets">Page of dataset summaries, in catalog order.</param>
+/// <param name="Page">Zero-based page index actually returned (post-clamp).</param>
+/// <param name="PageSize">Page size actually applied (post-clamp to 1..500).</param>
+/// <param name="TotalCount">Total number of datasets matching the filter, across all pages.</param>
+/// <param name="HasMore">True when more pages exist beyond the one returned.</param>
 public sealed record ListDatasetsResult(
-    ImmutableArray<DatasetSummary> Datasets,
-    int Page,
-    int PageSize,
-    int TotalCount,
-    bool HasMore);
+    [property: Description("Page of dataset summaries, in catalog order.")] ImmutableArray<DatasetSummary> Datasets,
+    [property: Description("Zero-based page index actually returned (post-clamp).")] int Page,
+    [property: Description("Page size actually applied (post-clamp to 1..500).")] int PageSize,
+    [property: Description("Total number of datasets matching the filter, across all pages.")] int TotalCount,
+    [property: Description("True when more pages exist beyond the one returned.")] bool HasMore);
 
 /// <summary>
 /// Lists datasets currently loaded in an <see cref="IDatasetCatalog"/>,

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -6,6 +6,22 @@ abstraction and the tool surface only** — no MCP protocol code, no
 viewer code, no transport. PR MCP-2 will layer the wire protocol on
 top of this.
 
+## Field conventions
+
+Every public property on every record that crosses the MCP wire —
+requests, results, payload variants, `ToolError` subtypes, and the
+shared `BoundingBox` / `SpecRef` / `TimeRange` / `DatasetId` types —
+carries a `[System.ComponentModel.Description]` attribute with a
+single-sentence statement of units, coordinate reference system, and
+semantics. The conventions (degrees decimal WGS-84, UTC ISO-8601,
+metres, m/s + knots, depths positive down, bearings 0..360 from true
+north, lower camelCase JSON keys) are documented in
+[`docs/mcp-server.md`](../../docs/mcp-server.md#field-conventions).
+
+A reflection-based test (`AnnotationContractTests` in
+`tests/EncDotNet.S100.Mcp.Tools.Tests`) enforces that every newly
+added wire-crossing property carries a non-empty `[Description]`.
+
 ## Architecture
 
 ```

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -5,6 +5,7 @@ using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using System.ComponentModel;
 
 namespace EncDotNet.S100.Mcp.Tools;
 
@@ -19,23 +20,31 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// selected; times outside the dataset's range clamp to the first or last step.
 /// </param>
 public sealed record SampleCoverageRequest(
-    SpecRef Spec,
-    double Latitude,
-    double Longitude,
-    DateTimeOffset? Time = null);
+    [property: Description("Spec of the coverage to sample (S-102, S-104, or S-111).")] SpecRef Spec,
+    [property: Description("Sample latitude in decimal degrees, WGS-84, range -90..+90.")] double Latitude,
+    [property: Description("Sample longitude in decimal degrees, WGS-84, range -180..+180.")] double Longitude,
+    [property: Description("UTC ISO-8601 time selector for time-varying products; ignored for S-102. Null selects the first time step; non-null selects the nearest step (clamped to the dataset range).")] DateTimeOffset? Time = null);
 
 /// <summary>Result of <see cref="SampleCoverageTool"/>.</summary>
+/// <param name="DatasetId">Dataset that produced the sample.</param>
+/// <param name="Latitude">Latitude that was requested, echoed back (decimal degrees, WGS-84).</param>
+/// <param name="Longitude">Longitude that was requested, echoed back (decimal degrees, WGS-84).</param>
+/// <param name="Value">Typed sample payload; discriminated on the JSON <c>$kind</c> property.</param>
 public sealed record SampleCoverageResult(
-    DatasetId DatasetId,
-    double Latitude,
-    double Longitude,
-    SampledValue Value);
+    [property: Description("Identifier of the dataset that produced the sample.")] DatasetId DatasetId,
+    [property: Description("Latitude that was requested, echoed back in decimal degrees, WGS-84.")] double Latitude,
+    [property: Description("Longitude that was requested, echoed back in decimal degrees, WGS-84.")] double Longitude,
+    [property: Description("Typed sample payload; the JSON \"$kind\" discriminator selects the variant.")] SampledValue Value);
 
 /// <summary>Discriminated payload returned by <see cref="SampleCoverageTool"/>.</summary>
 public abstract record SampledValue;
 
 /// <summary>S-102 depth sample (metres below the vertical datum, positive down).</summary>
-public sealed record DepthSample(double DepthMeters, double? UncertaintyMeters) : SampledValue;
+/// <param name="DepthMeters">Depth in metres below the vertical datum, positive down (per S-102).</param>
+/// <param name="UncertaintyMeters">Vertical uncertainty in metres at the resolved cell; null when the source dataset has no uncertainty layer.</param>
+public sealed record DepthSample(
+    [property: Description("Depth in metres below the vertical datum, positive down (per S-102).")] double DepthMeters,
+    [property: Description("Vertical uncertainty in metres at the resolved cell; null when the source dataset has no uncertainty layer.")] double? UncertaintyMeters) : SampledValue;
 
 /// <summary>
 /// S-104 water level sample read from a dcf8 ("time series at fixed
@@ -51,14 +60,14 @@ public sealed record DepthSample(double DepthMeters, double? UncertaintyMeters) 
 /// <param name="StationLatitude">Latitude of the matched station.</param>
 /// <param name="StationLongitude">Longitude of the matched station.</param>
 public sealed record WaterLevelStationSample(
-    string StationId,
-    double StationDistanceMetres,
-    double WaterLevelHeight,
-    string Trend,
-    DateTime SampleTime,
-    DateTimeOffset? RequestedTime,
-    double StationLatitude,
-    double StationLongitude) : SampledValue;
+    [property: Description("Reporting station identifier (S-104 stationIdentification).")] string StationId,
+    [property: Description("Great-circle distance from requested point to the station, in metres.")] double StationDistanceMetres,
+    [property: Description("Water level height in metres relative to the vertical datum, positive up (per S-104).")] double WaterLevelHeight,
+    [property: Description("S-104 decoded trend: \"decreasing\", \"increasing\", \"steady\", \"unknown\" (S-104 §10.2.2). Raw integer surfaced as a string for unrecognised values.")] string Trend,
+    [property: Description("UTC instant of the time step actually selected for this sample.")] DateTime SampleTime,
+    [property: Description("UTC instant the caller asked for, or null if unspecified.")] DateTimeOffset? RequestedTime,
+    [property: Description("Latitude of the matched station, decimal degrees, WGS-84.")] double StationLatitude,
+    [property: Description("Longitude of the matched station, decimal degrees, WGS-84.")] double StationLongitude) : SampledValue;
 
 /// <summary>
 /// S-104 water level sample at the nearest grid cell and time step.
@@ -76,14 +85,14 @@ public sealed record WaterLevelStationSample(
 /// <param name="CellCentreLatitude">Latitude of the resolved cell centre.</param>
 /// <param name="CellCentreLongitude">Longitude of the resolved cell centre.</param>
 public sealed record WaterLevelSample(
-    double WaterLevelHeight,
-    string Trend,
-    DateTime SampleTime,
-    DateTimeOffset? RequestedTime,
-    int Row,
-    int Column,
-    double CellCentreLatitude,
-    double CellCentreLongitude) : SampledValue;
+    [property: Description("Water level height in metres relative to the vertical datum, positive up (per S-104).")] double WaterLevelHeight,
+    [property: Description("S-104 decoded trend: \"decreasing\", \"increasing\", \"steady\", \"unknown\" (S-104 §10.2.2). Raw integer surfaced as a string for unrecognised values.")] string Trend,
+    [property: Description("UTC instant of the time step actually selected for this sample.")] DateTime SampleTime,
+    [property: Description("UTC instant the caller asked for, or null if unspecified.")] DateTimeOffset? RequestedTime,
+    [property: Description("Zero-based row index of the resolved cell in the source grid.")] int Row,
+    [property: Description("Zero-based column index of the resolved cell in the source grid.")] int Column,
+    [property: Description("Latitude of the resolved cell centre, decimal degrees, WGS-84.")] double CellCentreLatitude,
+    [property: Description("Longitude of the resolved cell centre, decimal degrees, WGS-84.")] double CellCentreLongitude) : SampledValue;
 
 /// <summary>
 /// S-111 surface current sample at the nearest grid cell and time step.
@@ -102,15 +111,15 @@ public sealed record WaterLevelSample(
 /// <param name="CellCentreLatitude">Latitude of the resolved cell centre.</param>
 /// <param name="CellCentreLongitude">Longitude of the resolved cell centre.</param>
 public sealed record SurfaceCurrentSample(
-    double SpeedMetresPerSecond,
-    double SpeedKnots,
-    double DirectionDegreesTrue,
-    DateTime SampleTime,
-    DateTimeOffset? RequestedTime,
-    int Row,
-    int Column,
-    double CellCentreLatitude,
-    double CellCentreLongitude) : SampledValue;
+    [property: Description("Current speed in metres per second — canonical S-111 unit (§10.2.5).")] double SpeedMetresPerSecond,
+    [property: Description("Current speed in knots (m/s × 1.94384), provided as a convenience.")] double SpeedKnots,
+    [property: Description("Direction the current is flowing toward, in degrees from true north, clockwise, 0..360.")] double DirectionDegreesTrue,
+    [property: Description("UTC instant of the time step actually selected for this sample.")] DateTime SampleTime,
+    [property: Description("UTC instant the caller asked for, or null if unspecified.")] DateTimeOffset? RequestedTime,
+    [property: Description("Zero-based row index of the resolved cell in the source grid.")] int Row,
+    [property: Description("Zero-based column index of the resolved cell in the source grid.")] int Column,
+    [property: Description("Latitude of the resolved cell centre, decimal degrees, WGS-84.")] double CellCentreLatitude,
+    [property: Description("Longitude of the resolved cell centre, decimal degrees, WGS-84.")] double CellCentreLongitude) : SampledValue;
 
 /// <summary>
 /// S-111 surface current sample read from a dcf8 ("time series at
@@ -128,15 +137,15 @@ public sealed record SurfaceCurrentSample(
 /// <param name="StationLatitude">Latitude of the matched station.</param>
 /// <param name="StationLongitude">Longitude of the matched station.</param>
 public sealed record SurfaceCurrentStationSample(
-    string StationId,
-    double StationDistanceMetres,
-    double SpeedMetresPerSecond,
-    double SpeedKnots,
-    double DirectionDegreesTrue,
-    DateTime SampleTime,
-    DateTimeOffset? RequestedTime,
-    double StationLatitude,
-    double StationLongitude) : SampledValue;
+    [property: Description("Reporting station identifier (S-111 stationIdentification).")] string StationId,
+    [property: Description("Great-circle distance from requested point to the station, in metres.")] double StationDistanceMetres,
+    [property: Description("Current speed in metres per second — canonical S-111 unit (§10.2.5).")] double SpeedMetresPerSecond,
+    [property: Description("Current speed in knots (m/s × 1.94384), provided as a convenience.")] double SpeedKnots,
+    [property: Description("Direction the current is flowing toward, in degrees from true north, clockwise, 0..360.")] double DirectionDegreesTrue,
+    [property: Description("UTC instant of the time step actually selected for this sample.")] DateTime SampleTime,
+    [property: Description("UTC instant the caller asked for, or null if unspecified.")] DateTimeOffset? RequestedTime,
+    [property: Description("Latitude of the matched station, decimal degrees, WGS-84.")] double StationLatitude,
+    [property: Description("Longitude of the matched station, decimal degrees, WGS-84.")] double StationLongitude) : SampledValue;
 
 /// <summary>
 /// Samples a coverage product at a single lat/lon, returning the nearest

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 
@@ -15,30 +16,53 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// wire format flexible while giving in-process callers a typed
 /// surface they can match on.
 /// </remarks>
-public abstract record ToolError(string Code, string Message);
+public abstract record ToolError(
+    [property: Description("Stable error code; safe to switch on.")] string Code,
+    [property: Description("Human-readable error message; not localised.")] string Message);
 
 /// <summary>The named dataset is not present in the catalog snapshot.</summary>
-public sealed record DatasetNotFound(DatasetId Id) : ToolError(
+/// <param name="Id">The dataset identifier that could not be resolved.</param>
+[Description("Raised when the requested datasetId is not present in the current catalog snapshot.")]
+public sealed record DatasetNotFound(
+    [property: Description("The dataset identifier that could not be resolved.")] DatasetId Id) : ToolError(
     "dataset_not_found",
     $"Dataset '{Id}' is not present in the catalog.");
 
 /// <summary>The dataset was unloaded after the catalog snapshot was taken but before the read completed.</summary>
-public sealed record DatasetClosedDuringQuery(DatasetId Id) : ToolError(
+/// <param name="Id">The dataset whose coverage handle was disposed mid-read.</param>
+[Description("Raised when a coverage handle was disposed between the catalog snapshot and the read; safe to retry once the dataset is reopened.")]
+public sealed record DatasetClosedDuringQuery(
+    [property: Description("The dataset whose coverage handle was disposed mid-read.")] DatasetId Id) : ToolError(
     "dataset_closed_during_query",
     $"Dataset '{Id}' was closed while the query was in flight; retry once the dataset is reopened.");
 
 /// <summary>No loaded dataset of the requested spec covers the supplied lat/lon.</summary>
-public sealed record NoDatasetCoversPoint(double Latitude, double Longitude) : ToolError(
+/// <param name="Latitude">Requested latitude (decimal degrees, WGS-84).</param>
+/// <param name="Longitude">Requested longitude (decimal degrees, WGS-84).</param>
+[Description("Raised when no loaded dataset's bounds contain the requested point (decimal degrees, WGS-84).")]
+public sealed record NoDatasetCoversPoint(
+    [property: Description("Requested latitude in decimal degrees, WGS-84.")] double Latitude,
+    [property: Description("Requested longitude in decimal degrees, WGS-84.")] double Longitude) : ToolError(
     "no_dataset_covers_point",
     $"No loaded dataset's bounds contain the point ({Latitude}, {Longitude}).");
 
 /// <summary>The named feature is not present in the named dataset.</summary>
-public sealed record FeatureNotFound(DatasetId Id, string FeatureId) : ToolError(
+/// <param name="Id">The dataset that was searched.</param>
+/// <param name="FeatureId">The feature identifier that could not be located.</param>
+[Description("Raised when the requested featureId is not present in the named dataset.")]
+public sealed record FeatureNotFound(
+    [property: Description("The dataset that was searched.")] DatasetId Id,
+    [property: Description("The feature identifier that could not be located.")] string FeatureId) : ToolError(
     "feature_not_found",
     $"Feature '{FeatureId}' is not present in dataset '{Id}'.");
 
 /// <summary>The tool does not (yet) support the requested spec.</summary>
-public sealed record SpecNotSupportedForTool(SpecRef Spec, string Tool) : ToolError(
+/// <param name="Spec">The product specification carried by the dataset.</param>
+/// <param name="Tool">The tool that has no end-to-end implementation for this spec.</param>
+[Description("Raised when the tool has no end-to-end implementation for the dataset's product specification.")]
+public sealed record SpecNotSupportedForTool(
+    [property: Description("The product specification carried by the dataset.")] SpecRef Spec,
+    [property: Description("Name of the tool that has no end-to-end implementation for this spec.")] string Tool) : ToolError(
     "spec_not_supported_for_tool",
     $"Spec '{Spec}' is not supported by tool '{Tool}'.");
 
@@ -49,7 +73,14 @@ public sealed record SpecNotSupportedForTool(SpecRef Spec, string Tool) : ToolEr
 /// requested spec is loaded at all — callers may want to retry once a
 /// dataset is loaded — by carrying the dataset spec.
 /// </summary>
-public sealed record OutOfBounds(SpecRef Spec, double Latitude, double Longitude) : ToolError(
+/// <param name="Spec">The product specification that was searched.</param>
+/// <param name="Latitude">Requested latitude (decimal degrees, WGS-84).</param>
+/// <param name="Longitude">Requested longitude (decimal degrees, WGS-84).</param>
+[Description("Raised when the requested point lies outside the bounds of every loaded dataset of the requested spec.")]
+public sealed record OutOfBounds(
+    [property: Description("The product specification that was searched.")] SpecRef Spec,
+    [property: Description("Requested latitude in decimal degrees, WGS-84.")] double Latitude,
+    [property: Description("Requested longitude in decimal degrees, WGS-84.")] double Longitude) : ToolError(
     "out_of_bounds",
     $"Point ({Latitude}, {Longitude}) is outside the bounds of every loaded {Spec.Name} dataset.");
 
@@ -58,11 +89,16 @@ public sealed record OutOfBounds(SpecRef Spec, double Latitude, double Longitude
 /// spec-defined no-data fill value. The cell index and time step are
 /// surfaced in the message so callers can correlate with the source grid.
 /// </summary>
+/// <param name="Id">The dataset that produced the no-data cell.</param>
+/// <param name="Row">Zero-based row index of the resolved cell.</param>
+/// <param name="Column">Zero-based column index of the resolved cell.</param>
+/// <param name="Time">UTC instant of the selected time step, or null for static products.</param>
+[Description("Raised when the resolved grid cell carries the spec-defined no-data fill value (e.g. 1,000,000 in S-102).")]
 public sealed record NoDataAtPoint(
-    DatasetId Id,
-    int Row,
-    int Column,
-    DateTime? Time) : ToolError(
+    [property: Description("The dataset that produced the no-data cell.")] DatasetId Id,
+    [property: Description("Zero-based row index of the resolved cell in the source grid.")] int Row,
+    [property: Description("Zero-based column index of the resolved cell in the source grid.")] int Column,
+    [property: Description("UTC instant of the selected time step, or null for static products.")] DateTime? Time) : ToolError(
     "no_data_at_point",
     Time is null
         ? $"Cell ({Row}, {Column}) in dataset '{Id}' carries the no-data fill value."
@@ -74,6 +110,13 @@ public sealed record NoDataAtPoint(
 /// Distinguished from <see cref="SpecNotSupportedForTool"/> in that the
 /// spec itself is supported — only this particular variant isn't yet.
 /// </summary>
-public sealed record NotSupportedYet(SpecRef Spec, string Tool, string Reason) : ToolError(
+/// <param name="Spec">The product specification carried by the dataset.</param>
+/// <param name="Tool">The tool that supports the spec but not this particular variant.</param>
+/// <param name="Reason">Single-sentence reason explaining what is not yet wired.</param>
+[Description("Raised when the spec is supported by the tool, but this specific dataset shape is not yet wired (e.g. S-104 data coding format other than 2).")]
+public sealed record NotSupportedYet(
+    [property: Description("The product specification carried by the dataset.")] SpecRef Spec,
+    [property: Description("Name of the tool that supports the spec but not this particular variant.")] string Tool,
+    [property: Description("Single-sentence reason explaining what is not yet wired.")] string Reason) : ToolError(
     "not_supported_yet",
     $"Spec '{Spec}' is supported by tool '{Tool}', but: {Reason}.");

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -26,7 +26,10 @@ public abstract record ToolError(
 /// names the request property that was rejected and
 /// <paramref name="Reason"/> describes why.
 /// </summary>
-public sealed record InvalidArgument(string Parameter, string Reason) : ToolError(
+[Description("Raised when a tool argument fails validation (e.g. a latitude or longitude outside the WGS-84 range).")]
+public sealed record InvalidArgument(
+    [property: Description("Name of the request property that was rejected.")] string Parameter,
+    [property: Description("Human-readable description of why the value was rejected; not localised.")] string Reason) : ToolError(
     "invalid_argument",
     $"Invalid argument '{Parameter}': {Reason}.");
 

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -76,13 +76,14 @@ internal static class S100McpServerToolFactory
         var description =
             "Lists the S-100 datasets currently loaded in the host (viewer or CLI). " +
             "Supports optional spec and bounding-box filters and pagination. " +
-            "Returns dataset IDs, spec, bounds, and time range.";
+            "Returns dataset IDs, spec, bounds (decimal degrees, WGS-84), and UTC time range. " +
+            "Read-only and side-effect free.";
 
         var del = ([Description("Optional spec filter (e.g. \"S-101/1.2.0\"); null matches every spec.")] string? spec = null,
-                   [Description("Optional bounding box south latitude (decimal degrees, WGS-84). Pass null to omit the bbox filter; if any one of south/west/north/east is supplied, all four must be.")] double? south = null,
-                   [Description("Optional bounding box west longitude.")] double? west = null,
-                   [Description("Optional bounding box north latitude.")] double? north = null,
-                   [Description("Optional bounding box east longitude.")] double? east = null,
+                   [Description("Optional bounding-box south latitude (decimal degrees, WGS-84). Pass null to omit the bbox filter; if any one of south/west/north/east is supplied, all four must be.")] double? south = null,
+                   [Description("Optional bounding-box west longitude (decimal degrees, WGS-84).")] double? west = null,
+                   [Description("Optional bounding-box north latitude (decimal degrees, WGS-84).")] double? north = null,
+                   [Description("Optional bounding-box east longitude (decimal degrees, WGS-84).")] double? east = null,
                    [Description("Zero-based page index.")] int page = 0,
                    [Description("Page size (clamped to 1..500).")] int pageSize = 50,
                    CancellationToken ct = default) =>
@@ -106,12 +107,13 @@ internal static class S100McpServerToolFactory
     private static McpServerTool CreateDescribeFeatureTool(DescribeFeatureTool inner)
     {
         var description =
-            "Returns spec, feature-type code, attributes (as JSON), and xlink-resolved cross-references " +
-            "for a single feature in a loaded dataset. Currently supports S-124 (Navigational Warnings); " +
-            "other vector specs return spec_not_supported_for_tool.";
+            "Returns spec, feature-type code, attributes (as a JSON object) and xlink-resolved cross-references " +
+            "for a single feature in a loaded vector dataset. Per-spec strategy: S-124 (Navigational Warnings) is " +
+            "wired end-to-end today; other vector specs return spec_not_supported_for_tool. " +
+            "Read-only and side-effect free.";
 
-        var del = ([Description("Stable dataset ID returned by list_datasets.")] string datasetId,
-                   [Description("The feature's GML id within the dataset.")] string featureId,
+        var del = ([Description("Stable dataset identifier returned by list_datasets.")] string datasetId,
+                   [Description("GML id of the feature within the dataset.")] string featureId,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(
@@ -129,14 +131,17 @@ internal static class S100McpServerToolFactory
     private static McpServerTool CreateSampleCoverageTool(SampleCoverageTool inner)
     {
         var description =
-            "Samples a coverage product at a single latitude/longitude, returning the nearest grid " +
-            "cell's value. Currently supports S-102 (Bathymetric Surfaces); S-104 and S-111 return " +
-            "spec_not_supported_for_tool.";
+            "Samples a coverage product at a single latitude/longitude (decimal degrees, WGS-84). " +
+            "Returns the value of the nearest grid cell — no interpolation, no bbox aggregation. " +
+            "S-102 returns depth (and optional uncertainty) in metres, positive down. " +
+            "S-104 returns water-level height (metres) and the decoded trend at the nearest time step. " +
+            "S-111 returns current speed (m/s and knots) and direction (degrees from true north, 0..360) at the nearest time step. " +
+            "Times outside a dataset's range clamp to its first or last step. Read-only and side-effect free.";
 
-        var del = ([Description("Spec of the coverage to sample (e.g. \"S-102/2.1.0\").")] string spec,
-                   [Description("Sample latitude in decimal degrees, WGS-84.")] double latitude,
-                   [Description("Sample longitude in decimal degrees, WGS-84.")] double longitude,
-                   [Description("Optional time selector (ISO-8601, time-varying products only).")] DateTimeOffset? time = null,
+        var del = ([Description("Spec of the coverage to sample (S-102, S-104, or S-111; e.g. \"S-102/2.1.0\").")] string spec,
+                   [Description("Sample latitude in decimal degrees, WGS-84, range -90..+90.")] double latitude,
+                   [Description("Sample longitude in decimal degrees, WGS-84, range -180..+180.")] double longitude,
+                   [Description("Optional UTC ISO-8601 time selector for time-varying products (S-104, S-111); ignored for S-102. Nearest time step is selected; times outside the dataset range clamp to the first or last step.")] DateTimeOffset? time = null,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/AnnotationContractTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/AnnotationContractTests.cs
@@ -1,0 +1,125 @@
+using System.ComponentModel;
+using System.Reflection;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+/// <summary>
+/// Reflection-based contract test. Every public property of every
+/// record type that crosses the MCP wire must carry a non-empty
+/// <see cref="DescriptionAttribute"/>. This guards against future
+/// drift — when a sibling session adds a new tool, result variant,
+/// or error type, this test fails until the new properties are
+/// annotated.
+/// </summary>
+public class AnnotationContractTests
+{
+    [Fact]
+    public void Every_wire_crossing_property_has_a_description()
+    {
+        var assemblies = new[]
+        {
+            typeof(ListDatasetsResult).Assembly,    // EncDotNet.S100.Mcp.Tools
+            typeof(BoundingBox).Assembly,           // EncDotNet.S100.Core
+        };
+
+        var types = new HashSet<Type>();
+        foreach (var asm in assemblies)
+        {
+            foreach (var t in asm.GetExportedTypes())
+            {
+                if (IsWireType(t))
+                {
+                    types.Add(t);
+                }
+            }
+        }
+
+        // Sanity: the suite is meaningless if no types were collected.
+        Assert.True(types.Count >= 10,
+            $"AnnotationContractTests collected only {types.Count} wire types; the predicate is too narrow.");
+
+        var failures = new List<string>();
+        foreach (var t in types)
+        {
+            foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                if (!p.CanRead) continue;
+                if (IsRecordSynthetic(p)) continue;
+
+                var desc = p.GetCustomAttribute<DescriptionAttribute>();
+                if (desc is null || string.IsNullOrWhiteSpace(desc.Description))
+                {
+                    failures.Add($"{t.FullName}.{p.Name} is missing a [Description] attribute.");
+                }
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            "Wire-crossing properties without [Description]:" + Environment.NewLine +
+            string.Join(Environment.NewLine, failures));
+    }
+
+    private static bool IsWireType(Type t)
+    {
+        if (t.IsAbstract && t.IsSealed) return false; // static classes
+        if (t.IsInterface) return false;
+        if (t.IsEnum) return false;
+        if (t.IsGenericTypeDefinition) return false;
+        if (t.IsNested) return false; // skip nested types like ToolResult<T>.OkResult
+
+        // ToolError and its subtypes are part of the agent-facing
+        // contract (their non-base members surface as the error
+        // `details` payload).
+        if (typeof(ToolError).IsAssignableFrom(t)) return true;
+
+        // SampledValue and its subtypes are the discriminated payload
+        // returned by sample_coverage.
+        if (typeof(SampledValue).IsAssignableFrom(t)) return true;
+
+        // Shared coordinate / spec types used across every tool result.
+        if (t == typeof(BoundingBox)) return true;
+        if (t == typeof(SpecRef) || t == typeof(SpecVersion)) return true;
+        if (t == typeof(DatasetId) || t == typeof(TimeRange)) return true;
+
+        // Tool request / result records, plus the supporting summary /
+        // reference records they contain. The suffix-based rule is the
+        // codebase convention and naturally picks up sibling sessions'
+        // future tools (e.g. FindAtRequest / FindAtResult).
+        if (t.Namespace == "EncDotNet.S100.Mcp.Tools" && IsRecordType(t))
+        {
+            var name = t.Name;
+            if (name.EndsWith("Request", StringComparison.Ordinal)) return true;
+            if (name.EndsWith("Result", StringComparison.Ordinal)) return true;
+            if (name.EndsWith("Summary", StringComparison.Ordinal)) return true;
+            if (name.EndsWith("Reference", StringComparison.Ordinal)) return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsRecordType(Type t)
+    {
+        // C# emits a synthetic `EqualityContract` property only on
+        // record types; that's the standard reflection-time signal.
+        if (t.GetProperty("EqualityContract", BindingFlags.NonPublic | BindingFlags.Instance) is not null)
+        {
+            return true;
+        }
+
+        // record struct: detect via the compiler-emitted PrintMembers
+        // method that all records carry.
+        return t.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance) is not null
+            || t.GetMethod("PrintMembers", BindingFlags.Public | BindingFlags.Instance) is not null;
+    }
+
+    private static bool IsRecordSynthetic(PropertyInfo p)
+    {
+        // `EqualityContract` is the only compiler-synthesised public
+        // property on records and is not part of the wire payload.
+        return string.Equals(p.Name, "EqualityContract", StringComparison.Ordinal);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SerializationContractTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SerializationContractTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+/// <summary>
+/// Golden-key assertions on the JSON shape that MCP tool result records
+/// produce on the wire. These tests are deliberately about
+/// <em>property names</em>, not values — they exist so the agent-facing
+/// contract (camelCase keys with units in the suffix) cannot drift
+/// silently.
+/// </summary>
+public class SerializationContractTests
+{
+    private static JsonSerializerOptions CreateWireOptions()
+    {
+        // Mirrors the options shape in
+        // S100McpServerToolFactory.JsonOptions. The factory uses
+        // JsonSerializerDefaults.Web (which sets camelCase naming) and
+        // configures polymorphism on SampledValue with a "$kind"
+        // discriminator. We replicate the full set of SampledValue
+        // variants here so each one's JSON shape can be asserted.
+        return new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver
+            {
+                Modifiers =
+                {
+                    static typeInfo =>
+                    {
+                        if (typeInfo.Type == typeof(SampledValue))
+                        {
+                            typeInfo.PolymorphismOptions = new JsonPolymorphismOptions
+                            {
+                                TypeDiscriminatorPropertyName = "$kind",
+                                DerivedTypes =
+                                {
+                                    new JsonDerivedType(typeof(DepthSample), "depth"),
+                                    new JsonDerivedType(typeof(WaterLevelSample), "waterLevel"),
+                                    new JsonDerivedType(typeof(WaterLevelStationSample), "waterLevelStation"),
+                                    new JsonDerivedType(typeof(SurfaceCurrentSample), "surfaceCurrent"),
+                                    new JsonDerivedType(typeof(SurfaceCurrentStationSample), "surfaceCurrentStation"),
+                                },
+                            };
+                        }
+                    },
+                },
+            },
+        };
+    }
+
+    [Fact]
+    public void ListDatasetsResult_uses_camelCase_and_unambiguous_bbox_keys()
+    {
+        var result = new ListDatasetsResult(
+            ImmutableArray.Create(
+                new DatasetSummary(
+                    new DatasetId("ds-1"),
+                    new SpecRef("S-104", new SpecVersion(1, 0, 0)),
+                    new BoundingBox(southLatitude: 47.0, westLongitude: -123.0, northLatitude: 48.0, eastLongitude: -122.0),
+                    new TimeRange(
+                        new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2025, 1, 2, 0, 0, 0, TimeSpan.Zero)))),
+            Page: 0,
+            PageSize: 50,
+            TotalCount: 1,
+            HasMore: false);
+
+        var json = JsonSerializer.Serialize(result, CreateWireOptions());
+
+        // Outer page envelope.
+        Assert.Contains("\"datasets\":", json);
+        Assert.Contains("\"page\":0", json);
+        Assert.Contains("\"pageSize\":50", json);
+        Assert.Contains("\"totalCount\":1", json);
+        Assert.Contains("\"hasMore\":false", json);
+
+        // Per-dataset summary.
+        Assert.Contains("\"id\":", json);
+        Assert.Contains("\"spec\":", json);
+        Assert.Contains("\"bounds\":", json);
+        Assert.Contains("\"timeRange\":", json);
+
+        // Bounding-box keys must be the unambiguous four-edge form, in
+        // camelCase, never a bare lat/lon pair. This is the single
+        // assertion that the agent-facing dogfooding bug surfaced.
+        Assert.Contains("\"southLatitude\":47", json);
+        Assert.Contains("\"westLongitude\":-123", json);
+        Assert.Contains("\"northLatitude\":48", json);
+        Assert.Contains("\"eastLongitude\":-122", json);
+
+        // SpecRef projects onto camelCase too.
+        Assert.Contains("\"name\":\"S-104\"", json);
+        Assert.Contains("\"edition\":", json);
+        Assert.Contains("\"major\":1", json);
+
+        // TimeRange.
+        Assert.Contains("\"start\":", json);
+        Assert.Contains("\"end\":", json);
+    }
+
+    [Fact]
+    public void DepthSample_serialises_with_kind_discriminator_and_unit_suffix()
+    {
+        var result = new SampleCoverageResult(
+            new DatasetId("ds-1"),
+            Latitude: 47.6,
+            Longitude: -122.3,
+            Value: new DepthSample(DepthMeters: 12.5, UncertaintyMeters: 0.25));
+
+        var json = JsonSerializer.Serialize(result, CreateWireOptions());
+
+        Assert.Contains("\"datasetId\":", json);
+        Assert.Contains("\"latitude\":47.6", json);
+        Assert.Contains("\"longitude\":-122.3", json);
+        Assert.Contains("\"value\":", json);
+        Assert.Contains("\"$kind\":\"depth\"", json);
+        Assert.Contains("\"depthMeters\":12.5", json);
+        Assert.Contains("\"uncertaintyMeters\":0.25", json);
+    }
+
+    [Fact]
+    public void WaterLevelSample_emits_camelCase_with_grid_and_time_fields()
+    {
+        var result = new SampleCoverageResult(
+            new DatasetId("ds-2"),
+            Latitude: 47.6,
+            Longitude: -122.3,
+            Value: new WaterLevelSample(
+                WaterLevelHeight: 1.42,
+                Trend: "increasing",
+                SampleTime: new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                RequestedTime: null,
+                Row: 10,
+                Column: 20,
+                CellCentreLatitude: 47.61,
+                CellCentreLongitude: -122.31));
+
+        var json = JsonSerializer.Serialize(result, CreateWireOptions());
+
+        Assert.Contains("\"$kind\":\"waterLevel\"", json);
+        Assert.Contains("\"waterLevelHeight\":1.42", json);
+        Assert.Contains("\"trend\":\"increasing\"", json);
+        Assert.Contains("\"sampleTime\":", json);
+        Assert.Contains("\"row\":10", json);
+        Assert.Contains("\"column\":20", json);
+        Assert.Contains("\"cellCentreLatitude\":47.61", json);
+        Assert.Contains("\"cellCentreLongitude\":-122.31", json);
+        // RequestedTime null is omitted by the WhenWritingNull policy.
+        Assert.DoesNotContain("\"requestedTime\":null", json);
+    }
+
+    [Fact]
+    public void SurfaceCurrentSample_carries_dual_unit_speed_and_bearing_keys()
+    {
+        var result = new SampleCoverageResult(
+            new DatasetId("ds-3"),
+            Latitude: 47.6,
+            Longitude: -122.3,
+            Value: new SurfaceCurrentSample(
+                SpeedMetresPerSecond: 1.5,
+                SpeedKnots: 2.9157667386609,
+                DirectionDegreesTrue: 270.0,
+                SampleTime: new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                RequestedTime: null,
+                Row: 5,
+                Column: 7,
+                CellCentreLatitude: 47.6,
+                CellCentreLongitude: -122.3));
+
+        var json = JsonSerializer.Serialize(result, CreateWireOptions());
+
+        Assert.Contains("\"$kind\":\"surfaceCurrent\"", json);
+        Assert.Contains("\"speedMetresPerSecond\":1.5", json);
+        Assert.Contains("\"speedKnots\":", json);
+        Assert.Contains("\"directionDegreesTrue\":270", json);
+        Assert.Contains("\"cellCentreLatitude\":", json);
+        Assert.Contains("\"cellCentreLongitude\":", json);
+    }
+
+    [Fact]
+    public void StationSamples_emit_station_distance_and_position_keys()
+    {
+        var wls = new SampleCoverageResult(
+            new DatasetId("ds-4"),
+            Latitude: 47.6,
+            Longitude: -122.3,
+            Value: new WaterLevelStationSample(
+                StationId: "STA-1",
+                StationDistanceMetres: 1234.5,
+                WaterLevelHeight: 1.0,
+                Trend: "steady",
+                SampleTime: new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                RequestedTime: null,
+                StationLatitude: 47.5,
+                StationLongitude: -122.2));
+
+        var json = JsonSerializer.Serialize(wls, CreateWireOptions());
+        Assert.Contains("\"$kind\":\"waterLevelStation\"", json);
+        Assert.Contains("\"stationId\":\"STA-1\"", json);
+        Assert.Contains("\"stationDistanceMetres\":1234.5", json);
+        Assert.Contains("\"stationLatitude\":47.5", json);
+        Assert.Contains("\"stationLongitude\":-122.2", json);
+
+        var scs = new SampleCoverageResult(
+            new DatasetId("ds-5"),
+            Latitude: 47.6,
+            Longitude: -122.3,
+            Value: new SurfaceCurrentStationSample(
+                StationId: "STA-2",
+                StationDistanceMetres: 5000.0,
+                SpeedMetresPerSecond: 2.0,
+                SpeedKnots: 3.88,
+                DirectionDegreesTrue: 180.0,
+                SampleTime: new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                RequestedTime: null,
+                StationLatitude: 47.55,
+                StationLongitude: -122.25));
+
+        var json2 = JsonSerializer.Serialize(scs, CreateWireOptions());
+        Assert.Contains("\"$kind\":\"surfaceCurrentStation\"", json2);
+        Assert.Contains("\"speedMetresPerSecond\":2", json2);
+        Assert.Contains("\"directionDegreesTrue\":180", json2);
+        Assert.Contains("\"stationDistanceMetres\":5000", json2);
+    }
+}


### PR DESCRIPTION
Triggered by real dogfooding: an external agent reading `list_datasets` JSON could not tell whether an S-104 bbox had swapped lat/lon. The values were correct, but the wire shape was ambiguous. This PR is a pure metadata + docs + tests sweep that makes the agent-facing contract unambiguous.

## What changed

**Annotation pass** — added `[System.ComponentModel.Description]` to every public property on every record that crosses the MCP wire (~70 properties):

- `EncDotNet.S100.Core`: `BoundingBox`, `SpecRef`, `SpecVersion`.
- `EncDotNet.S100.Mcp.Tools.Catalog`: `TimeRange`, `DatasetId`, `LoadedDataset`, `DatasetCatalogChangedEventArgs`.
- `EncDotNet.S100.Mcp.Tools`: `ListDatasetsRequest/Result`, `DatasetSummary`, `DescribeFeatureRequest/Result`, `FeatureReference`, `SampleCoverageRequest/Result`, plus all 5 `SampledValue` variants (`DepthSample`, `WaterLevelSample`, `WaterLevelStationSample`, `SurfaceCurrentSample`, `SurfaceCurrentStationSample`).
- `EncDotNet.S100.Mcp.Tools.ToolError`: base type + all 8 variants (type-level descriptions explaining when each is raised + per-ctor-param descriptions for the carried context).

**Tool-level descriptions** tightened in `S100McpServerToolFactory.cs` — each tool's description now spells out what it returns *and* what it doesn't (e.g. `sample_coverage` is nearest-cell, not bbox aggregation).

**JSON name audit**: `S100McpServerToolFactory.JsonOptions` is built from `JsonSerializerDefaults.Web`, which already applies camelCase. Every property therefore serialises as `southLatitude` / `westLongitude` / `northLatitude` / `eastLongitude` / `waterLevelHeight` / `speedMetresPerSecond` / `directionDegreesTrue` / etc. **No `[JsonPropertyName]` renames were needed** — the contract test below pins this.

**Docs**:
- `docs/mcp-server.md` — new "Field conventions" section (CRS, units, JSON naming, `$kind` discriminator, error envelope).
- `src/EncDotNet.S100.Mcp.Tools/README.md` — pointer to the conventions section.

**Tests** (under `tests/EncDotNet.S100.Mcp.Tools.Tests/`):
- `SerializationContractTests` — round-trips `ListDatasetsResult` and `SampleCoverageResult` (with each `SampledValue` variant) through the web JSON options; asserts the golden camelCase keys, the unambiguous bbox keys, and the `$kind` discriminator values (`depth`, `waterLevel`, `waterLevelStation`, `surfaceCurrent`, `surfaceCurrentStation`).
- `AnnotationContractTests` — reflects over wire-crossing types and fails if any public property is missing a non-empty `[Description]`. The predicate iterates assemblies / suffixes so new tools (e.g. `find_at` in a sibling PR) and new `SampledValue` / `ToolError` subtypes are automatically covered.

## Out of scope (explicit)

- No new tools, no new result fields.
- `FindAtTool` (sibling session).
- `S102/S104/S111FeatureDescriber` (sibling session) — the contract tests iterate registered describers reflectively, so they'll pick up siblings on merge.

## Verification

- `dotnet build tests/EncDotNet.S100.Mcp.Tools.Tests/...` — 0 warnings, 0 errors.
- `dotnet test tests/EncDotNet.S100.Mcp.Tools.Tests/...` — **60/60 passed** (54 pre-existing + 6 new).
- `dotnet test tests/EncDotNet.S100.Mcp.Tests/...` — **12/12 passed**.