### PR TITLE
MCP tool surface: Phase 1 (spatial) + Phase 2 (temporal) foundation

### DIFF
--- a/src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/FindAtTool.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
 using EncDotNet.S100.Pipelines;
 
 namespace EncDotNet.S100.Mcp.Tools;
@@ -8,20 +9,29 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// <summary>
 /// Request payload for <see cref="FindAtTool"/>.
 /// </summary>
-/// <param name="Latitude">Query latitude (decimal degrees, WGS-84). Must be in <c>[-90, 90]</c>.</param>
-/// <param name="Longitude">Query longitude (decimal degrees, WGS-84). Must be in <c>[-180, 180]</c>.</param>
+/// <param name="Latitude">Query latitude (decimal degrees, WGS-84). Must be in <c>[-90, 90]</c>. Ignored when <paramref name="Query"/> is supplied.</param>
+/// <param name="Longitude">Query longitude (decimal degrees, WGS-84). Must be in <c>[-180, 180]</c>. Ignored when <paramref name="Query"/> is supplied.</param>
 /// <param name="Spec">Optional spec filter; <c>null</c> matches every spec.</param>
 /// <param name="Page">Zero-based page index.</param>
 /// <param name="PageSize">Page size; clamped to 1..500.</param>
+/// <param name="Query">
+/// Optional richer geographic query (point, bbox, polygon, polyline).
+/// When supplied, takes precedence over <paramref name="Latitude"/> /
+/// <paramref name="Longitude"/>. For point queries the semantics match
+/// the legacy lat/lon path; for bbox/polygon/polyline the tool returns
+/// every dataset whose declared bounding box intersects the query's
+/// coarse bounding box.
+/// </param>
 public sealed record FindAtRequest(
     double Latitude,
     double Longitude,
     SpecRef? Spec = null,
     int Page = 0,
-    int PageSize = 50);
+    int PageSize = 50,
+    GeoQuery? Query = null);
 
 /// <summary>Result of <see cref="FindAtTool"/>.</summary>
-/// <param name="Datasets">Datasets whose declared bounding box contains the query point, in catalog insertion order.</param>
+/// <param name="Datasets">Datasets whose declared bounding box contains or intersects the query, in catalog insertion order.</param>
 /// <param name="Page">Echoed (and floored) page index.</param>
 /// <param name="PageSize">Echoed (and clamped) page size.</param>
 /// <param name="TotalCount">Total number of matching datasets across all pages.</param>
@@ -34,28 +44,33 @@ public sealed record FindAtResult(
     bool HasMore);
 
 /// <summary>
-/// Returns every loaded dataset whose declared bounding box contains the
-/// supplied latitude/longitude point.
+/// Returns every loaded dataset whose declared bounding box intersects
+/// the supplied geographic query.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Containment is evaluated against the dataset's declared bounding box
-/// only — there is no per-cell coverage check, no NoData masking, and no
-/// vector geometry intersection. A positive result means the point lies
-/// within the rectangle <c>[SouthLatitude, NorthLatitude] × [WestLongitude,
-/// EastLongitude]</c>. Actual cell coverage may differ; callers that need
-/// the actual value at the point should follow up with
+/// Intersection is evaluated against the dataset's declared bounding
+/// box only — there is no per-cell coverage check, no NoData masking,
+/// and no vector geometry intersection.
+/// </para>
+/// <para>
+/// For point queries, a positive result means the point lies within
+/// the rectangle <c>[SouthLatitude, NorthLatitude] × [WestLongitude,
+/// EastLongitude]</c>. Actual cell coverage may differ; callers that
+/// need the actual value at the point should follow up with
 /// <see cref="SampleCoverageTool"/>.
 /// </para>
 /// <para>
-/// Bounds are treated as inclusive on every edge, matching
-/// <see cref="SampleCoverageTool"/>'s contains check.
+/// For bbox, polygon, and polyline queries the tool projects the
+/// query to its coarse bounding box (polyline corridors are inflated
+/// by <c>CorridorWidthMeters</c> using an equirectangular
+/// approximation) and returns datasets whose bounds intersect that
+/// rectangle.
 /// </para>
 /// <para>
-/// The current implementation assumes <c>WestLongitude ≤ EastLongitude</c>,
-/// matching <see cref="ListDatasetsTool"/>'s intersection helper. Datasets
-/// whose bounding box crosses the antimeridian (stored with
-/// <c>West &gt; East</c>) will not match. See S-100 Part 10b §6.2.
+/// Bounds are treated as inclusive on every edge. Antimeridian-
+/// crossing dataset bounding boxes (stored with <c>West &gt; East</c>)
+/// will not match; see S-100 Part 10b §6.2.
 /// </para>
 /// </remarks>
 public sealed class FindAtTool
@@ -77,16 +92,33 @@ public sealed class FindAtTool
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (double.IsNaN(request.Latitude) || request.Latitude < -90.0 || request.Latitude > 90.0)
+        // Resolve the spatial query. If the caller supplied a typed
+        // GeoQuery it wins; otherwise we synthesise a point query from
+        // the legacy lat/lon fields.
+        GeoQuery query;
+        if (request.Query is { } supplied)
         {
-            return Task.FromResult(ToolResult<FindAtResult>.Err(
-                new InvalidArgument("latitude", $"value {request.Latitude} is outside the WGS-84 range [-90, 90]")));
+            if (GeoQueryValidator.Validate(supplied) is { } err)
+            {
+                return Task.FromResult(ToolResult<FindAtResult>.Err(err));
+            }
+            query = supplied;
         }
-
-        if (double.IsNaN(request.Longitude) || request.Longitude < -180.0 || request.Longitude > 180.0)
+        else
         {
-            return Task.FromResult(ToolResult<FindAtResult>.Err(
-                new InvalidArgument("longitude", $"value {request.Longitude} is outside the WGS-84 range [-180, 180]")));
+            if (double.IsNaN(request.Latitude) || request.Latitude < -90.0 || request.Latitude > 90.0)
+            {
+                return Task.FromResult(ToolResult<FindAtResult>.Err(
+                    new InvalidArgument("latitude", $"value {request.Latitude} is outside the WGS-84 range [-90, 90]")));
+            }
+
+            if (double.IsNaN(request.Longitude) || request.Longitude < -180.0 || request.Longitude > 180.0)
+            {
+                return Task.FromResult(ToolResult<FindAtResult>.Err(
+                    new InvalidArgument("longitude", $"value {request.Longitude} is outside the WGS-84 range [-180, 180]")));
+            }
+
+            query = new GeoQuery.Point(new GeoPoint(request.Latitude, request.Longitude));
         }
 
         var pageSize = Math.Clamp(request.PageSize, 1, 500);
@@ -101,7 +133,7 @@ public sealed class FindAtTool
                 continue;
             }
 
-            if (!Contains(dataset.Bounds, request.Latitude, request.Longitude))
+            if (!MatchesQuery(dataset.Bounds, query))
             {
                 continue;
             }
@@ -139,9 +171,9 @@ public sealed class FindAtTool
         return filter.Edition == default || actual.Edition == filter.Edition;
     }
 
