### PR TITLE
MCP tool surface: Phase 2 — temporal axis

### DIFF
--- a/src/EncDotNet.S100.Mcp.Tools/ListSpecsTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ListSpecsTool.cs
@@ -41,10 +41,15 @@ public sealed record SpecSummary(
 /// <c>true</c> when <see cref="SampleCoverageTool"/> can sample a
 /// scalar / vector value at a point for this spec.
 /// </param>
+/// <param name="CanListTimeSteps">
+/// <c>true</c> when <see cref="ListTimeStepsTool"/> can enumerate time
+/// steps for this spec (i.e. it is a time-varying coverage product).
+/// </param>
 public sealed record SpecCapabilities(
-    bool CanQueryFeatures,
-    bool CanDescribeFeature,
-    bool CanSampleCoverage);
+    [property: Description("True when query_features can enumerate features for this spec.")] bool CanQueryFeatures,
+    [property: Description("True when describe_feature has a describer registered for this spec.")] bool CanDescribeFeature,
+    [property: Description("True when sample_coverage can sample a scalar/vector value at a point for this spec.")] bool CanSampleCoverage,
+    [property: Description("True when list_time_steps can enumerate time steps for this spec (time-varying coverage products only).")] bool CanListTimeSteps);
 
 /// <summary>Result of <see cref="ListSpecsTool"/>.</summary>
 public sealed record ListSpecsResult([property: Description("Per-spec summaries in catalog order, one entry per known spec.")] ImmutableArray<SpecSummary> Specs);
@@ -102,6 +107,13 @@ public sealed class ListSpecsTool
         "S-102", "S-104", "S-111",
     };
 
+    // Time-varying coverage specs (subset of CoverageSpecs) that
+    // ListTimeStepsTool can enumerate. S-102 is static.
+    private static readonly HashSet<string> TimeVaryingCoverageSpecs = new(StringComparer.Ordinal)
+    {
+        "S-104", "S-111",
+    };
+
     // Specs with a registered describer.
     private static readonly HashSet<string> DescribableSpecs = new(StringComparer.Ordinal)
     {
@@ -145,7 +157,8 @@ public sealed class ListSpecsTool
             var caps = new SpecCapabilities(
                 CanQueryFeatures: GmlVectorSpecs.Contains(name),
                 CanDescribeFeature: DescribableSpecs.Contains(name),
-                CanSampleCoverage: CoverageSpecs.Contains(name));
+                CanSampleCoverage: CoverageSpecs.Contains(name),
+                CanListTimeSteps: TimeVaryingCoverageSpecs.Contains(name));
             summaries.Add(new SpecSummary(name, loaded, caps));
         }
 

--- a/src/EncDotNet.S100.Mcp.Tools/ListTimeStepsTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ListTimeStepsTool.cs
@@ -1,0 +1,209 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools;
+
+/// <summary>Request payload for <see cref="ListTimeStepsTool"/>.</summary>
+/// <param name="DatasetId">
+/// Identifier of the time-varying coverage dataset to introspect. Must
+/// be currently loaded in the host catalog.
+/// </param>
+public sealed record ListTimeStepsRequest(
+    [property: Description("Identifier of a currently loaded time-varying coverage dataset (S-104 or S-111). The agent typically obtains this from list_datasets.")] DatasetId DatasetId);
+
+/// <summary>Result of <see cref="ListTimeStepsTool"/>.</summary>
+/// <param name="DatasetId">The dataset that was introspected, echoed back.</param>
+/// <param name="Spec">Spec of the dataset that was introspected.</param>
+/// <param name="Times">
+/// All UTC time-step instants in ascending order. For gridded datasets
+/// these are the per-step <c>TimePoint</c> values; for station-series
+/// datasets these are derived from the first station's <c>StartTime</c>
+/// + <c>k * TimeRecordInterval</c>.
+/// </param>
+/// <param name="Cadence">
+/// Regular interval between consecutive samples when the series is
+/// strictly uniform; otherwise <c>null</c>. Gridded coverages need not
+/// be uniform, so callers must not rely on this being set.
+/// </param>
+/// <param name="FirstTime">First time step in <see cref="Times"/>, or <c>null</c> when empty.</param>
+/// <param name="LastTime">Last time step in <see cref="Times"/>, or <c>null</c> when empty.</param>
+public sealed record ListTimeStepsResult(
+    [property: Description("The dataset that was introspected, echoed back.")] DatasetId DatasetId,
+    [property: Description("Spec of the dataset that was introspected.")] SpecRef Spec,
+    [property: Description("All UTC time-step instants in ascending order. ISO-8601 with explicit UTC offset.")] ImmutableArray<DateTimeOffset> Times,
+    [property: Description("Regular interval between consecutive samples when the series is strictly uniform; otherwise null. Callers must not rely on this being set.")] TimeSpan? Cadence,
+    [property: Description("First time step in Times, or null when empty.")] DateTimeOffset? FirstTime,
+    [property: Description("Last time step in Times, or null when empty.")] DateTimeOffset? LastTime);
+
+/// <summary>
+/// Returns the available time-step instants for a time-varying coverage
+/// dataset (S-104 water level, S-111 surface currents). Helps the agent
+/// ground temporal questions before issuing <c>sample_coverage</c> /
+/// <c>sample_coverage_along</c> calls.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gridded datasets (S-104/S-111 data coding format 2) carry an
+/// explicit <c>TimePoint</c> per coverage instance; the result lists
+/// these in ascending order. Station-series datasets (data coding
+/// format 8) carry <c>StartTime</c> + <c>TimeRecordInterval</c> per
+/// station; the result derives the series from the first station and
+/// sets <see cref="ListTimeStepsResult.Cadence"/>.
+/// </para>
+/// <para>
+/// S-102 bathymetry is static (no time axis) and returns an empty
+/// <see cref="ListTimeStepsResult.Times"/> series. Non-coverage specs
+/// raise <see cref="NotSupportedYet"/>.
+/// </para>
+/// </remarks>
+public sealed class ListTimeStepsTool
+{
+    /// <summary>Tool name used in error payloads.</summary>
+    public const string Name = "list_time_steps";
+
+    private readonly IDatasetCatalog _catalog;
+
+    /// <summary>Creates a new <see cref="ListTimeStepsTool"/>.</summary>
+    public ListTimeStepsTool(IDatasetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<ListTimeStepsResult>> InvokeAsync(
+        ListTimeStepsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        LoadedDataset? match = null;
+        foreach (var dataset in _catalog.Datasets)
+        {
+            if (dataset.Id == request.DatasetId)
+            {
+                match = dataset;
+                break;
+            }
+        }
+
+        if (match is null)
+        {
+            return Task.FromResult(ToolResult<ListTimeStepsResult>.Err(
+                new DatasetNotFound(request.DatasetId)));
+        }
+
+        return Task.FromResult(match.Data switch
+        {
+            S102CoverageData => Empty(match),
+            S104CoverageData s104g => FromGridded(match, ExtractWaterLevelTimes(s104g)),
+            S104StationSeriesData s104s => FromStations(match, ExtractStationTimes(s104s)),
+            S111CoverageData s111g => FromGridded(match, ExtractSurfaceCurrentTimes(s111g)),
+            S111StationSeriesData s111s => FromStations(match, ExtractStationTimes(s111s)),
+            _ => ToolResult<ListTimeStepsResult>.Err(new NotSupportedYet(
+                match.Spec,
+                Name,
+                $"spec '{match.Spec.Name}' is not a coverage product with a time axis")),
+        });
+    }
+
+    private static ToolResult<ListTimeStepsResult> Empty(LoadedDataset dataset) =>
+        ToolResult<ListTimeStepsResult>.Ok(new ListTimeStepsResult(
+            dataset.Id, dataset.Spec,
+            ImmutableArray<DateTimeOffset>.Empty,
+            Cadence: null, FirstTime: null, LastTime: null));
+
+    private static ToolResult<ListTimeStepsResult> FromGridded(
+        LoadedDataset dataset,
+        IEnumerable<DateTimeOffset> times)
+    {
+        var ordered = times.OrderBy(t => t).ToImmutableArray();
+        var cadence = DetectCadence(ordered);
+        return ToolResult<ListTimeStepsResult>.Ok(new ListTimeStepsResult(
+            dataset.Id, dataset.Spec, ordered, cadence,
+            ordered.Length == 0 ? null : ordered[0],
+            ordered.Length == 0 ? null : ordered[^1]));
+    }
+
+    private static ToolResult<ListTimeStepsResult> FromStations(
+        LoadedDataset dataset,
+        (DateTimeOffset Start, TimeSpan Interval, int Count)? series)
+    {
+        if (series is null)
+        {
+            return Empty(dataset);
+        }
+
+        var (start, interval, count) = series.Value;
+        var builder = ImmutableArray.CreateBuilder<DateTimeOffset>(count);
+        for (int i = 0; i < count; i++)
+        {
+            builder.Add(start + TimeSpan.FromTicks(interval.Ticks * i));
+        }
+        var times = builder.MoveToImmutable();
+        return ToolResult<ListTimeStepsResult>.Ok(new ListTimeStepsResult(
+            dataset.Id, dataset.Spec, times,
+            Cadence: interval > TimeSpan.Zero ? interval : null,
+            FirstTime: times.Length == 0 ? null : times[0],
+            LastTime: times.Length == 0 ? null : times[^1]));
+    }
+
+    private static IEnumerable<DateTimeOffset> ExtractWaterLevelTimes(S104CoverageData payload)
+    {
+        foreach (var step in payload.Source.Dataset.Coverages)
+        {
+            yield return new DateTimeOffset(DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc));
+        }
+    }
+
+    private static IEnumerable<DateTimeOffset> ExtractSurfaceCurrentTimes(S111CoverageData payload)
+    {
+        foreach (var step in payload.Source.Dataset.Coverages)
+        {
+            yield return new DateTimeOffset(DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc));
+        }
+    }
+
+    private static (DateTimeOffset Start, TimeSpan Interval, int Count)? ExtractStationTimes(S104StationSeriesData payload)
+    {
+        var stations = payload.Dataset.Stations;
+        if (stations.Count == 0) return null;
+        var first = stations[0];
+        if (first.NumberOfTimes <= 0) return null;
+        return (
+            new DateTimeOffset(DateTime.SpecifyKind(first.StartTime, DateTimeKind.Utc)),
+            first.TimeRecordInterval,
+            first.NumberOfTimes);
+    }
+
+    private static (DateTimeOffset Start, TimeSpan Interval, int Count)? ExtractStationTimes(S111StationSeriesData payload)
+    {
+        var stations = payload.Dataset.Stations;
+        if (stations.Count == 0) return null;
+        var first = stations[0];
+        if (first.NumberOfTimes <= 0) return null;
+        return (
+            new DateTimeOffset(DateTime.SpecifyKind(first.StartTime, DateTimeKind.Utc)),
+            first.TimeRecordInterval,
+            first.NumberOfTimes);
+    }
+
+    // Returns the common cadence if every adjacent pair is equally
+    // spaced; null otherwise. Single-element series returns null.
+    private static TimeSpan? DetectCadence(ImmutableArray<DateTimeOffset> times)
+    {
+        if (times.Length < 2) return null;
+        var first = times[1] - times[0];
+        if (first <= TimeSpan.Zero) return null;
+        for (int i = 2; i < times.Length; i++)
+        {
+            if (times[i] - times[i - 1] != first) return null;
+        }
+        return first;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/QueryFeaturesTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/QueryFeaturesTool.cs
@@ -4,6 +4,7 @@ using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Geometry;
 using EncDotNet.S100.Mcp.Tools.Spec;
+using EncDotNet.S100.Mcp.Tools.Time;
 using EncDotNet.S100.Pipelines;
 
 namespace EncDotNet.S100.Mcp.Tools;
@@ -31,6 +32,7 @@ public sealed record QueryFeaturesRequest(
     [property: Description("Spatial query envelope (point / box / polygon / polyline). Intersection is computed against each feature's bounding box.")] GeoQuery Query,
     [property: Description("Optional spec filter; null matches every spec. A default edition matches every edition of the same spec name.")] SpecRef? Spec = null,
     [property: Description("Optional case-sensitive feature-type filter (the GML element local name, e.g. \"NavwarnPart\", \"BuoyLateral\"); null returns every feature type.")] string? FeatureType = null,
+    [property: Description("Optional temporal filter. When supplied, features whose fixedDateRange/periodicDateRange validity window is disjoint from the query window are excluded; features without validity metadata are always included.")] TimeQuery? Times = null,
     [property: Description("Zero-based page index into the result set.")] int Page = 0,
     [property: Description("Maximum features per page; clamped to the range 1..500.")] int PageSize = 50);
 
@@ -153,6 +155,12 @@ public sealed class QueryFeaturesTool
                 }
 
                 if (!GmlFeatureGeometry.Intersects(feature, request.Query))
