### PR TITLE
PR-K — Local/UTC time-format setting and central formatter

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/PickAttribute.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/PickAttribute.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
@@ -39,6 +40,22 @@ public sealed class PickAttribute
     /// decoding applies.
     /// </summary>
     public string? DisplayValue { get; init; }
+
+    /// <summary>
+    /// Optional typed timestamp value backing this attribute. When set,
+    /// presentation layers should re-format the value through their own
+    /// date/time formatter rather than relying on <see cref="RawValue"/>
+    /// or <see cref="DisplayValue"/>. <see cref="RawValue"/> still
+    /// carries an ISO 8601 representation for non-UI consumers
+    /// (serialization, MCP, tests).
+    /// </summary>
+    public DateTime? DateTimeValue { get; init; }
+
+    /// <summary>
+    /// Optional typed time-range backing this attribute (start, end).
+    /// Same contract as <see cref="DateTimeValue"/>.
+    /// </summary>
+    public (DateTime Start, DateTime End)? DateTimeRangeValue { get; init; }
 
     /// <summary>
     /// Sub-attributes of a complex attribute. Empty for simple attributes

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -396,6 +396,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
                     Code = "timePoint",
                     Name = "Time",
                     RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                    DateTimeValue = sampleTime,
                 },
                 new()
                 {
@@ -415,6 +416,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
                         CultureInfo.InvariantCulture,
                         "{0:u} → {1:u}",
                         station.StartTime, station.EndTime),
+                    DateTimeRangeValue = (station.StartTime, station.EndTime),
                 },
             },
         };
@@ -496,6 +498,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
                 Code = "timePoint",
                 Name = "Time",
                 RawValue = selectedTime.ToString("u", CultureInfo.InvariantCulture),
+                DateTimeValue = selectedTime,
             },
         };
 
@@ -571,6 +574,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
                     Code = "timePoint",
                     Name = "Time",
                     RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                    DateTimeValue = sampleTime,
                 },
             },
         };

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -464,6 +464,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                     Code = "timePoint",
                     Name = "Time",
                     RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                    DateTimeValue = sampleTime,
                 },
                 new()
                 {
@@ -483,6 +484,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                         CultureInfo.InvariantCulture,
                         "{0:u} → {1:u}",
                         station.StartTime, station.EndTime),
+                    DateTimeRangeValue = (station.StartTime, station.EndTime),
                 },
             },
         };
@@ -584,6 +586,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                 Code = "timePoint",
                 Name = "Time",
                 RawValue = selectedTime.ToString("u", CultureInfo.InvariantCulture),
+                DateTimeValue = selectedTime,
             },
         };
 
@@ -658,6 +661,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                     Code = "timePoint",
                     Name = "Time",
                     RawValue = sampleTime.ToString("u", CultureInfo.InvariantCulture),
+                    DateTimeValue = sampleTime,
                 },
             },
         };

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -239,6 +239,7 @@ public partial class App : Application
         services.AddSingleton<FeatureSearchViewModel>();
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<IMarinerSettingsProvider, MarinerSettingsProvider>();
+        services.AddSingleton<ITimeFormatProvider, TimeFormatProvider>();
         services.AddSingleton<PickReportViewModel>();
         services.AddSingleton<TimelineViewModel>();
         services.AddSingleton<DisplayToolbarViewModel>();

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -190,6 +190,11 @@ internal static class Strings
     public static string Settings_TextScale_Help => Get(nameof(Settings_TextScale_Help));
     public static string Settings_DistanceUnits => Get(nameof(Settings_DistanceUnits));
     public static string Settings_DistanceUnits_Help => Get(nameof(Settings_DistanceUnits_Help));
+    public static string Settings_TimeFormat_Label => Get(nameof(Settings_TimeFormat_Label));
+    public static string Settings_TimeFormat_Tooltip => Get(nameof(Settings_TimeFormat_Tooltip));
+    public static string Settings_TimeFormat_Local => Get(nameof(Settings_TimeFormat_Local));
+    public static string Settings_TimeFormat_Utc => Get(nameof(Settings_TimeFormat_Utc));
+    public static string Time_Utc_Suffix => Get(nameof(Time_Utc_Suffix));
 
     // Mariner settings (S-100 Part 9 §4.2)
     public static string Settings_MarinerSection => Get(nameof(Settings_MarinerSection));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -467,6 +467,23 @@ Open an S-128 dataset to populate this panel.</value>
     <value>Units used by the map scale bar.</value>
   </data>
 
+  <!-- Date/time formatting -->
+  <data name="Settings_TimeFormat_Label" xml:space="preserve">
+    <value>Time Format</value>
+  </data>
+  <data name="Settings_TimeFormat_Tooltip" xml:space="preserve">
+    <value>Controls how every date/time the viewer displays is formatted. Local uses the current system culture; UTC uses an unambiguous ISO 8601 form with a "UTC" suffix.</value>
+  </data>
+  <data name="Settings_TimeFormat_Local" xml:space="preserve">
+    <value>Local time</value>
+  </data>
+  <data name="Settings_TimeFormat_Utc" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+  <data name="Time_Utc_Suffix" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+
   <!-- Mariner settings (S-100 Part 9 §4.2) -->
   <data name="Settings_MarinerSection" xml:space="preserve">
     <value>Mariner Settings</value>
@@ -694,7 +711,7 @@ Open an S-128 dataset to populate this panel.</value>
     <value>TIMELINE</value>
   </data>
   <data name="TimelinePanel_Range" xml:space="preserve">
-    <value>{0} steps from {1:u} to {2:u}</value>
+    <value>{0} steps from {1} to {2}</value>
   </data>
   <data name="TimelinePanel_NoData" xml:space="preserve">
     <value>No time-varying datasets loaded.</value>