-    private static bool Contains(BoundingBox b, double lat, double lon) =>
-        lat >= b.SouthLatitude
-        && lat <= b.NorthLatitude
-        && lon >= b.WestLongitude
-        && lon <= b.EastLongitude;
+    private static bool MatchesQuery(BoundingBox bounds, GeoQuery query) => query switch
+    {
+        GeoQuery.Point p => SpatialPredicates.Contains(bounds, p.Value),
+        _ => SpatialPredicates.Intersects(bounds, query),
+    };
 }

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoBoundingBox.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoBoundingBox.cs
@@ -1,0 +1,20 @@
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// A geographic bounding rectangle in WGS-84, expressed as decimal
+/// degrees with inclusive edges.
+/// </summary>
+/// <param name="SouthLatitude">Minimum latitude; must be in <c>[-90, 90]</c>.</param>
+/// <param name="WestLongitude">Minimum longitude; must be in <c>[-180, 180]</c>.</param>
+/// <param name="NorthLatitude">Maximum latitude; must be in <c>[-90, 90]</c> and <c>&gt;= SouthLatitude</c>.</param>
+/// <param name="EastLongitude">Maximum longitude; must be in <c>[-180, 180]</c>. May be less than <c>WestLongitude</c> for antimeridian-crossing boxes (not yet supported by tools).</param>
+/// <remarks>
+/// Mirrors <see cref="EncDotNet.S100.Pipelines.BoundingBox"/> but ships
+/// as an MCP-tool-facing value type. Conversion helpers live on
+/// <see cref="GeoQuery"/>.
+/// </remarks>
+public sealed record GeoBoundingBox(
+    double SouthLatitude,
+    double WestLongitude,
+    double NorthLatitude,
+    double EastLongitude);

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoPoint.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoPoint.cs
@@ -1,0 +1,14 @@
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// A single geographic point in WGS-84, expressed as decimal degrees.
+/// </summary>
+/// <param name="Latitude">Latitude in degrees; valid range <c>[-90, 90]</c>.</param>
+/// <param name="Longitude">Longitude in degrees; valid range <c>[-180, 180]</c>.</param>
+/// <remarks>
+/// Per S-100 Part 10b §6.2 the canonical coordinate order in GML
+/// <c>gml:pos</c> for <c>EPSG:4326</c> is <c>lat lon</c>. This type
+/// matches that convention. Tool requests that accept a
+/// <see cref="GeoPoint"/> validate both components on the way in.
+/// </remarks>
+public sealed record GeoPoint(double Latitude, double Longitude);

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoPolygon.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoPolygon.cs
@@ -1,0 +1,22 @@
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// A simple (non-self-intersecting) geographic polygon, expressed as a
+/// closed ring of WGS-84 points in <c>lat lon</c> order.
+/// </summary>
+/// <param name="Ring">
+/// At least four points (the first and last must be equal). Points are
+/// interpreted as a planar ring on the lat/lon graticule — no
+/// great-circle interpolation is performed.
+/// </param>
+/// <remarks>
+/// Polygon membership in this layer is computed via a planar
+/// ray-casting test against the supplied ring. This is consistent with
+/// the bbox-only spatial filters used elsewhere in the tools surface
+/// and intentionally avoids pulling in a heavier geometry library.
+/// Polygons that span large arcs of latitude or cross the antimeridian
+/// are not supported.
+/// </remarks>
+public sealed record GeoPolygon(ImmutableArray<GeoPoint> Ring);

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoPolyline.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoPolyline.cs
@@ -1,0 +1,26 @@
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// A geographic polyline (open line string) in WGS-84.
+/// </summary>
+/// <param name="Vertices">Ordered list of at least two points in <c>lat lon</c>.</param>
+/// <param name="CorridorWidthMeters">
+/// Optional buffer applied around the line for corridor-style spatial
+/// queries (e.g. "features along this route"). <c>null</c> means
+/// "line only — no buffer". A positive value is interpreted as a
+/// half-width applied symmetrically on both sides.
+/// </param>
+/// <remarks>
+/// Segments are treated as planar in lat/lon space — no great-circle
+/// reprojection. For route-corridor queries the polyline is converted
+/// to a bbox per segment using a fast equirectangular approximation
+/// (1° lat ≈ 111 320 m; 1° lon ≈ 111 320 m · cos(lat)), then
+/// per-feature bbox intersection is used. This is sufficient for
+/// "near this route" coarse filtering and matches the precision of
+/// the underlying spec bounding boxes.
+/// </remarks>
+public sealed record GeoPolyline(
+    ImmutableArray<GeoPoint> Vertices,
+    double? CorridorWidthMeters = null);

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoQuery.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoQuery.cs
@@ -1,0 +1,113 @@
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// Discriminated union over the supported geographic input shapes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tools that accept a spatial parameter take a <see cref="GeoQuery"/>
+/// rather than a bare lat/lon pair so the same wire shape handles
+/// point, bbox, polygon and polyline-with-corridor questions.
+/// </para>
+/// <para>
+/// Every variant projects to a coarse <see cref="GeoBoundingBox"/>
+/// (via <see cref="GetBoundingBox"/>) for use against the
+/// <c>BoundingBox</c>-based filters elsewhere in the catalog. Finer
+/// containment / intersection (ray casting for polygons, per-vertex
+/// expansion for polylines) is delegated to the per-tool consumer.
+/// </para>
+/// </remarks>
+public abstract record GeoQuery
+{
+    private GeoQuery() { }
+
+    /// <summary>Single-point query.</summary>
+    public sealed record Point(GeoPoint Value) : GeoQuery;
+
+    /// <summary>Bounding-box query.</summary>
+    public sealed record Box(GeoBoundingBox Value) : GeoQuery;
+
+    /// <summary>Polygon-membership query.</summary>
+    public sealed record Polygon(GeoPolygon Value) : GeoQuery;
+
+    /// <summary>Polyline / corridor query.</summary>
+    public sealed record Polyline(GeoPolyline Value) : GeoQuery;
+
+    /// <summary>
+    /// Coarse bounding box for the query, suitable for first-pass
+    /// dataset-bounds intersection.
+    /// </summary>
+    public GeoBoundingBox GetBoundingBox() => this switch
+    {
+        Point p => new GeoBoundingBox(
+            p.Value.Latitude,
+            p.Value.Longitude,
+            p.Value.Latitude,
+            p.Value.Longitude),
+        Box b => b.Value,
+        Polygon pg => BoundingBoxOf(pg.Value.Ring),
+        Polyline pl => InflateForCorridor(BoundingBoxOf(pl.Value.Vertices), pl.Value.CorridorWidthMeters),
+        _ => throw new InvalidOperationException("Unknown GeoQuery variant."),
+    };
+
+    /// <summary>Project to the legacy pipeline <see cref="BoundingBox"/> shape.</summary>
+    public BoundingBox ToPipelineBoundingBox()
+    {
+        var b = GetBoundingBox();
+        return new BoundingBox(
+            b.SouthLatitude,
+            b.WestLongitude,
+            b.NorthLatitude,
+            b.EastLongitude);
+    }
+
+    private static GeoBoundingBox BoundingBoxOf(System.Collections.Immutable.ImmutableArray<GeoPoint> points)
+    {
+        if (points.IsDefaultOrEmpty)
+        {
+            return new GeoBoundingBox(0, 0, 0, 0);
+        }
+
+        var south = double.PositiveInfinity;
+        var north = double.NegativeInfinity;
+        var west = double.PositiveInfinity;
+        var east = double.NegativeInfinity;
+
+        foreach (var p in points)
+        {
+            if (p.Latitude < south) south = p.Latitude;
+            if (p.Latitude > north) north = p.Latitude;
+            if (p.Longitude < west) west = p.Longitude;
+            if (p.Longitude > east) east = p.Longitude;
+        }
+
+        return new GeoBoundingBox(south, west, north, east);
+    }
+
+    private static GeoBoundingBox InflateForCorridor(GeoBoundingBox box, double? halfWidthMeters)
+    {
+        if (halfWidthMeters is not { } half || half <= 0)
+        {
+            return box;
+        }
+
+        // Equirectangular approximation. 1° lat ≈ 111 320 m; longitude
+        // shrinks with latitude. Use the polewards-most latitude so the
+        // inflated box never under-covers the corridor.
+        const double MetersPerDegreeLat = 111_320.0;
+        var latPad = half / MetersPerDegreeLat;
+        var refLat = Math.Max(Math.Abs(box.SouthLatitude), Math.Abs(box.NorthLatitude));
+        var cosLat = Math.Cos(refLat * Math.PI / 180.0);
+        var lonPad = cosLat > 1e-9
+            ? half / (MetersPerDegreeLat * cosLat)
+            : 180.0;
+
+        return new GeoBoundingBox(
+            Math.Max(-90.0, box.SouthLatitude - latPad),
+            Math.Max(-180.0, box.WestLongitude - lonPad),
+            Math.Min(90.0, box.NorthLatitude + latPad),
+            Math.Min(180.0, box.EastLongitude + lonPad));
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoQueryValidator.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/GeoQueryValidator.cs
@@ -1,0 +1,147 @@
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// Validates <see cref="GeoQuery"/> inputs against the WGS-84 ranges
+/// and the shape-specific constraints (closed ring, ≥2 vertices, etc.).
+/// </summary>
+/// <remarks>
+/// Returns a typed <see cref="ToolError"/> rather than throwing so
+/// tool implementations can surface the failure through the standard
+/// <see cref="ToolResult{T}"/> pipeline.
+/// </remarks>
+public static class GeoQueryValidator
+{
+    /// <summary>
+    /// Validates <paramref name="query"/>. Returns <c>null</c> when the
+    /// query is well-formed, or an <see cref="InvalidArgument"/> /
+    /// <see cref="GeometryInvalid"/> error otherwise.
+    /// </summary>
+    public static ToolError? Validate(GeoQuery query, string parameterName = "query")
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(parameterName);
+
+        return query switch
+        {
+            GeoQuery.Point p => ValidatePoint(p.Value, parameterName),
+            GeoQuery.Box b => ValidateBox(b.Value, parameterName),
+            GeoQuery.Polygon pg => ValidatePolygon(pg.Value, parameterName),
+            GeoQuery.Polyline pl => ValidatePolyline(pl.Value, parameterName),
+            _ => new InvalidArgument(parameterName, "unknown GeoQuery variant"),
+        };
+    }
+
+    private static ToolError? ValidatePoint(GeoPoint point, string parameterName)
+    {
+        if (!IsValidLat(point.Latitude))
+        {
+            return new InvalidArgument(
+                $"{parameterName}.latitude",
+                $"value {point.Latitude} is outside the WGS-84 range [-90, 90]");
+        }
+
+        if (!IsValidLon(point.Longitude))
+        {
+            return new InvalidArgument(
+                $"{parameterName}.longitude",
+                $"value {point.Longitude} is outside the WGS-84 range [-180, 180]");
+        }
+
+        return null;
+    }
+
+    private static ToolError? ValidateBox(GeoBoundingBox box, string parameterName)
+    {
+        if (!IsValidLat(box.SouthLatitude) || !IsValidLat(box.NorthLatitude))
+        {
+            return new InvalidArgument(
+                parameterName,
+                "latitude bounds must be within the WGS-84 range [-90, 90]");
+        }
+
+        if (!IsValidLon(box.WestLongitude) || !IsValidLon(box.EastLongitude))
+        {
+            return new InvalidArgument(
+                parameterName,
+                "longitude bounds must be within the WGS-84 range [-180, 180]");
+        }
+
+        if (box.NorthLatitude < box.SouthLatitude)
+        {
+            return new GeometryInvalid(
+                parameterName,
+                $"north latitude {box.NorthLatitude} is south of south latitude {box.SouthLatitude}");
+        }
+
+        // Antimeridian-crossing boxes (west > east) are not supported by
+        // the current tool implementations and are flagged so callers
+        // get a clear error rather than silently empty results.
+        if (box.EastLongitude < box.WestLongitude)
+        {
+            return new GeometryInvalid(
+                parameterName,
+                "antimeridian-crossing bounding boxes (west > east) are not supported");
+        }
+
+        return null;
+    }
+
+    private static ToolError? ValidatePolygon(GeoPolygon polygon, string parameterName)
+    {
+        if (polygon.Ring.IsDefaultOrEmpty || polygon.Ring.Length < 4)
+        {
+            return new GeometryInvalid(
+                parameterName,
+                "polygon ring must contain at least four points");
+        }
+
+        foreach (var p in polygon.Ring)
+        {
+            if (ValidatePoint(p, parameterName) is { } err)
+            {
+                return err;
+            }
+        }
+
+        var first = polygon.Ring[0];
+        var last = polygon.Ring[^1];
+        if (first.Latitude != last.Latitude || first.Longitude != last.Longitude)
+        {
+            return new GeometryInvalid(
+                parameterName,
+                "polygon ring must be closed (first and last point must be equal)");
+        }
+
+        return null;
+    }
+
+    private static ToolError? ValidatePolyline(GeoPolyline polyline, string parameterName)
+    {
+        if (polyline.Vertices.IsDefaultOrEmpty || polyline.Vertices.Length < 2)
+        {
+            return new GeometryInvalid(
+                parameterName,
+                "polyline must contain at least two vertices");
+        }
+
+        foreach (var p in polyline.Vertices)
+        {
+            if (ValidatePoint(p, parameterName) is { } err)
+            {
+                return err;
+            }
+        }
+
+        if (polyline.CorridorWidthMeters is { } width && (double.IsNaN(width) || width < 0))
+        {
+            return new InvalidArgument(
+                $"{parameterName}.corridorWidthMeters",
+                $"value {width} must be null or non-negative");
+        }
+
+        return null;
+    }
+
+    private static bool IsValidLat(double v) => !double.IsNaN(v) && v >= -90.0 && v <= 90.0;
+    private static bool IsValidLon(double v) => !double.IsNaN(v) && v >= -180.0 && v <= 180.0;
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Geometry/SpatialPredicates.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Geometry/SpatialPredicates.cs
@@ -1,0 +1,81 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Geometry;
+
+/// <summary>
+/// Static spatial predicates shared by every tool that accepts a
+/// <see cref="GeoQuery"/>. All predicates operate in planar
+/// lat/lon space and treat bounding-box edges as inclusive.
+/// </summary>
+public static class SpatialPredicates
+{
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="box"/> intersects (or
+    /// touches) <paramref name="query"/>'s coarse bounding box.
+    /// </summary>
+    public static bool Intersects(BoundingBox box, GeoQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(box);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var q = query.GetBoundingBox();
+        return box.WestLongitude <= q.EastLongitude
+            && box.EastLongitude >= q.WestLongitude
+            && box.SouthLatitude <= q.NorthLatitude
+            && box.NorthLatitude >= q.SouthLatitude;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="box"/> contains every
+    /// point of <paramref name="query"/>'s coarse bounding box. Used
+    /// by point-style queries where the query bbox collapses to the
+    /// point itself.
+    /// </summary>
+    public static bool Contains(BoundingBox box, GeoPoint point)
+    {
+        ArgumentNullException.ThrowIfNull(box);
+        ArgumentNullException.ThrowIfNull(point);
+
+        return point.Latitude >= box.SouthLatitude
+            && point.Latitude <= box.NorthLatitude
+            && point.Longitude >= box.WestLongitude
+            && point.Longitude <= box.EastLongitude;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="point"/> lies inside
+    /// the polygon <paramref name="ring"/>, using a planar ray-casting
+    /// test. Points on the ring boundary are reported as inside.
+    /// </summary>
+    public static bool ContainsPoint(ImmutableArray<GeoPoint> ring, GeoPoint point)
+    {
+        ArgumentNullException.ThrowIfNull(point);
+
+        if (ring.IsDefaultOrEmpty || ring.Length < 4)
+        {
+            return false;
+        }
+
+        var x = point.Longitude;
+        var y = point.Latitude;
+        var inside = false;
+
+        for (int i = 0, j = ring.Length - 2; i < ring.Length - 1; j = i++)
+        {
+            var xi = ring[i].Longitude;
+            var yi = ring[i].Latitude;
+            var xj = ring[j].Longitude;
+            var yj = ring[j].Latitude;
+
+            var intersect = ((yi > y) != (yj > y))
+                && (x < (xj - xi) * (y - yi) / ((yj - yi) == 0 ? 1e-12 : (yj - yi)) + xi);
+            if (intersect)
+            {
+                inside = !inside;
+            }
+        }
+
+        return inside;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/ListSpecsTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ListSpecsTool.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>Request payload for <see cref="ListSpecsTool"/>.</summary>
+public sealed record ListSpecsRequest();
+
+/// <summary>
+/// Per-spec summary returned by <see cref="ListSpecsTool"/>.
+/// </summary>
+/// <param name="Name">Canonical spec name (<c>"S-NNN"</c>).</param>
+/// <param name="LoadedDatasetCount">Number of datasets of this spec currently loaded.</param>
+/// <param name="Capabilities">
+/// Capability flags advertising which tools the agent can productively
+/// invoke against this spec in the current session.
+/// </param>
+public sealed record SpecSummary(
+    string Name,
+    int LoadedDatasetCount,
+    SpecCapabilities Capabilities);
+
+/// <summary>
+/// Per-spec capability flags. All flags are conservative — they reflect
+/// what the codebase actually implements today, not what the spec
+/// *could* in principle support.
+/// </summary>
+/// <param name="CanQueryFeatures">
+/// <c>true</c> when <see cref="QueryFeaturesTool"/> can enumerate
+/// features for this spec (i.e. the spec is a GML-encoded vector
+/// product whose <c>LoadedDatasetData</c> variant is wired into
+/// <c>GmlFeatureAccessor</c>).
+/// </param>
+/// <param name="CanDescribeFeature">
+/// <c>true</c> when <see cref="DescribeFeatureTool"/> has a describer
+/// registered in <see cref="Spec.FeatureDescriberRegistry.Default"/>
+/// for this spec.
+/// </param>
+/// <param name="CanSampleCoverage">
+/// <c>true</c> when <see cref="SampleCoverageTool"/> can sample a
+/// scalar / vector value at a point for this spec.
+/// </param>
+public sealed record SpecCapabilities(
+    bool CanQueryFeatures,
+    bool CanDescribeFeature,
+    bool CanSampleCoverage);
+
+/// <summary>Result of <see cref="ListSpecsTool"/>.</summary>
+public sealed record ListSpecsResult(ImmutableArray<SpecSummary> Specs);
+
+/// <summary>
+/// Returns the product specifications this MCP-tools assembly knows
+/// about, the number of datasets of each spec currently loaded, and
+/// per-spec capability flags. Helps the agent introspect what tools
+/// are productive against the current session before issuing them.
+/// </summary>
+/// <remarks>
+/// The catalogue of known specs is fixed by the assembly (matches the
+/// product set under <c>src/EncDotNet.S100.Datasets.*/</c>). Datasets
+/// of unknown specs that somehow appear in the catalog are still
+/// surfaced — the summary list is the union of the known-spec list
+/// and the spec names observed in the catalog snapshot.
+/// </remarks>
+public sealed class ListSpecsTool
+{
+    /// <summary>Tool name used in error payloads.</summary>
+    public const string Name = "list_specs";
+
+    // Canonical list of spec names this assembly ships support for.
+    // Update in lockstep with EncDotNet.S100.Datasets.* projects.
+    private static readonly string[] KnownSpecs =
+    [
+        "S-101",
+        "S-102",
+        "S-104",
+        "S-111",
+        "S-122",
+        "S-124",
+        "S-125",
+        "S-127",
+        "S-128",
+        "S-129",
+        "S-131",
+        "S-201",
+        "S-411",
+        "S-421",
+    ];
+
+    // Specs whose features are exposed via the shared IGmlFeature
+    // interface and addressable by QueryFeaturesTool. Must match the
+    // switch arms in Spec.GmlFeatureAccessor.GetFeatures.
+    private static readonly HashSet<string> GmlVectorSpecs = new(StringComparer.Ordinal)
+    {
+        "S-122", "S-124", "S-125", "S-127", "S-128",
+        "S-129", "S-131", "S-201", "S-411", "S-421",
+    };
+
+    // Specs SampleCoverageTool routes to a sampler.
+    private static readonly HashSet<string> CoverageSpecs = new(StringComparer.Ordinal)
+    {
+        "S-102", "S-104", "S-111",
+    };
+
+    // Specs with a registered describer.
+    private static readonly HashSet<string> DescribableSpecs = new(StringComparer.Ordinal)
+    {
+        "S-101", "S-102", "S-104", "S-111", "S-124",
+        "S-122", "S-125", "S-127", "S-128", "S-129",
+        "S-131", "S-201", "S-411", "S-421",
+    };
+
+    private readonly IDatasetCatalog _catalog;
+
+    /// <summary>Creates a new <see cref="ListSpecsTool"/>.</summary>
+    public ListSpecsTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<ListSpecsResult>> InvokeAsync(
+        ListSpecsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var snapshot = _catalog.Datasets;
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var dataset in snapshot)
+        {
+            counts.TryGetValue(dataset.Spec.Name, out var count);
+            counts[dataset.Spec.Name] = count + 1;
+        }
+
+        var names = new SortedSet<string>(KnownSpecs, StringComparer.Ordinal);
+        foreach (var k in counts.Keys) names.Add(k);
+
+        var summaries = ImmutableArray.CreateBuilder<SpecSummary>(names.Count);
+        foreach (var name in names)
+        {
+            counts.TryGetValue(name, out var loaded);
+            var caps = new SpecCapabilities(
+                CanQueryFeatures: GmlVectorSpecs.Contains(name),
+                CanDescribeFeature: DescribableSpecs.Contains(name),
+                CanSampleCoverage: CoverageSpecs.Contains(name));
+            summaries.Add(new SpecSummary(name, loaded, caps));
+        }
+
+        return Task.FromResult(ToolResult<ListSpecsResult>.Ok(
+            new ListSpecsResult(summaries.MoveToImmutable())));
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/QueryFeaturesTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/QueryFeaturesTool.cs
@@ -1,0 +1,196 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Spec;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>
+/// Request payload for <see cref="QueryFeaturesTool"/>.
+/// </summary>
+/// <param name="Query">
+/// The geographic query. All four <see cref="GeoQuery"/> variants are
+/// supported; intersection is computed against each feature's bounding
+/// box (no full polygon intersection).
+/// </param>
+/// <param name="Spec">
+/// Optional spec filter. When supplied, only loaded datasets whose
+/// spec name (and optionally edition) match are queried. A
+/// <c>default</c> edition matches every edition of the same spec name.
+/// </param>
+/// <param name="FeatureType">
+/// Optional case-sensitive feature-type filter (the GML element local
+/// name, e.g. <c>NavwarnPart</c>, <c>BuoyLateral</c>, <c>Berth</c>).
+/// </param>
+/// <param name="Page">Zero-based page index.</param>
+/// <param name="PageSize">Page size; clamped to 1..500.</param>
+public sealed record QueryFeaturesRequest(
+    GeoQuery Query,
+    SpecRef? Spec = null,
+    string? FeatureType = null,
+    int Page = 0,
+    int PageSize = 50);
+
+/// <summary>
+/// Per-feature summary returned by <see cref="QueryFeaturesTool"/>.
+/// </summary>
+/// <param name="DatasetId">Dataset the feature belongs to.</param>
+/// <param name="Spec">Spec the dataset declares.</param>
+/// <param name="FeatureId">Stable feature identifier (<c>gml:id</c>).</param>
+/// <param name="FeatureType">Feature type code (the GML element local name).</param>
+/// <param name="Bounds">Bounding box of the feature's geometry, or <c>null</c> if the feature carries no geometry.</param>
+public sealed record FeatureMatch(
+    DatasetId DatasetId,
+    SpecRef Spec,
+    string FeatureId,
+    string FeatureType,
+    BoundingBox? Bounds);
+
+/// <summary>Result of <see cref="QueryFeaturesTool"/>.</summary>
+public sealed record QueryFeaturesResult(
+    ImmutableArray<FeatureMatch> Features,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    bool HasMore);
+
+/// <summary>
+/// Returns features from loaded GML-encoded vector datasets whose
+/// geometry intersects the supplied geographic query.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This tool works against every GML-encoded spec the codebase
+/// supports — S-122, S-124, S-125, S-127, S-128, S-129, S-131,
+/// S-201, S-411, S-421 — via the shared <see cref="IGmlFeature"/>
+/// abstraction. Coverage products (S-102, S-104, S-111) and the
+/// ISO 8211-encoded S-101 are not queried; use
+/// <see cref="SampleCoverageTool"/> or <see cref="FindAtTool"/>
+/// for those.
+/// </para>
+/// <para>
+/// Intersection is computed at bounding-box precision per feature.
+/// Features with no geometry at all (e.g. container-style features
+/// such as <c>S131:Authority</c>) are not returned even when their
+/// dataset's bounds intersect the query.
+/// </para>
+/// <para>
+/// First-pass filtering uses the dataset-level bounding box; datasets
+/// whose declared bounds are disjoint from the query bbox are skipped
+/// without enumerating their features.
+/// </para>
+/// </remarks>
+public sealed class QueryFeaturesTool
+{
+    /// <summary>Tool name used in <see cref="SpecNotSupportedForTool"/> errors.</summary>
+    public const string Name = "query_features";
+
+    private readonly IDatasetCatalog _catalog;
+
+    /// <summary>Creates a new <see cref="QueryFeaturesTool"/>.</summary>
+    public QueryFeaturesTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<QueryFeaturesResult>> InvokeAsync(
+        QueryFeaturesRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (request.Query is null)
+        {
+            return Task.FromResult(ToolResult<QueryFeaturesResult>.Err(
+                new InvalidArgument("query", "must be supplied")));
+        }
+
+        if (GeoQueryValidator.Validate(request.Query) is { } err)
+        {
+            return Task.FromResult(ToolResult<QueryFeaturesResult>.Err(err));
+        }
+
+        var pageSize = Math.Clamp(request.PageSize, 1, 500);
+        var page = Math.Max(0, request.Page);
+
+        var snapshot = _catalog.Datasets;
+        var matched = ImmutableArray.CreateBuilder<FeatureMatch>();
+
+        foreach (var dataset in snapshot)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (request.Spec is { } spec && !SpecMatches(dataset.Spec, spec))
+            {
+                continue;
+            }
+
+            // Coarse skip: if the dataset's declared bounds are disjoint
+            // from the query, no feature in it can match either.
+            if (!SpatialPredicates.Intersects(dataset.Bounds, request.Query))
+            {
+                continue;
+            }
+
+            var features = GmlFeatureAccessor.GetFeatures(dataset);
+            if (features is null)
+            {
+                continue;
+            }
+
+            foreach (var feature in features)
+            {
+                if (request.FeatureType is { } ft
+                    && !string.Equals(feature.FeatureType, ft, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!GmlFeatureGeometry.Intersects(feature, request.Query))
+                {
+                    continue;
+                }
+
+                matched.Add(new FeatureMatch(
+                    dataset.Id,
+                    dataset.Spec,
+                    feature.Id,
+                    feature.FeatureType,
+                    GmlFeatureGeometry.TryGetBoundingBox(feature)));
+            }
+        }
+
+        var totalCount = matched.Count;
+        var skip = page * pageSize;
+        var take = Math.Max(0, Math.Min(pageSize, totalCount - skip));
+        var pageBuilder = ImmutableArray.CreateBuilder<FeatureMatch>(take);
+        for (var i = 0; i < take; i++)
+        {
+            pageBuilder.Add(matched[skip + i]);
+        }
+
+        var hasMore = skip + take < totalCount;
+        return Task.FromResult(ToolResult<QueryFeaturesResult>.Ok(
+            new QueryFeaturesResult(
+                pageBuilder.MoveToImmutable(),
+                page,
+                pageSize,
+                totalCount,
+                hasMore)));
+    }
+
+    private static bool SpecMatches(SpecRef actual, SpecRef filter)
+    {
+        if (!string.Equals(actual.Name, filter.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return filter.Edition == default || actual.Edition == filter.Edition;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -174,6 +174,7 @@ return `SpecNotSupportedForTool`.
 ```csharp
 using EncDotNet.S100.Mcp.Tools;
 using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
 
 // A host (e.g. the viewer) implements IDatasetCatalog and publishes
 // LoadedDataset instances whenever its loaded set changes.
@@ -183,6 +184,7 @@ var list = new ListDatasetsTool(catalog);
 var describe = new DescribeFeatureTool(catalog);
 var sample = new SampleCoverageTool(catalog);
 var findAt = new FindAtTool(catalog);
+var queryFeatures = new QueryFeaturesTool(catalog);
 
 var listed = await list.InvokeAsync(new ListDatasetsRequest());
 if (listed.TryGetValue(out var summary))
@@ -214,6 +216,24 @@ var depth = await sample.InvokeAsync(new SampleCoverageRequest(
 if (depth.TryGetValue(out var ok) && ok.Value is DepthSample d)
 {
     Console.WriteLine($"Depth at point: {d.DepthMeters} m");
+}
+
+// What GML features overlap a bounding box? query_features works across
+// every GML-encoded spec (S-122/S-124/S-125/S-127/S-128/S-129/S-131/
+// S-201/S-411/S-421) via the shared IGmlFeature abstraction. Pass any
+// GeoQuery variant — point, bbox, polygon, or polyline (with optional
+// corridor width). Results are paginated.
+var features = await queryFeatures.InvokeAsync(new QueryFeaturesRequest(
+    new GeoQuery.Box(new GeoBoundingBox(47.5, -122.5, 47.7, -122.2)),
+    Spec: new SpecRef("S-124", default),       // any S-124 edition
+    FeatureType: "NavwarnPart",
+    PageSize: 50));
+if (features.TryGetValue(out var page))
+{
+    foreach (var match in page.Features)
+    {
+        Console.WriteLine($"{match.Spec} {match.FeatureType} {match.FeatureId}");
+    }
 }
 ```
 

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -244,5 +244,8 @@ if (features.TryGetValue(out var page))
 - Pan/zoom/screenshot tools.
 - Search / NL tools.
 - Write-back tools.
-- Comprehensive feature describer coverage for every spec.
+- Comprehensive xlink reference resolution for backfilled describers
+  (S-122/S-125/S-127/S-128/S-129/S-131/S-201/S-411/S-421 return their
+  feature attributes via the generic `GmlFeatureDescriber`, but
+  references arrive as an empty list pending per-spec resolution).
 - S-104 / S-111 sampling (only S-102 is wired end-to-end).

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -37,10 +37,44 @@ The project intentionally has **no MCP SDK, no Avalonia, and no viewer
 reference**. The same tool surface can therefore be hosted by a CLI, a
 headless service, or a different viewer in the future.
 
-## `IDatasetCatalog`
+## Geometry primitives
 
-The abstraction is in `EncDotNet.S100.Mcp.Tools.Catalog` and exposes a
-single property + an event:
+Spatial inputs to tools are typed as `GeoQuery`, a discriminated union
+over the four shapes the surface needs:
+
+| Variant            | Carries                                | Use case                              |
+|--------------------|----------------------------------------|---------------------------------------|
+| `GeoQuery.Point`    | `GeoPoint(lat, lon)`                   | "at this position"                    |
+| `GeoQuery.Box`      | `GeoBoundingBox(s, w, n, e)`           | "within this rectangle"               |
+| `GeoQuery.Polygon`  | `GeoPolygon(closed ring of GeoPoints)` | "inside this area"                    |
+| `GeoQuery.Polyline` | `GeoPolyline(vertices, corridorWidthMeters?)` | "along this route / line"     |
+
+Every variant projects to a coarse `GeoBoundingBox` via
+`GetBoundingBox()`. Polylines with a non-null `CorridorWidthMeters`
+inflate the bbox by an equirectangular metres-to-degrees
+approximation; this is suitable for "near this route" coarse filtering
+and matches the precision of the underlying dataset bounding boxes.
+
+All inputs are validated with `GeoQueryValidator.Validate(...)`, which
+returns:
+
+- `null` on success;
+- `InvalidArgument` for a scalar that's out of range (lat/lon, NaN,
+  negative corridor width);
+- `GeometryInvalid` for a composite-shape failure (unclosed polygon
+  ring, polygon with < 4 points, polyline with < 2 vertices, inverted
+  bounding box, antimeridian-crossing bounding box).
+
+`SpatialPredicates` exposes the planar primitives every tool reuses:
+`Intersects(box, GeoQuery)`, `Contains(box, GeoPoint)`, and
+`ContainsPoint(polygonRing, GeoPoint)` (ray-cast).
+
+The legacy `FindAtRequest(Latitude, Longitude, ...)` shape continues
+to work; tools that accept a `GeoQuery` carry it as an optional
+`Query` property that, when supplied, takes precedence over the
+scalar lat/lon fields.
+
+## `IDatasetCatalog`
 
 ```csharp
 public interface IDatasetCatalog
@@ -110,6 +144,7 @@ The five error variants implemented in this PR:
 | `feature_not_found`           | The named feature is not present in the named dataset.                |
 | `spec_not_supported_for_tool` | The tool does not (yet) support the requested spec.                   |
 | `invalid_argument`            | A request property failed validation (e.g. latitude / longitude out of WGS-84 range). |
+| `geometry_invalid`            | A composite-shape input failed validation (unclosed polygon ring, antimeridian-crossing bbox, etc.). |
 
 ## Spec strategy pattern
 

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -183,6 +183,7 @@ IDatasetCatalog catalog = host.Catalog;
 var list = new ListDatasetsTool(catalog);
 var describe = new DescribeFeatureTool(catalog);
 var sample = new SampleCoverageTool(catalog);
+var sampleAlong = new SampleCoverageAlongTool(catalog);
 var findAt = new FindAtTool(catalog);
 var queryFeatures = new QueryFeaturesTool(catalog);
 
@@ -235,6 +236,27 @@ if (features.TryGetValue(out var page))
         Console.WriteLine($"{match.Spec} {match.FeatureType} {match.FeatureId}");
     }
 }
+
+// Sample a coverage product at every vertex of a polyline. Useful for
+// route-level questions like "minimum depth along this leg" or "max
+// current speed along this transit". Per-vertex misses (OutOfBounds /
+// NoDataAtPoint) surface as null entries rather than aborting the
+// whole call, so a partial route still returns usable data.
+var route = new GeoPolyline(ImmutableArray.Create(
+    new GeoPoint(47.60, -122.35),
+    new GeoPoint(47.62, -122.33),
+    new GeoPoint(47.64, -122.31)));
+var depths = await sampleAlong.InvokeAsync(new SampleCoverageAlongRequest(
+    new SpecRef("S-102", new SpecVersion(2, 1, 0)),
+    route));
+if (depths.TryGetValue(out var series))
+{
+    foreach (var s in series.Samples)
+    {
+        var d = s.Result?.Value as DepthSample;
+        Console.WriteLine($"v{s.VertexIndex} depth={d?.DepthMeters}m");
+    }
+}
 ```
 
 ## Out of scope (PR MCP-1)
@@ -248,4 +270,3 @@ if (features.TryGetValue(out var page))
   (S-122/S-125/S-127/S-128/S-129/S-131/S-201/S-411/S-421 return their
   feature attributes via the generic `GmlFeatureDescriber`, but
   references arrive as an empty list pending per-spec resolution).
-- S-104 / S-111 sampling (only S-102 is wired end-to-end).

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageAlongTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageAlongTool.cs
@@ -1,0 +1,144 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>
+/// Request payload for <see cref="SampleCoverageAlongTool"/>.
+/// </summary>
+/// <param name="Spec">The coverage spec to sample (<c>S-102</c>, <c>S-104</c>, or <c>S-111</c>).</param>
+/// <param name="Polyline">
+/// The polyline to sample. Each vertex is sampled at the supplied
+/// coordinate; the polyline's <c>CorridorWidthMeters</c> is ignored
+/// (corridor width applies to membership queries, not point sampling).
+/// </param>
+/// <param name="Time">
+/// Optional time selector for time-varying products (S-104, S-111).
+/// Applied identically to every vertex — useful for "depth/level at
+/// each waypoint at the same instant" queries. Ignored for S-102.
+/// </param>
+public sealed record SampleCoverageAlongRequest(
+    SpecRef Spec,
+    GeoPolyline Polyline,
+    DateTimeOffset? Time = null);
+
+/// <summary>
+/// A single sample along the polyline.
+/// </summary>
+/// <param name="VertexIndex">Zero-based index of the vertex in the request polyline.</param>
+/// <param name="Latitude">Latitude of the vertex.</param>
+/// <param name="Longitude">Longitude of the vertex.</param>
+/// <param name="Result">
+/// The per-vertex sample result. <c>null</c> when no dataset of the
+/// requested spec covers this vertex (or the spec returned
+/// <c>OutOfBounds</c>/<c>NoDataAtPoint</c>); the agent should treat a
+/// <c>null</c> entry as "no value available at this position" and
+/// continue with the remaining vertices.
+/// </param>
+public sealed record CoverageSampleAlong(
+    int VertexIndex,
+    double Latitude,
+    double Longitude,
+    SampleCoverageResult? Result);
+
+/// <summary>Result of <see cref="SampleCoverageAlongTool"/>.</summary>
+/// <param name="Spec">The spec that was sampled.</param>
+/// <param name="Samples">One entry per polyline vertex, in input order.</param>
+public sealed record SampleCoverageAlongResult(
+    SpecRef Spec,
+    ImmutableArray<CoverageSampleAlong> Samples);
+
+/// <summary>
+/// Samples a coverage product (<see cref="SampleCoverageTool"/>) at
+/// every vertex of a polyline, returning per-vertex results in input
+/// order. Per-vertex failures are tolerated — only request-level
+/// failures (invalid geometry, unsupported spec) bubble up as
+/// <see cref="ToolError"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This tool composes <see cref="SampleCoverageTool"/>: each vertex is
+/// sampled independently. It is the natural primitive behind questions
+/// like "minimum depth along this route leg" and "max current speed
+/// along this transit". Aggregation (min/max/mean) is intentionally
+/// not performed here — the agent can compute it from
+/// <see cref="SampleCoverageAlongResult.Samples"/>.
+/// </para>
+/// <para>
+/// The polyline is sampled at its supplied vertices only. Callers that
+/// want denser sampling should subdivide the polyline before calling
+/// (a future <c>sample_coverage_along_dense</c> tool may automate
+/// this).
+/// </para>
+/// </remarks>
+public sealed class SampleCoverageAlongTool
+{
+    /// <summary>Tool name used in error payloads.</summary>
+    public const string Name = "sample_coverage_along";
+
+    private readonly SampleCoverageTool _sampler;
+
+    /// <summary>Creates a new <see cref="SampleCoverageAlongTool"/>.</summary>
+    public SampleCoverageAlongTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _sampler = new SampleCoverageTool(catalog);
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public async Task<ToolResult<SampleCoverageAlongResult>> InvokeAsync(
+        SampleCoverageAlongRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (request.Polyline is null)
+        {
+            return ToolResult<SampleCoverageAlongResult>.Err(
+                new InvalidArgument("polyline", "must be supplied"));
+        }
+
+        // Reuse the same validation that GeoQuery does for polylines.
+        var asQuery = new GeoQuery.Polyline(request.Polyline);
+        if (GeoQueryValidator.Validate(asQuery) is { } err)
+        {
+            return ToolResult<SampleCoverageAlongResult>.Err(err);
+        }
+
+        var vertices = request.Polyline.Vertices;
+        var samples = ImmutableArray.CreateBuilder<CoverageSampleAlong>(vertices.Length);
+
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var v = vertices[i];
+            var inner = await _sampler.InvokeAsync(
+                new SampleCoverageRequest(request.Spec, v.Latitude, v.Longitude, request.Time),
+                cancellationToken).ConfigureAwait(false);
+
+            // Request-level errors (unsupported spec) propagate; per-
+            // vertex misses (OutOfBounds / NoDataAtPoint / NoDatasetCoversPoint)
+            // surface as null entries so a partial route still returns
+            // usable data.
+            if (inner.TryGetError(out var innerErr))
+            {
+                if (innerErr is SpecNotSupportedForTool)
+                {
+                    return ToolResult<SampleCoverageAlongResult>.Err(innerErr);
+                }
+
+                samples.Add(new CoverageSampleAlong(i, v.Latitude, v.Longitude, null));
+                continue;
+            }
+
+            inner.TryGetValue(out var value);
+            samples.Add(new CoverageSampleAlong(i, v.Latitude, v.Longitude, value));
+        }
+
+        return ToolResult<SampleCoverageAlongResult>.Ok(
+            new SampleCoverageAlongResult(request.Spec, samples.MoveToImmutable()));
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
@@ -29,6 +29,15 @@ public sealed class FeatureDescriberRegistry
         new S104FeatureDescriber(),
         new S111FeatureDescriber(),
         new S124FeatureDescriber(),
+        new GmlFeatureDescriber("S-122"),
+        new GmlFeatureDescriber("S-125"),
+        new GmlFeatureDescriber("S-127"),
+        new GmlFeatureDescriber("S-128"),
+        new GmlFeatureDescriber("S-129"),
+        new GmlFeatureDescriber("S-131"),
+        new GmlFeatureDescriber("S-201"),
+        new GmlFeatureDescriber("S-411"),
+        new GmlFeatureDescriber("S-421"),
     ]);
 
     internal ISpecFeatureDescriber? Get(string specName) =>

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureAccessor.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureAccessor.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Extracts the GML feature collection from a <see cref="LoadedDataset"/>.
+/// Every GML-encoded S-100 spec implemented in this codebase models its
+/// features as <see cref="IGmlFeature"/>, so a single accessor — rather
+/// than per-spec strategies — can power generic feature-query tools.
+/// </summary>
+/// <remarks>
+/// Returns <c>null</c> for catalog entries that are not GML feature
+/// collections (coverage products S-102 / S-104 / S-111 and the
+/// ISO 8211-encoded S-101). Callers should treat <c>null</c> as
+/// "this spec does not contribute to GML feature queries".
+/// </remarks>
+public static class GmlFeatureAccessor
+{
+    /// <summary>
+    /// Returns the GML features for the supplied dataset, or <c>null</c>
+    /// if the dataset's payload is not a GML feature collection.
+    /// </summary>
+    public static IEnumerable<IGmlFeature>? GetFeatures(LoadedDataset dataset)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return dataset.Data switch
+        {
+            S122DatasetData s122 => s122.Model.Features,
+            S124DatasetData s124 => s124.Model.Features,
+            S125DatasetData s125 => s125.Model.Features,
+            S127DatasetData s127 => s127.Model.Features,
+            S128DatasetData s128 => s128.Model.Features,
+            S129DatasetData s129 => s129.Model.Features,
+            S131DatasetData s131 => s131.Model.Features,
+            S201DatasetData s201 => s201.Model.Features,
+            S411DatasetData s411 => s411.Model.Features,
+            S421DatasetData s421 => s421.Model.Features,
+            _ => null,
+        };
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureDescriber.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Generic describer for GML-encoded specs that expose their features
+/// via <see cref="IGmlFeature"/> through <see cref="GmlFeatureAccessor"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One instance is registered per spec name (S-122, S-125, S-127,
+/// S-128, S-129, S-131, S-201, S-411, S-421). The describer serialises
+/// the feature's identity, type, geometry kind, simple attributes, and
+/// complex attributes — the minimum set of information an agent needs
+/// after locating features with <see cref="QueryFeaturesTool"/>.
+/// </para>
+/// <para>
+/// References (xlink:href cross-feature bindings) are intentionally
+/// returned as <see cref="ImmutableArray{T}.Empty"/> here because each
+/// spec models references with its own type
+/// (<c>S125InformationReference</c>, <c>S131Reference</c>,
+/// <c>S201FeatureReference</c>, …) and unifying them requires a
+/// follow-up slice. S-124 — which carries <c>GmlReference</c>-shaped
+/// references with full cross-dataset resolution — keeps its
+/// purpose-built <see cref="S124FeatureDescriber"/>.
+/// </para>
+/// </remarks>
+internal sealed class GmlFeatureDescriber : ISpecFeatureDescriber
+{
+    public string SpecName { get; }
+
+    public GmlFeatureDescriber(string specName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(specName);
+        SpecName = specName;
+    }
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        var features = GmlFeatureAccessor.GetFeatures(context.Dataset);
+        if (features is null)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+        }
+
+        IGmlFeature? feature = null;
+        foreach (var f in features)
+        {
+            if (string.Equals(f.Id, context.FeatureId, StringComparison.Ordinal))
+            {
+                feature = f;
+                break;
+            }
+        }
+
+        if (feature is null)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var attributesJson = SerializeFeature(feature);
+        return ToolResult<DescribeFeatureResult>.Ok(
+            new DescribeFeatureResult(
+                context.Dataset.Spec,
+                feature.FeatureType,
+                attributesJson,
+                ImmutableArray<FeatureReference>.Empty));
+    }
+
+    private static JsonElement SerializeFeature(IGmlFeature feature)
+    {
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = feature.Id,
+            ["featureType"] = feature.FeatureType,
+            ["geometryType"] = feature.GeometryType.ToString(),
+            ["attributes"] = feature.Attributes,
+            ["complexAttributes"] = feature.GmlComplexAttributes
+                .Select(c => new
+                {
+                    code = c.Code,
+                    subAttributes = c.SubAttributes,
+                })
+                .ToArray(),
+        };
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureGeometry.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureGeometry.cs
@@ -1,0 +1,88 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Geometry helpers for <see cref="IGmlFeature"/> instances.
+/// </summary>
+/// <remarks>
+/// All operations work in planar lat/lon space and match the precision
+/// of the per-dataset bounding box. Surface geometry takes precedence
+/// over curve, which takes precedence over point — matching the
+/// preference order in
+/// <see cref="EncDotNet.S100.Pipelines.Vector.GmlFeatureGeometryProvider{TFeature}"/>.
+/// </remarks>
+public static class GmlFeatureGeometry
+{
+    /// <summary>
+    /// Computes the bounding box of <paramref name="feature"/>'s
+    /// geometry. Returns <c>null</c> when the feature has no geometry
+    /// at all (e.g. container-style features such as
+    /// <c>S131:Authority</c>).
+    /// </summary>
+    public static BoundingBox? TryGetBoundingBox(IGmlFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        var south = double.PositiveInfinity;
+        var north = double.NegativeInfinity;
+        var west = double.PositiveInfinity;
+        var east = double.NegativeInfinity;
+        var any = false;
+
+        void Accumulate((double Latitude, double Longitude) p)
+        {
+            any = true;
+            if (p.Latitude < south) south = p.Latitude;
+            if (p.Latitude > north) north = p.Latitude;
+            if (p.Longitude < west) west = p.Longitude;
+            if (p.Longitude > east) east = p.Longitude;
+        }
+
+        if (!feature.ExteriorRing.IsDefaultOrEmpty)
+        {
+            foreach (var p in feature.ExteriorRing) Accumulate(p);
+        }
+
+        if (!feature.Curves.IsDefaultOrEmpty)
+        {
+            foreach (var curve in feature.Curves)
+            {
+                if (!curve.IsDefaultOrEmpty)
+                {
+                    foreach (var p in curve) Accumulate(p);
+                }
+            }
+        }
+
+        if (!feature.Points.IsDefaultOrEmpty)
+        {
+            foreach (var p in feature.Points) Accumulate(p);
+        }
+
+        return any ? new BoundingBox(south, west, north, east) : null;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="feature"/>'s bounding
+    /// box intersects (or touches) the supplied <paramref name="query"/>'s
+    /// coarse bounding box. Features without geometry never match.
+    /// </summary>
+    public static bool Intersects(IGmlFeature feature, GeoQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var bounds = TryGetBoundingBox(feature);
+        if (bounds is null) return false;
+
+        return query switch
+        {
+            GeoQuery.Point p => SpatialPredicates.Contains(bounds, p.Value),
+            _ => SpatialPredicates.Intersects(bounds, query),
+        };
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -87,3 +87,15 @@ public sealed record NoDataAtPoint(
 public sealed record NotSupportedYet(SpecRef Spec, string Tool, string Reason) : ToolError(
     "not_supported_yet",
     $"Spec '{Spec}' is supported by tool '{Tool}', but: {Reason}.");
+
+/// <summary>
+/// A supplied geometry is structurally invalid (e.g. an unclosed
+/// polygon ring, a polyline with fewer than two vertices, a bounding
+/// box whose north edge is south of its south edge, or an
+/// antimeridian-crossing bounding box where <c>west &gt; east</c>).
+/// Distinguished from <see cref="InvalidArgument"/> in that a single
+/// scalar is well-formed but the *composite* shape is not.
+/// </summary>
+public sealed record GeometryInvalid(string Parameter, string Reason) : ToolError(
+    "geometry_invalid",
+    $"Geometry in '{Parameter}' is invalid: {Reason}.");

--- a/src/EncDotNet.S100.Mcp/GeoQueryJsonReader.cs
+++ b/src/EncDotNet.S100.Mcp/GeoQueryJsonReader.cs
@@ -1,0 +1,114 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+
+namespace EncDotNet.S100.Mcp;
+
+/// <summary>
+/// Parses a <see cref="GeoQuery"/> from the JSON envelope passed
+/// across the MCP wire. The wire format wraps each variant in a
+/// <c>{ "kind": "...", … }</c> object:
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item><description><c>{"kind":"point","latitude":lat,"longitude":lon}</c></description></item>
+///   <item><description><c>{"kind":"box","south":s,"west":w,"north":n,"east":e}</c></description></item>
+///   <item><description><c>{"kind":"polyline","vertices":[[lat,lon],…],"corridorWidthMeters":w}</c> (<c>corridorWidthMeters</c> optional)</description></item>
+///   <item><description><c>{"kind":"polygon","ring":[[lat,lon],…]}</c></description></item>
+/// </list>
+/// <para>
+/// This is the JSON projection of the <see cref="GeoQuery"/>
+/// discriminated union; keeping the wire shape close to the in-memory
+/// shape avoids per-tool ad-hoc parameter sets and lets new spatial
+/// tools reuse one parser.
+/// </para>
+/// </remarks>
+internal static class GeoQueryJsonReader
+{
+    /// <summary>
+    /// Reads a <see cref="GeoQuery"/> from a JSON string. Throws
+    /// <see cref="ArgumentException"/> on shape errors so the calling
+    /// tool wrapper's <c>internal_error</c> fallback surfaces a
+    /// meaningful message — geometry-level validation is done later
+    /// by <see cref="GeoQueryValidator"/>.
+    /// </summary>
+    public static GeoQuery Parse(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException("Query must be a JSON object.", nameof(json));
+        }
+
+        if (!root.TryGetProperty("kind", out var kindEl) || kindEl.ValueKind != JsonValueKind.String)
+        {
+            throw new ArgumentException("Query is missing 'kind'.", nameof(json));
+        }
+
+        return kindEl.GetString() switch
+        {
+            "point" => ParsePoint(root),
+            "box" => ParseBox(root),
+            "polyline" => ParsePolyline(root),
+            "polygon" => ParsePolygon(root),
+            var k => throw new ArgumentException($"Unknown query kind '{k}'.", nameof(json)),
+        };
+    }
+
+    private static GeoQuery ParsePoint(JsonElement root)
+    {
+        var lat = root.GetProperty("latitude").GetDouble();
+        var lon = root.GetProperty("longitude").GetDouble();
+        return new GeoQuery.Point(new GeoPoint(lat, lon));
+    }
+
+    private static GeoQuery ParseBox(JsonElement root)
+    {
+        var s = root.GetProperty("south").GetDouble();
+        var w = root.GetProperty("west").GetDouble();
+        var n = root.GetProperty("north").GetDouble();
+        var e = root.GetProperty("east").GetDouble();
+        return new GeoQuery.Box(new GeoBoundingBox(s, w, n, e));
+    }
+
+    private static GeoQuery ParsePolyline(JsonElement root)
+    {
+        var vertices = ReadVertexArray(root.GetProperty("vertices"));
+        double? width = null;
+        if (root.TryGetProperty("corridorWidthMeters", out var widthEl)
+            && widthEl.ValueKind != JsonValueKind.Null)
+        {
+            width = widthEl.GetDouble();
+        }
+        return new GeoQuery.Polyline(new GeoPolyline(vertices, width));
+    }
+
+    private static GeoQuery ParsePolygon(JsonElement root)
+    {
+        var ring = ReadVertexArray(root.GetProperty("ring"));
+        return new GeoQuery.Polygon(new GeoPolygon(ring));
+    }
+
+    private static ImmutableArray<GeoPoint> ReadVertexArray(JsonElement el)
+    {
+        if (el.ValueKind != JsonValueKind.Array)
+        {
+            throw new ArgumentException("Vertex array must be a JSON array of [lat,lon] pairs.");
+        }
+        var builder = ImmutableArray.CreateBuilder<GeoPoint>(el.GetArrayLength());
+        foreach (var item in el.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Array || item.GetArrayLength() != 2)
+            {
+                throw new ArgumentException("Each vertex must be a [lat,lon] pair.");
+            }
+            var lat = item[0].GetDouble();
+            var lon = item[1].GetDouble();
+            builder.Add(new GeoPoint(lat, lon));
+        }
+        return builder.MoveToImmutable();
+    }
+}

--- a/src/EncDotNet.S100.Mcp/README.md
+++ b/src/EncDotNet.S100.Mcp/README.md
@@ -45,7 +45,7 @@ client, `mcp-inspector`, etc.).
 
 ## Tools
 
-The server exposes exactly the three tools defined by
+The server exposes the read-only tools defined by
 `EncDotNet.S100.Mcp.Tools`:
 
 | Tool name | Returns |
@@ -53,6 +53,20 @@ The server exposes exactly the three tools defined by
 | `list_datasets` | Per-dataset summaries (id, spec, name, extent) |
 | `describe_feature` | Spec / feature type / attributes for a feature in a dataset |
 | `sample_coverage` | Sampled value at a lat/lon for a coverage dataset (S-102 / S-104 / S-111) |
+| `find_at` | Datasets whose declared bbox contains a point or intersects a `GeoQuery` envelope |
+| `query_features` | Features from loaded GML datasets that intersect a spatial query (point / box / polygon / polyline) |
+| `sample_coverage_along` | Per-vertex coverage samples for a polyline (S-102 / S-104 / S-111) |
+| `list_specs` | Spec catalogue with per-spec capability flags (query / describe / sample) |
+
+Spatial queries are passed as a JSON envelope on the `query` (or
+`polyline`) parameter:
+
+```json
+{"kind": "point",    "latitude": 47.6, "longitude": -122.3}
+{"kind": "box",      "south": 47, "west": -123, "north": 48, "east": -122}
+{"kind": "polygon",  "ring": [[47, -123], [48, -123], [48, -122], [47, -123]]}
+{"kind": "polyline", "vertices": [[47.6, -122.3], [47.7, -122.4]], "corridorWidthMeters": 1000}
+```
 
 See `src/EncDotNet.S100.Mcp.Tools/README.md` for the full tool
 contract, request/response schemas, and error codes.

--- a/src/EncDotNet.S100.Mcp/S100McpServer.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServer.cs
@@ -112,8 +112,11 @@ public sealed class S100McpServer : IAsyncDisposable
         var describeFeature = new DescribeFeatureTool(_catalog);
         var sampleCoverage = new SampleCoverageTool(_catalog);
         var findAt = new FindAtTool(_catalog);
+        var queryFeatures = new QueryFeaturesTool(_catalog);
+        var sampleCoverageAlong = new SampleCoverageAlongTool(_catalog);
+        var listSpecs = new ListSpecsTool(_catalog);
         var tools = S100McpServerToolFactory
-            .CreateTools(listDatasets, describeFeature, sampleCoverage, findAt)
+            .CreateTools(listDatasets, describeFeature, sampleCoverage, findAt, queryFeatures, sampleCoverageAlong, listSpecs)
             .ToArray();
 
         builder.Services

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools;
 using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
 using EncDotNet.S100.Pipelines;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -53,6 +54,10 @@ internal static class S100McpServerToolFactory
                             DerivedTypes =
                             {
                                 new System.Text.Json.Serialization.Metadata.JsonDerivedType(typeof(DepthSample), "depth"),
+                                new System.Text.Json.Serialization.Metadata.JsonDerivedType(typeof(WaterLevelSample), "water_level"),
+                                new System.Text.Json.Serialization.Metadata.JsonDerivedType(typeof(WaterLevelStationSample), "water_level_station"),
+                                new System.Text.Json.Serialization.Metadata.JsonDerivedType(typeof(SurfaceCurrentSample), "surface_current"),
+                                new System.Text.Json.Serialization.Metadata.JsonDerivedType(typeof(SurfaceCurrentStationSample), "surface_current_station"),
                             },
                         };
                     }
@@ -65,12 +70,18 @@ internal static class S100McpServerToolFactory
         ListDatasetsTool listDatasets,
         DescribeFeatureTool describeFeature,
         SampleCoverageTool sampleCoverage,
-        FindAtTool findAt)
+        FindAtTool findAt,
+        QueryFeaturesTool queryFeatures,
+        SampleCoverageAlongTool sampleCoverageAlong,
+        ListSpecsTool listSpecs)
     {
         yield return CreateListDatasetsTool(listDatasets);
         yield return CreateDescribeFeatureTool(describeFeature);
         yield return CreateSampleCoverageTool(sampleCoverage);
         yield return CreateFindAtTool(findAt);
+        yield return CreateQueryFeaturesTool(queryFeatures);
+        yield return CreateSampleCoverageAlongTool(sampleCoverageAlong);
+        yield return CreateListSpecsTool(listSpecs);
     }
 
     private static McpServerTool CreateListDatasetsTool(ListDatasetsTool inner)
@@ -109,8 +120,9 @@ internal static class S100McpServerToolFactory
     {
         var description =
             "Returns spec, feature-type code, attributes (as JSON), and xlink-resolved cross-references " +
-            "for a single feature in a loaded dataset. Currently supports S-124 (Navigational Warnings); " +
-            "other vector specs return spec_not_supported_for_tool.";
+            "for a single feature in a loaded dataset. Supports S-122, S-124, S-125, S-127, S-128, S-129, " +
+            "S-131, S-201, S-411, and S-421. References for backfilled GML specs are currently returned empty " +
+            "(spec-specific reference resolution is staged).";
 
         var del = ([Description("Stable dataset ID returned by list_datasets.")] string datasetId,
                    [Description("The feature's GML id within the dataset.")] string featureId,
@@ -132,8 +144,9 @@ internal static class S100McpServerToolFactory
     {
         var description =
             "Samples a coverage product at a single latitude/longitude, returning the nearest grid " +
-            "cell's value. Currently supports S-102 (Bathymetric Surfaces); S-104 and S-111 return " +
-            "spec_not_supported_for_tool.";
+            "cell's value. Supports S-102 (bathymetric surfaces), S-104 (water levels), and S-111 " +
+            "(surface currents). For time-varying products (S-104, S-111) pass an optional ISO-8601 " +
+            "time; omitting it selects the first available time step.";
 
         var del = ([Description("Spec of the coverage to sample (e.g. \"S-102/2.1.0\").")] string spec,
                    [Description("Sample latitude in decimal degrees, WGS-84.")] double latitude,
@@ -161,17 +174,20 @@ internal static class S100McpServerToolFactory
     {
         var description =
             "Returns every dataset currently loaded in the host (viewer or CLI) whose declared " +
-            "bounding box contains the supplied lat/lon point. Coordinates are decimal degrees, " +
-            "WGS-84. Containment is bbox-only — a positive result means the point lies inside the " +
-            "dataset's declared rectangle, not that the point has actual cell coverage (call " +
-            "sample_coverage to read a value). Optionally filtered by spec. Returns dataset IDs, " +
-            "spec, bounds, and time range, with pagination.";
+            "bounding box contains or intersects the supplied geographic query. The simplest call " +
+            "is point-based (latitude/longitude in WGS-84 decimal degrees); for richer spatial " +
+            "selection (bbox / polygon / polyline), pass the optional 'query' JSON envelope and the " +
+            "tool will use it in place of the lat/lon point. Containment is bbox-only — a positive " +
+            "result means the point lies inside the dataset's declared rectangle, not that the " +
+            "point has actual cell coverage (call sample_coverage to read a value). Optionally " +
+            "filtered by spec. Returns dataset IDs, spec, bounds, and time range, with pagination.";
 
-        var del = ([Description("Query latitude in decimal degrees, WGS-84. Must be in [-90, 90].")] double latitude,
-                   [Description("Query longitude in decimal degrees, WGS-84. Must be in [-180, 180].")] double longitude,
+        var del = ([Description("Query latitude in decimal degrees, WGS-84. Must be in [-90, 90]. Ignored when 'query' is supplied.")] double latitude,
+                   [Description("Query longitude in decimal degrees, WGS-84. Must be in [-180, 180]. Ignored when 'query' is supplied.")] double longitude,
                    [Description("Optional spec filter (e.g. \"S-101/1.2.0\"); null matches every spec.")] string? spec = null,
                    [Description("Zero-based page index.")] int page = 0,
                    [Description("Page size (clamped to 1..500).")] int pageSize = 50,
+                   [Description("Optional spatial query JSON envelope. Shapes: {\"kind\":\"point\",\"latitude\":lat,\"longitude\":lon}, {\"kind\":\"box\",\"south\":s,\"west\":w,\"north\":n,\"east\":e}, {\"kind\":\"polygon\",\"ring\":[[lat,lon],...]}, {\"kind\":\"polyline\",\"vertices\":[[lat,lon],...],\"corridorWidthMeters\":w}. When supplied, overrides latitude/longitude.")] string? query = null,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(
@@ -180,7 +196,8 @@ internal static class S100McpServerToolFactory
                         longitude,
                         ParseSpec(spec),
                         page,
-                        pageSize),
+                        pageSize,
+                        ParseGeoQuery(query)),
                     ct));
 
         return McpServerTool.Create(del, new McpServerToolCreateOptions
@@ -191,8 +208,135 @@ internal static class S100McpServerToolFactory
         });
     }
 
+    private static McpServerTool CreateQueryFeaturesTool(QueryFeaturesTool inner)
+    {
+        var description =
+            "Returns features from loaded GML-encoded vector datasets whose geometry intersects a " +
+            "geographic query (point / bounding box / polygon / polyline). Supports S-122, S-124, " +
+            "S-125, S-127, S-128, S-129, S-131, S-201, S-411, and S-421. Each result includes the " +
+            "dataset ID, spec, feature ID, feature type, and bounding box — follow up with " +
+            "describe_feature for full attributes. Pagination is server-side.";
+
+        var del = ([Description("Spatial query JSON envelope. Shapes: {\"kind\":\"point\",\"latitude\":lat,\"longitude\":lon}, {\"kind\":\"box\",\"south\":s,\"west\":w,\"north\":n,\"east\":e}, {\"kind\":\"polygon\",\"ring\":[[lat,lon],...]}, {\"kind\":\"polyline\",\"vertices\":[[lat,lon],...],\"corridorWidthMeters\":w}.")] string query,
+                   [Description("Optional spec filter (e.g. \"S-124/1.5.0\"); null matches every spec.")] string? spec = null,
+                   [Description("Optional case-sensitive feature-type filter (the GML element local name, e.g. \"NavwarnPart\", \"BuoyLateral\"); null returns every feature type.")] string? featureType = null,
+                   [Description("Zero-based page index.")] int page = 0,
+                   [Description("Page size (clamped to 1..500).")] int pageSize = 50,
+                   CancellationToken ct = default) =>
+            DispatchAsync(() =>
+                inner.InvokeAsync(
+                    new QueryFeaturesRequest(
+                        ParseGeoQuery(query) ?? throw new ArgumentException("query is required.", nameof(query)),
+                        ParseSpec(spec),
+                        featureType,
+                        page,
+                        pageSize),
+                    ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = QueryFeaturesTool.Name,
+            Description = description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static McpServerTool CreateSampleCoverageAlongTool(SampleCoverageAlongTool inner)
+    {
+        var description =
+            "Samples a coverage product (S-102 / S-104 / S-111) at every vertex of a polyline, " +
+            "returning per-vertex results in input order. Vertices that fall outside coverage or " +
+            "have no data return null entries so the agent can still use the rest of the route. " +
+            "For time-varying products (S-104, S-111), the optional time applies identically to " +
+            "every vertex — useful for \"depth/level/current at each waypoint at the same instant\". " +
+            "The polyline's corridor width is ignored (corridors apply to membership queries, not " +
+            "point sampling).";
+
+        var del = ([Description("Spec of the coverage to sample (\"S-102/2.1.0\", \"S-104/1.1.0\", or \"S-111/1.1.1\").")] string spec,
+                   [Description("Polyline JSON: {\"vertices\":[[lat,lon],...]} — corridor width is not used here. Coordinates are WGS-84 decimal degrees.")] string polyline,
+                   [Description("Optional time selector (ISO-8601, time-varying products only).")] DateTimeOffset? time = null,
+                   CancellationToken ct = default) =>
+            DispatchAsync(() =>
+                inner.InvokeAsync(
+                    new SampleCoverageAlongRequest(
+                        ParseSpec(spec) ?? throw new ArgumentException("spec is required.", nameof(spec)),
+                        ParsePolyline(polyline),
+                        time),
+                    ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SampleCoverageAlongTool.Name,
+            Description = description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static McpServerTool CreateListSpecsTool(ListSpecsTool inner)
+    {
+        var description =
+            "Returns the S-100 specs the server is built against and, for each spec, the number of " +
+            "loaded datasets and the tools applicable to it (query_features / describe_feature / " +
+            "sample_coverage). Use this to introspect what the agent can ask in the current session " +
+            "before issuing spatial or temporal queries.";
+
+        var del = (CancellationToken ct = default) =>
+            DispatchAsync(() =>
+                inner.InvokeAsync(new ListSpecsRequest(), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = ListSpecsTool.Name,
+            Description = description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
     private static SpecRef? ParseSpec(string? spec)
         => string.IsNullOrWhiteSpace(spec) ? null : SpecRef.Parse(spec);
+
+    private static GeoQuery? ParseGeoQuery(string? queryJson)
+        => string.IsNullOrWhiteSpace(queryJson) ? null : GeoQueryJsonReader.Parse(queryJson);
+
+    private static GeoPolyline ParsePolyline(string polylineJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(polylineJson);
+        // Accept either a bare polyline object {"vertices":[…]} or the
+        // full GeoQuery polyline envelope so callers can copy/paste the
+        // same shape used by query_features.
+        using var doc = JsonDocument.Parse(polylineJson);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException("polyline must be a JSON object.", nameof(polylineJson));
+        }
+
+        // If the caller sent a {"kind":"polyline",…} envelope, reuse the GeoQuery reader.
+        if (root.TryGetProperty("kind", out var _))
+        {
+            var query = GeoQueryJsonReader.Parse(polylineJson);
+            if (query is GeoQuery.Polyline pl)
+            {
+                return pl.Value;
+            }
+            throw new ArgumentException("polyline query envelope must have kind='polyline'.", nameof(polylineJson));
+        }
+
+        // Otherwise expect {"vertices":[[lat,lon],…], "corridorWidthMeters":w?}
+        // — synthesise an envelope and reuse the same parser.
+        var synthesized = new JsonObject
+        {
+            ["kind"] = "polyline",
+            ["vertices"] = JsonNode.Parse(root.GetProperty("vertices").GetRawText()),
+        };
+        if (root.TryGetProperty("corridorWidthMeters", out var widthEl)
+            && widthEl.ValueKind != JsonValueKind.Null)
+        {
+            synthesized["corridorWidthMeters"] = widthEl.GetDouble();
+        }
+        var parsed = GeoQueryJsonReader.Parse(synthesized.ToJsonString(JsonOptions));
+        return ((GeoQuery.Polyline)parsed).Value;
+    }
 
     private static BoundingBox? ParseBox(double? south, double? west, double? north, double? east)
     {

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
@@ -1,8 +1,12 @@
+using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Gml;
 using EncDotNet.S100.Mcp.Tools;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+using EncDotNet.S100.Pipelines;
 using ModelContextProtocol.Protocol;
 
 namespace EncDotNet.S100.Mcp.Tests;
@@ -10,7 +14,7 @@ namespace EncDotNet.S100.Mcp.Tests;
 public class S100McpServerRoundTripTests
 {
     [Fact]
-    public async Task ListTools_returns_four_tools_with_schemas()
+    public async Task ListTools_returns_seven_tools_with_schemas()
     {
         var catalog = McpTestHelpers.NewCatalog();
         await using var server = await McpTestHelpers.StartServerAsync(catalog);
@@ -19,7 +23,18 @@ public class S100McpServerRoundTripTests
         var tools = await client.ListToolsAsync();
         var names = tools.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
 
-        Assert.Equal(new[] { "describe_feature", "find_at", "list_datasets", "sample_coverage" }, names);
+        Assert.Equal(
+            new[]
+            {
+                "describe_feature",
+                "find_at",
+                "list_datasets",
+                "list_specs",
+                "query_features",
+                "sample_coverage",
+                "sample_coverage_along",
+            },
+            names);
         foreach (var tool in tools)
         {
             // ProtocolTool exposes the JSON schema; ensure it is non-empty.
@@ -170,6 +185,139 @@ public class S100McpServerRoundTripTests
         var payload = ParseSingleJson(result);
         Assert.Equal("invalid_argument", payload["code"]!.GetValue<string>());
         Assert.Equal("latitude", payload["details"]!["parameter"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task QueryFeatures_round_trip_returns_matching_features()
+    {
+        var feature = new S124Feature
+        {
+            Id = "feat-1",
+            FeatureType = "NavwarnPart",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((5.0, 5.0)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty.Add("warningInformation", "Test warning text."),
+            ComplexAttributes = ImmutableArray<S124ComplexAttribute>.Empty,
+            References = ImmutableArray<GmlReference>.Empty,
+        };
+        var dataset = S124Synth.Dataset(feature);
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S124("synth-warn-1", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10), model: dataset));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("query_features", new Dictionary<string, object?>
+        {
+            ["query"] = """{"kind":"box","south":-5,"west":-5,"north":15,"east":15}""",
+        });
+
+        Assert.False(result.IsError ?? false, $"query_features returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var features = payload["features"]!.AsArray();
+        Assert.NotEmpty(features);
+        Assert.Equal("feat-1", features[0]!["featureId"]!.GetValue<string>());
+        Assert.Equal("NavwarnPart", features[0]!["featureType"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task QueryFeatures_invalid_query_json_returns_error()
+    {
+        var catalog = McpTestHelpers.NewCatalog();
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("query_features", new Dictionary<string, object?>
+        {
+            ["query"] = """{"kind":"unknown"}""",
+        });
+
+        Assert.True(result.IsError ?? false, "Expected isError=true for unknown query kind.");
+        var payload = ParseSingleJson(result);
+        Assert.Equal("internal_error", payload["code"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task SampleCoverageAlong_round_trip_returns_per_vertex_results()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S102("synth-bathy-1",
+                bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+                source: S102Synth.Source(S102Synth.Dataset(depth: 17.5f, uncertainty: 0.5f))));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("sample_coverage_along", new Dictionary<string, object?>
+        {
+            ["spec"] = "S-102/2.1.0",
+            ["polyline"] = """{"vertices":[[0.01,0.01],[0.02,0.02],[50.0,50.0]]}""",
+        });
+
+        Assert.False(result.IsError ?? false, $"sample_coverage_along returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var samples = payload["samples"]!.AsArray();
+        Assert.Equal(3, samples.Count);
+        // First two vertices are inside the bathy bounds and should resolve.
+        Assert.NotNull(samples[0]!["result"]);
+        Assert.NotNull(samples[1]!["result"]);
+        // Last vertex is far outside any coverage — per-vertex miss -> null.
+        Assert.Null(samples[2]!["result"]);
+    }
+
+    [Fact]
+    public async Task ListSpecs_round_trip_returns_capabilities()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S102("synth-bathy-1"),
+            LoadedDatasetFactory.S124("synth-warn-1"));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("list_specs", new Dictionary<string, object?>());
+
+        Assert.False(result.IsError ?? false, $"list_specs returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var specs = payload["specs"]!.AsArray();
+        Assert.NotEmpty(specs);
+        // Every entry exposes its capability flags.
+        foreach (var entry in specs)
+        {
+            Assert.NotNull(entry!["name"]);
+            var caps = entry!["capabilities"]!.AsObject();
+            Assert.NotNull(caps["canQueryFeatures"]);
+            Assert.NotNull(caps["canDescribeFeature"]);
+            Assert.NotNull(caps["canSampleCoverage"]);
+        }
+    }
+
+    [Fact]
+    public async Task FindAt_with_box_query_envelope_returns_intersecting_datasets()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S124("warn-here", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)),
+            LoadedDatasetFactory.S124("warn-elsewhere", bounds: LoadedDatasetFactory.Box(50, 50, 60, 60)));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("find_at", new Dictionary<string, object?>
+        {
+            // latitude/longitude are ignored when 'query' is supplied.
+            ["latitude"] = 0.0,
+            ["longitude"] = 0.0,
+            ["query"] = """{"kind":"box","south":-5,"west":-5,"north":15,"east":15}""",
+        });
+
+        Assert.False(result.IsError ?? false, $"find_at returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var datasets = payload["datasets"]!.AsArray();
+        Assert.Single(datasets);
+        Assert.Equal("warn-here", datasets[0]!["id"]!["value"]!.GetValue<string>());
     }
 
     private static JsonObject ParseSingleJson(CallToolResult result)

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureGmlBackfillTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureGmlBackfillTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S131;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DescribeFeatureGmlBackfillTests
+{
+    [Fact]
+    public async Task S122_feature_is_described_via_generic_GmlFeatureDescriber()
+    {
+        var feature = new S122Feature
+        {
+            Id = "mpa-1",
+            FeatureType = "MarineProtectedArea",
+            GeometryType = GmlGeometryType.Surface,
+            Points = default,
+            Curves = default,
+            ExteriorRing = ImmutableArray.Create<(double, double)>((0, 0), (0, 1), (1, 1), (0, 0)),
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty
+                .Add("categoryOfMarineProtectedArea", "nature reserve"),
+            ComplexAttributes = ImmutableArray<S122ComplexAttribute>.Empty,
+        };
+        var model = new S122Dataset
+        {
+            Features = ImmutableArray.Create(feature),
+            InformationTypes = ImmutableArray<S122InformationType>.Empty,
+        };
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(new LoadedDataset(
+            new DatasetId("mpa"),
+            LoadedDatasetFactory.S122Spec,
+            LoadedDatasetFactory.Box(0, 0, 1, 1),
+            null,
+            new S122DatasetData(model)));
+
+        var tool = new DescribeFeatureTool(catalog);
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(
+            new DatasetId("mpa"),
+            "mpa-1"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("MarineProtectedArea", value.FeatureTypeName);
+        Assert.Empty(value.References);
+        var attrs = value.Attributes;
+        Assert.Equal("mpa-1", attrs.GetProperty("id").GetString());
+        Assert.Equal("Surface", attrs.GetProperty("geometryType").GetString());
+        Assert.Equal(
+            "nature reserve",
+            attrs.GetProperty("attributes").GetProperty("categoryOfMarineProtectedArea").GetString());
+    }
+
+    [Fact]
+    public async Task S131_geometryless_authority_feature_round_trips_attributes()
+    {
+        var authority = new S131Feature
+        {
+            Id = "auth-1",
+            FeatureType = "Authority",
+            GeometryType = GmlGeometryType.None,
+            Points = default,
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty
+                .Add("authorityName", "Port of Test"),
+            ComplexAttributes = ImmutableArray<S131ComplexAttribute>.Empty,
+            References = ImmutableArray<S131Reference>.Empty,
+        };
+        var model = new S131Dataset
+        {
+            Features = ImmutableArray.Create(authority),
+            InformationTypes = ImmutableArray<S131InformationType>.Empty,
+        };
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(new LoadedDataset(
+            new DatasetId("harbour"),
+            LoadedDatasetFactory.S131Spec,
+            LoadedDatasetFactory.Box(0, 0, 1, 1),
+            null,
+            new S131DatasetData(model)));
+
+        var tool = new DescribeFeatureTool(catalog);
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(
+            new DatasetId("harbour"),
+            "auth-1"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("Authority", value.FeatureTypeName);
+        Assert.Equal(
+            "Port of Test",
+            value.Attributes.GetProperty("attributes").GetProperty("authorityName").GetString());
+    }
+
+    [Fact]
+    public async Task Missing_feature_id_returns_FeatureNotFound_for_generic_spec()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S122("mpa", bounds: LoadedDatasetFactory.Box()));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(
+            new DatasetId("mpa"),
+            "does-not-exist"));
+
+        Assert.False(result.TryGetValue(out _));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolTests.cs
@@ -21,8 +21,11 @@ public class DescribeFeatureToolTests
     }
 
     [Fact]
-    public async Task Returns_SpecNotSupported_for_unsupported_spec()
+    public async Task Returns_FeatureNotFound_for_unknown_feature_in_backfilled_spec()
     {
+        // S-122 is now supported via the generic GmlFeatureDescriber
+        // (PR-backfill), so an unknown feature returns FeatureNotFound
+        // rather than SpecNotSupportedForTool.
         var catalog = new FakeDatasetCatalog();
         catalog.Add(LoadedDatasetFactory.S122("s122-ds"));
         var tool = new DescribeFeatureTool(catalog);
@@ -30,9 +33,9 @@ public class DescribeFeatureToolTests
         var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("s122-ds"), "x"));
 
         Assert.True(result.TryGetError(out var error));
-        var unsupported = Assert.IsType<SpecNotSupportedForTool>(error);
-        Assert.Equal("S-122", unsupported.Spec.Name);
-        Assert.Equal(DescribeFeatureTool.Name, unsupported.Tool);
+        var notFound = Assert.IsType<FeatureNotFound>(error);
+        Assert.Equal(new DatasetId("s122-ds"), notFound.Id);
+        Assert.Equal("x", notFound.FeatureId);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/FindAtToolQueryTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/FindAtToolQueryTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class FindAtToolQueryTests
+{
+    [Fact]
+    public async Task Query_point_matches_legacy_lat_lon_path()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("inside", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        catalog.Add(LoadedDatasetFactory.S124("outside", bounds: LoadedDatasetFactory.Box(20, 20, 30, 30)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            Latitude: 0,
+            Longitude: 0,
+            Query: new GeoQuery.Point(new GeoPoint(5, 5))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Datasets);
+        Assert.Equal(new DatasetId("inside"), value.Datasets[0].Id);
+    }
+
+    [Fact]
+    public async Task Query_bbox_returns_every_dataset_with_overlapping_bounds()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+        catalog.Add(LoadedDatasetFactory.S122("b", bounds: LoadedDatasetFactory.Box(5, 5, 15, 15)));
+        catalog.Add(LoadedDatasetFactory.S124("c", bounds: LoadedDatasetFactory.Box(50, 50, 60, 60)));
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            Latitude: 0,
+            Longitude: 0,
+            Query: new GeoQuery.Box(new GeoBoundingBox(3, 3, 12, 12))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(2, value.Datasets.Length);
+        Assert.Equal(new[] { "a", "b" }, value.Datasets.Select(d => d.Id.Value).ToArray());
+    }
+
+    [Fact]
+    public async Task Query_polyline_with_corridor_inflates_match_radius()
+    {
+        var catalog = new FakeDatasetCatalog();
+        // Dataset is a small bbox just north of the equator at longitude 0.
+        catalog.Add(LoadedDatasetFactory.S124("near", bounds: LoadedDatasetFactory.Box(0.5, -0.1, 0.6, 0.1)));
+        var tool = new FindAtTool(catalog);
+
+        // A polyline running along the equator with a 111 km corridor
+        // (≈1°) should pick up the dataset 0.5° to the north; without a
+        // corridor it should not.
+        var line = new GeoPolyline(
+            ImmutableArray.Create(new GeoPoint(0, -1), new GeoPoint(0, 1)),
+            CorridorWidthMeters: 111_320.0);
+
+        var withCorridor = await tool.InvokeAsync(new FindAtRequest(
+            0, 0, Query: new GeoQuery.Polyline(line)));
+        Assert.True(withCorridor.TryGetValue(out var withVal));
+        Assert.Single(withVal.Datasets);
+
+        var withoutCorridor = await tool.InvokeAsync(new FindAtRequest(
+            0, 0, Query: new GeoQuery.Polyline(line with { CorridorWidthMeters = null })));
+        Assert.True(withoutCorridor.TryGetValue(out var withoutVal));
+        Assert.Empty(withoutVal.Datasets);
+    }
+
+    [Fact]
+    public async Task Query_with_invalid_geometry_returns_geometry_invalid()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new FindAtTool(catalog);
+
+        var open = new GeoPolygon(ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 1),
+            new GeoPoint(1, 1),
+            new GeoPoint(1, 0))); // unclosed
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            0, 0, Query: new GeoQuery.Polygon(open)));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Fact]
+    public async Task Query_with_out_of_range_point_returns_invalid_argument()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new FindAtTool(catalog);
+
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            0, 0, Query: new GeoQuery.Point(new GeoPoint(91, 0))));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Query_takes_precedence_over_legacy_lat_lon()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("northern", bounds: LoadedDatasetFactory.Box(50, 50, 60, 60)));
+        var tool = new FindAtTool(catalog);
+
+        // Lat/Lon are invalid here but should be ignored because Query
+        // is supplied and validates cleanly.
+        var result = await tool.InvokeAsync(new FindAtRequest(
+            Latitude: 1000,
+            Longitude: 1000,
+            Query: new GeoQuery.Point(new GeoPoint(55, 55))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Datasets);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Geometry/GeoQueryTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Geometry/GeoQueryTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Geometry;
+
+public class GeoQueryTests
+{
+    [Fact]
+    public void Point_bounding_box_is_a_zero_area_rectangle()
+    {
+        var q = new GeoQuery.Point(new GeoPoint(47.6, -122.3));
+        var b = q.GetBoundingBox();
+
+        Assert.Equal(47.6, b.SouthLatitude);
+        Assert.Equal(47.6, b.NorthLatitude);
+        Assert.Equal(-122.3, b.WestLongitude);
+        Assert.Equal(-122.3, b.EastLongitude);
+    }
+
+    [Fact]
+    public void Box_bounding_box_is_passthrough()
+    {
+        var box = new GeoBoundingBox(0, -10, 5, 10);
+        var q = new GeoQuery.Box(box);
+
+        Assert.Equal(box, q.GetBoundingBox());
+    }
+
+    [Fact]
+    public void Polygon_bounding_box_covers_every_vertex()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 10),
+            new GeoPoint(5, 10),
+            new GeoPoint(5, 0),
+            new GeoPoint(0, 0));
+        var q = new GeoQuery.Polygon(new GeoPolygon(ring));
+
+        var b = q.GetBoundingBox();
+
+        Assert.Equal(0, b.SouthLatitude);
+        Assert.Equal(5, b.NorthLatitude);
+        Assert.Equal(0, b.WestLongitude);
+        Assert.Equal(10, b.EastLongitude);
+    }
+
+    [Fact]
+    public void Polyline_with_corridor_inflates_bounding_box()
+    {
+        var line = new GeoPolyline(
+            ImmutableArray.Create(new GeoPoint(0, 0), new GeoPoint(0, 1)),
+            CorridorWidthMeters: 111_320.0); // ~1°
+        var q = new GeoQuery.Polyline(line);
+
+        var b = q.GetBoundingBox();
+
+        // Lat pad is exactly 1° (we used a 1° half-width in metres). The
+        // longitude pad is 1°/cos(0°) = 1° at the equator.
+        Assert.InRange(b.SouthLatitude, -1.001, -0.999);
+        Assert.InRange(b.NorthLatitude, 0.999, 1.001);
+        Assert.InRange(b.WestLongitude, -1.001, -0.999);
+        Assert.InRange(b.EastLongitude, 1.999, 2.001);
+    }
+
+    [Fact]
+    public void Polyline_without_corridor_returns_tight_bbox()
+    {
+        var line = new GeoPolyline(
+            ImmutableArray.Create(new GeoPoint(0, 0), new GeoPoint(0, 1)));
+        var q = new GeoQuery.Polyline(line);
+
+        var b = q.GetBoundingBox();
+
+        Assert.Equal(0, b.SouthLatitude);
+        Assert.Equal(0, b.NorthLatitude);
+        Assert.Equal(0, b.WestLongitude);
+        Assert.Equal(1, b.EastLongitude);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Geometry/GeoQueryValidatorTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Geometry/GeoQueryValidatorTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Geometry;
+
+public class GeoQueryValidatorTests
+{
+    [Fact]
+    public void Valid_point_returns_null()
+    {
+        var q = new GeoQuery.Point(new GeoPoint(0, 0));
+        Assert.Null(GeoQueryValidator.Validate(q));
+    }
+
+    [Theory]
+    [InlineData(91, 0)]
+    [InlineData(-91, 0)]
+    [InlineData(0, 181)]
+    [InlineData(0, -181)]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.NaN)]
+    public void Out_of_range_point_returns_invalid_argument(double lat, double lon)
+    {
+        var q = new GeoQuery.Point(new GeoPoint(lat, lon));
+        var err = GeoQueryValidator.Validate(q);
+
+        var ia = Assert.IsType<InvalidArgument>(err);
+        Assert.StartsWith("query.", ia.Parameter);
+    }
+
+    [Fact]
+    public void Box_with_inverted_latitude_returns_geometry_invalid()
+    {
+        var q = new GeoQuery.Box(new GeoBoundingBox(10, 0, 5, 10));
+        var err = GeoQueryValidator.Validate(q);
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Fact]
+    public void Antimeridian_crossing_box_returns_geometry_invalid()
+    {
+        var q = new GeoQuery.Box(new GeoBoundingBox(0, 170, 5, -170));
+        var err = GeoQueryValidator.Validate(q);
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Fact]
+    public void Open_polygon_returns_geometry_invalid()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 1),
+            new GeoPoint(1, 1),
+            new GeoPoint(1, 0));
+        var q = new GeoQuery.Polygon(new GeoPolygon(ring));
+
+        var err = GeoQueryValidator.Validate(q);
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Fact]
+    public void Polygon_with_too_few_points_returns_geometry_invalid()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 1),
+            new GeoPoint(0, 0));
+        var q = new GeoQuery.Polygon(new GeoPolygon(ring));
+
+        var err = GeoQueryValidator.Validate(q);
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Fact]
+    public void Closed_quad_polygon_validates()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 1),
+            new GeoPoint(1, 1),
+            new GeoPoint(1, 0),
+            new GeoPoint(0, 0));
+        var q = new GeoQuery.Polygon(new GeoPolygon(ring));
+
+        Assert.Null(GeoQueryValidator.Validate(q));
+    }
+
+    [Fact]
+    public void Polyline_with_single_vertex_returns_geometry_invalid()
+    {
+        var line = new GeoPolyline(ImmutableArray.Create(new GeoPoint(0, 0)));
+        var q = new GeoQuery.Polyline(line);
+        Assert.IsType<GeometryInvalid>(GeoQueryValidator.Validate(q));
+    }
+
+    [Fact]
+    public void Polyline_with_negative_corridor_returns_invalid_argument()
+    {
+        var line = new GeoPolyline(
+            ImmutableArray.Create(new GeoPoint(0, 0), new GeoPoint(0, 1)),
+            CorridorWidthMeters: -1);
+        var q = new GeoQuery.Polyline(line);
+
+        var err = GeoQueryValidator.Validate(q);
+        var ia = Assert.IsType<InvalidArgument>(err);
+        Assert.Contains("corridorWidthMeters", ia.Parameter);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Geometry/SpatialPredicatesTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Geometry/SpatialPredicatesTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Geometry;
+
+public class SpatialPredicatesTests
+{
+    [Fact]
+    public void Intersects_box_query_returns_true_when_overlapping()
+    {
+        var bounds = new BoundingBox(0, 0, 10, 10);
+        var query = new GeoQuery.Box(new GeoBoundingBox(5, 5, 15, 15));
+
+        Assert.True(SpatialPredicates.Intersects(bounds, query));
+    }
+
+    [Fact]
+    public void Intersects_box_query_returns_false_when_disjoint()
+    {
+        var bounds = new BoundingBox(0, 0, 10, 10);
+        var query = new GeoQuery.Box(new GeoBoundingBox(20, 20, 30, 30));
+
+        Assert.False(SpatialPredicates.Intersects(bounds, query));
+    }
+
+    [Fact]
+    public void Intersects_touching_edges_returns_true()
+    {
+        var bounds = new BoundingBox(0, 0, 10, 10);
+        var query = new GeoQuery.Box(new GeoBoundingBox(10, 10, 20, 20));
+
+        Assert.True(SpatialPredicates.Intersects(bounds, query));
+    }
+
+    [Fact]
+    public void Contains_point_returns_true_on_boundary()
+    {
+        var bounds = new BoundingBox(0, 0, 10, 10);
+        Assert.True(SpatialPredicates.Contains(bounds, new GeoPoint(0, 0)));
+        Assert.True(SpatialPredicates.Contains(bounds, new GeoPoint(10, 10)));
+    }
+
+    [Fact]
+    public void ContainsPoint_simple_quad_ray_cast()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 10),
+            new GeoPoint(10, 10),
+            new GeoPoint(10, 0),
+            new GeoPoint(0, 0));
+
+        Assert.True(SpatialPredicates.ContainsPoint(ring, new GeoPoint(5, 5)));
+        Assert.False(SpatialPredicates.ContainsPoint(ring, new GeoPoint(15, 5)));
+    }
+
+    [Fact]
+    public void ContainsPoint_empty_ring_returns_false()
+    {
+        Assert.False(SpatialPredicates.ContainsPoint(
+            ImmutableArray<GeoPoint>.Empty,
+            new GeoPoint(0, 0)));
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/ListSpecsToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/ListSpecsToolTests.cs
@@ -1,0 +1,74 @@
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class ListSpecsToolTests
+{
+    [Fact]
+    public async Task Empty_catalog_lists_every_known_spec_with_zero_counts()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new ListSpecsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListSpecsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        var names = value.Specs.Select(s => s.Name).ToArray();
+        Assert.Contains("S-101", names);
+        Assert.Contains("S-124", names);
+        Assert.Contains("S-421", names);
+        foreach (var s in value.Specs)
+        {
+            Assert.Equal(0, s.LoadedDatasetCount);
+        }
+    }
+
+    [Fact]
+    public async Task Loaded_dataset_counts_are_reflected_per_spec()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124("a"));
+        catalog.Add(LoadedDatasetFactory.S124("b"));
+        catalog.Add(LoadedDatasetFactory.S122("c"));
+        var tool = new ListSpecsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListSpecsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        var s124 = value.Specs.Single(s => s.Name == "S-124");
+        var s122 = value.Specs.Single(s => s.Name == "S-122");
+        var s101 = value.Specs.Single(s => s.Name == "S-101");
+        Assert.Equal(2, s124.LoadedDatasetCount);
+        Assert.Equal(1, s122.LoadedDatasetCount);
+        Assert.Equal(0, s101.LoadedDatasetCount);
+    }
+
+    [Fact]
+    public async Task Capabilities_flag_coverage_versus_vector_specs_correctly()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new ListSpecsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListSpecsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        var s102 = value.Specs.Single(s => s.Name == "S-102");
+        var s124 = value.Specs.Single(s => s.Name == "S-124");
+        var s101 = value.Specs.Single(s => s.Name == "S-101");
+
+        // S-102 is a coverage product, not a GML vector product.
+        Assert.True(s102.Capabilities.CanSampleCoverage);
+        Assert.False(s102.Capabilities.CanQueryFeatures);
+        Assert.True(s102.Capabilities.CanDescribeFeature);
+
+        // S-124 is GML vector; not a coverage product.
+        Assert.False(s124.Capabilities.CanSampleCoverage);
+        Assert.True(s124.Capabilities.CanQueryFeatures);
+        Assert.True(s124.Capabilities.CanDescribeFeature);
+
+        // S-101 is neither coverage nor GML — describer only.
+        Assert.False(s101.Capabilities.CanSampleCoverage);
+        Assert.False(s101.Capabilities.CanQueryFeatures);
+        Assert.True(s101.Capabilities.CanDescribeFeature);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/QueryFeaturesToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/QueryFeaturesToolTests.cs
@@ -1,0 +1,289 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S131;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class QueryFeaturesToolTests
+{
+    private static S124Feature PointFeature(
+        string id,
+        double lat,
+        double lon,
+        string featureType = "NavwarnPart")
+    {
+        return new S124Feature
+        {
+            Id = id,
+            FeatureType = featureType,
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((lat, lon)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S124ComplexAttribute>.Empty,
+        };
+    }
+
+    private static S122Feature S122PointFeature(string id, double lat, double lon)
+    {
+        return new S122Feature
+        {
+            Id = id,
+            FeatureType = "MarineProtectedArea",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((lat, lon)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S122ComplexAttribute>.Empty,
+        };
+    }
+
+    private static S131Feature S131GeometrylessFeature(string id, string featureType)
+    {
+        return new S131Feature
+        {
+            Id = id,
+            FeatureType = featureType,
+            GeometryType = GmlGeometryType.None,
+            Points = default,
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S131ComplexAttribute>.Empty,
+            References = ImmutableArray<S131Reference>.Empty,
+        };
+    }
+
+    [Fact]
+    public async Task Empty_catalog_returns_no_features()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new QueryFeaturesTool(catalog);
+
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Point(new GeoPoint(0, 0))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Features);
+        Assert.Equal(0, value.TotalCount);
+        Assert.False(value.HasMore);
+    }
+
+    [Fact]
+    public async Task Point_query_matches_features_whose_geometry_contains_the_point()
+    {
+        var inside = PointFeature("inside", 5, 5);
+        var outside = PointFeature("outside", 9, 9);
+        var dataset = LoadedDatasetFactory.S124(
+            "a",
+            S124Synth.Dataset(inside, outside),
+            bounds: LoadedDatasetFactory.Box(0, 0, 10, 10));
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(dataset);
+        var tool = new QueryFeaturesTool(catalog);
+
+        // Point queries match feature bbox; a feature with a single
+        // point has a degenerate bbox at that point. The 'inside'
+        // feature at (5,5) is exactly the query point and matches; the
+        // 'outside' feature at (9,9) does not.
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Point(new GeoPoint(5, 5))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Features);
+        Assert.Equal("inside", value.Features[0].FeatureId);
+    }
+
+    [Fact]
+    public async Task Bbox_query_returns_matches_across_multiple_specs()
+    {
+        var s124Inside = PointFeature("s124-inside", 5, 5);
+        var s124Outside = PointFeature("s124-outside", 50, 50);
+        var s122Inside = S122PointFeature("s122-inside", 6, 6);
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124(
+            "warnings",
+            S124Synth.Dataset(s124Inside, s124Outside),
+            bounds: LoadedDatasetFactory.Box(0, 0, 100, 100)));
+
+        var s122 = new S122Dataset
+        {
+            Features = ImmutableArray.Create(s122Inside),
+            InformationTypes = ImmutableArray<S122InformationType>.Empty,
+        };
+        catalog.Add(new LoadedDataset(
+            new DatasetId("mpa"),
+            LoadedDatasetFactory.S122Spec,
+            LoadedDatasetFactory.Box(0, 0, 10, 10),
+            null,
+            new EncDotNet.S100.Mcp.Tools.Catalog.S122DatasetData(s122)));
+
+        var tool = new QueryFeaturesTool(catalog);
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(2, value.TotalCount);
+        Assert.Equal(
+            new[] { "s124-inside", "s122-inside" }.OrderBy(x => x),
+            value.Features.Select(f => f.FeatureId).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task Geometryless_features_are_excluded_even_when_dataset_bounds_intersect()
+    {
+        var authority = S131GeometrylessFeature("auth-1", "Authority");
+        var s131 = new S131Dataset
+        {
+            Features = ImmutableArray.Create(authority),
+            InformationTypes = ImmutableArray<S131InformationType>.Empty,
+        };
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(new LoadedDataset(
+            new DatasetId("harbour"),
+            LoadedDatasetFactory.S131Spec,
+            LoadedDatasetFactory.Box(0, 0, 10, 10),
+            null,
+            new EncDotNet.S100.Mcp.Tools.Catalog.S131DatasetData(s131)));
+
+        var tool = new QueryFeaturesTool(catalog);
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Features);
+    }
+
+    [Fact]
+    public async Task Spec_filter_restricts_to_matching_spec_name()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124(
+            "warnings",
+            S124Synth.Dataset(PointFeature("w1", 5, 5)),
+            bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+
+        var s122 = new S122Dataset
+        {
+            Features = ImmutableArray.Create(S122PointFeature("m1", 6, 6)),
+            InformationTypes = ImmutableArray<S122InformationType>.Empty,
+        };
+        catalog.Add(new LoadedDataset(
+            new DatasetId("mpa"),
+            LoadedDatasetFactory.S122Spec,
+            LoadedDatasetFactory.Box(0, 0, 10, 10),
+            null,
+            new EncDotNet.S100.Mcp.Tools.Catalog.S122DatasetData(s122)));
+
+        var tool = new QueryFeaturesTool(catalog);
+
+        // Spec filter with default (any) edition matches every dataset
+        // of that spec name.
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Spec: new SpecRef("S-122", default)));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Features);
+        Assert.Equal("m1", value.Features[0].FeatureId);
+    }
+
+    [Fact]
+    public async Task FeatureType_filter_uses_case_sensitive_exact_match()
+    {
+        var matching = PointFeature("a", 5, 5, featureType: "NavwarnPart");
+        var other = PointFeature("b", 5, 5, featureType: "NavwarnAreaAffected");
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124(
+            "x",
+            S124Synth.Dataset(matching, other),
+            bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+
+        var tool = new QueryFeaturesTool(catalog);
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            FeatureType: "NavwarnPart"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Single(value.Features);
+        Assert.Equal("a", value.Features[0].FeatureId);
+    }
+
+    [Fact]
+    public async Task Pagination_returns_consecutive_pages_with_HasMore_flag()
+    {
+        var features = Enumerable.Range(0, 5)
+            .Select(i => PointFeature($"f{i}", 5, 5))
+            .ToArray();
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S124(
+            "x",
+            S124Synth.Dataset(features),
+            bounds: LoadedDatasetFactory.Box(0, 0, 10, 10)));
+
+        var tool = new QueryFeaturesTool(catalog);
+
+        var page0 = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Page: 0,
+            PageSize: 2));
+        Assert.True(page0.TryGetValue(out var p0));
+        Assert.Equal(5, p0.TotalCount);
+        Assert.Equal(2, p0.Features.Length);
+        Assert.True(p0.HasMore);
+
+        var page2 = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Page: 2,
+            PageSize: 2));
+        Assert.True(page2.TryGetValue(out var p2));
+        Assert.Single(p2.Features);
+        Assert.False(p2.HasMore);
+    }
+
+    [Fact]
+    public async Task Invalid_geometry_returns_geometry_invalid()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new QueryFeaturesTool(catalog);
+
+        // Polygon must close on itself; an open ring is invalid.
+        var open = new GeoPolygon(ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 1),
+            new GeoPoint(1, 1)));
+
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Polygon(open)));
+
+        Assert.False(result.TryGetValue(out _));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Fact]
+    public async Task Coverage_specs_contribute_no_features()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102("bathy"));
+        var tool = new QueryFeaturesTool(catalog);
+
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(-1, -1, 1, 1))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Features);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageAlongToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageAlongToolTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class SampleCoverageAlongToolTests
+{
+    [Fact]
+    public async Task Samples_every_vertex_inside_bounds_returns_depth_at_each()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S102Synth.Dataset(originLat: 0, originLon: 0, spacingLat: 0.01, spacingLon: 0.01,
+            numRows: 4, numCols: 4, depth: 25.0f, uncertainty: 0.5f);
+        catalog.Add(LoadedDatasetFactory.S102(
+            "s102-1",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S102CoverageSource(dataset)));
+        var tool = new SampleCoverageAlongTool(catalog);
+
+        var polyline = new GeoPolyline(ImmutableArray.Create(
+            new GeoPoint(0.01, 0.01),
+            new GeoPoint(0.02, 0.02),
+            new GeoPoint(0.03, 0.03)));
+
+        var result = await tool.InvokeAsync(new SampleCoverageAlongRequest(
+            LoadedDatasetFactory.S102Spec, polyline));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.Samples.Length);
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(i, value.Samples[i].VertexIndex);
+            Assert.NotNull(value.Samples[i].Result);
+            var depth = Assert.IsType<DepthSample>(value.Samples[i].Result!.Value);
+            Assert.Equal(25.0, depth.DepthMeters);
+        }
+    }
+
+    [Fact]
+    public async Task Vertices_outside_bounds_yield_null_results_in_order()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var dataset = S102Synth.Dataset(originLat: 0, originLon: 0, spacingLat: 0.01, spacingLon: 0.01,
+            numRows: 4, numCols: 4, depth: 10.0f, uncertainty: 0.1f);
+        catalog.Add(LoadedDatasetFactory.S102(
+            "s102-1",
+            bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04),
+            source: new S102CoverageSource(dataset)));
+        var tool = new SampleCoverageAlongTool(catalog);
+
+        var polyline = new GeoPolyline(ImmutableArray.Create(
+            new GeoPoint(0.02, 0.02),       // inside
+            new GeoPoint(50, 50),           // outside — NoDatasetCoversPoint
+            new GeoPoint(0.03, 0.03)));     // inside
+
+        var result = await tool.InvokeAsync(new SampleCoverageAlongRequest(
+            LoadedDatasetFactory.S102Spec, polyline));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.Samples.Length);
+        Assert.NotNull(value.Samples[0].Result);
+        Assert.Null(value.Samples[1].Result);
+        Assert.NotNull(value.Samples[2].Result);
+    }
+
+    [Fact]
+    public async Task Unsupported_spec_propagates_as_request_level_error()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new SampleCoverageAlongTool(catalog);
+
+        var polyline = new GeoPolyline(ImmutableArray.Create(
+            new GeoPoint(0, 0),
+            new GeoPoint(1, 1)));
+
+        var result = await tool.InvokeAsync(new SampleCoverageAlongRequest(
+            new SpecRef("S-101", new SpecVersion(1, 0, 0)),
+            polyline));
+
+        Assert.False(result.TryGetValue(out _));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<SpecNotSupportedForTool>(err);
+    }
+
+    [Fact]
+    public async Task Empty_polyline_returns_geometry_invalid()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new SampleCoverageAlongTool(catalog);
+
+        var polyline = new GeoPolyline(ImmutableArray<GeoPoint>.Empty);
+
+        var result = await tool.InvokeAsync(new SampleCoverageAlongRequest(
+            LoadedDatasetFactory.S102Spec, polyline));
+
+        Assert.False(result.TryGetValue(out _));
+        Assert.True(result.TryGetError(out var err));
+        Assert.True(err is GeometryInvalid or InvalidArgument);
+    }
+}


