### PR TITLE
PR-I — dcf8 station plumbing for S-104 and S-111

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -33,6 +33,23 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     // dcf8 only
     private readonly S104StationSeriesDataset? _stationSeries;
     private readonly IReadOnlyList<DateTime> _stationTimes = Array.Empty<DateTime>();
+    private readonly Dictionary<string, WaterLevelStation> _stationsById = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Last time-step selected via <see cref="Render"/> for dcf8 station
+    /// series. Cached so <see cref="GetFeatureInfo"/> reports the sample
+    /// at the same time the rendered glyph is showing. <c>null</c> until
+    /// the first render.
+    /// </summary>
+    private DateTime? _stationSelectedTime;
+
+    /// <summary>
+    /// Prefix used on <see cref="MapsuiDisplayListRenderer.FeatureRefKey"/>
+    /// tags for dcf8 station-series point features. The remainder is the
+    /// station identifier. <see cref="GetFeatureInfo"/> recognises this
+    /// prefix to route station picks back through this processor.
+    /// </summary>
+    internal const string StationFeatureRefPrefix = "station:";
 
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly S104DatasetData _data;
@@ -97,6 +114,10 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             case S104DatasetData.StationSeries s:
                 _stationSeries = s.Dataset;
                 _stationTimes = ComputeStationUnionTimes(s.Dataset);
+                foreach (var station in s.Dataset.Stations)
+                {
+                    _stationsById[station.Identifier] = station;
+                }
                 break;
         }
     }
@@ -184,6 +205,8 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             selectedTime = ds.MinTime ?? DateTime.UtcNow;
         }
 
+        _stationSelectedTime = selectedTime;
+
         var nativeToMerc = _crsTransformFactory.Create($"EPSG:{ds.HorizontalCRS ?? 4326}", "EPSG:3857");
 
         var features = new List<IFeature>(ds.Stations.Count);
@@ -219,6 +242,8 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             {
                 Geometry = new Point(mx, my),
             };
+            feature[MapsuiDisplayListRenderer.FeatureRefKey] =
+                StationFeatureRefPrefix + station.Identifier;
             feature["StationId"] = station.Identifier;
             feature["WaterLevelHeight"] = height;
             feature["WaterLevelTrend"] = (int)trend;
@@ -294,7 +319,105 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             : new Color(0, 0, 0);
     }
 