--- a/src/EncDotNet.S100.Viewer/Services/ITimeFormatProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ITimeFormatProvider.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Read-only snapshot of the user-selected <see cref="TimeFormat"/>
+/// setting, plus a change notification. Consumers should subscribe to
+/// <see cref="TimeFormatChanged"/> and re-render any timestamp strings
+/// they expose.
+/// </summary>
+internal interface ITimeFormatProvider
+{
+    /// <summary>Currently active time format.</summary>
+    TimeFormat Current { get; }
+
+    /// <summary>
+    /// Raised after the user changes the time-format setting and the
+    /// settings file has been saved.
+    /// </summary>
+    event Action<TimeFormat>? TimeFormatChanged;
+}

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -34,12 +34,13 @@ internal sealed class PickService : IPickService
     private readonly PickReportViewModel _pickReport;
     private readonly IStatusPresenter _status;
     private readonly GlobalTimeService? _globalTime;
+    private readonly ITimeFormatProvider? _timeFormat;
 
     public PickService(
         IDatasetLoaderService loader,
         PickReportViewModel pickReport,
         IStatusPresenter status)
-        : this(loader, pickReport, status, globalTime: null)
+        : this(loader, pickReport, status, globalTime: null, timeFormat: null)
     {
     }
 
@@ -48,6 +49,16 @@ internal sealed class PickService : IPickService
         PickReportViewModel pickReport,
         IStatusPresenter status,
         GlobalTimeService? globalTime)
+        : this(loader, pickReport, status, globalTime, timeFormat: null)
+    {
+    }
+
+    public PickService(
+        IDatasetLoaderService loader,
+        PickReportViewModel pickReport,
+        IStatusPresenter status,
+        GlobalTimeService? globalTime,
+        ITimeFormatProvider? timeFormat)
     {
         ArgumentNullException.ThrowIfNull(loader);
         ArgumentNullException.ThrowIfNull(pickReport);
@@ -56,6 +67,7 @@ internal sealed class PickService : IPickService
         _pickReport = pickReport;
         _status = status;
         _globalTime = globalTime;
+        _timeFormat = timeFormat;
 
         // The pick-report VM raises NavigateRequested when the user
         // clicks a row in the References list. Failures surface as a
@@ -183,8 +195,8 @@ internal sealed class PickService : IPickService
         // exposes a single height channel; S-111 exposes speed + direction.
         return processor.Spec.Name switch
         {
-            "S-104" => new S104StationTimeSeriesViewModel(snapshot, _globalTime),
-            "S-111" => new S111StationTimeSeriesViewModel(snapshot, _globalTime),
+            "S-104" => new S104StationTimeSeriesViewModel(snapshot, _globalTime, _timeFormat),
+            "S-111" => new S111StationTimeSeriesViewModel(snapshot, _globalTime, _timeFormat),
             _ => null,
         };
     }

--- a/src/EncDotNet.S100.Viewer/Services/TimeFormatProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/TimeFormatProvider.cs
@@ -1,0 +1,30 @@
+using System;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="ITimeFormatProvider"/> implementation. Subscribes
+/// to <see cref="SettingsViewModel.TimeFormatChanged"/> and re-broadcasts
+/// the new value so viewmodels can refresh display strings without
+/// taking a direct dependency on the settings view-model.
+/// </summary>
+internal sealed class TimeFormatProvider : ITimeFormatProvider
+{
+    private readonly SettingsViewModel _settings;
+
+    public TimeFormatProvider(SettingsViewModel settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+        _settings.TimeFormatChanged += OnSettingsChanged;
+    }
+
+    /// <inheritdoc />
+    public TimeFormat Current => _settings.SelectedTimeFormat;
+
+    /// <inheritdoc />
+    public event Action<TimeFormat>? TimeFormatChanged;
+
+    private void OnSettingsChanged(TimeFormat format) => TimeFormatChanged?.Invoke(format);
+}

--- a/src/EncDotNet.S100.Viewer/TimeFormat.cs
+++ b/src/EncDotNet.S100.Viewer/TimeFormat.cs
@@ -1,0 +1,33 @@
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Selects how date/time values are formatted across the viewer UI.
+/// Persisted to <see cref="ViewerSettings.TimeFormat"/>.
+/// </summary>
+internal enum TimeFormat
+{
+    /// <summary>
+    /// Render timestamps in the user's local time zone using the current
+    /// culture's short date/time conventions. No UTC indicator is shown.
+    /// </summary>
+    Local,
+
+    /// <summary>
+    /// Render timestamps in UTC with an explicit "UTC" suffix
+    /// (ISO-8601-ish: <c>yyyy-MM-dd HH:mm:ss UTC</c>, invariant culture).
+    /// </summary>
+    Utc,
+}
+
+internal static class TimeFormatExtensions
+{
+    /// <summary>Human-readable display name for use in the settings UI.</summary>
+    public static string DisplayName(this TimeFormat format) => format switch
+    {
+        TimeFormat.Local => Strings.Settings_TimeFormat_Local,
+        TimeFormat.Utc => Strings.Settings_TimeFormat_Utc,
+        _ => format.ToString(),
+    };
+}