### PR DESCRIPTION
Lands the **spatial + temporal foundation** for the S-100 MCP tool surface, working backwards from the per-spec and cross-spec synthesis question taxonomy. Phases 3 (vessel context) and 4 (route synthesis) are intentionally deferred until we have evidence about whether the general primitives below already compose to answer those questions.

## Phase 1 — spatial primitives (merged earlier in this PR)

- `GeoPoint` / `GeoBoundingBox` / `GeoPolygon` / `GeoPolyline` records + a `GeoQuery` discriminated union.
- New `query_features` tool: returns features from every GML-encoded spec (S-122, S-124, S-125, S-127, S-128, S-129, S-131, S-201, S-411, S-421) whose geometry intersects a `GeoQuery`. Filters by spec / feature type; server-side pagination.
- New `sample_coverage_along` tool: per-vertex coverage samples for a polyline (S-102 / S-104 / S-111).
- `find_at` accepts a `GeoQuery` envelope so the agent can ask "what overlaps this region?" as well as "what's at this point?".
- S-104 and S-111 sampling wired end-to-end in `sample_coverage`.
- GML feature describers backfilled for S-122, S-125, S-127, S-128, S-131, S-201, S-411, S-421.
- `list_specs` exposes per-spec capability flags.

## Phase 2 — temporal axis

