### PR TITLE
Add S-122 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S122/README.md
+++ b/src/EncDotNet.S100.Datasets.S122/README.md
@@ -102,3 +102,41 @@ Notes:
 - Unrecognised feature / information types are preserved as
   `S122OtherFeature` / `S122OtherInformationType` so future-edition
   catalogues round-trip without information loss.
+
+## Validation
+
+The library ships a default rule pack for the typed dataset projection
+at `EncDotNet.S100.Datasets.S122.Validation.S122MarineProtectedAreaRules`.
+It follows the framework introduced for S-421 in PR #100 — see
+`EncDotNet.S100.Core/Validation/` for `IValidationRule<TModel>`,
+`ValidationRuleSet`, `ValidationFinding`, `ValidationSeverity`.
+
+```csharp
+using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S122.DataModel;
+using EncDotNet.S100.Datasets.S122.Validation;
+
+var dataset = S122Dataset.Open("122TESTDATASET.gml");
+var typed = S122MarineProtectedAreaDataset.From(dataset, out _);
+var report = S122MarineProtectedAreaRules.Validate(typed);
+
+foreach (var finding in report.Findings)
+    Console.WriteLine($"[{finding.Severity}] {finding.RuleId}: {finding.Message}");
+```
+
+The default rule pack contains seven rules:
+
+| Rule ID        | Severity | Summary                                                           |
+| -------------- | -------- | ----------------------------------------------------------------- |
+| `S122-R-3.1`   | Warning  | Features that declare a Point/Curve/Surface kind must have coords. |
+| `S122-R-4.1`   | Error    | All coordinates must lie within WGS-84 lat/lon ranges.            |
+| `S122-R-5.1`   | Error    | Surface features need a closed exterior ring (≥4 coords, first=last). |
+| `S122-R-6.1`   | Error    | Feature `gml:id` values must be unique within the dataset.        |
+| `S122-R-6.2`   | Error    | Information-type `gml:id` values must be unique within the dataset. |
+| `S122-R-7.1`   | Warning  | When present, `scaleMinimum` must be a positive denominator (≥1). |
+| `S122-R-9.1`   | Warning  | When present, `productIdentifier` must start with `S-122`.        |
+
+Tier-3 cross-dataset rules (e.g. an S-122 restricted area overlapping
+an S-101 routing zone) are deliberately out of scope for this pack;
+they will land alongside the MCP `validate_all` surface that exposes
+sibling datasets via `ValidationContext.Services`.

