### PR TITLE
Add S-131 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S131/README.md
+++ b/src/EncDotNet.S100.Datasets.S131/README.md
@@ -195,6 +195,35 @@ foreach (var feature in dataset.Features)
 }
 ```
 
+## Validation
+
+`S131HarbourInfrastructureRules.Default` is a pilot rule set of
+Tier-1/Tier-2 checks that run against a typed
+`S131HarbourInfrastructureDataset`. Each rule's ID traces to an S-131
+or S-100 spec clause.
+
+| Rule ID | Description | Severity |
+|---|---|---|
+| `S131-R-1.1` | `HarbourPhysicalInfrastructure` features must have non-empty geometry (container `HarbourFacility` exempt). | Error |
+| `S131-R-1.2` | `Layout` features must have non-empty geometry. | Error |
+| `S131-R-2.1` | `availableBerthingLength`, when present, must be a non-negative numeric value (metres). | Warning |
+| `S131-R-3.1` | Every coordinate must lie within the WGS-84 lat/lon ranges (S-100 Part 10b §6.2). | Error |
+| `S131-R-3.2` | Surface rings must have ≥ 4 vertices and be closed (first = last). | Error |
+| `S131-R-4.1` | Feature and information-type `gml:id` values must be unique within the dataset. | Error |
+| `S131-R-5.1` | All `xlink:href` references must resolve to a peer in the dataset (covers both feature and information-type axes). | Warning |
+| `S131-R-6.1` | Feature and information-type codes must be declared in the S-131 Feature Catalogue. | Warning |
+
+```csharp
+var typed = S131HarbourInfrastructureDataset.From(dataset, out _);
+var report = S131HarbourInfrastructureRules.Validate(typed);
+foreach (var f in report.Findings)
+    Console.WriteLine($"[{f.Severity}] {f.RuleId}: {f.Message}");
+```
+
+Tier-3 cross-dataset rules (e.g. cross-checking `Berth` depths against
+a loaded S-102 bathymetric surface) are out of scope here; they would
+reach sibling datasets via `ValidationContext.Services`.
+
 ## Dependencies
 
 - `EncDotNet.S100.Core` — GML abstractions, pipeline interfaces

--- a/src/EncDotNet.S100.Datasets.S131/Validation/S131HarbourInfrastructureRules.cs
+++ b/src/EncDotNet.S100.Datasets.S131/Validation/S131HarbourInfrastructureRules.cs
@@ -1,0 +1,555 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S131.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S131.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-131 <see cref="S131HarbourInfrastructureDataset"/>. Rule
+/// identifiers follow the convention <c>S131-R-{clause}</c>, where
+/// <c>{clause}</c> traces to the relevant section of the S-131
+/// Product Specification (FC Edition 1.0.0 / PC Edition 2.0.0) or the
+/// S-100 framework (Part 10b §6.2 for coordinate encoding).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single
+/// <see cref="S131HarbourInfrastructureDataset"/> in isolation. Tier-3
+/// cross-dataset rules (e.g. cross-checking <c>Berth</c> depths against a
+/// loaded S-102 bathymetric surface) are out of scope here — they would
+/// reach sibling datasets via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// <para>
+/// S-131 has a few characteristics worth flagging up-front:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///     Container-style information types (e.g. <c>Authority</c>) never
+///     carry geometry — these are modelled as <see cref="IS131InformationType"/>
+///     and are excluded from geometry-presence rules by construction.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     A handful of <c>HarbourPhysicalInfrastructure</c> features
+///     (e.g. <see cref="S131HarbourInfrastructureKind.HarbourFacility"/>)
+///     are container-style in practice — they aggregate child features
+///     through xlinks and may legitimately have no geometry. These
+///     kinds are exempted from <see cref="HarbourInfrastructureGeometryPresent"/>.
+///     </description>
+///   </item>
+/// </list>
+/// </remarks>
+public static class S131HarbourInfrastructureRules
+{
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static IEnumerable<GeoPosition> EnumerateCoordinates(S131Geometry geometry)
+    {
+        if (geometry.IsEmpty)
+            yield break;
+
+        foreach (var p in geometry.Points)
+            yield return p;
+
+        foreach (var curve in geometry.Curves)
+            foreach (var p in curve)
+                yield return p;
+
+        foreach (var p in geometry.ExteriorRing)
+            yield return p;
+
+        foreach (var ring in geometry.InteriorRings)
+            foreach (var p in ring)
+                yield return p;
+    }
+
+    private static bool IsValidWgs84(GeoPosition p) =>
+        p.Latitude is >= -90 and <= 90 && p.Longitude is >= -180 and <= 180;
+
+    /// <summary>
+    /// Harbour-physical-infrastructure kinds that, per the S-131 FC
+    /// (§B.2), are container-style and may legitimately appear without
+    /// geometry — they aggregate child features through xlinks. These
+    /// are exempted from the geometry-presence rule.
+    /// </summary>
+    private static readonly ImmutableHashSet<S131HarbourInfrastructureKind> ContainerHarbourKinds =
+        ImmutableHashSet.Create(
+            S131HarbourInfrastructureKind.HarbourFacility);
+
+    // ── S131-R-1.1 — harbour-infrastructure geometry present ───────────
+
+    /// <summary>
+    /// <c>S131-R-1.1</c> — Every non-container
+    /// <c>HarbourPhysicalInfrastructure</c> feature must carry a
+    /// non-empty geometry.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-131 FC Edition 1.0.0 §B.2 — features such as
+    /// <c>Bollard</c>, <c>Dolphin</c>, <c>DryDock</c>, <c>MooringBuoy</c>,
+    /// <c>LockBasin</c>, etc. describe fixed physical installations and
+    /// require a spatial anchor. Container-style kinds (currently only
+    /// <c>HarbourFacility</c>) are exempted because they aggregate
+    /// constituent features by xlink and may have no geometry of their
+    /// own.
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> HarbourInfrastructureGeometryPresent { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-1.1")
+            .WithDescription("HarbourPhysicalInfrastructure features must have non-empty geometry.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in dataset.HarbourInfrastructure)
+                {
+                    if (ContainerHarbourKinds.Contains(f.Kind)) continue;
+                    if (!f.Geometry.IsEmpty) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S131-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Harbour infrastructure feature '{f.Id}' ({f.FeatureType}) has no geometry.",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S131-R-1.2 — layout-feature geometry present ───────────────────
+
+    /// <summary>
+    /// <c>S131-R-1.2</c> — Every <c>Layout</c> feature (berths,
+    /// terminals, anchorage areas, harbour basins, etc.) must carry a
+    /// non-empty geometry.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-131 FC Edition 1.0.0 §B.2 — every
+    /// <c>Layout</c>-derived feature is intrinsically spatial; a berth
+    /// without coordinates cannot be drawn or routed to. Unlike the
+    /// <c>HarbourPhysicalInfrastructure</c> branch there are no
+    /// container exceptions among layout features.
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> LayoutFeatureGeometryPresent { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-1.2")
+            .WithDescription("Layout features must have non-empty geometry.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in dataset.LayoutFeatures)
+                {
+                    if (!f.Geometry.IsEmpty) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S131-R-1.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Layout feature '{f.Id}' ({f.FeatureType}) has no geometry.",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S131-R-2.1 — available berthing length non-negative ────────────
+
+    /// <summary>
+    /// <c>S131-R-2.1</c> — When the <c>availableBerthingLength</c>
+    /// attribute is present on a feature, its value must be a valid
+    /// non-negative number expressed in metres.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-131 FC Edition 1.0.0 — the
+    /// <c>availableBerthingLength</c> simple attribute is bound to
+    /// <c>Berth</c>, <c>BerthPosition</c>, and related layout features;
+    /// the FC declares the quantity specification as <c>length</c>
+    /// with the SI base unit (metres), so negative or non-numeric
+    /// values are nonsensical.
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> AvailableBerthingLengthNonNegative { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-2.1")
+            .WithDescription("availableBerthingLength must be a non-negative numeric value.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                const string code = "availableBerthingLength";
+                var findings = new List<ValidationFinding>();
+
+                foreach (var f in dataset.Features)
+                {
+                    if (!f.Source.Attributes.TryGetValue(code, out var raw)) continue;
+                    if (string.IsNullOrWhiteSpace(raw)) continue;
+
+                    if (!double.TryParse(
+                            raw,
+                            System.Globalization.NumberStyles.Float,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out var value))
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-2.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Feature '{f.Id}' ({f.FeatureType}) has non-numeric " +
+                                $"{code} value '{raw}'.",
+                            RelatedFeatureId = f.Id,
+                        });
+                        continue;
+                    }
+
+                    if (value < 0)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-2.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Feature '{f.Id}' ({f.FeatureType}) has negative " +
+                                $"{code} value ({value} m).",
+                            RelatedFeatureId = f.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S131-R-3.1 — WGS-84 lat/lon ranges ─────────────────────────────
+
+    /// <summary>
+    /// <c>S131-R-3.1</c> — Every coordinate on every feature geometry
+    /// (point, curve, exterior ring, interior ring) must lie within
+    /// the valid WGS-84 ranges: latitude in [-90, +90] and longitude
+    /// in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded. S-131 uses the S-100 GML 5.0
+    /// profile with lat/lon ordering for <c>gml:pos</c> and
+    /// <c>gml:posList</c>.
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> CoordinatesInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-3.1")
+            .WithDescription("All coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var f in dataset.Features)
+                {
+                    foreach (var p in EnumerateCoordinates(f.Geometry))
+                    {
+                        if (IsValidWgs84(p)) continue;
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-3.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{f.Id}' ({f.FeatureType}) has coordinate " +
+                                $"({p.Latitude}, {p.Longitude}) outside WGS-84 bounds.",
+                            Point = p,
+                            RelatedFeatureId = f.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S131-R-3.2 — surface ring closure ──────────────────────────────
+
+    /// <summary>
+    /// <c>S131-R-3.2</c> — Every surface feature's exterior and
+    /// interior rings must be closed (first vertex equals last) and
+    /// contain at least four vertices.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b (GML profile) — surface rings are
+    /// encoded as <c>gml:LinearRing</c>, which by the OGC GML 3.2 rules
+    /// must be closed and contain at least four positions (three
+    /// distinct vertices plus the closing repeat).
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> SurfaceRingsClosed { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-3.2")
+            .WithDescription("Surface rings must have ≥ 4 vertices and be closed (first = last).")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                const double tolerance = 1e-9;
+                var findings = new List<ValidationFinding>();
+
+                foreach (var f in dataset.Features)
+                {
+                    if (f.Geometry.GeometryType != S131GeometryType.Surface) continue;
+
+                    CheckRing(f, "exterior ring", f.Geometry.ExteriorRing, findings, tolerance);
+                    for (int i = 0; i < f.Geometry.InteriorRings.Length; i++)
+                    {
+                        CheckRing(f, $"interior ring [{i}]", f.Geometry.InteriorRings[i], findings, tolerance);
+                    }
+                }
+                return findings;
+
+                static void CheckRing(
+                    IS131Feature f,
+                    string label,
+                    ImmutableArray<GeoPosition> ring,
+                    List<ValidationFinding> sink,
+                    double tolerance)
+                {
+                    if (ring.IsDefaultOrEmpty) return;
+
+                    if (ring.Length < 4)
+                    {
+                        sink.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-3.2",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{f.Id}' ({f.FeatureType}) {label} has only " +
+                                $"{ring.Length} vertex/vertices; a closed ring requires at least 4.",
+                            RelatedFeatureId = f.Id,
+                        });
+                        return;
+                    }
+
+                    var first = ring[0];
+                    var last = ring[^1];
+                    if (Math.Abs(first.Latitude - last.Latitude) > tolerance
+                        || Math.Abs(first.Longitude - last.Longitude) > tolerance)
+                    {
+                        sink.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-3.2",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Feature '{f.Id}' ({f.FeatureType}) {label} is not closed " +
+                                $"(first=({first.Latitude}, {first.Longitude}), " +
+                                $"last=({last.Latitude}, {last.Longitude})).",
+                            Point = first,
+                            RelatedFeatureId = f.Id,
+                        });
+                    }
+                }
+            })
+            .Build();
+
+    // ── S131-R-4.1 — unique feature / info-type identifiers ────────────
+
+    /// <summary>
+    /// <c>S131-R-4.1</c> — No two features (and no two information
+    /// types) in a dataset may share the same <c>gml:id</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §7 (GML identifier model) —
+    /// <c>gml:id</c> values must be unique within the document. The
+    /// typed-projection layer also emits an <c>s131.id.duplicate</c>
+    /// diagnostic for this condition; the rule re-surfaces it as an
+    /// addressable Error finding in the validation report.
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> UniqueFeatureIds { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-4.1")
+            .WithDescription("Feature and information-type gml:id values must be unique within the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                ReportDuplicates(
+                    dataset.Features.Select(f => (f.Id, Kind: "feature")),
+                    findings);
+                ReportDuplicates(
+                    dataset.InformationTypes.Select(i => (i.Id, Kind: "information type")),
+                    findings);
+
+                return findings;
+
+                static void ReportDuplicates(
+                    IEnumerable<(string Id, string Kind)> items,
+                    List<ValidationFinding> sink)
+                {
+                    var seen = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var (id, kind) in items)
+                    {
+                        if (string.IsNullOrEmpty(id)) continue;
+                        if (seen.TryGetValue(id, out var n))
+                        {
+                            seen[id] = n + 1;
+                            sink.Add(new ValidationFinding
+                            {
+                                RuleId = "S131-R-4.1",
+                                Severity = ValidationSeverity.Error,
+                                Message = $"Duplicate {kind} gml:id '{id}'.",
+                                RelatedFeatureId = id,
+                            });
+                        }
+                        else
+                        {
+                            seen[id] = 1;
+                        }
+                    }
+                }
+            })
+            .Build();
+
+    // ── S131-R-5.1 — xlink resolution sanity ──────────────────────────
+
+    /// <summary>
+    /// <c>S131-R-5.1</c> — Every <c>xlink:href</c> reference recorded
+    /// in <see cref="IS131Feature.ResolvedReferences"/> or
+    /// <see cref="IS131InformationType.ResolvedReferences"/> must
+    /// resolve to a typed peer in the same dataset.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Spec reference: S-131 FC Edition 1.0.0 §B.3 — feature/info-type
+    /// associations are encoded as <c>xlink:href</c> attributes on
+    /// role-bearing child elements; the target must exist within the
+    /// dataset's id space.
+    /// </para>
+    /// <para>
+    /// <b>Deviation from S-421 R-7.x:</b> S-421 only carries
+    /// feature-to-feature xlinks (waypoints, legs, action points) which
+    /// can be reasoned about purely from the typed
+    /// <c>S421RoutePlan</c> graph. S-131 also carries information-type
+    /// bindings (e.g. <c>Authority</c> → <c>ContactDetails</c>) that
+    /// are surfaced through <see cref="IS131InformationType.ResolvedReferences"/>,
+    /// so this rule checks both axes.
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> ResolvedReferencesNotNull { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-5.1")
+            .WithDescription("All xlink:href references must resolve to a peer in the dataset.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                foreach (var f in dataset.Features)
+                {
+                    foreach (var r in f.ResolvedReferences)
+                    {
+                        if (r.Target is not null) continue;
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-5.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Feature '{f.Id}' ({f.FeatureType}) has unresolved " +
+                                $"{r.Role} xlink to '{r.TargetRef}'.",
+                            RelatedFeatureId = f.Id,
+                        });
+                    }
+                }
+
+                foreach (var i in dataset.InformationTypes)
+                {
+                    foreach (var r in i.ResolvedReferences)
+                    {
+                        if (r.Target is not null) continue;
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S131-R-5.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Information type '{i.Id}' ({i.TypeCode}) has unresolved " +
+                                $"{r.Role} xlink to '{r.TargetRef}'.",
+                            RelatedFeatureId = i.Id,
+                        });
+                    }
+                }
+
+                return findings;
+            })
+            .Build();
+
+    // ── S131-R-6.1 — feature/info-type code recognised ─────────────────
+
+    /// <summary>
+    /// <c>S131-R-6.1</c> — Every feature and information type in the
+    /// dataset must use a code declared in the S-131 Feature Catalogue
+    /// (Edition 1.0.0). Unknown codes — i.e. projections that surface
+    /// as <see cref="S131OtherFeature"/> or
+    /// <see cref="S131OtherInformationType"/> — are surfaced as Warnings.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-131 FC Edition 1.0.0 §B.1, §B.2 — the FC
+    /// closes over the legal feature- and information-type code lists.
+    /// A warning (rather than an error) is used so that forward-compat
+    /// extensions in future FC editions remain consumable while still
+    /// flagging unrecognised codes for follow-up.
+    /// </remarks>
+    public static IValidationRule<S131HarbourInfrastructureDataset> FeatureCodeRecognised { get; } =
+        ValidationRuleBuilder.RuleFor<S131HarbourInfrastructureDataset>("S131-R-6.1")
+            .WithDescription("Feature and information-type codes must be declared in the S-131 FC.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                foreach (var f in dataset.OtherFeatures)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S131-R-6.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Feature '{f.Id}' uses unrecognised feature type '{f.FeatureType}'.",
+                        RelatedFeatureId = f.Id,
+                    });
+                }
+
+                foreach (var i in dataset.InformationTypes.OfType<S131OtherInformationType>())
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S131-R-6.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"Information type '{i.Id}' uses unrecognised type code '{i.TypeCode}'.",
+                        RelatedFeatureId = i.Id,
+                    });
+                }
+
+                return findings;
+            })
+            .Build();
+
+    // ── Default rule set ──────────────────────────────────────────────
+
+    /// <summary>The canonical default rule set for S-131 harbour-infrastructure datasets.</summary>
+    public static ValidationRuleSet<S131HarbourInfrastructureDataset> Default { get; } = new(
+        HarbourInfrastructureGeometryPresent,
+        LayoutFeatureGeometryPresent,
+        AvailableBerthingLengthNonNegative,
+        CoordinatesInWgs84Range,
+        SurfaceRingsClosed,
+        UniqueFeatureIds,
+        ResolvedReferencesNotNull,
+        FeatureCodeRecognised);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(
+        S131HarbourInfrastructureDataset dataset,
+        ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S131.Tests/Validation/S131HarbourInfrastructureRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S131.Tests/Validation/S131HarbourInfrastructureRulesTests.cs
@@ -1,0 +1,568 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S131.Validation;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S131.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S131HarbourInfrastructureRules"/>. Each test
+/// constructs a minimal synthetic <see cref="S131HarbourInfrastructureDataset"/>
+/// in memory by directly composing typed projection records, bypassing
+/// the GML reader and the projection factory. This keeps the tests
+/// focused on validation logic and independent of fixture files.
+/// </summary>
+public class S131HarbourInfrastructureRulesTests
+{
+    // ── Synthetic-model helpers ──────────────────────────────────────
+
+    private static S131Feature RawFeature(
+        string id,
+        string featureType,
+        ImmutableDictionary<string, string>? attributes = null) => new()
+        {
+            Id = id,
+            FeatureType = featureType,
+            Attributes = attributes ?? ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S131ComplexAttribute>.Empty,
+            References = ImmutableArray<S131Reference>.Empty,
+        };
+
+    private static S131InformationType RawInfoType(string id, string typeCode) => new()
+    {
+        Id = id,
+        TypeCode = typeCode,
+        Attributes = ImmutableDictionary<string, string>.Empty,
+        ComplexAttributes = ImmutableArray<S131ComplexAttribute>.Empty,
+    };
+
+    private static S131Geometry PointGeometry(double lat, double lon) => new()
+    {
+        GeometryType = S131GeometryType.Point,
+        Points = ImmutableArray.Create(new GeoPosition(lat, lon)),
+    };
+
+    private static S131Geometry CurveGeometry(params (double lat, double lon)[] coords) => new()
+    {
+        GeometryType = S131GeometryType.Curve,
+        Curves = ImmutableArray.Create(
+            coords.Select(c => new GeoPosition(c.lat, c.lon)).ToImmutableArray()),
+    };
+
+    private static S131Geometry SurfaceGeometry(
+        ImmutableArray<GeoPosition> exterior,
+        ImmutableArray<ImmutableArray<GeoPosition>>? interior = null) => new()
+        {
+            GeometryType = S131GeometryType.Surface,
+            ExteriorRing = exterior,
+            InteriorRings = interior ?? ImmutableArray<ImmutableArray<GeoPosition>>.Empty,
+        };
+
+    private static ImmutableArray<GeoPosition> Ring(params (double lat, double lon)[] coords) =>
+        coords.Select(c => new GeoPosition(c.lat, c.lon)).ToImmutableArray();
+
+    private static S131HarbourInfrastructure HarbourInfra(
+        string id,
+        string featureType,
+        S131HarbourInfrastructureKind kind,
+        S131Geometry? geometry = null,
+        ImmutableDictionary<string, string>? attributes = null,
+        ImmutableArray<S131ResolvedReference>? resolved = null)
+    {
+        var raw = RawFeature(id, featureType, attributes);
+        return new S131HarbourInfrastructure
+        {
+            Id = id,
+            FeatureType = featureType,
+            Kind = kind,
+            Geometry = geometry ?? S131Geometry.Empty,
+            Source = raw,
+            ResolvedReferences = resolved ?? ImmutableArray<S131ResolvedReference>.Empty,
+        };
+    }
+
+    private static S131LayoutFeature Layout(
+        string id,
+        string featureType,
+        S131LayoutKind kind,
+        S131Geometry? geometry = null,
+        ImmutableDictionary<string, string>? attributes = null,
+        ImmutableArray<S131ResolvedReference>? resolved = null)
+    {
+        var raw = RawFeature(id, featureType, attributes);
+        return new S131LayoutFeature
+        {
+            Id = id,
+            FeatureType = featureType,
+            Kind = kind,
+            Geometry = geometry ?? S131Geometry.Empty,
+            Source = raw,
+            ResolvedReferences = resolved ?? ImmutableArray<S131ResolvedReference>.Empty,
+        };
+    }
+
+    private static S131OtherFeature Other(string id, string featureType) => new()
+    {
+        Id = id,
+        FeatureType = featureType,
+        Geometry = PointGeometry(0, 0),
+        Source = RawFeature(id, featureType),
+    };
+
+    private static S131Authority Authority(
+        string id,
+        ImmutableArray<S131ResolvedReference>? resolved = null) => new()
+        {
+            Id = id,
+            Source = RawInfoType(id, "Authority"),
+            ResolvedReferences = resolved ?? ImmutableArray<S131ResolvedReference>.Empty,
+        };
+
+    private static S131OtherInformationType OtherInfo(string id, string typeCode) => new()
+    {
+        Id = id,
+        TypeCode = typeCode,
+        Source = RawInfoType(id, typeCode),
+    };
+
+    private static S131HarbourInfrastructureDataset Dataset(
+        IEnumerable<IS131Feature>? features = null,
+        IEnumerable<IS131InformationType>? infoTypes = null)
+    {
+        var feats = (features ?? Array.Empty<IS131Feature>()).ToImmutableArray();
+        var infos = (infoTypes ?? Array.Empty<IS131InformationType>()).ToImmutableArray();
+
+        var rawDataset = new S131Dataset
+        {
+            ProductIdentifier = "S-131",
+            Features = feats.Select(f => f.Source).ToImmutableArray(),
+            InformationTypes = infos.Select(i => i.Source).ToImmutableArray(),
+        };
+
+        return new S131HarbourInfrastructureDataset
+        {
+            ProductIdentifier = "S-131",
+            Features = feats,
+            InformationTypes = infos,
+            HarbourInfrastructure = feats.OfType<S131HarbourInfrastructure>().ToImmutableArray(),
+            LayoutFeatures = feats.OfType<S131LayoutFeature>().ToImmutableArray(),
+            MetadataFeatures = feats.OfType<S131MetadataFeature>().ToImmutableArray(),
+            OtherFeatures = feats.OfType<S131OtherFeature>().ToImmutableArray(),
+            Authorities = infos.OfType<S131Authority>().ToImmutableArray(),
+            ContactDetails = infos.OfType<S131ContactDetails>().ToImmutableArray(),
+            RxNInformation = infos.OfType<S131RxNInformation>().ToImmutableArray(),
+            Source = rawDataset,
+        };
+    }
+
+    // ── S131-R-1.1 — harbour-infrastructure geometry present ─────────
+
+    [Fact]
+    public void HarbourInfrastructureGeometryPresent_Passes_WhenGeometryNonEmpty()
+    {
+        var f = HarbourInfra("BOLLARD-1", "Bollard", S131HarbourInfrastructureKind.Bollard,
+            PointGeometry(44.6, -63.5));
+        var report = S131HarbourInfrastructureRules.HarbourInfrastructureGeometryPresent
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default);
+        Assert.Empty(report);
+    }
+
+    [Fact]
+    public void HarbourInfrastructureGeometryPresent_Fails_WhenEmpty()
+    {
+        var f = HarbourInfra("BOLLARD-2", "Bollard", S131HarbourInfrastructureKind.Bollard);
+        var findings = S131HarbourInfrastructureRules.HarbourInfrastructureGeometryPresent
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("S131-R-1.1", finding.RuleId);
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Equal("BOLLARD-2", finding.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void HarbourInfrastructureGeometryPresent_Exempts_ContainerKind_HarbourFacility()
+    {
+        // HarbourFacility may legitimately have no geometry (it
+        // aggregates child features via xlinks).
+        var f = HarbourInfra("HARBOUR-FAC-1", "HarbourFacility",
+            S131HarbourInfrastructureKind.HarbourFacility);
+        var findings = S131HarbourInfrastructureRules.HarbourInfrastructureGeometryPresent
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    // ── S131-R-1.2 — layout-feature geometry present ─────────────────
+
+    [Fact]
+    public void LayoutFeatureGeometryPresent_Passes_WhenSurfacePopulated()
+    {
+        var berth = Layout("BERTH-1", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 1), (1, 1), (0, 0))));
+        var findings = S131HarbourInfrastructureRules.LayoutFeatureGeometryPresent
+            .Evaluate(Dataset(features: new[] { berth }), ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void LayoutFeatureGeometryPresent_Fails_WhenEmpty()
+    {
+        var berth = Layout("BERTH-EMPTY", "Berth", S131LayoutKind.Berth);
+        var findings = S131HarbourInfrastructureRules.LayoutFeatureGeometryPresent
+            .Evaluate(Dataset(features: new[] { berth }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("S131-R-1.2", finding.RuleId);
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Equal("BERTH-EMPTY", finding.RelatedFeatureId);
+        Assert.Contains("Berth", finding.Message);
+    }
+
+    // ── S131-R-2.1 — availableBerthingLength ─────────────────────────
+
+    [Fact]
+    public void AvailableBerthingLengthNonNegative_Passes_WhenAttributeAbsent()
+    {
+        var berth = Layout("BERTH-A", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 1), (1, 1), (0, 0))));
+        var findings = S131HarbourInfrastructureRules.AvailableBerthingLengthNonNegative
+            .Evaluate(Dataset(features: new[] { berth }), ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void AvailableBerthingLengthNonNegative_Passes_OnPositiveValue()
+    {
+        var attrs = ImmutableDictionary<string, string>.Empty
+            .Add("availableBerthingLength", "200.5");
+        var berth = Layout("BERTH-B", "Berth", S131LayoutKind.Berth, attributes: attrs);
+        var findings = S131HarbourInfrastructureRules.AvailableBerthingLengthNonNegative
+            .Evaluate(Dataset(features: new[] { berth }), ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void AvailableBerthingLengthNonNegative_Fails_OnNegativeValue()
+    {
+        var attrs = ImmutableDictionary<string, string>.Empty
+            .Add("availableBerthingLength", "-1");
+        var berth = Layout("BERTH-NEG", "Berth", S131LayoutKind.Berth, attributes: attrs);
+        var findings = S131HarbourInfrastructureRules.AvailableBerthingLengthNonNegative
+            .Evaluate(Dataset(features: new[] { berth }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal(ValidationSeverity.Warning, finding.Severity);
+        Assert.Equal("BERTH-NEG", finding.RelatedFeatureId);
+        Assert.Contains("negative", finding.Message);
+    }
+
+    [Fact]
+    public void AvailableBerthingLengthNonNegative_Fails_OnNonNumericValue()
+    {
+        var attrs = ImmutableDictionary<string, string>.Empty
+            .Add("availableBerthingLength", "two hundred");
+        var berth = Layout("BERTH-NAN", "Berth", S131LayoutKind.Berth, attributes: attrs);
+        var findings = S131HarbourInfrastructureRules.AvailableBerthingLengthNonNegative
+            .Evaluate(Dataset(features: new[] { berth }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Contains("non-numeric", finding.Message);
+    }
+
+    // ── S131-R-3.1 — coordinates in WGS-84 range ─────────────────────
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Passes_OnValidCoordinates()
+    {
+        var bollard = HarbourInfra("BO-1", "Bollard", S131HarbourInfrastructureKind.Bollard,
+            PointGeometry(44.6, -63.5));
+        var line = Layout("FEN-1", "FenderLine", S131LayoutKind.FenderLine,
+            CurveGeometry((44.6, -63.5), (44.7, -63.4)));
+        var findings = S131HarbourInfrastructureRules.CoordinatesInWgs84Range
+            .Evaluate(Dataset(features: new IS131Feature[] { bollard, line }), ValidationContext.Default);
+        Assert.Empty(findings);
+    }
+
+    [Theory]
+    [InlineData(91.0, 0.0)]
+    [InlineData(-90.5, 0.0)]
+    [InlineData(0.0, 181.0)]
+    [InlineData(0.0, -180.5)]
+    public void CoordinatesInWgs84Range_Fails_OnOutOfRange(double lat, double lon)
+    {
+        var f = HarbourInfra("BAD-COORD", "Bollard", S131HarbourInfrastructureKind.Bollard,
+            PointGeometry(lat, lon));
+        var findings = S131HarbourInfrastructureRules.CoordinatesInWgs84Range
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("S131-R-3.1", finding.RuleId);
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Equal("BAD-COORD", finding.RelatedFeatureId);
+        Assert.NotNull(finding.Point);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Checks_SurfaceRings()
+    {
+        var bad = Layout("BAD-SURF", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 200), (1, 200), (1, 0), (0, 0))));
+        var findings = S131HarbourInfrastructureRules.CoordinatesInWgs84Range
+            .Evaluate(Dataset(features: new[] { bad }), ValidationContext.Default).ToList();
+        Assert.NotEmpty(findings);
+        Assert.All(findings, f => Assert.Equal("BAD-SURF", f.RelatedFeatureId));
+    }
+
+    // ── S131-R-3.2 — surface ring closure ────────────────────────────
+
+    [Fact]
+    public void SurfaceRingsClosed_Passes_OnClosedRing()
+    {
+        var f = Layout("OK-SURF", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 1), (1, 1), (0, 0))));
+        Assert.Empty(S131HarbourInfrastructureRules.SurfaceRingsClosed
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingsClosed_Fails_WhenRingTooShort()
+    {
+        var f = Layout("SHORT", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 1), (0, 0))));
+        var findings = S131HarbourInfrastructureRules.SurfaceRingsClosed
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Contains("at least 4", finding.Message);
+        Assert.Equal("SHORT", finding.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void SurfaceRingsClosed_Fails_WhenNotClosed()
+    {
+        var f = Layout("OPEN", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 1), (1, 1), (1, 0))));
+        var findings = S131HarbourInfrastructureRules.SurfaceRingsClosed
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Contains("not closed", finding.Message);
+        Assert.Equal("OPEN", finding.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void SurfaceRingsClosed_Checks_InteriorRings()
+    {
+        var ext = Ring((0, 0), (0, 10), (10, 10), (10, 0), (0, 0));
+        var badInterior = Ring((1, 1), (1, 2), (2, 2), (2, 1)); // not closed
+        var f = Layout("HOLE", "HarbourBasin", S131LayoutKind.HarbourBasin,
+            SurfaceGeometry(ext, ImmutableArray.Create(badInterior)));
+        var findings = S131HarbourInfrastructureRules.SurfaceRingsClosed
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Contains("interior ring", finding.Message);
+    }
+
+    [Fact]
+    public void SurfaceRingsClosed_Ignores_PointAndCurveFeatures()
+    {
+        var pt = HarbourInfra("P", "Bollard", S131HarbourInfrastructureKind.Bollard,
+            PointGeometry(0, 0));
+        var cv = Layout("C", "FenderLine", S131LayoutKind.FenderLine,
+            CurveGeometry((0, 0), (1, 1)));
+        Assert.Empty(S131HarbourInfrastructureRules.SurfaceRingsClosed
+            .Evaluate(Dataset(features: new IS131Feature[] { pt, cv }), ValidationContext.Default));
+    }
+
+    // ── S131-R-4.1 — unique IDs ──────────────────────────────────────
+
+    [Fact]
+    public void UniqueFeatureIds_Passes_WhenAllUnique()
+    {
+        var a = HarbourInfra("A", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var b = HarbourInfra("B", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        Assert.Empty(S131HarbourInfrastructureRules.UniqueFeatureIds
+            .Evaluate(Dataset(features: new[] { a, b }), ValidationContext.Default));
+    }
+
+    [Fact]
+    public void UniqueFeatureIds_Fails_OnDuplicateFeatureId()
+    {
+        var a = HarbourInfra("DUP", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var b = HarbourInfra("DUP", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var findings = S131HarbourInfrastructureRules.UniqueFeatureIds
+            .Evaluate(Dataset(features: new[] { a, b }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("S131-R-4.1", finding.RuleId);
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Equal("DUP", finding.RelatedFeatureId);
+        Assert.Contains("feature", finding.Message);
+    }
+
+    [Fact]
+    public void UniqueFeatureIds_Fails_OnDuplicateInformationTypeId()
+    {
+        var a = Authority("AUTH-DUP");
+        var b = Authority("AUTH-DUP");
+        var findings = S131HarbourInfrastructureRules.UniqueFeatureIds
+            .Evaluate(Dataset(infoTypes: new[] { a, b }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Contains("information type", finding.Message);
+    }
+
+    // ── S131-R-5.1 — xlink resolution ────────────────────────────────
+
+    [Fact]
+    public void ResolvedReferencesNotNull_Passes_WhenAllTargetsResolved()
+    {
+        var target = HarbourInfra("T", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var resolved = ImmutableArray.Create(new S131ResolvedReference
+        {
+            Role = "theBollard",
+            TargetRef = "T",
+            Target = target,
+        });
+        var src = HarbourInfra("S", "Dolphin", S131HarbourInfrastructureKind.Dolphin,
+            PointGeometry(0, 0), resolved: resolved);
+        Assert.Empty(S131HarbourInfrastructureRules.ResolvedReferencesNotNull
+            .Evaluate(Dataset(features: new[] { src, target }), ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ResolvedReferencesNotNull_Fails_OnUnresolvedFeatureXlink()
+    {
+        var unresolved = ImmutableArray.Create(new S131ResolvedReference
+        {
+            Role = "theBollard",
+            TargetRef = "MISSING",
+            Target = null,
+        });
+        var src = HarbourInfra("S", "Dolphin", S131HarbourInfrastructureKind.Dolphin,
+            PointGeometry(0, 0), resolved: unresolved);
+        var findings = S131HarbourInfrastructureRules.ResolvedReferencesNotNull
+            .Evaluate(Dataset(features: new[] { src }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("S131-R-5.1", finding.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, finding.Severity);
+        Assert.Equal("S", finding.RelatedFeatureId);
+        Assert.Contains("MISSING", finding.Message);
+        Assert.Contains("theBollard", finding.Message);
+    }
+
+    [Fact]
+    public void ResolvedReferencesNotNull_Fails_OnUnresolvedInformationTypeXlink()
+    {
+        var unresolved = ImmutableArray.Create(new S131ResolvedReference
+        {
+            Role = "theContactDetails",
+            TargetRef = "MISSING-CD",
+            Target = null,
+        });
+        var auth = Authority("AUTH-1", resolved: unresolved);
+        var findings = S131HarbourInfrastructureRules.ResolvedReferencesNotNull
+            .Evaluate(Dataset(infoTypes: new[] { auth }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("AUTH-1", finding.RelatedFeatureId);
+        Assert.Contains("Authority", finding.Message);
+    }
+
+    // ── S131-R-6.1 — feature/info-type code recognised ──────────────
+
+    [Fact]
+    public void FeatureCodeRecognised_Passes_OnRecognisedKinds()
+    {
+        var f = HarbourInfra("OK", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var i = Authority("OK-AUTH");
+        Assert.Empty(S131HarbourInfrastructureRules.FeatureCodeRecognised
+            .Evaluate(Dataset(features: new[] { f }, infoTypes: new[] { i }), ValidationContext.Default));
+    }
+
+    [Fact]
+    public void FeatureCodeRecognised_Fails_OnOtherFeature()
+    {
+        var f = Other("MYST", "MysteryFeature");
+        var findings = S131HarbourInfrastructureRules.FeatureCodeRecognised
+            .Evaluate(Dataset(features: new[] { f }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Equal("S131-R-6.1", finding.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, finding.Severity);
+        Assert.Equal("MYST", finding.RelatedFeatureId);
+        Assert.Contains("MysteryFeature", finding.Message);
+    }
+
+    [Fact]
+    public void FeatureCodeRecognised_Fails_OnOtherInformationType()
+    {
+        var i = OtherInfo("WAT", "WatfordCode");
+        var findings = S131HarbourInfrastructureRules.FeatureCodeRecognised
+            .Evaluate(Dataset(infoTypes: new[] { i }), ValidationContext.Default).ToList();
+        var finding = Assert.Single(findings);
+        Assert.Contains("WatfordCode", finding.Message);
+    }
+
+    // ── Default rule set composition ────────────────────────────────
+
+    [Fact]
+    public void Default_ContainsAllEightRules()
+    {
+        Assert.Equal(8, S131HarbourInfrastructureRules.Default.Rules.Length);
+        var ids = S131HarbourInfrastructureRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Contains("S131-R-1.1", ids);
+        Assert.Contains("S131-R-1.2", ids);
+        Assert.Contains("S131-R-2.1", ids);
+        Assert.Contains("S131-R-3.1", ids);
+        Assert.Contains("S131-R-3.2", ids);
+        Assert.Contains("S131-R-4.1", ids);
+        Assert.Contains("S131-R-5.1", ids);
+        Assert.Contains("S131-R-6.1", ids);
+    }
+
+    [Fact]
+    public void Validate_OnValidDataset_ProducesNoFindings()
+    {
+        var bollard = HarbourInfra("BO-1", "Bollard", S131HarbourInfrastructureKind.Bollard,
+            PointGeometry(44.6, -63.5));
+        var berth = Layout("BE-1", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((44.6, -63.5), (44.6, -63.4), (44.7, -63.4), (44.6, -63.5))));
+        var auth = Authority("AU-1");
+
+        var report = S131HarbourInfrastructureRules.Validate(
+            Dataset(features: new IS131Feature[] { bollard, berth }, infoTypes: new[] { auth }));
+        Assert.True(report.IsValid);
+        Assert.Empty(report.Findings);
+        Assert.Equal(8, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_OnInvalidDataset_AggregatesFindingsAcrossRules()
+    {
+        // Empty-geometry harbour infra (1.1), empty-geometry layout (1.2),
+        // negative berthing length (2.1), out-of-range coord (3.1),
+        // unknown feature type (6.1), duplicate id (4.1).
+        var emptyBollard = HarbourInfra("EMPTY-BO", "Bollard", S131HarbourInfrastructureKind.Bollard);
+        var emptyBerth = Layout("EMPTY-BE", "Berth", S131LayoutKind.Berth);
+        var negBerth = Layout("NEG-BE", "Berth", S131LayoutKind.Berth,
+            SurfaceGeometry(Ring((0, 0), (0, 1), (1, 1), (0, 0))),
+            attributes: ImmutableDictionary<string, string>.Empty.Add("availableBerthingLength", "-5"));
+        var badCoord = HarbourInfra("BAD", "Bollard", S131HarbourInfrastructureKind.Bollard,
+            PointGeometry(99, 0));
+        var dup1 = HarbourInfra("DUP", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var dup2 = HarbourInfra("DUP", "Bollard", S131HarbourInfrastructureKind.Bollard, PointGeometry(0, 0));
+        var mystery = Other("MYST", "Mystery");
+
+        var report = S131HarbourInfrastructureRules.Validate(
+            Dataset(features: new IS131Feature[]
+            {
+                emptyBollard, emptyBerth, negBerth, badCoord, dup1, dup2, mystery,
+            }));
+
+        Assert.False(report.IsValid);
+        var ids = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S131-R-1.1", ids);
+        Assert.Contains("S131-R-1.2", ids);
+        Assert.Contains("S131-R-2.1", ids);
+        Assert.Contains("S131-R-3.1", ids);
+        Assert.Contains("S131-R-4.1", ids);
+        Assert.Contains("S131-R-6.1", ids);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullDataset()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            S131HarbourInfrastructureRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Introduce `S131HarbourInfrastructureRules`, a Tier-1/Tier-2 validation rule pack for the typed `S131HarbourInfrastructureDataset` projection. Follows the pattern established by the S-421 rule pack (PR #100).

## Rules

| ID | Description | Severity |
|---|---|---|
| `S131-R-1.1` | HarbourPhysicalInfrastructure features must have non-empty geometry (`HarbourFacility` container exempt). | Error |
| `S131-R-1.2` | Layout features must have non-empty geometry. | Error |
| `S131-R-2.1` | `availableBerthingLength`, when present, must be a non-negative numeric value (metres). | Warning |
| `S131-R-3.1` | Coordinates must lie within WGS-84 lat/lon ranges (S-100 Part 10b §6.2). | Error |
| `S131-R-3.2` | Surface rings must have ≥ 4 vertices and be closed (first = last). | Error |
| `S131-R-4.1` | Feature and information-type `gml:id` values must be unique within the dataset. | Error |
| `S131-R-5.1` | All `xlink:href` references must resolve to a peer (covers both feature and info-type axes). | Warning |
| `S131-R-6.1` | Feature and information-type codes must be declared in the S-131 Feature Catalogue. | Warning |

## Tests

33 new validation tests under `tests/EncDotNet.S100.Datasets.S131.Tests/Validation/`. Happy + failing case per rule, plus Default-ruleset composition and aggregate `Validate()` smoke tests. Full S-131 test suite (53 tests) green.

## Deviations from S-421 pack

- **R-5.1 covers two axes.** Unlike S-421 (features only), S-131 also resolves info-type↔feature xlinks (`Authority`/`ContactDetails`/`RxNInformation`), so R-5.1 walks both `Features[*].ResolvedReferences` and `InformationTypes[*].ResolvedReferences`.
- **Enumeration validation deferred.** S-131 enumeration values (e.g. `categoryOfHarbourFacility`) are numeric FC codes — better validated by the FC reader than by hand-rolled lookups. Skipped per the spec's "drop structurally-guaranteed rules" guidance.
- **`HarbourFacility` exemption in R-1.1.** Container-style features are geometry-less by design (S-131 FC), so the rule short-circuits for that kind.
- **R-2.1 reads the raw `Source.Attributes` dictionary** rather than typed properties because the FC's quantity-with-units attribute (`availableBerthingLength`) is surfaced as a raw string on the source feature.

## Scope

- No edits outside `src/EncDotNet.S100.Datasets.S131/Validation/`, `tests/EncDotNet.S100.Datasets.S131.Tests/Validation/`, and the S-131 README.
- No MCP, no Tier-3 cross-dataset rules, no viewer changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>