### Slice A — `list_time_steps`

Cheapest first slice: lets the agent discover available UTC time-step instants (plus cadence) for a coverage dataset before sampling. Supports S-104 and S-111; returns null cadence for S-102 (no time dimension).

### Slice B — `TimeQuery` on `sample_coverage` and `sample_coverage_along`

`TimeQuery = Instant(t) | Range(from, to) | Series(from, to, step)`, parsed from a JSON envelope on a new `times` parameter. Additive — the legacy `time` field still works (instant queries lower to it).

- Range / Series queries populate a new `series[]` array on the result with `(sampleTime, requestedTime, value)` per step.
- `Value` stays populated (first non-null step) so all existing instant-shape consumers keep working.
- Series count capped at 4096 to protect against unreasonable enumerations.
- New `time_out_of_range` error variant for zero-overlap windows; S-102 returns `not_supported_yet` for windowed queries.

### Slice C — `TimeQuery` on `query_features`

Optional `times` envelope on `query_features` filters out features whose `fixedDateRange` / `periodicDateRange` complex attributes are disjoint from the query window. Features without validity metadata are **always included** (per the open-question recommendation in the plan: absence of metadata means "always valid").

The validity helper is generic over `IGmlFeature` so any spec carrying the standard S-100 GFM date-range pattern (S-122, S-124, S-201, S-411 features that opt in) benefits without per-spec code.

## Deferred (out of scope)

- Vessel-context tools (`compute_ukc_along`, `find_berths_for_vessel`).
- Route-synthesis tools (`query_route_hazards`, `summarize_route`).
- The `VesselContext` and `RouteRef` types themselves.
- S-129 describer.

These remain on the radar — see the plan file checked into the session for the reasoning — and will only be picked up after we've watched real agents use the Phase 1–2 primitives.

## Test status

- `EncDotNet.S100.Mcp.Tools.Tests`: 188 passed, 1 skipped.
- `EncDotNet.S100.Mcp.Tests` (round-trip): 22 passed.
- Full solution: 0 failures across 24 test suites.

🤖 Co-authored with [Copilot CLI](https://github.com/features/copilot/copilot-cli)