### PR TITLE
Add S-411 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S411/README.md
+++ b/src/EncDotNet.S100.Datasets.S411/README.md
@@ -132,6 +132,31 @@ the unmodified PC. The adapter handles both GML shapes described above.
 - Coordinate ordering in `<gml:pos>` / `<gml:posList>` follows the S-100 Part 10b convention of **lat lon** for `EPSG:4326`.
 - The S-411 Portrayal Catalogue ships several top-level XSLT entry points (`mainRule`, plus per-ice-class rules such as `SeaiceClass1ARule`). Only `mainRule` is exposed as an active portrayal rule by default; class-specific rules are still loadable by name via `GetCompiledRule`.
 
+## Validation rules
+
+`EncDotNet.S100.Datasets.S411.Validation.S411SeaIceRules` exposes a pilot
+rule pack (8 rules) for an `S411SeaIceInventory`, mirroring the S-421 rule
+pack (PR [#100](https://github.com/philliphoff/EncDotNet.S100/pull/100)).
+Rule identifiers follow `S411-R-{clause}`:
+
+| Rule | Severity | Summary |
+|------|----------|---------|
+| `S411-R-3.1` | Error | Feature coordinates must lie within WGS-84 lat/lon ranges (S-100 Part 10b §6.2). |
+| `S411-R-3.2` | Error | Surface features must have a closed ring with ≥ 4 coordinates. |
+| `S411-R-3.3` | Error | Curve features must have ≥ 2 vertices. |
+| `S411-R-4.1` | Warning | Egg-code `totalConcentration` must be one of the S-411 Annex A enumerated WMO codes. |
+| `S411-R-4.2` | Error | `iceAverageThickness` must be ≥ 0 when present. |
+| `S411-R-4.3` | Error | Egg-code `snowDepth` must be ≥ 0 when present. |
+| `S411-R-4.4` | Warning | `icebergSize` must be one of the S-411 Annex A enumerated codes (1–9, 99). |
+| `S411-R-5.1` | Error | Feature identifiers must be unique across the dataset. |
+
+Rules bind to the typed projection (`S411SeaIceInventory`, `S411IceFeature`
+subclasses) and are therefore agnostic to the two real-world GML shapes
+(JCOMM/Canadian Ice Service operational shape and IHO 1.2.1 sample shape).
+Use `S411SeaIceRules.Validate(inventory)` for a one-shot run against the
+default rule set, or compose a custom set via
+`ValidationRuleSet<S411SeaIceInventory>`.
+
 ## License
 
 The bundled S-411 specification assets in `EncDotNet.S100.Specifications` are © JCOMM/IHO and used in accordance with their open-publication terms; see <https://github.com/iho-ohi/S-411-Product-Specification>.

--- a/src/EncDotNet.S100.Datasets.S411/Validation/S411SeaIceRules.cs
+++ b/src/EncDotNet.S100.Datasets.S411/Validation/S411SeaIceRules.cs
@@ -1,0 +1,450 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S411.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S411.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-411 <see cref="S411SeaIceInventory"/>. Rule identifiers follow
+/// the convention <c>S411-R-{clause}</c>, where <c>{clause}</c> traces to
+/// the relevant section of the S-411 (Sea Ice Information for Surface
+/// Navigation) product specification, Edition 1.2.1.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single
+/// <see cref="S411SeaIceInventory"/> in isolation. Tier-3 cross-dataset
+/// rules will be added in a follow-up once the MCP <c>validate_all</c>
+/// surface is wired up.
+/// </para>
+/// <para>
+/// All rules bind to the typed projection (<see cref="S411SeaIceInventory"/>
+/// and <see cref="S411IceFeature"/> subclasses) rather than to either of
+/// the two real-world GML shapes encountered in production
+/// (JCOMM / Canadian Ice Service operational shape and IHO 1.2.1 sample
+/// shape). Both shapes normalise to the same typed model, so the rules
+/// are shape-agnostic.
+/// </para>
+/// </remarks>
+public static class S411SeaIceRules
+{
+    // ── S411-R-3.1 — WGS-84 lat/lon bounds ──────────────────────────
+
+    /// <summary>
+    /// <c>S411-R-3.1</c> — Every feature coordinate must lie within the
+    /// valid WGS-84 ranges: latitude in [-90, +90] and longitude in
+    /// [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded. Applied uniformly to every typed
+    /// feature regardless of geometry kind.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> CoordinatesInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-3.1")
+            .WithDescription("Feature coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inv, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in EnumerateAllFeatures(inv))
+                {
+                    foreach (var pos in f.Coordinates)
+                    {
+                        bool latOk = pos.Latitude is >= -90 and <= 90;
+                        bool lonOk = pos.Longitude is >= -180 and <= 180;
+                        if (latOk && lonOk) continue;
+
+                        var details = (latOk, lonOk) switch
+                        {
+                            (false, true) => $"latitude {pos.Latitude} is outside [-90, +90]",
+                            (true, false) => $"longitude {pos.Longitude} is outside [-180, +180]",
+                            _ => $"latitude {pos.Latitude} and longitude {pos.Longitude} are both out of range",
+                        };
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S411-R-3.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"Feature '{f.Id}' ({f.NormalizedFeatureType}): {details}.",
+                            Point = pos,
+                            RelatedFeatureId = f.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-3.2 — surface polygon closure ────────────────────────
+
+    /// <summary>
+    /// <c>S411-R-3.2</c> — Surface (area) features must have a closed
+    /// exterior ring of at least four coordinates with the first and last
+    /// coincident.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.3 (GML surface encoding) —
+    /// <c>gml:LinearRing</c> must be closed (first point equals last)
+    /// and must contain at least four positions to enclose a non-zero
+    /// area. Closure is tested with a tight tolerance (1e-9 degrees) so
+    /// floating-point round-trip does not trigger the rule.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> SurfacePolygonClosed { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-3.2")
+            .WithDescription("Surface features must have a closed ring with ≥ 4 coordinates.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inv, _) =>
+            {
+                const double tolerance = 1e-9;
+                var findings = new List<ValidationFinding>();
+                foreach (var f in EnumerateAllFeatures(inv))
+                {
+                    if (f.GeometryKind != S411GeometryKind.Surface) continue;
+
+                    var coords = f.Coordinates;
+                    if (coords.Length < 4)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S411-R-3.2",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Surface feature '{f.Id}' ({f.NormalizedFeatureType}) has " +
+                                $"{coords.Length} coordinate(s); a closed ring requires ≥ 4.",
+                            RelatedFeatureId = f.Id,
+                        });
+                        continue;
+                    }
+
+                    var first = coords[0];
+                    var last = coords[^1];
+                    if (Math.Abs(first.Latitude - last.Latitude) > tolerance
+                        || Math.Abs(first.Longitude - last.Longitude) > tolerance)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S411-R-3.2",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Surface feature '{f.Id}' ({f.NormalizedFeatureType}) is not closed: " +
+                                $"first ({first.Latitude}, {first.Longitude}) ≠ last " +
+                                $"({last.Latitude}, {last.Longitude}).",
+                            Point = first,
+                            RelatedFeatureId = f.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-3.3 — curve minimum vertex count ─────────────────────
+
+    /// <summary>
+    /// <c>S411-R-3.3</c> — Curve (line) features (e.g. <c>IceEdge</c>,
+    /// <c>IcebergLimit</c>, <c>LineOfIceCrack</c>) must have at least two
+    /// vertices.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.3 (GML curve encoding) — a
+    /// <c>gml:LineString</c> requires at least two positions to describe
+    /// a non-degenerate segment.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> CurveHasMinimumVertices { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-3.3")
+            .WithDescription("Curve features must have at least two vertices.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inv, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in EnumerateAllFeatures(inv))
+                {
+                    if (f.GeometryKind != S411GeometryKind.Curve) continue;
+                    if (f.Coordinates.Length >= 2) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S411-R-3.3",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Curve feature '{f.Id}' ({f.NormalizedFeatureType}) has " +
+                            $"{f.Coordinates.Length} vertex(es); a linestring requires ≥ 2.",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-4.1 — total concentration enumeration ────────────────
+
+    /// <summary>
+    /// The set of valid <c>totalConcentration</c> enumeration codes from
+    /// S-411 Edition 1.2.1 Annex A (WMO sea-ice concentration in tenths
+    /// plus sentinels: 1 = Ice Free, 2 = Open Water, 3 = Bergy Water,
+    /// 10/20/…/90 = N/10 ice, 12/13/23/24/… = range pairs, 91 = ice of
+    /// land origin, 92 = undefined / unknown, 99 = not surveyed).
+    /// </summary>
+    private static readonly ImmutableHashSet<int> ValidTotalConcentrationCodes = ImmutableHashSet.Create(
+        1, 2, 3,
+        10, 12, 13,
+        20, 23, 24,
+        30, 34, 35,
+        40, 45, 46,
+        50, 56, 57,
+        60, 67, 68,
+        70, 78, 79,
+        80, 81, 89,
+        90, 91, 92, 99);
+
+    /// <summary>
+    /// <c>S411-R-4.1</c> — When a <c>SeaIce</c> or <c>LakeIce</c> feature
+    /// carries an egg-code total concentration, the value must be one of
+    /// the enumerated WMO codes defined by the S-411 Feature Catalogue.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-411 Annex A <c>totalConcentration</c> (ICEACT) —
+    /// an enumeration of WMO sea-ice concentration codes. The allowed
+    /// codes include both single-tenth values (10, 20, … 90) and WMO
+    /// range pairs (e.g. 23 = "2/10 to 3/10"), plus reserved sentinels
+    /// (1 = Ice Free, 2 = Open Water, 3 = Bergy Water, 91 = ice of land
+    /// origin, 92 = undefined, 99 = not surveyed). Values outside this
+    /// closed set are reported as warnings because some producers extend
+    /// the vocabulary informally.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> TotalConcentrationInEnumeration { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-4.1")
+            .WithDescription("Egg-code total concentration must be one of the S-411 enumerated WMO codes.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inv, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in inv.IceFeatures)
+                {
+                    var egg = f switch
+                    {
+                        S411SeaIce s => s.EggCode,
+                        S411LakeIce l => l.EggCode,
+                        _ => null,
+                    };
+                    if (egg?.TotalConcentration is not { } code) continue;
+                    if (ValidTotalConcentrationCodes.Contains(code)) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S411-R-4.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Feature '{f.Id}' ({f.NormalizedFeatureType}) carries " +
+                            $"totalConcentration={code}, which is not in the S-411 enumerated WMO code set.",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-4.2 — ice average thickness non-negative ─────────────
+
+    /// <summary>
+    /// <c>S411-R-4.2</c> — When an <see cref="S411IceThickness"/> feature
+    /// carries an <c>iceAverageThickness</c> value, it must be
+    /// non-negative.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-411 Annex A <c>iceAverageThickness</c> (ICETCK)
+    /// — a real-valued ice-thickness measurement. Negative thickness has
+    /// no physical meaning.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> IceAverageThicknessNonNegative { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-4.2")
+            .WithDescription("Ice average thickness must be non-negative when present.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inv, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in inv.IceFeatures.OfType<S411IceThickness>())
+                {
+                    if (f.IceAverageThickness is not { } thickness || thickness >= 0) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S411-R-4.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"IceThickness feature '{f.Id}' has negative iceAverageThickness " +
+                            $"({thickness}).",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-4.3 — snow depth non-negative ────────────────────────
+
+    /// <summary>
+    /// <c>S411-R-4.3</c> — When an egg-code <c>snowDepth</c> value is
+    /// present, it must be non-negative.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-411 Annex A <c>snowDepth</c> (ICESCT) — the
+    /// depth of snow cover on the ice, measured in centimetres. Negative
+    /// values are nonsensical.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> SnowDepthNonNegative { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-4.3")
+            .WithDescription("Egg-code snow depth must be non-negative when present.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inv, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in inv.IceFeatures)
+                {
+                    var egg = f switch
+                    {
+                        S411SeaIce s => s.EggCode,
+                        S411LakeIce l => l.EggCode,
+                        _ => null,
+                    };
+                    if (egg?.SnowDepth is not { } depth || depth >= 0) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S411-R-4.3",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Feature '{f.Id}' ({f.NormalizedFeatureType}) has negative snowDepth " +
+                            $"({depth}).",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-4.4 — iceberg size code enumeration ──────────────────
+
+    /// <summary>
+    /// Valid <c>icebergSize</c> enumeration codes from S-411 Edition 1.2.1
+    /// Annex A: 1 = Growler, 2 = Bergy Bit, 3 = Small, 4 = Medium,
+    /// 5 = Large, 6 = Very Large, 7 = Tabular, 8 = Pinnacle, 9 = Dome,
+    /// 99 = Other.
+    /// </summary>
+    private static readonly ImmutableHashSet<int> ValidIcebergSizeCodes =
+        ImmutableHashSet.Create(1, 2, 3, 4, 5, 6, 7, 8, 9, 99);
+
+    /// <summary>
+    /// <c>S411-R-4.4</c> — When an <see cref="S411Iceberg"/> feature
+    /// carries an <c>icebergSize</c> value, it must be one of the
+    /// enumerated codes defined by the S-411 Feature Catalogue.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-411 Annex A <c>icebergSize</c> (ICEBSZ) — a
+    /// closed enumeration with codes 1–9 (Growler … Dome) plus 99
+    /// (Other). Any other value is a producer error.
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> IcebergSizeInEnumeration { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-4.4")
+            .WithDescription("Iceberg size code must be one of the S-411 enumerated values.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inv, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in inv.IceFeatures.OfType<S411Iceberg>())
+                {
+                    if (f.IcebergSizeCode is not { } code) continue;
+                    if (ValidIcebergSizeCodes.Contains(code)) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S411-R-4.4",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Iceberg feature '{f.Id}' has icebergSize={code}, which is not in " +
+                            $"the S-411 enumeration (1–9, 99).",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S411-R-5.1 — unique feature identifiers ─────────────────────
+
+    /// <summary>
+    /// <c>S411-R-5.1</c> — Every feature in the dataset must carry a
+    /// unique identifier.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §5 — <c>gml:id</c> uniqueness is a
+    /// GML schema requirement; duplicate IDs break xlink resolution and
+    /// downstream lookups. Empty IDs are ignored (they're a separate
+    /// schema-shape concern handled by the projection).
+    /// </remarks>
+    public static IValidationRule<S411SeaIceInventory> UniqueFeatureIdentifiers { get; } =
+        ValidationRuleBuilder.RuleFor<S411SeaIceInventory>("S411-R-5.1")
+            .WithDescription("Feature identifiers must be unique across the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inv, _) =>
+            {
+                var seen = new Dictionary<string, S411GeometryKind>(StringComparer.Ordinal);
+                var reported = new HashSet<string>(StringComparer.Ordinal);
+                var findings = new List<ValidationFinding>();
+                foreach (var f in EnumerateAllFeatures(inv))
+                {
+                    if (string.IsNullOrEmpty(f.Id)) continue;
+                    if (!seen.ContainsKey(f.Id))
+                    {
+                        seen.Add(f.Id, f.GeometryKind);
+                        continue;
+                    }
+
+                    if (!reported.Add(f.Id)) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S411-R-5.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Duplicate feature identifier '{f.Id}'.",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-411 sea-ice inventories.</summary>
+    public static ValidationRuleSet<S411SeaIceInventory> Default { get; } = new(
+        CoordinatesInWgs84Range,
+        SurfacePolygonClosed,
+        CurveHasMinimumVertices,
+        TotalConcentrationInEnumeration,
+        IceAverageThicknessNonNegative,
+        SnowDepthNonNegative,
+        IcebergSizeInEnumeration,
+        UniqueFeatureIdentifiers);
+
+    /// <summary>
+    /// Convenience wrapper around
+    /// <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/> using
+    /// the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S411SeaIceInventory inventory, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+        return Default.Run(inventory, context);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private static IEnumerable<S411IceFeature> EnumerateAllFeatures(S411SeaIceInventory inv)
+    {
+        foreach (var f in inv.IceFeatures) yield return f;
+        foreach (var f in inv.DataCoverages) yield return f;
+        foreach (var f in inv.OtherFeatures) yield return f;
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S411.Tests/Validation/S411SeaIceRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S411.Tests/Validation/S411SeaIceRulesTests.cs
@@ -1,0 +1,504 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S411;
+using EncDotNet.S100.Datasets.S411.DataModel;
+using EncDotNet.S100.Datasets.S411.Validation;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S411.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S411SeaIceRules"/>. Each test constructs a
+/// minimal synthetic <see cref="S411SeaIceInventory"/> in memory (no GML
+/// fixtures) and asserts the rule fires (or doesn't) with the expected
+/// finding shape.
+/// </summary>
+public class S411SeaIceRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static readonly S411Dataset EmptyDataset = new()
+    {
+        Features = ImmutableArray<S411Feature>.Empty,
+        SourceDocument = new System.Xml.Linq.XDocument(),
+    };
+
+    private static readonly S411Feature DummySource = new()
+    {
+        Id = "_dummy",
+        FeatureType = "SeaIce",
+        Attributes = ImmutableDictionary<string, string>.Empty,
+        ComplexAttributes = ImmutableArray<S411ComplexAttribute>.Empty,
+    };
+
+    private static ImmutableArray<GeoPosition> Coords(params (double lat, double lon)[] pts) =>
+        pts.Select(p => new GeoPosition(p.lat, p.lon)).ToImmutableArray();
+
+    private static S411SeaIce SeaIce(
+        string id,
+        S411GeometryKind kind = S411GeometryKind.Surface,
+        ImmutableArray<GeoPosition>? coordinates = null,
+        S411EggCode? eggCode = null) => new()
+    {
+        Id = id,
+        NormalizedFeatureType = "SeaIce",
+        SourceFeatureType = "SeaIce",
+        GeometryKind = kind,
+        Coordinates = coordinates ?? ImmutableArray<GeoPosition>.Empty,
+        EggCode = eggCode,
+        Source = DummySource,
+    };
+
+    private static S411LakeIce LakeIce(string id, S411EggCode? eggCode = null) => new()
+    {
+        Id = id,
+        NormalizedFeatureType = "LakeIce",
+        SourceFeatureType = "LakeIce",
+        GeometryKind = S411GeometryKind.Surface,
+        Coordinates = ClosedSquare(),
+        EggCode = eggCode,
+        Source = DummySource,
+    };
+
+    private static S411Iceberg Iceberg(string id, int? sizeCode = null) => new()
+    {
+        Id = id,
+        NormalizedFeatureType = "Iceberg",
+        SourceFeatureType = "Iceberg",
+        GeometryKind = S411GeometryKind.Point,
+        Coordinates = Coords((45, -50)),
+        IcebergSizeCode = sizeCode,
+        Source = DummySource,
+    };
+
+    private static S411IceEdge IceEdge(string id, ImmutableArray<GeoPosition> coords) => new()
+    {
+        Id = id,
+        NormalizedFeatureType = "IceEdge",
+        SourceFeatureType = "IceEdge",
+        GeometryKind = S411GeometryKind.Curve,
+        Coordinates = coords,
+        Source = DummySource,
+    };
+
+    private static S411IceThickness IceThickness(string id, double? thickness) => new()
+    {
+        Id = id,
+        NormalizedFeatureType = "IceThickness",
+        SourceFeatureType = "IceThickness",
+        GeometryKind = S411GeometryKind.Point,
+        Coordinates = Coords((45, -50)),
+        IceAverageThickness = thickness,
+        Source = DummySource,
+    };
+
+    private static S411DataCoverage DataCoverage(string id, ImmutableArray<GeoPosition> coords) => new()
+    {
+        Id = id,
+        NormalizedFeatureType = "DataCoverage",
+        SourceFeatureType = "DataCoverage",
+        GeometryKind = S411GeometryKind.Surface,
+        Coordinates = coords,
+        Source = DummySource,
+    };
+
+    private static ImmutableArray<GeoPosition> ClosedSquare() =>
+        Coords((0, 0), (0, 1), (1, 1), (1, 0), (0, 0));
+
+    private static S411SeaIceInventory Inventory(
+        IEnumerable<S411IceFeature>? ice = null,
+        IEnumerable<S411DataCoverage>? coverages = null,
+        IEnumerable<S411OtherFeature>? others = null) => new()
+    {
+        IceFeatures = ice?.ToImmutableArray() ?? ImmutableArray<S411IceFeature>.Empty,
+        DataCoverages = coverages?.ToImmutableArray() ?? ImmutableArray<S411DataCoverage>.Empty,
+        OtherFeatures = others?.ToImmutableArray() ?? ImmutableArray<S411OtherFeature>.Empty,
+        Source = EmptyDataset,
+    };
+
+    // ── S411-R-3.1 — WGS-84 lat/lon range ────────────────────────
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Passes_ForValidCoordinates()
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", coordinates: ClosedSquare()) });
+        var findings = S411SeaIceRules.CoordinatesInWgs84Range.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Theory]
+    [InlineData(91.0, 0.0)]
+    [InlineData(-90.5, 0.0)]
+    [InlineData(0.0, 181.0)]
+    [InlineData(0.0, -200.0)]
+    public void CoordinatesInWgs84Range_Fails_WhenOutOfRange(double lat, double lon)
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", S411GeometryKind.Point, Coords((lat, lon))) });
+        var findings = S411SeaIceRules.CoordinatesInWgs84Range
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-3.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("F1", f.RelatedFeatureId);
+        Assert.NotNull(f.Point);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_ReportsBothAxes_WhenBothInvalid()
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", S411GeometryKind.Point, Coords((200, 200))) });
+        var findings = S411SeaIceRules.CoordinatesInWgs84Range
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Contains("both out of range", f.Message);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_AlsoChecksDataCoveragesAndOthers()
+    {
+        var inv = Inventory(
+            coverages: new[] { DataCoverage("C1", Coords((100, 0), (0, 0), (0, 1), (100, 0))) });
+        var findings = S411SeaIceRules.CoordinatesInWgs84Range
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        Assert.Equal(2, findings.Count);
+        Assert.All(findings, f => Assert.Equal("C1", f.RelatedFeatureId));
+    }
+
+    // ── S411-R-3.2 — surface polygon closure ─────────────────────
+
+    [Fact]
+    public void SurfacePolygonClosed_Passes_ForClosedSquare()
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", coordinates: ClosedSquare()) });
+        var findings = S411SeaIceRules.SurfacePolygonClosed.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void SurfacePolygonClosed_Fails_WhenFewerThanFourPoints()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("F1", coordinates: Coords((0, 0), (0, 1), (0, 0))),
+        });
+        var findings = S411SeaIceRules.SurfacePolygonClosed
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-3.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Contains("requires ≥ 4", f.Message);
+    }
+
+    [Fact]
+    public void SurfacePolygonClosed_Fails_WhenNotClosed()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("F1", coordinates: Coords((0, 0), (0, 1), (1, 1), (1, 0))),
+        });
+        var findings = S411SeaIceRules.SurfacePolygonClosed
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-3.2", f.RuleId);
+        Assert.Contains("not closed", f.Message);
+    }
+
+    [Fact]
+    public void SurfacePolygonClosed_IgnoresNonSurfaceFeatures()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            (S411IceFeature)IceEdge("E1", Coords((0, 0), (1, 1))),
+            Iceberg("I1"),
+        });
+        var findings = S411SeaIceRules.SurfacePolygonClosed.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    // ── S411-R-3.3 — curve minimum vertex count ──────────────────
+
+    [Fact]
+    public void CurveHasMinimumVertices_Passes_WhenTwoOrMore()
+    {
+        var inv = Inventory(ice: new[] { (S411IceFeature)IceEdge("E1", Coords((0, 0), (1, 1))) });
+        var findings = S411SeaIceRules.CurveHasMinimumVertices.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void CurveHasMinimumVertices_Fails_WhenFewerThanTwo(int n)
+    {
+        var coords = Enumerable.Range(0, n).Select(i => new GeoPosition(i, i)).ToImmutableArray();
+        var inv = Inventory(ice: new[] { (S411IceFeature)IceEdge("E1", coords) });
+        var findings = S411SeaIceRules.CurveHasMinimumVertices
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-3.3", f.RuleId);
+        Assert.Equal("E1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void CurveHasMinimumVertices_IgnoresSurfaceFeatures()
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", coordinates: ClosedSquare()) });
+        var findings = S411SeaIceRules.CurveHasMinimumVertices.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    // ── S411-R-4.1 — total concentration enumeration ─────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(35)]
+    [InlineData(91)]
+    [InlineData(99)]
+    public void TotalConcentrationInEnumeration_Passes_ForValidCodes(int code)
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("F1", coordinates: ClosedSquare(),
+                eggCode: new S411EggCode { TotalConcentration = code }),
+        });
+        var findings = S411SeaIceRules.TotalConcentrationInEnumeration
+            .Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(11)]
+    [InlineData(15)]
+    [InlineData(100)]
+    public void TotalConcentrationInEnumeration_Fails_ForUnknownCodes(int code)
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("F1", coordinates: ClosedSquare(),
+                eggCode: new S411EggCode { TotalConcentration = code }),
+        });
+        var findings = S411SeaIceRules.TotalConcentrationInEnumeration
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-4.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("F1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void TotalConcentrationInEnumeration_Skips_WhenEggCodeAbsent()
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", coordinates: ClosedSquare()) });
+        var findings = S411SeaIceRules.TotalConcentrationInEnumeration
+            .Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void TotalConcentrationInEnumeration_AppliesToLakeIce()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            (S411IceFeature)LakeIce("L1", new S411EggCode { TotalConcentration = 11 }),
+        });
+        var findings = S411SeaIceRules.TotalConcentrationInEnumeration
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("L1", f.RelatedFeatureId);
+    }
+
+    // ── S411-R-4.2 — ice average thickness non-negative ──────────
+
+    [Fact]
+    public void IceAverageThicknessNonNegative_Passes_WhenZeroOrPositive()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            (S411IceFeature)IceThickness("T1", 0.0),
+            IceThickness("T2", 2.5),
+        });
+        var findings = S411SeaIceRules.IceAverageThicknessNonNegative
+            .Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void IceAverageThicknessNonNegative_Fails_WhenNegative()
+    {
+        var inv = Inventory(ice: new[] { (S411IceFeature)IceThickness("T1", -0.5) });
+        var findings = S411SeaIceRules.IceAverageThicknessNonNegative
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-4.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("T1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void IceAverageThicknessNonNegative_Skips_WhenAbsent()
+    {
+        var inv = Inventory(ice: new[] { (S411IceFeature)IceThickness("T1", null) });
+        var findings = S411SeaIceRules.IceAverageThicknessNonNegative
+            .Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    // ── S411-R-4.3 — snow depth non-negative ─────────────────────
+
+    [Fact]
+    public void SnowDepthNonNegative_Passes_WhenZeroOrPositive()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("F1", coordinates: ClosedSquare(), eggCode: new S411EggCode { SnowDepth = 0.0 }),
+            SeaIce("F2", coordinates: ClosedSquare(), eggCode: new S411EggCode { SnowDepth = 5.5 }),
+        });
+        var findings = S411SeaIceRules.SnowDepthNonNegative.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void SnowDepthNonNegative_Fails_WhenNegative()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("F1", coordinates: ClosedSquare(), eggCode: new S411EggCode { SnowDepth = -1.0 }),
+        });
+        var findings = S411SeaIceRules.SnowDepthNonNegative
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-4.3", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("F1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void SnowDepthNonNegative_AppliesToLakeIce()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            (S411IceFeature)LakeIce("L1", new S411EggCode { SnowDepth = -3.0 }),
+        });
+        var findings = S411SeaIceRules.SnowDepthNonNegative
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        Assert.Single(findings);
+    }
+
+    // ── S411-R-4.4 — iceberg size code enumeration ───────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(9)]
+    [InlineData(99)]
+    public void IcebergSizeInEnumeration_Passes_ForValidCodes(int code)
+    {
+        var inv = Inventory(ice: new[] { (S411IceFeature)Iceberg("I1", code) });
+        var findings = S411SeaIceRules.IcebergSizeInEnumeration
+            .Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void IcebergSizeInEnumeration_Fails_ForUnknownCodes(int code)
+    {
+        var inv = Inventory(ice: new[] { (S411IceFeature)Iceberg("I1", code) });
+        var findings = S411SeaIceRules.IcebergSizeInEnumeration
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-4.4", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("I1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void IcebergSizeInEnumeration_Skips_WhenAbsent()
+    {
+        var inv = Inventory(ice: new[] { (S411IceFeature)Iceberg("I1", null) });
+        var findings = S411SeaIceRules.IcebergSizeInEnumeration
+            .Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    // ── S411-R-5.1 — unique feature identifiers ──────────────────
+
+    [Fact]
+    public void UniqueFeatureIdentifiers_Passes_WhenAllUnique()
+    {
+        var inv = Inventory(
+            ice: new[]
+            {
+                SeaIce("F1", coordinates: ClosedSquare()),
+                (S411IceFeature)Iceberg("I1"),
+            },
+            coverages: new[] { DataCoverage("C1", ClosedSquare()) });
+        var findings = S411SeaIceRules.UniqueFeatureIdentifiers.Evaluate(inv, ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void UniqueFeatureIdentifiers_Fails_WhenDuplicatesAcrossLists()
+    {
+        var inv = Inventory(
+            ice: new[] { SeaIce("X1", coordinates: ClosedSquare()) },
+            coverages: new[] { DataCoverage("X1", ClosedSquare()) });
+        var findings = S411SeaIceRules.UniqueFeatureIdentifiers
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S411-R-5.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("X1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void UniqueFeatureIdentifiers_ReportsEachDuplicateOnce()
+    {
+        var inv = Inventory(ice: new[]
+        {
+            SeaIce("X1", coordinates: ClosedSquare()),
+            SeaIce("X1", coordinates: ClosedSquare()),
+            SeaIce("X1", coordinates: ClosedSquare()),
+        });
+        var findings = S411SeaIceRules.UniqueFeatureIdentifiers
+            .Evaluate(inv, ValidationContext.Default).ToList();
+        Assert.Single(findings);
+    }
+
+    // ── Default rule set ────────────────────────────────────────
+
+    [Fact]
+    public void Default_RuleSet_Contains_AllEightRules()
+    {
+        var ids = S411SeaIceRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Equal(8, ids.Count);
+        Assert.Contains("S411-R-3.1", ids);
+        Assert.Contains("S411-R-3.2", ids);
+        Assert.Contains("S411-R-3.3", ids);
+        Assert.Contains("S411-R-4.1", ids);
+        Assert.Contains("S411-R-4.2", ids);
+        Assert.Contains("S411-R-4.3", ids);
+        Assert.Contains("S411-R-4.4", ids);
+        Assert.Contains("S411-R-5.1", ids);
+    }
+
+    [Fact]
+    public void Validate_Returns_EmptyReport_ForCleanInventory()
+    {
+        var inv = Inventory(ice: new[] { SeaIce("F1", coordinates: ClosedSquare()) });
+        var report = S411SeaIceRules.Validate(inv);
+        Assert.Empty(report.Findings);
+    }
+
+    [Fact]
+    public void Validate_Throws_OnNullInventory()
+    {
+        Assert.Throws<ArgumentNullException>(() => S411SeaIceRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Introduce `S411SeaIceRules` — a pilot Tier-1/Tier-2 validation rule pack for an `S411SeaIceInventory`, following the pattern established by the S-421 rule pack in #100.

## Rules

All citations against S-411 Edition 1.2.1 Annex A (Feature Catalogue) or S-100 Part 10b.

| Rule | Severity | Summary |
|------|----------|---------|
| `S411-R-3.1` | Error | Feature coordinates within WGS-84 lat/lon ranges (S-100 Part 10b §6.2). |
| `S411-R-3.2` | Error | Surface features closed with ≥ 4 coordinates (S-100 Part 10b §6.3, `gml:LinearRing`). |
| `S411-R-3.3` | Error | Curve features have ≥ 2 vertices (S-100 Part 10b §6.3, `gml:LineString`). |
| `S411-R-4.1` | Warning | Egg-code `totalConcentration` (ICEACT) in the FC-enumerated WMO code set. |
| `S411-R-4.2` | Error | `iceAverageThickness` (ICETCK) non-negative when present. |
| `S411-R-4.3` | Error | Egg-code `snowDepth` (ICESCT) non-negative when present. |
| `S411-R-4.4` | Warning | `icebergSize` (ICEBSZ) in the FC enumeration `{1..9, 99}`. |
| `S411-R-5.1` | Error | Feature identifiers unique across the dataset. |

Rules bind only to the typed projection (`S411SeaIceInventory` + `S411IceFeature` subclasses), so they are agnostic to the two real-world GML shapes (JCOMM/Canadian Ice Service operational + IHO 1.2.1 sample) that both normalise to the same typed model.

## Tests

`tests/EncDotNet.S100.Datasets.S411.Tests/Validation/S411SeaIceRulesTests.cs` — **35 new unit tests** (synthetic models, no GML fixtures). Full S-411 test suite: **55 passing**.

## Deviations from the brief

- Did not implement candidate rule #3 (`observationTime`/`validityTime`) — the typed `S411SeaIceInventory` exposes `IssueDate` only at the dataset level and individual ice features in the typed model have no per-feature observation timestamp surfaced (raw values would live in `ExtraAttributes` under unstandardised keys across the two GML shapes). Skipping until the typed projection grows a per-feature timestamp.
- Did not implement candidate rule #7 (iceberg height/draft non-negative) — `S411Iceberg` only surfaces `IcebergSizeCode`; dimensional attributes (height/draft) are not in the typed model today.
- Surface-polygon closure (`S411-R-3.2`) and curve minimum-vertex (`S411-R-3.3`) replace the simpler "polygon closure" / "ice edge minimum length" sketches and apply uniformly to every surface/curve feature in the inventory (ice + data coverages + other).
- Stage-of-development enumeration check was dropped: the typed model only exposes `StagesOfDevelopmentRaw` as opaque text (producers serialise it as Python-list-style strings), so a meaningful enumeration check would need to parse those first.

## Acceptance criteria

- [x] 6–8 rules with spec citations (8 rules)
- [x] Happy + failing tests per rule
- [x] `dotnet build` green
- [x] `dotnet test -c Release` green for `EncDotNet.S100.Datasets.S411.Tests` (55/55)
- [x] No edits outside `src/EncDotNet.S100.Datasets.S411/Validation/`, the matching test folder, and the S-411 README

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>