### PR TITLE
Honour mariner depth unit in pick panel; localise chart tooltip time

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/FeatureInfoBuilder.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/FeatureInfoBuilder.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using EncDotNet.S100.Features;
+using EncDotNet.S100.Pipelines;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -72,12 +75,80 @@ public static class FeatureInfoBuilder
 
     private static PickAttribute BuildLeaf(string code, string value, FeatureCatalogueDecoder? decoder)
     {
+        double? depthMetres = TryParseKnownDepthMetres(code, value);
         return new PickAttribute
         {
             Code = code,
             Name = decoder?.ResolveAttributeName(code),
             RawValue = value,
             DisplayValue = decoder?.ResolveListedValue(code, value),
+            DepthMetresValue = depthMetres,
+            Children = [],
+        };
+    }
+
+    /// <summary>
+    /// Well-known S-100 depth-typed attribute codes (and their S-57-era
+    /// aliases) whose raw values are interpreted as metres below the
+    /// vertical datum. The set is intentionally narrow: it covers the
+    /// attributes whose semantics demand mariner-selectable depth units
+    /// (S-100 Part 9 §4.2) and excludes vertical-distance attributes that
+    /// represent heights, elevations, or clearances above the water.
+    /// </summary>
+    private static readonly HashSet<string> KnownDepthAttributeCodes =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // S-101 (Edition 2.0.0, Feature Catalogue §SimpleAttributes).
+            "buriedDepth",                "BURDEP",
+            "depthRangeMinimumValue",     "DRVAL1",
+            "depthRangeMaximumValue",     "DRVAL2",
+            "valueOfDepthContour",        "VALDCO",
+            "valueOfSounding",            "VALSOU",
+            "defaultClearanceDepth",
+            "soundingDatumDepth",
+            // S-102 coverage pick (synthesised attributes — depth + vertical uncertainty in metres).
+            "depth",
+            "uncertainty",
+        };
+
+    /// <summary>
+    /// Returns the metres value of <paramref name="rawValue"/> when
+    /// <paramref name="code"/> is a known depth-typed attribute and the
+    /// value parses as a finite real (invariant culture). Returns
+    /// <c>null</c> for non-depth codes, non-numeric values, NaN/Infinity,
+    /// and dataset sentinel "NoData" markers (e.g. <c>"—"</c>) so the
+    /// presentation layer keeps showing the raw text untouched.
+    /// </summary>
+    internal static double? TryParseKnownDepthMetres(string code, string rawValue)
+    {
+        if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(rawValue))
+            return null;
+        if (!KnownDepthAttributeCodes.Contains(code))
+            return null;
+        if (!double.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var metres))
+            return null;
+        if (!double.IsFinite(metres))
+            return null;
+        return metres;
+    }
+
+    /// <summary>
+    /// Builds a depth-typed <see cref="PickAttribute"/> for a value that
+    /// is already known to be metres (e.g. an S-102 coverage sample).
+    /// Sets <see cref="PickAttribute.DepthMetresValue"/> so the viewer
+    /// can re-format the value through the active <see cref="DepthUnit"/>
+    /// without re-parsing <see cref="PickAttribute.RawValue"/>.
+    /// </summary>
+    public static PickAttribute BuildDepthLeaf(string code, string name, double metres)
+    {
+        var raw = metres.ToString("0.##########", CultureInfo.InvariantCulture);
+        return new PickAttribute
+        {
+            Code = code,
+            Name = name,
+            RawValue = raw,
+            DisplayValue = DepthFormatting.Format(metres, DepthUnit.Metres),
+            DepthMetresValue = metres,
             Children = [],
         };
     }

--- a/src/EncDotNet.S100.Datasets.Pipelines/PickAttribute.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/PickAttribute.cs
@@ -58,6 +58,16 @@ public sealed class PickAttribute
     public (DateTime Start, DateTime End)? DateTimeRangeValue { get; init; }
 
     /// <summary>
+    /// Optional typed depth value (canonical metres) backing this attribute.
+    /// When set, presentation layers should re-format the value through the
+    /// active mariner <c>DepthUnit</c> setting (S-100 Part 9 §4.2) rather
+    /// than relying on <see cref="RawValue"/> or <see cref="DisplayValue"/>.
+    /// <see cref="RawValue"/> still carries the unit-less numeric metres
+    /// representation for non-UI consumers (serialization, MCP, tests).
+    /// </summary>
+    public double? DepthMetresValue { get; init; }
+
+    /// <summary>
     /// Sub-attributes of a complex attribute. Empty for simple attributes
     /// and for leaf rows of a complex attribute.
     /// </summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -178,6 +178,11 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
                 Name = "Depth",
                 RawValue = FormatFloat(depth, sample.NoDataValue),
                 DisplayValue = depth == sample.NoDataValue ? "—" : $"{depth.ToString("0.##", CultureInfo.InvariantCulture)} m",