+                {
+                    continue;
+                }
+
+                if (request.Times is { } times
+                    && FeatureValidity.Check(feature, times) == FeatureValidity.Verdict.Disjoint)
                 {
                     continue;
                 }

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageAlongTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageAlongTool.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Time;
 
 namespace EncDotNet.S100.Mcp.Tools;
 
@@ -20,10 +21,16 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// Applied identically to every vertex — useful for "depth/level at
 /// each waypoint at the same instant" queries. Ignored for S-102.
 /// </param>
+/// <param name="Times">
+/// Optional richer temporal query, applied identically to every vertex.
+/// Takes precedence over <paramref name="Time"/>. Range/Series produce
+/// per-vertex series (see <see cref="SampleCoverageResult.Series"/>).
+/// </param>
 public sealed record SampleCoverageAlongRequest(
     [property: Description("Coverage spec to sample (S-102, S-104, or S-111).")] SpecRef Spec,
     [property: Description("Polyline to sample. Each vertex is sampled at its coordinate; the polyline's CorridorWidthMeters is ignored (corridor width applies to membership queries, not point sampling).")] GeoPolyline Polyline,
-    [property: Description("Optional UTC ISO-8601 time selector applied identically to every vertex; for time-varying products (S-104, S-111) only. Ignored for S-102.")] DateTimeOffset? Time = null);
+    [property: Description("Optional UTC ISO-8601 time selector applied identically to every vertex; for time-varying products (S-104, S-111) only. Ignored for S-102.")] DateTimeOffset? Time = null,
+    [property: Description("Optional TimeQuery (instant / range / series) applied identically to every vertex; takes precedence over 'Time'.")] TimeQuery? Times = null);
 
 /// <summary>
 /// A single sample along the polyline.
@@ -117,7 +124,7 @@ public sealed class SampleCoverageAlongTool
             cancellationToken.ThrowIfCancellationRequested();
             var v = vertices[i];
             var inner = await _sampler.InvokeAsync(
-                new SampleCoverageRequest(request.Spec, v.Latitude, v.Longitude, request.Time),
+                new SampleCoverageRequest(request.Spec, v.Latitude, v.Longitude, request.Time, request.Times),
                 cancellationToken).ConfigureAwait(false);
 
             // Request-level errors (unsupported spec) propagate; per-

--- a/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/SampleCoverageTool.cs
@@ -3,8 +3,10 @@ using EncDotNet.S100.Datasets.S102;
 using EncDotNet.S100.Datasets.S104;
 using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Time;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using System.Collections.Immutable;
 using System.ComponentModel;
 
 namespace EncDotNet.S100.Mcp.Tools;
@@ -19,22 +21,55 @@ namespace EncDotNet.S100.Mcp.Tools;
 /// step of the matched coverage is used. When supplied, the nearest time step is
 /// selected; times outside the dataset's range clamp to the first or last step.
 /// </param>
+/// <param name="Times">
+/// Optional richer temporal query. Takes precedence over <paramref name="Time"/>
+/// when supplied. <c>Instant</c> behaves like <paramref name="Time"/>; <c>Range</c>
+/// and <c>Series</c> populate <see cref="SampleCoverageResult.Series"/> with a
+/// per-step entry. Currently honoured for gridded S-104 and S-111; ignored
+/// elsewhere.
+/// </param>
 public sealed record SampleCoverageRequest(
     [property: Description("Spec of the coverage to sample (S-102, S-104, or S-111).")] SpecRef Spec,
     [property: Description("Sample latitude in decimal degrees, WGS-84, range -90..+90.")] double Latitude,
     [property: Description("Sample longitude in decimal degrees, WGS-84, range -180..+180.")] double Longitude,
-    [property: Description("UTC ISO-8601 time selector for time-varying products; ignored for S-102. Null selects the first time step; non-null selects the nearest step (clamped to the dataset range).")] DateTimeOffset? Time = null);
+    [property: Description("UTC ISO-8601 time selector for time-varying products; ignored for S-102. Null selects the first time step; non-null selects the nearest step (clamped to the dataset range).")] DateTimeOffset? Time = null,
+    [property: Description("Optional TimeQuery (instant / range / series). Takes precedence over 'Time'. Range/Series populate the result's 'Series' field with one entry per dataset step in window.")] TimeQuery? Times = null);
 
 /// <summary>Result of <see cref="SampleCoverageTool"/>.</summary>
 /// <param name="DatasetId">Dataset that produced the sample.</param>
 /// <param name="Latitude">Latitude that was requested, echoed back (decimal degrees, WGS-84).</param>
 /// <param name="Longitude">Longitude that was requested, echoed back (decimal degrees, WGS-84).</param>
 /// <param name="Value">Typed sample payload; discriminated on the JSON <c>$kind</c> property.</param>
+/// <param name="Series">
+/// Optional per-time-step series, populated when the request's
+/// <see cref="SampleCoverageRequest.Times"/> is a <c>Range</c> or <c>Series</c>
+/// and the matched dataset is a supported time-varying coverage. Null for
+/// single-instant queries, for S-102, and for station-series datasets (which
+/// currently honour only single-instant time selection).
+/// </param>
 public sealed record SampleCoverageResult(
     [property: Description("Identifier of the dataset that produced the sample.")] DatasetId DatasetId,
     [property: Description("Latitude that was requested, echoed back in decimal degrees, WGS-84.")] double Latitude,
     [property: Description("Longitude that was requested, echoed back in decimal degrees, WGS-84.")] double Longitude,
-    [property: Description("Typed sample payload; the JSON \"$kind\" discriminator selects the variant.")] SampledValue Value);
+    [property: Description("Typed sample payload; the JSON \"$kind\" discriminator selects the variant.")] SampledValue Value,
+    [property: Description("Optional per-step series; populated when the request's Times is Range/Series and the dataset is gridded S-104 or S-111.")] ImmutableArray<TimedSampledValue>? Series = null);
+
+/// <summary>
+/// A single entry in a <see cref="SampleCoverageResult.Series"/>: the
+/// dataset's actual time-step instant alongside the sampled value at the
+/// requested cell.
+/// </summary>
+/// <param name="SampleTime">UTC instant of the time step actually selected for this entry.</param>
+/// <param name="RequestedTime">
+/// UTC instant the caller asked for. For <c>Range</c> queries this is the
+/// dataset's step instant itself (the window selected it); for <c>Series</c>
+/// queries this is the enumerated series instant the step was snapped to.
+/// </param>
+/// <param name="Value">Typed sample payload, or <c>null</c> when the cell has no data at this step.</param>
+public sealed record TimedSampledValue(
+    [property: Description("UTC instant of the time step actually selected for this entry.")] DateTime SampleTime,
+    [property: Description("UTC instant the caller asked for (the dataset step for Range; the enumerated instant for Series).")] DateTimeOffset RequestedTime,
+    [property: Description("Typed sample payload, or null when the cell has no data at this step.")] SampledValue? Value);
 
 /// <summary>Discriminated payload returned by <see cref="SampleCoverageTool"/>.</summary>
 public abstract record SampledValue;
@@ -185,13 +220,35 @@ public sealed class SampleCoverageTool
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        return Task.FromResult(request.Spec.Name switch
+        // Normalise the temporal selector: if Times is an Instant, lower
+        // it onto the legacy 'Time' field so the existing single-instant
+        // paths apply unchanged. Range/Series dispatch to a windowed path.
+        var effective = request;
+        if (request.Times is TimeQuery.Instant inst)
         {
-            "S-102" => SampleS102(request),
-            "S-104" => SampleS104(request),
-            "S-111" => SampleS111(request),
+            effective = request with { Time = inst.Value, Times = null };
+        }
+
+        if (effective.Times is TimeQuery.Range or TimeQuery.Series)
+        {
+            return Task.FromResult(effective.Spec.Name switch
+            {
+                "S-102" => ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
+                    effective.Spec, Name, "S-102 has no time dimension; supply 'Time'/'Times' only for S-104 or S-111")),
+                "S-104" => SampleS104Windowed(effective),
+                "S-111" => SampleS111Windowed(effective),
+                _ => ToolResult<SampleCoverageResult>.Err(
+                    new SpecNotSupportedForTool(effective.Spec, Name)),
+            });
+        }
+
+        return Task.FromResult(effective.Spec.Name switch
+        {
+            "S-102" => SampleS102(effective),
+            "S-104" => SampleS104(effective),
+            "S-111" => SampleS111(effective),
             _ => ToolResult<SampleCoverageResult>.Err(
-                new SpecNotSupportedForTool(request.Spec, Name)),
+                new SpecNotSupportedForTool(effective.Spec, Name)),
         });
     }
 
@@ -618,6 +675,306 @@ public sealed class SampleCoverageTool
                 request.Time,
                 bestStation.Latitude,
                 bestStation.Longitude)));