--- a/src/EncDotNet.S100.Datasets.S122/Validation/S122MarineProtectedAreaRules.cs
+++ b/src/EncDotNet.S100.Datasets.S122/Validation/S122MarineProtectedAreaRules.cs
@@ -1,0 +1,413 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S122.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S122.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-122 <see cref="S122MarineProtectedAreaDataset"/>. Rule
+/// identifiers follow the convention <c>S122-R-{clause}</c>, where
+/// <c>{clause}</c> traces to the relevant section of the S-122 product
+/// specification (FC 2.0.0) or — for clauses not cleanly attributable to
+/// a single FC element — to a locally-assigned number in the <c>9.x</c>
+/// range. The XML <c>&lt;remarks&gt;</c> on each rule cites the
+/// supporting clause.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This rule pack focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) checks that can be evaluated against a single typed
+/// dataset projection in isolation. Tier-3 cross-dataset rules (e.g.
+/// cross-referencing an S-122 restricted area against an overlapping
+/// S-101 routing zone) will be added in a follow-up once
+/// <see cref="ValidationContext.Services"/> is wired up by the MCP
+/// <c>validate_all</c> surface.
+/// </para>
+/// <para>
+/// Rules deliberately omitted from this pack:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <em>Information-type binding resolution</em> — the typed
+///     projection silently drops unresolved <c>xlink</c> targets and
+///     surfaces them as <see cref="Diagnostics.ProjectionDiagnostic"/>
+///     entries, not as fields on the projected feature. There is
+///     nothing for a typed-model rule to observe. Mirror the deviation
+///     note in the S-421 pilot.
+///   </description></item>
+///   <item><description>
+///     <em>Dataset emptiness</em> — <see cref="S122MarineProtectedAreaDataset.From"/>
+///     already throws <see cref="InvalidOperationException"/> when both
+///     <see cref="S122MarineProtectedAreaDataset.Features"/> and
+///     <see cref="S122MarineProtectedAreaDataset.InformationTypes"/>
+///     are empty, so there is no observable empty-dataset case at the
+///     typed-model layer.
+///   </description></item>
+/// </list>
+/// </remarks>
+public static class S122MarineProtectedAreaRules
+{
+    private const double ClosureToleranceDegrees = 1e-9;
+
+    /// <summary>
+    /// <c>S122-R-3.1</c> — Every feature that declares a non-<see cref="S122GeometryKind.None"/>
+    /// geometry kind must carry at least one coordinate.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-122 FC 2.0.0 § Feature Types — a feature whose
+    /// geometry primitive is <em>Point</em>, <em>Curve</em>, or
+    /// <em>Surface</em> must have coordinates conveying that geometry.
+    /// Geometry-less features (<c>GeometryKind == None</c>) are tolerated
+    /// for container-style projections that delegate their boundary via
+    /// an <c>xlink</c> association (see the project-level S-122
+    /// instructions, "Renderers must tolerate geometry-less features").
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> GeometryPresentWhenKindSet { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-3.1")
+            .WithDescription(
+                "Features that declare a Point/Curve/Surface geometry kind must carry at least one coordinate.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.GeometryKind == S122GeometryKind.None)
+                        continue;
+                    if (!feature.Coordinates.IsDefaultOrEmpty)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S122-R-3.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Feature '{feature.Id}' ({feature.FeatureType}) declares geometry kind " +
+                            $"'{feature.GeometryKind}' but carries no coordinates.",
+                        RelatedFeatureId = feature.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S122-R-4.1</c> — Every coordinate on every feature must lie
+    /// within the valid WGS-84 ranges: latitude in <c>[-90, +90]</c>
+    /// and longitude in <c>[-180, +180]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded. The S-122 application schema
+    /// inherits this constraint via its dependency on the S-100 GML
+    /// profile. The S-122 instructions also remind authors that
+    /// coordinate ordering in <c>&lt;gml:pos&gt;</c> is lat-lon for
+    /// EPSG:4326.
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> CoordinatesWithinWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-4.1")
+            .WithDescription("All feature coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.Coordinates.IsDefaultOrEmpty)
+                        continue;
+
+                    for (int i = 0; i < feature.Coordinates.Length; i++)
+                    {
+                        var pos = feature.Coordinates[i];
+                        bool latOk = pos.Latitude is >= -90 and <= 90;
+                        bool lonOk = pos.Longitude is >= -180 and <= 180;
+                        if (latOk && lonOk) continue;
+
+                        var details = (latOk, lonOk) switch
+                        {
+                            (false, true) => $"latitude {pos.Latitude} is outside [-90, +90]",
+                            (true, false) => $"longitude {pos.Longitude} is outside [-180, +180]",
+                            _ => $"latitude {pos.Latitude} and longitude {pos.Longitude} are both out of range",
+                        };
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S122-R-4.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{feature.Id}' ({feature.FeatureType}) coordinate #{i}: {details}.",
+                            Point = pos,
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S122-R-5.1</c> — Surface features must have a closed exterior
+    /// ring with at least four coordinates (three distinct plus the
+    /// closing point) and the first / last positions must coincide
+    /// within a small tolerance.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2.4 / OGC GML 3.2 §10.5 —
+    /// <c>gml:LinearRing</c> is closed by definition: the first and
+    /// last positions are identical. Surface features therefore require
+    /// at least four coordinates (a degenerate triangle plus closure).
+    /// The tolerance (<c>1e-9</c> degrees, about 0.1 mm at the equator)
+    /// matches the tolerance used by the S-421 pilot's coincident-
+    /// waypoint rule so that ordinary floating-point round-trip does
+    /// not falsely trigger this rule.
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> SurfaceRingClosure { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-5.1")
+            .WithDescription(
+                "Surface features must have a closed exterior ring (>= 4 coordinates, first == last).")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.GeometryKind != S122GeometryKind.Surface)
+                        continue;
+                    if (feature.Coordinates.IsDefaultOrEmpty)
+                        continue;
+
+                    var ring = feature.Coordinates;
+                    if (ring.Length < 4)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S122-R-5.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{feature.Id}' ({feature.FeatureType}) surface exterior ring " +
+                                $"has {ring.Length} coordinate(s); a closed ring requires at least 4.",
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                        continue;
+                    }
+
+                    var first = ring[0];
+                    var last = ring[ring.Length - 1];
+                    if (Math.Abs(first.Latitude - last.Latitude) > ClosureToleranceDegrees
+                        || Math.Abs(first.Longitude - last.Longitude) > ClosureToleranceDegrees)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S122-R-5.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{feature.Id}' ({feature.FeatureType}) surface exterior ring " +
+                                $"is not closed: first = ({first.Latitude}, {first.Longitude}), " +
+                                $"last = ({last.Latitude}, {last.Longitude}).",
+                            Point = first,
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S122-R-6.1</c> — No two features within the dataset may share
+    /// the same identifier (<c>gml:id</c>).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.4 / OGC GML 3.2 §7.2.4.2 —
+    /// <c>gml:id</c> is of XSD type <c>ID</c>, which requires uniqueness
+    /// per XML document. Duplicate feature identifiers also break the
+    /// projection's <c>xlink</c> resolver, since references can no
+    /// longer be disambiguated.
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> UniqueFeatureIds { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-6.1")
+            .WithDescription("Feature identifiers (gml:id) must be unique within the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var feature in dataset.Features)
+                {
+                    if (string.IsNullOrEmpty(feature.Id))
+                        continue;
+                    if (seen.Add(feature.Id))
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S122-R-6.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Feature identifier '{feature.Id}' ({feature.FeatureType}) is not unique " +
+                            "within the dataset.",
+                        RelatedFeatureId = feature.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S122-R-6.2</c> — No two information types within the dataset
+    /// may share the same identifier (<c>gml:id</c>).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.4 / OGC GML 3.2 §7.2.4.2 —
+    /// <c>gml:id</c> uniqueness is per XML document, spanning both
+    /// features and information types. This rule covers the
+    /// information-type subset; <see cref="UniqueFeatureIds"/> covers
+    /// the feature subset. (We split the rule along that boundary so
+    /// per-finding <see cref="ValidationFinding.RelatedFeatureId"/>
+    /// remains meaningful — feature vs. info type IDs land in
+    /// different result lanes in viewer / MCP consumers.)
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> UniqueInformationTypeIds { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-6.2")
+            .WithDescription("Information-type identifiers (gml:id) must be unique within the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var info in dataset.InformationTypes)
+                {
+                    if (string.IsNullOrEmpty(info.Id))
+                        continue;
+                    if (seen.Add(info.Id))
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S122-R-6.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Information-type identifier '{info.Id}' ({info.TypeCode}) is not unique " +
+                            "within the dataset.",
+                        RelatedFeatureId = info.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S122-R-7.1</c> — When a feature carries a
+    /// <c>scaleMinimum</c> attribute, the value must be a positive
+    /// display-scale denominator (≥ 1).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-122 FC 2.0.0 §scaleMinimum (inherited from
+    /// the FC-abstract <c>FeatureType</c>). The attribute is a display
+    /// scale denominator (the "S" in 1:S), so zero or negative values
+    /// have no cartographic meaning. Surfaced as a <em>warning</em>
+    /// rather than an error because some producer pipelines emit
+    /// <c>0</c> as a sentinel for "no scale limit" — non-conformant
+    /// but observed in the wild.
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> ScaleMinimumPositive { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-7.1")
+            .WithDescription("When present, scaleMinimum must be a positive display-scale denominator (>= 1).")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature is not S122FeatureBase fb || fb.ScaleMinimum is not { } scaleMin)
+                        continue;
+                    if (scaleMin >= 1)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S122-R-7.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Feature '{feature.Id}' ({feature.FeatureType}) has non-positive scaleMinimum " +
+                            $"({scaleMin}); a display-scale denominator must be >= 1.",
+                        RelatedFeatureId = feature.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S122-R-9.1</c> — When present, the dataset
+    /// <see cref="S122MarineProtectedAreaDataset.ProductIdentifier"/>
+    /// must identify the S-122 product specification (i.e. start with
+    /// <c>"S-122"</c>, case-insensitive).
+    /// </summary>
+    /// <remarks>
+    /// Local clause numbering (9.x) — there is no single S-122 FC
+    /// clause for product-identifier conformance. The check derives
+    /// from the S-122 instructions file: "the S-100
+    /// <c>&lt;productIdentifier&gt;</c> element is the source of
+    /// truth" for distinguishing S-122 from incorrectly-namespaced
+    /// trial datasets (the official 2.0.0 sample is mis-labelled with
+    /// the S-123 namespace prefix). A dataset whose product identifier
+    /// does not name S-122 should not be consumed as an S-122 dataset.
+    /// </remarks>
+    public static IValidationRule<S122MarineProtectedAreaDataset> ProductIdentifierIsS122 { get; } =
+        ValidationRuleBuilder.RuleFor<S122MarineProtectedAreaDataset>("S122-R-9.1")
+            .WithDescription("When present, productIdentifier must identify S-122 (start with 'S-122').")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var pid = dataset.ProductIdentifier;
+                if (string.IsNullOrEmpty(pid))
+                    return Array.Empty<ValidationFinding>();
+                if (pid.StartsWith("S-122", StringComparison.OrdinalIgnoreCase))
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S122-R-9.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Dataset productIdentifier '{pid}' does not name S-122; " +
+                            "this dataset may have been opened against the wrong product specification.",
+                        DatasetId = dataset.DatasetIdentifier,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-122 datasets.</summary>
+    public static ValidationRuleSet<S122MarineProtectedAreaDataset> Default { get; } = new(
+        GeometryPresentWhenKindSet,
+        CoordinatesWithinWgs84Range,
+        SurfaceRingClosure,
+        UniqueFeatureIds,
+        UniqueInformationTypeIds,
+        ScaleMinimumPositive,
+        ProductIdentifierIsS122);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(
+        S122MarineProtectedAreaDataset dataset,
+        ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S122.Tests/Validation/S122MarineProtectedAreaRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S122.Tests/Validation/S122MarineProtectedAreaRulesTests.cs
@@ -1,0 +1,424 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S122.DataModel;
+using EncDotNet.S100.Datasets.S122.Validation;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S122.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S122MarineProtectedAreaRules"/>. Each test
+/// builds a minimal synthetic <see cref="S122MarineProtectedAreaDataset"/>
+/// in memory (no GML fixtures) and asserts the corresponding rule fires
+/// (or doesn't) with the expected finding shape.
+/// </summary>
+public class S122MarineProtectedAreaRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static S122Dataset EmptySource() => new()
+    {
+        Features = ImmutableArray<S122Feature>.Empty,
+        InformationTypes = ImmutableArray<S122InformationType>.Empty,
+    };
+
+    private static S122MarineProtectedArea Mpa(
+        string id,
+        S122GeometryKind kind = S122GeometryKind.Surface,
+        ImmutableArray<GeoPosition>? coords = null,
+        int? scaleMinimum = null)
+        => new()
+        {
+            Id = id,
+            GeometryKind = kind,
+            Coordinates = coords ?? ImmutableArray<GeoPosition>.Empty,
+            ScaleMinimum = scaleMinimum,
+            References = ImmutableArray<GmlReference>.Empty,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+    private static S122RestrictedArea Restricted(
+        string id,
+        S122GeometryKind kind = S122GeometryKind.Surface,
+        ImmutableArray<GeoPosition>? coords = null)
+        => new()
+        {
+            Id = id,
+            GeometryKind = kind,
+            Coordinates = coords ?? ImmutableArray<GeoPosition>.Empty,
+            References = ImmutableArray<GmlReference>.Empty,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+    private static S122Authority Authority(string id) => new()
+    {
+        Id = id,
+        References = ImmutableArray<GmlReference>.Empty,
+        ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+    };
+
+    private static ImmutableArray<GeoPosition> ClosedSquare(double lat, double lon, double size = 0.1)
+        => ImmutableArray.Create(
+            new GeoPosition(lat, lon),
+            new GeoPosition(lat + size, lon),
+            new GeoPosition(lat + size, lon + size),
+            new GeoPosition(lat, lon + size),
+            new GeoPosition(lat, lon));
+
+    private static S122MarineProtectedAreaDataset Dataset(
+        IEnumerable<IS122Feature>? features = null,
+        IEnumerable<IS122InformationType>? infoTypes = null,
+        string? productIdentifier = "S-122",
+        string? datasetIdentifier = "DS-1")
+        => new()
+        {
+            Features = (features ?? Array.Empty<IS122Feature>()).ToImmutableArray(),
+            InformationTypes = (infoTypes ?? Array.Empty<IS122InformationType>()).ToImmutableArray(),
+            ProductIdentifier = productIdentifier,
+            DatasetIdentifier = datasetIdentifier,
+            Source = EmptySource(),
+        };
+
+    // ── S122-R-3.1 — geometry present when kind is set ──────────
+
+    [Fact]
+    public void GeometryPresentWhenKindSet_Passes_WhenSurfaceHasCoords()
+    {
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Surface, ClosedSquare(0, 0)) });
+        Assert.Empty(S122MarineProtectedAreaRules.GeometryPresentWhenKindSet
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void GeometryPresentWhenKindSet_Passes_OnGeometryLessContainer()
+    {
+        // GeometryKind.None — tolerated (e.g. Authority-style containers).
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.None) });
+        Assert.Empty(S122MarineProtectedAreaRules.GeometryPresentWhenKindSet
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void GeometryPresentWhenKindSet_Fails_WhenSurfaceMissingCoords()
+    {
+        var ds = Dataset(features: new[] { Mpa("BAD", S122GeometryKind.Surface, ImmutableArray<GeoPosition>.Empty) });
+        var findings = S122MarineProtectedAreaRules.GeometryPresentWhenKindSet
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-3.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void GeometryPresentWhenKindSet_Fails_WhenPointMissingCoords()
+    {
+        var ds = Dataset(features: new[] { Mpa("P1", S122GeometryKind.Point, ImmutableArray<GeoPosition>.Empty) });
+        var findings = S122MarineProtectedAreaRules.GeometryPresentWhenKindSet
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("P1", f.RelatedFeatureId);
+        Assert.Contains("Point", f.Message);
+    }
+
+    // ── S122-R-4.1 — coordinates within WGS-84 ──────────────────
+
+    [Fact]
+    public void CoordinatesWithinWgs84Range_Passes_OnValidCoords()
+    {
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Surface, ClosedSquare(45, 100)) });
+        Assert.Empty(S122MarineProtectedAreaRules.CoordinatesWithinWgs84Range
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesWithinWgs84Range_Fails_OnOutOfRangeLatitude()
+    {
+        var bad = ImmutableArray.Create(
+            new GeoPosition(95.0, 0.0),
+            new GeoPosition(0.0, 0.0));
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Curve, bad) });
+        var findings = S122MarineProtectedAreaRules.CoordinatesWithinWgs84Range
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-4.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("F1", f.RelatedFeatureId);
+        Assert.Contains("latitude", f.Message);
+        Assert.Equal(new GeoPosition(95.0, 0.0), f.Point);
+    }
+
+    [Fact]
+    public void CoordinatesWithinWgs84Range_Fails_OnOutOfRangeLongitude()
+    {
+        var bad = ImmutableArray.Create(new GeoPosition(0.0, 200.0));
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Point, bad) });
+        var findings = S122MarineProtectedAreaRules.CoordinatesWithinWgs84Range
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Contains("longitude", f.Message);
+    }
+
+    [Fact]
+    public void CoordinatesWithinWgs84Range_ReportsMultipleFindingsAcrossFeatures()
+    {
+        var bad1 = ImmutableArray.Create(new GeoPosition(0, 200));
+        var bad2 = ImmutableArray.Create(new GeoPosition(-100, 0));
+        var ds = Dataset(features: new IS122Feature[]
+        {
+            Mpa("A", S122GeometryKind.Point, bad1),
+            Restricted("B", S122GeometryKind.Point, bad2),
+        });
+        var ids = S122MarineProtectedAreaRules.CoordinatesWithinWgs84Range
+            .Evaluate(ds, ValidationContext.Default)
+            .Select(f => f.RelatedFeatureId)
+            .ToHashSet();
+        Assert.Contains("A", ids);
+        Assert.Contains("B", ids);
+    }
+
+    // ── S122-R-5.1 — surface ring closure ───────────────────────
+
+    [Fact]
+    public void SurfaceRingClosure_Passes_OnClosedRing()
+    {
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Surface, ClosedSquare(10, 20)) });
+        Assert.Empty(S122MarineProtectedAreaRules.SurfaceRingClosure
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingClosure_Passes_OnNonSurfaceFeature()
+    {
+        // A curve with 3 points and unequal endpoints — non-surface, rule doesn't apply.
+        var curve = ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(1, 1), new GeoPosition(2, 2));
+        var ds = Dataset(features: new[] { Mpa("C1", S122GeometryKind.Curve, curve) });
+        Assert.Empty(S122MarineProtectedAreaRules.SurfaceRingClosure
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingClosure_Fails_OnTooFewCoordinates()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(0, 1), new GeoPosition(0, 0));
+        var ds = Dataset(features: new[] { Mpa("SHORT", S122GeometryKind.Surface, ring) });
+        var findings = S122MarineProtectedAreaRules.SurfaceRingClosure
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-5.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("SHORT", f.RelatedFeatureId);
+        Assert.Contains("at least 4", f.Message);
+    }
+
+    [Fact]
+    public void SurfaceRingClosure_Fails_WhenRingNotClosed()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0),
+            new GeoPosition(0, 1),
+            new GeoPosition(1, 1),
+            new GeoPosition(1, 0));
+        var ds = Dataset(features: new[] { Mpa("OPEN", S122GeometryKind.Surface, ring) });
+        var findings = S122MarineProtectedAreaRules.SurfaceRingClosure
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("OPEN", f.RelatedFeatureId);
+        Assert.Contains("not closed", f.Message);
+    }
+
+    // ── S122-R-6.1 — unique feature ids ─────────────────────────
+
+    [Fact]
+    public void UniqueFeatureIds_Passes_OnDistinctIds()
+    {
+        var ds = Dataset(features: new IS122Feature[]
+        {
+            Mpa("A", S122GeometryKind.Surface, ClosedSquare(0, 0)),
+            Mpa("B", S122GeometryKind.Surface, ClosedSquare(1, 1)),
+        });
+        Assert.Empty(S122MarineProtectedAreaRules.UniqueFeatureIds
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void UniqueFeatureIds_Fails_OnDuplicateId()
+    {
+        var ds = Dataset(features: new IS122Feature[]
+        {
+            Mpa("DUP", S122GeometryKind.Surface, ClosedSquare(0, 0)),
+            Restricted("DUP", S122GeometryKind.Surface, ClosedSquare(1, 1)),
+            Mpa("OK", S122GeometryKind.Surface, ClosedSquare(2, 2)),
+        });
+        var findings = S122MarineProtectedAreaRules.UniqueFeatureIds
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-6.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("DUP", f.RelatedFeatureId);
+    }
+
+    // ── S122-R-6.2 — unique information type ids ────────────────
+
+    [Fact]
+    public void UniqueInformationTypeIds_Passes_OnDistinctIds()
+    {
+        var ds = Dataset(infoTypes: new[] { Authority("AUTH-1"), Authority("AUTH-2") });
+        Assert.Empty(S122MarineProtectedAreaRules.UniqueInformationTypeIds
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void UniqueInformationTypeIds_Fails_OnDuplicateId()
+    {
+        var ds = Dataset(infoTypes: new[] { Authority("X"), Authority("X") });
+        var findings = S122MarineProtectedAreaRules.UniqueInformationTypeIds
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-6.2", f.RuleId);
+        Assert.Equal("X", f.RelatedFeatureId);
+    }
+
+    // ── S122-R-7.1 — scale minimum positive ─────────────────────
+
+    [Fact]
+    public void ScaleMinimumPositive_Passes_WhenAbsent()
+    {
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Surface, ClosedSquare(0, 0)) });
+        Assert.Empty(S122MarineProtectedAreaRules.ScaleMinimumPositive
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50_000)]
+    [InlineData(10_000_000)]
+    public void ScaleMinimumPositive_Passes_OnPositiveValue(int scale)
+    {
+        var ds = Dataset(features: new[] { Mpa("F1", S122GeometryKind.Surface, ClosedSquare(0, 0), scaleMinimum: scale) });
+        Assert.Empty(S122MarineProtectedAreaRules.ScaleMinimumPositive
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public void ScaleMinimumPositive_Fails_OnNonPositiveValue(int scale)
+    {
+        var ds = Dataset(features: new[] { Mpa("BAD", S122GeometryKind.Surface, ClosedSquare(0, 0), scaleMinimum: scale) });
+        var findings = S122MarineProtectedAreaRules.ScaleMinimumPositive
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-7.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Contains(scale.ToString(), f.Message);
+    }
+
+    // ── S122-R-9.1 — product identifier names S-122 ─────────────
+
+    [Fact]
+    public void ProductIdentifierIsS122_Passes_WhenAbsent()
+    {
+        var ds = Dataset(productIdentifier: null);
+        Assert.Empty(S122MarineProtectedAreaRules.ProductIdentifierIsS122
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData("S-122")]
+    [InlineData("s-122")]
+    [InlineData("S-122 Marine Protected Areas")]
+    [InlineData("INT.IHO.S-122.0.1.0")] // tolerate trailing fragments? — only checks prefix; this fails.
+    public void ProductIdentifierIsS122_PassesOrFails_ByPrefix(string pid)
+    {
+        var ds = Dataset(productIdentifier: pid);
+        var findings = S122MarineProtectedAreaRules.ProductIdentifierIsS122
+            .Evaluate(ds, ValidationContext.Default).ToList();
+
+        if (pid.StartsWith("S-122", StringComparison.OrdinalIgnoreCase))
+            Assert.Empty(findings);
+        else
+            Assert.Single(findings);
+    }
+
+    [Fact]
+    public void ProductIdentifierIsS122_Fails_OnWrongSpec()
+    {
+        var ds = Dataset(productIdentifier: "S-123");
+        var findings = S122MarineProtectedAreaRules.ProductIdentifierIsS122
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S122-R-9.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Contains("S-123", f.Message);
+    }
+
+    // ── Default ruleset composition + Validate convenience ──────
+
+    [Fact]
+    public void Default_ContainsAllSevenRules()
+    {
+        Assert.Equal(7, S122MarineProtectedAreaRules.Default.Rules.Length);
+        var ids = S122MarineProtectedAreaRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Contains("S122-R-3.1", ids);
+        Assert.Contains("S122-R-4.1", ids);
+        Assert.Contains("S122-R-5.1", ids);
+        Assert.Contains("S122-R-6.1", ids);
+        Assert.Contains("S122-R-6.2", ids);
+        Assert.Contains("S122-R-7.1", ids);
+        Assert.Contains("S122-R-9.1", ids);
+    }
+
+    [Fact]
+    public void Validate_OnValidDataset_ProducesNoFindings()
+    {
+        var ds = Dataset(
+            features: new IS122Feature[]
+            {
+                Mpa("MPA-1", S122GeometryKind.Surface, ClosedSquare(10, 20), scaleMinimum: 50_000),
+                Restricted("RA-1", S122GeometryKind.Surface, ClosedSquare(11, 21)),
+            },
+            infoTypes: new[] { Authority("AUTH-1") },
+            productIdentifier: "S-122");
+
+        var report = S122MarineProtectedAreaRules.Validate(ds);
+        Assert.True(report.IsValid);
+        Assert.Empty(report.Findings);
+        Assert.Equal(7, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_OnInvalidDataset_AggregatesFindingsFromMultipleRules()
+    {
+        // Surface w/ missing coords (3.1), bad lat (4.1) on a point feature,
+        // duplicate ID (6.1), zero scaleMinimum (7.1), wrong product id (9.1).
+        var ds = Dataset(
+            features: new IS122Feature[]
+            {
+                Mpa("EMPTY", S122GeometryKind.Surface, ImmutableArray<GeoPosition>.Empty),
+                Mpa("BADLL", S122GeometryKind.Point, ImmutableArray.Create(new GeoPosition(95, 0)), scaleMinimum: 0),
+                Restricted("DUP", S122GeometryKind.Surface, ClosedSquare(0, 0)),
+                Restricted("DUP", S122GeometryKind.Surface, ClosedSquare(1, 1)),
+            },
+            productIdentifier: "S-201");
+
+        var report = S122MarineProtectedAreaRules.Validate(ds);
+        Assert.False(report.IsValid);
+        var ids = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S122-R-3.1", ids);
+        Assert.Contains("S122-R-4.1", ids);
+        Assert.Contains("S122-R-6.1", ids);
+        Assert.Contains("S122-R-7.1", ids);
+        Assert.Contains("S122-R-9.1", ids);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullDataset()
+    {
+        Assert.Throws<ArgumentNullException>(() => S122MarineProtectedAreaRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Follows the validation framework introduced for S-421 in #100.
Adds a default rule set for the typed
`S122MarineProtectedAreaDataset` projection, an xunit test suite, and
a documentation block in the project README.

## Rules

| Rule ID      | Severity | Summary                                                                |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `S122-R-3.1` | Warning  | Features that declare a Point/Curve/Surface geometry kind must carry coordinates. |
| `S122-R-4.1` | Error    | All feature coordinates must lie within WGS-84 lat/lon ranges (S-100 Part 10b §6.2). |
| `S122-R-5.1` | Error    | Surface features need a closed exterior ring (≥ 4 coords, first == last within `1e-9°`). |
| `S122-R-6.1` | Error    | Feature `gml:id` values must be unique within the dataset (GML 3.2 §7.2.4.2). |
| `S122-R-6.2` | Error    | Information-type `gml:id` values must be unique within the dataset.    |
| `S122-R-7.1` | Warning  | When present, `scaleMinimum` must be a positive display-scale denominator (≥ 1). |
| `S122-R-9.1` | Warning  | When present, `productIdentifier` must start with `S-122` (locally numbered; per the S-122 instructions file). |

## Tests

- 32 new xunit tests in
  `tests/EncDotNet.S100.Datasets.S122.Tests/Validation/S122MarineProtectedAreaRulesTests.cs`.
- One happy-path `[Fact]` (or `[Theory]`) per rule plus 1–3 failing-path
  facts each, asserting `RuleId`, `Severity`, and (where applicable)
  `RelatedFeatureId` / `Point` shape.
- Default rule-set composition test confirms all seven rule IDs are
  present.
- `Validate()` aggregation test crafts a dataset that violates five
  rules at once and asserts every expected rule ID surfaces.
- Full suite: **1472 passed / 2 skipped / 0 failed**.

## Rules dropped from the candidate list

The prompt suggested 8 candidate rules; this PR ships 7 of them with
two deviations:

1. **Restriction period validity** — dropped. The typed model surfaces
   restriction periods only as raw `string?` (`FixedDateRange` /
   `PeriodicDateRange` on `S122FeatureBase` and the RxN information
   types), with no parsed start/end pair. Adding a date-range parser
   here would expand the PR's scope beyond a rule pack.
2. **Category-of-restriction enumeration** — dropped. The S-122 typed
   model carries categorical attributes (`CategoryOfMarineProtectedArea`,
   `CategoryOfRestrictedArea`, `Restriction`, `Status`, …) as plain
   `int?` without a closed-enum type to check against. A numeric-range
   rule here would be guesswork without consulting the FC enumeration
   tables; deferred until those constants exist in the typed model.
3. **Bounding-box sanity** — dropped. The typed dataset projection
   does not expose a top-level extent / bounding polygon, so there is
   nothing observable for a rule to bind to.
4. **Information-type binding (`xlink` resolution)** — dropped for the
   same reason called out in the S-421 pilot: unresolved xlinks
   surface as `ProjectionDiagnostic` entries, not as fields on the
   typed object, so a typed-model rule has nothing to observe.

A new rule (`S122-R-9.1`, product identifier check) was added in
their place, motivated by the S-122 instructions file noting that the
official 2.0.0 sample is mis-labelled with the **S-123** namespace
prefix — making `productIdentifier` the source of truth for product
identity.

## Acceptance criteria

- [x] One file under `src/EncDotNet.S100.Datasets.S122/Validation/`
      with seven rules, each citing a spec clause or the S-122
      instructions file in `<remarks>`.
- [x] New test file with happy + failing case coverage per rule.
- [x] `dotnet build EncDotNet.S100.slnx` succeeds.
- [x] `dotnet test --configuration Release` — 1472 passed / 2 skipped.
- [x] No edits outside the validation directories and a minor README
      update.
- [x] No changes to `EncDotNet.S100.Core/Validation/` or any other
      spec library.

## Non-goals

- No MCP `validate_dataset` tool wiring (deferred).
- No Tier-3 cross-dataset rules (needs `ValidationContext.Services`).
- No viewer findings-panel integration.
- No bundled fixture files; tests build synthetic models in-process.