+                // Surface the metres value so the viewer can re-format it
+                // through the mariner's DepthUnit (S-100 Part 9 §4.2).
+                // NoData cells keep DepthMetresValue null and remain rendered
+                // as the localised em-dash placeholder.
+                DepthMetresValue = depth == sample.NoDataValue ? null : (double?)depth,
             },
             new()
             {
@@ -185,6 +190,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
                 Name = "Uncertainty",
                 RawValue = FormatFloat(uncertainty, sample.NoDataValue),
                 DisplayValue = uncertainty == sample.NoDataValue ? "—" : $"{uncertainty.ToString("0.##", CultureInfo.InvariantCulture)} m",
+                DepthMetresValue = uncertainty == sample.NoDataValue ? null : (double?)uncertainty,
             },
         };
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Viewer.Services;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
@@ -23,6 +25,7 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 internal sealed class PickReportViewModel : ViewModelBase
 {
     private readonly ITimeFormatProvider? _timeFormat;
+    private readonly IMarinerSettingsProvider? _marinerSettings;
     private string? _featureType;
     private string? _featureTypeName;
     private string? _featureRef;
@@ -32,13 +35,21 @@ internal sealed class PickReportViewModel : ViewModelBase
     private PickHit? _selectedHit;
 
     public PickReportViewModel()
-        : this(timeFormat: null)
+        : this(timeFormat: null, marinerSettings: null)
     {
     }
 
     public PickReportViewModel(ITimeFormatProvider? timeFormat)
+        : this(timeFormat, marinerSettings: null)
+    {
+    }
+
+    public PickReportViewModel(
+        ITimeFormatProvider? timeFormat,
+        IMarinerSettingsProvider? marinerSettings)
     {
         _timeFormat = timeFormat;
+        _marinerSettings = marinerSettings;
         ClearCommand = new RelayCommand(Clear);
         NavigateCommand = new RelayCommand<FeatureReference>(
             r => { if (r is not null) NavigateRequested?.Invoke(this, r); },
@@ -46,35 +57,50 @@ internal sealed class PickReportViewModel : ViewModelBase
 
         if (_timeFormat is not null)
             _timeFormat.TimeFormatChanged += OnTimeFormatChanged;
+
+        if (_marinerSettings is not null)
+            _marinerSettings.Changed += OnMarinerSettingsChanged;
     }
 
     private void OnTimeFormatChanged(TimeFormat _)
     {
-        // Re-format attribute rows that carry typed date/time values so
-        // the displayed strings reflect the new setting immediately.
+        ReformatAttributesFromSelectedHit();
+    }
+
+    private void OnMarinerSettingsChanged(MarinerSettings _)
+    {
+        // DepthUnit is the only mariner setting the pick panel renders;
+        // re-run the same projection used for time-format changes so
+        // depth-typed rows pick up the new unit immediately.
+        ReformatAttributesFromSelectedHit();
+    }
+
+    private void ReformatAttributesFromSelectedHit()
+    {
         if (_selectedHit is null) return;
-        var reformatted = ReformatTimeAttributes(_selectedHit.Attributes);
+        var reformatted = ReformatTypedAttributes(_selectedHit.Attributes);
         Attributes.Clear();
         foreach (var a in reformatted) Attributes.Add(a);
         OnPropertyChanged(nameof(HasAttributes));
     }
 
-    private IReadOnlyList<PickAttribute> ReformatTimeAttributes(IReadOnlyList<PickAttribute> source)
+    private IReadOnlyList<PickAttribute> ReformatTypedAttributes(IReadOnlyList<PickAttribute> source)
     {
-        var fmt = _timeFormat?.Current ?? TimeFormat.Local;
+        var timeFmt = _timeFormat?.Current ?? TimeFormat.Local;
+        var depthUnit = _marinerSettings?.Current.DepthUnit ?? DepthUnit.Metres;
         var list = new List<PickAttribute>(source.Count);
         foreach (var attr in source)
         {
-            list.Add(ReformatOne(attr, fmt));
+            list.Add(ReformatOne(attr, timeFmt, depthUnit));
         }
         return list;
     }
 
-    private PickAttribute ReformatOne(PickAttribute attr, TimeFormat fmt)
+    private PickAttribute ReformatOne(PickAttribute attr, TimeFormat timeFmt, DepthUnit depthUnit)
     {
         var children = attr.Children.Count == 0
             ? attr.Children
-            : (IReadOnlyList<PickAttribute>)ReformatTimeAttributes(attr.Children);
+            : (IReadOnlyList<PickAttribute>)ReformatTypedAttributes(attr.Children);
 
         if (attr.DateTimeValue is { } dt)
         {
@@ -83,9 +109,10 @@ internal sealed class PickReportViewModel : ViewModelBase
                 Code = attr.Code,
                 Name = attr.Name,
                 RawValue = attr.RawValue,
-                DisplayValue = TimeFormatting.Format(dt, fmt),
+                DisplayValue = TimeFormatting.Format(dt, timeFmt),
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
+                DepthMetresValue = attr.DepthMetresValue,
                 Children = children,
             };
         }
@@ -97,9 +124,25 @@ internal sealed class PickReportViewModel : ViewModelBase
                 Code = attr.Code,
                 Name = attr.Name,
                 RawValue = attr.RawValue,
-                DisplayValue = TimeFormatting.FormatTimeRange(range.Start, range.End, fmt),
+                DisplayValue = TimeFormatting.FormatTimeRange(range.Start, range.End, timeFmt),
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
+                DepthMetresValue = attr.DepthMetresValue,
+                Children = children,
+            };
+        }
+
+        if (attr.DepthMetresValue is { } metres)
+        {
+            return new PickAttribute
+            {
+                Code = attr.Code,
+                Name = attr.Name,
+                RawValue = attr.RawValue,
+                DisplayValue = DepthFormatting.Format(metres, depthUnit),
+                DateTimeValue = attr.DateTimeValue,
+                DateTimeRangeValue = attr.DateTimeRangeValue,
+                DepthMetresValue = attr.DepthMetresValue,
                 Children = children,
             };
         }
