### PR TITLE
Add S-125 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S125/README.md
+++ b/src/EncDotNet.S100.Datasets.S125/README.md
@@ -70,6 +70,36 @@ foreach (var aid in typed.Aids)
 }
 ```
 
+## Validation
+
+The `EncDotNet.S100.Datasets.S125.Validation` namespace exposes
+`S125AtonRules.Default`, a `ValidationRuleSet<S125AtonDataset>` of
+normative checks built on the typed `S125AtonDataset` projection. The
+pilot pack covers:
+
+| Rule | Severity | Summary |
+| ---- | -------- | ------- |
+| `S125-R-1.1` | Error   | Aid position lat/lon in WGS-84 ranges (S-100 Part 10b §6.2) |
+| `S125-R-1.2` | Error   | Aid `gml:id` unique within the dataset |
+| `S125-R-2.1` | Error   | AIS aid carries a 9-digit `mMSICode` |
+| `S125-R-3.1` | Error   | `AtonStatusInformation.changeTypes` in {1..5} |
+| `S125-R-3.2` | Error   | Status date range `dateStart ≤ dateEnd` |
+| `S125-R-4.1` | Warning | `AtonAggregation` / `AtonAssociation` binds ≥ 1 aid |
+| `S125-R-5.1` | Warning | `AtonStatusIndication` has a point geometry |
+
+```csharp
+var raw = S125Dataset.Open("aids.gml");
+var typed = S125AtonDataset.From(raw, out _);
+var report = S125AtonRules.Validate(typed);
+foreach (var f in report.Findings)
+    Console.WriteLine($"{f.Severity} {f.RuleId} {f.RelatedFeatureId}: {f.Message}");
+```
+
+Projection-time issues (unresolved xlinks, duplicate ids) are not
+exposed on the typed model and so are not surfaced as rules; capture
+the `out IReadOnlyList<ProjectionDiagnostic>` from
+`S125AtonDataset.From` if you need them.
+
 ## Notes
 
 - S-125 application schema namespace is `http://www.iho.int/S125/1.0`; geometry uses the S-100 GML 5.0 profile namespace `http://www.iho.int/s100gml/5.0`. Older sample datasets that still declare the S-100 GML 1.0 profile are read transparently.

