### PR TITLE
Add S-127 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S127/README.md
+++ b/src/EncDotNet.S100.Datasets.S127/README.md
@@ -70,6 +70,38 @@ The projection:
 
 The viewer, FeatureXML adapter, and XSLT portrayal pipeline continue to drive off `S127Dataset` and are unaffected by this layer.
 
+## Validation
+
+`EncDotNet.S100.Datasets.S127.Validation.S127MarineServicesRules` exposes a pilot rule set of Tier-1 / Tier-2 validation rules that operate on `S127MarineServicesDataset`. Rule identifiers follow the `S127-R-{clause}` convention and trace back to S-127 Edition 2.0.0 § references.
+
+```csharp
+using EncDotNet.S100.Datasets.S127;
+using EncDotNet.S100.Datasets.S127.DataModel;
+using EncDotNet.S100.Datasets.S127.Validation;
+
+var dataset = S127Dataset.Open("marine_services.gml");
+var typed = S127MarineServicesDataset.From(dataset, out _);
+var report = S127MarineServicesRules.Validate(typed);
+
+foreach (var finding in report.Findings)
+    Console.WriteLine($"{finding.RuleId} [{finding.Severity}] {finding.Message}");
+```
+
+Default rules:
+
+| Rule ID | Summary | Severity |
+| --- | --- | --- |
+| `S127-R-12.1` | Coordinates must lie within WGS-84 lat/lon ranges (S-100 Part 10b §6.2). | Error |
+| `S127-R-12.2` | `PilotBoardingPlace` features must carry a non-empty geometry. | Error |
+| `S127-R-12.3` | Surface exterior rings must have ≥4 vertices and be closed. | Error |
+| `S127-R-12.4` | Curve geometries must have ≥2 vertices. | Error |
+| `S127-R-12.5` | Vessel-size limit minimums (length / draught / beam) must not exceed their maximums. | Warning |
+| `S127-R-12.6` | Availability time-of-day / date ranges must have start ≤ end. | Warning |
+| `S127-R-12.7` | Feature identifiers must be unique within the dataset. | Error |
+| `S127-R-12.8` | `Authority` features should carry a non-empty `authorityName`. | Warning |
+
+Container-style features (e.g. `Authority`) without geometry are tolerated — they trivially pass geometry-shape rules. Two candidate rules — VTS report-point geometry (deferred pending cross-feature xlink resolution) and closed-enumeration validity for `categoryOfService` (deferred pending typed enum surfaces) — are intentionally not included; see the class-level remarks in `S127MarineServicesRules` for the reasoning.
+
 ## Spec compliance
 
 - Coordinate ordering in `<gml:pos>` / `<gml:posList>` is `lat lon` (EPSG:4326), per S-100 Part 10b §6.2.