@@ -114,6 +157,7 @@ internal sealed class PickReportViewModel : ViewModelBase
                 DisplayValue = attr.DisplayValue,
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
+                DepthMetresValue = attr.DepthMetresValue,
                 Children = children,
             };
         }
@@ -347,7 +391,7 @@ internal sealed class PickReportViewModel : ViewModelBase
         ProductSpec = hit.ProductSpec;
 
         Attributes.Clear();
-        foreach (var attr in ReformatTimeAttributes(hit.Attributes))
+        foreach (var attr in ReformatTypedAttributes(hit.Attributes))
             Attributes.Add(attr);
         OnPropertyChanged(nameof(HasAttributes));
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/S104StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/S104StationTimeSeriesViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
@@ -37,6 +38,12 @@ internal sealed class S104StationTimeSeriesViewModel : StationTimeSeriesViewMode
                 GeometrySize = 0,
                 GeometryStroke = null,
                 GeometryFill = null,
+                // Override LiveCharts2's default tooltip (which prints the
+                // raw UTC DateTime regardless of mariner time-zone setting)
+                // with one that routes through FormatTooltipDateTime.
+                XToolTipLabelFormatter = p => FormatTooltipDateTime(
+                    new System.DateTime((long)p.Coordinate.SecondaryValue, System.DateTimeKind.Utc)),
+                YToolTipLabelFormatter = p => p.Coordinate.PrimaryValue.ToString("0.##", CultureInfo.InvariantCulture) + " m",
             },
         };
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/S111StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/S111StationTimeSeriesViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
@@ -46,6 +47,9 @@ internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewMode
                 GeometrySize = 0,
                 GeometryStroke = null,
                 GeometryFill = null,
+                XToolTipLabelFormatter = p => FormatTooltipDateTime(
+                    new System.DateTime((long)p.Coordinate.SecondaryValue, System.DateTimeKind.Utc)),
+                YToolTipLabelFormatter = p => p.Coordinate.PrimaryValue.ToString("0.##", CultureInfo.InvariantCulture) + " m/s",
             },
         };
 
@@ -60,6 +64,9 @@ internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewMode
                 GeometrySize = 0,
                 GeometryStroke = null,
                 GeometryFill = null,
+                XToolTipLabelFormatter = p => FormatTooltipDateTime(
+                    new System.DateTime((long)p.Coordinate.SecondaryValue, System.DateTimeKind.Utc)),
+                YToolTipLabelFormatter = p => p.Coordinate.PrimaryValue.ToString("0.#", CultureInfo.InvariantCulture) + "°",
             },
         };
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/StationTimeSeriesViewModel.cs
@@ -177,6 +177,26 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
         TimeAxis.Labeler = FormatTimeAxisLabel;
     }
 