--- a/src/EncDotNet.S100.Datasets.S125/Validation/S125AtonRules.cs
+++ b/src/EncDotNet.S100.Datasets.S125/Validation/S125AtonRules.cs
@@ -1,0 +1,361 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S125.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S125.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-125 <see cref="S125AtonDataset"/>. Rule identifiers follow
+/// the convention <c>S125-R-{clause}</c>, where <c>{clause}</c> traces
+/// to the relevant section of the S-125 specification
+/// (Edition 1.0.0 — Marine Aids to Navigation).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single
+/// <see cref="S125AtonDataset"/> in isolation. Tier-3 cross-dataset
+/// rules (e.g. checking an AtoN's charted position against an S-101
+/// chart) will be added in a follow-up once the MCP
+/// <c>validate_all</c> surface is wired up — they need access to
+/// sibling datasets via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// <para>
+/// <b>Deviation from the S-421 pilot.</b> Projection-time issues
+/// surfaced by <see cref="S125AtonDataset.From"/> (unresolved xlinks,
+/// duplicate ids, etc.) are reported through the
+/// <c>ProjectionDiagnostic</c> out-parameter rather than carried on
+/// the typed model, so there is no rule that mirrors S-421's
+/// "information binding sanity" check. Callers that care about those
+/// diagnostics should capture them at projection time.
+/// </para>
+/// </remarks>
+public static class S125AtonRules
+{
+    /// <summary>
+    /// <c>S125-R-1.1</c> — Every aid to navigation's position must fall
+    /// within the WGS-84 ranges: latitude in [-90, +90] and longitude
+    /// in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded. Aids without a position are
+    /// ignored by this rule; geometry presence is covered separately
+    /// where the spec requires it.
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> AidLatLonInRange { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-1.1")
+            .WithDescription("Aid to navigation positions must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var aid in dataset.Aids)
+                {
+                    if (aid.Position is not { } pos) continue;
+
+                    bool latOk = pos.Latitude is >= -90 and <= 90;
+                    bool lonOk = pos.Longitude is >= -180 and <= 180;
+                    if (latOk && lonOk) continue;
+
+                    var details = (latOk, lonOk) switch
+                    {
+                        (false, true) => $"latitude {pos.Latitude} is outside [-90, +90]",
+                        (true, false) => $"longitude {pos.Longitude} is outside [-180, +180]",
+                        _ => $"latitude {pos.Latitude} and longitude {pos.Longitude} are both out of range",
+                    };
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S125-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"{aid.FeatureType} '{aid.Id}': {details}.",
+                        Point = pos,
+                        RelatedFeatureId = aid.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S125-R-1.2</c> — Every aid to navigation must have a
+    /// dataset-unique <c>gml:id</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.4 — every GML object exposed
+    /// at the dataset level must carry a unique <c>gml:id</c> so that
+    /// xlink references can resolve. Duplicate aid identifiers also
+    /// break the typed model's <c>parent</c> / aggregation lookups.
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> AidIdsUnique { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-1.2")
+            .WithDescription("Aid to navigation gml:id values must be unique within the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var dupes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var aid in dataset.Aids)
+                {
+                    if (string.IsNullOrEmpty(aid.Id)) continue;
+                    if (!seen.Add(aid.Id)) dupes.Add(aid.Id);
+                }
+                foreach (var dup in dupes)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S125-R-1.2",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Duplicate aid gml:id '{dup}'.",
+                        RelatedFeatureId = dup,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S125-R-2.1</c> — Every AIS aid to navigation
+    /// (Physical / Synthetic / Virtual) must carry an <c>mMSICode</c>
+    /// of exactly nine decimal digits.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-125 Edition 1.0.0 §PhysicalAISAidToNavigation,
+    /// §SyntheticAISAidToNavigation, §VirtualAISAidToNavigation —
+    /// <c>mMSICode</c> (Maritime Mobile Service Identity) is the
+    /// 9-digit MMSI broadcast in the AIS message. The check is most
+    /// load-bearing on <see cref="S125AisKind.Virtual"/> aids, which
+    /// have no physical presence and so cannot be cross-validated
+    /// against a real-world fix. The attribute is read from
+    /// <see cref="IS125Aid.ExtraAttributes"/> because the typed model
+    /// does not break it out as a strongly-typed property.
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> AisAidHasMmsi { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-2.1")
+            .WithDescription("Every AIS aid to navigation must carry a 9-digit mMSICode.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var aid in dataset.Aids.OfType<S125AisAton>())
+                {
+                    aid.ExtraAttributes.TryGetValue("mMSICode", out var mmsi);
+                    if (string.IsNullOrEmpty(mmsi))
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S125-R-2.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"AIS aid '{aid.Id}' ({aid.FeatureType}) is missing the required mMSICode attribute.",
+                            Point = aid.Position,
+                            RelatedFeatureId = aid.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                        continue;
+                    }
+
+                    if (mmsi.Length != 9 || !mmsi.All(char.IsAsciiDigit))
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S125-R-2.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"AIS aid '{aid.Id}' ({aid.FeatureType}) has malformed mMSICode '{mmsi}'; " +
+                                "must be exactly 9 decimal digits.",
+                            Point = aid.Position,
+                            RelatedFeatureId = aid.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S125-R-3.1</c> — When an <c>AtonStatusInformation</c>
+    /// carries a numeric <c>changeTypes</c> code it must fall within
+    /// the closed enumeration declared by the Feature Catalogue.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-125 Edition 1.0.0 §changeTypes (Feature
+    /// Catalogue listed values 1–5: Advance Notice of Change,
+    /// Discrepancy, Proposed Change, Temporary Change, Permanent
+    /// Change). The typed projection maps an out-of-range numeric
+    /// value to <see cref="S125ChangeType.Unknown"/>, so this rule
+    /// fires precisely when <see cref="S125AtonStatusInformation.ChangeTypeCode"/>
+    /// is present but the projection refused to classify it.
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> ChangeTypeCodeInEnumeration { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-3.1")
+            .WithDescription("AtonStatusInformation changeTypes must be one of the FC listed values 1–5.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var info in dataset.StatusInformation)
+                {
+                    if (info.ChangeTypeCode is not { } code) continue;
+                    if (info.ChangeType != S125ChangeType.Unknown) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S125-R-3.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"AtonStatusInformation '{info.Id}' has changeTypes code {code}; " +
+                            "expected one of 1 (Advance Notice), 2 (Discrepancy), 3 (Proposed), " +
+                            "4 (Temporary), 5 (Permanent).",
+                        RelatedFeatureId = info.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S125-R-3.2</c> — When a status date range
+    /// (<c>fixedDateRange</c> or <c>periodicDateRange</c>) carries
+    /// both <c>dateStart</c> and <c>dateEnd</c>, the start must not
+    /// be after the end.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-125 Edition 1.0.0 §fixedDateRange and
+    /// §periodicDateRange — the complex attribute is composed of
+    /// <c>dateStart</c> / <c>dateEnd</c>; the spec is silent on
+    /// degenerate ranges but a status whose validity begins after it
+    /// ends is non-actionable.
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> StatusDateRangeOrdered { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-3.2")
+            .WithDescription("Status date ranges must have dateStart ≤ dateEnd when both are present.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                void CheckRange(string ownerId, string label, S125DateRange? range)
+                {
+                    if (range is null) return;
+                    if (range.Start is not { } s || range.End is not { } e) return;
+                    if (s <= e) return;
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S125-R-3.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"AtonStatusInformation '{ownerId}' {label} has dateStart " +
+                            $"({s:O}) after dateEnd ({e:O}).",
+                        RelatedFeatureId = ownerId,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+
+                foreach (var info in dataset.StatusInformation)
+                {
+                    CheckRange(info.Id, "fixedDateRange", info.FixedDateRange);
+                    foreach (var p in info.PeriodicDateRanges)
+                        CheckRange(info.Id, "periodicDateRange", p);
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S125-R-4.1</c> — Every <c>AtonAggregation</c> /
+    /// <c>AtonAssociation</c> must bind at least one aid to
+    /// navigation.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-125 Edition 1.0.0 §AtonAggregation,
+    /// §AtonAssociation — these features are geometry-less containers
+    /// whose entire purpose is to group AtoN by xlink. An aggregation
+    /// with zero resolved members has no semantic content (either the
+    /// aggregation is empty in the source or every xlink failed to
+    /// resolve, which is itself a defect).
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> AggregationHasMembers { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-4.1")
+            .WithDescription("AtonAggregation / AtonAssociation must reference at least one aid to navigation.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var agg in dataset.Aggregations)
+                {
+                    if (!agg.Members.IsDefaultOrEmpty && agg.Members.Length > 0) continue;
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S125-R-4.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"{agg.Kind} '{agg.Id}' has no resolved member aids to navigation.",
+                        RelatedFeatureId = agg.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S125-R-5.1</c> — Every <c>AtonStatusIndication</c> feature
+    /// must have a position.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-125 Edition 1.0.0 §AtonStatusIndication —
+    /// <c>permittedPrimitives = point</c>. The feature is portrayed
+    /// at its position; an indication with no geometry cannot be
+    /// drawn and adds nothing the bound <c>AtonStatusInformation</c>
+    /// does not already convey through its xlink.
+    /// </remarks>
+    public static IValidationRule<S125AtonDataset> StatusIndicationHasPosition { get; } =
+        ValidationRuleBuilder.RuleFor<S125AtonDataset>("S125-R-5.1")
+            .WithDescription("AtonStatusIndication features must have a point geometry.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var ind in dataset.StatusIndications)
+                {
+                    if (ind.Position is not null) continue;
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S125-R-5.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message = $"AtonStatusIndication '{ind.Id}' has no point geometry.",
+                        RelatedFeatureId = ind.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-125 AtoN datasets.</summary>
+    public static ValidationRuleSet<S125AtonDataset> Default { get; } = new(
+        AidLatLonInRange,
+        AidIdsUnique,
+        AisAidHasMmsi,
+        ChangeTypeCodeInEnumeration,
+        StatusDateRangeOrdered,
+        AggregationHasMembers,
+        StatusIndicationHasPosition);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S125AtonDataset dataset, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S125.Tests/Validation/S125AtonRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S125.Tests/Validation/S125AtonRulesTests.cs
@@ -1,0 +1,442 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S125.DataModel;
+using EncDotNet.S100.Datasets.S125.Validation;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S125.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S125AtonRules"/>. Each test constructs a
+/// minimal synthetic <see cref="S125AtonDataset"/> in memory (no GML
+/// fixtures) and asserts the rule fires (or doesn't) with the expected
+/// finding shape.
+/// </summary>
+public class S125AtonRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static S125Buoy Buoy(string id, double? lat = 0, double? lon = 0,
+        S125AtonStatusInformation? status = null) => new()
+    {
+        Id = id,
+        FeatureType = "LateralBuoy",
+        Kind = S125BuoyKind.Lateral,
+        Position = (lat is null || lon is null) ? null : new GeoPosition(lat.Value, lon.Value),
+        Status = status,
+    };
+
+    private static S125AisAton Ais(string id, S125AisKind kind = S125AisKind.Virtual, string? mmsi = "123456789") => new()
+    {
+        Id = id,
+        FeatureType = kind switch
+        {
+            S125AisKind.Physical => "PhysicalAISAidToNavigation",
+            S125AisKind.Synthetic => "SyntheticAISAidToNavigation",
+            _ => "VirtualAISAidToNavigation",
+        },
+        Kind = kind,
+        Position = new GeoPosition(0, 0),
+        ExtraAttributes = mmsi is null
+            ? ImmutableDictionary<string, string>.Empty
+            : ImmutableDictionary<string, string>.Empty.Add("mMSICode", mmsi),
+    };
+
+    private static S125AtonStatusInformation Status(
+        string id,
+        int? code = 1,
+        S125ChangeType type = S125ChangeType.AdvanceNoticeOfChange,
+        S125DateRange? fixedRange = null,
+        ImmutableArray<S125DateRange>? periodic = null) => new()
+    {
+        Id = id,
+        ChangeTypeCode = code,
+        ChangeType = type,
+        FixedDateRange = fixedRange,
+        PeriodicDateRanges = periodic ?? ImmutableArray<S125DateRange>.Empty,
+    };
+
+    private static S125AtonStatusIndication Indication(string id, GeoPosition? pos) => new()
+    {
+        Id = id,
+        Position = pos,
+    };
+
+    private static S125Aggregation Aggregation(string id, params IS125Aid[] members) => new()
+    {
+        Id = id,
+        Kind = S125AggregationKind.Aggregation,
+        Members = members.ToImmutableArray(),
+    };
+
+    private static S125AtonDataset Dataset(
+        ImmutableArray<IS125Aid>? aids = null,
+        ImmutableArray<S125AtonStatusInformation>? statusInfo = null,
+        ImmutableArray<S125AtonStatusIndication>? indications = null,
+        ImmutableArray<S125Aggregation>? aggregations = null,
+        string? datasetId = "DS-1")
+    {
+        var source = new S125Dataset
+        {
+            DatasetIdentifier = datasetId,
+            ProductIdentifier = "S-125",
+            Features = ImmutableArray<S125Feature>.Empty,
+            InformationTypes = ImmutableArray<S125InformationType>.Empty,
+        };
+        return new S125AtonDataset
+        {
+            DatasetIdentifier = datasetId,
+            ProductIdentifier = "S-125",
+            Aids = aids ?? ImmutableArray<IS125Aid>.Empty,
+            StatusInformation = statusInfo ?? ImmutableArray<S125AtonStatusInformation>.Empty,
+            StatusIndications = indications ?? ImmutableArray<S125AtonStatusIndication>.Empty,
+            SpatialQualities = ImmutableArray<S125SpatialQuality>.Empty,
+            Aggregations = aggregations ?? ImmutableArray<S125Aggregation>.Empty,
+            OtherFeatures = ImmutableArray<S125OtherFeature>.Empty,
+            Source = source,
+        };
+    }
+
+    // ── S125-R-1.1 — aid lat/lon in range ───────────────────────
+
+    [Fact]
+    public void AidLatLonInRange_Passes_OnValidPositions()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(
+            Buoy("B1", -89.9, -179.9), Buoy("B2", 89.9, 179.9), Buoy("B3", 0, 0)));
+        Assert.Empty(S125AtonRules.AidLatLonInRange.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AidLatLonInRange_IgnoresAidsWithoutPosition()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Buoy("B1", lat: null, lon: null)));
+        Assert.Empty(S125AtonRules.AidLatLonInRange.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AidLatLonInRange_Fails_OnOutOfRangeLatitude()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Buoy("BAD", 95.0, 0)));
+        var f = Assert.Single(S125AtonRules.AidLatLonInRange.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-1.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Equal("DS-1", f.DatasetId);
+        Assert.Contains("latitude", f.Message);
+    }
+
+    [Fact]
+    public void AidLatLonInRange_Fails_OnOutOfRangeLongitude()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Buoy("BAD", 0, 181.0)));
+        var f = Assert.Single(S125AtonRules.AidLatLonInRange.Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("longitude", f.Message);
+    }
+
+    [Fact]
+    public void AidLatLonInRange_Fails_OnBothOutOfRange()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Buoy("BAD", 91.0, 181.0)));
+        var f = Assert.Single(S125AtonRules.AidLatLonInRange.Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("both out of range", f.Message);
+    }
+
+    // ── S125-R-1.2 — unique aid IDs ─────────────────────────────
+
+    [Fact]
+    public void AidIdsUnique_Passes_OnDistinctIds()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(
+            Buoy("B1"), Buoy("B2"), Buoy("B3")));
+        Assert.Empty(S125AtonRules.AidIdsUnique.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AidIdsUnique_Fails_OnDuplicate()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(
+            Buoy("B1"), Buoy("B1"), Buoy("B2")));
+        var f = Assert.Single(S125AtonRules.AidIdsUnique.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-1.2", f.RuleId);
+        Assert.Equal("B1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void AidIdsUnique_CaseInsensitive()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(
+            Buoy("Aid-1"), Buoy("aid-1")));
+        Assert.Single(S125AtonRules.AidIdsUnique.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AidIdsUnique_EmitsOneFindingPerDuplicateId()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(
+            Buoy("A"), Buoy("A"), Buoy("A"), Buoy("B"), Buoy("B")));
+        var findings = S125AtonRules.AidIdsUnique.Evaluate(ds, ValidationContext.Default).ToList();
+        Assert.Equal(2, findings.Count);
+        var ids = findings.Select(f => f.RelatedFeatureId).ToHashSet();
+        Assert.Contains("A", ids);
+        Assert.Contains("B", ids);
+    }
+
+    // ── S125-R-2.1 — AIS MMSI ───────────────────────────────────
+
+    [Theory]
+    [InlineData(S125AisKind.Physical)]
+    [InlineData(S125AisKind.Synthetic)]
+    [InlineData(S125AisKind.Virtual)]
+    public void AisAidHasMmsi_Passes_OnNineDigitMmsi(S125AisKind kind)
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Ais("A1", kind, "992341001")));
+        Assert.Empty(S125AtonRules.AisAidHasMmsi.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AisAidHasMmsi_IgnoresNonAisAids()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Buoy("B1")));
+        Assert.Empty(S125AtonRules.AisAidHasMmsi.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AisAidHasMmsi_Fails_WhenMissing()
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Ais("AIS1", mmsi: null)));
+        var f = Assert.Single(S125AtonRules.AisAidHasMmsi.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-2.1", f.RuleId);
+        Assert.Contains("missing", f.Message);
+        Assert.Equal("AIS1", f.RelatedFeatureId);
+    }
+
+    [Theory]
+    [InlineData("12345")]      // too short
+    [InlineData("1234567890")] // too long
+    [InlineData("12345678A")]  // non-digit
+    [InlineData("12345-789")]  // punctuation
+    public void AisAidHasMmsi_Fails_WhenMalformed(string mmsi)
+    {
+        var ds = Dataset(aids: ImmutableArray.Create<IS125Aid>(Ais("AIS1", mmsi: mmsi)));
+        var f = Assert.Single(S125AtonRules.AisAidHasMmsi.Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("malformed", f.Message);
+        Assert.Contains(mmsi, f.Message);
+    }
+
+    // ── S125-R-3.1 — changeTypes enumeration ────────────────────
+
+    [Fact]
+    public void ChangeTypeCodeInEnumeration_Passes_WhenNoCode()
+    {
+        var ds = Dataset(statusInfo: ImmutableArray.Create(Status("S1", code: null, type: S125ChangeType.Unknown)));
+        Assert.Empty(S125AtonRules.ChangeTypeCodeInEnumeration.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(1, S125ChangeType.AdvanceNoticeOfChange)]
+    [InlineData(2, S125ChangeType.Discrepancy)]
+    [InlineData(3, S125ChangeType.ProposedChange)]
+    [InlineData(4, S125ChangeType.TemporaryChange)]
+    [InlineData(5, S125ChangeType.PermanentChange)]
+    public void ChangeTypeCodeInEnumeration_Passes_OnListedValue(int code, S125ChangeType type)
+    {
+        var ds = Dataset(statusInfo: ImmutableArray.Create(Status("S1", code: code, type: type)));
+        Assert.Empty(S125AtonRules.ChangeTypeCodeInEnumeration.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(6)]
+    [InlineData(99)]
+    public void ChangeTypeCodeInEnumeration_Fails_OnOutOfRangeCode(int code)
+    {
+        // The projection would set ChangeType=Unknown for any out-of-range numeric code.
+        var ds = Dataset(statusInfo: ImmutableArray.Create(Status("S1", code: code, type: S125ChangeType.Unknown)));
+        var f = Assert.Single(S125AtonRules.ChangeTypeCodeInEnumeration.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-3.1", f.RuleId);
+        Assert.Equal("S1", f.RelatedFeatureId);
+        Assert.Contains(code.ToString(), f.Message);
+    }
+
+    // ── S125-R-3.2 — date range ordering ────────────────────────
+
+    [Fact]
+    public void StatusDateRangeOrdered_Passes_WhenAbsent()
+    {
+        var ds = Dataset(statusInfo: ImmutableArray.Create(Status("S1")));
+        Assert.Empty(S125AtonRules.StatusDateRangeOrdered.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void StatusDateRangeOrdered_Passes_WhenStartOnlyOrEndOnly()
+    {
+        var startOnly = new S125DateRange { Start = DateTimeOffset.UtcNow };
+        var endOnly = new S125DateRange { End = DateTimeOffset.UtcNow };
+        var ds = Dataset(statusInfo: ImmutableArray.Create(
+            Status("S1", fixedRange: startOnly),
+            Status("S2", fixedRange: endOnly)));
+        Assert.Empty(S125AtonRules.StatusDateRangeOrdered.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void StatusDateRangeOrdered_Passes_WhenStartEqualsEnd()
+    {
+        var t = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var range = new S125DateRange { Start = t, End = t };
+        var ds = Dataset(statusInfo: ImmutableArray.Create(Status("S1", fixedRange: range)));
+        Assert.Empty(S125AtonRules.StatusDateRangeOrdered.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void StatusDateRangeOrdered_Fails_OnFixedRangeInverted()
+    {
+        var range = new S125DateRange
+        {
+            Start = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
+            End = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        var ds = Dataset(statusInfo: ImmutableArray.Create(Status("S1", fixedRange: range)));
+        var f = Assert.Single(S125AtonRules.StatusDateRangeOrdered.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-3.2", f.RuleId);
+        Assert.Equal("S1", f.RelatedFeatureId);
+        Assert.Contains("fixedDateRange", f.Message);
+    }
+
+    [Fact]
+    public void StatusDateRangeOrdered_Fails_OnPeriodicRangeInverted()
+    {
+        var range = new S125DateRange
+        {
+            Start = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero),
+            End = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        var ds = Dataset(statusInfo: ImmutableArray.Create(
+            Status("S1", periodic: ImmutableArray.Create(range))));
+        var f = Assert.Single(S125AtonRules.StatusDateRangeOrdered.Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("periodicDateRange", f.Message);
+    }
+
+    // ── S125-R-4.1 — aggregation members ────────────────────────
+
+    [Fact]
+    public void AggregationHasMembers_Passes_OnNonEmpty()
+    {
+        var ds = Dataset(
+            aids: ImmutableArray.Create<IS125Aid>(Buoy("B1")),
+            aggregations: ImmutableArray.Create(Aggregation("AGG1", Buoy("B1"))));
+        Assert.Empty(S125AtonRules.AggregationHasMembers.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AggregationHasMembers_Fails_OnEmpty()
+    {
+        var ds = Dataset(aggregations: ImmutableArray.Create(Aggregation("AGG1")));
+        var f = Assert.Single(S125AtonRules.AggregationHasMembers.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-4.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("AGG1", f.RelatedFeatureId);
+    }
+
+    // ── S125-R-5.1 — status indication geometry ────────────────
+
+    [Fact]
+    public void StatusIndicationHasPosition_Passes_WhenPositioned()
+    {
+        var ds = Dataset(indications: ImmutableArray.Create(Indication("I1", new GeoPosition(10, 20))));
+        Assert.Empty(S125AtonRules.StatusIndicationHasPosition.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void StatusIndicationHasPosition_Fails_WhenMissing()
+    {
+        var ds = Dataset(indications: ImmutableArray.Create(Indication("I1", null)));
+        var f = Assert.Single(S125AtonRules.StatusIndicationHasPosition.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S125-R-5.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("I1", f.RelatedFeatureId);
+    }
+
+    // ── Default ruleset composition ─────────────────────────────
+
+    [Fact]
+    public void Default_ContainsAllSevenRules()
+    {
+        Assert.Equal(7, S125AtonRules.Default.Rules.Length);
+        var ids = S125AtonRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Contains("S125-R-1.1", ids);
+        Assert.Contains("S125-R-1.2", ids);
+        Assert.Contains("S125-R-2.1", ids);
+        Assert.Contains("S125-R-3.1", ids);
+        Assert.Contains("S125-R-3.2", ids);
+        Assert.Contains("S125-R-4.1", ids);
+        Assert.Contains("S125-R-5.1", ids);
+    }
+
+    [Fact]
+    public void Validate_OnValidDataset_ProducesNoFindings()
+    {
+        var ds = Dataset(
+            aids: ImmutableArray.Create<IS125Aid>(
+                Buoy("B1", 10, 20),
+                Ais("AIS1", S125AisKind.Virtual, "992341001")),
+            statusInfo: ImmutableArray.Create(Status("S1", code: 1, type: S125ChangeType.AdvanceNoticeOfChange)),
+            indications: ImmutableArray.Create(Indication("I1", new GeoPosition(10, 20))),
+            aggregations: ImmutableArray.Create(Aggregation("AGG1", Buoy("B1", 10, 20))));
+
+        var report = S125AtonRules.Validate(ds);
+        Assert.True(report.IsValid);
+        Assert.Empty(report.Findings);
+        Assert.Equal(7, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_OnInvalidDataset_AggregatesFindingsFromMultipleRules()
+    {
+        // Out-of-range pos (1.1), duplicate id (1.2), missing MMSI (2.1),
+        // bad change code (3.1), inverted range (3.2), empty aggregation (4.1),
+        // and missing indication position (5.1).
+        var inverted = new S125DateRange
+        {
+            Start = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
+            End = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        var ds = Dataset(
+            aids: ImmutableArray.Create<IS125Aid>(
+                Buoy("B1", 200, 0),
+                Buoy("B1", 0, 0),
+                Ais("AIS-NoMmsi", S125AisKind.Virtual, mmsi: null)),
+            statusInfo: ImmutableArray.Create(
+                Status("S1", code: 42, type: S125ChangeType.Unknown),
+                Status("S2", code: 1, type: S125ChangeType.AdvanceNoticeOfChange, fixedRange: inverted)),
+            indications: ImmutableArray.Create(Indication("I1", null)),
+            aggregations: ImmutableArray.Create(Aggregation("AGG1")));
+
+        var report = S125AtonRules.Validate(ds);
+        Assert.False(report.IsValid);
+        var ids = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S125-R-1.1", ids);
+        Assert.Contains("S125-R-1.2", ids);
+        Assert.Contains("S125-R-2.1", ids);
+        Assert.Contains("S125-R-3.1", ids);
+        Assert.Contains("S125-R-3.2", ids);
+        Assert.Contains("S125-R-4.1", ids);
+        Assert.Contains("S125-R-5.1", ids);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullDataset()
+    {
+        Assert.Throws<ArgumentNullException>(() => S125AtonRules.Validate(null!));
+    }
+
+    [Fact]
+    public void Validate_PropagatesDatasetIdOntoFindings()
+    {
+        var ds = Dataset(
+            aids: ImmutableArray.Create<IS125Aid>(Buoy("BAD", 95, 0)),
+            datasetId: "MY-DATASET");
+        var report = S125AtonRules.Validate(ds);
+        Assert.All(report.Findings, f => Assert.Equal("MY-DATASET", f.DatasetId));
+    }
+}


### PR DESCRIPTION
Adds a `Validation/` rule pack on top of the S-125 typed `S125AtonDataset`, matching the pattern established by the S-421 pilot in #100. Rules are evaluated through a single `ValidationRuleSet<S125AtonDataset>` with per-rule exception trapping; each finding traces back to a clause of S-125 Edition 1.0.0 (Marine Aids to Navigation).

## Rules (7)

| Rule | Severity | Summary |
| ---- | -------- | ------- |
| `S125-R-1.1` | Error   | Aid position lat/lon in WGS-84 ranges (S-100 Part 10b §6.2) |
| `S125-R-1.2` | Error   | Aid `gml:id` unique within the dataset (S-100 Part 10b §6.4) |
| `S125-R-2.1` | Error   | AIS aid (Physical / Synthetic / Virtual) carries a 9-digit `mMSICode` |
| `S125-R-3.1` | Error   | `AtonStatusInformation.changeTypes` is one of the FC listed values 1–5 |
| `S125-R-3.2` | Error   | Status `fixedDateRange` / `periodicDateRange` has `dateStart ≤ dateEnd` |
| `S125-R-4.1` | Warning | `AtonAggregation` / `AtonAssociation` binds ≥ 1 resolved aid |
| `S125-R-5.1` | Warning | `AtonStatusIndication` has a point geometry |

## Tests

35 new test cases in `S125AtonRulesTests` covering happy + failing paths for every rule, the default ruleset composition, dataset-id propagation onto findings, null-guards, and a multi-rule aggregation test. Synthetic in-memory `S125AtonDataset` instances — no GML fixtures.

S-125 test suite: **56 passed / 0 failed**. Full `dotnet build --configuration Release` clean.

## Deviation from the S-421 pilot

Projection-time issues (unresolved xlinks, duplicate ids, parse failures) are reported by `S125AtonDataset.From` through its `out IReadOnlyList<ProjectionDiagnostic>` parameter rather than carried on the typed model, so there is no rule that mirrors S-421's "information-binding sanity" idea. Callers that need those diagnostics should capture them at projection time. The deviation is documented in the rule class's XML remarks.

## Files

- `src/EncDotNet.S100.Datasets.S125/Validation/S125AtonRules.cs`
- `src/EncDotNet.S100.Datasets.S125/README.md` — new "Validation" section
- `tests/EncDotNet.S100.Datasets.S125.Tests/Validation/S125AtonRulesTests.cs`

No edits outside the S-125 spec library's `Validation/` folder, its test folder, and the S-125 README.