### PR TITLE
Add S-129 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S129/README.md
+++ b/src/EncDotNet.S100.Datasets.S129/README.md
@@ -62,3 +62,24 @@ dotnet add package EncDotNet.S100.Datasets.S129
   it references (timeline iteration, reference resolution, route
   binding). Strictly additive on top of the types in this library.
 
+## Validation
+
+The `Validation/` namespace provides a default rule pack for the typed
+projection (mirroring the pattern introduced for S-421 in PR #100):
+
+- **`S129UkcRules`** — a static class exposing each rule as a typed
+  `IValidationRule<S129UnderKeelClearancePlan>` property, composed
+  into `S129UkcRules.Default` (a `ValidationRuleSet<…>`), with a
+  `Validate(plan)` convenience wrapper that runs the default set.
+- Rule identifiers follow `S129-R-{clause}` and cite the relevant
+  S-129 Edition 2.0.0 feature-catalogue elements in their XML doc
+  comments. The pilot set covers seven Tier-1 / Tier-2 rules:
+  plan-validity-period inversion, control-point time monotonicity,
+  WGS-84 coordinate bounds across every feature, plan-area geometry
+  populated, positive maximum draught, finite UKC / speed
+  measurements, and control-point geometry presence.
+- Tier-3 cross-dataset rules — e.g. comparing a control point's UKC
+  margin against a sibling S-102 bathymetric grid — are intentionally
+  deferred to the MCP `validate_all` surface and the `S129Fusion`
+  library.
+

--- a/src/EncDotNet.S100.Datasets.S129/Validation/S129UkcRules.cs
+++ b/src/EncDotNet.S100.Datasets.S129/Validation/S129UkcRules.cs
@@ -1,0 +1,370 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S129.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-129 <see cref="S129UnderKeelClearancePlan"/>. Rule identifiers
+/// follow the convention <c>S129-R-{clause}</c>, where <c>{clause}</c>
+/// traces to the relevant section of the S-129 Edition 2.0.0 specification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single
+/// <see cref="S129UnderKeelClearancePlan"/> in isolation. Tier-3
+/// cross-dataset rules — for example comparing a control-point UKC
+/// margin against the charted depth at the same position in a loaded
+/// S-102 bathymetric coverage — will be added in a follow-up once the
+/// MCP <c>validate_all</c> surface is wired up. They need access to
+/// sibling datasets via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// </remarks>
+public static class S129UkcRules
+{
+    /// <summary>
+    /// <c>S129-R-1.1</c> — When both bounds of the plan's
+    /// <c>fixedTimeRange</c> are present, the start must not be after
+    /// the end.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-129 Edition 2.0.0 §<c>fixedTimeRange</c> —
+    /// the plan applies during the interval <c>[timeStart, timeEnd]</c>;
+    /// an interval whose start is after its end is empty and cannot
+    /// describe a valid plan window.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> PlanValidityPeriod { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-1.1")
+            .WithDescription("Plan fixedTimeRange start must not be after end.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((plan, _) =>
+            {
+                var range = plan.Plan?.FixedTimeRange;
+                if (range?.Start is not { } start || range.End is not { } end)
+                    return Array.Empty<ValidationFinding>();
+                if (start <= end)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S129-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Plan fixedTimeRange is inverted: start ({start:O}) " +
+                            $"is after end ({end:O}).",
+                        RelatedFeatureId = plan.Plan?.Id,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S129-R-2.1</c> — Control points carrying an
+    /// <c>expectedPassingTime</c> must be strictly monotonically
+    /// increasing in time (no duplicates, no backwards steps).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-129 Edition 2.0.0 §<c>expectedPassingTime</c>
+    /// — control points form an ordered time series along the route.
+    /// Two control points expected to be passed at the same instant,
+    /// or expected to be passed in an order that contradicts the
+    /// route sequence, are not navigationally meaningful. The typed
+    /// projection already sorts by time; this rule reports duplicates
+    /// that survive that sort.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> ControlPointTimeMonotonic { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-2.1")
+            .WithDescription("Control-point expectedPassingTime must be strictly increasing.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((plan, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                DateTimeOffset? previous = null;
+                string? previousId = null;
+                foreach (var cp in plan.ControlPoints)
+                {
+                    if (cp.ExpectedPassingTime is not { } current)
+                        continue;
+                    if (previous is { } prev && current <= prev)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S129-R-2.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Control point '{cp.Id}' expectedPassingTime ({current:O}) " +
+                                $"is not strictly after preceding control point " +
+                                $"'{previousId}' ({prev:O}).",
+                            Point = cp.Position,
+                            RelatedFeatureId = cp.Id,
+                        });
+                    }
+                    previous = current;
+                    previousId = cp.Id;
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S129-R-3.1</c> — Every coordinate on every S-129 feature
+    /// (control-point positions, plan-area rings, non-navigable and
+    /// almost-non-navigable area rings) must fall within the valid
+    /// WGS-84 ranges: latitude in [-90, +90], longitude in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> CoordinatesInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-3.1")
+            .WithDescription("All feature coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((plan, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                foreach (var cp in plan.ControlPoints)
+                {
+                    if (cp.Position is { } pos && !InRange(pos))
+                        findings.Add(OutOfRange("control point", cp.Id, pos));
+                }
+
+                if (plan.PlanArea is { } pa)
+                    CheckSurface("plan area", pa.Id, pa.Coordinates, pa.InteriorRings, findings);
+
+                foreach (var area in plan.NonNavigableAreas)
+                    CheckSurface("non-navigable area", area.Id, area.Coordinates, area.InteriorRings, findings);
+
+                foreach (var area in plan.AlmostNonNavigableAreas)
+                    CheckSurface("almost-non-navigable area", area.Id, area.Coordinates, area.InteriorRings, findings);
+
+                return findings;
+
+                static bool InRange(GeoPosition p) =>
+                    p.Latitude is >= -90 and <= 90 && p.Longitude is >= -180 and <= 180;
+
+                static ValidationFinding OutOfRange(string kind, string id, GeoPosition p) => new()
+                {
+                    RuleId = "S129-R-3.1",
+                    Severity = ValidationSeverity.Error,
+                    Message =
+                        $"{kind} '{id}' has coordinate out of WGS-84 range: " +
+                        $"({p.Latitude}, {p.Longitude}).",
+                    Point = p,
+                    RelatedFeatureId = id,
+                };
+
+                static void CheckSurface(
+                    string kind,
+                    string id,
+                    ImmutableArray<GeoPosition> exterior,
+                    ImmutableArray<ImmutableArray<GeoPosition>> holes,
+                    List<ValidationFinding> findings)
+                {
+                    if (!exterior.IsDefaultOrEmpty)
+                    {
+                        foreach (var p in exterior)
+                            if (!InRange(p)) findings.Add(OutOfRange(kind, id, p));
+                    }
+                    if (!holes.IsDefaultOrEmpty)
+                    {
+                        foreach (var ring in holes)
+                            if (!ring.IsDefaultOrEmpty)
+                                foreach (var p in ring)
+                                    if (!InRange(p)) findings.Add(OutOfRange(kind, id, p));
+                    }
+                }
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S129-R-3.2</c> — When the dataset carries a plan-area feature,
+    /// its surface geometry must be populated with at least three
+    /// distinct coordinates (the minimum to enclose a non-degenerate
+    /// area).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-129 Edition 2.0.0 <c>UnderKeelClearancePlanArea</c>
+    /// — the plan area describes the spatial extent over which the UKC
+    /// plan is valid. A degenerate ring (fewer than three vertices)
+    /// cannot bound any area and provides no useful spatial extent.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> PlanAreaGeometryPopulated { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-3.2")
+            .WithDescription("UnderKeelClearancePlanArea must have at least three coordinates.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((plan, _) =>
+            {
+                if (plan.PlanArea is not { } pa)
+                    return Array.Empty<ValidationFinding>();
+
+                var ring = pa.Coordinates;
+                int distinct = ring.IsDefaultOrEmpty
+                    ? 0
+                    : ring.Distinct().Count();
+
+                if (distinct >= 3)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S129-R-3.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Plan area '{pa.Id}' has degenerate geometry: " +
+                            $"{distinct} distinct vertex(es) on the exterior ring " +
+                            "(at least 3 required).",
+                        RelatedFeatureId = pa.Id,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S129-R-4.1</c> — When present, the plan's <c>maximumDraught</c>
+    /// must be strictly positive.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-129 Edition 2.0.0 §<c>maximumDraught</c> — the
+    /// vessel draught used as input to the UKC calculation, expressed in
+    /// metres. Zero or negative draught is not physically meaningful and
+    /// would invalidate every UKC margin in the plan.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> MaximumDraughtPositive { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-4.1")
+            .WithDescription("Plan maximumDraught, when present, must be > 0.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((plan, _) =>
+            {
+                if (plan.Plan?.MaximumDraught is not { } draught)
+                    return Array.Empty<ValidationFinding>();
+                if (draught > 0 && !double.IsInfinity(draught) && !double.IsNaN(draught))
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S129-R-4.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Plan maximumDraught must be a positive finite value, found {draught}.",
+                        RelatedFeatureId = plan.Plan?.Id,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S129-R-5.1</c> — Numeric control-point measurements
+    /// (<c>distanceAboveUKCLimit</c> and <c>expectedPassingSpeed</c>),
+    /// when present, must be finite (no <c>NaN</c>, no
+    /// <c>±Infinity</c>).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-129 Edition 2.0.0 §<c>distanceAboveUKCLimit</c>
+    /// and §<c>expectedPassingSpeed</c> — these are real-valued
+    /// measurements (metres and knots respectively). A non-finite value
+    /// indicates the producer's calculation failed or the value was
+    /// corrupted in transit; either way it cannot be used to drive a
+    /// navigational decision.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> ControlPointMeasurementsFinite { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-5.1")
+            .WithDescription("Control-point UKC and speed measurements must be finite.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((plan, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var cp in plan.ControlPoints)
+                {
+                    if (cp.DistanceAboveUkcLimit is { } d && !double.IsFinite(d))
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S129-R-5.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Control point '{cp.Id}' distanceAboveUKCLimit is non-finite ({d}).",
+                            Point = cp.Position,
+                            RelatedFeatureId = cp.Id,
+                        });
+
+                    if (cp.ExpectedPassingSpeed is { } s && !double.IsFinite(s))
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S129-R-5.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Control point '{cp.Id}' expectedPassingSpeed is non-finite ({s}).",
+                            Point = cp.Position,
+                            RelatedFeatureId = cp.Id,
+                        });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S129-R-5.2</c> — Every control point should carry a point
+    /// position; a control point without geometry cannot be plotted on
+    /// the chart.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-129 Edition 2.0.0 <c>UnderKeelClearanceControlPoint</c>
+    /// — the feature class is geometry-bearing (point primitive) by
+    /// definition. The typed projection tolerates absent geometry to
+    /// avoid throwing on malformed input; this rule surfaces it as a
+    /// finding instead.
+    /// </remarks>
+    public static IValidationRule<S129UnderKeelClearancePlan> ControlPointHasPosition { get; } =
+        ValidationRuleBuilder.RuleFor<S129UnderKeelClearancePlan>("S129-R-5.2")
+            .WithDescription("Each control point must have a point position.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((plan, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var cp in plan.ControlPoints)
+                {
+                    if (cp.Position is null)
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S129-R-5.2",
+                            Severity = ValidationSeverity.Warning,
+                            Message = $"Control point '{cp.Id}' has no point geometry.",
+                            RelatedFeatureId = cp.Id,
+                        });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-129 UKC plans.</summary>
+    public static ValidationRuleSet<S129UnderKeelClearancePlan> Default { get; } = new(
+        PlanValidityPeriod,
+        ControlPointTimeMonotonic,
+        CoordinatesInWgs84Range,
+        PlanAreaGeometryPopulated,
+        MaximumDraughtPositive,
+        ControlPointMeasurementsFinite,
+        ControlPointHasPosition);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(
+        S129UnderKeelClearancePlan plan,
+        ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        return Default.Run(plan, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S129.Tests/Validation/S129UkcRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S129.Tests/Validation/S129UkcRulesTests.cs
@@ -1,0 +1,468 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Datasets.S129.Validation;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S129.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S129UkcRules"/>. Each test constructs a
+/// minimal synthetic <see cref="S129UnderKeelClearancePlan"/> in memory
+/// (no GML fixtures) and asserts the rule fires (or doesn't) with the
+/// expected finding shape.
+/// </summary>
+public class S129UkcRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static readonly S129Dataset EmptyDataset = new()
+    {
+        Features = ImmutableArray<S129Feature>.Empty,
+    };
+
+    private static S129UkcPlanMetadata PlanMeta(
+        string id = "PLAN-1",
+        DateTimeOffset? start = null,
+        DateTimeOffset? end = null,
+        double? maximumDraught = null) => new()
+    {
+        Id = id,
+        FixedTimeRange = (start is null && end is null)
+            ? null
+            : new S129TimeRange { Start = start, End = end },
+        MaximumDraught = maximumDraught,
+    };
+
+    private static S129ControlPoint ControlPoint(
+        string id,
+        DateTimeOffset? time = null,
+        double lat = 0,
+        double lon = 0,
+        bool withPosition = true,
+        double? distance = null,
+        double? speed = null) => new()
+    {
+        Id = id,
+        ExpectedPassingTime = time,
+        ExpectedPassingSpeed = speed,
+        DistanceAboveUkcLimit = distance,
+        Position = withPosition ? new GeoPosition(lat, lon) : null,
+    };
+
+    private static S129UkcPlanArea PlanArea(
+        string id,
+        ImmutableArray<GeoPosition> coords,
+        ImmutableArray<ImmutableArray<GeoPosition>>? holes = null) => new()
+    {
+        Id = id,
+        GeometryKind = S129GeometryKind.Surface,
+        Coordinates = coords,
+        InteriorRings = holes ?? ImmutableArray<ImmutableArray<GeoPosition>>.Empty,
+    };
+
+    private static S129NonNavigableArea NonNav(
+        string id,
+        ImmutableArray<GeoPosition> coords) => new()
+    {
+        Id = id,
+        GeometryKind = S129GeometryKind.Surface,
+        Coordinates = coords,
+        InteriorRings = ImmutableArray<ImmutableArray<GeoPosition>>.Empty,
+    };
+
+    private static S129AlmostNonNavigableArea AlmostNonNav(
+        string id,
+        ImmutableArray<GeoPosition> coords) => new()
+    {
+        Id = id,
+        GeometryKind = S129GeometryKind.Surface,
+        Coordinates = coords,
+        InteriorRings = ImmutableArray<ImmutableArray<GeoPosition>>.Empty,
+    };
+
+    private static S129UnderKeelClearancePlan Plan(
+        S129UkcPlanMetadata? meta = null,
+        S129UkcPlanArea? area = null,
+        ImmutableArray<S129ControlPoint>? controlPoints = null,
+        ImmutableArray<S129NonNavigableArea>? nonNav = null,
+        ImmutableArray<S129AlmostNonNavigableArea>? almostNonNav = null) => new()
+    {
+        Plan = meta,
+        PlanArea = area,
+        ControlPoints = controlPoints ?? ImmutableArray<S129ControlPoint>.Empty,
+        NonNavigableAreas = nonNav ?? ImmutableArray<S129NonNavigableArea>.Empty,
+        AlmostNonNavigableAreas = almostNonNav ?? ImmutableArray<S129AlmostNonNavigableArea>.Empty,
+        Source = EmptyDataset,
+    };
+
+    private static DateTimeOffset T(int minute) =>
+        new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero).AddMinutes(minute);
+
+    // ── S129-R-1.1 — plan validity period ─────────────────────────
+
+    [Fact]
+    public void PlanValidityPeriod_Passes_WhenNoRange()
+    {
+        var plan = Plan(meta: PlanMeta());
+        Assert.Empty(S129UkcRules.PlanValidityPeriod.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PlanValidityPeriod_Passes_WhenOnlyOneBoundPresent()
+    {
+        var plan = Plan(meta: PlanMeta(start: T(0)));
+        Assert.Empty(S129UkcRules.PlanValidityPeriod.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PlanValidityPeriod_Passes_WhenStartBeforeEnd()
+    {
+        var plan = Plan(meta: PlanMeta(start: T(0), end: T(30)));
+        Assert.Empty(S129UkcRules.PlanValidityPeriod.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PlanValidityPeriod_Passes_WhenStartEqualsEnd()
+    {
+        var plan = Plan(meta: PlanMeta(start: T(0), end: T(0)));
+        Assert.Empty(S129UkcRules.PlanValidityPeriod.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PlanValidityPeriod_Fails_WhenInverted()
+    {
+        var plan = Plan(meta: PlanMeta(id: "PLAN-X", start: T(30), end: T(0)));
+        var f = Assert.Single(
+            S129UkcRules.PlanValidityPeriod.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-1.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("PLAN-X", f.RelatedFeatureId);
+    }
+
+    // ── S129-R-2.1 — control-point time monotonicity ─────────────
+
+    [Fact]
+    public void ControlPointTimeMonotonic_Passes_OnStrictlyIncreasing()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1", time: T(0)),
+            ControlPoint("CP2", time: T(5)),
+            ControlPoint("CP3", time: T(10))));
+        Assert.Empty(S129UkcRules.ControlPointTimeMonotonic.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ControlPointTimeMonotonic_Passes_WhenSomeHaveNoTime()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1", time: T(0)),
+            ControlPoint("CP2"),
+            ControlPoint("CP3", time: T(10))));
+        Assert.Empty(S129UkcRules.ControlPointTimeMonotonic.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ControlPointTimeMonotonic_Fails_OnDuplicateTime()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1", time: T(5)),
+            ControlPoint("CP2", time: T(5))));
+        var f = Assert.Single(
+            S129UkcRules.ControlPointTimeMonotonic.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-2.1", f.RuleId);
+        Assert.Equal("CP2", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void ControlPointTimeMonotonic_Fails_OnBackwardsStep()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1", time: T(10)),
+            ControlPoint("CP2", time: T(5))));
+        var f = Assert.Single(
+            S129UkcRules.ControlPointTimeMonotonic.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Contains("CP1", f.Message);
+        Assert.Contains("CP2", f.Message);
+    }
+
+    // ── S129-R-3.1 — WGS-84 coordinate range ─────────────────────
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Passes_OnValidCoordinates()
+    {
+        var plan = Plan(
+            controlPoints: ImmutableArray.Create(
+                ControlPoint("CP1", lat: 10, lon: 20),
+                ControlPoint("CP2", lat: -45, lon: 178)),
+            area: PlanArea("PA", ImmutableArray.Create(
+                new GeoPosition(0, 0), new GeoPosition(0, 1), new GeoPosition(1, 1))));
+        Assert.Empty(S129UkcRules.CoordinatesInWgs84Range.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnControlPointOutOfRange()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1", lat: 91, lon: 0)));
+        var f = Assert.Single(
+            S129UkcRules.CoordinatesInWgs84Range.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-3.1", f.RuleId);
+        Assert.Equal("CP1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnPlanAreaOutOfRange()
+    {
+        var plan = Plan(area: PlanArea("PA", ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(0, 200), new GeoPosition(1, 1))));
+        var findings = S129UkcRules.CoordinatesInWgs84Range
+            .Evaluate(plan, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("PA", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnNonNavigableAreaOutOfRange()
+    {
+        var plan = Plan(nonNav: ImmutableArray.Create(
+            NonNav("NN1", ImmutableArray.Create(
+                new GeoPosition(-95, 0), new GeoPosition(0, 0), new GeoPosition(1, 1)))));
+        var f = Assert.Single(
+            S129UkcRules.CoordinatesInWgs84Range.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("NN1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnAlmostNonNavigableAreaOutOfRange()
+    {
+        var plan = Plan(almostNonNav: ImmutableArray.Create(
+            AlmostNonNav("AN1", ImmutableArray.Create(
+                new GeoPosition(0, -181), new GeoPosition(0, 0), new GeoPosition(1, 1)))));
+        var f = Assert.Single(
+            S129UkcRules.CoordinatesInWgs84Range.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("AN1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnInteriorRingOutOfRange()
+    {
+        var holes = ImmutableArray.Create(
+            ImmutableArray.Create(
+                new GeoPosition(0, 0), new GeoPosition(0, 0.5), new GeoPosition(95, 0.5)));
+        var plan = Plan(area: PlanArea(
+            "PA",
+            ImmutableArray.Create(new GeoPosition(0, 0), new GeoPosition(0, 1), new GeoPosition(1, 1)),
+            holes));
+        var f = Assert.Single(
+            S129UkcRules.CoordinatesInWgs84Range.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("PA", f.RelatedFeatureId);
+    }
+
+    // ── S129-R-3.2 — plan-area geometry populated ────────────────
+
+    [Fact]
+    public void PlanAreaGeometryPopulated_Passes_WhenNoPlanArea()
+    {
+        var plan = Plan();
+        Assert.Empty(S129UkcRules.PlanAreaGeometryPopulated.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PlanAreaGeometryPopulated_Passes_WhenThreeDistinctVertices()
+    {
+        var plan = Plan(area: PlanArea("PA", ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(0, 1), new GeoPosition(1, 1), new GeoPosition(0, 0))));
+        Assert.Empty(S129UkcRules.PlanAreaGeometryPopulated.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PlanAreaGeometryPopulated_Fails_WhenEmpty()
+    {
+        var plan = Plan(area: PlanArea("PA", ImmutableArray<GeoPosition>.Empty));
+        var f = Assert.Single(
+            S129UkcRules.PlanAreaGeometryPopulated.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-3.2", f.RuleId);
+        Assert.Equal("PA", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void PlanAreaGeometryPopulated_Fails_WhenAllVerticesIdentical()
+    {
+        var plan = Plan(area: PlanArea("PA", ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(0, 0), new GeoPosition(0, 0))));
+        var f = Assert.Single(
+            S129UkcRules.PlanAreaGeometryPopulated.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Contains("1 distinct", f.Message);
+    }
+
+    // ── S129-R-4.1 — maximum draught positive ────────────────────
+
+    [Fact]
+    public void MaximumDraughtPositive_Passes_WhenAbsent()
+    {
+        var plan = Plan(meta: PlanMeta());
+        Assert.Empty(S129UkcRules.MaximumDraughtPositive.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void MaximumDraughtPositive_Passes_WhenPositive()
+    {
+        var plan = Plan(meta: PlanMeta(maximumDraught: 8.5));
+        Assert.Empty(S129UkcRules.MaximumDraughtPositive.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1.0)]
+    public void MaximumDraughtPositive_Fails_WhenZeroOrNegative(double value)
+    {
+        var plan = Plan(meta: PlanMeta(id: "PLAN-Z", maximumDraught: value));
+        var f = Assert.Single(
+            S129UkcRules.MaximumDraughtPositive.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-4.1", f.RuleId);
+        Assert.Equal("PLAN-Z", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void MaximumDraughtPositive_Fails_WhenNonFinite()
+    {
+        var plan = Plan(meta: PlanMeta(maximumDraught: double.NaN));
+        var f = Assert.Single(
+            S129UkcRules.MaximumDraughtPositive.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-4.1", f.RuleId);
+    }
+
+    // ── S129-R-5.1 — measurements finite ─────────────────────────
+
+    [Fact]
+    public void ControlPointMeasurementsFinite_Passes_OnFiniteValues()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1", distance: 1.5, speed: 10.0),
+            ControlPoint("CP2", distance: -0.2, speed: 0.0)));
+        Assert.Empty(
+            S129UkcRules.ControlPointMeasurementsFinite.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ControlPointMeasurementsFinite_Passes_WhenMeasurementsAbsent()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(ControlPoint("CP1")));
+        Assert.Empty(
+            S129UkcRules.ControlPointMeasurementsFinite.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ControlPointMeasurementsFinite_Fails_OnNaNDistance()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP-NAN", distance: double.NaN)));
+        var f = Assert.Single(
+            S129UkcRules.ControlPointMeasurementsFinite
+                .Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-5.1", f.RuleId);
+        Assert.Equal("CP-NAN", f.RelatedFeatureId);
+        Assert.Contains("distanceAboveUKCLimit", f.Message);
+    }
+
+    [Fact]
+    public void ControlPointMeasurementsFinite_Fails_OnInfiniteSpeed()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP-INF", speed: double.PositiveInfinity)));
+        var f = Assert.Single(
+            S129UkcRules.ControlPointMeasurementsFinite
+                .Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Contains("expectedPassingSpeed", f.Message);
+    }
+
+    [Fact]
+    public void ControlPointMeasurementsFinite_ReportsBothMeasurementsSeparately()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP-BAD", distance: double.NaN, speed: double.NegativeInfinity)));
+        var findings = S129UkcRules.ControlPointMeasurementsFinite
+            .Evaluate(plan, ValidationContext.Default).ToList();
+        Assert.Equal(2, findings.Count);
+    }
+
+    // ── S129-R-5.2 — control point has position ──────────────────
+
+    [Fact]
+    public void ControlPointHasPosition_Passes_WhenAllHavePositions()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1"), ControlPoint("CP2", lat: 1, lon: 2)));
+        Assert.Empty(S129UkcRules.ControlPointHasPosition.Evaluate(plan, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ControlPointHasPosition_Fails_WhenMissing()
+    {
+        var plan = Plan(controlPoints: ImmutableArray.Create(
+            ControlPoint("CP1"),
+            ControlPoint("CP-NOPOS", withPosition: false)));
+        var f = Assert.Single(
+            S129UkcRules.ControlPointHasPosition.Evaluate(plan, ValidationContext.Default).ToList());
+        Assert.Equal("S129-R-5.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("CP-NOPOS", f.RelatedFeatureId);
+    }
+
+    // ── Rule set composition ─────────────────────────────────────
+
+    [Fact]
+    public void Default_ContainsSevenRules()
+    {
+        Assert.Equal(7, S129UkcRules.Default.Rules.Length);
+        Assert.Equal(
+            new[]
+            {
+                "S129-R-1.1", "S129-R-2.1", "S129-R-3.1", "S129-R-3.2",
+                "S129-R-4.1", "S129-R-5.1", "S129-R-5.2",
+            },
+            S129UkcRules.Default.Rules.Select(r => r.RuleId).ToArray());
+    }
+
+    [Fact]
+    public void Validate_ReturnsEmptyReport_OnClean()
+    {
+        var plan = Plan(
+            meta: PlanMeta(start: T(0), end: T(60), maximumDraught: 10.0),
+            area: PlanArea("PA", ImmutableArray.Create(
+                new GeoPosition(0, 0), new GeoPosition(0, 1), new GeoPosition(1, 1))),
+            controlPoints: ImmutableArray.Create(
+                ControlPoint("CP1", time: T(5), lat: 0.1, lon: 0.1, distance: 2.0, speed: 8.0),
+                ControlPoint("CP2", time: T(15), lat: 0.2, lon: 0.2, distance: 1.5, speed: 8.0)));
+
+        var report = S129UkcRules.Validate(plan);
+
+        Assert.Empty(report.Findings);
+    }
+
+    [Fact]
+    public void Validate_AggregatesFindingsAcrossRules()
+    {
+        var plan = Plan(
+            meta: PlanMeta(start: T(60), end: T(0), maximumDraught: -1.0),
+            controlPoints: ImmutableArray.Create(
+                ControlPoint("CP-NOPOS", withPosition: false),
+                ControlPoint("CP1", time: T(5), lat: 0, lon: 0, distance: double.NaN)));
+
+        var report = S129UkcRules.Validate(plan);
+
+        var ruleIds = report.Findings.Select(f => f.RuleId).Distinct().OrderBy(x => x).ToArray();
+        Assert.Contains("S129-R-1.1", ruleIds);
+        Assert.Contains("S129-R-4.1", ruleIds);
+        Assert.Contains("S129-R-5.1", ruleIds);
+        Assert.Contains("S129-R-5.2", ruleIds);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullPlan()
+    {
+        Assert.Throws<ArgumentNullException>(() => S129UkcRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `S129UkcRules`, a typed validation rule pack for `S129UnderKeelClearancePlan`, following the pattern established by the S-421 pilot in #100. Layout mirrors `S421RoutePlanRules`: a `Validation/` folder inside `EncDotNet.S100.Datasets.S129`, each rule exposed as a static `IValidationRule<S129UnderKeelClearancePlan>` property, composed into a `Default` `ValidationRuleSet<…>` with a `Validate(plan)` convenience wrapper.

## Rules

Seven Tier-1 / Tier-2 rules, each citing the relevant S-129 Edition 2.0.0 feature-catalogue element in its XML doc:

| ID | Severity | What it checks |
|---|---|---|
| `S129-R-1.1` | Error | Plan `fixedTimeRange` start ≤ end when both bounds present |
| `S129-R-2.1` | Error | Control-point `expectedPassingTime` is strictly increasing |
| `S129-R-3.1` | Error | Every feature coordinate lies within WGS-84 bounds — S-100 Part 10b §6.2 |
| `S129-R-3.2` | Error | `UnderKeelClearancePlanArea` exterior ring has ≥ 3 distinct vertices |
| `S129-R-4.1` | Error | Plan `maximumDraught`, when present, is positive and finite |
| `S129-R-5.1` | Error | Control-point `distanceAboveUKCLimit` and `expectedPassingSpeed` are finite |
| `S129-R-5.2` | Warning | Every control point carries a point position |

## Tests

35 new xunit tests using synthetic in-memory plans (no GML fixtures): happy paths, edge cases (open-bound time ranges, equal start/end, mixed control points with/without times, interior-ring coordinates), and failure modes for each rule, plus composition tests for `Default` and `Validate`.

Full suite green: `dotnet test --configuration Release` — 0 failures.

## Deviations from the candidate rule list

- **Time-step monotonicity** is implemented as a per-control-point rule rather than per-CP nested time-series rule, because the typed projection collapses control points to a single record per CP — there is no inner `Group_NNN`-style time-step array to walk.
- **Reference depth positive** was retargeted to `maximumDraught`: the typed `S129UkcPlanMetadata` does not surface a `referenceDepth` property; `maximumDraught` is the closest semantically-equivalent positive-magnitude field on the plan.
- **No coincident consecutive waypoints** was dropped: S-129 control points are not S-421 waypoints (they are per-time-step measurements at producer-chosen positions), so the zero-length-leg rationale does not transfer. `ControlPointTimeMonotonic` covers the analogous "no duplicate step" concern in the time dimension.
- **UKC unit consistency** was dropped as structurally guaranteed: the typed model exposes `DistanceAboveUkcLimit` as a `double?` in metres per the S-129 attribute definition; there is no per-CP unit field to disagree with.
- **Plan geometry non-empty** is implemented as the plan-area-ring rule (`S129-R-3.2`): the S-129 plan's spatial extent is the `UnderKeelClearancePlanArea` surface, not a polyline of waypoints.

Tier-3 cross-dataset rules (e.g. comparing a control-point UKC margin against the charted depth at the same position in a loaded S-102 coverage) are deferred to the MCP `validate_all` surface and the `S129Fusion` library, mirroring the deferral #100 makes for S-421.

## Spec alignment

- [x] S-100 framework (`s100-framework`) — cited Part 10b §6.2 in `S129-R-3.1`
- [x] S-129 under keel clearance (`s129-ukc`)

## Tests

- [x] Added xunit tests under `tests/EncDotNet.S100.Datasets.S129.Tests/Validation/`
- [x] New tests use synthetic in-memory plans (no real fixtures required)
- [x] `dotnet test --configuration Release` passes locally

## Documentation

- [x] Updated `src/EncDotNet.S100.Datasets.S129/README.md` with a new "Validation" section
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None. All additions.