+    /// <summary>
+    /// Formats a chart point's underlying <see cref="DateTime"/> (always
+    /// stored as UTC ticks via <see cref="DateTimePoint"/>) for display
+    /// in the per-point tooltip, honouring the mariner's selected
+    /// time-zone display (<see cref="TimeFormat"/>). Used by subclasses
+    /// to override the default LiveCharts2 tooltip, which otherwise
+    /// renders the raw UTC <c>DateTime.ToString()</c> regardless of the
+    /// chosen format (LiveCharts2 v2 has no awareness of local zones).
+    /// </summary>
+    protected internal string FormatTooltipDateTime(DateTime utc)
+    {
+        var fmt = _timeFormat?.Current ?? TimeFormat.Local;
+        if (fmt == TimeFormat.Utc)
+            return DateTime.SpecifyKind(utc, DateTimeKind.Utc)
+                .ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture);
+        return DateTime.SpecifyKind(utc, DateTimeKind.Utc)
+            .ToLocalTime()
+            .ToString("g", CultureInfo.CurrentCulture);
+    }
+
     private string FormatTimeAxisLabel(double ticks)
     {
         if (!double.IsFinite(ticks)) return string.Empty;

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 
 namespace EncDotNet.S100.Viewer.Tests;
@@ -334,5 +337,78 @@ public class PickReportViewModelTests
         vm.NavigateCommand.Execute(null);
 
         Assert.False(invoked);
+    }
+
+    private sealed class StubMarinerSettings : IMarinerSettingsProvider
+    {
+        public MarinerSettings Current { get; private set; }
+        public StubMarinerSettings(MarinerSettings initial) => Current = initial;
+        public event Action<MarinerSettings>? Changed;
+        public void Update(MarinerSettings value)
+        {
+            Current = value;
+            Changed?.Invoke(value);
+        }
+    }
+
+    [Fact]
+    public void SetPick_FormatsDepthAttribute_InCurrentDepthUnit()
+    {
+        var mariner = new StubMarinerSettings(new MarinerSettings { DepthUnit = DepthUnit.Feet });
+        var vm = new PickReportViewModel(timeFormat: null, marinerSettings: mariner);
+
+        vm.SetPick(
+            featureType: "DepthArea",
+            featureTypeName: "Depth Area",
+            featureRef: "1",
+            datasetFileName: "x.000",
+            productSpec: "S-101",
+            attributes: new[]
+            {
+                new PickAttribute
+                {
+                    Code = "DRVAL1",
+                    Name = "Depth Range Min",
+                    RawValue = "10",
+                    DisplayValue = "10",
+                    DepthMetresValue = 10.0,
+                    Children = Array.Empty<PickAttribute>(),
+                },
+            });
+
+        // 10 m → ~32.8 ft via DepthFormatting.
+        Assert.Contains("ft", vm.Attributes[0].DisplayValue!);
+    }
+
+    [Fact]
+    public void DepthUnitChange_Rewrites_DepthAttribute_DisplayValue_Live()
+    {
+        var mariner = new StubMarinerSettings(new MarinerSettings { DepthUnit = DepthUnit.Metres });
+        var vm = new PickReportViewModel(timeFormat: null, marinerSettings: mariner);
+
+        vm.SetPick(
+            featureType: "DepthArea",
+            featureTypeName: "Depth Area",
+            featureRef: "1",
+            datasetFileName: "x.000",
+            productSpec: "S-101",
+            attributes: new[]
+            {
+                new PickAttribute
+                {
+                    Code = "VALDCO",
+                    Name = "Value of Depth Contour",
+                    RawValue = "5",
+                    DisplayValue = "5 m",
+                    DepthMetresValue = 5.0,
+                    Children = Array.Empty<PickAttribute>(),
+                },
+            });
+
+        Assert.Contains("m", vm.Attributes[0].DisplayValue!);
+
+        mariner.Update(new MarinerSettings { DepthUnit = DepthUnit.Feet });
+
+        Assert.Contains("ft", vm.Attributes[0].DisplayValue!);
     }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/StationTimeSeriesTimeFormatTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/StationTimeSeriesTimeFormatTests.cs
@@ -92,4 +92,32 @@ public class StationTimeSeriesTimeFormatTests
 
         Assert.Equal("09:30", vm.TimeAxis.Labeler(ticks));
     }
