### PR TITLE
Add typed DataModel projection for S-131 Marine Harbour Infrastructure

### DIFF
--- a/src/EncDotNet.S100.Datasets.S131/DataModel/S131Features.cs
+++ b/src/EncDotNet.S100.Datasets.S131/DataModel/S131Features.cs
@@ -1,0 +1,165 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S131.DataModel;
+
+/// <summary>
+/// Common contract exposed by every typed S-131 feature
+/// (<see cref="S131HarbourInfrastructure"/>, <see cref="S131LayoutFeature"/>,
+/// <see cref="S131MetadataFeature"/>, <see cref="S131OtherFeature"/>).
+/// Allows callers to enumerate <see cref="S131HarbourInfrastructureDataset.Features"/>
+/// uniformly and dispatch on <see cref="Family"/> when the high-level
+/// classification matters.
+/// </summary>
+/// <remarks>
+/// S-131 features span all three GML geometric primitives plus the
+/// geometry-less case (container features such as <c>Authority</c> are
+/// modelled as information types in this codebase, but a feature may
+/// still legitimately have no geometry — see FC §B.2). Consumers
+/// should consult <see cref="S131Geometry.GeometryType"/> before
+/// indexing into the coordinate arrays.
+/// </remarks>
+public interface IS131Feature
+{
+    /// <summary>The GML identifier of the source feature.</summary>
+    string Id { get; }
+
+    /// <summary>The raw S-131 feature type code (e.g. <c>"Bollard"</c>).</summary>
+    string FeatureType { get; }
+
+    /// <summary>The high-level family the feature belongs to.</summary>
+    S131FeatureFamily Family { get; }
+
+    /// <summary>The typed geometry payload (never <c>null</c>; check
+    /// <see cref="S131Geometry.IsEmpty"/> for geometry-less features).</summary>
+    S131Geometry Geometry { get; }
+
+    /// <summary>
+    /// Cross-references from this feature to other objects in the
+    /// dataset, resolved via <c>xlink:href</c>. References whose target
+    /// did not resolve carry a <c>null</c>
+    /// <see cref="S131ResolvedReference.Target"/> and an associated
+    /// <c>xlink.unresolved</c> projection diagnostic.
+    /// </summary>
+    ImmutableArray<S131ResolvedReference> ResolvedReferences { get; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    ImmutableDictionary<string, string> ExtraAttributes { get; }
+
+    /// <summary>The originating raw GML feature.</summary>
+    S131Feature Source { get; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 feature derived from
+/// <c>HarbourPhysicalInfrastructure</c> in the FC supertype graph —
+/// bollards, dolphins, dry docks, mooring buoys, lock basins, ship
+/// lifts, and other fixed harbour-side installations
+/// (S-131 FC Edition 1.0.0 §B.2).
+/// </summary>
+public sealed class S131HarbourInfrastructure : IS131Feature
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <inheritdoc/>
+    public S131FeatureFamily Family => S131FeatureFamily.HarbourInfrastructure;
+    /// <summary>The concrete harbour-infrastructure kind, decoded from <see cref="FeatureType"/>.</summary>
+    public required S131HarbourInfrastructureKind Kind { get; init; }
+    /// <inheritdoc/>
+    public required S131Geometry Geometry { get; init; }
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 feature derived from <c>Layout</c> in
+/// the FC supertype graph — area- and berth-style features such as
+/// berths, anchorage areas, terminals, harbour basins, pilot boarding
+/// places, dumping grounds, and fender lines
+/// (S-131 FC Edition 1.0.0 §B.2).
+/// </summary>
+public sealed class S131LayoutFeature : IS131Feature
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <inheritdoc/>
+    public S131FeatureFamily Family => S131FeatureFamily.Layout;
+    /// <summary>The concrete layout kind, decoded from <see cref="FeatureType"/>.</summary>
+    public required S131LayoutKind Kind { get; init; }
+    /// <inheritdoc/>
+    public required S131Geometry Geometry { get; init; }
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 standalone-metadata feature —
+/// <c>DataCoverage</c>, <c>QualityOfNonBathymetricData</c>,
+/// <c>SoundingDatum</c>, <c>VerticalDatumOfData</c>, or
+/// <c>TextPlacement</c> (S-131 FC Edition 1.0.0 §B.2; no shared
+/// supertype).
+/// </summary>
+public sealed class S131MetadataFeature : IS131Feature
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <inheritdoc/>
+    public S131FeatureFamily Family => S131FeatureFamily.Metadata;
+    /// <summary>The concrete metadata kind, decoded from <see cref="FeatureType"/>.</summary>
+    public required S131MetadataKind Kind { get; init; }
+    /// <inheritdoc/>
+    public required S131Geometry Geometry { get; init; }
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131Feature Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection fallback for a feature whose
+/// <see cref="S131Feature.FeatureType"/> code is not recognised in the
+/// S-131 FC enumeration baked into the typed model. The projection
+/// also emits an <c>s131.feature.unknown</c> info diagnostic so callers
+/// can detect a forward-compatibility gap.
+/// </summary>
+public sealed class S131OtherFeature : IS131Feature
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string FeatureType { get; init; }
+    /// <inheritdoc/>
+    public S131FeatureFamily Family => S131FeatureFamily.Unknown;
+    /// <inheritdoc/>
+    public required S131Geometry Geometry { get; init; }
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131Feature Source { get; init; }
+}

--- a/src/EncDotNet.S100.Datasets.S131/DataModel/S131HarbourInfrastructureDataset.cs
+++ b/src/EncDotNet.S100.Datasets.S131/DataModel/S131HarbourInfrastructureDataset.cs
@@ -1,0 +1,735 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S131.DataModel;
+
+/// <summary>
+/// Strongly-typed "Pass 2" projection of an <see cref="S131Dataset"/>
+/// as a graph of typed harbour-infrastructure features and information
+/// types (S-131 FC Edition 1.0.0 / PC Edition 2.0.0).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projection follows the same pattern used by the other GML-encoded
+/// products (S-122 / S-124 / S-125 / S-127 / S-128 / S-129 / S-201 /
+/// S-411 / S-421): a static <see cref="From"/> factory walks the raw
+/// feature bag, builds an <see cref="XlinkResolver"/> over every
+/// addressable <c>gml:id</c>, and emits typed records with resolved
+/// cross-references. Issues surface as
+/// <see cref="ProjectionDiagnostic"/> entries rather than exceptions;
+/// the only fatal condition is a fully empty source dataset.
+/// </para>
+/// <para>
+/// Feature-type discrimination is performed against the static FC enum
+/// lists in <see cref="S131Types"/>; the projection does <b>not</b>
+/// walk the FC supertype graph at runtime. Schema-level introspection
+/// is handled by the Feature Catalogue reader and the Lua data
+/// provider (see <see cref="S131LuaDataProvider"/>).
+/// </para>
+/// <para>
+/// <b>Portrayal stays untouched.</b> The typed model is independent
+/// of <see cref="S131LuaDataProvider"/> / <see cref="S131LuaRuleExecutor"/> —
+/// portrayal continues to consume the raw <see cref="S131Feature"/>
+/// graph through the Lua Host API.
+/// </para>
+/// </remarks>
+public sealed class S131HarbourInfrastructureDataset
+{
+    /// <summary>The dataset identifier carried by the source GML <c>Dataset</c> element.</summary>
+    public string? DatasetIdentifier { get; init; }
+
+    /// <summary>The S-131 product identifier (typically <c>"S-131"</c>).</summary>
+    public string? ProductIdentifier { get; init; }
+
+    /// <summary>Every typed feature in the dataset, in source order.</summary>
+    public required ImmutableArray<IS131Feature> Features { get; init; }
+
+    /// <summary>Every typed information type in the dataset, in source order.</summary>
+    public required ImmutableArray<IS131InformationType> InformationTypes { get; init; }
+
+    /// <summary>Typed view of <see cref="Features"/> filtered to <see cref="S131HarbourInfrastructure"/>.</summary>
+    public ImmutableArray<S131HarbourInfrastructure> HarbourInfrastructure { get; init; } =
+        ImmutableArray<S131HarbourInfrastructure>.Empty;
+
+    /// <summary>Typed view of <see cref="Features"/> filtered to <see cref="S131LayoutFeature"/>.</summary>
+    public ImmutableArray<S131LayoutFeature> LayoutFeatures { get; init; } =
+        ImmutableArray<S131LayoutFeature>.Empty;
+
+    /// <summary>Typed view of <see cref="Features"/> filtered to <see cref="S131MetadataFeature"/>.</summary>
+    public ImmutableArray<S131MetadataFeature> MetadataFeatures { get; init; } =
+        ImmutableArray<S131MetadataFeature>.Empty;
+
+    /// <summary>Typed view of <see cref="Features"/> filtered to <see cref="S131OtherFeature"/> (FC misses).</summary>
+    public ImmutableArray<S131OtherFeature> OtherFeatures { get; init; } =
+        ImmutableArray<S131OtherFeature>.Empty;
+
+    /// <summary>Typed view of <see cref="InformationTypes"/> filtered to <see cref="S131Authority"/>.</summary>
+    public ImmutableArray<S131Authority> Authorities { get; init; } =
+        ImmutableArray<S131Authority>.Empty;
+
+    /// <summary>Typed view of <see cref="InformationTypes"/> filtered to <see cref="S131ContactDetails"/>.</summary>
+    public ImmutableArray<S131ContactDetails> ContactDetails { get; init; } =
+        ImmutableArray<S131ContactDetails>.Empty;
+
+    /// <summary>Typed view of <see cref="InformationTypes"/> filtered to <see cref="S131RxNInformation"/>.</summary>
+    public ImmutableArray<S131RxNInformation> RxNInformation { get; init; } =
+        ImmutableArray<S131RxNInformation>.Empty;
+
+    /// <summary>The originating raw feature-bag dataset.</summary>
+    public required S131Dataset Source { get; init; }
+
+    /// <summary>
+    /// Projects a raw <see cref="S131Dataset"/> into the typed data
+    /// model. Issues encountered during projection are reported via
+    /// <paramref name="diagnostics"/>; the projection only throws when
+    /// the source dataset is fully empty.
+    /// </summary>
+    /// <param name="dataset">The source dataset to project.</param>
+    /// <param name="diagnostics">
+    /// Receives the accumulated projection diagnostics (unresolved
+    /// xlinks, parse failures, unknown codes, duplicate identifiers)
+    /// as an immutable snapshot.
+    /// </param>
+    /// <exception cref="ArgumentNullException">If <paramref name="dataset"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the dataset contains neither features nor information
+    /// types.
+    /// </exception>
+    public static S131HarbourInfrastructureDataset From(
+        S131Dataset dataset,
+        out IReadOnlyList<ProjectionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        if (dataset.Features.IsDefaultOrEmpty && dataset.InformationTypes.IsDefaultOrEmpty)
+            throw new InvalidOperationException("Dataset contains no features and no information types.");
+
+        // Pre-pass: project every information type into a stub (without
+        // its resolved references) so feature projection can dereference
+        // xlink targets. Info-type-to-info-type refs (e.g. Authority →
+        // ContactDetails) are filled in by a follow-up back-fill pass.
+        var emptyResolver = XlinkResolver.Build(Array.Empty<KeyValuePair<string, object>>());
+        var preCtx = new ProjectionContext(emptyResolver);
+        var infoTypeById = new Dictionary<string, IS131InformationType>(StringComparer.OrdinalIgnoreCase);
+        var infoTypeList = ImmutableArray.CreateBuilder<IS131InformationType>();
+
+        var infoIdsSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var i in dataset.InformationTypes)
+        {
+            if (!string.IsNullOrEmpty(i.Id) && !infoIdsSeen.Add(i.Id))
+                preCtx.Warn(
+                    $"Duplicate gml:id '{i.Id}' on information type.",
+                    code: "s131.id.duplicate",
+                    relatedId: i.Id);
+
+            var typed = ProjectInformationType(i, preCtx);
+            infoTypeList.Add(typed);
+            if (!string.IsNullOrEmpty(typed.Id))
+                infoTypeById[typed.Id] = typed;
+        }
+
+        // Pass 1: build xlink resolver over every typed info type plus
+        // the raw feature graph (typed features are constructed in
+        // pass 2). Features cannot reference each other at runtime via
+        // the resolver yet — that's fine: feature-to-feature refs in
+        // the resolved reference list are resolved against typed peers
+        // in a final pass below.
+        var featureById = new Dictionary<string, S131Feature>(StringComparer.OrdinalIgnoreCase);
+        var ctx = new ProjectionContext(BuildXlinkResolver(dataset, infoTypeById, featureById));
+        foreach (var d in preCtx.Diagnostics) ctx.Report(d);
+
+        var featureIdsSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in dataset.Features)
+        {
+            if (!string.IsNullOrEmpty(f.Id))
+            {
+                featureById[f.Id] = f;
+                if (!featureIdsSeen.Add(f.Id))
+                    ctx.Warn(
+                        $"Duplicate gml:id '{f.Id}' on feature.",
+                        code: "s131.id.duplicate",
+                        relatedId: f.Id);
+            }
+        }
+
+        // Pass 2: project each feature using the resolver. References
+        // are resolved eagerly because xlink targets in S-131 are
+        // either information types (already projected) or other
+        // features (resolved against featureById; we attach typed
+        // feature peers in a final back-fill pass).
+        var typedFeatures = ImmutableArray.CreateBuilder<IS131Feature>(dataset.Features.Length);
+        var typedById = new Dictionary<string, IS131Feature>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in dataset.Features)
+        {
+            var typed = ProjectFeature(f, infoTypeById, ctx);
+            typedFeatures.Add(typed);
+            if (!string.IsNullOrEmpty(typed.Id))
+                typedById[typed.Id] = typed;
+        }
+
+        // Final pass: back-fill any ResolvedReference whose target was
+        // a feature (we constructed those after the resolver was built).
+        var finalFeatures = ImmutableArray.CreateBuilder<IS131Feature>(typedFeatures.Count);
+        foreach (var typed in typedFeatures)
+        {
+            finalFeatures.Add(BackfillFeatureReferences(typed, typedById));
+        }
+
+        // Info-type back-fill: resolve outgoing xlinks on information
+        // types (e.g. Authority → ContactDetails / Applicability) now
+        // that every typed info type has been built. Authority's typed
+        // shortcuts (ContactDetails / Applicability) are populated here.
+        var finalInfoTypes = ImmutableArray.CreateBuilder<IS131InformationType>(infoTypeList.Count);
+        foreach (var typed in infoTypeList)
+        {
+            finalInfoTypes.Add(BackfillInformationTypeReferences(typed, infoTypeById, ctx));
+        }
+
+        diagnostics = ctx.ToImmutableDiagnostics();
+
+        var finalFeaturesImm = finalFeatures.ToImmutable();
+        var finalInfoTypesImm = finalInfoTypes.ToImmutable();
+
+        return new S131HarbourInfrastructureDataset
+        {
+            DatasetIdentifier = dataset.DatasetIdentifier,
+            ProductIdentifier = dataset.ProductIdentifier,
+            Features = finalFeaturesImm,
+            InformationTypes = finalInfoTypesImm,
+            HarbourInfrastructure = finalFeaturesImm.OfType<S131HarbourInfrastructure>().ToImmutableArray(),
+            LayoutFeatures = finalFeaturesImm.OfType<S131LayoutFeature>().ToImmutableArray(),
+            MetadataFeatures = finalFeaturesImm.OfType<S131MetadataFeature>().ToImmutableArray(),
+            OtherFeatures = finalFeaturesImm.OfType<S131OtherFeature>().ToImmutableArray(),
+            Authorities = finalInfoTypesImm.OfType<S131Authority>().ToImmutableArray(),
+            ContactDetails = finalInfoTypesImm.OfType<S131ContactDetails>().ToImmutableArray(),
+            RxNInformation = finalInfoTypesImm.OfType<S131RxNInformation>().ToImmutableArray(),
+            Source = dataset,
+        };
+    }
+
+    // ── Xlink resolver build ──────────────────────────────────────────
+
+    private static XlinkResolver BuildXlinkResolver(
+        S131Dataset dataset,
+        IReadOnlyDictionary<string, IS131InformationType> infoTypesById,
+        IReadOnlyDictionary<string, S131Feature> featureById)
+    {
+        IEnumerable<KeyValuePair<string, object>> All()
+        {
+            foreach (var kv in infoTypesById)
+                yield return new KeyValuePair<string, object>(kv.Key, kv.Value);
+            // Features are indexed by raw graph at this point; the
+            // back-fill pass replaces them with typed peers.
+            foreach (var f in dataset.Features)
+                if (!string.IsNullOrEmpty(f.Id))
+                    yield return new KeyValuePair<string, object>(f.Id, f);
+        }
+        return XlinkResolver.Build(All());
+    }
+
+    // ── Information-type projection ───────────────────────────────────
+
+    private static IS131InformationType ProjectInformationType(S131InformationType i, ProjectionContext ctx)
+    {
+        return i.TypeCode switch
+        {
+            "Authority" => new S131Authority
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "ContactDetails" => new S131ContactDetails
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "Applicability" => new S131Applicability
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "AvailablePortServices" => new S131AvailablePortServices
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "Entrance" => new S131Entrance
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "ServiceHours" => new S131ServiceHours
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "NonStandardWorkingDay" => new S131NonStandardWorkingDay
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "SpatialQuality" => new S131SpatialQuality
+            {
+                Id = i.Id,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "NauticalInformation" => new S131RxNInformation
+            {
+                Id = i.Id,
+                TypeCode = i.TypeCode,
+                Kind = S131RxNKind.NauticalInformation,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "Recommendations" => new S131RxNInformation
+            {
+                Id = i.Id,
+                TypeCode = i.TypeCode,
+                Kind = S131RxNKind.Recommendations,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "Regulations" => new S131RxNInformation
+            {
+                Id = i.Id,
+                TypeCode = i.TypeCode,
+                Kind = S131RxNKind.Regulations,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            "Restrictions" => new S131RxNInformation
+            {
+                Id = i.Id,
+                TypeCode = i.TypeCode,
+                Kind = S131RxNKind.Restrictions,
+                ExtraAttributes = i.Attributes,
+                Source = i,
+            },
+            _ => ProjectUnknownInformationType(i, ctx),
+        };
+    }
+
+    private static S131OtherInformationType ProjectUnknownInformationType(
+        S131InformationType i, ProjectionContext ctx)
+    {
+        ctx.Report(new ProjectionDiagnostic
+        {
+            Severity = DiagnosticSeverity.Info,
+            Message = $"Information type code '{i.TypeCode}' is not in the S-131 FC enumeration.",
+            Code = "s131.information.unknown",
+            RelatedId = i.Id,
+        });
+        return new S131OtherInformationType
+        {
+            Id = i.Id,
+            TypeCode = i.TypeCode,
+            ExtraAttributes = i.Attributes,
+            Source = i,
+        };
+    }
+
+    // ── Feature projection ────────────────────────────────────────────
+
+    private static IS131Feature ProjectFeature(
+        S131Feature f,
+        IReadOnlyDictionary<string, IS131InformationType> infoTypesById,
+        ProjectionContext ctx)
+    {
+        var geometry = ProjectGeometry(f);
+        var resolved = ResolveReferences(f, infoTypesById, ctx);
+
+        if (TryClassifyHarbourInfrastructure(f.FeatureType, out var harbourKind))
+        {
+            return new S131HarbourInfrastructure
+            {
+                Id = f.Id,
+                FeatureType = f.FeatureType,
+                Kind = harbourKind,
+                Geometry = geometry,
+                ResolvedReferences = resolved,
+                ExtraAttributes = f.Attributes,
+                Source = f,
+            };
+        }
+        if (TryClassifyLayout(f.FeatureType, out var layoutKind))
+        {
+            return new S131LayoutFeature
+            {
+                Id = f.Id,
+                FeatureType = f.FeatureType,
+                Kind = layoutKind,
+                Geometry = geometry,
+                ResolvedReferences = resolved,
+                ExtraAttributes = f.Attributes,
+                Source = f,
+            };
+        }
+        if (TryClassifyMetadata(f.FeatureType, out var metaKind))
+        {
+            return new S131MetadataFeature
+            {
+                Id = f.Id,
+                FeatureType = f.FeatureType,
+                Kind = metaKind,
+                Geometry = geometry,
+                ResolvedReferences = resolved,
+                ExtraAttributes = f.Attributes,
+                Source = f,
+            };
+        }
+
+        ctx.Report(new ProjectionDiagnostic
+        {
+            Severity = DiagnosticSeverity.Info,
+            Message = $"Feature type code '{f.FeatureType}' is not in the S-131 FC enumeration.",
+            Code = "s131.feature.unknown",
+            RelatedId = f.Id,
+        });
+        return new S131OtherFeature
+        {
+            Id = f.Id,
+            FeatureType = f.FeatureType,
+            Geometry = geometry,
+            ResolvedReferences = resolved,
+            ExtraAttributes = f.Attributes,
+            Source = f,
+        };
+    }
+
+    // ── Reference resolution ──────────────────────────────────────────
+
+    private static ImmutableArray<S131ResolvedReference> ResolveReferences(
+        S131Feature f,
+        IReadOnlyDictionary<string, IS131InformationType> infoTypesById,
+        ProjectionContext ctx)
+    {
+        if (f.References.IsDefaultOrEmpty)
+            return ImmutableArray<S131ResolvedReference>.Empty;
+
+        var b = ImmutableArray.CreateBuilder<S131ResolvedReference>(f.References.Length);
+        foreach (var r in f.References)
+        {
+            // Prefer typed info-type peers; the back-fill pass swaps in
+            // typed features for feature-to-feature refs.
+            object? target = infoTypesById.TryGetValue(r.TargetRef, out var info)
+                ? info
+                : null;
+
+            if (target is null)
+            {
+                // Defer raising xlink.unresolved until back-fill — the
+                // reference may still resolve to a typed feature peer.
+                target = ctx.Xlinks.ResolveAny(
+                    "#" + r.TargetRef, r.Role, ctx, relatedId: f.Id);
+            }
+
+            if (target is null)
+            {
+                ctx.Warn(
+                    $"Dangling {r.Role} reference '#{r.TargetRef}'.",
+                    code: "s131.reference.dangling",
+                    relatedId: f.Id,
+                    relatedAttribute: r.Role);
+            }
+
+            b.Add(new S131ResolvedReference
+            {
+                Role = r.Role,
+                TargetRef = r.TargetRef,
+                Target = target,
+            });
+        }
+        return b.ToImmutable();
+    }
+
+    private static IS131Feature BackfillFeatureReferences(
+        IS131Feature typed,
+        IReadOnlyDictionary<string, IS131Feature> typedById)
+    {
+        if (typed.ResolvedReferences.IsDefaultOrEmpty)
+            return typed;
+
+        var b = ImmutableArray.CreateBuilder<S131ResolvedReference>(typed.ResolvedReferences.Length);
+        var changed = false;
+        foreach (var r in typed.ResolvedReferences)
+        {
+            // If a reference still points at the raw S131Feature graph
+            // (the resolver indexed it that way), swap in the typed
+            // peer constructed during pass 2.
+            if (r.Target is S131Feature && typedById.TryGetValue(r.TargetRef, out var typedPeer))
+            {
+                b.Add(new S131ResolvedReference
+                {
+                    Role = r.Role,
+                    TargetRef = r.TargetRef,
+                    Target = typedPeer,
+                });
+                changed = true;
+            }
+            else
+            {
+                b.Add(r);
+            }
+        }
+
+        if (!changed) return typed;
+
+        var resolved = b.ToImmutable();
+        return typed switch
+        {
+            S131HarbourInfrastructure h => new S131HarbourInfrastructure
+            {
+                Id = h.Id, FeatureType = h.FeatureType, Kind = h.Kind,
+                Geometry = h.Geometry, ResolvedReferences = resolved,
+                ExtraAttributes = h.ExtraAttributes, Source = h.Source,
+            },
+            S131LayoutFeature l => new S131LayoutFeature
+            {
+                Id = l.Id, FeatureType = l.FeatureType, Kind = l.Kind,
+                Geometry = l.Geometry, ResolvedReferences = resolved,
+                ExtraAttributes = l.ExtraAttributes, Source = l.Source,
+            },
+            S131MetadataFeature m => new S131MetadataFeature
+            {
+                Id = m.Id, FeatureType = m.FeatureType, Kind = m.Kind,
+                Geometry = m.Geometry, ResolvedReferences = resolved,
+                ExtraAttributes = m.ExtraAttributes, Source = m.Source,
+            },
+            S131OtherFeature o => new S131OtherFeature
+            {
+                Id = o.Id, FeatureType = o.FeatureType,
+                Geometry = o.Geometry, ResolvedReferences = resolved,
+                ExtraAttributes = o.ExtraAttributes, Source = o.Source,
+            },
+            _ => typed,
+        };
+    }
+
+    private static IS131InformationType BackfillInformationTypeReferences(
+        IS131InformationType typed,
+        IReadOnlyDictionary<string, IS131InformationType> infoTypesById,
+        ProjectionContext ctx)
+    {
+        var src = typed.Source;
+        if (src.References.IsDefaultOrEmpty)
+            return typed;
+
+        var resolved = ImmutableArray.CreateBuilder<S131ResolvedReference>(src.References.Length);
+        S131ContactDetails? contactShortcut = null;
+        S131Applicability? applicabilityShortcut = null;
+
+        foreach (var r in src.References)
+        {
+            IS131InformationType? target = null;
+            if (!string.IsNullOrEmpty(r.TargetRef) && infoTypesById.TryGetValue(r.TargetRef, out var peer))
+                target = peer;
+
+            if (target is null)
+            {
+                ctx.Warn(
+                    $"Unresolved {r.Role} reference '#{r.TargetRef}'.",
+                    code: "xlink.unresolved",
+                    relatedId: src.Id,
+                    relatedAttribute: r.Role);
+                ctx.Warn(
+                    $"Dangling {r.Role} reference '#{r.TargetRef}'.",
+                    code: "s131.reference.dangling",
+                    relatedId: src.Id,
+                    relatedAttribute: r.Role);
+            }
+
+            resolved.Add(new S131ResolvedReference
+            {
+                Role = r.Role,
+                TargetRef = r.TargetRef,
+                Target = target,
+            });
+
+            contactShortcut ??= target as S131ContactDetails;
+            applicabilityShortcut ??= target as S131Applicability;
+        }
+
+        var resolvedImm = resolved.ToImmutable();
+        return typed switch
+        {
+            S131Authority a => new S131Authority
+            {
+                Id = a.Id,
+                ContactDetails = contactShortcut,
+                Applicability = applicabilityShortcut,
+                ResolvedReferences = resolvedImm,
+                ExtraAttributes = a.ExtraAttributes,
+                Source = a.Source,
+            },
+            S131ContactDetails c => new S131ContactDetails
+            {
+                Id = c.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = c.ExtraAttributes, Source = c.Source,
+            },
+            S131Applicability ap => new S131Applicability
+            {
+                Id = ap.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = ap.ExtraAttributes, Source = ap.Source,
+            },
+            S131AvailablePortServices aps => new S131AvailablePortServices
+            {
+                Id = aps.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = aps.ExtraAttributes, Source = aps.Source,
+            },
+            S131Entrance e => new S131Entrance
+            {
+                Id = e.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = e.ExtraAttributes, Source = e.Source,
+            },
+            S131ServiceHours s => new S131ServiceHours
+            {
+                Id = s.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = s.ExtraAttributes, Source = s.Source,
+            },
+            S131NonStandardWorkingDay n => new S131NonStandardWorkingDay
+            {
+                Id = n.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = n.ExtraAttributes, Source = n.Source,
+            },
+            S131SpatialQuality q => new S131SpatialQuality
+            {
+                Id = q.Id, ResolvedReferences = resolvedImm,
+                ExtraAttributes = q.ExtraAttributes, Source = q.Source,
+            },
+            S131RxNInformation rx => new S131RxNInformation
+            {
+                Id = rx.Id, TypeCode = rx.TypeCode, Kind = rx.Kind,
+                ResolvedReferences = resolvedImm,
+                ExtraAttributes = rx.ExtraAttributes, Source = rx.Source,
+            },
+            S131OtherInformationType o => new S131OtherInformationType
+            {
+                Id = o.Id, TypeCode = o.TypeCode,
+                ResolvedReferences = resolvedImm,
+                ExtraAttributes = o.ExtraAttributes, Source = o.Source,
+            },
+            _ => typed,
+        };
+    }
+
+    // ── Geometry projection ───────────────────────────────────────────
+
+    private static S131Geometry ProjectGeometry(S131Feature f)
+    {
+        switch (f.GeometryType)
+        {
+            case GmlGeometryType.None:
+                return S131Geometry.Empty;
+            case GmlGeometryType.Point:
+                return new S131Geometry
+                {
+                    GeometryType = S131GeometryType.Point,
+                    Points = f.Points.IsDefaultOrEmpty
+                        ? ImmutableArray<GeoPosition>.Empty
+                        : f.Points.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray(),
+                };
+            case GmlGeometryType.Curve:
+                return new S131Geometry
+                {
+                    GeometryType = S131GeometryType.Curve,
+                    Curves = f.Curves.IsDefaultOrEmpty
+                        ? ImmutableArray<ImmutableArray<GeoPosition>>.Empty
+                        : f.Curves.Select(c =>
+                            c.IsDefaultOrEmpty
+                                ? ImmutableArray<GeoPosition>.Empty
+                                : c.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray())
+                            .ToImmutableArray(),
+                };
+            case GmlGeometryType.Surface:
+                return new S131Geometry
+                {
+                    GeometryType = S131GeometryType.Surface,
+                    ExteriorRing = f.ExteriorRing.IsDefaultOrEmpty
+                        ? ImmutableArray<GeoPosition>.Empty
+                        : f.ExteriorRing.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray(),
+                    InteriorRings = f.InteriorRings.IsDefaultOrEmpty
+                        ? ImmutableArray<ImmutableArray<GeoPosition>>.Empty
+                        : f.InteriorRings.Select(r =>
+                            r.IsDefaultOrEmpty
+                                ? ImmutableArray<GeoPosition>.Empty
+                                : r.Select(p => new GeoPosition(p.Latitude, p.Longitude)).ToImmutableArray())
+                            .ToImmutableArray(),
+                };
+            default:
+                return S131Geometry.Empty;
+        }
+    }
+
+    // ── Family classifiers (FC Ed 1.0.0 §B.2) ─────────────────────────
+
+    private static bool TryClassifyHarbourInfrastructure(string code, out S131HarbourInfrastructureKind kind)
+    {
+        kind = code switch
+        {
+            "AutomatedGuidedVehicle" => S131HarbourInfrastructureKind.AutomatedGuidedVehicle,
+            "Bollard" => S131HarbourInfrastructureKind.Bollard,
+            "Dolphin" => S131HarbourInfrastructureKind.Dolphin,
+            "DryDock" => S131HarbourInfrastructureKind.DryDock,
+            "FloatingDock" => S131HarbourInfrastructureKind.FloatingDock,
+            "Gridiron" => S131HarbourInfrastructureKind.Gridiron,
+            "HarbourFacility" => S131HarbourInfrastructureKind.HarbourFacility,
+            "LockBasin" => S131HarbourInfrastructureKind.LockBasin,
+            "LockBasinPart" => S131HarbourInfrastructureKind.LockBasinPart,
+            "MooringBuoy" => S131HarbourInfrastructureKind.MooringBuoy,
+            "OnshorePowerFacility" => S131HarbourInfrastructureKind.OnshorePowerFacility,
+            "ShipLift" => S131HarbourInfrastructureKind.ShipLift,
+            "StraddleCarrier" => S131HarbourInfrastructureKind.StraddleCarrier,
+            _ => S131HarbourInfrastructureKind.Unknown,
+        };
+        return kind != S131HarbourInfrastructureKind.Unknown;
+    }
+
+    private static bool TryClassifyLayout(string code, out S131LayoutKind kind)
+    {
+        kind = code switch
+        {
+            "AnchorBerth" => S131LayoutKind.AnchorBerth,
+            "AnchorageArea" => S131LayoutKind.AnchorageArea,
+            "Berth" => S131LayoutKind.Berth,
+            "BerthPosition" => S131LayoutKind.BerthPosition,
+            "DockArea" => S131LayoutKind.DockArea,
+            "DumpingGround" => S131LayoutKind.DumpingGround,
+            "FenderLine" => S131LayoutKind.FenderLine,
+            "HarbourAreaAdministrative" => S131LayoutKind.HarbourAreaAdministrative,
+            "HarbourAreaSection" => S131LayoutKind.HarbourAreaSection,
+            "HarbourBasin" => S131LayoutKind.HarbourBasin,
+            "MooringWarpingFacility" => S131LayoutKind.MooringWarpingFacility,
+            "OuterLimit" => S131LayoutKind.OuterLimit,
+            "PilotBoardingPlace" => S131LayoutKind.PilotBoardingPlace,
+            "SeaplaneLandingArea" => S131LayoutKind.SeaplaneLandingArea,
+            "Terminal" => S131LayoutKind.Terminal,
+            "TurningBasin" => S131LayoutKind.TurningBasin,
+            "WaterwayArea" => S131LayoutKind.WaterwayArea,
+            _ => S131LayoutKind.Unknown,
+        };
+        return kind != S131LayoutKind.Unknown;
+    }
+
+    private static bool TryClassifyMetadata(string code, out S131MetadataKind kind)
+    {
+        kind = code switch
+        {
+            "DataCoverage" => S131MetadataKind.DataCoverage,
+            "QualityOfNonBathymetricData" => S131MetadataKind.QualityOfNonBathymetricData,
+            "SoundingDatum" => S131MetadataKind.SoundingDatum,
+            "TextPlacement" => S131MetadataKind.TextPlacement,
+            "VerticalDatumOfData" => S131MetadataKind.VerticalDatumOfData,
+            _ => S131MetadataKind.Unknown,
+        };
+        return kind != S131MetadataKind.Unknown;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S131/DataModel/S131InformationTypes.cs
+++ b/src/EncDotNet.S100.Datasets.S131/DataModel/S131InformationTypes.cs
@@ -1,0 +1,258 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S131.DataModel;
+
+/// <summary>
+/// Common contract exposed by every typed S-131 information type
+/// (<see cref="S131Authority"/>, <see cref="S131ContactDetails"/>,
+/// <see cref="S131RxNInformation"/>, etc.). Mirrors
+/// <see cref="IS131Feature"/> but without the geometry surface —
+/// information types in S-131 (FC §B.1) never carry geometry.
+/// </summary>
+public interface IS131InformationType
+{
+    /// <summary>The GML identifier of the source information type.</summary>
+    string Id { get; }
+
+    /// <summary>The raw information type code (e.g. <c>"ContactDetails"</c>).</summary>
+    string TypeCode { get; }
+
+    /// <summary>
+    /// Cross-references from this information type to other objects in
+    /// the dataset, resolved via <c>xlink:href</c>. Most concrete S-131
+    /// information types do not declare outgoing references, but the
+    /// surface is preserved for forward compatibility.
+    /// </summary>
+    ImmutableArray<S131ResolvedReference> ResolvedReferences { get; }
+
+    /// <summary>Source attributes that the typed model did not consume.</summary>
+    ImmutableDictionary<string, string> ExtraAttributes { get; }
+
+    /// <summary>The originating raw GML information type instance.</summary>
+    S131InformationType Source { get; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>Authority</c> information type
+/// (FC Ed 1.0.0 §B.1). A container-style record that aggregates
+/// contact, applicability, and service-hours bindings for a port,
+/// terminal, pilotage, or other operating authority.
+/// </summary>
+/// <remarks>
+/// Authority is treated as an information type in this codebase per
+/// the S-131 FC (<c>S100_FC_InformationType</c>); it never carries
+/// geometry and is exclusively referenced by other features /
+/// information types via <c>xlink:href</c>.
+/// </remarks>
+public sealed class S131Authority : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "Authority";
+
+    /// <summary>The first resolved <c>contactDetails</c> peer, when present.</summary>
+    public S131ContactDetails? ContactDetails { get; init; }
+
+    /// <summary>The first resolved <c>applicability</c> peer, when present.</summary>
+    public S131Applicability? Applicability { get; init; }
+
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>ContactDetails</c> information type
+/// (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131ContactDetails : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "ContactDetails";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>Applicability</c> information type
+/// (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131Applicability : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "Applicability";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>AvailablePortServices</c>
+/// information type (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131AvailablePortServices : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "AvailablePortServices";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>Entrance</c> information type
+/// (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131Entrance : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "Entrance";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>ServiceHours</c> information type
+/// (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131ServiceHours : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "ServiceHours";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>NonStandardWorkingDay</c>
+/// information type (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131NonStandardWorkingDay : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "NonStandardWorkingDay";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 information type derived from
+/// <c>AbstractRxN</c> — i.e. <c>NauticalInformation</c>,
+/// <c>Recommendations</c>, <c>Regulations</c>, or <c>Restrictions</c>
+/// (FC Ed 1.0.0 §B.1). These types share a common attribute footprint
+/// (textual <c>information</c>, <c>language</c>, optional file
+/// locator) so they are projected into a single record discriminated by
+/// <see cref="Kind"/>.
+/// </summary>
+public sealed class S131RxNInformation : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string TypeCode { get; init; }
+    /// <summary>The concrete kind, decoded from <see cref="TypeCode"/>.</summary>
+    public required S131RxNKind Kind { get; init; }
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection of an S-131 <c>SpatialQuality</c> information type
+/// (FC Ed 1.0.0 §B.1).
+/// </summary>
+public sealed class S131SpatialQuality : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public string TypeCode => "SpatialQuality";
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}
+
+/// <summary>
+/// Typed projection fallback for an information type whose
+/// <see cref="S131InformationType.TypeCode"/> is not recognised in the
+/// S-131 FC enumeration baked into the typed model. The projection
+/// also emits an <c>s131.information.unknown</c> info diagnostic.
+/// </summary>
+public sealed class S131OtherInformationType : IS131InformationType
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+    /// <inheritdoc/>
+    public required string TypeCode { get; init; }
+    /// <inheritdoc/>
+    public ImmutableArray<S131ResolvedReference> ResolvedReferences { get; init; } =
+        ImmutableArray<S131ResolvedReference>.Empty;
+    /// <inheritdoc/>
+    public ImmutableDictionary<string, string> ExtraAttributes { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+    /// <inheritdoc/>
+    public required S131InformationType Source { get; init; }
+}

--- a/src/EncDotNet.S100.Datasets.S131/DataModel/S131Types.cs
+++ b/src/EncDotNet.S100.Datasets.S131/DataModel/S131Types.cs
@@ -1,0 +1,254 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Datasets.S131.DataModel;
+
+/// <summary>
+/// Family of an S-131 feature, statically derived from the FC supertype
+/// chain (S-131 FC Edition 1.0.0). The family enum lets callers dispatch
+/// on the high-level kind of harbour infrastructure without enumerating
+/// 36 concrete feature codes.
+/// </summary>
+public enum S131FeatureFamily
+{
+    /// <summary>The feature code is not present in the S-131 FC.</summary>
+    Unknown,
+
+    /// <summary>
+    /// Derived from <c>HarbourPhysicalInfrastructure</c> (FC §B.2) —
+    /// fixed installations such as bollards, dolphins, dry docks,
+    /// mooring buoys, lock basins, and ship-handling equipment.
+    /// </summary>
+    HarbourInfrastructure,
+
+    /// <summary>
+    /// Derived from <c>Layout</c> (FC §B.2) — the area- and
+    /// berth-style features that describe the spatial layout of a
+    /// harbour: berths, anchorage areas, terminals, harbour basins,
+    /// pilot boarding places, dumping grounds, fender lines, etc.
+    /// </summary>
+    Layout,
+
+    /// <summary>
+    /// Standalone feature types that do not derive from a harbour
+    /// supertype: <c>DataCoverage</c>, <c>QualityOfNonBathymetricData</c>,
+    /// <c>SoundingDatum</c>, <c>VerticalDatumOfData</c>,
+    /// <c>TextPlacement</c>.
+    /// </summary>
+    Metadata,
+}
+
+/// <summary>
+/// Concrete S-131 harbour-physical-infrastructure feature kind
+/// (S-131 FC Edition 1.0.0 §B.2). One entry per feature type whose
+/// supertype chain rises to <c>HarbourPhysicalInfrastructure</c>.
+/// </summary>
+public enum S131HarbourInfrastructureKind
+{
+    /// <summary>Unrecognised feature code.</summary>
+    Unknown,
+    /// <summary>§AutomatedGuidedVehicle.</summary>
+    AutomatedGuidedVehicle,
+    /// <summary>§Bollard.</summary>
+    Bollard,
+    /// <summary>§Dolphin.</summary>
+    Dolphin,
+    /// <summary>§DryDock.</summary>
+    DryDock,
+    /// <summary>§FloatingDock.</summary>
+    FloatingDock,
+    /// <summary>§Gridiron.</summary>
+    Gridiron,
+    /// <summary>§HarbourFacility.</summary>
+    HarbourFacility,
+    /// <summary>§LockBasin.</summary>
+    LockBasin,
+    /// <summary>§LockBasinPart.</summary>
+    LockBasinPart,
+    /// <summary>§MooringBuoy.</summary>
+    MooringBuoy,
+    /// <summary>§OnshorePowerFacility.</summary>
+    OnshorePowerFacility,
+    /// <summary>§ShipLift.</summary>
+    ShipLift,
+    /// <summary>§StraddleCarrier.</summary>
+    StraddleCarrier,
+}
+
+/// <summary>
+/// Concrete S-131 layout feature kind (S-131 FC Edition 1.0.0 §B.2).
+/// One entry per feature type whose supertype chain rises to
+/// <c>Layout</c>.
+/// </summary>
+public enum S131LayoutKind
+{
+    /// <summary>Unrecognised feature code.</summary>
+    Unknown,
+    /// <summary>§AnchorBerth.</summary>
+    AnchorBerth,
+    /// <summary>§AnchorageArea.</summary>
+    AnchorageArea,
+    /// <summary>§Berth.</summary>
+    Berth,
+    /// <summary>§BerthPosition.</summary>
+    BerthPosition,
+    /// <summary>§DockArea.</summary>
+    DockArea,
+    /// <summary>§DumpingGround.</summary>
+    DumpingGround,
+    /// <summary>§FenderLine.</summary>
+    FenderLine,
+    /// <summary>§HarbourAreaAdministrative.</summary>
+    HarbourAreaAdministrative,
+    /// <summary>§HarbourAreaSection.</summary>
+    HarbourAreaSection,
+    /// <summary>§HarbourBasin.</summary>
+    HarbourBasin,
+    /// <summary>§MooringWarpingFacility.</summary>
+    MooringWarpingFacility,
+    /// <summary>§OuterLimit.</summary>
+    OuterLimit,
+    /// <summary>§PilotBoardingPlace.</summary>
+    PilotBoardingPlace,
+    /// <summary>§SeaplaneLandingArea.</summary>
+    SeaplaneLandingArea,
+    /// <summary>§Terminal.</summary>
+    Terminal,
+    /// <summary>§TurningBasin.</summary>
+    TurningBasin,
+    /// <summary>§WaterwayArea.</summary>
+    WaterwayArea,
+}
+
+/// <summary>
+/// Concrete S-131 standalone-metadata feature kind
+/// (S-131 FC Edition 1.0.0 §B.2). One entry per feature type that
+/// has no shared supertype in the FC.
+/// </summary>
+public enum S131MetadataKind
+{
+    /// <summary>Unrecognised feature code.</summary>
+    Unknown,
+    /// <summary>§DataCoverage.</summary>
+    DataCoverage,
+    /// <summary>§QualityOfNonBathymetricData.</summary>
+    QualityOfNonBathymetricData,
+    /// <summary>§SoundingDatum.</summary>
+    SoundingDatum,
+    /// <summary>§TextPlacement.</summary>
+    TextPlacement,
+    /// <summary>§VerticalDatumOfData.</summary>
+    VerticalDatumOfData,
+}
+
+/// <summary>
+/// Concrete kind of an <c>AbstractRxN</c>-derived S-131 information
+/// type (S-131 FC Edition 1.0.0 §B.1).
+/// </summary>
+public enum S131RxNKind
+{
+    /// <summary>Unrecognised information-type code.</summary>
+    Unknown,
+    /// <summary>§NauticalInformation — descriptive nautical text.</summary>
+    NauticalInformation,
+    /// <summary>§Recommendations — advisory text.</summary>
+    Recommendations,
+    /// <summary>§Regulations — mandatory regulatory text.</summary>
+    Regulations,
+    /// <summary>§Restrictions — restriction-style regulatory text.</summary>
+    Restrictions,
+}
+
+/// <summary>
+/// Geometric primitive of an <see cref="S131Geometry"/> instance.
+/// Mirrors <see cref="GmlGeometryType"/> but is re-exported here so
+/// callers can stay within the S-131 typed namespace.
+/// </summary>
+public enum S131GeometryType
+{
+    /// <summary>The feature carries no geometry (information type or
+    /// container feature).</summary>
+    None = 0,
+    /// <summary>One or more point geometries.</summary>
+    Point = 1,
+    /// <summary>One or more curve / line string geometries.</summary>
+    Curve = 2,
+    /// <summary>A single surface with optional interior rings.</summary>
+    Surface = 3,
+}
+
+/// <summary>
+/// Strongly-typed geometry payload of an <see cref="IS131Feature"/>.
+/// Wraps the four parallel coordinate collections on
+/// <see cref="S131Feature"/> into a single record so typed consumers do
+/// not have to inspect <see cref="GmlGeometryType"/> separately.
+/// </summary>
+/// <remarks>
+/// Coordinates are <c>(lat, lon)</c> in decimal degrees per
+/// S-100 Part 10b §6.2.
+/// </remarks>
+public sealed class S131Geometry
+{
+    /// <summary>The geometric primitive type.</summary>
+    public required S131GeometryType GeometryType { get; init; }
+
+    /// <summary>Point coordinates (non-empty when <see cref="GeometryType"/> is <see cref="S131GeometryType.Point"/>).</summary>
+    public ImmutableArray<GeoPosition> Points { get; init; } = ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Curve coordinate sequences (one inner array per curve segment chain).</summary>
+    public ImmutableArray<ImmutableArray<GeoPosition>> Curves { get; init; } =
+        ImmutableArray<ImmutableArray<GeoPosition>>.Empty;
+
+    /// <summary>Exterior ring of a surface (empty for non-surface geometries).</summary>
+    public ImmutableArray<GeoPosition> ExteriorRing { get; init; } = ImmutableArray<GeoPosition>.Empty;
+
+    /// <summary>Interior rings (holes) of a surface (empty for non-surface geometries).</summary>
+    public ImmutableArray<ImmutableArray<GeoPosition>> InteriorRings { get; init; } =
+        ImmutableArray<ImmutableArray<GeoPosition>>.Empty;
+
+    /// <summary>Convenience: <c>true</c> when the feature has no geometry.</summary>
+    public bool IsEmpty => GeometryType == S131GeometryType.None;
+
+    internal static readonly S131Geometry Empty = new()
+    {
+        GeometryType = S131GeometryType.None,
+    };
+}
+
+/// <summary>
+/// A typed cross-reference from an S-131 object to another object in the
+/// same dataset, recovered from an <c>xlink:href</c> attribute on a
+/// role-bearing child element.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The role is preserved verbatim from the source GML (e.g.
+/// <c>"theContactDetails"</c>, <c>"applicability"</c>). <see cref="Target"/>
+/// is the resolved typed peer; it is <c>null</c> when the
+/// <c>xlink:href</c> did not resolve (a <c>xlink.unresolved</c> diagnostic
+/// is also emitted) or when the source feature has been projected before
+/// its target was constructed (this latter case does not occur in the
+/// current two-pass projection — see <see cref="S131HarbourInfrastructureDataset.From"/>).
+/// </para>
+/// <para>
+/// <see cref="TargetRef"/> exposes the original <c>gml:id</c> of the
+/// target so that consumers can record a stable identifier even when
+/// resolution failed.
+/// </para>
+/// </remarks>
+public sealed class S131ResolvedReference
+{
+    /// <summary>The role / association name on the source GML element.</summary>
+    public required string Role { get; init; }
+
+    /// <summary>The target <c>gml:id</c> (without leading <c>#</c>).</summary>
+    public required string TargetRef { get; init; }
+
+    /// <summary>
+    /// The resolved typed peer — an <see cref="IS131Feature"/> or
+    /// <see cref="IS131InformationType"/> — or <c>null</c> when the
+    /// reference did not resolve.
+    /// </summary>
+    public object? Target { get; init; }
+}

--- a/src/EncDotNet.S100.Datasets.S131/README.md
+++ b/src/EncDotNet.S100.Datasets.S131/README.md
@@ -73,11 +73,110 @@ S-131 GML → S131DatasetReader → S131Dataset
 |---|---|
 | `S131Dataset` | Parsed dataset model (features + information types) |
 | `S131Feature` | Feature with geometry, attributes, complex attributes, xlink refs |
-| `S131InformationType` | Information type with attributes |
+| `S131InformationType` | Information type with attributes and xlink refs |
 | `S131DatasetReader` | GML parser; namespace-driven feature recognition |
 | `S131LuaDataProvider` | GML-to-Lua Host API bridge |
 | `S131LuaRuleExecutor` | Lua portrayal executor (Part 9A) |
 | `S131PortrayalCatalogue` | Portrayal catalogue (symbols, palettes, rules) |
+| `DataModel.S131HarbourInfrastructureDataset` | **Typed projection** of `S131Dataset` (see below) |
+
+## Typed DataModel
+
+The `EncDotNet.S100.Datasets.S131.DataModel` namespace provides a
+"Pass 2" strongly-typed projection layered on top of the raw
+`S131Dataset` graph, following the same pattern used by the other
+GML-encoded products (S-122 / S-124 / S-125 / S-127 / S-128 / S-129 /
+S-201 / S-411 / S-421). The projection is **independent of
+portrayal** — the Lua pipeline continues to consume the raw feature
+graph unchanged.
+
+### Entry point
+
+```csharp
+var raw = S131Dataset.Open("dataset.gml");
+var typed = S131HarbourInfrastructureDataset.From(raw, out var diagnostics);
+
+foreach (var berth in typed.LayoutFeatures.Where(l => l.Kind == S131LayoutKind.Berth))
+    Console.WriteLine($"{berth.Id}: {berth.Geometry.Points.FirstOrDefault()}");
+
+foreach (var authority in typed.Authorities)
+    Console.WriteLine($"{authority.Id} → contact={authority.ContactDetails?.Id}");
+```
+
+### Family hierarchy
+
+Concrete feature types are grouped into four families derived
+statically from the FC supertype graph (FC Ed 1.0.0 §B.2 / §B.5).
+The projection does **not** walk the FC at runtime — schema
+introspection remains the job of the Feature Catalogue reader.
+
+| Family | Typed record | Enum | FC supertype |
+|---|---|---|---|
+| `HarbourInfrastructure` | `S131HarbourInfrastructure` | `S131HarbourInfrastructureKind` | `HarbourPhysicalInfrastructure` (Bollard, Dolphin, DryDock, FloatingDock, Gridiron, HarbourFacility, LockBasin, LockBasinPart, MooringBuoy, OnshorePowerFacility, ShipLift, StraddleCarrier, AutomatedGuidedVehicle) |
+| `Layout` | `S131LayoutFeature` | `S131LayoutKind` | `Layout` (AnchorBerth, AnchorageArea, Berth, BerthPosition, DockArea, DumpingGround, FenderLine, HarbourAreaAdministrative, HarbourAreaSection, HarbourBasin, MooringWarpingFacility, OuterLimit, PilotBoardingPlace, SeaplaneLandingArea, Terminal, TurningBasin, WaterwayArea) |
+| `Metadata` | `S131MetadataFeature` | `S131MetadataKind` | Standalone (DataCoverage, QualityOfNonBathymetricData, SoundingDatum, TextPlacement, VerticalDatumOfData) |
+| `Unknown` | `S131OtherFeature` | — | Forward-compat catch-all |
+
+### Information-type hierarchy
+
+| Typed record | Source code(s) | Notes |
+|---|---|---|
+| `S131Authority` | `Authority` | Container; resolves `contactDetails` / `applicability` xlinks to typed peers via shortcut properties |
+| `S131ContactDetails` | `ContactDetails` | |
+| `S131Applicability` | `Applicability` | |
+| `S131AvailablePortServices` | `AvailablePortServices` | |
+| `S131Entrance` | `Entrance` | |
+| `S131ServiceHours` | `ServiceHours` | |
+| `S131NonStandardWorkingDay` | `NonStandardWorkingDay` | |
+| `S131SpatialQuality` | `SpatialQuality` | |
+| `S131RxNInformation` | `NauticalInformation` / `Recommendations` / `Regulations` / `Restrictions` | Discriminated by `S131RxNKind`; mirrors the FC `AbstractRxN` subtree |
+| `S131OtherInformationType` | — | Forward-compat catch-all |
+
+Information types in S-131 never carry geometry; the
+`S131Authority` shortcuts (`ContactDetails`, `Applicability`) are
+typed for the common Authority-binding pattern.
+
+### Geometry
+
+`S131Geometry` wraps the four parallel coordinate collections on
+`S131Feature` into a single record with `GeometryType` (`None`,
+`Point`, `Curve`, `Surface`). Coordinates are
+`GeoPosition(Latitude, Longitude)` in decimal degrees per S-100 Part
+10b §6.2.
+
+### Cross-references
+
+`xlink:href` references on role-bearing child elements (e.g.
+`<S131:applicability xlink:href="#info1"/>`) are resolved into
+`S131ResolvedReference { Role, TargetRef, Target }` entries on the
+`ResolvedReferences` property of both features and information
+types. Unresolved references carry a `null` `Target` plus a paired
+`xlink.unresolved` / `s131.reference.dangling` diagnostic.
+
+### Diagnostic codes
+
+The projection reports issues via `ProjectionDiagnostic` rather
+than throwing (the only fatal condition is an empty source dataset):
+
+| Code | Severity | Meaning |
+|---|---|---|
+| `xlink.unresolved` | Warning | `xlink:href` target not present in the dataset (from `XlinkResolver`) |
+| `s131.reference.dangling` | Warning | An `S131Reference` ended up with `Target == null` — raised at the role level for easier filtering |
+| `s131.feature.unknown` | Info | Feature type code not in the FC enumeration — falls back to `S131OtherFeature` |
+| `s131.information.unknown` | Info | Information type code not in the FC enumeration — falls back to `S131OtherInformationType` |
+| `s131.id.duplicate` | Warning | Two source objects share a `gml:id` |
+| `attribute.parse.{int,double,bool,datetime}` | Warning | From `AttributeParser` (currently unused — present for forward compatibility) |
+
+### Feature Catalogue note
+
+The typed enum lists are derived from the standalone FC at
+`content/S131/fc/FeatureCatalogue.xml` (FC Ed 1.0.0). The PC-bundled
+FC at `content/S131/pc/.../131_FC_2.0.0.20251025.xml` may contain
+additional codes — any divergence surfaces as
+`s131.feature.unknown` / `s131.information.unknown` diagnostics, and
+the affected objects still project cleanly as
+`S131OtherFeature` / `S131OtherInformationType`. The projection has
+no runtime FC dependency.
 
 ## Usage
 

--- a/src/EncDotNet.S100.Datasets.S131/S131Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131Dataset.cs
@@ -111,6 +111,16 @@ public sealed class S131InformationType : IGmlInformationType
 
     /// <summary>Complex attribute groups.</summary>
     public required ImmutableArray<S131ComplexAttribute> ComplexAttributes { get; init; }
+
+    /// <summary>
+    /// Cross-references parsed from <c>xlink:href</c> attributes on the
+    /// information type's child elements (e.g. an <c>Authority</c> info
+    /// type binding its <c>theContactDetails</c> / <c>theApplicability</c>
+    /// peers). Defaults to an empty array for information types that do
+    /// not carry outgoing references.
+    /// </summary>
+    public ImmutableArray<S131Reference> References { get; init; } =
+        ImmutableArray<S131Reference>.Empty;
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.S131/S131DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131DatasetReader.cs
@@ -151,7 +151,7 @@ internal static class S131DatasetReader
             ?? "";
         var typeCode = element.Name.LocalName;
 
-        var (simpleAttrs, complexAttrs, _) = ParseAttributes(element);
+        var (simpleAttrs, complexAttrs, refs) = ParseAttributes(element);
 
         return new S131InformationType
         {
@@ -159,6 +159,7 @@ internal static class S131DatasetReader
             TypeCode = typeCode,
             Attributes = simpleAttrs,
             ComplexAttributes = complexAttrs,
+            References = refs,
         };
     }
 

--- a/tests/EncDotNet.S100.Datasets.S131.Tests/DataModel/S131HarbourInfrastructureDatasetTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S131.Tests/DataModel/S131HarbourInfrastructureDatasetTests.cs
@@ -1,0 +1,238 @@
+using System.Collections.Immutable;
+using System.Linq;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Datasets.S131.Tests.DataModel;
+
+public class S131HarbourInfrastructureDatasetTests
+{
+    private static string TestDataPath(string filename) =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", filename);
+
+    private static S131Dataset Open(string filename) => S131Dataset.Open(TestDataPath(filename));
+
+    [Fact]
+    public void From_EmptyDataset_Throws()
+    {
+        var empty = new S131Dataset
+        {
+            ProductIdentifier = "S-131",
+            Features = ImmutableArray<S131Feature>.Empty,
+            InformationTypes = ImmutableArray<S131InformationType>.Empty,
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            S131HarbourInfrastructureDataset.From(empty, out _));
+    }
+
+    [Fact]
+    public void From_NullDataset_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            S131HarbourInfrastructureDataset.From(null!, out _));
+    }
+
+    [Fact]
+    public void From_TypedFixture_FamilyDiscriminationIsCorrect()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out _);
+
+        Assert.Single(typed.HarbourInfrastructure, h => h.Kind == S131HarbourInfrastructureKind.Bollard);
+        Assert.Contains(typed.LayoutFeatures, l => l.Kind == S131LayoutKind.AnchorageArea);
+        Assert.Contains(typed.LayoutFeatures, l => l.Kind == S131LayoutKind.FenderLine);
+        Assert.Contains(typed.LayoutFeatures, l => l.Kind == S131LayoutKind.Berth);
+        Assert.Single(typed.MetadataFeatures, m => m.Kind == S131MetadataKind.DataCoverage);
+        Assert.Single(typed.OtherFeatures, o => o.FeatureType == "MysteryFeature");
+
+        // Family enum consistency
+        foreach (var f in typed.Features)
+        {
+            var expected = f switch
+            {
+                S131HarbourInfrastructure => S131FeatureFamily.HarbourInfrastructure,
+                S131LayoutFeature => S131FeatureFamily.Layout,
+                S131MetadataFeature => S131FeatureFamily.Metadata,
+                _ => S131FeatureFamily.Unknown,
+            };
+            Assert.Equal(expected, f.Family);
+        }
+    }
+
+    [Fact]
+    public void From_TypedFixture_GeometryShapesArePreserved()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out _);
+
+        var bollard = typed.HarbourInfrastructure.Single(h => h.Id == "f-bollard");
+        Assert.Equal(S131GeometryType.Point, bollard.Geometry.GeometryType);
+        Assert.Equal(44.6475, bollard.Geometry.Points[0].Latitude, 4);
+        Assert.Equal(-63.5713, bollard.Geometry.Points[0].Longitude, 4);
+
+        var anchorage = typed.LayoutFeatures.Single(l => l.Id == "f-anchorage");
+        Assert.Equal(S131GeometryType.Surface, anchorage.Geometry.GeometryType);
+        Assert.Equal(5, anchorage.Geometry.ExteriorRing.Length);
+        Assert.Single(anchorage.Geometry.InteriorRings);
+        Assert.Equal(5, anchorage.Geometry.InteriorRings[0].Length);
+
+        var fender = typed.LayoutFeatures.Single(l => l.Id == "f-fender");
+        Assert.Equal(S131GeometryType.Curve, fender.Geometry.GeometryType);
+        Assert.Single(fender.Geometry.Curves);
+        Assert.Equal(3, fender.Geometry.Curves[0].Length);
+    }
+
+    [Fact]
+    public void From_TypedFixture_AuthorityShortcutsResolveToTypedPeers()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out _);
+
+        var authority = Assert.Single(typed.Authorities);
+        Assert.Equal("info-authority", authority.Id);
+        Assert.NotNull(authority.ContactDetails);
+        Assert.Equal("info-contact", authority.ContactDetails!.Id);
+        Assert.NotNull(authority.Applicability);
+        Assert.Equal("info-applic", authority.Applicability!.Id);
+
+        // Both shortcut peers also appear in the resolved references list.
+        Assert.Contains(authority.ResolvedReferences, r => r.Role == "contactDetails" && r.Target is S131ContactDetails);
+        Assert.Contains(authority.ResolvedReferences, r => r.Role == "applicability" && r.Target is S131Applicability);
+    }
+
+    [Fact]
+    public void From_TypedFixture_AuthorityHasNoGeometryAndIsTolerated()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out _);
+
+        var authority = Assert.Single(typed.Authorities);
+        // Authority is modelled as an information type — it has no Geometry surface;
+        // its presence in InformationTypes (not Features) is the contract.
+        Assert.Contains(authority, typed.InformationTypes);
+        Assert.DoesNotContain(typed.Features, f => f.Id == "info-authority");
+    }
+
+    [Fact]
+    public void From_TypedFixture_FeatureXlinkResolvesToInformationType()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out _);
+
+        var bollard = typed.HarbourInfrastructure.Single(h => h.Id == "f-bollard");
+        var applicRef = Assert.Single(bollard.ResolvedReferences);
+        Assert.Equal("applicability", applicRef.Role);
+        Assert.Equal("info-applic", applicRef.TargetRef);
+        var applic = Assert.IsType<S131Applicability>(applicRef.Target);
+        Assert.Equal("info-applic", applic.Id);
+    }
+
+    [Fact]
+    public void From_TypedFixture_DanglingXlinkReportsDiagnostics()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out var diags);
+
+        var dangling = typed.LayoutFeatures.Single(l => l.Id == "f-dangling");
+        var r = Assert.Single(dangling.ResolvedReferences);
+        Assert.Equal("missing-target", r.TargetRef);
+        Assert.Null(r.Target);
+
+        Assert.Contains(diags, d => d.Code == "xlink.unresolved" && d.RelatedId == "f-dangling");
+        Assert.Contains(diags, d => d.Code == "s131.reference.dangling" && d.RelatedId == "f-dangling");
+    }
+
+    [Fact]
+    public void From_TypedFixture_UnknownFeatureCodeEmitsDiagnosticAndFallback()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out var diags);
+
+        // The fixture's MysteryFeature is unknown to the FC enumeration; the
+        // raw reader's InformationTypeCodes set also captures MysteryInformation
+        // as a feature (anything not in the hard-coded info-type list is a
+        // feature). Both surface as S131OtherFeature with the
+        // s131.feature.unknown diagnostic.
+        Assert.Equal(2, typed.OtherFeatures.Length);
+        Assert.Contains(typed.OtherFeatures, o => o.FeatureType == "MysteryFeature" && o.Id == "f-unknown");
+        Assert.Contains(diags, d => d.Code == "s131.feature.unknown" && d.RelatedId == "f-unknown");
+        Assert.All(typed.OtherFeatures, o => Assert.Equal(S131FeatureFamily.Unknown, o.Family));
+    }
+
+    [Fact]
+    public void From_UnknownInformationType_FallsBackWithDiagnostic()
+    {
+        // The raw reader recognises only a hard-coded set of information
+        // type codes; future codes must still project cleanly. Construct
+        // the raw dataset directly so we can exercise the typed
+        // s131.information.unknown path independently of the reader.
+        var raw = new S131Dataset
+        {
+            ProductIdentifier = "S-131",
+            Features = ImmutableArray<S131Feature>.Empty,
+            InformationTypes = ImmutableArray.Create(new S131InformationType
+            {
+                Id = "info-mystery",
+                TypeCode = "MysteryInformation",
+                Attributes = ImmutableDictionary<string, string>.Empty,
+                ComplexAttributes = ImmutableArray<S131ComplexAttribute>.Empty,
+            }),
+        };
+
+        var typed = S131HarbourInfrastructureDataset.From(raw, out var diags);
+
+        var info = Assert.IsType<S131OtherInformationType>(Assert.Single(typed.InformationTypes));
+        Assert.Equal("info-mystery", info.Id);
+        Assert.Equal("MysteryInformation", info.TypeCode);
+        Assert.Contains(diags, d => d.Code == "s131.information.unknown" && d.RelatedId == "info-mystery");
+    }
+
+    [Fact]
+    public void From_TypedFixture_DuplicateIdsAreReported()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out var diags);
+
+        // Two features share gml:id "f-bollard" in the fixture (a Bollard and a Berth).
+        Assert.Equal(2, typed.Features.Count(f => f.Id == "f-bollard"));
+        Assert.Contains(diags, d => d.Code == "s131.id.duplicate" && d.RelatedId == "f-bollard");
+    }
+
+    [Fact]
+    public void From_TypedFixture_EveryRxNKindProjectsCorrectly()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_typed.gml"), out _);
+
+        Assert.Contains(typed.RxNInformation, r => r.Kind == S131RxNKind.NauticalInformation);
+        Assert.Contains(typed.RxNInformation, r => r.Kind == S131RxNKind.Regulations);
+
+        // Each RxN entry's TypeCode must match its source.
+        foreach (var rxn in typed.RxNInformation)
+        {
+            Assert.Equal(rxn.Source.TypeCode, rxn.TypeCode);
+        }
+    }
+
+    [Fact]
+    public void From_XlinkFixture_PointFeatureAndContainerInfoTypes()
+    {
+        // The existing harbour_xlink.gml fixture exercises a typical
+        // Authority + ContactDetails + Applicability + feature graph.
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_xlink.gml"), out var diags);
+
+        // No "unresolved" diagnostics — every xlink in the fixture is satisfied.
+        Assert.DoesNotContain(diags, d => d.Code == "xlink.unresolved");
+
+        var berth = Assert.Single(typed.LayoutFeatures);
+        Assert.Equal(S131LayoutKind.Berth, berth.Kind);
+        var applic = Assert.Single(berth.ResolvedReferences);
+        Assert.IsType<S131Applicability>(applic.Target);
+
+        var authority = Assert.Single(typed.Authorities);
+        Assert.NotNull(authority.ContactDetails);
+        Assert.NotNull(authority.Applicability);
+    }
+
+    [Fact]
+    public void From_SurfaceFixture_LayoutAnchorageArea()
+    {
+        var typed = S131HarbourInfrastructureDataset.From(Open("harbour_surface.gml"), out _);
+
+        var area = Assert.Single(typed.LayoutFeatures);
+        Assert.Equal(S131LayoutKind.AnchorageArea, area.Kind);
+        Assert.Equal(S131GeometryType.Surface, area.Geometry.GeometryType);
+        Assert.True(area.Geometry.ExteriorRing.Length >= 4);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S131.Tests/EncDotNet.S100.Datasets.S131.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S131.Tests/EncDotNet.S100.Datasets.S131.Tests.csproj
@@ -26,4 +26,10 @@
     <Content Include="..\datasets\S131\*.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="EncDotNet.S100.DataModel" />
+    <Using Include="EncDotNet.S100.Datasets.S131" />
+    <Using Include="EncDotNet.S100.Datasets.S131.DataModel" />
+  </ItemGroup>
+
 </Project>

--- a/tests/datasets/S131/harbour_typed.gml
+++ b/tests/datasets/S131/harbour_typed.gml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic S-131 GML fixture covering every typed-projection family:
+    f-bollard          HarbourInfrastructure / Bollard          (Point)
+    f-anchorage        Layout / AnchorageArea                   (Surface, with hole)
+    f-fender           Layout / FenderLine                      (Curve)
+    f-coverage         Metadata / DataCoverage                  (Surface)
+    f-unknown          OtherFeature (unknown FC code)           (Point)
+    f-dup              Layout / Berth, duplicates f-bollard id  (Point, dup id)
+    f-dangling         Layout / Berth with unresolved xlink     (Point)
+    info-applic        S131Applicability
+    info-contact       S131ContactDetails
+    info-authority     S131Authority -> info-contact, info-applic (xlinks)
+    info-rxn-nautical  S131RxNInformation / NauticalInformation
+    info-rxn-regs      S131RxNInformation / Regulations
+    info-spatial-q     S131SpatialQuality
+    info-mystery       S131OtherInformationType (unknown FC code)
+-->
+<S131:Dataset xmlns:S131="http://www.iho.int/S131/1.0"
+              xmlns:S100="http://www.iho.int/s100gml/5.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              gml:id="DS_S131_TypedTest">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-131</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <S131:members>
+
+    <S131:Applicability gml:id="info-applic">
+      <S131:categoryOfCargo>1</S131:categoryOfCargo>
+    </S131:Applicability>
+
+    <S131:ContactDetails gml:id="info-contact">
+      <S131:contactInstructions>VHF Ch 12</S131:contactInstructions>
+    </S131:ContactDetails>
+
+    <S131:Authority gml:id="info-authority">
+      <S131:contactDetails xlink:href="#info-contact"/>
+      <S131:applicability xlink:href="#info-applic"/>
+    </S131:Authority>
+
+    <S131:NauticalInformation gml:id="info-rxn-nautical">
+      <S131:information>Tide rip in approaches</S131:information>
+    </S131:NauticalInformation>
+
+    <S131:Regulations gml:id="info-rxn-regs">
+      <S131:information>Speed limit 5 knots</S131:information>
+    </S131:Regulations>
+
+    <S131:SpatialQuality gml:id="info-spatial-q">
+      <S131:qualityOfPosition>1</S131:qualityOfPosition>
+    </S131:SpatialQuality>
+
+    <S131:MysteryInformation gml:id="info-mystery">
+      <S131:somethingNew>future-info</S131:somethingNew>
+    </S131:MysteryInformation>
+
+    <S131:Bollard gml:id="f-bollard">
+      <S131:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-b" srsName="EPSG:4326">
+            <gml:pos>44.6475 -63.5713</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S131:geometry>
+      <S131:bollardNumber>B-001</S131:bollardNumber>
+      <S131:applicability xlink:href="#info-applic"/>
+    </S131:Bollard>
+
+    <S131:AnchorageArea gml:id="f-anchorage">
+      <S131:geometry>
+        <S100:surfaceProperty>
+          <gml:Surface gml:id="srf-a" srsName="EPSG:4326">
+            <gml:patches>
+              <gml:PolygonPatch>
+                <gml:exterior>
+                  <gml:LinearRing>
+                    <gml:posList>44.64 -63.58 44.64 -63.56 44.66 -63.56 44.66 -63.58 44.64 -63.58</gml:posList>
+                  </gml:LinearRing>
+                </gml:exterior>
+                <gml:interior>
+                  <gml:LinearRing>
+                    <gml:posList>44.645 -63.575 44.645 -63.565 44.655 -63.565 44.655 -63.575 44.645 -63.575</gml:posList>
+                  </gml:LinearRing>
+                </gml:interior>
+              </gml:PolygonPatch>
+            </gml:patches>
+          </gml:Surface>
+        </S100:surfaceProperty>
+      </S131:geometry>
+    </S131:AnchorageArea>
+
+    <S131:FenderLine gml:id="f-fender">
+      <S131:geometry>
+        <S100:curveProperty>
+          <gml:Curve gml:id="crv-f" srsName="EPSG:4326">
+            <gml:segments>
+              <gml:LineStringSegment>
+                <gml:posList>44.6475 -63.5713 44.6480 -63.5720 44.6485 -63.5725</gml:posList>
+              </gml:LineStringSegment>
+            </gml:segments>
+          </gml:Curve>
+        </S100:curveProperty>
+      </S131:geometry>
+    </S131:FenderLine>
+
+    <S131:DataCoverage gml:id="f-coverage">
+      <S131:geometry>
+        <S100:surfaceProperty>
+          <gml:Surface gml:id="srf-c" srsName="EPSG:4326">
+            <gml:patches>
+              <gml:PolygonPatch>
+                <gml:exterior>
+                  <gml:LinearRing>
+                    <gml:posList>44.0 -64.0 44.0 -63.0 45.0 -63.0 45.0 -64.0 44.0 -64.0</gml:posList>
+                  </gml:LinearRing>
+                </gml:exterior>
+              </gml:PolygonPatch>
+            </gml:patches>
+          </gml:Surface>
+        </S100:surfaceProperty>
+      </S131:geometry>
+    </S131:DataCoverage>
+
+    <S131:MysteryFeature gml:id="f-unknown">
+      <S131:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-u" srsName="EPSG:4326">
+            <gml:pos>44.0 -63.0</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S131:geometry>
+    </S131:MysteryFeature>
+
+    <S131:Berth gml:id="f-bollard">
+      <S131:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-d" srsName="EPSG:4326">
+            <gml:pos>44.6 -63.6</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S131:geometry>
+    </S131:Berth>
+
+    <S131:Berth gml:id="f-dangling">
+      <S131:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt-x" srsName="EPSG:4326">
+            <gml:pos>44.1 -63.1</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S131:geometry>
+      <S131:applicability xlink:href="#missing-target"/>
+    </S131:Berth>
+
+  </S131:members>
+</S131:Dataset>


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

S-131 was the last GML-encoded spec without a strongly-typed "Pass 2"
projection on top of its raw feature graph. This PR adds
`EncDotNet.S100.Datasets.S131.DataModel`, mirroring the pattern used
by S-122 / S-124 / S-125 / S-127 / S-128 / S-129 / S-201 / S-411 /
S-421 (typed records + xlink-resolved cross-references + projection
diagnostics over the shared `Core/DataModel/` plumbing).

The typed model is independent of portrayal: the S-131 Lua pipeline
(`S131LuaDataProvider` / `S131LuaRuleExecutor`) continues to consume
the raw `S131Feature` graph unchanged.

**Shape of the new API:**

- Entry point: `S131HarbourInfrastructureDataset.From(raw, out diagnostics)`.
- Feature family hierarchy derived statically from the FC supertype
  graph: `S131HarbourInfrastructure` (Bollard, Dolphin, DryDock, ...),
  `S131LayoutFeature` (Berth, AnchorageArea, FenderLine, ...),
  `S131MetadataFeature` (DataCoverage, SoundingDatum, ...), plus
  `S131OtherFeature` for forward-compat.
- Info-type hierarchy: `S131Authority` (with typed `ContactDetails` /
  `Applicability` shortcut properties), `S131RxNInformation` keyed by
  `S131RxNKind`, plus dedicated records for ContactDetails,
  Applicability, AvailablePortServices, Entrance, ServiceHours,
  NonStandardWorkingDay, SpatialQuality, and an Other fallback.
- `S131Geometry` wraps the four parallel coordinate arrays on
  `S131Feature` into a single record keyed by `S131GeometryType`.
- `S131ResolvedReference { Role, TargetRef, Target }` carries
  xlink-resolved cross-references; unresolved refs surface as paired
  `xlink.unresolved` + `s131.reference.dangling` diagnostics.

**One additive raw-reader change:** `S131InformationType` gained a
`References` property (default empty) so Authority's typed shortcuts
can actually resolve. `S131DatasetReader.ParseInformationType` now
preserves xlink refs that were previously discarded. The
`IGmlInformationType` interface is unchanged.

## Spec alignment

Check each spec this PR touches and confirm the relevant skill was
consulted (`.github/skills/<spec>/SKILL.md`):

- [x] S-131 marine harbour infrastructure (`s131-marine-harbour`)

**Spec section references cited in code/docs:**

- S-131 FC Edition 1.0.0 §B.1 (information-type hierarchy)
- S-131 FC Edition 1.0.0 §B.2 (feature supertype graph: HarbourPhysicalInfrastructure / Layout / standalone metadata)
- S-100 Part 10b §6.2 (lat,lon coordinate ordering for EPSG:4326)

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (N/A here — uses synthetic GML fixtures)
- [x] `dotnet test --configuration Release` passes locally — 20/20 in `EncDotNet.S100.Datasets.S131.Tests` (existing `S131DatasetReaderTests` still green; the info-type `References` addition is purely additive).

New `tests/EncDotNet.S100.Datasets.S131.Tests/DataModel/S131HarbourInfrastructureDatasetTests.cs` covers family discrimination, geometry shapes (point / curve / surface with hole), Authority typed shortcuts, geometry-less info types, xlink resolution to typed peers, dangling xlinks (both diagnostic codes), duplicate `gml:id` detection, unknown feature codes, every `S131RxNKind`, and a programmatic path for unknown info-type codes (since the raw reader's hard-coded `InformationTypeCodes` set re-classifies unknown info-type element names as features). New fixture `tests/datasets/S131/harbour_typed.gml`.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` — new "Typed DataModel" section documenting the entry point, family hierarchy, info-type hierarchy, geometry, xlink resolution, diagnostic codes, and the standalone-vs-PC-bundled FC note.
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A)
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to
      `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependencies)

## Breaking changes

None. The new `DataModel/` namespace is purely additive. The single
raw-graph change (`S131InformationType.References`) is an additive
property with a default empty value; no existing constructor sites or
interface contracts change.