-    public FeatureInfo? GetFeatureInfo(string featureRef) => null;
+    /// <summary>
+    /// Resolves dcf8 station picks routed via the Mapsui
+    /// <see cref="MapsuiDisplayListRenderer.FeatureRefKey"/> tag the
+    /// glyph layer attaches to each station point. Refs are formatted as
+    /// <c>"station:&lt;id&gt;"</c> (see <see cref="StationFeatureRefPrefix"/>).
+    /// For dcf2 gridded datasets and other refs this returns <c>null</c>;
+    /// callers should fall back to <see cref="GetCoverageInfo"/>.
+    /// </summary>
+    public FeatureInfo? GetFeatureInfo(string featureRef)
+    {
+        ArgumentNullException.ThrowIfNull(featureRef);
+
+        if (_stationSeries is null) return null;
+        if (!featureRef.StartsWith(StationFeatureRefPrefix, StringComparison.Ordinal))
+            return null;
+
+        var id = featureRef[StationFeatureRefPrefix.Length..];
+        if (!_stationsById.TryGetValue(id, out var station))
+            return null;
+
+        return BuildStationFeatureInfo(station, _stationSelectedTime);
+    }
+
+    private FeatureInfo BuildStationFeatureInfo(WaterLevelStation station, DateTime? time)
+    {
+        var selectedTime = time ?? station.StartTime;
+        int idx = station.NearestTimeIndex(selectedTime);
+        var height = station.Heights[idx];
+        var trend = station.Trends[idx];
+        var sampleTime = station.TimeAt(idx);
+
+        return new FeatureInfo
+        {
+            FeatureRef = StationFeatureRefPrefix + station.Identifier,
+            FeatureType = "WaterLevel",
+            FeatureTypeName = "Water Level (Station)",
+            Attributes = new List<PickAttribute>
+            {
+                new()
+                {
+                    Code = "stationIdentification",
+                    Name = "Station",
+                    RawValue = station.Identifier,
+                },
+                new()
+                {
+                    Code = "stationPosition",
+                    Name = "Position",
+                    RawValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:0.######},{1:0.######}",
+                        station.Latitude, station.Longitude),
+                    DisplayValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:0.####}°, {1:0.####}°",
+                        station.Latitude, station.Longitude),
+                },
+                new()
+                {
+                    Code = "waterLevelHeight",
+                    Name = "Water Level Height",
+                    RawValue = height.ToString("0.##########", CultureInfo.InvariantCulture),
+                    DisplayValue = $"{height.ToString("0.##", CultureInfo.InvariantCulture)} m",
+                },
+                new()
+                {
+                    Code = "waterLevelTrend",
+                    Name = "Water Level Trend",
+                    RawValue = ((int)trend).ToString(CultureInfo.InvariantCulture),
+                    DisplayValue = DecodeTrend(trend),
+                },
+                new()
+                {
+                    Code = "timePoint",
+                    Name = "Time",
+                    RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                },
+                new()
+                {
+                    Code = "sampleCount",
+                    Name = "Sample Count",
+                    RawValue = station.NumberOfTimes.ToString(CultureInfo.InvariantCulture),
+                },
+                new()
+                {
+                    Code = "timeRange",
+                    Name = "Time Range",
+                    RawValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:u}/{1:u}",
+                        station.StartTime, station.EndTime),
+                    DisplayValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:u} → {1:u}",
+                        station.StartTime, station.EndTime),
+                },
+            },
+        };
+    }
 
     public FeatureInfo? GetCoverageInfo(double latitude, double longitude, DateTime? time)
     {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -37,6 +37,23 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
     // dcf8 only
     private readonly S111StationSeriesDataset? _stationSeries;
     private readonly IReadOnlyList<DateTime> _stationTimes = Array.Empty<DateTime>();
+    private readonly Dictionary<string, SurfaceCurrentStation> _stationsById = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Last time-step selected via <see cref="Render"/> for dcf8 station
+    /// series. Cached so <see cref="GetFeatureInfo"/> reports the sample
+    /// at the same time the rendered arrow is showing. <c>null</c> until
+    /// the first render.
+    /// </summary>
+    private DateTime? _stationSelectedTime;
+
+    /// <summary>
+    /// Prefix used on <see cref="MapsuiDisplayListRenderer.FeatureRefKey"/>
+    /// tags for dcf8 station-series point features. The remainder is the
+    /// station identifier. <see cref="GetFeatureInfo"/> recognises this
+    /// prefix to route station picks back through this processor.
+    /// </summary>
+    internal const string StationFeatureRefPrefix = "station:";
 
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly S111DatasetData _data;
@@ -117,6 +134,10 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             case S111DatasetData.StationSeries s:
                 _stationSeries = s.Dataset;
                 _stationTimes = ComputeStationUnionTimes(s.Dataset);
+                foreach (var station in s.Dataset.Stations)
+                {
+                    _stationsById[station.Identifier] = station;
+                }
                 // dcf8 uses an inline arrow glyph — no portrayal
                 // catalogue required.
                 break;
@@ -237,6 +258,8 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             selectedTime = ds.MinTime ?? DateTime.UtcNow;
         }
 
+        _stationSelectedTime = selectedTime;
+
         var nativeToMerc = _crsTransformFactory.Create($"EPSG:{ds.HorizontalCRS ?? 4326}", "EPSG:3857");
 
         var features = new List<IFeature>(ds.Stations.Count);
@@ -269,6 +292,8 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             {
                 Geometry = new Point(mx, my),
             };
