### PR TITLE
Add dedicated S-129 MCP feature describer

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -81,7 +81,7 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 |---|---|
 | `list_datasets` | Summarises every dataset currently loaded in the viewer. |
 | `find_at` | Returns every loaded dataset whose declared bounding box contains a lat/lon point (decimal degrees, WGS-84). Bbox-only — does not check per-cell coverage or NoData masks. |
-| `describe_feature` | Returns spec, feature type, and attributes for a feature id in a given dataset. Supported specs: S-101 (RCID), S-102 (`BathymetryCoverage[.01]`), S-104 / S-111 (`WaterLevel`/`SurfaceCurrent[.NN][.Group_KKK]` or bare station identifier), and S-124 (`gml:id`). |
+| `describe_feature` | Returns spec, feature type, and attributes for a feature id in a given dataset. Supported specs: S-101 (RCID), S-102 (`BathymetryCoverage[.01]`), S-104 / S-111 (`WaterLevel`/`SurfaceCurrent[.NN][.Group_KKK]` or bare station identifier), S-124 (`gml:id`), and S-129 (`gml:id` of plan / plan-area / control-point / non-navigable-area). |
 | `sample_coverage` | Samples a depth / water-level / current value at a lat/lon from an S-102 / S-104 / S-111 dataset. |
 
 ## Sample agent prompts

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -168,7 +168,7 @@ The five error variants implemented in this PR:
 `FeatureDescriberRegistry` keyed on `SpecRef.Name`. Each describer
 implements an internal `ISpecFeatureDescriber` strategy.
 
-The registry currently wires five describers:
+The registry currently wires six describers:
 
 | Spec   | Describer                  | Feature id convention                                                                                       |
 |--------|----------------------------|-------------------------------------------------------------------------------------------------------------|
@@ -177,6 +177,7 @@ The registry currently wires five describers:
 | S-104  | `S104FeatureDescriber`     | Coverage path `WaterLevel[.NN][.Group_KKK]` (dcf2 grid / dcf8 station-series), or a bare station identifier. |
 | S-111  | `S111FeatureDescriber`     | Coverage path `SurfaceCurrent[.NN][.Group_KKK]` (dcf2 / dcf8), or a bare station identifier.                 |
 | S-124  | `S124FeatureDescriber`     | GML `gml:id` of the warning feature.                                                                        |