+
+    [Fact]
+    public void Tooltip_UtcMode_FormatsAsUtcWithSuffix()
+    {
+        var snap = Synthetic();
+        var tf = new StubTimeFormat(TimeFormat.Utc);
+        using var vm = new S104StationTimeSeriesViewModel(snap, globalTime: null, timeFormat: tf);
+
+        var utc = new DateTime(2026, 1, 1, 9, 30, 0, DateTimeKind.Utc);
+        var label = vm.FormatTooltipDateTime(utc);
+
+        Assert.Equal("2026-01-01 09:30 UTC", label);
+    }
+
+    [Fact]
+    public void Tooltip_LocalMode_FormatsAsLocalShortDateTime()
+    {
+        var snap = Synthetic();
+        var tf = new StubTimeFormat(TimeFormat.Local);
+        using var vm = new S104StationTimeSeriesViewModel(snap, globalTime: null, timeFormat: tf);
+
+        var utc = new DateTime(2026, 1, 1, 9, 30, 0, DateTimeKind.Utc);
+        var label = vm.FormatTooltipDateTime(utc);
+
+        var expected = utc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+        Assert.Equal(expected, label);
+        Assert.DoesNotContain("UTC", label);
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

Fixes two viewer bugs reported against the pick panel:

1. **Pick attribute depth values ignored the mariner `DepthUnit` setting** and were always rendered in metres. Affected attributes include `DRVAL1` / `DRVAL2`, `VALDCO`, `VALSOU`, `BURDEP` (and canonical S-100 names) on S-101/GML features plus `depth` and `uncertainty` on S-102 coverage picks.
2. **The station time-series chart tooltips always rendered UTC**, even when the mariner had selected Local time. The axis labels already honoured the setting (proven by existing tests); only the per-point tooltip was stuck on `DateTimePoint`'s default UTC `ToString`.

### Approach

For depth, I extend the typed-attribute pattern already established for date/times: `PickAttribute` gains a nullable `DepthMetresValue` (in metres, the canonical S-100 storage unit). `FeatureInfoBuilder.BuildLeaf` auto-populates it for a small, well-known set of depth attribute codes (S-101 FC §SimpleAttributes plus their S-57-era aliases), and `S102DatasetProcessor` sets it on synthesised depth + uncertainty pick rows. `PickReportViewModel` takes an `IMarinerSettingsProvider`, subscribes to its `Changed` event, and reformats depth rows through `DepthFormatting.Format(metres, depthUnit)` both on the initial pick and live on toggle. Heights / elevations / vertical clearances are deliberately out of scope — the mariner setting is `DepthUnit`, not a general vertical-distance unit.

For the chart tooltip, I added an explicit `XToolTipLabelFormatter` on each `LineSeries<DateTimePoint>` (S-104 height, S-111 speed + direction) that routes through a new `StationTimeSeriesViewModel.FormatTooltipDateTime(DateTime utc)` helper. The helper honours `ITimeFormatProvider.Current` (UTC -> `"yyyy-MM-dd HH:mm UTC"`, Local -> `ToLocalTime().ToString("g")`). Y-axis tooltip values get their units appended too (m, m/s, deg).

## Spec alignment

- [x] S-100 framework (`s100-framework`) — depth-unit conversion is S-100 Part 9 sec 4.2 Mariner Selections; metres remain the canonical storage unit
- [x] S-101 ENC (`s101-enc`) — known depth attribute codes from FC Edition 2.0.0
- [x] S-102 bathymetry (`s102-bathymetry`) — coverage pick depth + uncertainty are metres per S-102 Edition 2.1.0
- [x] S-104 water level (`s104-water-level`) — chart tooltip time-zone localisation
- [x] S-111 surface currents (`s111-surface-currents`) — chart tooltip time-zone localisation

**Spec section references cited in code/docs:**

S-100 Part 9 sec 4.2 (Mariner Selections / DepthUnit), S-101 Feature Catalogue Edition 2.0.0 simple-attribute codes.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally (0 failures across all test assemblies)

New tests:

- `PickReportViewModelTests.SetPick_FormatsDepthAttribute_InCurrentDepthUnit`
- `PickReportViewModelTests.DepthUnitChange_Rewrites_DepthAttribute_DisplayValue_Live`
- `StationTimeSeriesTimeFormatTests.Tooltip_UtcMode_FormatsAsUtcWithSuffix`
- `StationTimeSeriesTimeFormatTests.Tooltip_LocalMode_FormatsAsLocalShortDateTime`

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` — N/A (no public surface or user-facing doc change beyond the bug fix itself)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed — N/A
- [x] New public APIs have XML doc comments (`PickAttribute.DepthMetresValue`, `FeatureInfoBuilder.BuildDepthLeaf`, `FormatTooltipDateTime`)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency — N/A

## Breaking changes

None. `PickAttribute.DepthMetresValue` is an additive `init`-only property. `PickReportViewModel` keeps its existing parameterless and `(ITimeFormatProvider?)` constructors and adds a new greedy `(ITimeFormatProvider?, IMarinerSettingsProvider?)` overload that DI now resolves automatically.