+            feature[MapsuiDisplayListRenderer.FeatureRefKey] =
+                StationFeatureRefPrefix + station.Identifier;
             feature["StationId"] = station.Identifier;
             feature["SpeedMetresPerSecond"] = speed;
             feature["SpeedKnots"] = speed * 1.9438444924406046;
@@ -361,7 +386,106 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         return minScale + (maxScale - minScale) * t;
     }
 
-    public FeatureInfo? GetFeatureInfo(string featureRef) => null;
+    /// <summary>
+    /// Resolves dcf8 station picks routed via the Mapsui
+    /// <see cref="MapsuiDisplayListRenderer.FeatureRefKey"/> tag the
+    /// arrow layer attaches to each station point. Refs are formatted as
+    /// <c>"station:&lt;id&gt;"</c> (see <see cref="StationFeatureRefPrefix"/>).
+    /// For dcf2 gridded datasets and other refs this returns <c>null</c>;
+    /// callers should fall back to <see cref="GetCoverageInfo"/>.
+    /// </summary>
+    public FeatureInfo? GetFeatureInfo(string featureRef)
+    {
+        ArgumentNullException.ThrowIfNull(featureRef);
+
+        if (_stationSeries is null) return null;
+        if (!featureRef.StartsWith(StationFeatureRefPrefix, StringComparison.Ordinal))
+            return null;
+
+        var id = featureRef[StationFeatureRefPrefix.Length..];
+        if (!_stationsById.TryGetValue(id, out var station))
+            return null;
+
+        return BuildStationFeatureInfo(station, _stationSelectedTime);
+    }
+
+    private FeatureInfo BuildStationFeatureInfo(SurfaceCurrentStation station, DateTime? time)
+    {
+        var selectedTime = time ?? station.StartTime;
+        int idx = station.NearestTimeIndex(selectedTime);
+        var speed = station.SpeedsMetresPerSecond[idx];
+        var direction = station.DirectionsDegreesTrue[idx];
+        var sampleTime = station.TimeAt(idx);
+        var speedKnots = speed * 1.9438444924406046;
+
+        return new FeatureInfo
+        {
+            FeatureRef = StationFeatureRefPrefix + station.Identifier,
+            FeatureType = "SurfaceCurrent",
+            FeatureTypeName = "Surface Current (Station)",
+            Attributes = new List<PickAttribute>
+            {
+                new()
+                {
+                    Code = "stationIdentification",
+                    Name = "Station",
+                    RawValue = station.Identifier,
+                },
+                new()
+                {
+                    Code = "stationPosition",
+                    Name = "Position",
+                    RawValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:0.######},{1:0.######}",
+                        station.Latitude, station.Longitude),
+                    DisplayValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:0.####}°, {1:0.####}°",
+                        station.Latitude, station.Longitude),
+                },
+                new()
+                {
+                    Code = "surfaceCurrentSpeed",
+                    Name = "Current Speed",
+                    RawValue = speed.ToString("0.##########", CultureInfo.InvariantCulture),
+                    DisplayValue = $"{speed.ToString("0.##", CultureInfo.InvariantCulture)} m/s ({speedKnots.ToString("0.##", CultureInfo.InvariantCulture)} kn)",
+                },
+                new()
+                {
+                    Code = "surfaceCurrentDirection",
+                    Name = "Current Direction (going to)",
+                    RawValue = direction.ToString("0.##########", CultureInfo.InvariantCulture),
+                    DisplayValue = $"{direction.ToString("0.#", CultureInfo.InvariantCulture)}°",
+                },
+                new()
+                {
+                    Code = "timePoint",
+                    Name = "Time",
+                    RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                },
+                new()
+                {
+                    Code = "sampleCount",
+                    Name = "Sample Count",
+                    RawValue = station.NumberOfTimes.ToString(CultureInfo.InvariantCulture),
+                },
+                new()
+                {
+                    Code = "timeRange",
+                    Name = "Time Range",
+                    RawValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:u}/{1:u}",
+                        station.StartTime, station.EndTime),
+                    DisplayValue = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0:u} → {1:u}",
+                        station.StartTime, station.EndTime),
+                },
+            },
+        };
+    }
 
     /// <summary>
     /// Samples the surface-current grid at the supplied geographic