+| S-129  | `S129FeatureDescriber`     | GML `gml:id` of the plan-metadata, plan-area, (almost-)non-navigable-area, or control-point feature.        |
 
 For the coverage describers (S-102/S-104/S-111) the result returns
 instance-level metadata (origin, spacing, grid dimensions, CRS,
@@ -283,6 +284,6 @@ if (depths.TryGetValue(out var series))
 - Search / NL tools.
 - Write-back tools.
 - Comprehensive xlink reference resolution for backfilled describers
-  (S-122/S-125/S-127/S-128/S-129/S-131/S-201/S-411/S-421 return their
+  (S-122/S-125/S-127/S-128/S-131/S-201/S-411/S-421 return their
   feature attributes via the generic `GmlFeatureDescriber`, but
   references arrive as an empty list pending per-spec resolution).

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/FeatureDescriberRegistry.cs
@@ -33,7 +33,7 @@ public sealed class FeatureDescriberRegistry
         new GmlFeatureDescriber("S-125"),
         new GmlFeatureDescriber("S-127"),
         new GmlFeatureDescriber("S-128"),
-        new GmlFeatureDescriber("S-129"),
+        new S129FeatureDescriber(),
         new GmlFeatureDescriber("S-131"),
         new GmlFeatureDescriber("S-201"),
         new GmlFeatureDescriber("S-411"),

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/GmlFeatureDescriber.cs
@@ -12,7 +12,7 @@ namespace EncDotNet.S100.Mcp.Tools.Spec;
 /// <remarks>
 /// <para>
 /// One instance is registered per spec name (S-122, S-125, S-127,
-/// S-128, S-129, S-131, S-201, S-411, S-421). The describer serialises
+/// S-128, S-131, S-201, S-411, S-421). The describer serialises
 /// the feature's identity, type, geometry kind, simple attributes, and
 /// complex attributes — the minimum set of information an agent needs
 /// after locating features with <see cref="QueryFeaturesTool"/>.

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S129FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S129FeatureDescriber.cs
@@ -1,0 +1,239 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+
+namespace EncDotNet.S100.Mcp.Tools.Spec;
+
+/// <summary>
+/// Describer strategy for S-129 Under Keel Clearance Management
+/// (Edition 2.0.0). Projects the dataset onto
+/// <see cref="S129UnderKeelClearancePlan"/> and resolves the requested
+/// feature id against the five typed feature families: plan-metadata
+/// header, plan-area surface, non-navigable and almost-non-navigable
+/// surfaces, and control-point time-step records.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Feature ids are GML ids (e.g. <c>"TEST_PLAN_TORRES_STRAIT"</c>,
+/// <c>"CP_01"</c>) — no synthetic indexed form. The describer surfaces
+/// spec-specific semantics that the generic <see cref="GmlFeatureDescriber"/>
+/// would otherwise flatten away: vessel / source-route identifiers as
+/// textual cross-product references, per-CP UKC measurements with
+/// explicit units in the field name, scale-minimum on non-navigable
+/// surfaces, and structured time ranges.
+/// </para>
+/// <para>
+/// Per S-129 Edition 2.0.0 §<c>sourceRouteName</c> / <c>vesselID</c>,
+/// these references are <em>textual identifiers</em> (not xlink hrefs)
+/// and are returned in the JSON payload as
+/// <c>externalReferences</c> entries. The
+/// <see cref="DescribeFeatureResult.References"/> array — reserved for
+/// xlink-style resolved cross-dataset links — stays empty.
+/// </para>
+/// </remarks>
+internal sealed class S129FeatureDescriber : ISpecFeatureDescriber
+{
+    public string SpecName => "S-129";
+
+    public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Dataset.Data is not S129DatasetData s129)
+        {
+            return ToolResult<DescribeFeatureResult>.Err(
+                new SpecNotSupportedForTool(context.Dataset.Spec, DescribeFeatureTool.Name));
+        }
+
+        S129UnderKeelClearancePlan typed;
+        try
+        {
+            typed = S129UnderKeelClearancePlan.From(s129.Model, out _);
+        }
+        catch (InvalidOperationException)
+        {
+            // Empty dataset — no features to match.
+            return ToolResult<DescribeFeatureResult>.Err(
+                new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+        }
+
+        var id = context.FeatureId;
+
+        if (typed.Plan is { } plan && string.Equals(plan.Id, id, StringComparison.Ordinal))
+        {
+            return Ok(context, "UnderKeelClearancePlan", SerializePlan(plan, typed));
+        }
+
+        if (typed.PlanArea is { } planArea && string.Equals(planArea.Id, id, StringComparison.Ordinal))
+        {
+            return Ok(context, "UnderKeelClearancePlanArea", SerializeSurface(
+                "UnderKeelClearancePlanArea", planArea.Id, planArea.GeometryKind,
+                planArea.Coordinates, planArea.InteriorRings, scaleMinimum: null,
+                planArea.ExtraAttributes));
+        }
+
+        foreach (var area in typed.NonNavigableAreas)
+        {
+            if (string.Equals(area.Id, id, StringComparison.Ordinal))
+            {
+                return Ok(context, "UnderKeelClearanceNonNavigableArea", SerializeSurface(
+                    "UnderKeelClearanceNonNavigableArea", area.Id, area.GeometryKind,
+                    area.Coordinates, area.InteriorRings, area.ScaleMinimum,
+                    area.ExtraAttributes));
+            }
+        }
+
+        foreach (var area in typed.AlmostNonNavigableAreas)
+        {
+            if (string.Equals(area.Id, id, StringComparison.Ordinal))
+            {
+                return Ok(context, "UnderKeelClearanceAlmostNonNavigableArea", SerializeSurface(
+                    "UnderKeelClearanceAlmostNonNavigableArea", area.Id, area.GeometryKind,
+                    area.Coordinates, area.InteriorRings, area.ScaleMinimum,
+                    area.ExtraAttributes));
+            }
+        }
+
+        foreach (var cp in typed.ControlPoints)
+        {
+            if (string.Equals(cp.Id, id, StringComparison.Ordinal))
+            {
+                return Ok(context, "UnderKeelClearanceControlPoint", SerializeControlPoint(cp));
+            }
+        }
+
+        return ToolResult<DescribeFeatureResult>.Err(
+            new FeatureNotFound(context.Dataset.Id, context.FeatureId));
+    }
+
+    private static ToolResult<DescribeFeatureResult> Ok(
+        FeatureDescriberContext context,
+        string featureTypeName,
+        JsonElement attributes) =>
+        ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
+            context.Dataset.Spec,
+            featureTypeName,
+            attributes,
+            ImmutableArray<FeatureReference>.Empty));
+
+    private static JsonElement SerializePlan(S129UkcPlanMetadata plan, S129UnderKeelClearancePlan typed)
+    {
+        var externalReferences = new List<Dictionary<string, object?>>();
+        if (!string.IsNullOrEmpty(plan.VesselId))
+        {
+            externalReferences.Add(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["kind"] = "vessel",
+                ["identifier"] = plan.VesselId,
+            });
+        }
+        if (plan.SourceRoute is { } route)
+        {
+            var entry = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["kind"] = route.Kind,
+                ["identifier"] = route.Identifier,
+            };
+            if (!string.IsNullOrEmpty(route.Version))
+            {
+                entry["version"] = route.Version;
+            }
+            externalReferences.Add(entry);
+        }
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = plan.Id,
+            ["featureType"] = "UnderKeelClearancePlan",
+            ["generationTime"] = plan.GenerationTime,
+            ["fixedTimeRange"] = SerializeTimeRange(plan.FixedTimeRange),
+            ["maximumDraughtMetres"] = plan.MaximumDraught,
+            ["underKeelClearancePurpose"] = plan.UnderKeelClearancePurpose,
+            ["underKeelClearanceCalculationRequested"] = plan.UnderKeelClearanceCalculationRequested,
+            ["externalReferences"] = externalReferences,
+            ["counts"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["controlPoints"] = typed.ControlPoints.Length,
+                ["nonNavigableAreas"] = typed.NonNavigableAreas.Length,
+                ["almostNonNavigableAreas"] = typed.AlmostNonNavigableAreas.Length,
+            },
+            ["extraAttributes"] = plan.ExtraAttributes,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeSurface(
+        string featureType,
+        string id,
+        S129GeometryKind kind,
+        ImmutableArray<GeoPosition> exterior,
+        ImmutableArray<ImmutableArray<GeoPosition>> interior,
+        int? scaleMinimum,
+        ImmutableDictionary<string, string> extraAttributes)
+    {
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = id,
+            ["featureType"] = featureType,
+            ["geometryType"] = kind.ToString(),
+            ["scaleMinimum"] = scaleMinimum,
+            ["exteriorRing"] = exterior.Select(SerializePoint).ToArray(),
+            ["interiorRings"] = interior
+                .Select(r => r.Select(SerializePoint).ToArray())
+                .ToArray(),
+            ["extraAttributes"] = extraAttributes,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static JsonElement SerializeControlPoint(S129ControlPoint cp)
+    {
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = cp.Id,
+            ["featureType"] = "UnderKeelClearanceControlPoint",
+            ["position"] = cp.Position is { } pos ? SerializePoint(pos) : null,
+            ["expectedPassingTime"] = cp.ExpectedPassingTime,
+            ["expectedPassingSpeedKnots"] = cp.ExpectedPassingSpeed,
+            ["distanceAboveUkcLimitMetres"] = cp.DistanceAboveUkcLimit,
+            ["fixedTimeRange"] = SerializeTimeRange(cp.FixedTimeRange),
+            ["featureName"] = cp.FeatureName is { } fn ? new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["language"] = fn.Language,
+                ["name"] = fn.Name,
+                ["nameUsage"] = fn.NameUsage,
+            } : null,
+            ["extraAttributes"] = cp.ExtraAttributes,
+        };
+
+        return ToJsonElement(payload);
+    }
+
+    private static Dictionary<string, object?> SerializePoint(GeoPosition p) =>
+        new(StringComparer.Ordinal)
+        {
+            ["latitude"] = p.Latitude,
+            ["longitude"] = p.Longitude,
+        };
+
+    private static Dictionary<string, object?>? SerializeTimeRange(S129TimeRange? range)
+    {
+        if (range is null) return null;
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["start"] = range.Start,
+            ["end"] = range.End,
+        };
+    }
+
+    private static JsonElement ToJsonElement(object payload)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return JsonSerializer.Deserialize<JsonElement>(bytes);
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tests/EncDotNet.S100.Mcp.Tests.csproj
+++ b/tests/EncDotNet.S100.Mcp.Tests/EncDotNet.S100.Mcp.Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S124\EncDotNet.S100.Datasets.S124.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S129\EncDotNet.S100.Datasets.S129.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S131\EncDotNet.S100.Datasets.S131.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp\EncDotNet.S100.Mcp.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Mcp.Tools\EncDotNet.S100.Mcp.Tools.csproj" />
@@ -44,6 +45,7 @@
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S104Synth.cs" Link="Fakes\S104Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S111Synth.cs" Link="Fakes\S111Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S124Synth.cs" Link="Fakes\S124Synth.cs" />
+    <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S129Synth.cs" Link="Fakes\S129Synth.cs" />
     <Compile Include="..\EncDotNet.S100.Mcp.Tools.Tests\Fakes\S131Synth.cs" Link="Fakes\S131Synth.cs" />
   </ItemGroup>
 

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS129Tests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS129Tests.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+public class DescribeFeatureToolS129Tests
+{
+    [Fact]
+    public async Task PlanId_ResolvesToPlanHeader_WithExternalReferencesAndDraught()
+    {
+        var dataset = S129Synth.Dataset(
+            S129Synth.Plan(id: "PLAN_1"),
+            S129Synth.PlanArea(),
+            S129Synth.ControlPoint(id: "CP_01"),
+            S129Synth.ControlPoint(id: "CP_02", expectedPassingTime: "2024-04-17T22:30:00Z"),
+            S129Synth.NonNavigableArea(id: "NN_1"));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S129("ds", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "PLAN_1"));
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("UnderKeelClearancePlan", value.FeatureTypeName);
+        Assert.Equal("S-129", value.Spec.Name);
+        Assert.Empty(value.References);
+
+        var attrs = value.Attributes;
+        Assert.Equal("PLAN_1", attrs.GetProperty("id").GetString());
+        Assert.Equal(12.2, attrs.GetProperty("maximumDraughtMetres").GetDouble());
+        Assert.Equal("passage planning", attrs.GetProperty("underKeelClearancePurpose").GetString());
+
+        var refs = attrs.GetProperty("externalReferences");
+        Assert.Equal(JsonValueKind.Array, refs.ValueKind);
+        Assert.Equal(2, refs.GetArrayLength());
+        // First reference: vessel.
+        Assert.Equal("vessel", refs[0].GetProperty("kind").GetString());
+        Assert.Equal("9800738", refs[0].GetProperty("identifier").GetString());
+        // Second reference: S-421 route with version.
+        Assert.Equal("S-421 route", refs[1].GetProperty("kind").GetString());
+        Assert.Equal("Test Route", refs[1].GetProperty("identifier").GetString());
+        Assert.Equal("1", refs[1].GetProperty("version").GetString());
+
+        var counts = attrs.GetProperty("counts");
+        Assert.Equal(2, counts.GetProperty("controlPoints").GetInt32());
+        Assert.Equal(1, counts.GetProperty("nonNavigableAreas").GetInt32());
+        Assert.Equal(0, counts.GetProperty("almostNonNavigableAreas").GetInt32());
+
+        var range = attrs.GetProperty("fixedTimeRange");
+        Assert.Equal("2024-04-17T21:41:00+00:00", range.GetProperty("start").GetString());
+        Assert.Equal("2024-04-18T01:13:00+00:00", range.GetProperty("end").GetString());
+    }
+
+    [Fact]
+    public async Task PlanAreaId_ResolvesToSurface_WithExteriorRing()
+    {
+        var dataset = S129Synth.Dataset(
+            S129Synth.Plan(),
+            S129Synth.PlanArea(id: "PLAN_AREA_1"));
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S129("ds", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "PLAN_AREA_1"));
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("UnderKeelClearancePlanArea", value.FeatureTypeName);
+
+        var attrs = value.Attributes;
+        Assert.Equal("Surface", attrs.GetProperty("geometryType").GetString());
+        var ring = attrs.GetProperty("exteriorRing");
+        Assert.True(ring.GetArrayLength() >= 3);
+        Assert.Equal(47.0, ring[0].GetProperty("latitude").GetDouble());
+        Assert.Equal(-122.0, ring[0].GetProperty("longitude").GetDouble());
+    }
+
+    [Fact]
+    public async Task ControlPointId_ResolvesToCP_WithUkcMargin()
+    {
+        var dataset = S129Synth.Dataset(
+            S129Synth.Plan(),
+            S129Synth.PlanArea(),
+            S129Synth.ControlPoint(id: "CP_01", latitude: 47.15, longitude: -121.85,
+                expectedPassingSpeed: 6.0, distanceAboveUkcLimit: 0.113));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S129("ds", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "CP_01"));
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("UnderKeelClearanceControlPoint", value.FeatureTypeName);
+
+        var attrs = value.Attributes;
+        var pos = attrs.GetProperty("position");
+        Assert.Equal(47.15, pos.GetProperty("latitude").GetDouble(), 6);
+        Assert.Equal(-121.85, pos.GetProperty("longitude").GetDouble(), 6);
+        Assert.Equal("2024-04-17T22:00:00+00:00", attrs.GetProperty("expectedPassingTime").GetString());
+        Assert.Equal(6.0, attrs.GetProperty("expectedPassingSpeedKnots").GetDouble());
+        Assert.Equal(0.113, attrs.GetProperty("distanceAboveUkcLimitMetres").GetDouble(), 6);
+    }
+
+    [Fact]
+    public async Task NonNavigableAreaId_ResolvesToSurface_WithScaleMinimum()
+    {
+        var dataset = S129Synth.Dataset(
+            S129Synth.Plan(),
+            S129Synth.PlanArea(),
+            S129Synth.NonNavigableArea(id: "NN_1", scaleMinimum: 50000));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S129("ds", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "NN_1"));
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("UnderKeelClearanceNonNavigableArea", value.FeatureTypeName);
+        var attrs = value.Attributes;
+        Assert.Equal(50000, attrs.GetProperty("scaleMinimum").GetInt32());
+        Assert.Equal("Surface", attrs.GetProperty("geometryType").GetString());
+        Assert.True(attrs.GetProperty("exteriorRing").GetArrayLength() >= 3);
+    }
+
+    [Fact]
+    public async Task UnknownId_ReturnsFeatureNotFound()
+    {
+        var dataset = S129Synth.Dataset(S129Synth.Plan(), S129Synth.PlanArea());
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S129("ds", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "does-not-exist"));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<FeatureNotFound>(err);
+    }
+
+    [Fact]
+    public async Task SpecMismatch_S129SpecWithS101Payload_ReturnsSpecNotSupported()
+    {
+        var catalog = new FakeDatasetCatalog();
+        var s101 = LoadedDatasetFactory.S101("ds");
+        catalog.Add(new LoadedDataset(
+            s101.Id,
+            LoadedDatasetFactory.S129Spec,
+            s101.Bounds,
+            null,
+            s101.Data));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "PLAN_1"));
+        Assert.True(result.TryGetError(out var err));
+        var unsupported = Assert.IsType<SpecNotSupportedForTool>(err);
+        Assert.Equal("S-129", unsupported.Spec.Name);
+    }
+
+    [Fact]
+    public async Task GeometrylessPlanArea_StillResolves_WithEmptyRings()
+    {
+        var dataset = S129Synth.Dataset(
+            S129Synth.Plan(),
+            S129Synth.GeometrylessPlanArea(id: "PLAN_AREA_1"));
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S129("ds", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(new DescribeFeatureRequest(new DatasetId("ds"), "PLAN_AREA_1"));
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("UnderKeelClearancePlanArea", value.FeatureTypeName);
+        var attrs = value.Attributes;
+        Assert.Equal("None", attrs.GetProperty("geometryType").GetString());
+        Assert.Equal(0, attrs.GetProperty("exteriorRing").GetArrayLength());
+        Assert.Equal(0, attrs.GetProperty("interiorRings").GetArrayLength());
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/LoadedDatasetFactory.cs
@@ -5,6 +5,7 @@ using EncDotNet.S100.Datasets.S104;
 using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Datasets.S122;
 using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S129;
 using EncDotNet.S100.Datasets.S131;
 using EncDotNet.S100.Mcp.Tools.Catalog;
 using EncDotNet.S100.Pipelines;
@@ -18,6 +19,7 @@ internal static class LoadedDatasetFactory
     public static SpecRef S124Spec => new("S-124", new SpecVersion(1, 1, 0));
     public static SpecRef S122Spec => new("S-122", new SpecVersion(1, 0, 0));
     public static SpecRef S131Spec => new("S-131", new SpecVersion(1, 0, 0));
+    public static SpecRef S129Spec => new("S-129", new SpecVersion(2, 0, 0));
     public static SpecRef S102Spec => new("S-102", new SpecVersion(2, 1, 0));
     public static SpecRef S104Spec => new("S-104", new SpecVersion(1, 0, 0));
     public static SpecRef S111Spec => new("S-111", new SpecVersion(1, 2, 0));
@@ -77,6 +79,19 @@ internal static class LoadedDatasetFactory
             bounds ?? Box(),
             null,
             new S131DatasetData(model ?? S131Synth.Dataset()));
+    }
+
+    public static LoadedDataset S129(
+        string id,
+        S129Dataset? model = null,
+        BoundingBox? bounds = null)
+    {
+        return new LoadedDataset(
+            new DatasetId(id),
+            S129Spec,
+            bounds ?? Box(),
+            null,
+            new S129DatasetData(model ?? S129Synth.Dataset(S129Synth.Plan(), S129Synth.PlanArea())));
     }
 
     public static LoadedDataset S102(

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S129Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S129Synth.cs
@@ -1,0 +1,163 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Gml;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+/// <summary>
+/// Builders for synthetic <see cref="S129Dataset"/> instances used by
+/// MCP describer tests. Mirrors the pattern of <c>S124Synth</c>.
+/// </summary>
+internal static class S129Synth
+{
+    public static S129Dataset Dataset(params S129Feature[] features) => new()
+    {
+        ProductIdentifier = "S-129",
+        DatasetIdentifier = "TEST_DATASET",
+        Features = features.ToImmutableArray(),
+    };
+
+    public static S129Feature Plan(
+        string id = "PLAN_1",
+        string? vesselId = "9800738",
+        string? sourceRouteName = "Test Route",
+        string? sourceRouteVersion = "1",
+        double? maximumDraught = 12.2,
+        string? generationTime = "2024-04-17T20:00:00Z",
+        string? timeStart = "2024-04-17T21:41:00Z",
+        string? timeEnd = "2024-04-18T01:13:00Z",
+        string? underKeelClearancePurpose = "passage planning",
+        IDictionary<string, string>? extra = null)
+    {
+        var attrs = ImmutableDictionary.CreateBuilder<string, string>();
+        if (vesselId is not null) attrs["vesselID"] = vesselId;
+        if (sourceRouteName is not null) attrs["sourceRouteName"] = sourceRouteName;
+        if (sourceRouteVersion is not null) attrs["sourceRouteVersion"] = sourceRouteVersion;
+        if (maximumDraught is { } md)
+            attrs["maximumDraught"] = md.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (generationTime is not null) attrs["generationTime"] = generationTime;
+        if (underKeelClearancePurpose is not null)
+            attrs["underKeelClearancePurpose"] = underKeelClearancePurpose;
+        if (extra is not null)
+        {
+            foreach (var kv in extra) attrs[kv.Key] = kv.Value;
+        }
+
+        var complex = ImmutableArray<S129ComplexAttribute>.Empty;
+        if (timeStart is not null || timeEnd is not null)
+        {
+            var sub = ImmutableDictionary.CreateBuilder<string, string>();
+            if (timeStart is not null) sub["timeStart"] = timeStart;
+            if (timeEnd is not null) sub["timeEnd"] = timeEnd;
+            complex = ImmutableArray.Create(new S129ComplexAttribute
+            {
+                Code = "fixedTimeRange",
+                SubAttributes = sub.ToImmutable(),
+            });
+        }
+
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearancePlan",
+            GeometryType = GmlGeometryType.None,
+            Points = default,
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = attrs.ToImmutable(),
+            ComplexAttributes = complex,
+        };
+    }
+
+    public static S129Feature PlanArea(
+        string id = "PLAN_AREA_1",
+        IEnumerable<(double Lat, double Lon)>? ring = null)
+    {
+        var ext = (ring ?? new[] { (47.0, -122.0), (47.0, -121.0), (48.0, -121.0), (47.0, -122.0) })
+            .Select(p => (p.Lat, p.Lon)).ToImmutableArray();
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearancePlanArea",
+            GeometryType = GmlGeometryType.Surface,
+            Points = default,
+            Curves = default,
+            ExteriorRing = ext,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S129ComplexAttribute>.Empty,
+        };
+    }
+
+    public static S129Feature GeometrylessPlanArea(string id = "PLAN_AREA_1")
+    {
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearancePlanArea",
+            GeometryType = GmlGeometryType.None,
+            Points = default,
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S129ComplexAttribute>.Empty,
+        };
+    }
+
+    public static S129Feature NonNavigableArea(
+        string id = "NN_1",
+        int? scaleMinimum = 50000,
+        IEnumerable<(double Lat, double Lon)>? ring = null)
+    {
+        var attrs = ImmutableDictionary.CreateBuilder<string, string>();
+        if (scaleMinimum is { } sm)
+            attrs["scaleMinimum"] = sm.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        var ext = (ring ?? new[] { (47.1, -121.9), (47.1, -121.8), (47.2, -121.8), (47.1, -121.9) })
+            .Select(p => (p.Lat, p.Lon)).ToImmutableArray();
+
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearanceNonNavigableArea",
+            GeometryType = GmlGeometryType.Surface,
+            Points = default,
+            Curves = default,
+            ExteriorRing = ext,
+            InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+            Attributes = attrs.ToImmutable(),
+            ComplexAttributes = ImmutableArray<S129ComplexAttribute>.Empty,
+        };
+    }
+
+    public static S129Feature ControlPoint(
+        string id = "CP_01",
+        double latitude = 47.15,
+        double longitude = -121.85,
+        string? expectedPassingTime = "2024-04-17T22:00:00Z",
+        double? expectedPassingSpeed = 6.0,
+        double? distanceAboveUkcLimit = 0.113)
+    {
+        var attrs = ImmutableDictionary.CreateBuilder<string, string>();
+        if (expectedPassingTime is not null) attrs["expectedPassingTime"] = expectedPassingTime;
+        if (expectedPassingSpeed is { } sp)
+            attrs["expectedPassingSpeed"] = sp.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (distanceAboveUkcLimit is { } d)
+            attrs["distanceAboveUKCLimit"] = d.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        return new S129Feature
+        {
+            Id = id,
+            FeatureType = "UnderKeelClearanceControlPoint",
+            GeometryType = GmlGeometryType.Point,
+            Points = ImmutableArray.Create<(double, double)>((latitude, longitude)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = attrs.ToImmutable(),
+            ComplexAttributes = ImmutableArray<S129ComplexAttribute>.Empty,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

S-129 was previously routed through the generic `GmlFeatureDescriber`, which surfaces catalogue-level attributes but misses the UKC plan's distinctive semantics. This PR adds a purpose-built `S129FeatureDescriber` that consumes the existing typed `S129UnderKeelClearancePlan` projection and exposes plan metadata, per-waypoint UKC measurements, non-navigable surfaces, and textual cross-product references in a shape that's useful to MCP agents.

The describer dispatches on GML id (mirroring S-124) across five families: plan header, plan area, non-navigable, almost-non-navigable, and control point. Vessel ID and source-route name/version are folded into a single `externalReferences[]` block (kind/identifier/version) inside the plan payload — per S-129 Edition 2.0.0 these are textual identifiers, not xlink hrefs, so `DescribeFeatureResult.References` stays empty and nothing is eagerly resolved. Control points emit one scalar record each (`expectedPassingTime`, `expectedPassingSpeedKnots`, `distanceAboveUkcLimitMetres`, optional `featureName`); the time series is the ordered CP list rather than a SampledValue payload. Geometry-less plan areas and empty datasets are tolerated (the latter maps to `FeatureNotFound` rather than a new error variant).

No new wire-crossing records were introduced — all payloads live inside the existing `Attributes` `JsonElement` — so `AnnotationContractTests` and `SerializationContractTests` are unaffected.

## Spec alignment

- [ ] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [x] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

S-129 Edition 2.0.0 Feature Catalogue (UnderKeelClearancePlan, ControlPoint, NonNavigableArea, AlmostNonNavigableArea, externalReference textual identifiers).

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Seven new cases in `DescribeFeatureToolS129Tests.cs` cover plan, plan-area, control-point, non-navigable, unknown-id, spec-mismatch, and geometry-less plan-area. Synthetic builders in `Fakes/S129Synth.cs`. Full Mcp.Tools suite: 195 passed, 0 failed, 1 skipped (pre-existing).

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

`src/EncDotNet.S100.Mcp.Tools/README.md` describer-inventory table gains an S-129 row and the "backfilled with generic describer" out-of-scope bullet is updated; `docs/mcp-server.md` `describe_feature` supported-specs list updated.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

None added.

## Breaking changes

None. The MCP wire contract (records, JSON keys, error variants) is unchanged; only the JSON shape inside the existing `Attributes` blob for S-129 features is richer.