--- a/src/EncDotNet.S100.Viewer/TimeFormatNameConverter.cs
+++ b/src/EncDotNet.S100.Viewer/TimeFormatNameConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>Converts a <see cref="TimeFormat"/> value to its human-readable display name.</summary>
+internal sealed class TimeFormatNameConverter : IValueConverter
+{
+    public static TimeFormatNameConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is TimeFormat tf ? tf.DisplayName() : value?.ToString();
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Viewer/TimeFormatting.cs
+++ b/src/EncDotNet.S100.Viewer/TimeFormatting.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Globalization;
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Central formatter for every date/time value the viewer displays.
+/// Routing through this class is how the user-selected
+/// <see cref="TimeFormat"/> setting is honoured uniformly across the UI.
+/// </summary>
+/// <remarks>
+/// <para>UTC mode uses the invariant pattern
+/// <c><see cref="UtcPattern"/></c> (yyyy-MM-dd HH:mm:ss UTC). The literal
+/// "UTC" suffix comes from <see cref="Strings.Time_Utc_Suffix"/> so it
+/// can be localised later.</para>
+/// <para>Local mode uses <see cref="CultureInfo.CurrentCulture"/>'s
+/// short date/time pattern (<c>"g"</c>) with no UTC indicator.</para>
+/// <para>Inputs of <see cref="DateTimeKind.Unspecified"/> are treated as
+/// UTC; S-100 dataset timestamps are conventionally UTC and many
+/// upstream readers leave <see cref="DateTime.Kind"/> unset.</para>
+/// </remarks>
+internal static class TimeFormatting
+{
+    /// <summary>Invariant pattern used when the active format is <see cref="TimeFormat.Utc"/>.</summary>
+    public const string UtcPattern = "yyyy-MM-dd HH:mm:ss";
+
+    /// <summary>Invariant date-only pattern, used for time-range comparisons.</summary>
+    private const string DateCompareKey = "yyyyMMdd";
+
+    /// <summary>
+    /// Formats a <see cref="DateTime"/> for display. Treats
+    /// <see cref="DateTimeKind.Unspecified"/> as UTC.
+    /// </summary>
+    public static string Format(DateTime value, TimeFormat format)
+    {
+        var utc = NormalizeToUtc(value);
+        return format == TimeFormat.Utc
+            ? FormatUtc(utc)
+            : utc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Formats a <see cref="DateTimeOffset"/> for display.
+    /// </summary>
+    public static string Format(DateTimeOffset value, TimeFormat format)
+    {
+        return format == TimeFormat.Utc
+            ? FormatUtc(value.UtcDateTime)
+            : value.LocalDateTime.ToString("g", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Formats a date-only value using the current culture's short-date
+    /// pattern. The active <see cref="TimeFormat"/> is intentionally
+    /// ignored — date-only values (e.g. catalogue edition dates) have no
+    /// time-zone component and never get a UTC suffix.
+    /// </summary>
+    public static string FormatDateOnly(DateOnly value)
+        => value.ToString("d", CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Formats a compact <c>start – end</c> range. When start and end fall
+    /// on the same calendar day (in the active format's frame of
+    /// reference) the date portion is shown once.
+    /// </summary>
+    public static string FormatTimeRange(DateTime start, DateTime end, TimeFormat format)
+    {
+        var s = NormalizeToUtc(start);
+        var e = NormalizeToUtc(end);
+
+        if (format == TimeFormat.Utc)
+        {
+            if (s.ToString(DateCompareKey, CultureInfo.InvariantCulture) ==
+                e.ToString(DateCompareKey, CultureInfo.InvariantCulture))
+            {
+                return string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{s.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)} – {e.ToString("HH:mm:ss", CultureInfo.InvariantCulture)} {Strings.Time_Utc_Suffix}");
+            }
+
+            return $"{FormatUtc(s)} – {FormatUtc(e)}";
+        }
+
+        var sl = s.ToLocalTime();
+        var el = e.ToLocalTime();
+        var culture = CultureInfo.CurrentCulture;
+        if (sl.Date == el.Date)
+        {
+            // Same local day: "<short-date> <short-time> – <short-time>".
+            return string.Create(
+                culture,
+                $"{sl.ToString("d", culture)} {sl.ToString("t", culture)} – {el.ToString("t", culture)}");
+        }
+
+        return $"{sl.ToString("g", culture)} – {el.ToString("g", culture)}";
+    }
+
+    private static string FormatUtc(DateTime utc)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{utc.ToString(UtcPattern, CultureInfo.InvariantCulture)} {Strings.Time_Utc_Suffix}");
+    }
+
+    private static DateTime NormalizeToUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        // S-100 datasets conventionally express times in UTC even when the
+        // upstream reader leaves Kind unset, so we treat Unspecified as UTC.
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+    };
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Services;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -21,6 +22,7 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// </remarks>
 internal sealed class PickReportViewModel : ViewModelBase
 {
+    private readonly ITimeFormatProvider? _timeFormat;
     private string? _featureType;
     private string? _featureTypeName;
     private string? _featureRef;
@@ -30,11 +32,93 @@ internal sealed class PickReportViewModel : ViewModelBase
     private PickHit? _selectedHit;
 
     public PickReportViewModel()
+        : this(timeFormat: null)
     {
+    }
+
+    public PickReportViewModel(ITimeFormatProvider? timeFormat)
+    {
+        _timeFormat = timeFormat;
         ClearCommand = new RelayCommand(Clear);
         NavigateCommand = new RelayCommand<FeatureReference>(
             r => { if (r is not null) NavigateRequested?.Invoke(this, r); },
             r => r is not null);
+
+        if (_timeFormat is not null)
+            _timeFormat.TimeFormatChanged += OnTimeFormatChanged;
+    }
+
+    private void OnTimeFormatChanged(TimeFormat _)
+    {
+        // Re-format attribute rows that carry typed date/time values so
+        // the displayed strings reflect the new setting immediately.
+        if (_selectedHit is null) return;
+        var reformatted = ReformatTimeAttributes(_selectedHit.Attributes);
+        Attributes.Clear();
+        foreach (var a in reformatted) Attributes.Add(a);
+        OnPropertyChanged(nameof(HasAttributes));
+    }
+
+    private IReadOnlyList<PickAttribute> ReformatTimeAttributes(IReadOnlyList<PickAttribute> source)
+    {
+        var fmt = _timeFormat?.Current ?? TimeFormat.Local;
+        var list = new List<PickAttribute>(source.Count);
+        foreach (var attr in source)
+        {
+            list.Add(ReformatOne(attr, fmt));
+        }
+        return list;
+    }
+
+    private PickAttribute ReformatOne(PickAttribute attr, TimeFormat fmt)
+    {
+        var children = attr.Children.Count == 0
+            ? attr.Children
+            : (IReadOnlyList<PickAttribute>)ReformatTimeAttributes(attr.Children);
+
+        if (attr.DateTimeValue is { } dt)
+        {
+            return new PickAttribute
+            {
+                Code = attr.Code,
+                Name = attr.Name,
+                RawValue = attr.RawValue,
+                DisplayValue = TimeFormatting.Format(dt, fmt),
+                DateTimeValue = attr.DateTimeValue,
+                DateTimeRangeValue = attr.DateTimeRangeValue,
+                Children = children,
+            };
+        }
+
+        if (attr.DateTimeRangeValue is { } range)
+        {
+            return new PickAttribute
+            {
+                Code = attr.Code,
+                Name = attr.Name,
+                RawValue = attr.RawValue,
+                DisplayValue = TimeFormatting.FormatTimeRange(range.Start, range.End, fmt),
+                DateTimeValue = attr.DateTimeValue,
+                DateTimeRangeValue = attr.DateTimeRangeValue,
+                Children = children,
+            };
+        }
+
+        if (attr.Children.Count != 0 && !ReferenceEquals(children, attr.Children))
+        {
+            return new PickAttribute
+            {
+                Code = attr.Code,
+                Name = attr.Name,
+                RawValue = attr.RawValue,
+                DisplayValue = attr.DisplayValue,
+                DateTimeValue = attr.DateTimeValue,
+                DateTimeRangeValue = attr.DateTimeRangeValue,
+                Children = children,
+            };
+        }
+
+        return attr;
     }
 
     /// <summary>The picked feature's class/type code (e.g. "DepthArea", "LateralBuoy").</summary>
@@ -263,7 +347,7 @@ internal sealed class PickReportViewModel : ViewModelBase
         ProductSpec = hit.ProductSpec;
 
         Attributes.Clear();
-        foreach (var attr in hit.Attributes)
+        foreach (var attr in ReformatTimeAttributes(hit.Attributes))
             Attributes.Add(attr);
         OnPropertyChanged(nameof(HasAttributes));
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/S104StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/S104StationTimeSeriesViewModel.cs
@@ -17,8 +17,11 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// </summary>
 internal sealed class S104StationTimeSeriesViewModel : StationTimeSeriesViewModel
 {
-    public S104StationTimeSeriesViewModel(StationTimeSeriesSnapshot snapshot, GlobalTimeService? globalTime)
-        : base(snapshot, globalTime)
+    public S104StationTimeSeriesViewModel(
+        StationTimeSeriesSnapshot snapshot,
+        GlobalTimeService? globalTime,
+        ITimeFormatProvider? timeFormat = null)
+        : base(snapshot, globalTime, timeFormat)
     {
         var channel = FindChannel(snapshot, "waterLevelHeight");
         var points = channel is null ? new List<DateTimePoint>() : ProjectChannel(snapshot.Times, channel);

--- a/src/EncDotNet.S100.Viewer/ViewModels/S111StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/S111StationTimeSeriesViewModel.cs
@@ -19,8 +19,11 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// </summary>
 internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewModel
 {
-    public S111StationTimeSeriesViewModel(StationTimeSeriesSnapshot snapshot, GlobalTimeService? globalTime)
-        : base(snapshot, globalTime)
+    public S111StationTimeSeriesViewModel(
+        StationTimeSeriesSnapshot snapshot,
+        GlobalTimeService? globalTime,
+        ITimeFormatProvider? timeFormat = null)
+        : base(snapshot, globalTime, timeFormat)
     {
         var speedChannel = FindChannel(snapshot, "surfaceCurrentSpeed");
         var directionChannel = FindChannel(snapshot, "surfaceCurrentDirection");

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -105,6 +105,38 @@ internal sealed class SettingsViewModel : ViewModelBase
 
     public event Action<DistanceUnit>? DistanceUnitChanged;
 
+    public static TimeFormat[] AvailableTimeFormats { get; } =
+    [
+        EncDotNet.S100.Viewer.TimeFormat.Local,
+        EncDotNet.S100.Viewer.TimeFormat.Utc,
+    ];
+
+    private TimeFormat _selectedTimeFormat;
+    /// <summary>
+    /// Display format used for every date/time the viewer surfaces.
+    /// Persisted to <see cref="ViewerSettings.TimeFormat"/>.
+    /// </summary>
+    public TimeFormat SelectedTimeFormat
+    {
+        get => _selectedTimeFormat;
+        set
+        {
+            if (SetProperty(ref _selectedTimeFormat, value))
+            {
+                _settings.TimeFormat = value.ToString();
+                _settings.Save();
+                TimeFormatChanged?.Invoke(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raised after <see cref="SelectedTimeFormat"/> changes and the
+    /// settings file has been saved. <see cref="Services.TimeFormatProvider"/>
+    /// listens for this and re-broadcasts to viewmodels.
+    /// </summary>
+    public event Action<TimeFormat>? TimeFormatChanged;
+
     // -------------------------------------------------------------------
     // Mariner settings (S-100 Part 9 §4.2).
     //
@@ -405,6 +437,9 @@ internal sealed class SettingsViewModel : ViewModelBase
         _distanceUnit = Enum.TryParse<DistanceUnit>(settings.DistanceUnit, ignoreCase: true, out var u)
             ? u
             : EncDotNet.S100.Viewer.DistanceUnit.NauticalMiles;
+        _selectedTimeFormat = Enum.TryParse<TimeFormat>(settings.TimeFormat, ignoreCase: true, out var tf)
+            ? tf
+            : EncDotNet.S100.Viewer.TimeFormat.Local;
 
         // Mariner settings — pull from JSON, falling back to MarinerSettings.Default.
         var def = MarinerSettings.Default;

--- a/src/EncDotNet.S100.Viewer/ViewModels/StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/StationTimeSeriesViewModel.cs
@@ -34,6 +34,7 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
 {
     private readonly GlobalTimeService? _globalTime;
+    private readonly ITimeFormatProvider? _timeFormat;
     private readonly RectangularSection _nowSection;
     private bool _disposed;
 
@@ -43,11 +44,15 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
     /// tests; when supplied, <see cref="GlobalTimeService.CurrentTimeChanged"/>
     /// is observed for the lifetime of this view model.
     /// </summary>
-    protected StationTimeSeriesViewModel(StationTimeSeriesSnapshot snapshot, GlobalTimeService? globalTime)
+    protected StationTimeSeriesViewModel(
+        StationTimeSeriesSnapshot snapshot,
+        GlobalTimeService? globalTime,
+        ITimeFormatProvider? timeFormat = null)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
         Snapshot = snapshot;
         _globalTime = globalTime;
+        _timeFormat = timeFormat;
 
         _nowSection = new RectangularSection
         {
@@ -74,6 +79,9 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
             if (_globalTime.CurrentTime is { } current)
                 UpdateNowMarker(current);
         }
+
+        if (_timeFormat is not null)
+            _timeFormat.TimeFormatChanged += OnTimeFormatChanged;
     }
 
     /// <summary>The raw snapshot that backs this view model.</summary>
@@ -128,6 +136,8 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
         _disposed = true;
         if (_globalTime is not null)
             _globalTime.CurrentTimeChanged -= OnGlobalTimeChanged;
+        if (_timeFormat is not null)
+            _timeFormat.TimeFormatChanged -= OnTimeFormatChanged;
     }
 
     /// <summary>
@@ -160,13 +170,23 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
 
     private void OnGlobalTimeChanged(DateTime time) => UpdateNowMarker(time);
 
-    private static string FormatTimeAxisLabel(double ticks)
+    private void OnTimeFormatChanged(TimeFormat format)
+    {
+        // Force LiveCharts2 to re-evaluate the axis labels — the labeler
+        // closes over _timeFormat.Current so simply notifying is enough.
+        TimeAxis.Labeler = FormatTimeAxisLabel;
+    }
+
+    private string FormatTimeAxisLabel(double ticks)
     {
         if (!double.IsFinite(ticks)) return string.Empty;
         var t = (long)ticks;
         if (t < DateTime.MinValue.Ticks || t > DateTime.MaxValue.Ticks)
             return string.Empty;
         var dt = new DateTime(t, DateTimeKind.Utc);
-        return dt.ToString("HH:mm", CultureInfo.InvariantCulture);
+        var fmt = _timeFormat?.Current ?? TimeFormat.Local;
+        if (fmt == TimeFormat.Utc)
+            return dt.ToString("HH:mm", CultureInfo.InvariantCulture);
+        return dt.ToLocalTime().ToString("t", CultureInfo.CurrentCulture);
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/TimelineViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/TimelineViewModel.cs
@@ -20,11 +20,18 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 internal sealed class TimelineViewModel : ViewModelBase
 {
     private readonly GlobalTimeService _service;
+    private readonly ITimeFormatProvider? _timeFormat;
 
     public TimelineViewModel(GlobalTimeService service)
+        : this(service, timeFormat: null)
+    {
+    }
+
+    public TimelineViewModel(GlobalTimeService service, ITimeFormatProvider? timeFormat)
     {
         ArgumentNullException.ThrowIfNull(service);
         _service = service;
+        _timeFormat = timeFormat;
 
         PreviousStepCommand = new RelayCommand(StepPrevious, CanStepPrevious);
         NextStepCommand = new RelayCommand(StepNext, CanStepNext);
@@ -38,6 +45,15 @@ internal sealed class TimelineViewModel : ViewModelBase
             ((RelayCommand)PreviousStepCommand).NotifyCanExecuteChanged();
             ((RelayCommand)NextStepCommand).NotifyCanExecuteChanged();
         };
+
+        if (_timeFormat is not null)
+        {
+            _timeFormat.TimeFormatChanged += _ =>
+            {
+                OnPropertyChanged(nameof(CurrentTimeLabel));
+                OnPropertyChanged(nameof(RangeLabel));
+            };
+        }
     }
 
     /// <summary>
@@ -221,10 +237,10 @@ internal sealed class TimelineViewModel : ViewModelBase
         }
     }
 
-    /// <summary>ISO-8601 UTC text for the currently selected time.</summary>
+    /// <summary>Display text for the currently selected time, formatted via <see cref="TimeFormatting"/>.</summary>
     public string CurrentTimeLabel =>
         _service.CurrentTime is { } t
-            ? t.ToString("u", CultureInfo.InvariantCulture)
+            ? TimeFormatting.Format(t, ActiveFormat)
             : string.Empty;
 
     /// <summary>"N steps from T0 to T1"-style summary of the timeline.</summary>
@@ -235,12 +251,15 @@ internal sealed class TimelineViewModel : ViewModelBase
             var samples = _service.AllSamples;
             if (samples.Count == 0 || _service.MinTime is null || _service.MaxTime is null)
                 return Strings.TimelinePanel_NoData;
+            var fmt = ActiveFormat;
             return string.Format(
                 CultureInfo.CurrentCulture,
                 Strings.TimelinePanel_Range,
                 samples.Count,
-                _service.MinTime.Value,
-                _service.MaxTime.Value);
+                TimeFormatting.Format(_service.MinTime.Value, fmt),
+                TimeFormatting.Format(_service.MaxTime.Value, fmt));
         }
     }
+
+    private TimeFormat ActiveFormat => _timeFormat?.Current ?? TimeFormat.Local;
 }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -53,6 +53,13 @@ internal sealed class ViewerSettings
     public string DistanceUnit { get; set; } = "NauticalMiles";
 
     /// <summary>
+    /// Display format for date/time values across the viewer
+    /// ("Local" or "Utc"). Defaults to <c>"Local"</c>. Stored as a
+    /// string for forward-compat with other enum-shaped settings.
+    /// </summary>
+    public string? TimeFormat { get; set; }
+
+    /// <summary>
     /// Active ECDIS display category — one of "DisplayBase",
     /// "Standard", "OtherInformation", "All". Defaults to Standard
     /// (S-100 Part 9 §11.7).

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -116,6 +116,28 @@
                 </ComboBox>
             </StackPanel>
 
+            <!-- Time Format -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_TimeFormat_Label}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBlock Text="{x:Static loc:Strings.Settings_TimeFormat_Tooltip}"
+                           FontSize="11"
+                           Opacity="0.6"
+                           TextWrapping="Wrap" />
+                <ComboBox ItemsSource="{Binding AvailableTimeFormats}"
+                          SelectedItem="{Binding SelectedTimeFormat}"
+                          ToolTip.Tip="{x:Static loc:Strings.Settings_TimeFormat_Tooltip}"
+                          MinWidth="180"
+                          HorizontalAlignment="Left">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate DataType="viewer:TimeFormat">
+                            <TextBlock Text="{Binding Converter={x:Static viewer:TimeFormatNameConverter.Instance}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+
             <!-- Mariner Settings (S-100 Part 9 §4.2) -->
             <Separator Margin="0,8,0,0" />
             <TextBlock Text="{x:Static loc:Strings.Settings_MarinerSection}"

--- a/tests/EncDotNet.S100.Viewer.Tests/SettingsViewModelTimeFormatTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/SettingsViewModelTimeFormatTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class SettingsViewModelTimeFormatTests
+{
+    private static ViewerSettings NewSettings()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        return new ViewerSettings { SettingsFilePath = path };
+    }
+
+    [Fact]
+    public void DefaultsTo_Local_When_Missing()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s);
+        Assert.Equal(TimeFormat.Local, vm.SelectedTimeFormat);
+    }
+
+    [Fact]
+    public void Parses_Persisted_Utc_CaseInsensitive()
+    {
+        var s = NewSettings();
+        s.TimeFormat = "utc";
+        var vm = new SettingsViewModel(s);
+        Assert.Equal(TimeFormat.Utc, vm.SelectedTimeFormat);
+    }
+
+    [Fact]
+    public void InvalidValue_FallsBackTo_Local()
+    {
+        var s = NewSettings();
+        s.TimeFormat = "totally-bogus";
+        var vm = new SettingsViewModel(s);
+        Assert.Equal(TimeFormat.Local, vm.SelectedTimeFormat);
+    }
+
+    [Fact]
+    public void Setting_Raises_Event_And_Persists()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s);
+        TimeFormat? raised = null;
+        vm.TimeFormatChanged += f => raised = f;
+
+        vm.SelectedTimeFormat = TimeFormat.Utc;
+
+        Assert.Equal(TimeFormat.Utc, raised);
+        Assert.Equal("Utc", s.TimeFormat);
+        Assert.True(File.Exists(s.SettingsFilePath));
+        File.Delete(s.SettingsFilePath);
+    }
+}
+
+public class TimeFormatProviderTests
+{
+    private static ViewerSettings NewSettings()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        return new ViewerSettings { SettingsFilePath = path };
+    }
+
+    [Fact]
+    public void Current_Reflects_SettingsViewModel()
+    {
+        var settings = NewSettings();
+        var vm = new SettingsViewModel(settings);
+        var provider = new TimeFormatProvider(vm);
+        Assert.Equal(TimeFormat.Local, provider.Current);
+
+        vm.SelectedTimeFormat = TimeFormat.Utc;
+        Assert.Equal(TimeFormat.Utc, provider.Current);
+
+        if (File.Exists(settings.SettingsFilePath)) File.Delete(settings.SettingsFilePath);
+    }
+
+    [Fact]
+    public void Provider_ReBroadcasts_Change()
+    {
+        var settings = NewSettings();
+        var vm = new SettingsViewModel(settings);
+        var provider = new TimeFormatProvider(vm);
+        TimeFormat? heard = null;
+        provider.TimeFormatChanged += f => heard = f;
+
+        vm.SelectedTimeFormat = TimeFormat.Utc;
+        Assert.Equal(TimeFormat.Utc, heard);
+
+        if (File.Exists(settings.SettingsFilePath)) File.Delete(settings.SettingsFilePath);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/StationTimeSeriesTimeFormatTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/StationTimeSeriesTimeFormatTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests that station-time-series axis labels honour the active
+/// <see cref="TimeFormat"/> setting and refresh live on toggle.
+/// </summary>
+public class StationTimeSeriesTimeFormatTests
+{
+    private sealed class StubTimeFormat : ITimeFormatProvider
+    {
+        public TimeFormat Current { get; private set; }
+
+        public StubTimeFormat(TimeFormat initial) => Current = initial;
+
+        public event Action<TimeFormat>? TimeFormatChanged;
+
+        public void Set(TimeFormat value)
+        {
+            Current = value;
+            TimeFormatChanged?.Invoke(value);
+        }
+    }
+
+    private static StationTimeSeriesSnapshot Synthetic()
+    {
+        var start = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var times = new[] { start, start.AddMinutes(15), start.AddMinutes(30) };
+        var values = new[] { 1f, 2f, 3f };
+        return new StationTimeSeriesSnapshot
+        {
+            StationId = "ST01",
+            Latitude = 0,
+            Longitude = 0,
+            Times = times,
+            Channels = new[]
+            {
+                new StationTimeSeriesChannel
+                {
+                    Key = "waterLevelHeight",
+                    DisplayName = "Water Level Height",
+                    Unit = "m",
+                    Values = values,
+                    FillValue = -9999f,
+                },
+            },
+        };
+    }
+
+    [Fact]
+    public void AxisLabel_UtcMode_ProducesInvariantHourMinute()
+    {
+        var snap = Synthetic();
+        var tf = new StubTimeFormat(TimeFormat.Utc);
+        using var vm = new S104StationTimeSeriesViewModel(snap, globalTime: null, timeFormat: tf);
+
+        var ticks = (double)new DateTime(2026, 1, 1, 9, 30, 0, DateTimeKind.Utc).Ticks;
+        Assert.Equal("09:30", vm.TimeAxis.Labeler(ticks));
+    }
+
+    [Fact]
+    public void AxisLabel_LocalMode_UsesCurrentCultureShortTime()
+    {
+        var snap = Synthetic();
+        var tf = new StubTimeFormat(TimeFormat.Local);
+        using var vm = new S104StationTimeSeriesViewModel(snap, globalTime: null, timeFormat: tf);
+
+        var dt = new DateTime(2026, 1, 1, 9, 30, 0, DateTimeKind.Utc);
+        var ticks = (double)dt.Ticks;
+        var expected = dt.ToLocalTime().ToString("t", CultureInfo.CurrentCulture);
+        Assert.Equal(expected, vm.TimeAxis.Labeler(ticks));
+    }
+
+    [Fact]
+    public void Switching_TimeFormat_Updates_AxisLabel_Live()
+    {
+        var snap = Synthetic();
+        var tf = new StubTimeFormat(TimeFormat.Local);
+        using var vm = new S104StationTimeSeriesViewModel(snap, globalTime: null, timeFormat: tf);
+
+        var ticks = (double)new DateTime(2026, 1, 1, 9, 30, 0, DateTimeKind.Utc).Ticks;
+
+        tf.Set(TimeFormat.Utc);
+
+        Assert.Equal("09:30", vm.TimeAxis.Labeler(ticks));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/TimeFormattingTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/TimeFormattingTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Globalization;
+using EncDotNet.S100.Viewer;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class TimeFormattingTests
+{
+    [Fact]
+    public void Format_Utc_DateTime_Produces_IsoLike_String_With_UtcSuffix()
+    {
+        var dt = new DateTime(2026, 3, 14, 9, 26, 53, DateTimeKind.Utc);
+        var s = TimeFormatting.Format(dt, TimeFormat.Utc);
+        Assert.Equal("2026-03-14 09:26:53 UTC", s);
+    }
+
+    [Fact]
+    public void Format_Local_DateTime_Uses_CurrentCulture_ShortDateTime()
+    {
+        var dt = new DateTime(2026, 3, 14, 9, 26, 53, DateTimeKind.Utc);
+        var s = TimeFormatting.Format(dt, TimeFormat.Local);
+        // 'g' produces short date + short time in CurrentCulture; assert no UTC suffix.
+        Assert.DoesNotContain("UTC", s, StringComparison.Ordinal);
+        var expected = dt.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+        Assert.Equal(expected, s);
+    }
+
+    [Fact]
+    public void Format_Unspecified_Kind_IsTreatedAs_Utc()
+    {
+        var unspec = new DateTime(2026, 3, 14, 9, 26, 53, DateTimeKind.Unspecified);
+        var utc = new DateTime(2026, 3, 14, 9, 26, 53, DateTimeKind.Utc);
+        Assert.Equal(TimeFormatting.Format(utc, TimeFormat.Utc),
+            TimeFormatting.Format(unspec, TimeFormat.Utc));
+    }
+
+    [Fact]
+    public void Format_DateTimeOffset_Utc_RoundTrips()
+    {
+        var dto = new DateTimeOffset(2026, 3, 14, 9, 26, 53, TimeSpan.FromHours(5));
+        var s = TimeFormatting.Format(dto, TimeFormat.Utc);
+        Assert.Equal("2026-03-14 04:26:53 UTC", s);
+    }
+
+    [Fact]
+    public void FormatDateOnly_Ignores_TimeFormat_Toggle()
+    {
+        var d = new DateOnly(2026, 3, 14);
+        var s = TimeFormatting.FormatDateOnly(d);
+        Assert.DoesNotContain("UTC", s, StringComparison.Ordinal);
+        Assert.Equal(d.ToString("d", CultureInfo.CurrentCulture), s);
+    }
+
+    [Fact]
+    public void FormatTimeRange_SameDay_Utc_OmitsSecondDate()
+    {
+        var a = new DateTime(2026, 3, 14, 9, 0, 0, DateTimeKind.Utc);
+        var b = new DateTime(2026, 3, 14, 10, 0, 0, DateTimeKind.Utc);
+        var s = TimeFormatting.FormatTimeRange(a, b, TimeFormat.Utc);
+        Assert.Contains("2026-03-14", s);
+        // Only one date occurrence.
+        Assert.Equal(1, s.Split("2026-03-14").Length - 1);
+        Assert.Contains("UTC", s);
+    }
+
+    [Fact]
+    public void FormatTimeRange_DifferentDays_Utc_IncludesBothDates()
+    {
+        var a = new DateTime(2026, 3, 14, 23, 0, 0, DateTimeKind.Utc);
+        var b = new DateTime(2026, 3, 15, 1, 0, 0, DateTimeKind.Utc);
+        var s = TimeFormatting.FormatTimeRange(a, b, TimeFormat.Utc);
+        Assert.Contains("2026-03-14", s);
+        Assert.Contains("2026-03-15", s);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/TimelineViewModelTimeFormatTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/TimelineViewModelTimeFormatTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class TimelineViewModelTimeFormatTests
+{
+    private sealed class StubTimeAware : ITimeAwareDataset
+    {
+        public IReadOnlyList<DateTime> AvailableTimes { get; }
+        public DateTime? CurrentTime { get; set; }
+        public StubTimeAware(params DateTime[] times) { AvailableTimes = times; }
+        public DateTime? SnapTo(DateTime t)
+        {
+            DateTime? best = null;
+            var bestDelta = TimeSpan.MaxValue;
+            foreach (var s in AvailableTimes)
+            {
+                var d = (s - t).Duration();
+                if (d < bestDelta) { bestDelta = d; best = s; }
+            }
+            return best;
+        }
+    }
+
+    private sealed class StubTimeFormat : ITimeFormatProvider
+    {
+        public TimeFormat Current { get; private set; }
+        public StubTimeFormat(TimeFormat initial) => Current = initial;
+        public event Action<TimeFormat>? TimeFormatChanged;
+        public void Set(TimeFormat v) { Current = v; TimeFormatChanged?.Invoke(v); }
+    }
+
+    private static DatasetEntry NewEntry() => new("/tmp/d", "S104");
+
+    private static GlobalTimeService WithSamples()
+    {
+        var s = new GlobalTimeService();
+        var t1 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        s.Register(NewEntry(), new StubTimeAware(t1, t2));
+        return s;
+    }
+
+    [Fact]
+    public void CurrentTimeLabel_UtcMode_HasUtcSuffix()
+    {
+        var svc = WithSamples();
+        var tf = new StubTimeFormat(TimeFormat.Utc);
+        var vm = new TimelineViewModel(svc, tf);
+        Assert.Contains("UTC", vm.CurrentTimeLabel);
+    }
+
+    [Fact]
+    public void CurrentTimeLabel_LocalMode_HasNoUtcSuffix()
+    {
+        var svc = WithSamples();
+        var tf = new StubTimeFormat(TimeFormat.Local);
+        var vm = new TimelineViewModel(svc, tf);
+        Assert.DoesNotContain("UTC", vm.CurrentTimeLabel, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Switching_Format_Raises_CurrentTimeLabel_Change()
+    {
+        var svc = WithSamples();
+        var tf = new StubTimeFormat(TimeFormat.Local);
+        var vm = new TimelineViewModel(svc, tf);
+        var changed = new HashSet<string>();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is not null) changed.Add(e.PropertyName);
+        };
+        tf.Set(TimeFormat.Utc);
+        Assert.Contains(nameof(vm.CurrentTimeLabel), changed);
+        Assert.Contains(nameof(vm.RangeLabel), changed);
+    }
+}


### PR DESCRIPTION
## Summary
Adds an application setting that selects how date/time values are displayed throughout the viewer:

- **Local** → current culture's short date+time (`g`), no UTC suffix.
- **UTC** → `yyyy-MM-dd HH:mm:ss UTC` (invariant).

Every viewer surface that shows a timestamp now routes through a central `TimeFormatting` static class, so the toggle is honoured universally.

## Architecture
- `TimeFormat` enum + `TimeFormatting` static helper (`Format(DateTime)`, `Format(DateTimeOffset)`, `FormatDateOnly`, `FormatTimeRange` with same-day collapse).
- `ITimeFormatProvider` + `TimeFormatProvider` singleton — wraps `SettingsViewModel.TimeFormatChanged` and re-broadcasts so viewmodels don't take a direct dep on settings.
- `ViewerSettings.TimeFormat` (string, default `"Local"`), `SettingsViewModel.SelectedTimeFormat` + `TimeFormatChanged` event, ComboBox in `SettingsView.axaml`.
- `TimelineViewModel`, `StationTimeSeriesViewModel` (and derived S104/S111 chart VMs) accept an optional provider and refresh their displayed strings on change.
- `PickAttribute` gains typed `DateTimeValue` / `DateTimeRangeValue` siblings (`RawValue` keeps ISO 8601 for serialization and the MCP contract). S104/S111 processors populate them at every `timePoint` / `timeRange` site. `PickReportViewModel` re-formats time attributes on hit ingest and on toggle.
- Strings: `Settings_TimeFormat_{Label,Tooltip,Local,Utc}`, `Time_Utc_Suffix`.

## Decisions
- UTC pattern: `yyyy-MM-dd HH:mm:ss 'UTC'` (invariant culture).
- Local pattern: `g` (CurrentCulture short date + short time).
- Date-only values ignore the toggle (no UTC suffix; `d` pattern in CurrentCulture).
- `DateTime.Kind.Unspecified` is treated as UTC (S-100 dataset convention; documented on `TimeFormatting`).
- `PickAttribute` stays sealed with init-only props — added typed siblings rather than turning `RawValue` into `object?` to avoid churn for MCP/serialization callers.

## Tests
- `TimeFormattingTests` — UTC, Local, Unspecified→UTC, `DateTimeOffset`, date-only, same-day range collapse.
- `SettingsViewModelTimeFormatTests` — default, parse, invalid fallback, persist + event.
- `TimeFormatProviderTests` — `Current` reflects settings, re-broadcast.
- `TimelineViewModelTimeFormatTests` — UTC / Local labels, property-change on toggle.
- `StationTimeSeriesTimeFormatTests` — axis labels honour format, live relabel on toggle.

Full solution test run: **1794 passed / 0 failed / 2 skipped** (release config).

## Out of scope
- Time-zone-other-than-Local-or-UTC dropdown.
- Pipeline-layer locale support (English column headers remain — separate item).
- Per-dataset time-zone overrides.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>