+    }
+
+    /// <summary>
+    /// Windowed S-104 sampling: dispatched when <see cref="SampleCoverageRequest.Times"/>
+    /// is <see cref="TimeQuery.Range"/> or <see cref="TimeQuery.Series"/>. Only the
+    /// gridded (dcf=2) path is currently honoured — station-series datasets fall back
+    /// to the existing single-instant behaviour.
+    /// </summary>
+    private ToolResult<SampleCoverageResult> SampleS104Windowed(SampleCoverageRequest request)
+    {
+        var snapshot = _catalog.Datasets;
+        LoadedDataset? bestDataset = null;
+        S104Dataset? bestModel = null;
+        WaterLevelCoverage? bestCoverage = null;
+        double bestArea = double.PositiveInfinity;
+        bool anyS104Gridded = false;
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S104CoverageData s104) continue;
+            anyS104Gridded = true;
+            var model = s104.Source.Dataset;
+            if (model.Coverages.Count == 0) continue;
+            var probe = model.Coverages[0];
+            if (!CoverageContains(probe, request.Latitude, request.Longitude)) continue;
+            var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
+            if (area < bestArea)
+            {
+                bestArea = area;
+                bestDataset = dataset;
+                bestModel = model;
+                bestCoverage = probe;
+            }
+        }
+
+        if (bestDataset is null || bestModel is null || bestCoverage is null)
+        {
+            return ToolResult<SampleCoverageResult>.Err(anyS104Gridded
+                ? new NotSupportedYet(request.Spec, Name, "windowed time queries are only supported for gridded S-104 (dcf=2); no in-bounds gridded dataset was found")
+                : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+        }
+
+        if (bestModel.DataCodingFormat != 2)
+        {
+            return ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
+                request.Spec, Name,
+                $"data coding format {bestModel.DataCodingFormat} is not yet supported (only dcf=2 / regular grid)"));
+        }
+
+        var instants = ResolveStepIndices(bestModel.Coverages, request.Times!, out var firstStep, out var lastStep);
+        if (instants.Length == 0)
+        {
+            var (from, to) = request.Times!.GetWindow();
+            return ToolResult<SampleCoverageResult>.Err(new TimeOutOfRange(
+                "times", from, to,
+                firstStep is null ? null : new DateTimeOffset(DateTime.SpecifyKind(firstStep.Value, DateTimeKind.Utc)),
+                lastStep is null ? null : new DateTimeOffset(DateTime.SpecifyKind(lastStep.Value, DateTimeKind.Utc))));
+        }
+
+        try
+        {
+            var (row, col) = NearestCellInCoverage(bestCoverage, request.Latitude, request.Longitude);
+            var cellLat = bestCoverage.OriginLatitude + row * bestCoverage.SpacingLatitudinal;
+            var cellLon = bestCoverage.OriginLongitude + col * bestCoverage.SpacingLongitudinal;
+
+            var series = ImmutableArray.CreateBuilder<TimedSampledValue>(instants.Length);
+            SampledValue? firstValue = null;
+            DateTime firstSampleTime = default;
+            foreach (var (requestedInstant, stepIndex) in instants)
+            {
+                var step = bestModel.Coverages[stepIndex];
+                var idx = row * step.NumPointsLongitudinal + col;
+                var value = step.Values[idx];
+                SampledValue? sampled;
+                if (value.Height == S104CoverageSource.FillValue)
+                {
+                    sampled = null;
+                }
+                else
+                {
+                    sampled = new WaterLevelSample(
+                        value.Height,
+                        DecodeWaterLevelTrend(value.Trend),
+                        DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc),
+                        requestedInstant,
+                        row,
+                        col,
+                        cellLat,
+                        cellLon);
+                }
+                var stepTimeUtc = DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc);
+                series.Add(new TimedSampledValue(stepTimeUtc, requestedInstant, sampled));
+                if (firstValue is null && sampled is not null)
+                {
+                    firstValue = sampled;
+                    firstSampleTime = stepTimeUtc;
+                }
+            }
+
+            // Fall back to a placeholder Value if every step had NoData,
+            // since SampleCoverageResult.Value is non-nullable.
+            firstValue ??= new WaterLevelSample(
+                double.NaN, "unknown", firstSampleTime == default
+                    ? DateTime.SpecifyKind(bestModel.Coverages[instants[0].StepIndex].TimePoint, DateTimeKind.Utc)
+                    : firstSampleTime,
+                instants[0].RequestedTime, 0, 0, cellLat, cellLon);
+
+            return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
+                bestDataset.Id,
+                request.Latitude,
+                request.Longitude,
+                firstValue,
+                series.MoveToImmutable()));
+        }
+        catch (ObjectDisposedException)
+        {
+            return ToolResult<SampleCoverageResult>.Err(
+                new DatasetClosedDuringQuery(bestDataset.Id));
+        }
+    }
+
+    /// <summary>
+    /// Windowed S-111 sampling — mirror of <see cref="SampleS104Windowed"/>.
+    /// </summary>
+    private ToolResult<SampleCoverageResult> SampleS111Windowed(SampleCoverageRequest request)
+    {
+        var snapshot = _catalog.Datasets;
+        LoadedDataset? bestDataset = null;
+        S111Dataset? bestModel = null;
+        SurfaceCurrentCoverage? bestCoverage = null;
+        double bestArea = double.PositiveInfinity;
+        bool anyS111Gridded = false;
+        foreach (var dataset in snapshot)
+        {
+            if (dataset.Data is not S111CoverageData s111) continue;
+            anyS111Gridded = true;
+            var model = s111.Source.Dataset;
+            if (model.Coverages.Count == 0) continue;
+            var probe = model.Coverages[0];
+            if (!CoverageContains(probe, request.Latitude, request.Longitude)) continue;
+            var area = probe.SpacingLatitudinal * probe.SpacingLongitudinal;
+            if (area < bestArea)
+            {
+                bestArea = area;
+                bestDataset = dataset;
+                bestModel = model;
+                bestCoverage = probe;
+            }
+        }
+
+        if (bestDataset is null || bestModel is null || bestCoverage is null)
+        {
+            return ToolResult<SampleCoverageResult>.Err(anyS111Gridded
+                ? new NotSupportedYet(request.Spec, Name, "windowed time queries are only supported for gridded S-111 (dcf=2); no in-bounds gridded dataset was found")
+                : new NoDatasetCoversPoint(request.Latitude, request.Longitude));
+        }
+
+        if (bestModel.DataCodingFormat != 2)
+        {
+            return ToolResult<SampleCoverageResult>.Err(new NotSupportedYet(
+                request.Spec, Name,
+                $"data coding format {bestModel.DataCodingFormat} is not yet supported (only dcf=2 / regular grid)"));
+        }
+
+        var instants = ResolveStepIndices(bestModel.Coverages, request.Times!, out var firstStep, out var lastStep);
+        if (instants.Length == 0)
+        {
+            var (from, to) = request.Times!.GetWindow();
+            return ToolResult<SampleCoverageResult>.Err(new TimeOutOfRange(
+                "times", from, to,
+                firstStep is null ? null : new DateTimeOffset(DateTime.SpecifyKind(firstStep.Value, DateTimeKind.Utc)),
+                lastStep is null ? null : new DateTimeOffset(DateTime.SpecifyKind(lastStep.Value, DateTimeKind.Utc))));
+        }
+
+        try
+        {
+            var (row, col) = NearestCellInCoverage(bestCoverage, request.Latitude, request.Longitude);
+            var cellLat = bestCoverage.OriginLatitude + row * bestCoverage.SpacingLatitudinal;
+            var cellLon = bestCoverage.OriginLongitude + col * bestCoverage.SpacingLongitudinal;
+
+            var series = ImmutableArray.CreateBuilder<TimedSampledValue>(instants.Length);
+            SampledValue? firstValue = null;
+            DateTime firstSampleTime = default;
+            foreach (var (requestedInstant, stepIndex) in instants)
+            {
+                var step = bestModel.Coverages[stepIndex];
+                var idx = row * step.NumPointsLongitudinal + col;
+                var value = step.Values[idx];
+                SampledValue? sampled;
+                if (value.Speed == S111CoverageSource.FillValue)
+                {
+                    sampled = null;
+                }
+                else
+                {
+                    sampled = new SurfaceCurrentSample(
+                        value.Speed,
+                        value.Speed * MetresPerSecondToKnots,
+                        value.Direction,
+                        DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc),
+                        requestedInstant,
+                        row,
+                        col,
+                        cellLat,
+                        cellLon);
+                }
+                var stepTimeUtc = DateTime.SpecifyKind(step.TimePoint, DateTimeKind.Utc);
+                series.Add(new TimedSampledValue(stepTimeUtc, requestedInstant, sampled));
+                if (firstValue is null && sampled is not null)
+                {
+                    firstValue = sampled;
+                    firstSampleTime = stepTimeUtc;
+                }
+            }
+
+            firstValue ??= new SurfaceCurrentSample(
+                double.NaN, double.NaN, double.NaN,
+                firstSampleTime == default
+                    ? DateTime.SpecifyKind(bestModel.Coverages[instants[0].StepIndex].TimePoint, DateTimeKind.Utc)
+                    : firstSampleTime,
+                instants[0].RequestedTime, 0, 0, cellLat, cellLon);
+
+            return ToolResult<SampleCoverageResult>.Ok(new SampleCoverageResult(
+                bestDataset.Id,
+                request.Latitude,
+                request.Longitude,
+                firstValue,
+                series.MoveToImmutable()));
+        }
+        catch (ObjectDisposedException)
+        {
+            return ToolResult<SampleCoverageResult>.Err(
+                new DatasetClosedDuringQuery(bestDataset.Id));
+        }
+    }
+
+    /// <summary>
+    /// Resolves the time-step indices for a windowed <see cref="TimeQuery"/>:
+    /// <list type="bullet">
+    /// <item><description><see cref="TimeQuery.Range"/>: every dataset step whose
+    /// <c>TimePoint</c> falls within the window, with the step's own time used as
+    /// the requested-time echo.</description></item>
+    /// <item><description><see cref="TimeQuery.Series"/>: one entry per enumerated
+    /// instant, snapped to the nearest dataset step; consecutive duplicates are
+    /// suppressed but the agent's requested instants are preserved.</description></item>
+    /// </list>
+    /// Returns an empty array when no overlap exists.
+    /// </summary>
+    private static ImmutableArray<(DateTimeOffset RequestedTime, int StepIndex)> ResolveStepIndices<TCoverage>(
+        IReadOnlyList<TCoverage> coverages,
+        TimeQuery query,
+        out DateTime? firstStep,
+        out DateTime? lastStep)
+        where TCoverage : class
+    {
+        firstStep = coverages.Count == 0 ? null : GetTimePoint(coverages[0]);
+        lastStep = coverages.Count == 0 ? null : GetTimePoint(coverages[coverages.Count - 1]);
+        if (coverages.Count == 0)
+        {
+            return ImmutableArray<(DateTimeOffset, int)>.Empty;
+        }
+
+        switch (query)
+        {
+            case TimeQuery.Range r:
+            {
+                var fromUtc = r.From.UtcDateTime;
+                var toUtc = r.To.UtcDateTime;
+                var builder = ImmutableArray.CreateBuilder<(DateTimeOffset, int)>();
+                for (int i = 0; i < coverages.Count; i++)
+                {
+                    var tp = GetTimePoint(coverages[i]);
+                    if (tp >= fromUtc && tp <= toUtc)
+                    {
+                        builder.Add((new DateTimeOffset(DateTime.SpecifyKind(tp, DateTimeKind.Utc)), i));
+                    }
+                }
+                return builder.ToImmutable();
+            }
+            case TimeQuery.Series s:
+            {
+                var enumerated = s.Enumerate();
+                var builder = ImmutableArray.CreateBuilder<(DateTimeOffset, int)>(enumerated.Length);
+                int? lastIndex = null;
+                foreach (var instant in enumerated)
+                {
+                    var idx = SelectTimeStep(coverages, instant);
+                    if (lastIndex == idx)
+                    {
+                        // Preserve the requested-time echo but skip duplicate dataset rows.
+                        builder.Add((instant, idx));
+                        continue;
+                    }
+                    builder.Add((instant, idx));
+                    lastIndex = idx;
+                }
+                return builder.ToImmutable();
+            }
+            default:
+                return ImmutableArray<(DateTimeOffset, int)>.Empty;
+        }
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Mcp.Tools/Time/FeatureValidity.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Time/FeatureValidity.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Mcp.Tools.Time;
+
+/// <summary>
+/// Inspects an <see cref="IGmlFeature"/> for S-100 validity metadata
+/// — the <c>fixedDateRange</c> and <c>periodicDateRange</c> complex
+/// attributes carried by specs such as S-122 (seasonal MPA
+/// restrictions), S-124 (warning in-force periods), S-201 (AtoN
+/// status reports), and S-411 (per-feature ice product valid time).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The S-100 General Feature Model declares both ranges as complex
+/// attributes with <c>dateStart</c> and <c>dateEnd</c> sub-attributes
+/// in ISO-8601 form. Either bound may be absent, which means
+/// "open-ended on that side".
+/// </para>
+/// <para>
+/// Per the Phase 2 plan question 4 recommendation, a feature with
+/// no validity metadata at all is treated as "always valid" — its
+/// validity is <see cref="Validity.Unknown"/> and callers should
+/// include it under any <see cref="TimeQuery"/>.
+/// </para>
+/// </remarks>
+internal static class FeatureValidity
+{
+    /// <summary>Validity verdict for a feature against a <see cref="TimeQuery"/>.</summary>
+    internal enum Verdict
+    {
+        /// <summary>The feature carries no validity metadata; include unconditionally.</summary>
+        Unknown,
+
+        /// <summary>The feature's validity range overlaps the query window.</summary>
+        Overlaps,
+
+        /// <summary>The feature's validity range is known and is disjoint from the query window.</summary>
+        Disjoint,
+    }
+
+    /// <summary>
+    /// Checks whether <paramref name="feature"/> overlaps
+    /// <paramref name="query"/>. Returns <see cref="Verdict.Unknown"/>
+    /// when no validity metadata is present.
+    /// </summary>
+    public static Verdict Check(IGmlFeature feature, TimeQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var (windowStart, windowEnd) = query.GetWindow();
+
+        var ranges = ExtractRanges(feature);
+        if (ranges.Count == 0)
+        {
+            return Verdict.Unknown;
+        }
+
+        foreach (var (start, end) in ranges)
+        {
+            if (Overlaps(start, end, windowStart, windowEnd))
+            {
+                return Verdict.Overlaps;
+            }
+        }
+
+        return Verdict.Disjoint;
+    }
+
+    private static bool Overlaps(
+        DateTimeOffset? rangeStart,
+        DateTimeOffset? rangeEnd,
+        DateTimeOffset windowStart,
+        DateTimeOffset windowEnd)
+    {
+        if (rangeStart.HasValue && rangeStart.Value > windowEnd)
+        {
+            return false;
+        }
+
+        if (rangeEnd.HasValue && rangeEnd.Value < windowStart)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static List<(DateTimeOffset? Start, DateTimeOffset? End)> ExtractRanges(IGmlFeature feature)
+    {
+        var ranges = new List<(DateTimeOffset?, DateTimeOffset?)>();
+
+        foreach (var complex in feature.GmlComplexAttributes)
+        {
+            if (!IsValidityRange(complex.Code))
+            {
+                continue;
+            }
+
+            var start = TryParseDate(complex.SubAttributes.GetValueOrDefault("dateStart"));
+            var end = TryParseDate(complex.SubAttributes.GetValueOrDefault("dateEnd"));
+            if (start is null && end is null)
+            {
+                continue;
+            }
+
+            ranges.Add((start, end));
+        }
+
+        return ranges;
+    }
+
+    private static bool IsValidityRange(string code)
+    {
+        return string.Equals(code, "fixedDateRange", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(code, "periodicDateRange", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static DateTimeOffset? TryParseDate(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Time/TimeQuery.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Time/TimeQuery.cs
@@ -1,0 +1,185 @@
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Mcp.Tools.Time;
+
+/// <summary>
+/// Discriminated union over the supported temporal input shapes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tools that accept a time parameter take a <see cref="TimeQuery"/>
+/// rather than a bare <c>DateTimeOffset?</c> so the same wire shape
+/// handles single-instant, range, and stepped-series questions.
+/// </para>
+/// <para>
+/// <see cref="Instant"/> selects a single point in time (the existing
+/// nearest-step semantics in coverage samplers). <see cref="Range"/>
+/// expresses "anywhere in [from, to]" — used both as a coverage-series
+/// window and as a feature-validity filter. <see cref="Series"/>
+/// expresses "every <c>step</c> from <c>from</c> through <c>to</c>",
+/// useful for "every 30 min for 6 hours" agent queries.
+/// </para>
+/// <para>
+/// Construct instances via the static factory methods; the underlying
+/// records validate their bounds and throw <see cref="ArgumentException"/>
+/// on degenerate inputs. Use <see cref="TimeQueryJsonReader.Parse"/>
+/// to construct from the wire format.
+/// </para>
+/// </remarks>
+public abstract record TimeQuery
+{
+    /// <summary>Hard cap on the number of instants a <see cref="Series"/> may enumerate.</summary>
+    /// <remarks>
+    /// Mirrors the page-size cap on <c>query_features</c> — server-side
+    /// protection against agents asking for a 1-second cadence over a
+    /// week. Tools should surface a structured error when the requested
+    /// cadence × window exceeds this.
+    /// </remarks>
+    public const int MaxSeriesCount = 4096;
+
+    private TimeQuery() { }
+
+    /// <summary>Single-instant query (nearest-step in coverage samplers).</summary>
+    /// <param name="Value">The instant of interest, normalised to UTC.</param>
+    public sealed record Instant(DateTimeOffset Value) : TimeQuery;
+
+    /// <summary>
+    /// Closed time window <c>[From, To]</c>. For coverage samplers this
+    /// returns every dataset time-step whose <c>TimePoint</c> falls
+    /// within the window. For feature-validity filters this matches any
+    /// feature whose validity interval overlaps the window.
+    /// </summary>
+    /// <param name="From">Window start (inclusive), normalised to UTC.</param>
+    /// <param name="To">Window end (inclusive), normalised to UTC; must be &gt;= <paramref name="From"/>.</param>
+    public sealed record Range(DateTimeOffset From, DateTimeOffset To) : TimeQuery
+    {
+        /// <summary>Span of the window, always &gt;= <see cref="TimeSpan.Zero"/>.</summary>
+        public TimeSpan Duration => To - From;
+    }
+
+    /// <summary>
+    /// Stepped enumeration from <see cref="From"/> through <see cref="To"/>
+    /// inclusive, separated by <see cref="Step"/>.
+    /// </summary>
+    /// <param name="From">First instant in the series.</param>
+    /// <param name="To">Last instant the series may not exceed.</param>
+    /// <param name="Step">Cadence between successive instants; must be &gt; <see cref="TimeSpan.Zero"/>.</param>
+    public sealed record Series(DateTimeOffset From, DateTimeOffset To, TimeSpan Step) : TimeQuery
+    {
+        /// <summary>
+        /// Materialises the series as an immutable array. Throws
+        /// <see cref="InvalidOperationException"/> if the count would
+        /// exceed <see cref="MaxSeriesCount"/>.
+        /// </summary>
+        public ImmutableArray<DateTimeOffset> Enumerate()
+        {
+            var count = EstimatedCount;
+            if (count > MaxSeriesCount)
+            {
+                throw new InvalidOperationException(
+                    $"Series would yield {count} instants which exceeds the cap of {MaxSeriesCount}.");
+            }
+            var builder = ImmutableArray.CreateBuilder<DateTimeOffset>(count);
+            for (int i = 0; i < count; i++)
+            {
+                builder.Add(From + TimeSpan.FromTicks(Step.Ticks * i));
+            }
+            return builder.MoveToImmutable();
+        }
+
+        /// <summary>
+        /// Number of instants that <see cref="Enumerate"/> would produce,
+        /// without materialising them. Always at least 1 when <c>From == To</c>.
+        /// </summary>
+        public int EstimatedCount
+        {
+            get
+            {
+                var span = To - From;
+                if (span <= TimeSpan.Zero) return 1;
+                var n = (long)(span.Ticks / Step.Ticks) + 1;
+                return n > int.MaxValue ? int.MaxValue : (int)n;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a single-instant query. The supplied <see cref="DateTimeOffset"/>
+    /// is normalised to UTC.
+    /// </summary>
+    public static Instant At(DateTimeOffset value) =>
+        new(value.ToUniversalTime());
+
+    /// <summary>
+    /// Creates a range query. Throws <see cref="ArgumentException"/> when
+    /// <paramref name="to"/> precedes <paramref name="from"/>.
+    /// </summary>
+    public static Range Between(DateTimeOffset from, DateTimeOffset to)
+    {
+        from = from.ToUniversalTime();
+        to = to.ToUniversalTime();
+        if (to < from)
+        {
+            throw new ArgumentException("'to' must be greater than or equal to 'from'.", nameof(to));
+        }
+        return new Range(from, to);
+    }
+
+    /// <summary>
+    /// Creates a stepped-series query. Throws <see cref="ArgumentException"/>
+    /// on degenerate ordering or non-positive step.
+    /// </summary>
+    public static Series Every(DateTimeOffset from, DateTimeOffset to, TimeSpan step)
+    {
+        from = from.ToUniversalTime();
+        to = to.ToUniversalTime();
+        if (to < from)
+        {
+            throw new ArgumentException("'to' must be greater than or equal to 'from'.", nameof(to));
+        }
+        if (step <= TimeSpan.Zero)
+        {
+            throw new ArgumentException("'step' must be strictly positive.", nameof(step));
+        }
+        return new Series(from, to, step);
+    }
+
+    /// <summary>
+    /// Window covered by this query. For <see cref="Instant"/> the
+    /// window is a degenerate (zero-length) range at the requested
+    /// instant; for <see cref="Series"/> it's the range from
+    /// <c>From</c> to <c>To</c> (the actual enumeration may end earlier
+    /// when <c>(To - From) % Step != 0</c>).
+    /// </summary>
+    public (DateTimeOffset From, DateTimeOffset To) GetWindow() => this switch
+    {
+        Instant i => (i.Value, i.Value),
+        Range r => (r.From, r.To),
+        Series s => (s.From, s.To),
+        _ => throw new InvalidOperationException("Unknown TimeQuery variant."),
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when this query's window overlaps the supplied
+    /// validity interval. Useful for feature-validity filtering.
+    /// </summary>
+    /// <param name="validityStart">Inclusive validity start; <c>null</c> means "open-ended in the past".</param>
+    /// <param name="validityEnd">Inclusive validity end; <c>null</c> means "open-ended in the future".</param>
+    public bool Overlaps(DateTimeOffset? validityStart, DateTimeOffset? validityEnd)
+    {
+        var (from, to) = GetWindow();
+        if (validityEnd is { } end && end < from) return false;
+        if (validityStart is { } start && start > to) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="instant"/> falls inside
+    /// this query's window. For <see cref="Instant"/> requires equality.
+    /// </summary>
+    public bool Contains(DateTimeOffset instant)
+    {
+        var (from, to) = GetWindow();
+        return instant >= from && instant <= to;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/Time/TimeQueryJsonReader.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Time/TimeQueryJsonReader.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+
+namespace EncDotNet.S100.Mcp.Tools.Time;
+
+/// <summary>
+/// Parses the wire-format JSON envelope for <see cref="TimeQuery"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The envelope is shared by every tool that accepts a temporal
+/// parameter. Three shapes are accepted:
+/// </para>
+/// <code>
+/// { "kind": "instant", "t": "2024-01-01T14:00:00Z" }
+/// { "kind": "range",   "from": "2024-01-01T00:00:00Z", "to": "2024-01-01T06:00:00Z" }
+/// { "kind": "series",  "from": "...", "to": "...", "stepSeconds": 1800 }
+/// </code>
+/// <para>
+/// All timestamps must be ISO-8601 with an explicit offset or trailing
+/// <c>Z</c>; values without offsets are rejected. <c>stepSeconds</c>
+/// must be a positive number.
+/// </para>
+/// </remarks>
+public static class TimeQueryJsonReader
+{
+    /// <summary>
+    /// Parses the JSON envelope. Throws <see cref="ArgumentException"/>
+    /// on malformed input.
+    /// </summary>
+    public static TimeQuery Parse(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        using var doc = JsonDocument.Parse(json);
+        return Parse(doc.RootElement);
+    }
+
+    /// <summary>Parses the JSON envelope from an already-loaded <see cref="JsonElement"/>.</summary>
+    public static TimeQuery Parse(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException("TimeQuery JSON must be an object.", nameof(root));
+        }
+
+        if (!root.TryGetProperty("kind", out var kindElement) || kindElement.ValueKind != JsonValueKind.String)
+        {
+            throw new ArgumentException("TimeQuery JSON must include a string 'kind' property.", nameof(root));
+        }
+
+        var kind = kindElement.GetString();
+        return kind switch
+        {
+            "instant" => ParseInstant(root),
+            "range" => ParseRange(root),
+            "series" => ParseSeries(root),
+            _ => throw new ArgumentException(
+                $"Unknown TimeQuery kind '{kind}'. Expected one of 'instant', 'range', 'series'.",
+                nameof(root)),
+        };
+    }
+
+    private static TimeQuery ParseInstant(JsonElement root)
+    {
+        if (!root.TryGetProperty("t", out var t) || t.ValueKind != JsonValueKind.String)
+        {
+            throw new ArgumentException("instant TimeQuery requires a string 't' property.", nameof(root));
+        }
+        return TimeQuery.At(ReadOffsetDateTime(t, "t"));
+    }
+
+    private static TimeQuery ParseRange(JsonElement root)
+    {
+        var from = ReadRequiredOffsetDateTime(root, "from");
+        var to = ReadRequiredOffsetDateTime(root, "to");
+        try
+        {
+            return TimeQuery.Between(from, to);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException($"range TimeQuery is invalid: {ex.Message}", nameof(root), ex);
+        }
+    }
+
+    private static TimeQuery ParseSeries(JsonElement root)
+    {
+        var from = ReadRequiredOffsetDateTime(root, "from");
+        var to = ReadRequiredOffsetDateTime(root, "to");
+        if (!root.TryGetProperty("stepSeconds", out var stepElement)
+            || stepElement.ValueKind != JsonValueKind.Number
+            || !stepElement.TryGetDouble(out var stepSeconds)
+            || stepSeconds <= 0
+            || double.IsNaN(stepSeconds)
+            || double.IsInfinity(stepSeconds))
+        {
+            throw new ArgumentException("series TimeQuery requires a positive numeric 'stepSeconds'.", nameof(root));
+        }
+        try
+        {
+            return TimeQuery.Every(from, to, TimeSpan.FromSeconds(stepSeconds));
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException($"series TimeQuery is invalid: {ex.Message}", nameof(root), ex);
+        }
+    }
+
+    private static DateTimeOffset ReadRequiredOffsetDateTime(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var element) || element.ValueKind != JsonValueKind.String)
+        {
+            throw new ArgumentException($"TimeQuery requires a string '{name}' property.", nameof(root));
+        }
+        return ReadOffsetDateTime(element, name);
+    }
+
+    // Require explicit offset / Z. JsonElement.GetDateTimeOffset() will
+    // happily accept naive timestamps and assume local; we reject those
+    // because cross-zone agent prompts would silently shift.
+    private static DateTimeOffset ReadOffsetDateTime(JsonElement element, string name)
+    {
+        var raw = element.GetString();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new ArgumentException($"TimeQuery '{name}' must be a non-empty ISO-8601 timestamp.", nameof(element));
+        }
+        if (!DateTimeOffset.TryParse(raw, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+            out var dto))
+        {
+            throw new ArgumentException($"TimeQuery '{name}' is not a valid ISO-8601 timestamp: '{raw}'.", nameof(element));
+        }
+        if (!raw.EndsWith('Z') && !ContainsOffset(raw))
+        {
+            throw new ArgumentException(
+                $"TimeQuery '{name}' must include an explicit UTC offset (trailing 'Z' or '+hh:mm'/'-hh:mm'). Got '{raw}'.",
+                nameof(element));
+        }
+        return dto;
+    }
+
+    // Heuristic: look for an offset suffix like "+05:00" or "-08:00"
+    // after the time portion (positions ≥ 11 in YYYY-MM-DDThh:mm:ss…).
+    // The date itself contains '-' separators but only in positions
+    // 4 and 7, so anything later is guaranteed to be an offset sign.
+    private static bool ContainsOffset(string raw)
+    {
+        for (int i = raw.Length - 1; i >= 11; i--)
+        {
+            var c = raw[i];
+            if (c == '+' || c == '-')
+            {
+                if (char.IsDigit(raw[i - 1])) return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/ToolError.cs
@@ -147,3 +147,24 @@ public sealed record GeometryInvalid(
     [property: Description("Human-readable reason the geometry was rejected (e.g. \"polygon has fewer than 4 vertices\", \"north < south\").")] string Reason) : ToolError(
     "geometry_invalid",
     $"Geometry in '{Parameter}' is invalid: {Reason}.");
+
+/// <summary>
+/// A supplied <c>TimeQuery</c> Range or Series falls entirely outside
+/// the dataset's available time-step range (no overlap at all), so no
+/// samples can be produced. Single-instant queries clamp instead of
+/// erroring; this variant fires only for windowed/series queries.
+/// </summary>
+/// <param name="Parameter">Name of the request parameter that carried the out-of-range query.</param>
+/// <param name="WindowStart">Inclusive start of the requested window (UTC ISO-8601).</param>
+/// <param name="WindowEnd">Inclusive end of the requested window (UTC ISO-8601).</param>
+/// <param name="DatasetFirstTime">First time step available in the matched dataset (UTC ISO-8601), if any.</param>
+/// <param name="DatasetLastTime">Last time step available in the matched dataset (UTC ISO-8601), if any.</param>
+[Description("Raised when a TimeQuery Range or Series window falls entirely outside the matched dataset's available time-step range.")]
+public sealed record TimeOutOfRange(
+    [property: Description("Name of the request parameter that carried the out-of-range time query.")] string Parameter,
+    [property: Description("Inclusive start of the requested window, UTC ISO-8601.")] DateTimeOffset WindowStart,
+    [property: Description("Inclusive end of the requested window, UTC ISO-8601.")] DateTimeOffset WindowEnd,
+    [property: Description("First time step available in the matched dataset, UTC ISO-8601; null when the dataset has no time steps.")] DateTimeOffset? DatasetFirstTime,
+    [property: Description("Last time step available in the matched dataset, UTC ISO-8601; null when the dataset has no time steps.")] DateTimeOffset? DatasetLastTime) : ToolError(
+    "time_out_of_range",
+    $"Time query in '{Parameter}' [{WindowStart:o} .. {WindowEnd:o}] is outside the dataset's range.");

--- a/src/EncDotNet.S100.Mcp/README.md
+++ b/src/EncDotNet.S100.Mcp/README.md
@@ -54,7 +54,7 @@ The server exposes the read-only tools defined by
 | `describe_feature` | Spec / feature type / attributes for a feature in a dataset |
 | `sample_coverage` | Sampled value at a lat/lon for a coverage dataset (S-102 / S-104 / S-111); optional `times` JSON envelope (instant / range / series) populates a per-step `series` array for S-104 / S-111 |
 | `find_at` | Datasets whose declared bbox contains a point or intersects a `GeoQuery` envelope |
-| `query_features` | Features from loaded GML datasets that intersect a spatial query (point / box / polygon / polyline) |
+| `query_features` | Features from loaded GML datasets that intersect a spatial query (point / box / polygon / polyline); optional `times` envelope filters out features whose `fixedDateRange`/`periodicDateRange` is disjoint from the window (features without validity metadata are always included) |
 | `sample_coverage_along` | Per-vertex coverage samples for a polyline (S-102 / S-104 / S-111); supports the same `times` envelope as `sample_coverage`, applied per vertex |
 | `list_specs` | Spec catalogue with per-spec capability flags (query / describe / sample / list time-steps) |
 | `list_time_steps` | Available UTC time-step instants (+ cadence) for a time-varying coverage dataset (S-104 / S-111) |

--- a/src/EncDotNet.S100.Mcp/README.md
+++ b/src/EncDotNet.S100.Mcp/README.md
@@ -56,7 +56,8 @@ The server exposes the read-only tools defined by
 | `find_at` | Datasets whose declared bbox contains a point or intersects a `GeoQuery` envelope |
 | `query_features` | Features from loaded GML datasets that intersect a spatial query (point / box / polygon / polyline) |
 | `sample_coverage_along` | Per-vertex coverage samples for a polyline (S-102 / S-104 / S-111) |
-| `list_specs` | Spec catalogue with per-spec capability flags (query / describe / sample) |
+| `list_specs` | Spec catalogue with per-spec capability flags (query / describe / sample / list time-steps) |
+| `list_time_steps` | Available UTC time-step instants (+ cadence) for a time-varying coverage dataset (S-104 / S-111) |
 
 Spatial queries are passed as a JSON envelope on the `query` (or
 `polyline`) parameter:

--- a/src/EncDotNet.S100.Mcp/README.md
+++ b/src/EncDotNet.S100.Mcp/README.md
@@ -52,10 +52,10 @@ The server exposes the read-only tools defined by
 |---|---|
 | `list_datasets` | Per-dataset summaries (id, spec, name, extent) |
 | `describe_feature` | Spec / feature type / attributes for a feature in a dataset |
-| `sample_coverage` | Sampled value at a lat/lon for a coverage dataset (S-102 / S-104 / S-111) |
+| `sample_coverage` | Sampled value at a lat/lon for a coverage dataset (S-102 / S-104 / S-111); optional `times` JSON envelope (instant / range / series) populates a per-step `series` array for S-104 / S-111 |
 | `find_at` | Datasets whose declared bbox contains a point or intersects a `GeoQuery` envelope |
 | `query_features` | Features from loaded GML datasets that intersect a spatial query (point / box / polygon / polyline) |
-| `sample_coverage_along` | Per-vertex coverage samples for a polyline (S-102 / S-104 / S-111) |
+| `sample_coverage_along` | Per-vertex coverage samples for a polyline (S-102 / S-104 / S-111); supports the same `times` envelope as `sample_coverage`, applied per vertex |
 | `list_specs` | Spec catalogue with per-spec capability flags (query / describe / sample / list time-steps) |
 | `list_time_steps` | Available UTC time-step instants (+ cadence) for a time-varying coverage dataset (S-104 / S-111) |
 

--- a/src/EncDotNet.S100.Mcp/S100McpServer.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServer.cs
@@ -115,8 +115,9 @@ public sealed class S100McpServer : IAsyncDisposable
         var queryFeatures = new QueryFeaturesTool(_catalog);
         var sampleCoverageAlong = new SampleCoverageAlongTool(_catalog);
         var listSpecs = new ListSpecsTool(_catalog);
+        var listTimeSteps = new ListTimeStepsTool(_catalog);
         var tools = S100McpServerToolFactory
-            .CreateTools(listDatasets, describeFeature, sampleCoverage, findAt, queryFeatures, sampleCoverageAlong, listSpecs)
+            .CreateTools(listDatasets, describeFeature, sampleCoverage, findAt, queryFeatures, sampleCoverageAlong, listSpecs, listTimeSteps)
             .ToArray();
 
         builder.Services

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -228,6 +228,7 @@ internal static class S100McpServerToolFactory
         var del = ([Description("Spatial query JSON envelope. Shapes: {\"kind\":\"point\",\"latitude\":lat,\"longitude\":lon}, {\"kind\":\"box\",\"south\":s,\"west\":w,\"north\":n,\"east\":e}, {\"kind\":\"polygon\",\"ring\":[[lat,lon],...]}, {\"kind\":\"polyline\",\"vertices\":[[lat,lon],...],\"corridorWidthMeters\":w}.")] string query,
                    [Description("Optional spec filter (e.g. \"S-124/1.5.0\"); null matches every spec.")] string? spec = null,
                    [Description("Optional case-sensitive feature-type filter (the GML element local name, e.g. \"NavwarnPart\", \"BuoyLateral\"); null returns every feature type.")] string? featureType = null,
+                   [Description("Optional temporal filter JSON envelope. Shapes: {\"kind\":\"instant\",\"t\":\"2024-01-01T12:00:00Z\"}, {\"kind\":\"range\",\"from\":\"...\",\"to\":\"...\"}, {\"kind\":\"series\",\"from\":\"...\",\"to\":\"...\",\"stepSeconds\":N}. Excludes features whose fixedDateRange/periodicDateRange is disjoint from the window; features without validity metadata are always included.")] string? times = null,
                    [Description("Zero-based page index.")] int page = 0,
                    [Description("Page size (clamped to 1..500).")] int pageSize = 50,
                    CancellationToken ct = default) =>
@@ -237,6 +238,7 @@ internal static class S100McpServerToolFactory
                         ParseGeoQuery(query) ?? throw new ArgumentException("query is required.", nameof(query)),
                         ParseSpec(spec),
                         featureType,
+                        ParseTimeQuery(times),
                         page,
                         pageSize),
                     ct));

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -5,6 +5,7 @@ using EncDotNet.S100.Core;
 using EncDotNet.S100.Mcp.Tools;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Time;
 using EncDotNet.S100.Pipelines;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -157,6 +158,7 @@ internal static class S100McpServerToolFactory
                    [Description("Sample latitude in decimal degrees, WGS-84, range -90..+90.")] double latitude,
                    [Description("Sample longitude in decimal degrees, WGS-84, range -180..+180.")] double longitude,
                    [Description("Optional UTC ISO-8601 time selector for time-varying products (S-104, S-111); ignored for S-102. Nearest time step is selected; times outside the dataset range clamp to the first or last step.")] DateTimeOffset? time = null,
+                   [Description("Optional temporal query JSON envelope. Shapes: {\"kind\":\"instant\",\"t\":\"2024-01-01T14:00:00Z\"}, {\"kind\":\"range\",\"from\":\"…\",\"to\":\"…\"}, {\"kind\":\"series\",\"from\":\"…\",\"to\":\"…\",\"stepSeconds\":1800}. Range/Series populate the result's 'series' field. Takes precedence over 'time'.")] string? times = null,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(
@@ -164,7 +166,8 @@ internal static class S100McpServerToolFactory
                         ParseSpec(spec) ?? throw new ArgumentException("spec is required.", nameof(spec)),
                         latitude,
                         longitude,
-                        time),
+                        time,
+                        ParseTimeQuery(times)),
                     ct));
 
         return McpServerTool.Create(del, new McpServerToolCreateOptions
@@ -260,13 +263,15 @@ internal static class S100McpServerToolFactory
         var del = ([Description("Spec of the coverage to sample (\"S-102/2.1.0\", \"S-104/1.1.0\", or \"S-111/1.1.1\").")] string spec,
                    [Description("Polyline JSON: {\"vertices\":[[lat,lon],...]} — corridor width is not used here. Coordinates are WGS-84 decimal degrees.")] string polyline,
                    [Description("Optional time selector (ISO-8601, time-varying products only).")] DateTimeOffset? time = null,
+                   [Description("Optional temporal query JSON envelope applied to every vertex; same shape as sample_coverage. Takes precedence over 'time'.")] string? times = null,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(
                     new SampleCoverageAlongRequest(
                         ParseSpec(spec) ?? throw new ArgumentException("spec is required.", nameof(spec)),
                         ParsePolyline(polyline),
-                        time),
+                        time,
+                        ParseTimeQuery(times)),
                     ct));
 
         return McpServerTool.Create(del, new McpServerToolCreateOptions
@@ -324,6 +329,9 @@ internal static class S100McpServerToolFactory
 
     private static GeoQuery? ParseGeoQuery(string? queryJson)
         => string.IsNullOrWhiteSpace(queryJson) ? null : GeoQueryJsonReader.Parse(queryJson);
+
+    private static TimeQuery? ParseTimeQuery(string? timesJson)
+        => string.IsNullOrWhiteSpace(timesJson) ? null : TimeQueryJsonReader.Parse(timesJson);
 
     private static GeoPolyline ParsePolyline(string polylineJson)
     {

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -73,7 +73,8 @@ internal static class S100McpServerToolFactory
         FindAtTool findAt,
         QueryFeaturesTool queryFeatures,
         SampleCoverageAlongTool sampleCoverageAlong,
-        ListSpecsTool listSpecs)
+        ListSpecsTool listSpecs,
+        ListTimeStepsTool listTimeSteps)
     {
         yield return CreateListDatasetsTool(listDatasets);
         yield return CreateDescribeFeatureTool(describeFeature);
@@ -82,6 +83,7 @@ internal static class S100McpServerToolFactory
         yield return CreateQueryFeaturesTool(queryFeatures);
         yield return CreateSampleCoverageAlongTool(sampleCoverageAlong);
         yield return CreateListSpecsTool(listSpecs);
+        yield return CreateListTimeStepsTool(listTimeSteps);
     }
 
     private static McpServerTool CreateListDatasetsTool(ListDatasetsTool inner)
@@ -290,6 +292,28 @@ internal static class S100McpServerToolFactory
         return McpServerTool.Create(del, new McpServerToolCreateOptions
         {
             Name = ListSpecsTool.Name,
+            Description = description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static McpServerTool CreateListTimeStepsTool(ListTimeStepsTool inner)
+    {
+        var description =
+            "Returns the available UTC time-step instants for a time-varying coverage dataset " +
+            "(S-104 water level, S-111 surface currents). Use this to ground temporal questions " +
+            "before issuing sample_coverage or sample_coverage_along — the agent can discover the " +
+            "first/last instant, the cadence (when uniform), and the full list of valid times. " +
+            "For S-102 (static bathymetry) the times array is empty. Read-only and side-effect free.";
+
+        var del = ([Description("Identifier of a currently loaded time-varying coverage dataset (typically obtained from list_datasets).")] string datasetId,
+                   CancellationToken ct = default) =>
+            DispatchAsync(() =>
+                inner.InvokeAsync(new ListTimeStepsRequest(new DatasetId(datasetId)), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = ListTimeStepsTool.Name,
             Description = description,
             SerializerOptions = JsonOptions,
         });

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
@@ -321,6 +321,36 @@ public class S100McpServerRoundTripTests
     }
 
     [Fact]
+    public async Task SampleCoverage_round_trip_with_times_range_returns_series()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S104("wl-series"));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("sample_coverage", new Dictionary<string, object?>
+        {
+            ["spec"] = "S-104/2.0.0",
+            ["latitude"] = 0.01,
+            ["longitude"] = 0.01,
+            ["times"] = """{"kind":"range","from":"2024-01-01T00:00:00Z","to":"2024-01-01T02:00:00Z"}""",
+        });
+
+        Assert.False(result.IsError ?? false, $"sample_coverage returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var series = payload["series"]!.AsArray();
+        Assert.Equal(3, series.Count);
+        foreach (var step in series)
+        {
+            Assert.NotNull(step!["sampleTime"]);
+            Assert.NotNull(step["requestedTime"]);
+            Assert.NotNull(step["value"]);
+        }
+    }
+
+
+    [Fact]
     public async Task FindAt_with_box_query_envelope_returns_intersecting_datasets()
     {
         var catalog = McpTestHelpers.NewCatalog(

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
@@ -30,6 +30,7 @@ public class S100McpServerRoundTripTests
                 "find_at",
                 "list_datasets",
                 "list_specs",
+                "list_time_steps",
                 "query_features",
                 "sample_coverage",
                 "sample_coverage_along",
@@ -292,7 +293,31 @@ public class S100McpServerRoundTripTests
             Assert.NotNull(caps["canQueryFeatures"]);
             Assert.NotNull(caps["canDescribeFeature"]);
             Assert.NotNull(caps["canSampleCoverage"]);
+            Assert.NotNull(caps["canListTimeSteps"]);
         }
+    }
+
+    [Fact]
+    public async Task ListTimeSteps_round_trip_returns_cadence_for_S104()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S104("wl-1"));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync(
+            "list_time_steps",
+            new Dictionary<string, object?> { ["datasetId"] = "wl-1" });
+
+        Assert.False(result.IsError ?? false, $"list_time_steps returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var times = payload["times"]!.AsArray();
+        Assert.NotEmpty(times);
+        Assert.NotNull(payload["firstTime"]);
+        Assert.NotNull(payload["lastTime"]);
+        Assert.NotNull(payload["cadence"]);
+        Assert.Equal("S-104", payload["spec"]!["name"]!.GetValue<string>());
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S122;
 using EncDotNet.S100.Datasets.S124;
 using EncDotNet.S100.Gml;
 using EncDotNet.S100.Mcp.Tools;
@@ -240,6 +242,64 @@ public class S100McpServerRoundTripTests
         var payload = ParseSingleJson(result);
         Assert.Equal("internal_error", payload["code"]!.GetValue<string>());
     }
+
+    [Fact]
+    public async Task QueryFeatures_round_trip_with_times_filters_out_disjoint_validity()
+    {
+        var inWindow = MakeS122WithFixedRange("in", "2024-01-01", "2024-12-31");
+        var outOfWindow = MakeS122WithFixedRange("out", "2030-01-01", "2030-12-31");
+        var s122 = new S122Dataset
+        {
+            Features = ImmutableArray.Create(inWindow, outOfWindow),
+            InformationTypes = ImmutableArray<S122InformationType>.Empty,
+        };
+        var loaded = new LoadedDataset(
+            new DatasetId("mpa-1"),
+            new SpecRef("S-122", new SpecVersion(1, 0, 0)),
+            LoadedDatasetFactory.Box(0, 0, 10, 10),
+            null,
+            new S122DatasetData(s122));
+        var catalog = McpTestHelpers.NewCatalog(loaded);
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("query_features", new Dictionary<string, object?>
+        {
+            ["query"] = """{"kind":"box","south":-5,"west":-5,"north":15,"east":15}""",
+            ["times"] = """{"kind":"instant","t":"2024-06-15T12:00:00Z"}""",
+        });
+
+        Assert.False(result.IsError ?? false, $"query_features returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var features = payload["features"]!.AsArray();
+        Assert.Single(features);
+        Assert.Equal("in", features[0]!["featureId"]!.GetValue<string>());
+    }
+
+    private static S122Feature MakeS122WithFixedRange(string id, string start, string end)
+    {
+        var sub = ImmutableDictionary<string, string>.Empty
+            .Add("dateStart", start)
+            .Add("dateEnd", end);
+        return new S122Feature
+        {
+            Id = id,
+            FeatureType = "MarineProtectedArea",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((5.0, 5.0)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray.Create(new S122ComplexAttribute
+            {
+                Code = "fixedDateRange",
+                SubAttributes = sub,
+            }),
+        };
+    }
+
 
     [Fact]
     public async Task SampleCoverageAlong_round_trip_returns_per_vertex_results()

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/ListSpecsToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/ListSpecsToolTests.cs
@@ -60,15 +60,25 @@ public class ListSpecsToolTests
         Assert.True(s102.Capabilities.CanSampleCoverage);
         Assert.False(s102.Capabilities.CanQueryFeatures);
         Assert.True(s102.Capabilities.CanDescribeFeature);
+        // S-102 is static; no time-step listing.
+        Assert.False(s102.Capabilities.CanListTimeSteps);
 
         // S-124 is GML vector; not a coverage product.
         Assert.False(s124.Capabilities.CanSampleCoverage);
         Assert.True(s124.Capabilities.CanQueryFeatures);
         Assert.True(s124.Capabilities.CanDescribeFeature);
+        Assert.False(s124.Capabilities.CanListTimeSteps);
 
         // S-101 is neither coverage nor GML — describer only.
         Assert.False(s101.Capabilities.CanSampleCoverage);
         Assert.False(s101.Capabilities.CanQueryFeatures);
         Assert.True(s101.Capabilities.CanDescribeFeature);
+        Assert.False(s101.Capabilities.CanListTimeSteps);
+
+        // S-104 / S-111 are time-varying coverage products.
+        var s104 = value.Specs.Single(s => s.Name == "S-104");
+        var s111 = value.Specs.Single(s => s.Name == "S-111");
+        Assert.True(s104.Capabilities.CanListTimeSteps);
+        Assert.True(s111.Capabilities.CanListTimeSteps);
     }
 }

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/ListTimeStepsToolTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/ListTimeStepsToolTests.cs
@@ -1,0 +1,131 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class ListTimeStepsToolTests
+{
+    [Fact]
+    public async Task Missing_dataset_returns_dataset_not_found()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(new DatasetId("nope")));
+
+        Assert.False(result.TryGetValue(out _));
+        Assert.True(result.TryGetError(out var error));
+        Assert.IsType<DatasetNotFound>(error);
+    }
+
+    [Fact]
+    public async Task S102_dataset_returns_empty_series()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var ds = LoadedDatasetFactory.S102("bathy");
+        catalog.Add(ds);
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(ds.Id));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Empty(value.Times);
+        Assert.Null(value.Cadence);
+        Assert.Null(value.FirstTime);
+        Assert.Null(value.LastTime);
+        Assert.Equal("S-102", value.Spec.Name);
+    }
+
+    [Fact]
+    public async Task S104_gridded_returns_per_step_times_with_detected_cadence()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var ds = LoadedDatasetFactory.S104("wl");
+        catalog.Add(ds);
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(ds.Id));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.Times.Length);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), value.FirstTime);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 2, 0, 0, TimeSpan.Zero), value.LastTime);
+        Assert.Equal(TimeSpan.FromHours(1), value.Cadence);
+        for (int i = 0; i < value.Times.Length; i++)
+        {
+            Assert.Equal(TimeSpan.Zero, value.Times[i].Offset);
+        }
+    }
+
+    [Fact]
+    public async Task S104_station_series_derives_from_first_station()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var stations = S104Synth.StationSeries(stationCount: 2, samplesPerStation: 5);
+        var ds = LoadedDatasetFactory.S104Stations("ss", stations);
+        catalog.Add(ds);
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(ds.Id));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(5, value.Times.Length);
+        Assert.Equal(TimeSpan.FromHours(1), value.Cadence);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), value.FirstTime);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 4, 0, 0, TimeSpan.Zero), value.LastTime);
+    }
+
+    [Fact]
+    public async Task S111_gridded_returns_per_step_times()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var ds = LoadedDatasetFactory.S111("cur");
+        catalog.Add(ds);
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(ds.Id));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.NotEmpty(value.Times);
+        Assert.Equal("S-111", value.Spec.Name);
+    }
+
+    [Fact]
+    public async Task Non_uniform_grid_returns_null_cadence()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var times = new[]
+        {
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc),
+        };
+        var s104 = S104Synth.Dataset(times: times);
+        var ds = LoadedDatasetFactory.S104("wl", source: new EncDotNet.S100.Datasets.S104.S104CoverageSource(s104));
+        catalog.Add(ds);
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(ds.Id));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.Times.Length);
+        Assert.Null(value.Cadence);
+    }
+
+    [Fact]
+    public async Task Non_coverage_dataset_returns_not_supported_yet()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var ds = LoadedDatasetFactory.S124("warn");
+        catalog.Add(ds);
+        var tool = new ListTimeStepsTool(catalog);
+
+        var result = await tool.InvokeAsync(new ListTimeStepsRequest(ds.Id));
+
+        Assert.False(result.TryGetValue(out _));
+        Assert.True(result.TryGetError(out var error));
+        Assert.IsType<NotSupportedYet>(error);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/QueryFeaturesToolValidityTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/QueryFeaturesToolValidityTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Geometry;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+using EncDotNet.S100.Mcp.Tools.Time;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class QueryFeaturesToolValidityTests
+{
+    private static S122Feature MpaWithFixedRange(string id, string? start, string? end)
+    {
+        var sub = ImmutableDictionary.CreateBuilder<string, string>();
+        if (start is not null) sub["dateStart"] = start;
+        if (end is not null) sub["dateEnd"] = end;
+
+        return new S122Feature
+        {
+            Id = id,
+            FeatureType = "MarineProtectedArea",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((5.0, 5.0)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray.Create(new S122ComplexAttribute
+            {
+                Code = "fixedDateRange",
+                SubAttributes = sub.ToImmutable(),
+            }),
+        };
+    }
+
+    private static S122Feature MpaWithoutValidity(string id)
+    {
+        return new S122Feature
+        {
+            Id = id,
+            FeatureType = "MarineProtectedArea",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create((5.0, 5.0)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S122ComplexAttribute>.Empty,
+        };
+    }
+
+    private static FakeDatasetCatalog BuildCatalog(params S122Feature[] features)
+    {
+        var dataset = new S122Dataset
+        {
+            Features = features.ToImmutableArray(),
+            InformationTypes = ImmutableArray<S122InformationType>.Empty,
+        };
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(new LoadedDataset(
+            new DatasetId("mpa"),
+            LoadedDatasetFactory.S122Spec,
+            LoadedDatasetFactory.Box(0, 0, 10, 10),
+            null,
+            new S122DatasetData(dataset)));
+        return catalog;
+    }
+
+    [Fact]
+    public async Task Times_null_includes_every_feature_regardless_of_validity()
+    {
+        var inWindow = MpaWithFixedRange("in", "2024-01-01", "2024-12-31");
+        var outOfWindow = MpaWithFixedRange("out", "2030-01-01", "2030-12-31");
+        var noMetadata = MpaWithoutValidity("nometa");
+
+        var tool = new QueryFeaturesTool(BuildCatalog(inWindow, outOfWindow, noMetadata));
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(3, value.TotalCount);
+    }
+
+    [Fact]
+    public async Task Times_instant_excludes_features_with_disjoint_validity()
+    {
+        var inWindow = MpaWithFixedRange("in", "2024-01-01", "2024-12-31");
+        var outOfWindow = MpaWithFixedRange("out", "2030-01-01", "2030-12-31");
+
+        var tool = new QueryFeaturesTool(BuildCatalog(inWindow, outOfWindow));
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Times: TimeQuery.At(DateTimeOffset.Parse("2024-06-15T12:00:00Z"))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(1, value.TotalCount);
+        Assert.Equal("in", value.Features[0].FeatureId);
+    }
+
+    [Fact]
+    public async Task Times_range_includes_overlapping_validity()
+    {
+        var ends2024 = MpaWithFixedRange("ends-2024", "2020-01-01", "2024-12-31");
+        var starts2025 = MpaWithFixedRange("starts-2025", "2025-01-01", "2025-12-31");
+
+        var tool = new QueryFeaturesTool(BuildCatalog(ends2024, starts2025));
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Times: TimeQuery.Between(
+                DateTimeOffset.Parse("2024-12-01T00:00:00Z"),
+                DateTimeOffset.Parse("2025-02-01T00:00:00Z"))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(2, value.TotalCount);
+    }
+
+    [Fact]
+    public async Task Times_filter_always_includes_features_without_validity_metadata()
+    {
+        var noMetadata = MpaWithoutValidity("nometa");
+        var outOfWindow = MpaWithFixedRange("out", "2030-01-01", "2030-12-31");
+
+        var tool = new QueryFeaturesTool(BuildCatalog(noMetadata, outOfWindow));
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Times: TimeQuery.At(DateTimeOffset.Parse("2024-06-15T12:00:00Z"))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(1, value.TotalCount);
+        Assert.Equal("nometa", value.Features[0].FeatureId);
+    }
+
+    [Fact]
+    public async Task Open_ended_range_with_only_start_overlaps_later_window()
+    {
+        var openEnded = MpaWithFixedRange("open", "2020-01-01", null);
+
+        var tool = new QueryFeaturesTool(BuildCatalog(openEnded));
+        var result = await tool.InvokeAsync(new QueryFeaturesRequest(
+            new GeoQuery.Box(new GeoBoundingBox(0, 0, 10, 10)),
+            Times: TimeQuery.At(DateTimeOffset.Parse("2050-01-01T00:00:00Z"))));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(1, value.TotalCount);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolWindowedTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/SampleCoverageToolWindowedTests.cs
@@ -1,0 +1,148 @@
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+using EncDotNet.S100.Mcp.Tools.Time;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class SampleCoverageToolWindowedTests
+{
+    private static readonly DateTime[] HourlyTimes =
+    {
+        new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        new(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+        new(2024, 1, 1, 2, 0, 0, DateTimeKind.Utc),
+        new(2024, 1, 1, 3, 0, 0, DateTimeKind.Utc),
+    };
+
+    [Fact]
+    public async Task Instant_Times_lowers_to_Time_and_returns_no_series()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104(
+            "s104-1", source: new EncDotNet.S100.Datasets.S104.S104CoverageSource(
+                S104Synth.Dataset(times: HourlyTimes))));
+        var tool = new SampleCoverageTool(catalog);
+
+        var t = new DateTimeOffset(2024, 1, 1, 2, 30, 0, TimeSpan.Zero);
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec,
+            Latitude: 0.02, Longitude: 0.02,
+            Times: TimeQuery.At(t)));
+
+        Assert.True(result.TryGetValue(out var v));
+        Assert.Null(v!.Series); // Instant → series stays null
+        Assert.IsType<WaterLevelSample>(v.Value);
+    }
+
+    [Fact]
+    public async Task Range_returns_series_with_steps_in_window_only()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104(
+            "s104-1", source: new EncDotNet.S100.Datasets.S104.S104CoverageSource(
+                S104Synth.Dataset(times: HourlyTimes))));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec,
+            Latitude: 0.02, Longitude: 0.02,
+            Times: TimeQuery.Between(
+                new DateTimeOffset(2024, 1, 1, 1, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2024, 1, 1, 2, 30, 0, TimeSpan.Zero))));
+
+        Assert.True(result.TryGetValue(out var v));
+        Assert.NotNull(v!.Series);
+        Assert.Equal(2, v.Series!.Value.Length); // 1:00 and 2:00
+        Assert.Equal(HourlyTimes[1], v.Series.Value[0].SampleTime);
+        Assert.Equal(HourlyTimes[2], v.Series.Value[1].SampleTime);
+    }
+
+    [Fact]
+    public async Task Series_snaps_each_instant_to_nearest_step()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104(
+            "s104-1", source: new EncDotNet.S100.Datasets.S104.S104CoverageSource(
+                S104Synth.Dataset(times: HourlyTimes))));
+        var tool = new SampleCoverageTool(catalog);
+
+        // Every 30 min from 00:00 to 03:00 = 7 instants.
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec,
+            Latitude: 0.02, Longitude: 0.02,
+            Times: TimeQuery.Every(
+                new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2024, 1, 1, 3, 0, 0, TimeSpan.Zero),
+                TimeSpan.FromMinutes(30))));
+
+        Assert.True(result.TryGetValue(out var v));
+        Assert.NotNull(v!.Series);
+        Assert.Equal(7, v.Series!.Value.Length);
+        // The requested-time echo preserves each enumerated instant.
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 0, 30, 0, TimeSpan.Zero),
+            v.Series.Value[1].RequestedTime);
+    }
+
+    [Fact]
+    public async Task Range_outside_dataset_returns_TimeOutOfRange()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S104(
+            "s104-1", source: new EncDotNet.S100.Datasets.S104.S104CoverageSource(
+                S104Synth.Dataset(times: HourlyTimes))));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S104Spec,
+            Latitude: 0.02, Longitude: 0.02,
+            Times: TimeQuery.Between(
+                new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2025, 1, 1, 6, 0, 0, TimeSpan.Zero))));
+
+        Assert.True(result.TryGetError(out var err));
+        var oor = Assert.IsType<TimeOutOfRange>(err);
+        Assert.Equal("times", oor.Parameter);
+        Assert.NotNull(oor.DatasetFirstTime);
+        Assert.NotNull(oor.DatasetLastTime);
+    }
+
+    [Fact]
+    public async Task S102_rejects_Range_with_NotSupportedYet()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S102(
+            "s102-1", bounds: LoadedDatasetFactory.Box(0, 0, 0.04, 0.04)));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S102Spec,
+            Latitude: 0.02, Longitude: 0.02,
+            Times: TimeQuery.Between(
+                new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2024, 1, 1, 6, 0, 0, TimeSpan.Zero))));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<NotSupportedYet>(err);
+    }
+
+    [Fact]
+    public async Task S111_Range_returns_per_step_SurfaceCurrentSamples()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S111(
+            "s111-1", source: new EncDotNet.S100.Datasets.S111.S111CoverageSource(
+                S111Synth.Dataset(times: HourlyTimes))));
+        var tool = new SampleCoverageTool(catalog);
+
+        var result = await tool.InvokeAsync(new SampleCoverageRequest(
+            LoadedDatasetFactory.S111Spec,
+            Latitude: 0.02, Longitude: 0.02,
+            Times: TimeQuery.Between(
+                new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2024, 1, 1, 3, 0, 0, TimeSpan.Zero))));
+
+        Assert.True(result.TryGetValue(out var v));
+        Assert.NotNull(v!.Series);
+        Assert.Equal(4, v.Series!.Value.Length);
+        Assert.All(v.Series.Value, e => Assert.IsType<SurfaceCurrentSample>(e.Value));
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Time/TimeQueryJsonReaderTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Time/TimeQueryJsonReaderTests.cs
@@ -1,0 +1,100 @@
+using EncDotNet.S100.Mcp.Tools.Time;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Time;
+
+public class TimeQueryJsonReaderTests
+{
+    [Fact]
+    public void Parses_instant_with_trailing_Z()
+    {
+        var q = TimeQueryJsonReader.Parse("""{"kind":"instant","t":"2024-01-01T14:00:00Z"}""");
+        var i = Assert.IsType<TimeQuery.Instant>(q);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 14, 0, 0, TimeSpan.Zero), i.Value);
+    }
+
+    [Fact]
+    public void Parses_instant_with_explicit_offset_normalising_to_utc()
+    {
+        var q = TimeQueryJsonReader.Parse("""{"kind":"instant","t":"2024-01-01T06:00:00-08:00"}""");
+        var i = Assert.IsType<TimeQuery.Instant>(q);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 14, 0, 0, TimeSpan.Zero), i.Value);
+        Assert.Equal(TimeSpan.Zero, i.Value.Offset);
+    }
+
+    [Fact]
+    public void Parses_range()
+    {
+        var q = TimeQueryJsonReader.Parse(
+            """{"kind":"range","from":"2024-01-01T00:00:00Z","to":"2024-01-01T06:00:00Z"}""");
+        var r = Assert.IsType<TimeQuery.Range>(q);
+        Assert.Equal(TimeSpan.FromHours(6), r.Duration);
+    }
+
+    [Fact]
+    public void Parses_series_with_step_seconds()
+    {
+        var q = TimeQueryJsonReader.Parse(
+            """{"kind":"series","from":"2024-01-01T00:00:00Z","to":"2024-01-01T06:00:00Z","stepSeconds":1800}""");
+        var s = Assert.IsType<TimeQuery.Series>(q);
+        Assert.Equal(TimeSpan.FromMinutes(30), s.Step);
+        Assert.Equal(13, s.EstimatedCount); // 00, 0:30, 1:00, ..., 6:00
+    }
+
+    [Fact]
+    public void Rejects_naive_timestamp_without_offset()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TimeQueryJsonReader.Parse("""{"kind":"instant","t":"2024-01-01T14:00:00"}"""));
+    }
+
+    [Fact]
+    public void Rejects_unknown_kind()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TimeQueryJsonReader.Parse("""{"kind":"forever"}"""));
+    }
+
+    [Fact]
+    public void Rejects_missing_kind()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TimeQueryJsonReader.Parse("""{"t":"2024-01-01T00:00:00Z"}"""));
+    }
+
+    [Fact]
+    public void Rejects_reversed_range()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TimeQueryJsonReader.Parse(
+                """{"kind":"range","from":"2024-01-01T06:00:00Z","to":"2024-01-01T00:00:00Z"}"""));
+    }
+
+    [Fact]
+    public void Rejects_series_with_zero_step()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TimeQueryJsonReader.Parse(
+                """{"kind":"series","from":"2024-01-01T00:00:00Z","to":"2024-01-01T06:00:00Z","stepSeconds":0}"""));
+    }
+
+    [Fact]
+    public void Rejects_series_with_missing_step()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TimeQueryJsonReader.Parse(
+                """{"kind":"series","from":"2024-01-01T00:00:00Z","to":"2024-01-01T06:00:00Z"}"""));
+    }
+
+    [Fact]
+    public void Rejects_non_object_payload()
+    {
+        Assert.Throws<ArgumentException>(() => TimeQueryJsonReader.Parse("\"hello\""));
+        Assert.Throws<ArgumentException>(() => TimeQueryJsonReader.Parse("[1,2]"));
+    }
+
+    [Fact]
+    public void Rejects_empty_string()
+    {
+        Assert.Throws<ArgumentException>(() => TimeQueryJsonReader.Parse(""));
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Time/TimeQueryTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Time/TimeQueryTests.cs
@@ -1,0 +1,112 @@
+using EncDotNet.S100.Mcp.Tools.Time;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Time;
+
+public class TimeQueryTests
+{
+    private static readonly DateTimeOffset T0 = new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset T6 = new(2024, 1, 1, 6, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void At_normalises_offset_to_utc()
+    {
+        var pst = new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.FromHours(-8));
+        var q = TimeQuery.At(pst);
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 16, 0, 0, TimeSpan.Zero), q.Value);
+        Assert.Equal(TimeSpan.Zero, q.Value.Offset);
+    }
+
+    [Fact]
+    public void Between_rejects_reversed_window()
+    {
+        Assert.Throws<ArgumentException>(() => TimeQuery.Between(T6, T0));
+    }
+
+    [Fact]
+    public void Between_accepts_zero_length_window()
+    {
+        var q = TimeQuery.Between(T0, T0);
+        Assert.Equal(TimeSpan.Zero, q.Duration);
+    }
+
+    [Fact]
+    public void Every_rejects_non_positive_step()
+    {
+        Assert.Throws<ArgumentException>(() => TimeQuery.Every(T0, T6, TimeSpan.Zero));
+        Assert.Throws<ArgumentException>(() => TimeQuery.Every(T0, T6, TimeSpan.FromMinutes(-30)));
+    }
+
+    [Fact]
+    public void Series_enumerate_produces_expected_step_count()
+    {
+        var q = TimeQuery.Every(T0, T6, TimeSpan.FromHours(2));
+        var instants = q.Enumerate();
+        Assert.Equal(4, instants.Length); // 00, 02, 04, 06
+        Assert.Equal(T0, instants[0]);
+        Assert.Equal(T6, instants[^1]);
+    }
+
+    [Fact]
+    public void Series_estimated_count_matches_enumeration()
+    {
+        var q = TimeQuery.Every(T0, T6, TimeSpan.FromHours(1));
+        Assert.Equal(7, q.EstimatedCount);
+        Assert.Equal(7, q.Enumerate().Length);
+    }
+
+    [Fact]
+    public void Series_above_max_throws_on_enumerate()
+    {
+        // 1-second cadence over 6 hours = 21601 instants > MaxSeriesCount (4096).
+        var q = TimeQuery.Every(T0, T6, TimeSpan.FromSeconds(1));
+        Assert.True(q.EstimatedCount > TimeQuery.MaxSeriesCount);
+        Assert.Throws<InvalidOperationException>(() => q.Enumerate());
+    }
+
+    [Fact]
+    public void GetWindow_returns_degenerate_range_for_instant()
+    {
+        var q = TimeQuery.At(T0);
+        var (from, to) = q.GetWindow();
+        Assert.Equal(T0, from);
+        Assert.Equal(T0, to);
+    }
+
+    [Fact]
+    public void Overlaps_treats_null_validity_as_open_ended()
+    {
+        var q = TimeQuery.Between(T0, T6);
+        Assert.True(q.Overlaps(null, null));
+        Assert.True(q.Overlaps(null, T6));
+        Assert.True(q.Overlaps(T0, null));
+    }
+
+    [Fact]
+    public void Overlaps_returns_false_for_disjoint_window()
+    {
+        var q = TimeQuery.Between(T0, T6);
+        var before = T0.AddHours(-2);
+        Assert.False(q.Overlaps(before.AddHours(-1), before));
+        var after = T6.AddHours(2);
+        Assert.False(q.Overlaps(after, after.AddHours(1)));
+    }
+
+    [Fact]
+    public void Overlaps_returns_true_for_touching_window()
+    {
+        var q = TimeQuery.Between(T0, T6);
+        Assert.True(q.Overlaps(T6, T6.AddHours(2)));
+        Assert.True(q.Overlaps(T0.AddHours(-2), T0));
+    }
+
+    [Fact]
+    public void Contains_matches_endpoints_inclusively()
+    {
+        var q = TimeQuery.Between(T0, T6);
+        Assert.True(q.Contains(T0));
+        Assert.True(q.Contains(T6));
+        Assert.True(q.Contains(T0.AddHours(3)));
+        Assert.False(q.Contains(T0.AddSeconds(-1)));
+        Assert.False(q.Contains(T6.AddSeconds(1)));
+    }
+}


