### PR TITLE
Add S-128 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.S128/README.md
+++ b/src/EncDotNet.S100.Datasets.S128/README.md
@@ -45,6 +45,7 @@ upstream sample (`DistributorInformation`, `ProducerInformation`,
 | `S128ProductStatus` | Heuristic enum: `InForce | Superseded | Withdrawn | Planned | Unknown` |
 | `S128CatalogueQuery` | Static helpers: `FilterByExtent`, `FilterByProductType`, `FilterBySpecification`, `FilterByStatus` |
 | `S128ProductCatalogue` (`DataModel/`) | Strongly-typed projection of the dataset as a catalogue of typed `S128CatalogueEntry` subclasses with resolved `Supersedes`/`SupersededBy` navigation. See [Strongly-typed data model](#strongly-typed-data-model). |
+| `S128CatalogueRules` (`Validation/`) | Default pilot rule pack for `S128ProductCatalogue` (rule IDs `S128-R-12.*` traced to S-128 § 12). See [Validation](#validation). |
 | `S128FeatureXmlSource` | Projects the dataset into the S-100 Part 9 FeatureXML neutral form consumed by the bundled XSLT |
 | `S128FeatureGeometryProvider` | `IFeatureGeometryProvider` adapter for the unified Mapsui display-list renderer |
 | `S128PortrayalCatalogue` | `IVectorPortrayalCatalogue` over the bundled PC (Day / Dusk / Night palettes) |
@@ -138,6 +139,43 @@ foreach (var d in diagnostics)
 
 Per S-100 Part 10b §6.2, all coordinates inside `<gml:pos>` /
 `<gml:posList>` for `EPSG:4326` are **lat lon**.
+
+## Validation
+
+`Validation/S128CatalogueRules.cs` ships a pilot pack of seven Tier-1 /
+Tier-2 rules over `S128ProductCatalogue`. Rule identifiers follow the
+convention `S128-R-{clause}` and trace to clauses of S-128 Edition
+2.0.0 (§ 12 Feature Catalogue, plus S-100 Part 10b §6 for geometry).
+
+| Rule ID | Severity | Summary |
+|---|---|---|
+| `S128-R-12.1` | Error | When present, every catalogue entry's `editionNumber` is ≥ 1. |
+| `S128-R-12.2` | Error | When both are present, `issueDate ≤ updateDate`. |
+| `S128-R-12.3` | Error | Every coverage coordinate lies in the WGS-84 lat/lon ranges. |
+| `S128-R-12.4` | Error | `Surface` exterior rings have ≥ 4 vertices and are closed. |
+| `S128-R-12.5` | Error | Product `gml:id` values are unique across the catalogue. |
+| `S128-R-12.6` | Warning | `onlineResource/linkage` values parse as absolute URIs when present. |
+| `S128-R-12.7` | Warning | The catalogue carries at least one `ProducerInformation` or `DistributorInformation` record. |
+
+Run the default pack:
+
+```csharp
+using EncDotNet.S100.Datasets.S128;
+using EncDotNet.S100.Datasets.S128.DataModel;
+using EncDotNet.S100.Datasets.S128.Validation;
+
+await using var stream = File.OpenRead("catalogue.gml");
+var dataset = S128Dataset.Open(stream);
+var catalogue = S128ProductCatalogue.From(dataset, out _);
+
+var report = S128CatalogueRules.Validate(catalogue);
+foreach (var f in report.Findings)
+    Console.WriteLine($"[{f.Severity}] {f.RuleId}: {f.Message}");
+```
+
+Tier-3 cross-dataset rules (e.g. cross-referencing catalogue entries
+against actually loaded S-1xx datasets) are deferred until the MCP
+`validate_all` surface lands.
 
 ## Portrayal
 

--- a/src/EncDotNet.S100.Datasets.S128/Validation/S128CatalogueRules.cs
+++ b/src/EncDotNet.S100.Datasets.S128/Validation/S128CatalogueRules.cs
@@ -1,0 +1,365 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S128.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S128.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-128 <see cref="S128ProductCatalogue"/>. Rule identifiers follow
+/// the convention <c>S128-R-{clause}</c>, where <c>{clause}</c> traces to
+/// the relevant section of the S-128 (Edition 2.0.0) specification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single
+/// <see cref="S128ProductCatalogue"/> in isolation. Tier-3 cross-dataset
+/// rules (e.g. comparing a catalogue's product references against actually
+/// loaded S-1xx datasets) will be added in a follow-up once the MCP
+/// <c>validate_all</c> surface is wired up — they need access to sibling
+/// datasets via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// </remarks>
+public static class S128CatalogueRules
+{
+    /// <summary>
+    /// <c>S128-R-12.1</c> — When present, every catalogue entry's
+    /// <c>editionNumber</c> must be ≥ 1.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-128 § 12 — <c>editionNumber</c> is the
+    /// author-assigned edition counter shared across
+    /// <c>ElectronicProduct</c>, <c>PhysicalProduct</c>, and
+    /// <c>S100Service</c>. The S-100 lifecycle treats edition 1 as the
+    /// first publishable edition; values of 0 or below are not meaningful.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> EditionNumberPositive { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.1")
+            .WithDescription("When present, product editionNumber must be ≥ 1.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((catalogue, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var entry in catalogue.Products)
+                {
+                    if (entry.EditionNumber is not { } edition || edition >= 1)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S128-R-12.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Product '{entry.Id}' ({entry.FeatureType}) has editionNumber " +
+                            $"{edition}; must be ≥ 1.",
+                        DatasetId = catalogue.DatasetIdentifier,
+                        RelatedFeatureId = entry.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S128-R-12.2</c> — When both an <c>issueDate</c> and an
+    /// <c>updateDate</c> are present on a catalogue entry, the issue date
+    /// must not be later than the update date.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-128 § 12 — <c>issueDate</c> records the original
+    /// release date of an edition; <c>updateDate</c> (falling back to
+    /// <c>editionDate</c>) records the most recent revision date for that
+    /// edition. An update cannot precede its own issue.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> IssueDateBeforeUpdateDate { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.2")
+            .WithDescription("issueDate must not be later than updateDate when both are present.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((catalogue, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var entry in catalogue.Products)
+                {
+                    if (entry.IssueDate is not { } issued || entry.UpdateDate is not { } updated)
+                        continue;
+                    if (issued <= updated)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S128-R-12.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"Product '{entry.Id}' issueDate ({issued:O}) is later than " +
+                            $"updateDate ({updated:O}).",
+                        DatasetId = catalogue.DatasetIdentifier,
+                        RelatedFeatureId = entry.Id,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S128-R-12.3</c> — Every coordinate on every catalogue entry must
+    /// lie within the WGS-84 ranges: latitude in [-90, +90] and longitude
+    /// in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded. S-128 catalogue entries carry
+    /// coverage geometry as a point, curve, or surface exterior ring.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> CoordinatesInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.3")
+            .WithDescription("Coverage coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((catalogue, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var entry in catalogue.Products)
+                {
+                    if (entry.Coordinates.IsDefaultOrEmpty)
+                        continue;
+
+                    for (int i = 0; i < entry.Coordinates.Length; i++)
+                    {
+                        var pos = entry.Coordinates[i];
+                        bool latOk = pos.Latitude is >= -90 and <= 90;
+                        bool lonOk = pos.Longitude is >= -180 and <= 180;
+                        if (latOk && lonOk) continue;
+
+                        var details = (latOk, lonOk) switch
+                        {
+                            (false, true) => $"latitude {pos.Latitude} is outside [-90, +90]",
+                            (true, false) => $"longitude {pos.Longitude} is outside [-180, +180]",
+                            _ => $"latitude {pos.Latitude} and longitude {pos.Longitude} are both out of range",
+                        };
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S128-R-12.3",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"Product '{entry.Id}' coordinate [{i}]: {details}.",
+                            Point = pos,
+                            DatasetId = catalogue.DatasetIdentifier,
+                            RelatedFeatureId = entry.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S128-R-12.4</c> — When a catalogue entry carries a
+    /// <see cref="S128GeometryKind.Surface"/> geometry, its exterior ring
+    /// must contain at least four vertices and its first and last vertex
+    /// must coincide (closed ring).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6 (surface primitives) — a GML
+    /// polygon's exterior ring is a closed <c>LinearRing</c>. The minimum
+    /// of four positions follows from "three distinct corners + repeat the
+    /// first to close". Coincidence is tested with a tight tolerance
+    /// (1e-9 degrees, about 0.1 mm at the equator) so that ordinary
+    /// floating-point round-trip does not trigger the rule.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> SurfaceRingClosed { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.4")
+            .WithDescription("Surface exterior rings must have ≥4 vertices and be closed.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((catalogue, _) =>
+            {
+                const double tolerance = 1e-9;
+                var findings = new List<ValidationFinding>();
+                foreach (var entry in catalogue.Products)
+                {
+                    if (entry.GeometryKind != S128GeometryKind.Surface)
+                        continue;
+
+                    var ring = entry.Coordinates;
+                    if (ring.IsDefaultOrEmpty || ring.Length < 4)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S128-R-12.4",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Product '{entry.Id}' surface ring has " +
+                                $"{(ring.IsDefault ? 0 : ring.Length)} vertices; ≥4 required.",
+                            DatasetId = catalogue.DatasetIdentifier,
+                            RelatedFeatureId = entry.Id,
+                        });
+                        continue;
+                    }
+
+                    var first = ring[0];
+                    var last = ring[^1];
+                    if (Math.Abs(first.Latitude - last.Latitude) > tolerance
+                        || Math.Abs(first.Longitude - last.Longitude) > tolerance)
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S128-R-12.4",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Product '{entry.Id}' surface ring is not closed: first " +
+                                $"({first.Latitude}, {first.Longitude}) != last " +
+                                $"({last.Latitude}, {last.Longitude}).",
+                            Point = first,
+                            DatasetId = catalogue.DatasetIdentifier,
+                            RelatedFeatureId = entry.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S128-R-12.5</c> — Every catalogue product must have a unique
+    /// <see cref="S128CatalogueEntry.Id"/>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §10 (GML identity) and S-128 § 12 —
+    /// the <c>gml:id</c> on a feature instance is the primary key used by
+    /// xlinks (e.g. <c>theReference</c> supersedes pointers) to address
+    /// catalogue entries. Duplicate identifiers break xlink resolution and
+    /// supersedes navigation.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> UniqueProductIds { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.5")
+            .WithDescription("Catalogue product gml:id values must be unique.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((catalogue, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var entry in catalogue.Products)
+                {
+                    if (!seen.Add(entry.Id))
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S128-R-12.5",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"Duplicate product gml:id '{entry.Id}' " +
+                                $"({entry.FeatureType}).",
+                            DatasetId = catalogue.DatasetIdentifier,
+                            RelatedFeatureId = entry.Id,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S128-R-12.6</c> — When an <c>onlineResource/linkage</c> is
+    /// supplied on a catalogue entry, it must parse as an absolute URI.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-128 § 12 <c>onlineResource</c> complex attribute
+    /// — <c>linkage</c> carries the URL at which the product may be
+    /// downloaded or accessed. A relative or malformed value cannot be
+    /// dereferenced by clients.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> OnlineResourceLinkageWellFormed { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.6")
+            .WithDescription("onlineResource/linkage values must be absolute URIs when present.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((catalogue, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var entry in catalogue.Products)
+                {
+                    if (entry.OnlineResources.IsDefaultOrEmpty)
+                        continue;
+
+                    for (int i = 0; i < entry.OnlineResources.Length; i++)
+                    {
+                        var linkage = entry.OnlineResources[i].Linkage;
+                        if (string.IsNullOrWhiteSpace(linkage))
+                            continue;
+
+                        if (!Uri.TryCreate(linkage, UriKind.Absolute, out Uri? _))
+                        {
+                            findings.Add(new ValidationFinding
+                            {
+                                RuleId = "S128-R-12.6",
+                                Severity = ValidationSeverity.Warning,
+                                Message =
+                                    $"Product '{entry.Id}' onlineResource[{i}].linkage " +
+                                    $"'{linkage}' is not an absolute URI.",
+                                DatasetId = catalogue.DatasetIdentifier,
+                                RelatedFeatureId = entry.Id,
+                            });
+                        }
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S128-R-12.7</c> — A catalogue dataset should carry at least one
+    /// producer or distributor metadata record.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-128 § 12 — a Catalogue of Nautical Products is
+    /// always published by an agency, and the encoded catalogue is
+    /// expected to identify either the producing agency
+    /// (<c>ProducerInformation</c>) or at least one distributor
+    /// (<c>DistributorInformation</c>). A catalogue with neither cannot
+    /// be attributed and is treated as a soft warning rather than a
+    /// hard error so legacy / partial fixtures still parse.
+    /// </remarks>
+    public static IValidationRule<S128ProductCatalogue> ProducerOrDistributorPresent { get; } =
+        ValidationRuleBuilder.RuleFor<S128ProductCatalogue>("S128-R-12.7")
+            .WithDescription("Catalogue must declare at least one producer or distributor.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((catalogue, _) =>
+            {
+                bool hasProducer = !catalogue.Producers.IsDefaultOrEmpty
+                    && catalogue.Producers.Length > 0;
+                bool hasDistributor = !catalogue.Distributors.IsDefaultOrEmpty
+                    && catalogue.Distributors.Length > 0;
+                if (hasProducer || hasDistributor)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S128-R-12.7",
+                        Severity = ValidationSeverity.Warning,
+                        Message = "Catalogue carries no ProducerInformation or DistributorInformation record.",
+                        DatasetId = catalogue.DatasetIdentifier,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-128 catalogues.</summary>
+    public static ValidationRuleSet<S128ProductCatalogue> Default { get; } = new(
+        EditionNumberPositive,
+        IssueDateBeforeUpdateDate,
+        CoordinatesInWgs84Range,
+        SurfaceRingClosed,
+        UniqueProductIds,
+        OnlineResourceLinkageWellFormed,
+        ProducerOrDistributorPresent);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S128ProductCatalogue catalogue, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+        return Default.Run(catalogue, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S128.Tests/Validation/S128CatalogueRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S128.Tests/Validation/S128CatalogueRulesTests.cs
@@ -1,0 +1,515 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S128;
+using EncDotNet.S100.Datasets.S128.DataModel;
+using EncDotNet.S100.Datasets.S128.Validation;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S128.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S128CatalogueRules"/>. Each test constructs
+/// a minimal synthetic <see cref="S128ProductCatalogue"/> in memory (no
+/// GML fixtures) and asserts the rule fires (or doesn't) with the
+/// expected finding shape.
+/// </summary>
+public class S128CatalogueRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static S128Feature SourceFeature(string id, string type = "ElectronicProduct") => new()
+    {
+        Id = id,
+        FeatureType = type,
+        Attributes = ImmutableDictionary<string, string>.Empty,
+        ComplexAttributes = ImmutableArray<S128ComplexAttribute>.Empty,
+        References = ImmutableArray<S128XlinkReference>.Empty,
+    };
+
+    private static S128ElectronicProduct ElectronicProduct(
+        string id,
+        int? editionNumber = null,
+        DateTimeOffset? issueDate = null,
+        DateTimeOffset? updateDate = null,
+        S128GeometryKind geometryKind = S128GeometryKind.None,
+        ImmutableArray<GeoPosition>? coordinates = null,
+        ImmutableArray<S128OnlineResource>? onlineResources = null) => new()
+    {
+        Id = id,
+        FeatureType = "ElectronicProduct",
+        EditionNumber = editionNumber,
+        IssueDate = issueDate,
+        UpdateDate = updateDate,
+        GeometryKind = geometryKind,
+        Coordinates = coordinates ?? ImmutableArray<GeoPosition>.Empty,
+        OnlineResources = onlineResources ?? ImmutableArray<S128OnlineResource>.Empty,
+        Source = SourceFeature(id),
+    };
+
+    private static S128ProducerInformation Producer(string id = "P1") => new()
+    {
+        Id = id,
+        AgencyResponsibleForProduction = "NOAA",
+        Source = SourceFeature(id, "ProducerInformation"),
+    };
+
+    private static S128DistributorInformation Distributor(string id = "D1") => new()
+    {
+        Id = id,
+        DistributorName = "NOAA Distribution",
+        Source = SourceFeature(id, "DistributorInformation"),
+    };
+
+    private static S128ProductCatalogue Catalogue(
+        ImmutableArray<S128CatalogueEntry>? products = null,
+        ImmutableArray<S128ProducerInformation>? producers = null,
+        ImmutableArray<S128DistributorInformation>? distributors = null,
+        string? datasetId = "DS-1")
+    {
+        var dataset = new S128Dataset
+        {
+            DatasetIdentifier = datasetId,
+            ProductIdentifier = "S-128",
+            Features = ImmutableArray<S128Feature>.Empty,
+            InformationTypes = ImmutableArray<S128InformationType>.Empty,
+        };
+
+        return new S128ProductCatalogue
+        {
+            DatasetIdentifier = datasetId,
+            ProductIdentifier = "S-128",
+            Products = products ?? ImmutableArray<S128CatalogueEntry>.Empty,
+            Producers = producers ?? ImmutableArray<S128ProducerInformation>.Empty,
+            Distributors = distributors ?? ImmutableArray<S128DistributorInformation>.Empty,
+            Source = dataset,
+        };
+    }
+
+    // ── S128-R-12.1 — edition number ≥ 1 ────────────────────────
+
+    [Fact]
+    public void EditionNumberPositive_Passes_WhenAbsent()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1", editionNumber: null)));
+        Assert.Empty(S128CatalogueRules.EditionNumberPositive.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(99)]
+    public void EditionNumberPositive_Passes_OnPositiveValue(int edition)
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1", editionNumber: edition)));
+        Assert.Empty(S128CatalogueRules.EditionNumberPositive.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void EditionNumberPositive_Fails_OnNonPositive(int edition)
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD", editionNumber: edition)));
+        var findings = S128CatalogueRules.EditionNumberPositive
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Equal("DS-1", f.DatasetId);
+    }
+
+    [Fact]
+    public void EditionNumberPositive_FlagsAllOffenders()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("OK", editionNumber: 3),
+            ElectronicProduct("BAD1", editionNumber: 0),
+            ElectronicProduct("BAD2", editionNumber: -1)));
+        var findings = S128CatalogueRules.EditionNumberPositive
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        Assert.Equal(2, findings.Count);
+        Assert.Equal(new[] { "BAD1", "BAD2" }, findings.Select(f => f.RelatedFeatureId).ToArray());
+    }
+
+    // ── S128-R-12.2 — issueDate ≤ updateDate ────────────────────
+
+    [Fact]
+    public void IssueDateBeforeUpdateDate_Passes_WhenEitherDateAbsent()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1", issueDate: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+            ElectronicProduct("E2", updateDate: new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero)),
+            ElectronicProduct("E3")));
+        Assert.Empty(S128CatalogueRules.IssueDateBeforeUpdateDate.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void IssueDateBeforeUpdateDate_Passes_WhenIssueEqualsUpdate()
+    {
+        var d = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1", issueDate: d, updateDate: d)));
+        Assert.Empty(S128CatalogueRules.IssueDateBeforeUpdateDate.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void IssueDateBeforeUpdateDate_Passes_WhenIssueBeforeUpdate()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                issueDate: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                updateDate: new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero))));
+        Assert.Empty(S128CatalogueRules.IssueDateBeforeUpdateDate.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void IssueDateBeforeUpdateDate_Fails_WhenIssueAfterUpdate()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD",
+                issueDate: new DateTimeOffset(2024, 12, 1, 0, 0, 0, TimeSpan.Zero),
+                updateDate: new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero))));
+        var findings = S128CatalogueRules.IssueDateBeforeUpdateDate
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+    }
+
+    // ── S128-R-12.3 — WGS-84 lat/lon bounds ─────────────────────
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Passes_WhenNoCoordinates()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1")));
+        Assert.Empty(S128CatalogueRules.CoordinatesInWgs84Range.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Passes_OnValidPoints()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                geometryKind: S128GeometryKind.Point,
+                coordinates: ImmutableArray.Create(new GeoPosition(45.0, -120.0)))));
+        Assert.Empty(S128CatalogueRules.CoordinatesInWgs84Range.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnOutOfRangeLatitude()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD",
+                geometryKind: S128GeometryKind.Point,
+                coordinates: ImmutableArray.Create(new GeoPosition(95.0, 0.0)))));
+        var findings = S128CatalogueRules.CoordinatesInWgs84Range
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.3", f.RuleId);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Contains("latitude", f.Message);
+        Assert.Equal(new GeoPosition(95.0, 0.0), f.Point);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnOutOfRangeLongitude()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD",
+                geometryKind: S128GeometryKind.Point,
+                coordinates: ImmutableArray.Create(new GeoPosition(0.0, 181.0)))));
+        var findings = S128CatalogueRules.CoordinatesInWgs84Range
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Contains("longitude", f.Message);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_FlagsAllOffendingVertices()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                geometryKind: S128GeometryKind.Curve,
+                coordinates: ImmutableArray.Create(
+                    new GeoPosition(0, 0),
+                    new GeoPosition(91, 0),
+                    new GeoPosition(0, -181)))));
+        var findings = S128CatalogueRules.CoordinatesInWgs84Range
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        Assert.Equal(2, findings.Count);
+    }
+
+    // ── S128-R-12.4 — surface ring closure ──────────────────────
+
+    [Fact]
+    public void SurfaceRingClosed_Passes_OnNonSurfaceEntries()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                geometryKind: S128GeometryKind.Point,
+                coordinates: ImmutableArray.Create(new GeoPosition(0, 0)))));
+        Assert.Empty(S128CatalogueRules.SurfaceRingClosed.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Passes_OnClosedSquareRing()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0),
+            new GeoPosition(0, 1),
+            new GeoPosition(1, 1),
+            new GeoPosition(1, 0),
+            new GeoPosition(0, 0));
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                geometryKind: S128GeometryKind.Surface,
+                coordinates: ring)));
+        Assert.Empty(S128CatalogueRules.SurfaceRingClosed.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Fails_WhenFewerThanFourVertices()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0),
+            new GeoPosition(0, 1),
+            new GeoPosition(1, 1));
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD",
+                geometryKind: S128GeometryKind.Surface,
+                coordinates: ring)));
+        var findings = S128CatalogueRules.SurfaceRingClosed
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.4", f.RuleId);
+        Assert.Contains("3 vertices", f.Message);
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Fails_WhenRingNotClosed()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0),
+            new GeoPosition(0, 1),
+            new GeoPosition(1, 1),
+            new GeoPosition(1, 0));
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD",
+                geometryKind: S128GeometryKind.Surface,
+                coordinates: ring)));
+        var findings = S128CatalogueRules.SurfaceRingClosed
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Contains("not closed", f.Message);
+    }
+
+    [Fact]
+    public void SurfaceRingClosed_Fails_WhenSurfaceHasNoCoordinates()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD", geometryKind: S128GeometryKind.Surface)));
+        var findings = S128CatalogueRules.SurfaceRingClosed
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Contains("0 vertices", f.Message);
+    }
+
+    // ── S128-R-12.5 — unique product IDs ────────────────────────
+
+    [Fact]
+    public void UniqueProductIds_Passes_OnAllUniqueIds()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1"), ElectronicProduct("E2"), ElectronicProduct("E3")));
+        Assert.Empty(S128CatalogueRules.UniqueProductIds.Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void UniqueProductIds_Fails_OnDuplicateId()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1"), ElectronicProduct("E1"), ElectronicProduct("E2")));
+        var findings = S128CatalogueRules.UniqueProductIds
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.5", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("E1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void UniqueProductIds_Fails_OnMultipleDuplicates()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1"), ElectronicProduct("E1"),
+            ElectronicProduct("E2"), ElectronicProduct("E2"), ElectronicProduct("E2")));
+        var findings = S128CatalogueRules.UniqueProductIds
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        // One finding per duplicate occurrence after the first.
+        Assert.Equal(3, findings.Count);
+    }
+
+    // ── S128-R-12.6 — onlineResource linkage well-formed ────────
+
+    [Fact]
+    public void OnlineResourceLinkageWellFormed_Passes_WhenNoOnlineResources()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1")));
+        Assert.Empty(S128CatalogueRules.OnlineResourceLinkageWellFormed
+            .Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void OnlineResourceLinkageWellFormed_Passes_WhenLinkageBlank()
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                onlineResources: ImmutableArray.Create(
+                    new S128OnlineResource { Linkage = null },
+                    new S128OnlineResource { Linkage = "   " }))));
+        Assert.Empty(S128CatalogueRules.OnlineResourceLinkageWellFormed
+            .Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData("https://charts.noaa.gov/ENCs/US5WA50M.zip")]
+    [InlineData("ftp://example.com/path")]
+    public void OnlineResourceLinkageWellFormed_Passes_OnAbsoluteUri(string linkage)
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("E1",
+                onlineResources: ImmutableArray.Create(
+                    new S128OnlineResource { Linkage = linkage }))));
+        Assert.Empty(S128CatalogueRules.OnlineResourceLinkageWellFormed
+            .Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData("not a url")]
+    [InlineData("relative/path/only")]
+    public void OnlineResourceLinkageWellFormed_Fails_OnMalformedLinkage(string linkage)
+    {
+        var cat = Catalogue(products: ImmutableArray.Create<S128CatalogueEntry>(
+            ElectronicProduct("BAD",
+                onlineResources: ImmutableArray.Create(
+                    new S128OnlineResource { Linkage = linkage }))));
+        var findings = S128CatalogueRules.OnlineResourceLinkageWellFormed
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.6", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Contains(linkage, f.Message);
+    }
+
+    // ── S128-R-12.7 — producer / distributor present ────────────
+
+    [Fact]
+    public void ProducerOrDistributorPresent_Passes_WithProducer()
+    {
+        var cat = Catalogue(producers: ImmutableArray.Create(Producer()));
+        Assert.Empty(S128CatalogueRules.ProducerOrDistributorPresent
+            .Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ProducerOrDistributorPresent_Passes_WithDistributorOnly()
+    {
+        var cat = Catalogue(distributors: ImmutableArray.Create(Distributor()));
+        Assert.Empty(S128CatalogueRules.ProducerOrDistributorPresent
+            .Evaluate(cat, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ProducerOrDistributorPresent_Fails_WhenNeitherPresent()
+    {
+        var cat = Catalogue();
+        var findings = S128CatalogueRules.ProducerOrDistributorPresent
+            .Evaluate(cat, ValidationContext.Default).ToList();
+        var f = Assert.Single(findings);
+        Assert.Equal("S128-R-12.7", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("DS-1", f.DatasetId);
+    }
+
+    // ── Default rule set + Validate entry point ─────────────────
+
+    [Fact]
+    public void Default_ContainsAllSevenRules()
+    {
+        Assert.Equal(7, S128CatalogueRules.Default.Rules.Length);
+        var ids = S128CatalogueRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Contains("S128-R-12.1", ids);
+        Assert.Contains("S128-R-12.2", ids);
+        Assert.Contains("S128-R-12.3", ids);
+        Assert.Contains("S128-R-12.4", ids);
+        Assert.Contains("S128-R-12.5", ids);
+        Assert.Contains("S128-R-12.6", ids);
+        Assert.Contains("S128-R-12.7", ids);
+    }
+
+    [Fact]
+    public void Validate_OnValidCatalogue_ProducesNoFindings()
+    {
+        var ring = ImmutableArray.Create(
+            new GeoPosition(0, 0), new GeoPosition(0, 1),
+            new GeoPosition(1, 1), new GeoPosition(1, 0), new GeoPosition(0, 0));
+        var cat = Catalogue(
+            products: ImmutableArray.Create<S128CatalogueEntry>(
+                ElectronicProduct("E1",
+                    editionNumber: 2,
+                    issueDate: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    updateDate: new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                    geometryKind: S128GeometryKind.Surface,
+                    coordinates: ring,
+                    onlineResources: ImmutableArray.Create(
+                        new S128OnlineResource { Linkage = "https://example.com/p1" }))),
+            producers: ImmutableArray.Create(Producer()));
+        var report = S128CatalogueRules.Validate(cat);
+        Assert.True(report.IsValid);
+        Assert.Empty(report.Findings);
+        Assert.Equal(7, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_OnInvalidCatalogue_AggregatesFindingsFromMultipleRules()
+    {
+        // Edition 0 (12.1), issue > update (12.2), out-of-range coord (12.3),
+        // duplicate id (12.5), bad linkage (12.6), no producer/distributor (12.7).
+        var cat = Catalogue(
+            products: ImmutableArray.Create<S128CatalogueEntry>(
+                ElectronicProduct("DUP",
+                    editionNumber: 0,
+                    issueDate: new DateTimeOffset(2024, 12, 1, 0, 0, 0, TimeSpan.Zero),
+                    updateDate: new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                    geometryKind: S128GeometryKind.Point,
+                    coordinates: ImmutableArray.Create(new GeoPosition(95.0, 0.0)),
+                    onlineResources: ImmutableArray.Create(
+                        new S128OnlineResource { Linkage = "not a url" })),
+                ElectronicProduct("DUP")));
+
+        var report = S128CatalogueRules.Validate(cat);
+        Assert.False(report.IsValid);
+        var ids = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S128-R-12.1", ids);
+        Assert.Contains("S128-R-12.2", ids);
+        Assert.Contains("S128-R-12.3", ids);
+        Assert.Contains("S128-R-12.5", ids);
+        Assert.Contains("S128-R-12.6", ids);
+        Assert.Contains("S128-R-12.7", ids);
+    }
+
+    [Fact]
+    public void Validate_ThrowsOnNullCatalogue()
+    {
+        Assert.Throws<ArgumentNullException>(() => S128CatalogueRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Introduce `S128CatalogueRules` — a default pack of **7 Tier-1/Tier-2 validation rules** over `S128ProductCatalogue`, following the pattern established for S-421 in #100.

## Rules

All identifiers follow `S128-R-{clause}` and cite **S-128 § 12** (Feature Catalogue) and **S-100 Part 10b §6** (geometry).

| Rule ID | Severity | Summary |
|---|---|---|
| `S128-R-12.1` | Error | `editionNumber` must be ≥ 1 when present |
| `S128-R-12.2` | Error | `issueDate ≤ updateDate` when both present |
| `S128-R-12.3` | Error | Coverage coordinates inside WGS-84 lat/lon bounds |
| `S128-R-12.4` | Error | `Surface` exterior rings have ≥ 4 vertices and are closed |
| `S128-R-12.5` | Error | Product `gml:id` values are unique |
| `S128-R-12.6` | Warning | `onlineResource/linkage` parses as absolute URI |
| `S128-R-12.7` | Warning | Catalogue carries ≥ 1 producer or distributor |

## Tests

**37 unit tests** in `S128CatalogueRulesTests` covering happy + failing paths per rule plus default-set composition and the `Validate(...)` aggregator. All synthetic — no GML fixtures required.

```
Passed!  - Failed: 0, Passed: 63, Skipped: 0, Total: 63 — EncDotNet.S100.Datasets.S128.Tests
```

(63 = 37 new + 26 pre-existing.)

## Verification

- `dotnet build --configuration Release` ✅ (0 errors, only pre-existing warnings)
- `dotnet test --configuration Release` ✅ for the S-128 project
- One unrelated parallel-execution flake observed in `EncDotNet.S100.Pipelines.Tests.TelemetrySmokeTests.VectorPipeline_emits_xslt_transform_span` (passes in isolation, unaffected by S-128 changes)

## Scope

- Files touched: `src/EncDotNet.S100.Datasets.S128/Validation/`, `tests/EncDotNet.S100.Datasets.S128.Tests/Validation/`, and the S-128 README.
- Out of scope (per task brief): MCP wiring, Tier-3 cross-dataset rules, viewer integration. Deferred until `validate_all` surface lands.

## Deviations from the brief

- The "bounding polygon corners" rule (south ≤ north / west ≤ east) was dropped because the S-128 typed projection does not expose a per-entry bounding box — coverage is carried as raw coordinates. The closure rule (R-12.4) covers the equivalent surface-shape concern.
- The "valid enumeration" rule (`categoryOfProduct` / `productStatus`) was dropped as structurally guaranteed: the typed model already projects these as `S128ServiceStatus` / `S128ProductMappingCategory` enums with unrecognised values landing on `Unknown` / `Other`.
- The "producer / distributor reference present" rule was tightened to apply at the **catalogue** level (R-12.7) rather than per-entry, because the typed model places `Producers` / `Distributors` on `S128ProductCatalogue`, not on `S128CatalogueEntry`.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;