--- a/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
+++ b/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!--
+      CS0649 fires on fixture-row variants from the linked S-104 / S-111
+      dcf8 fixture builders that aren't exercised by the pipeline tests
+      (only some row shapes are used here). Suppressed locally rather
+      than modifying the original test sources.
+    -->
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,6 +44,20 @@
   <ItemGroup>
     <Content Include="..\datasets\S102\*.h5" CopyToOutputDirectory="PreserveNewest" Link="TestData\%(Filename)%(Extension)" />
     <Content Include="..\datasets\S102\PortrayalCatalogue\**\*" CopyToOutputDirectory="PreserveNewest" Link="TestData\PortrayalCatalogue\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <!--
+    Reuse the dcf8 HDF5 fixture builders from the S-104 / S-111 reader-test
+    projects rather than duplicating them. Linked compile means the source
+    files participate in this assembly under the same namespace but as
+    internal types, which matches the original visibility. NoWarn silences
+    CS0649 for fixture row variants that aren't exercised by these tests.
+  -->
+  <ItemGroup>
+    <Compile Include="..\EncDotNet.S100.Datasets.S104.Tests\Fixtures\S104Dcf8FixtureBuilder.cs"
+             Link="Fixtures\S104Dcf8FixtureBuilder.cs" />
+    <Compile Include="..\EncDotNet.S100.Datasets.S111.Tests\Fixtures\S111Dcf8FixtureBuilder.cs"
+             Link="Fixtures\S111Dcf8FixtureBuilder.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Pipelines.Tests/S104Dcf8ProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S104Dcf8ProcessorTests.cs
@@ -1,0 +1,148 @@
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S104.Tests.Fixtures;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Pipeline-level tests for the S-104 dcf8 station-series branch of
+/// <see cref="S104DatasetProcessor"/>. Verifies that the processor
+/// emits a <see cref="MemoryLayer"/> tagged with one feature per
+/// station and that each feature carries the
+/// <c>"station:&lt;id&gt;"</c> ref recognised by the pick router.
+/// </summary>
+public class S104Dcf8ProcessorTests
+{
+    private sealed class IdentityFactory : ICrsTransformFactory
+    {
+        public static readonly IdentityFactory Instance = new();
+        public ICrsTransform Create(string sourceCrs, string targetCrs) => IdentityCrsTransform.Instance;
+    }
+
+    private static string WriteFixture()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        var stations = new[]
+        {
+            new S104Dcf8FixtureBuilder.Station<S104Dcf8FixtureBuilder.SpecValueRow>
+            {
+                Identifier = "Alpha",
+                Latitude = 51.5f,
+                Longitude = -0.1f,
+                StartDateTime = "20240101T000000Z",
+                EndDateTime = "20240101T020000Z",
+                TimeRecordInterval = 3600,
+                Values =
+                [
+                    new() { WaterLevelHeight = 1.0f, WaterLevelTrend = 1 },
+                    new() { WaterLevelHeight = 1.5f, WaterLevelTrend = 2 },
+                    new() { WaterLevelHeight = 1.2f, WaterLevelTrend = 3 },
+                ],
+            },
+            new S104Dcf8FixtureBuilder.Station<S104Dcf8FixtureBuilder.SpecValueRow>
+            {
+                Identifier = "Bravo",
+                Latitude = 51.6f,
+                Longitude = -0.2f,
+                StartDateTime = "20240101T000000Z",
+                EndDateTime = "20240101T020000Z",
+                TimeRecordInterval = 3600,
+                Values =
+                [
+                    new() { WaterLevelHeight = -0.3f, WaterLevelTrend = 2 },
+                    new() { WaterLevelHeight = 0.1f, WaterLevelTrend = 2 },
+                    new() { WaterLevelHeight = 0.4f, WaterLevelTrend = 3 },
+                ],
+            },
+        };
+
+        S104Dcf8FixtureBuilder.WriteFile(path, stations, waterLevelTrendThreshold: 0.5);
+        return path;
+    }
+
+    [Fact]
+    public void Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey()
+    {
+        var path = WriteFixture();
+        try
+        {
+            using var processor = (System.IDisposable?)null; // placeholder so analyzers don't complain about disposable processors
+            var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
+
+            var result = p.Render();
+
+            Assert.Single(result.Layers);
+            var memoryLayer = Assert.IsType<MemoryLayer>(result.Layers[0]);
+
+            var features = memoryLayer.Features?.ToList()
+                ?? throw new InvalidOperationException("MemoryLayer must expose features.");
+            Assert.Equal(2, features.Count);
+
+            var refs = features
+                .Select(f => f[MapsuiDisplayListRenderer.FeatureRefKey] as string)
+                .ToArray();
+
+            Assert.Contains("station:Alpha", refs);
+            Assert.Contains("station:Bravo", refs);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample()
+    {
+        var path = WriteFixture();
+        try
+        {
+            var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
+
+            // Render at the second time-step; GetFeatureInfo should report
+            // the value at the same step (height = 1.5, trend = 2 for Alpha).
+            var secondStep = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
+            _ = p.Render(new S104RenderContext { TimeStep = secondStep });
+
+            var info = p.GetFeatureInfo("station:Alpha");
+
+            Assert.NotNull(info);
+            Assert.Equal("WaterLevel", info!.FeatureType);
+            Assert.Equal("station:Alpha", info.FeatureRef);
+
+            var attrs = info.Attributes.ToDictionary(a => a.Code, a => a);
+            Assert.Equal("Alpha", attrs["stationIdentification"].RawValue);
+            Assert.Equal("1.5", attrs["waterLevelHeight"].RawValue);
+            Assert.Equal("2", attrs["waterLevelTrend"].RawValue);
+            Assert.Equal("3", attrs["sampleCount"].RawValue);
+            Assert.Contains("timePoint", attrs.Keys);
+            Assert.Contains("timeRange", attrs.Keys);
+            Assert.Contains("stationPosition", attrs.Keys);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void GetFeatureInfo_UnknownStationRef_ReturnsNull()
+    {
+        var path = WriteFixture();
+        try
+        {
+            var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
+            _ = p.Render();
+
+            Assert.Null(p.GetFeatureInfo("station:Missing"));
+            Assert.Null(p.GetFeatureInfo("not-a-station-ref"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111Dcf8ProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111Dcf8ProcessorTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S111.Tests.Fixtures;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Pipeline-level tests for the S-111 dcf8 station-series branch of
+/// <see cref="S111DatasetProcessor"/>. Verifies that the processor
+/// emits a <see cref="MemoryLayer"/> tagged with one feature per
+/// station and that each feature carries the
+/// <c>"station:&lt;id&gt;"</c> ref recognised by the pick router.
+/// </summary>
+public class S111Dcf8ProcessorTests
+{
+    private sealed class IdentityFactory : ICrsTransformFactory
+    {
+        public static readonly IdentityFactory Instance = new();
+        public ICrsTransform Create(string sourceCrs, string targetCrs) => IdentityCrsTransform.Instance;
+    }
+
+    private static string WriteFixture()
+    {
+        var path = Path.GetTempFileName() + ".h5";
+        var stations = new[]
+        {
+            new S111Dcf8FixtureBuilder.Station<S111Dcf8FixtureBuilder.SpecValueRow>
+            {
+                Identifier = "S1",
+                Latitude = 47.6f,
+                Longitude = -122.3f,
+                StartDateTime = "20240101T000000Z",
+                EndDateTime = "20240101T020000Z",
+                TimeRecordInterval = 3600,
+                Values =
+                [
+                    new() { SurfaceCurrentSpeed = 0.3f, SurfaceCurrentDirection = 45f },
+                    new() { SurfaceCurrentSpeed = 0.6f, SurfaceCurrentDirection = 50f },
+                    new() { SurfaceCurrentSpeed = 0.9f, SurfaceCurrentDirection = 60f },
+                ],
+            },
+            new S111Dcf8FixtureBuilder.Station<S111Dcf8FixtureBuilder.SpecValueRow>
+            {
+                Identifier = "S2",
+                Latitude = 47.7f,
+                Longitude = -122.4f,
+                StartDateTime = "20240101T000000Z",
+                EndDateTime = "20240101T020000Z",
+                TimeRecordInterval = 3600,
+                Values =
+                [
+                    new() { SurfaceCurrentSpeed = 1.0f, SurfaceCurrentDirection = 180f },
+                    new() { SurfaceCurrentSpeed = 1.2f, SurfaceCurrentDirection = 185f },
+                    new() { SurfaceCurrentSpeed = 1.1f, SurfaceCurrentDirection = 190f },
+                ],
+            },
+        };
+
+        S111Dcf8FixtureBuilder.WriteFile(path, stations);
+        return path;
+    }
+
+    [Fact]
+    public void Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey()
+    {
+        var path = WriteFixture();
+        try
+        {
+            // dcf8 path doesn't consult the portrayal catalogue manager,
+            // so an empty manager is fine.
+            using var catalogues = new PortrayalCatalogueManager();
+            var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
+
+            var result = p.Render();
+
+            Assert.Single(result.Layers);
+            var memoryLayer = Assert.IsType<MemoryLayer>(result.Layers[0]);
+
+            var features = memoryLayer.Features?.ToList()
+                ?? throw new InvalidOperationException("MemoryLayer must expose features.");
+            Assert.Equal(2, features.Count);
+
+            var refs = features
+                .Select(f => f[MapsuiDisplayListRenderer.FeatureRefKey] as string)
+                .ToArray();
+
+            Assert.Contains("station:S1", refs);
+            Assert.Contains("station:S2", refs);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample()
+    {
+        var path = WriteFixture();
+        try
+        {
+            using var catalogues = new PortrayalCatalogueManager();
+            var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
+
+            // Render at the second time-step; expected S1 speed = 0.6, dir = 50.
+            var secondStep = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
+            _ = p.Render(new S111RenderContext { TimeStep = secondStep });
+
+            var info = p.GetFeatureInfo("station:S1");
+
+            Assert.NotNull(info);
+            Assert.Equal("SurfaceCurrent", info!.FeatureType);
+            Assert.Equal("station:S1", info.FeatureRef);
+
+            var attrs = info.Attributes.ToDictionary(a => a.Code, a => a);
+            Assert.Equal("S1", attrs["stationIdentification"].RawValue);
+            Assert.Equal("0.6", attrs["surfaceCurrentSpeed"].RawValue);
+            Assert.Equal("50", attrs["surfaceCurrentDirection"].RawValue);
+            Assert.Equal("3", attrs["sampleCount"].RawValue);
+            Assert.Contains("timePoint", attrs.Keys);
+            Assert.Contains("timeRange", attrs.Keys);
+            Assert.Contains("stationPosition", attrs.Keys);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void GetFeatureInfo_UnknownStationRef_ReturnsNull()
+    {
+        var path = WriteFixture();
+        try
+        {
+            using var catalogues = new PortrayalCatalogueManager();
+            var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
+            _ = p.Render();
+
+            Assert.Null(p.GetFeatureInfo("station:Nope"));
+            Assert.Null(p.GetFeatureInfo("plain-ref"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
Wires up dcf=8 ("time series at fixed stations") data so the viewer can pick station glyphs and surface typed station metadata in the pick panel.

**PR-I deliberately ships no chart UI** — PR-J will add the LiveCharts2 time-series view. The pick panel renders the current-time sample as ordinary `PickAttribute` rows.

## Approach

The brief flagged most of this work as "missing", but extensive dcf8 infrastructure already exists on `main`:

- `WaterLevelStation` / `SurfaceCurrentStation` models (parallel `Heights[]`/`Trends[]` arrays + `NearestTimeIndex` helper)
- Discriminated unions `S104DatasetData.{GriddedCoverage,StationSeries}` and matching `S104StationSeriesDataset` / `S111StationSeriesDataset`
- Readers dispatching on `DataCodingFormat` and parsing dcf8 group structures
- Processors branching dcf2/dcf8 and emitting station-glyph `MemoryLayer`s
- Test fixture builders (`S104Dcf8FixtureBuilder` / `S111Dcf8FixtureBuilder`)

The actual gaps were: features lacked the `FeatureRefKey` tag PickService needs, `GetFeatureInfo` returned null for station refs, and there were no pipeline-level processor tests. This PR fills exactly those gaps.

## Changes

### `S104DatasetProcessor` / `S111DatasetProcessor`
- Tag each station `MemoryLayer` feature with `feature[MapsuiDisplayListRenderer.FeatureRefKey] = "station:" + station.Identifier` so `PickService.ResolveHits` (lines 128-134) routes hits through `GetFeatureInfo`.
- Cache the active `selectedTime` in `RenderStationSeries` so `GetFeatureInfo` can report the current-time sample without taking a time parameter (the `IDatasetProcessor` interface has no time arg).
- Implement `GetFeatureInfo("station:<id>")` returning a typed `FeatureInfo` with:
  - station id, position
  - current-time sample value(s): height + trend (S-104); speed + direction (S-111)
  - sample count, overall time range

### Tests (`tests/EncDotNet.S100.Pipelines.Tests/`)
Added 6 processor-level tests (3 each for S-104/S-111):
- `Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey`
- `GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample`
- `GetFeatureInfo_UnknownStationRef_ReturnsNull`

Fixture builders are reused from the per-spec test projects via `<Compile Link="..." />` (CS0649 suppressed for unused row variants in this consumer).

## Acceptance

- `dotnet build EncDotNet.S100.slnx` — clean
- `dotnet test --configuration Release` — **0 failures** across all suites
- Pipelines.Tests: 291 passing (6 new)

## Deviations from the brief

- **Existing dcf8 station shape retained.** Models use parallel arrays + `NearestTimeIndex` helper, not the brief's `IReadOnlyList<S10XSample>` record list. The pre-existing two-class discriminated-union model (`GriddedCoverage` vs `StationSeries`) doesn't fit the brief's "one S10XDataset with optional `Stations`" mental model either. Pre-existing on `main`; not changed in PR-I.
- **No new viewer `Strings.resx` keys.** The processors live in `EncDotNet.S100.Datasets.Pipelines`, which does not reference the viewer. The existing pattern in S-102/S-104/S-111 processors is hardcoded English in `PickAttribute.Name` ("Water Level Height", etc.). Followed the existing pattern rather than introducing a new resource dependency.
- **Pick-routing shape chosen: option (b)** from the brief. `GetFeatureInfo("station:<id>")` returns the typed hit; `PickService` is unchanged; no marker `IStation` interface added.

## Notes for PR-J

- Station ref format: `"station:" + station.Identifier`; constant `StationFeatureRefPrefix` on each processor.
- Each processor caches `_stationSelectedTime` (set by `RenderStationSeries`) and `_stationsById` (built in ctor when the dcf8 branch is hit). PR-J can reuse these to look up station + time-series for the chart.
- The existing `GetCoverageInfo(lat, lon, time)` station-fallback path was left intact (used when click misses the glyph hit-test); it coexists with the new ref-based path.