### PR DESCRIPTION
Builds on the Phase 1 spatial primitives (#96) by adding a temporal axis to the MCP tool surface. Working backwards from the per-spec and cross-spec question taxonomy, this lands three additive slices.

## Slice A — `list_time_steps`

Cheapest first slice: lets the agent discover available UTC time-step instants (plus cadence) for a coverage dataset before sampling. Supports S-104 and S-111; returns null cadence for S-102 (no time dimension).

## Slice B — `TimeQuery` on `sample_coverage` and `sample_coverage_along`

`TimeQuery = Instant(t) | Range(from, to) | Series(from, to, step)`, parsed from a JSON envelope on a new `times` parameter. Additive — the legacy `time` field still works (instant queries lower to it).

- Range / Series queries populate a new `series[]` array on the result with `(sampleTime, requestedTime, value)` per step.
- `value` stays populated (first non-null step) so all existing instant-shape consumers keep working.
- Series count capped at 4096 to protect against unreasonable enumerations.
- New `time_out_of_range` error variant for zero-overlap windows; S-102 returns `not_supported_yet` for windowed queries.

## Slice C — `TimeQuery` on `query_features`

Optional `times` envelope on `query_features` filters out features whose `fixedDateRange` / `periodicDateRange` complex attributes are disjoint from the query window. Features without validity metadata are **always included** (per the open-question recommendation in the plan: absence of metadata means "always valid").

The validity helper is generic over `IGmlFeature` so any spec carrying the standard S-100 GFM date-range pattern (S-122, S-124, S-201, S-411 features that opt in) benefits without per-spec code.

## Deferred (out of scope)

- Vessel-context tools (`compute_ukc_along`, `find_berths_for_vessel`).
- Route-synthesis tools (`query_route_hazards`, `summarize_route`).
- The `VesselContext` and `RouteRef` types themselves.
- S-129 describer.

These remain on the radar and will only be picked up after we've watched real agents use the Phase 1–2 primitives.

## Test status

- `EncDotNet.S100.Mcp.Tools.Tests`: 188 passed, 1 skipped.
- `EncDotNet.S100.Mcp.Tests` (round-trip): 22 passed.

🤖 Co-authored with [Copilot CLI](https://github.com/features/copilot/copilot-cli)