### PR TITLE
Add S-124 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S124/README.md
+++ b/src/EncDotNet.S100.Datasets.S124/README.md
@@ -81,3 +81,40 @@ foreach (var part in warning.Parts)
 foreach (var d in diagnostics) Console.WriteLine(d);
 ```
 
+## Validation
+
+The `EncDotNet.S100.Datasets.S124.Validation` namespace provides a pack of
+normative rules built on the `EncDotNet.S100.Validation` framework. Rule
+identifiers follow the convention `S124-R-{clause}`, traceable back to the
+S-124 (Edition 1.0.0) Feature Catalogue or to S-100 Part 10b for shared
+encoding constraints.
+
+```csharp
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S124.DataModel;
+using EncDotNet.S100.Datasets.S124.Validation;
+
+var dataset = S124Dataset.Open("navwarn.gml");
+var warning = S124NavigationalWarning.From(dataset, out _);
+
+var report = S124NavigationalWarningRules.Validate(warning);
+foreach (var finding in report.Findings)
+    Console.WriteLine($"[{finding.Severity}] {finding.RuleId}: {finding.Message}");
+```
+
+The default rule set covers eight Tier-1/Tier-2 rules:
+
+| Rule | Description |
+|---|---|
+| `S124-R-1.1` | A navigational warning must contain at least one `NavwarnPart`. |
+| `S124-R-2.1` | Every navigational warning must include a `NavwarnPreamble`. |
+| `S124-R-2.2` | `messageSeriesIdentifier` must carry a positive warning number and a plausible year. |
+| `S124-R-3.1` | `NAVAREA` must be one of the IMO NAVAREA codes (I…XXI). |
+| `S124-R-4.1` | All coordinates must lie within the WGS-84 lat/lon ranges. |
+| `S124-R-4.2` | Surface exterior rings must be closed and contain at least four positions. |
+| `S124-R-5.1` | Each `NavwarnPart` must carry non-empty warning text. |
+| `S124-R-6.1` | A `References` information type that sets `referenceCategory` must include `messageReference`. |
+
+Tier-3 cross-dataset rules (e.g. resolving the referenced warning of a
+cancellation against a sibling catalogue) are out of scope for this pack.
+

--- a/src/EncDotNet.S100.Datasets.S124/Validation/S124NavigationalWarningRules.cs
+++ b/src/EncDotNet.S100.Datasets.S124/Validation/S124NavigationalWarningRules.cs
@@ -1,0 +1,444 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S124.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S124.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-124 <see cref="S124NavigationalWarning"/>. Rule identifiers
+/// follow the convention <c>S124-R-{clause}</c>, where <c>{clause}</c>
+/// traces to the relevant section of the S-124 (Edition 1.0.0) Feature
+/// Catalogue or to S-100 Part 10b for shared encoding constraints.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This pack covers Tier-1 (schema-shape) and Tier-2 (spec-semantic)
+/// rules that can be evaluated against a single
+/// <see cref="S124NavigationalWarning"/> in isolation. Tier-3
+/// cross-dataset rules (e.g. resolving the referenced warning of a
+/// cancellation against a sibling catalogue) are out of scope; they need
+/// the MCP <c>validate_all</c> surface and access to sibling datasets
+/// via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// <para>
+/// Rules read from the strongly-typed projection produced by
+/// <see cref="S124NavigationalWarning.From(S124Dataset, out IReadOnlyList{ProjectionDiagnostic})"/>;
+/// projection diagnostics (duplicate preamble, unresolved xlinks,
+/// unparseable values) are surfaced separately and are not duplicated
+/// here.
+/// </para>
+/// </remarks>
+public static class S124NavigationalWarningRules
+{
+    /// <summary>
+    /// The set of NAVAREA codes recognised by the IHO/IMO World Wide
+    /// Navigational Warning Service (NAVAREAs I–XXI). The S-124
+    /// Feature Catalogue restricts the <c>NAVAREA</c> attribute on
+    /// <c>NavwarnPreamble</c> to this enumerated set.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> NavareaCodes = ImmutableHashSet.Create(
+        StringComparer.OrdinalIgnoreCase,
+        "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X",
+        "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX", "XXI");
+
+    /// <summary>
+    /// <c>S124-R-1.1</c> — A navigational warning must contain at least
+    /// one <c>NavwarnPart</c> feature.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-124 Edition 1.0.0 Feature Catalogue — a
+    /// <c>NavwarnPreamble</c> aggregates one or more <c>NavwarnPart</c>
+    /// features via the <c>header</c> association. A dataset that
+    /// projects with zero parts has no substantive warning content.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> MinimumPartCount { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-1.1")
+            .WithDescription("A navigational warning must contain at least one NavwarnPart.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                if (warning.Parts.Length > 0)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S124-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = "Navigational warning contains no NavwarnPart features.",
+                        DatasetId = warning.DatasetIdentifier,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-2.1</c> — Every navigational warning must include a
+    /// <c>NavwarnPreamble</c> information type.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-124 Edition 1.0.0 Feature Catalogue —
+    /// <c>NavwarnPreamble</c> is mandatory; it carries the
+    /// identification, classification, locality, and promulgating
+    /// authority of the warning.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> PreambleRequired { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-2.1")
+            .WithDescription("Every navigational warning must include a NavwarnPreamble.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                if (warning.Preamble is not null)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S124-R-2.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = "Navigational warning has no NavwarnPreamble information type.",
+                        DatasetId = warning.DatasetIdentifier,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-2.2</c> — When a <c>messageSeriesIdentifier</c> is
+    /// present on the preamble, the warning number must be ≥ 1 and the
+    /// year must be a plausible four-digit calendar year
+    /// (1900 ≤ year ≤ 2100).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-124 Edition 1.0.0 Feature Catalogue —
+    /// <c>messageSeriesIdentifier</c> sub-attributes <c>warningNumber</c>
+    /// (sequential, monotonically increasing within the series) and
+    /// <c>year</c> (the issuance calendar year). Zero or negative
+    /// warning numbers, and years outside the plausible publication
+    /// range, indicate authoring errors.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> MessageSeriesIdentifierWellFormed { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-2.2")
+            .WithDescription("messageSeriesIdentifier must carry a positive warning number and a plausible year.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                var msi = warning.Preamble?.MessageSeriesIdentifier;
+                if (msi is null)
+                    return Array.Empty<ValidationFinding>();
+
+                var findings = new List<ValidationFinding>();
+                if (msi.WarningNumber is { } wn && wn < 1)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S124-R-2.2",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"messageSeriesIdentifier.warningNumber must be ≥ 1, found {wn}.",
+                        DatasetId = warning.DatasetIdentifier,
+                        RelatedFeatureId = warning.Preamble!.Id,
+                    });
+                }
+
+                if (msi.Year is { } y && (y < 1900 || y > 2100))
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S124-R-2.2",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"messageSeriesIdentifier.year {y} is outside the plausible range [1900, 2100].",
+                        DatasetId = warning.DatasetIdentifier,
+                        RelatedFeatureId = warning.Preamble!.Id,
+                    });
+                }
+
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-3.1</c> — When <c>NAVAREA</c> is present on the
+    /// preamble, its value must be one of the IMO-recognised NAVAREA
+    /// Roman-numeral codes (I…XXI).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-124 Edition 1.0.0 Feature Catalogue, attribute
+    /// <c>NAVAREA</c> on <c>NavwarnPreamble</c>; codelist matches the
+    /// IMO World Wide Navigational Warning Service NAVAREA scheme.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> NavareaCodeValid { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-3.1")
+            .WithDescription("NAVAREA must be one of the IMO NAVAREA codes I…XXI.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                var code = warning.Preamble?.NavareaCode;
+                if (string.IsNullOrWhiteSpace(code) || NavareaCodes.Contains(code.Trim()))
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S124-R-3.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"NAVAREA code '{code}' is not one of the recognised IMO NAVAREAs (I…XXI).",
+                        DatasetId = warning.DatasetIdentifier,
+                        RelatedFeatureId = warning.Preamble!.Id,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-4.1</c> — Every coordinate on every part, affected
+    /// area, and text placement position must lie within the WGS-84
+    /// bounds: latitude in [-90, +90] and longitude in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> CoordinatesInRange { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-4.1")
+            .WithDescription("All coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                foreach (var part in warning.Parts)
+                {
+                    EmitOutOfRange(findings, warning.DatasetIdentifier, part.Id, "NavwarnPart", part.Coordinates);
+                    foreach (var area in part.AffectedAreas)
+                        EmitOutOfRange(findings, warning.DatasetIdentifier, area.Id, "NavwarnAreaAffected", area.Coordinates);
+                    foreach (var tp in part.TextPlacements)
+                    {
+                        if (tp.Position is { } pos)
+                            EmitOutOfRange(findings, warning.DatasetIdentifier, tp.Id, "TextPlacement",
+                                ImmutableArray.Create(pos));
+                    }
+                }
+
+                return findings;
+
+                static void EmitOutOfRange(
+                    List<ValidationFinding> sink,
+                    string? datasetId,
+                    string featureId,
+                    string featureType,
+                    ImmutableArray<GeoPosition> coords)
+                {
+                    if (coords.IsDefaultOrEmpty) return;
+                    for (int i = 0; i < coords.Length; i++)
+                    {
+                        var pos = coords[i];
+                        bool latOk = pos.Latitude is >= -90 and <= 90;
+                        bool lonOk = pos.Longitude is >= -180 and <= 180;
+                        if (latOk && lonOk) continue;
+
+                        var details = (latOk, lonOk) switch
+                        {
+                            (false, true) => $"latitude {pos.Latitude} is outside [-90, +90]",
+                            (true, false) => $"longitude {pos.Longitude} is outside [-180, +180]",
+                            _ => $"latitude {pos.Latitude} and longitude {pos.Longitude} are both out of range",
+                        };
+                        sink.Add(new ValidationFinding
+                        {
+                            RuleId = "S124-R-4.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"{featureType} '{featureId}' coordinate [{i}]: {details}.",
+                            Point = pos,
+                            DatasetId = datasetId,
+                            RelatedFeatureId = featureId,
+                        });
+                    }
+                }
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-4.2</c> — Surface geometries must be closed: the first
+    /// and last coordinate of the exterior ring must coincide, and the
+    /// ring must contain at least four positions.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: ISO 19136 / GML 3.2 §10.5.1 (<c>gml:LinearRing</c>)
+    /// and S-100 Part 10b §6.4 — a polygon's exterior ring is a closed
+    /// curve. A closed ring requires the start and end position to be
+    /// equal and a minimum of four positions (three distinct vertices
+    /// plus the closing copy).
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> SurfaceRingClosed { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-4.2")
+            .WithDescription("Surface exterior rings must be closed and contain at least four positions.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                const double tolerance = 1e-9;
+                var findings = new List<ValidationFinding>();
+
+                foreach (var part in warning.Parts)
+                {
+                    if (part.GeometryKind == S124GeometryKind.Surface)
+                        Check(findings, warning.DatasetIdentifier, part.Id, "NavwarnPart", part.Coordinates);
+                    foreach (var area in part.AffectedAreas)
+                    {
+                        if (area.GeometryKind == S124GeometryKind.Surface)
+                            Check(findings, warning.DatasetIdentifier, area.Id, "NavwarnAreaAffected", area.Coordinates);
+                    }
+                }
+
+                return findings;
+
+                static void Check(
+                    List<ValidationFinding> sink,
+                    string? datasetId,
+                    string featureId,
+                    string featureType,
+                    ImmutableArray<GeoPosition> coords)
+                {
+                    if (coords.IsDefaultOrEmpty || coords.Length < 4)
+                    {
+                        sink.Add(new ValidationFinding
+                        {
+                            RuleId = "S124-R-4.2",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"{featureType} '{featureId}' surface ring has " +
+                                $"{(coords.IsDefaultOrEmpty ? 0 : coords.Length)} position(s); a closed ring requires at least four.",
+                            DatasetId = datasetId,
+                            RelatedFeatureId = featureId,
+                        });
+                        return;
+                    }
+
+                    var first = coords[0];
+                    var last = coords[^1];
+                    if (Math.Abs(first.Latitude - last.Latitude) > tolerance
+                        || Math.Abs(first.Longitude - last.Longitude) > tolerance)
+                    {
+                        sink.Add(new ValidationFinding
+                        {
+                            RuleId = "S124-R-4.2",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"{featureType} '{featureId}' surface ring is not closed: " +
+                                $"first ({first.Latitude}, {first.Longitude}) ≠ last ({last.Latitude}, {last.Longitude}).",
+                            Point = first,
+                            DatasetId = datasetId,
+                            RelatedFeatureId = featureId,
+                        });
+                    }
+                }
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-5.1</c> — Each <c>NavwarnPart</c> must convey
+    /// substantive content via a non-empty <c>warningInformation</c>
+    /// text or at least one non-empty associated <c>TextPlacement</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-124 Edition 1.0.0 Feature Catalogue —
+    /// <c>NavwarnPart</c> exists to convey a navigational message; a
+    /// part with no text payload (neither <c>warningInformation</c>
+    /// nor an associated <c>TextPlacement</c>) is operationally
+    /// meaningless and almost certainly an authoring error.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> PartHasWarningText { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-5.1")
+            .WithDescription("Each NavwarnPart must carry non-empty warning text.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((warning, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var part in warning.Parts)
+                {
+                    if (!string.IsNullOrWhiteSpace(part.WarningInformation))
+                        continue;
+                    if (part.TextPlacements.Any(tp => !string.IsNullOrWhiteSpace(tp.Text)))
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S124-R-5.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"NavwarnPart '{part.Id}' has neither warningInformation text nor a non-empty " +
+                            "associated TextPlacement.",
+                        DatasetId = warning.DatasetIdentifier,
+                        RelatedFeatureId = part.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S124-R-6.1</c> — Every <c>References</c> information type
+    /// that sets <c>referenceCategory</c> must also supply a non-empty
+    /// <c>messageReference</c> identifying the warning being
+    /// referenced.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-124 Edition 1.0.0 Feature Catalogue,
+    /// information type <c>References</c>. A reference category
+    /// (cancellation, supersession, …) without a target message
+    /// identifier cannot be acted on by ECDIS or any downstream
+    /// consumer.
+    /// </remarks>
+    public static IValidationRule<S124NavigationalWarning> ReferenceTargetSpecified { get; } =
+        ValidationRuleBuilder.RuleFor<S124NavigationalWarning>("S124-R-6.1")
+            .WithDescription("A References information type that sets referenceCategory must include messageReference.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((warning, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var r in warning.References)
+                {
+                    if (r.ReferenceCategory is null)
+                        continue;
+                    if (!string.IsNullOrWhiteSpace(r.MessageReference))
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S124-R-6.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"References '{r.Id}' sets referenceCategory={r.ReferenceCategory} but has no " +
+                            "messageReference identifying the target warning.",
+                        DatasetId = warning.DatasetIdentifier,
+                        RelatedFeatureId = r.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-124 navigational warnings.</summary>
+    public static ValidationRuleSet<S124NavigationalWarning> Default { get; } = new(
+        MinimumPartCount,
+        PreambleRequired,
+        MessageSeriesIdentifierWellFormed,
+        NavareaCodeValid,
+        CoordinatesInRange,
+        SurfaceRingClosed,
+        PartHasWarningText,
+        ReferenceTargetSpecified);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S124NavigationalWarning warning, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(warning);
+        return Default.Run(warning, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S124.Tests/Validation/S124NavigationalWarningRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S124.Tests/Validation/S124NavigationalWarningRulesTests.cs
@@ -1,0 +1,476 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S124.DataModel;
+using EncDotNet.S100.Datasets.S124.Validation;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S124.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S124NavigationalWarningRules"/>. Each test
+/// constructs a minimal synthetic <see cref="S124NavigationalWarning"/>
+/// in memory (no GML fixtures) and asserts the rule fires (or doesn't)
+/// with the expected finding shape.
+/// </summary>
+public class S124NavigationalWarningRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static readonly S124Dataset EmptyDataset = new()
+    {
+        Features = ImmutableArray<S124Feature>.Empty,
+        InformationTypes = ImmutableArray<S124InformationType>.Empty,
+    };
+
+    private static S124NavwarnPart Part(
+        string id,
+        S124GeometryKind kind = S124GeometryKind.None,
+        ImmutableArray<GeoPosition>? coords = null,
+        string? text = "Notice to mariners.",
+        ImmutableArray<S124AffectedArea>? areas = null,
+        ImmutableArray<S124TextPlacement>? textPlacements = null) => new()
+        {
+            Id = id,
+            GeometryKind = kind,
+            Coordinates = coords ?? ImmutableArray<GeoPosition>.Empty,
+            WarningInformation = text,
+            AffectedAreas = areas ?? ImmutableArray<S124AffectedArea>.Empty,
+            TextPlacements = textPlacements ?? ImmutableArray<S124TextPlacement>.Empty,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+    private static S124AffectedArea Area(
+        string id,
+        S124GeometryKind kind,
+        ImmutableArray<GeoPosition> coords) => new()
+        {
+            Id = id,
+            GeometryKind = kind,
+            Coordinates = coords,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+    private static S124TextPlacement TextPlacement(string id, double? lat = null, double? lon = null, string? text = null) => new()
+    {
+        Id = id,
+        Position = (lat.HasValue && lon.HasValue) ? new GeoPosition(lat.Value, lon.Value) : null,
+        Text = text,
+        ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+    };
+
+    private static S124WarningReference Reference(string id, int? category, string? msgRef) => new()
+    {
+        Id = id,
+        ReferenceCategory = category,
+        MessageReference = msgRef,
+        ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+    };
+
+    private static S124NavwarnPreamble Preamble(
+        string id = "P1",
+        int? warningNumber = 42,
+        int? year = 2026,
+        string? navarea = null) => new()
+        {
+            Id = id,
+            MessageSeriesIdentifier = new S124MessageSeriesIdentifier
+            {
+                WarningNumber = warningNumber,
+                Year = year,
+            },
+            NavareaCode = navarea,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+
+    private static S124NavigationalWarning Warning(
+        S124NavwarnPreamble? preamble = null,
+        ImmutableArray<S124NavwarnPart>? parts = null,
+        ImmutableArray<S124WarningReference>? references = null,
+        bool includeDefaultPreamble = true,
+        string? datasetId = "DS-1") => new()
+        {
+            DatasetIdentifier = datasetId,
+            Preamble = preamble ?? (includeDefaultPreamble ? Preamble() : null),
+            Parts = parts ?? ImmutableArray.Create(Part("PART-1")),
+            References = references ?? ImmutableArray<S124WarningReference>.Empty,
+            SpatialQualities = ImmutableArray<S124SpatialQuality>.Empty,
+            Source = EmptyDataset,
+        };
+
+    private static ImmutableArray<GeoPosition> ClosedRing(double centerLat, double centerLon) =>
+        ImmutableArray.Create(
+            new GeoPosition(centerLat, centerLon),
+            new GeoPosition(centerLat + 0.1, centerLon),
+            new GeoPosition(centerLat + 0.1, centerLon + 0.1),
+            new GeoPosition(centerLat, centerLon));
+
+    // ── S124-R-1.1 — minimum part count ─────────────────────────
+
+    [Fact]
+    public void MinimumPartCount_Passes_WhenAtLeastOnePart()
+    {
+        var w = Warning(parts: ImmutableArray.Create(Part("P1")));
+        Assert.Empty(S124NavigationalWarningRules.MinimumPartCount.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void MinimumPartCount_Fails_WhenNoParts()
+    {
+        var w = Warning(parts: ImmutableArray<S124NavwarnPart>.Empty);
+        var f = Assert.Single(S124NavigationalWarningRules.MinimumPartCount
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-1.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("DS-1", f.DatasetId);
+    }
+
+    // ── S124-R-2.1 — preamble required ──────────────────────────
+
+    [Fact]
+    public void PreambleRequired_Passes_WhenPresent()
+    {
+        var w = Warning();
+        Assert.Empty(S124NavigationalWarningRules.PreambleRequired.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PreambleRequired_Fails_WhenAbsent()
+    {
+        var w = Warning(includeDefaultPreamble: false);
+        var f = Assert.Single(S124NavigationalWarningRules.PreambleRequired
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-2.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+    }
+
+    // ── S124-R-2.2 — message series identifier ──────────────────
+
+    [Fact]
+    public void MessageSeriesIdentifier_Passes_OnValidNumberAndYear()
+    {
+        var w = Warning(preamble: Preamble(warningNumber: 1, year: 2026));
+        Assert.Empty(S124NavigationalWarningRules.MessageSeriesIdentifierWellFormed
+            .Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void MessageSeriesIdentifier_Passes_WhenAbsent()
+    {
+        var noMsi = new S124NavwarnPreamble
+        {
+            Id = "P1",
+            MessageSeriesIdentifier = null,
+            ExtraAttributes = ImmutableDictionary<string, string>.Empty,
+        };
+        var w = Warning(preamble: noMsi);
+        Assert.Empty(S124NavigationalWarningRules.MessageSeriesIdentifierWellFormed
+            .Evaluate(w, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void MessageSeriesIdentifier_Fails_OnNonPositiveWarningNumber(int wn)
+    {
+        var w = Warning(preamble: Preamble(warningNumber: wn, year: 2026));
+        var f = Assert.Single(S124NavigationalWarningRules.MessageSeriesIdentifierWellFormed
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-2.2", f.RuleId);
+        Assert.Contains("warningNumber", f.Message);
+    }
+
+    [Theory]
+    [InlineData(1899)]
+    [InlineData(2101)]
+    public void MessageSeriesIdentifier_Fails_OnImplausibleYear(int year)
+    {
+        var w = Warning(preamble: Preamble(warningNumber: 1, year: year));
+        var f = Assert.Single(S124NavigationalWarningRules.MessageSeriesIdentifierWellFormed
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-2.2", f.RuleId);
+        Assert.Contains("year", f.Message);
+    }
+
+    // ── S124-R-3.1 — NAVAREA code valid ─────────────────────────
+
+    [Fact]
+    public void NavareaCode_Passes_WhenAbsent()
+    {
+        var w = Warning(preamble: Preamble(navarea: null));
+        Assert.Empty(S124NavigationalWarningRules.NavareaCodeValid.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData("I")]
+    [InlineData("IV")]
+    [InlineData("XII")]
+    [InlineData("XXI")]
+    [InlineData("xvi")] // case-insensitive
+    public void NavareaCode_Passes_OnRecognisedCode(string code)
+    {
+        var w = Warning(preamble: Preamble(navarea: code));
+        Assert.Empty(S124NavigationalWarningRules.NavareaCodeValid.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData("XXII")]
+    [InlineData("0")]
+    [InlineData("ATLANTIC")]
+    public void NavareaCode_Fails_OnUnknownCode(string code)
+    {
+        var w = Warning(preamble: Preamble(navarea: code));
+        var f = Assert.Single(S124NavigationalWarningRules.NavareaCodeValid
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-3.1", f.RuleId);
+        Assert.Contains(code, f.Message);
+    }
+
+    // ── S124-R-4.1 — coordinates in range ───────────────────────
+
+    [Fact]
+    public void CoordinatesInRange_Passes_WhenAllCoordinatesValid()
+    {
+        var part = Part("P1", S124GeometryKind.Curve, ImmutableArray.Create(
+            new GeoPosition(10.0, 20.0), new GeoPosition(11.0, 21.0)));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        Assert.Empty(S124NavigationalWarningRules.CoordinatesInRange.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesInRange_Fails_OnOutOfRangeLatitude()
+    {
+        var part = Part("BAD", S124GeometryKind.Point, ImmutableArray.Create(new GeoPosition(95.0, 0.0)));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.CoordinatesInRange
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-4.1", f.RuleId);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Contains("latitude", f.Message);
+    }
+
+    [Fact]
+    public void CoordinatesInRange_Fails_OnOutOfRangeLongitudeOnAffectedArea()
+    {
+        var area = Area("A1", S124GeometryKind.Point, ImmutableArray.Create(new GeoPosition(0, 200.0)));
+        var part = Part("P1", areas: ImmutableArray.Create(area));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.CoordinatesInRange
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("A1", f.RelatedFeatureId);
+        Assert.Contains("NavwarnAreaAffected", f.Message);
+        Assert.Contains("longitude", f.Message);
+    }
+
+    [Fact]
+    public void CoordinatesInRange_Fails_OnTextPlacementPosition()
+    {
+        var tp = TextPlacement("T1", lat: -100, lon: 0, text: "x");
+        var part = Part("P1", textPlacements: ImmutableArray.Create(tp));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.CoordinatesInRange
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("T1", f.RelatedFeatureId);
+        Assert.Contains("TextPlacement", f.Message);
+    }
+
+    // ── S124-R-4.2 — surface ring closed ────────────────────────
+
+    [Fact]
+    public void SurfaceRingClosed_Passes_OnClosedRingWithFourPoints()
+    {
+        var part = Part("P1", S124GeometryKind.Surface, ClosedRing(10, 20));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        Assert.Empty(S124NavigationalWarningRules.SurfaceRingClosed.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Passes_WhenNoSurfaceGeometries()
+    {
+        var part = Part("P1", S124GeometryKind.Point, ImmutableArray.Create(new GeoPosition(0, 0)));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        Assert.Empty(S124NavigationalWarningRules.SurfaceRingClosed.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Fails_WhenRingHasFewerThanFourPositions()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(1, 0), new GeoPosition(0, 0));
+        var part = Part("P1", S124GeometryKind.Surface, ring);
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.SurfaceRingClosed
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-4.2", f.RuleId);
+        Assert.Contains("at least four", f.Message);
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Fails_WhenFirstAndLastDiffer()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0),
+            new GeoPosition(1, 0),
+            new GeoPosition(1, 1),
+            new GeoPosition(0, 1));
+        var part = Part("P1", S124GeometryKind.Surface, ring);
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.SurfaceRingClosed
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Contains("not closed", f.Message);
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Fails_OnAffectedAreaWithOpenRing()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0),
+            new GeoPosition(1, 0),
+            new GeoPosition(1, 1),
+            new GeoPosition(0, 1));
+        var area = Area("A1", S124GeometryKind.Surface, ring);
+        var part = Part("P1", areas: ImmutableArray.Create(area));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.SurfaceRingClosed
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("A1", f.RelatedFeatureId);
+    }
+
+    // ── S124-R-5.1 — part has warning text ──────────────────────
+
+    [Fact]
+    public void PartHasWarningText_Passes_OnWarningInformation()
+    {
+        var part = Part("P1", text: "Buoy off station.");
+        var w = Warning(parts: ImmutableArray.Create(part));
+        Assert.Empty(S124NavigationalWarningRules.PartHasWarningText.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PartHasWarningText_Passes_OnTextPlacementFallback()
+    {
+        var tp = TextPlacement("T1", lat: 0, lon: 0, text: "Buoy off station.");
+        var part = Part("P1", text: null, textPlacements: ImmutableArray.Create(tp));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        Assert.Empty(S124NavigationalWarningRules.PartHasWarningText.Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PartHasWarningText_Fails_OnEmptyEverywhere()
+    {
+        var part = Part("P-EMPTY", text: "   ");
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.PartHasWarningText
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-5.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("P-EMPTY", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void PartHasWarningText_Fails_WhenTextPlacementsAreBlank()
+    {
+        var tp = TextPlacement("T1", lat: 0, lon: 0, text: "   ");
+        var part = Part("P1", text: null, textPlacements: ImmutableArray.Create(tp));
+        var w = Warning(parts: ImmutableArray.Create(part));
+        var f = Assert.Single(S124NavigationalWarningRules.PartHasWarningText
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("P1", f.RelatedFeatureId);
+    }
+
+    // ── S124-R-6.1 — reference target specified ─────────────────
+
+    [Fact]
+    public void ReferenceTargetSpecified_Passes_WhenCategoryAndRefPresent()
+    {
+        var w = Warning(references: ImmutableArray.Create(
+            Reference("R1", category: 1, msgRef: "HYDROLANT 0412/2026")));
+        Assert.Empty(S124NavigationalWarningRules.ReferenceTargetSpecified
+            .Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ReferenceTargetSpecified_Passes_WhenCategoryAbsent()
+    {
+        // Without a referenceCategory the rule cannot say anything, so it must
+        // pass — even though messageReference is also absent.
+        var w = Warning(references: ImmutableArray.Create(
+            Reference("R1", category: null, msgRef: null)));
+        Assert.Empty(S124NavigationalWarningRules.ReferenceTargetSpecified
+            .Evaluate(w, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ReferenceTargetSpecified_Fails_WhenCategorySetButRefMissing()
+    {
+        var w = Warning(references: ImmutableArray.Create(
+            Reference("R-BAD", category: 1, msgRef: null)));
+        var f = Assert.Single(S124NavigationalWarningRules.ReferenceTargetSpecified
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("S124-R-6.1", f.RuleId);
+        Assert.Equal("R-BAD", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void ReferenceTargetSpecified_Fails_WhenCategorySetButRefBlank()
+    {
+        var w = Warning(references: ImmutableArray.Create(
+            Reference("R-BLANK", category: 2, msgRef: "   ")));
+        var f = Assert.Single(S124NavigationalWarningRules.ReferenceTargetSpecified
+            .Evaluate(w, ValidationContext.Default));
+        Assert.Equal("R-BLANK", f.RelatedFeatureId);
+    }
+
+    // ── Default ruleset composition ─────────────────────────────
+
+    [Fact]
+    public void Default_ContainsAllEightRules()
+    {
+        Assert.Equal(8, S124NavigationalWarningRules.Default.Rules.Length);
+        var ids = S124NavigationalWarningRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Contains("S124-R-1.1", ids);
+        Assert.Contains("S124-R-2.1", ids);
+        Assert.Contains("S124-R-2.2", ids);
+        Assert.Contains("S124-R-3.1", ids);
+        Assert.Contains("S124-R-4.1", ids);
+        Assert.Contains("S124-R-4.2", ids);
+        Assert.Contains("S124-R-5.1", ids);
+        Assert.Contains("S124-R-6.1", ids);
+    }
+
+    [Fact]
+    public void Validate_OnValidWarning_ProducesNoFindings()
+    {
+        var part = Part("P1", S124GeometryKind.Surface, ClosedRing(10, 20), text: "Buoy off station.");
+        var w = Warning(
+            preamble: Preamble(warningNumber: 42, year: 2026, navarea: "IV"),
+            parts: ImmutableArray.Create(part),
+            references: ImmutableArray.Create(Reference("R1", 1, "HYDROLANT 0412/2026")));
+        var report = S124NavigationalWarningRules.Validate(w);
+        Assert.True(report.IsValid);
+        Assert.Empty(report.Findings);
+        Assert.Equal(8, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_OnInvalidWarning_AggregatesFindingsFromMultipleRules()
+    {
+        // No parts (1.1), missing preamble (2.1), and a bad reference (6.1).
+        var w = Warning(
+            includeDefaultPreamble: false,
+            parts: ImmutableArray<S124NavwarnPart>.Empty,
+            references: ImmutableArray.Create(Reference("R-BAD", 1, null)));
+        var report = S124NavigationalWarningRules.Validate(w);
+        Assert.False(report.IsValid);
+        var ids = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S124-R-1.1", ids);
+        Assert.Contains("S124-R-2.1", ids);
+        Assert.Contains("S124-R-6.1", ids);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullWarning()
+    {
+        Assert.Throws<ArgumentNullException>(() => S124NavigationalWarningRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Adds an 8-rule Tier-1/Tier-2 validation pack for S-124 navigational
warnings, following the framework + S-421 pilot pattern landed in #100.

## Rules

| Rule | Severity | Description |
|---|---|---|
| `S124-R-1.1` | Error | A navigational warning must contain at least one `NavwarnPart`. |
| `S124-R-2.1` | Error | Every navigational warning must include a `NavwarnPreamble`. |
| `S124-R-2.2` | Error | `messageSeriesIdentifier` must carry a positive warning number and a plausible year (1900 ≤ year ≤ 2100). |
| `S124-R-3.1` | Error | `NAVAREA` must be one of the IMO NAVAREA codes (I…XXI). |
| `S124-R-4.1` | Error | All coordinates must lie within the WGS-84 lat/lon ranges (S-100 Part 10b §6.2). |
| `S124-R-4.2` | Error | Surface exterior rings must be closed and contain ≥ 4 positions (ISO 19136 / GML 3.2 §10.5.1). |
| `S124-R-5.1` | Warning | Each `NavwarnPart` must carry non-empty warning text (or an associated `TextPlacement`). |
| `S124-R-6.1` | Error | A `References` info type setting `referenceCategory` must include `messageReference`. |

Each rule has an XML doc comment citing the relevant S-124 FC element or
S-100 Part 10b clause.

## Tests

`tests/EncDotNet.S100.Datasets.S124.Tests/Validation/S124NavigationalWarningRulesTests.cs`
— 38 test methods (~52 cases including `[Theory]` inlines) with happy +
failing path coverage for every rule, plus default-ruleset composition
and `Validate()` convenience checks. Synthetic in-memory models, no GML
fixtures.

`dotnet build` and `dotnet test --configuration Release` both green;
S-124 test project runs 91 tests total, all passing.

## Deviations from the brief

- Dropped suggested rules **in-force lifecycle / in-force start ≤ end**
  and **warning-type enumeration**: the typed
  `S124NavigationalWarning` model exposes neither lifecycle dates nor a
  warning-type field (S-124 surfaces type information indirectly via
  `NAVAREA`, `NAVTEX`, `messageSeriesIdentifier.nameOfSeries`, etc.).
  These belong to a follow-up that first extends the typed projection.
- Dropped **ID format conformance**: the FC does not impose a strict
  syntactic format on `messageSeriesIdentifier` beyond the sub-attribute
  semantics covered by `S124-R-2.2`.
- Dropped **cancellation reference resolves** beyond syntactic
  presence: deeper xlink/sibling resolution is Tier-3 and out of scope
  per the brief. `S124-R-6.1` covers the syntactic half (category set
  implies messageReference present).
- Added **`S124-R-4.2` surface-ring closed** instead, which is a
  spec-grounded rule the typed model can evaluate today.

## Scope

Only adds files under `src/EncDotNet.S100.Datasets.S124/Validation/`,
`tests/EncDotNet.S100.Datasets.S124.Tests/Validation/`, and the S-124
README. No MCP wire-up, no Tier-3 cross-dataset rules, no viewer changes.