--- a/src/EncDotNet.S100.Datasets.S127/Validation/S127MarineServicesRules.cs
+++ b/src/EncDotNet.S100.Datasets.S127/Validation/S127MarineServicesRules.cs
@@ -1,0 +1,526 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S127.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S127.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-127 <see cref="S127MarineServicesDataset"/>. Rule identifiers
+/// follow the convention <c>S127-R-{clause}</c>, where <c>{clause}</c>
+/// traces to the relevant section of the S-127 Edition 2.0.0 Product
+/// Specification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single typed
+/// <see cref="S127MarineServicesDataset"/> in isolation. Tier-3
+/// cross-dataset rules (for example, validating that a
+/// <c>VesselTrafficService</c>-area report point falls within charted
+/// waters in a loaded S-101 dataset) will be added in a follow-up once
+/// the cross-dataset validation surface is wired up — they need access
+/// to sibling datasets via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// <para>
+/// Two candidates from the initial design pass were intentionally
+/// dropped, mirroring the deferred-rule reasoning in
+/// <c>EncDotNet.S100.Datasets.S421.Validation.S421RoutePlanRules</c>:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <b>VTS report-point geometry</b> — <c>VesselTrafficServiceArea</c>
+///       features may reference report points via <c>xlink:href</c> to
+///       other features. The typed projection only resolves the
+///       <c>theAuthority</c> binding today; the other xlinks remain on
+///       <c>Source.FeatureReferences</c> and would need a cross-feature
+///       resolution pass to validate, so this rule is deferred.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Closed enumeration validity</b> for attributes such as
+///       <c>categoryOfService</c> — most S-127 category codes are
+///       carried in <c>ExtraAttributes</c> as opaque strings rather
+///       than being broken out as typed enums on the projection.
+///       Validating a closed enumeration off such a loose surface
+///       would be brittle (false positives on values the FC permits
+///       but the rule has not been updated for), so this is deferred
+///       pending a typed enum surface for the relevant attributes.
+///     </description>
+///   </item>
+/// </list>
+/// </remarks>
+public static class S127MarineServicesRules
+{
+    /// <summary>
+    /// <c>S127-R-12.1</c> — Every feature's geometry coordinates must
+    /// lie within the WGS-84 ranges: latitude in [-90, +90] and
+    /// longitude in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded; S-127 Edition 2.0.0 inherits this
+    /// CRS. Container-style features without geometry (for example
+    /// <see cref="S127Authority"/>) carry an empty
+    /// <see cref="IS127Feature.Coordinates"/> array and therefore
+    /// trivially pass this rule.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> WgsLatLonInRange { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.1")
+            .WithDescription("Feature coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.Coordinates.IsDefaultOrEmpty) continue;
+
+                    foreach (var pos in feature.Coordinates)
+                    {
+                        bool latOk = pos.Latitude is >= -90 and <= 90;
+                        bool lonOk = pos.Longitude is >= -180 and <= 180;
+                        if (latOk && lonOk) continue;
+
+                        var details = (latOk, lonOk) switch
+                        {
+                            (false, true) => $"latitude {pos.Latitude.ToString(CultureInfo.InvariantCulture)} is outside [-90, +90]",
+                            (true, false) => $"longitude {pos.Longitude.ToString(CultureInfo.InvariantCulture)} is outside [-180, +180]",
+                            _ => $"latitude {pos.Latitude.ToString(CultureInfo.InvariantCulture)} and longitude {pos.Longitude.ToString(CultureInfo.InvariantCulture)} are both out of range",
+                        };
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S127-R-12.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"Feature '{feature.Id}' ({feature.FeatureType}): {details}.",
+                            Point = pos,
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S127-R-12.2</c> — Every <see cref="S127PilotBoardingPlace"/>
+    /// feature must carry a non-empty point or surface geometry.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-127 Edition 2.0.0 §12 — <c>PilotBoardingPlace</c>
+    /// is a geographic feature whose <c>spatial</c> association is
+    /// mandatory; a pilot boarding place without coordinates has no
+    /// charted location and cannot be portrayed. Container-style
+    /// features (such as <see cref="S127Authority"/>) deliberately
+    /// carry no geometry and are out of scope for this rule.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> PilotBoardingPlaceHasGeometry { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.2")
+            .WithDescription("PilotBoardingPlace features must carry a non-empty geometry.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var pbp in dataset.Features.OfType<S127PilotBoardingPlace>())
+                {
+                    if (pbp.GeometryKind != S127GeometryKind.None
+                        && !pbp.Coordinates.IsDefaultOrEmpty)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S127-R-12.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"PilotBoardingPlace '{pbp.Id}' has no geometry " +
+                            $"(GeometryKind={pbp.GeometryKind}, {pbp.Coordinates.Length} coordinate(s)).",
+                        RelatedFeatureId = pbp.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S127-R-12.3</c> — Surface geometries must form a closed
+    /// polygon: at least four vertices, with the first and last
+    /// coincident.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6 — surface exterior rings are
+    /// GML <c>LinearRing</c>s and must be topologically closed. The
+    /// minimum-of-four-vertices rule is the canonical GML linear-ring
+    /// cardinality (three distinct corners plus a repeat of the start).
+    /// Closure is tested with a tight tolerance (1e-9 degrees, about
+    /// 0.1 mm at the equator) so ordinary floating-point round-trip
+    /// does not trigger the rule.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> SurfacePolygonClosure { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.3")
+            .WithDescription("Surface geometries must have ≥4 vertices and be closed (first == last).")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                const double tolerance = 1e-9;
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.GeometryKind != S127GeometryKind.Surface) continue;
+                    var ring = feature.Coordinates;
+                    if (ring.IsDefaultOrEmpty) continue;
+
+                    if (ring.Length < 4)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S127-R-12.3",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{feature.Id}' ({feature.FeatureType}) has a surface exterior ring " +
+                                $"with only {ring.Length} vertex(es); a closed polygon needs at least 4.",
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                        continue;
+                    }
+
+                    var first = ring[0];
+                    var last = ring[^1];
+                    if (Math.Abs(first.Latitude - last.Latitude) > tolerance
+                        || Math.Abs(first.Longitude - last.Longitude) > tolerance)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S127-R-12.3",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{feature.Id}' ({feature.FeatureType}) has an unclosed surface ring " +
+                                $"(first=({first.Latitude}, {first.Longitude}), last=({last.Latitude}, {last.Longitude})).",
+                            Point = first,
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S127-R-12.4</c> — Curve geometries must have at least two
+    /// vertices.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6 — a GML curve is encoded as a
+    /// <c>LineString</c> with at least two <c>pos</c> elements. A
+    /// single-point "curve" has no defined direction and cannot be
+    /// portrayed as a line.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> CurveMinimumVertices { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.4")
+            .WithDescription("Curve geometries must have at least two vertices.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.GeometryKind != S127GeometryKind.Curve) continue;
+                    if (feature.Coordinates.Length >= 2) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S127-R-12.4",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Feature '{feature.Id}' ({feature.FeatureType}) is a curve with only " +
+                            $"{feature.Coordinates.Length} vertex(es); a curve requires at least 2.",
+                        RelatedFeatureId = feature.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    private static readonly (string Min, string Max)[] s_vesselSizeLimitPairs =
+    {
+        ("minimumVesselsLength",  "maximumVesselsLength"),
+        ("minimumVesselsDraught", "maximumVesselsDraught"),
+        ("minimumVesselsBeam",    "maximumVesselsBeam"),
+    };
+
+    /// <summary>
+    /// <c>S127-R-12.5</c> — When a feature carries both a minimum and
+    /// maximum vessel size limit (length / draught / beam), the
+    /// minimum must not exceed the maximum.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-127 Edition 2.0.0 §12 — the vessel-dimension
+    /// envelope attributes (<c>minimumVesselsLength</c> /
+    /// <c>maximumVesselsLength</c>, and the corresponding draught and
+    /// beam pairs) describe the range of vessels eligible for, or
+    /// regulated by, a service area. A min greater than max inverts
+    /// the envelope. Attributes that are absent or unparseable are
+    /// skipped silently; this rule only fires on a sane-but-inverted
+    /// pairing.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> VesselSizeLimitsMonotonic { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.5")
+            .WithDescription("Vessel-size limit minimums must not exceed their corresponding maximums.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    var attrs = feature.Source.Attributes;
+                    if (attrs.IsEmpty) continue;
+
+                    foreach (var (minKey, maxKey) in s_vesselSizeLimitPairs)
+                    {
+                        if (!attrs.TryGetValue(minKey, out var minStr)
+                            || !attrs.TryGetValue(maxKey, out var maxStr))
+                            continue;
+
+                        if (!double.TryParse(minStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var min)
+                            || !double.TryParse(maxStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var max))
+                            continue;
+
+                        if (min <= max) continue;
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S127-R-12.5",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Feature '{feature.Id}' ({feature.FeatureType}) has {minKey}={minStr} " +
+                                $"greater than {maxKey}={maxStr}.",
+                            RelatedFeatureId = feature.Id,
+                            DatasetId = dataset.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S127-R-12.6</c> — Service-hours availability ranges must be
+    /// monotonic: when a complex attribute exposes a time-of-day pair
+    /// (<c>timeOfDayStart</c> / <c>timeOfDayEnd</c>) or a date pair
+    /// (<c>dateStart</c> / <c>dateEnd</c>), the start must not be
+    /// strictly after the end.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-127 Edition 2.0.0 §12 — the <c>availability</c>
+    /// (and related scheduling) complex attribute carries the periods
+    /// during which a service is offered. An inverted range cannot be
+    /// interpreted unambiguously and is almost always an authoring
+    /// mistake. Values that are absent or unparseable are skipped
+    /// silently; the rule only fires when both endpoints parse and the
+    /// start is strictly after the end. Times are compared on
+    /// <see cref="TimeSpan"/>; dates on <see cref="DateOnly"/>.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> ServiceHoursValidity { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.6")
+            .WithDescription("Availability time-of-day / date ranges must have start ≤ end.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var feature in dataset.Features)
+                {
+                    if (feature.Source.ComplexAttributes.IsDefaultOrEmpty) continue;
+
+                    foreach (var complex in feature.Source.ComplexAttributes)
+                    {
+                        var subs = complex.SubAttributes;
+
+                        if (subs.TryGetValue("timeOfDayStart", out var todStart)
+                            && subs.TryGetValue("timeOfDayEnd", out var todEnd)
+                            && TryParseTime(todStart, out var t0)
+                            && TryParseTime(todEnd, out var t1)
+                            && t0 > t1)
+                        {
+                            findings.Add(new ValidationFinding
+                            {
+                                RuleId = "S127-R-12.6",
+                                Severity = ValidationSeverity.Warning,
+                                Message =
+                                    $"Feature '{feature.Id}' ({feature.FeatureType}) has {complex.Code} " +
+                                    $"timeOfDayStart={todStart} after timeOfDayEnd={todEnd}.",
+                                RelatedFeatureId = feature.Id,
+                                DatasetId = dataset.DatasetIdentifier,
+                            });
+                        }
+
+                        if (subs.TryGetValue("dateStart", out var dStart)
+                            && subs.TryGetValue("dateEnd", out var dEnd)
+                            && TryParseDate(dStart, out var d0)
+                            && TryParseDate(dEnd, out var d1)
+                            && d0 > d1)
+                        {
+                            findings.Add(new ValidationFinding
+                            {
+                                RuleId = "S127-R-12.6",
+                                Severity = ValidationSeverity.Warning,
+                                Message =
+                                    $"Feature '{feature.Id}' ({feature.FeatureType}) has {complex.Code} " +
+                                    $"dateStart={dStart} after dateEnd={dEnd}.",
+                                RelatedFeatureId = feature.Id,
+                                DatasetId = dataset.DatasetIdentifier,
+                            });
+                        }
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S127-R-12.7</c> — Feature identifiers must be unique within
+    /// a dataset.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6 (GML encoding) — <c>gml:id</c>
+    /// is an XML ID and must be unique within the GML document. The
+    /// typed projection groups duplicates during a case-insensitive
+    /// pass; this rule surfaces them to callers (and protects against
+    /// upstream producers that emit non-unique IDs).
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> UniqueFeatureIds { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.7")
+            .WithDescription("Feature identifiers must be unique within the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.Features.IsDefaultOrEmpty)
+                    return Array.Empty<ValidationFinding>();
+
+                var findings = new List<ValidationFinding>();
+                var groups = dataset.Features
+                    .Where(f => !string.IsNullOrEmpty(f.Id))
+                    .GroupBy(f => f.Id, StringComparer.OrdinalIgnoreCase);
+
+                foreach (var group in groups)
+                {
+                    var count = group.Count();
+                    if (count <= 1) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S127-R-12.7",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Feature identifier '{group.Key}' is used by {count} features.",
+                        RelatedFeatureId = group.Key,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S127-R-12.8</c> — <see cref="S127Authority"/> features should
+    /// carry a non-empty <c>authorityName</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-127 Edition 2.0.0 §12 — an <c>Authority</c>
+    /// without a name has no human-readable identity and is of little
+    /// use when bound from a service via the <c>theAuthority</c>
+    /// xlink. Emitted as a warning (not an error) because the FC does
+    /// not strictly require the attribute; the projection tolerates
+    /// its absence.
+    /// </remarks>
+    public static IValidationRule<S127MarineServicesDataset> AuthorityNamePresent { get; } =
+        ValidationRuleBuilder.RuleFor<S127MarineServicesDataset>("S127-R-12.8")
+            .WithDescription("Authority features should carry a non-empty authorityName.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var authority in dataset.Authorities)
+                {
+                    if (!string.IsNullOrWhiteSpace(authority.AuthorityName)) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S127-R-12.8",
+                        Severity = ValidationSeverity.Warning,
+                        Message = $"Authority '{authority.Id}' has no authorityName.",
+                        RelatedFeatureId = authority.Id,
+                        DatasetId = dataset.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-127 marine resources and services datasets.</summary>
+    public static ValidationRuleSet<S127MarineServicesDataset> Default { get; } = new(
+        WgsLatLonInRange,
+        PilotBoardingPlaceHasGeometry,
+        SurfacePolygonClosure,
+        CurveMinimumVertices,
+        VesselSizeLimitsMonotonic,
+        ServiceHoursValidity,
+        UniqueFeatureIds,
+        AuthorityNamePresent);
+
+    /// <summary>
+    /// Convenience wrapper around
+    /// <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(
+        S127MarineServicesDataset dataset,
+        ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+
+    // ── Parsing helpers ──────────────────────────────────────────────
+
+    private static bool TryParseTime(string raw, out TimeSpan value)
+    {
+        // S-100 schedules use ISO 8601 time literals ("HH:mm[:ss]"),
+        // optionally with a trailing 'Z'.
+        var trimmed = raw?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            value = default;
+            return false;
+        }
+
+        if (trimmed.EndsWith('Z'))
+            trimmed = trimmed[..^1];
+
+        return TimeSpan.TryParseExact(trimmed, new[] { @"hh\:mm", @"hh\:mm\:ss" },
+            CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryParseDate(string raw, out DateOnly value)
+    {
+        var trimmed = raw?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            value = default;
+            return false;
+        }
+
+        // Drop any time component if a producer emits a full ISO 8601 datetime.
+        var tIndex = trimmed.IndexOf('T');
+        if (tIndex >= 0) trimmed = trimmed[..tIndex];
+
+        return DateOnly.TryParseExact(trimmed, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out value);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S127.Tests/Validation/S127MarineServicesRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S127.Tests/Validation/S127MarineServicesRulesTests.cs
@@ -1,0 +1,584 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S127;
+using EncDotNet.S100.Datasets.S127.DataModel;
+using EncDotNet.S100.Datasets.S127.Validation;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S127.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S127MarineServicesRules"/>. Each test
+/// constructs a minimal synthetic <see cref="S127MarineServicesDataset"/>
+/// in memory (no GML fixtures) and asserts the rule fires (or doesn't)
+/// with the expected finding shape.
+/// </summary>
+public class S127MarineServicesRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static S127Feature SourceFeature(
+        string id,
+        string featureType,
+        GmlGeometryType geometryType = GmlGeometryType.None,
+        IDictionary<string, string>? attributes = null,
+        IEnumerable<S127ComplexAttribute>? complex = null)
+        => new()
+        {
+            Id = id,
+            FeatureType = featureType,
+            GeometryType = geometryType,
+            Attributes = attributes is null
+                ? ImmutableDictionary<string, string>.Empty
+                : attributes.ToImmutableDictionary(),
+            ComplexAttributes = complex is null
+                ? ImmutableArray<S127ComplexAttribute>.Empty
+                : complex.ToImmutableArray(),
+            Points = ImmutableArray<(double, double)>.Empty,
+            Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            ExteriorRing = ImmutableArray<(double, double)>.Empty,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+        };
+
+    private static S127PilotBoardingPlace Pbp(
+        string id,
+        S127GeometryKind kind,
+        params (double lat, double lon)[] coords)
+        => new()
+        {
+            Id = id,
+            GeometryKind = kind,
+            Coordinates = coords.Select(c => new GeoPosition(c.lat, c.lon)).ToImmutableArray(),
+            Source = SourceFeature(id, "PilotBoardingPlace"),
+        };
+
+    private static S127RegulatedArea Area(
+        string id,
+        S127GeometryKind kind,
+        params (double lat, double lon)[] coords)
+        => new()
+        {
+            Id = id,
+            FeatureType = "RestrictedArea",
+            Kind = S127RegulatedAreaKind.RestrictedArea,
+            GeometryKind = kind,
+            Coordinates = coords.Select(c => new GeoPosition(c.lat, c.lon)).ToImmutableArray(),
+            Source = SourceFeature(id, "RestrictedArea"),
+        };
+
+    private static S127RouteingMeasure Curve(
+        string id,
+        params (double lat, double lon)[] coords)
+        => new()
+        {
+            Id = id,
+            GeometryKind = S127GeometryKind.Curve,
+            Coordinates = coords.Select(c => new GeoPosition(c.lat, c.lon)).ToImmutableArray(),
+            Source = SourceFeature(id, "RouteingMeasure"),
+        };
+
+    private static S127VesselTrafficServiceArea VtsArea(
+        string id,
+        IDictionary<string, string>? attrs = null,
+        IEnumerable<S127ComplexAttribute>? complex = null,
+        params (double lat, double lon)[] coords)
+        => new()
+        {
+            Id = id,
+            GeometryKind = coords.Length > 0 ? S127GeometryKind.Surface : S127GeometryKind.None,
+            Coordinates = coords.Select(c => new GeoPosition(c.lat, c.lon)).ToImmutableArray(),
+            Source = SourceFeature(
+                id, "VesselTrafficServiceArea",
+                geometryType: coords.Length > 0 ? GmlGeometryType.Surface : GmlGeometryType.None,
+                attributes: attrs,
+                complex: complex),
+        };
+
+    private static S127Authority Authority(string id, string? name = null)
+        => new()
+        {
+            Id = id,
+            GeometryKind = S127GeometryKind.None,
+            AuthorityName = name,
+            Source = SourceFeature(
+                id, "Authority",
+                attributes: name is null
+                    ? null
+                    : new Dictionary<string, string> { ["authorityName"] = name }),
+        };
+
+    private static S127MarineServicesDataset Dataset(params IS127Feature[] features)
+    {
+        var array = features.ToImmutableArray();
+        var source = new S127Dataset
+        {
+            DatasetIdentifier = "TEST",
+            ProductIdentifier = "S-127",
+            Features = ImmutableArray<S127Feature>.Empty,
+            InformationTypes = ImmutableArray<S127InformationType>.Empty,
+        };
+        return new S127MarineServicesDataset
+        {
+            DatasetIdentifier = "TEST",
+            ProductIdentifier = "S-127",
+            Features = array,
+            Authorities = array.OfType<S127Authority>().ToImmutableArray(),
+            OtherFeatures = array.OfType<S127OtherFeature>().ToImmutableArray(),
+            Source = source,
+        };
+    }
+
+    // ── S127-R-12.1 — WGS-84 lat/lon in range ─────────────────────
+
+    [Fact]
+    public void WgsLatLonInRange_Passes_OnValidCoordinates()
+    {
+        var ds = Dataset(Pbp("P1", S127GeometryKind.Point, (10, 20)));
+        Assert.Empty(S127MarineServicesRules.WgsLatLonInRange.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void WgsLatLonInRange_Passes_OnRangeBoundaries()
+    {
+        var ds = Dataset(
+            Pbp("MIN", S127GeometryKind.Point, (-90, -180)),
+            Pbp("MAX", S127GeometryKind.Point, (90, 180)));
+        Assert.Empty(S127MarineServicesRules.WgsLatLonInRange.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void WgsLatLonInRange_Passes_OnAuthorityWithoutGeometry()
+    {
+        // Container-feature tolerance: Authority carries no coordinates,
+        // so the lat/lon rule trivially passes.
+        var ds = Dataset(Authority("AUTH-1", "Port Authority"));
+        Assert.Empty(S127MarineServicesRules.WgsLatLonInRange.Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void WgsLatLonInRange_Fails_OnOutOfRangeLatitude()
+    {
+        var ds = Dataset(Pbp("BAD", S127GeometryKind.Point, (95, 0)));
+        var f = Assert.Single(
+            S127MarineServicesRules.WgsLatLonInRange.Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S127-R-12.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Equal("TEST", f.DatasetId);
+        Assert.Contains("latitude", f.Message);
+    }
+
+    [Fact]
+    public void WgsLatLonInRange_Fails_OnOutOfRangeLongitude()
+    {
+        var ds = Dataset(Pbp("BAD", S127GeometryKind.Point, (0, 181)));
+        var f = Assert.Single(
+            S127MarineServicesRules.WgsLatLonInRange.Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("longitude", f.Message);
+    }
+
+    [Fact]
+    public void WgsLatLonInRange_EmitsOneFindingPerOffendingCoordinate()
+    {
+        var ds = Dataset(Curve("LINE", (0, 0), (0, 181), (95, 0)));
+        var findings = S127MarineServicesRules.WgsLatLonInRange
+            .Evaluate(ds, ValidationContext.Default).ToList();
+        Assert.Equal(2, findings.Count);
+    }
+
+    // ── S127-R-12.2 — PilotBoardingPlace requires geometry ─────────
+
+    [Fact]
+    public void PilotBoardingPlaceHasGeometry_Passes_OnPoint()
+    {
+        var ds = Dataset(Pbp("P1", S127GeometryKind.Point, (10, 20)));
+        Assert.Empty(S127MarineServicesRules.PilotBoardingPlaceHasGeometry
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PilotBoardingPlaceHasGeometry_Passes_OnSurface()
+    {
+        var ds = Dataset(Pbp("P1", S127GeometryKind.Surface,
+            (0, 0), (0, 1), (1, 1), (0, 0)));
+        Assert.Empty(S127MarineServicesRules.PilotBoardingPlaceHasGeometry
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PilotBoardingPlaceHasGeometry_Fails_OnEmptyCoordinates()
+    {
+        var ds = Dataset(Pbp("NO_GEOM", S127GeometryKind.None));
+        var f = Assert.Single(S127MarineServicesRules.PilotBoardingPlaceHasGeometry
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S127-R-12.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("NO_GEOM", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void PilotBoardingPlaceHasGeometry_IgnoresOtherFeatureTypes()
+    {
+        // Authorities have no geometry but are NOT in scope of this rule.
+        var ds = Dataset(Authority("AUTH-1", "Pilot Service"));
+        Assert.Empty(S127MarineServicesRules.PilotBoardingPlaceHasGeometry
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    // ── S127-R-12.3 — Surface polygon closure ──────────────────────
+
+    [Fact]
+    public void SurfacePolygonClosure_Passes_OnClosedRing()
+    {
+        var ds = Dataset(Area("A1", S127GeometryKind.Surface,
+            (0, 0), (0, 1), (1, 1), (0, 0)));
+        Assert.Empty(S127MarineServicesRules.SurfacePolygonClosure
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfacePolygonClosure_Passes_OnFloatingPointDrift()
+    {
+        var ds = Dataset(Area("A1", S127GeometryKind.Surface,
+            (0, 0), (0, 1), (1, 1), (1e-12, 1e-12)));
+        Assert.Empty(S127MarineServicesRules.SurfacePolygonClosure
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfacePolygonClosure_Fails_OnTooFewVertices()
+    {
+        var ds = Dataset(Area("A1", S127GeometryKind.Surface,
+            (0, 0), (0, 1), (0, 0)));
+        var f = Assert.Single(S127MarineServicesRules.SurfacePolygonClosure
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("only 3 vertex", f.Message);
+    }
+
+    [Fact]
+    public void SurfacePolygonClosure_Fails_OnUnclosedRing()
+    {
+        var ds = Dataset(Area("A1", S127GeometryKind.Surface,
+            (0, 0), (0, 1), (1, 1), (1, 0)));
+        var f = Assert.Single(S127MarineServicesRules.SurfacePolygonClosure
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("unclosed", f.Message);
+    }
+
+    [Fact]
+    public void SurfacePolygonClosure_IgnoresNonSurfaceGeometries()
+    {
+        var ds = Dataset(
+            Pbp("P1", S127GeometryKind.Point, (0, 0)),
+            Curve("L1", (0, 0), (0, 1)));
+        Assert.Empty(S127MarineServicesRules.SurfacePolygonClosure
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    // ── S127-R-12.4 — Curve minimum vertices ───────────────────────
+
+    [Fact]
+    public void CurveMinimumVertices_Passes_OnTwoOrMore()
+    {
+        var ds = Dataset(Curve("L1", (0, 0), (0, 1)));
+        Assert.Empty(S127MarineServicesRules.CurveMinimumVertices
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CurveMinimumVertices_Fails_OnSingleVertex()
+    {
+        var ds = Dataset(Curve("L1", (0, 0)));
+        var f = Assert.Single(S127MarineServicesRules.CurveMinimumVertices
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S127-R-12.4", f.RuleId);
+        Assert.Equal("L1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void CurveMinimumVertices_IgnoresPointAndSurface()
+    {
+        var ds = Dataset(
+            Pbp("P1", S127GeometryKind.Point, (0, 0)),
+            Area("A1", S127GeometryKind.Surface, (0, 0), (0, 1), (1, 1), (0, 0)));
+        Assert.Empty(S127MarineServicesRules.CurveMinimumVertices
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    // ── S127-R-12.5 — Vessel size limits monotonic ────────────────
+
+    [Fact]
+    public void VesselSizeLimitsMonotonic_Passes_WhenAttributesAbsent()
+    {
+        var ds = Dataset(VtsArea("V1"));
+        Assert.Empty(S127MarineServicesRules.VesselSizeLimitsMonotonic
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void VesselSizeLimitsMonotonic_Passes_OnSaneEnvelope()
+    {
+        var ds = Dataset(VtsArea("V1",
+            attrs: new Dictionary<string, string>
+            {
+                ["minimumVesselsLength"] = "50",
+                ["maximumVesselsLength"] = "300",
+                ["minimumVesselsDraught"] = "2.5",
+                ["maximumVesselsDraught"] = "12",
+            }));
+        Assert.Empty(S127MarineServicesRules.VesselSizeLimitsMonotonic
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void VesselSizeLimitsMonotonic_Fails_WhenLengthInverted()
+    {
+        var ds = Dataset(VtsArea("V1",
+            attrs: new Dictionary<string, string>
+            {
+                ["minimumVesselsLength"] = "400",
+                ["maximumVesselsLength"] = "300",
+            }));
+        var f = Assert.Single(S127MarineServicesRules.VesselSizeLimitsMonotonic
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Contains("minimumVesselsLength=400", f.Message);
+    }
+
+    [Fact]
+    public void VesselSizeLimitsMonotonic_Fails_OnMultiplePairs()
+    {
+        var ds = Dataset(VtsArea("V1",
+            attrs: new Dictionary<string, string>
+            {
+                ["minimumVesselsLength"] = "400",
+                ["maximumVesselsLength"] = "300",
+                ["minimumVesselsBeam"] = "60",
+                ["maximumVesselsBeam"] = "40",
+            }));
+        Assert.Equal(2, S127MarineServicesRules.VesselSizeLimitsMonotonic
+            .Evaluate(ds, ValidationContext.Default).Count());
+    }
+
+    [Fact]
+    public void VesselSizeLimitsMonotonic_IgnoresUnparseableValues()
+    {
+        var ds = Dataset(VtsArea("V1",
+            attrs: new Dictionary<string, string>
+            {
+                ["minimumVesselsLength"] = "not-a-number",
+                ["maximumVesselsLength"] = "300",
+            }));
+        Assert.Empty(S127MarineServicesRules.VesselSizeLimitsMonotonic
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    // ── S127-R-12.6 — Service hours validity ───────────────────────
+
+    private static S127ComplexAttribute Availability(IDictionary<string, string> subs)
+        => new()
+        {
+            Code = "availability",
+            SubAttributes = subs.ToImmutableDictionary(),
+        };
+
+    [Fact]
+    public void ServiceHoursValidity_Passes_OnNormalTimeRange()
+    {
+        var ds = Dataset(VtsArea("V1", complex: new[]
+        {
+            Availability(new Dictionary<string, string>
+            {
+                ["timeOfDayStart"] = "08:00",
+                ["timeOfDayEnd"] = "18:00",
+            }),
+        }));
+        Assert.Empty(S127MarineServicesRules.ServiceHoursValidity
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ServiceHoursValidity_Fails_OnInvertedTimeRange()
+    {
+        var ds = Dataset(VtsArea("V1", complex: new[]
+        {
+            Availability(new Dictionary<string, string>
+            {
+                ["timeOfDayStart"] = "18:00",
+                ["timeOfDayEnd"] = "08:00",
+            }),
+        }));
+        var f = Assert.Single(S127MarineServicesRules.ServiceHoursValidity
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("timeOfDayStart=18:00", f.Message);
+    }
+
+    [Fact]
+    public void ServiceHoursValidity_Passes_OnNormalDateRange()
+    {
+        var ds = Dataset(VtsArea("V1", complex: new[]
+        {
+            Availability(new Dictionary<string, string>
+            {
+                ["dateStart"] = "2025-01-01",
+                ["dateEnd"] = "2025-12-31",
+            }),
+        }));
+        Assert.Empty(S127MarineServicesRules.ServiceHoursValidity
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ServiceHoursValidity_Fails_OnInvertedDateRange()
+    {
+        var ds = Dataset(VtsArea("V1", complex: new[]
+        {
+            Availability(new Dictionary<string, string>
+            {
+                ["dateStart"] = "2025-12-31",
+                ["dateEnd"] = "2025-01-01",
+            }),
+        }));
+        var f = Assert.Single(S127MarineServicesRules.ServiceHoursValidity
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Contains("dateStart=2025-12-31", f.Message);
+    }
+
+    [Fact]
+    public void ServiceHoursValidity_IgnoresUnparseableValues()
+    {
+        var ds = Dataset(VtsArea("V1", complex: new[]
+        {
+            Availability(new Dictionary<string, string>
+            {
+                ["timeOfDayStart"] = "not-a-time",
+                ["timeOfDayEnd"] = "08:00",
+            }),
+        }));
+        Assert.Empty(S127MarineServicesRules.ServiceHoursValidity
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    // ── S127-R-12.7 — Unique feature IDs ───────────────────────────
+
+    [Fact]
+    public void UniqueFeatureIds_Passes_WhenAllDistinct()
+    {
+        var ds = Dataset(
+            Pbp("A", S127GeometryKind.Point, (0, 0)),
+            Pbp("B", S127GeometryKind.Point, (1, 1)));
+        Assert.Empty(S127MarineServicesRules.UniqueFeatureIds
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void UniqueFeatureIds_Fails_OnDuplicate()
+    {
+        var ds = Dataset(
+            Pbp("DUP", S127GeometryKind.Point, (0, 0)),
+            Pbp("DUP", S127GeometryKind.Point, (1, 1)));
+        var f = Assert.Single(S127MarineServicesRules.UniqueFeatureIds
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Equal("S127-R-12.7", f.RuleId);
+        Assert.Equal("DUP", f.RelatedFeatureId);
+        Assert.Contains("2 features", f.Message);
+    }
+
+    [Fact]
+    public void UniqueFeatureIds_TreatsIdsCaseInsensitive()
+    {
+        var ds = Dataset(
+            Pbp("Dup", S127GeometryKind.Point, (0, 0)),
+            Pbp("DUP", S127GeometryKind.Point, (1, 1)));
+        var f = Assert.Single(S127MarineServicesRules.UniqueFeatureIds
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+    }
+
+    // ── S127-R-12.8 — Authority name present ───────────────────────
+
+    [Fact]
+    public void AuthorityNamePresent_Passes_WhenNameSupplied()
+    {
+        var ds = Dataset(Authority("A1", "Port Authority of New York and New Jersey"));
+        Assert.Empty(S127MarineServicesRules.AuthorityNamePresent
+            .Evaluate(ds, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AuthorityNamePresent_Fails_OnMissingOrBlankName(string? name)
+    {
+        var ds = Dataset(Authority("A1", name));
+        var f = Assert.Single(S127MarineServicesRules.AuthorityNamePresent
+            .Evaluate(ds, ValidationContext.Default));
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("A1", f.RelatedFeatureId);
+    }
+
+    // ── Default ruleset composition ───────────────────────────────
+
+    [Fact]
+    public void Default_ContainsAllEightRules()
+    {
+        Assert.Equal(8, S127MarineServicesRules.Default.Rules.Length);
+        var ids = S127MarineServicesRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Contains("S127-R-12.1", ids);
+        Assert.Contains("S127-R-12.2", ids);
+        Assert.Contains("S127-R-12.3", ids);
+        Assert.Contains("S127-R-12.4", ids);
+        Assert.Contains("S127-R-12.5", ids);
+        Assert.Contains("S127-R-12.6", ids);
+        Assert.Contains("S127-R-12.7", ids);
+        Assert.Contains("S127-R-12.8", ids);
+    }
+
+    [Fact]
+    public void Validate_OnValidDataset_ProducesNoFindings()
+    {
+        var ds = Dataset(
+            Pbp("P1", S127GeometryKind.Point, (40.5, -74.0)),
+            Area("RA1", S127GeometryKind.Surface,
+                (40, -75), (40, -74), (41, -74), (40, -75)),
+            Curve("L1", (40, -74), (41, -73)),
+            Authority("AUTH-1", "NY Harbor"));
+        var report = S127MarineServicesRules.Validate(ds);
+        Assert.True(report.IsValid);
+        Assert.Empty(report.Findings);
+        Assert.Equal(8, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_OnInvalidDataset_AggregatesFindingsFromMultipleRules()
+    {
+        // Out-of-range lat (12.1 fires), missing PBP geometry (12.2 fires),
+        // unclosed surface (12.3 fires), duplicate id (12.7 fires),
+        // authority without name (12.8 fires).
+        var ds = Dataset(
+            Pbp("BAD-LAT", S127GeometryKind.Point, (95, 0)),
+            Pbp("NO-GEOM", S127GeometryKind.None),
+            Area("UNCLOSED", S127GeometryKind.Surface,
+                (0, 0), (0, 1), (1, 1), (1, 0)),
+            Pbp("DUP", S127GeometryKind.Point, (0, 0)),
+            Pbp("DUP", S127GeometryKind.Point, (1, 1)),
+            Authority("A1"));
+
+        var report = S127MarineServicesRules.Validate(ds);
+        Assert.False(report.IsValid);
+        var ids = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S127-R-12.1", ids);
+        Assert.Contains("S127-R-12.2", ids);
+        Assert.Contains("S127-R-12.3", ids);
+        Assert.Contains("S127-R-12.7", ids);
+        Assert.Contains("S127-R-12.8", ids);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullDataset()
+    {
+        Assert.Throws<ArgumentNullException>(() => S127MarineServicesRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Introduces `S127MarineServicesRules` — a pilot Tier-1/Tier-2 validation rule set for the strongly-typed `S127MarineServicesDataset`, mirroring the pattern established by `S421RoutePlanRules` (#100).

## Rules (8)

| Rule ID | Summary | Severity |
| --- | --- | --- |
| `S127-R-12.1` | Coordinates within WGS-84 lat/lon ranges (S-100 Part 10b §6.2). | Error |
| `S127-R-12.2` | `PilotBoardingPlace` features must carry a non-empty geometry (S-127 §12). | Error |
| `S127-R-12.3` | Surface exterior rings ≥4 vertices and closed (GML `LinearRing`). | Error |
| `S127-R-12.4` | Curve geometries have ≥2 vertices. | Error |
| `S127-R-12.5` | Vessel-size limit min ≤ max for length / draught / beam (S-127 §12). | Warning |
| `S127-R-12.6` | Availability time-of-day / date ranges have start ≤ end (S-127 §12 `availability`). | Warning |
| `S127-R-12.7` | Feature identifiers unique within the dataset (GML `gml:id`). | Error |
| `S127-R-12.8` | `Authority` features carry a non-empty `authorityName`. | Warning |

## Tests

39 synthetic-model unit tests covering happy + failure paths per rule plus default-ruleset composition.

```
Passed!  - Failed:     0, Passed:    39, Skipped:     0, Total:    39
```

`dotnet build EncDotNet.S100.slnx -c Release` and `dotnet test tests/EncDotNet.S100.Datasets.S127.Tests -c Release` are both green; no new warnings introduced.

## Deviations from the original candidate list

Two candidate rules from the design sketch were intentionally deferred (reasoning captured in the class-level remarks on `S127MarineServicesRules`, mirroring the deferred-rule pattern from #100):

- **VTS report-point geometry** — `VesselTrafficServiceArea` features reference report points via `xlink:href` to other features. The typed projection only resolves the `theAuthority` binding today; the remaining xlinks stay on `Source.FeatureReferences` and would need a cross-feature resolution pass to validate.
- **Closed-enumeration validity** for attributes such as `categoryOfService` — most S-127 category codes are carried in `ExtraAttributes` as opaque strings rather than typed enums on the projection. Validating a closed enumeration off such a loose surface would be brittle (false positives on FC-valid values), so this is deferred pending a typed enum surface.

The "container-feature tolerance" sanity case from the brief is encoded as happy-path tests on the geometry rules — `Authority` features without coordinates trivially pass `S127-R-12.1` and are not in scope for `S127-R-12.2`.

## Scope

No edits outside `src/EncDotNet.S100.Datasets.S127/Validation/`, `tests/EncDotNet.S100.Datasets.S127.Tests/Validation/`, and the S-127 README. No MCP, viewer, or Tier-3 changes.