### PR TITLE
Add Validation tab to dataset properties panel

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -9,6 +9,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Projections;
@@ -208,6 +209,23 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
             };
         }
     }
+
+    /// <summary>
+    /// Hook for spec-specific subclasses to run their normative
+    /// validation rule pack against the parsed dataset. Returns
+    /// <c>null</c> by default, signalling that no rule pack is
+    /// defined for this product.
+    /// </summary>
+    /// <remarks>
+    /// Overrides should typically delegate to
+    /// <c>ValidationRunner.Run(...)</c> so that an
+    /// <see cref="System.InvalidOperationException"/> from the typed
+    /// projection (e.g. an empty dataset) surfaces as an empty
+    /// report rather than propagating out of <see cref="Validate"/>.
+    /// Overrides should also cache the result so repeated calls are
+    /// cheap.
+    /// </remarks>
+    public virtual ValidationReport? Validate() => null;
 
     private FeatureInfo BuildFeatureInfo(TFeature feature)
     {

--- a/src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -84,6 +85,31 @@ public interface IDatasetProcessor
     /// default empty enumeration.
     /// </remarks>
     IEnumerable<FeatureSummary> EnumerateFeatures() => System.Array.Empty<FeatureSummary>();
+
+    /// <summary>
+    /// Runs the spec's normative validation rule pack against this
+    /// processor's parsed dataset and returns the aggregated report,
+    /// or <c>null</c> when no rule pack is available for the spec
+    /// (e.g. coverage products and S-101 / S-201 / S-57 today).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Validation is a pure function of the parsed dataset and does
+    /// not depend on the current palette, opacity, or selected time
+    /// step; callers cache the report rather than re-running it on
+    /// every render. Implementations should run the projection
+    /// (<c>S125AtonDataset.From(...)</c>, etc.) lazily and cache the
+    /// resulting <see cref="ValidationReport"/> on a private field so
+    /// repeated calls are cheap.
+    /// </para>
+    /// <para>
+    /// A return value of <c>null</c> means "no rule pack is yet
+    /// defined for this spec" — distinct from
+    /// <see cref="ValidationReport.Empty"/>, which means "rules were
+    /// evaluated and found nothing".
+    /// </para>
+    /// </remarks>
+    ValidationReport? Validate() => null;
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
@@ -1,15 +1,20 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S122;
+using EncDotNet.S100.Datasets.S122.DataModel;
+using EncDotNet.S100.Datasets.S122.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
 public sealed class S122DatasetProcessor : GmlDatasetProcessorBase<S122Feature>
 {
     private readonly S122Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-122", default);
     protected override string ProductDescription => "Marine Protected Areas";
@@ -60,4 +65,18 @@ public sealed class S122DatasetProcessor : GmlDatasetProcessorBase<S122Feature>
 
     protected override IFeatureXmlSource CreateFeatureXmlSource() =>
         new GmlFeatureXmlSource<S122Feature>(_dataset.Features);
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S122MarineProtectedAreaDataset.From(raw, out _),
+                S122MarineProtectedAreaRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
@@ -1,15 +1,20 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S124;
+using EncDotNet.S100.Datasets.S124.DataModel;
+using EncDotNet.S100.Datasets.S124.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
 public sealed class S124DatasetProcessor : GmlDatasetProcessorBase<S124Feature>
 {
     private readonly S124Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-124", default);
     protected override string ProductDescription => "Navigational Warnings";
@@ -59,4 +64,18 @@ public sealed class S124DatasetProcessor : GmlDatasetProcessorBase<S124Feature>
 
     protected override IFeatureXmlSource CreateFeatureXmlSource() =>
         new GmlFeatureXmlSource<S124Feature>(_dataset.Features);
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S124NavigationalWarning.From(raw, out _),
+                S124NavigationalWarningRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
@@ -1,9 +1,12 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S125;
+using EncDotNet.S100.Datasets.S125.DataModel;
+using EncDotNet.S100.Datasets.S125.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -15,6 +18,8 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 public sealed class S125DatasetProcessor : GmlDatasetProcessorBase<S125Feature>
 {
     private readonly S125Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     /// <inheritdoc />
     public override SpecRef Spec => new("S-125", default);
@@ -85,4 +90,18 @@ public sealed class S125DatasetProcessor : GmlDatasetProcessorBase<S125Feature>
 
     protected override string BuildInfoSuffix() =>
         $"Information types: {_dataset.InformationTypes.Length}";
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S125AtonDataset.From(raw, out _),
+                S125AtonRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
@@ -1,9 +1,12 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S127;
+using EncDotNet.S100.Datasets.S127.DataModel;
+using EncDotNet.S100.Datasets.S127.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -15,6 +18,8 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 public sealed class S127DatasetProcessor : GmlDatasetProcessorBase<S127Feature>
 {
     private readonly S127Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-127", default);
     protected override string ProductDescription => "Marine Resources and Services";
@@ -64,4 +69,18 @@ public sealed class S127DatasetProcessor : GmlDatasetProcessorBase<S127Feature>
 
     protected override IFeatureXmlSource CreateFeatureXmlSource() =>
         new GmlFeatureXmlSource<S127Feature>(_dataset.Features);
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S127MarineServicesDataset.From(raw, out _),
+                S127MarineServicesRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
@@ -1,15 +1,20 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S128;
+using EncDotNet.S100.Datasets.S128.DataModel;
+using EncDotNet.S100.Datasets.S128.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
 public sealed class S128DatasetProcessor : GmlDatasetProcessorBase<S128Feature>
 {
     private readonly S128Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-128", default);
     protected override string ProductDescription => "Catalogue of Nautical Products";
@@ -62,4 +67,18 @@ public sealed class S128DatasetProcessor : GmlDatasetProcessorBase<S128Feature>
 
     protected override IFeatureXmlSource CreateFeatureXmlSource() =>
         new S128FeatureXmlSource(_dataset);
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S128ProductCatalogue.From(raw, out _),
+                S128CatalogueRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
@@ -2,15 +2,20 @@ using System;
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S129;
+using EncDotNet.S100.Datasets.S129.DataModel;
+using EncDotNet.S100.Datasets.S129.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
 public sealed class S129DatasetProcessor : GmlDatasetProcessorBase<S129Feature>
 {
     private readonly S129Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-129", default);
     protected override string ProductDescription => "Under Keel Clearance Management";
@@ -60,6 +65,20 @@ public sealed class S129DatasetProcessor : GmlDatasetProcessorBase<S129Feature>
 
     protected override IFeatureXmlSource CreateFeatureXmlSource() =>
         new GmlFeatureXmlSource<S129Feature>(_dataset.Features);
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S129UnderKeelClearancePlan.From(raw, out _),
+                S129UkcRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 
     protected override IReadOnlyList<DrawingInstruction> PostProcessInstructions(
         IReadOnlyList<DrawingInstruction> instructions) => ApplyAreaFillFallback(instructions);

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Xml;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S131;
+using EncDotNet.S100.Datasets.S131.DataModel;
+using EncDotNet.S100.Datasets.S131.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Gml;
 using EncDotNet.S100.Pipelines;
@@ -13,6 +15,7 @@ using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting;
+using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Projections;
@@ -49,6 +52,8 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
     private readonly MapsuiRenderAssetCache _renderAssetCache = new();
     private FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     /// <inheritdoc/>
     public SpecRef Spec => new("S-131", default);
@@ -218,6 +223,20 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
                 FeatureTypeName = _decoder?.ResolveFeatureTypeName(f.FeatureType),
             };
         }
+    }
+
+    /// <inheritdoc/>
+    public ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S131HarbourInfrastructureDataset.From(raw, out _),
+                S131HarbourInfrastructureRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
     }
 
     private void EnsureDecoder()

--- a/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
@@ -2,10 +2,13 @@ using System;
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S411;
+using EncDotNet.S100.Datasets.S411.DataModel;
+using EncDotNet.S100.Datasets.S411.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 using Mapsui.Layers;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
@@ -13,6 +16,8 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
 {
     private readonly S411Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-411", default);
     protected override string ProductDescription => "Sea Ice";
@@ -71,6 +76,20 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
 
     protected override IFeatureXmlSource CreateFeatureXmlSource() =>
         new S411FeatureXmlSource(_dataset);
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S411SeaIceInventory.From(raw, out _),
+                S411SeaIceRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 
     protected override DatasetResult? CheckPreRender(RenderContext? context)
     {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
@@ -1,15 +1,20 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S421;
+using EncDotNet.S100.Datasets.S421.DataModel;
+using EncDotNet.S100.Datasets.S421.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
 public sealed class S421DatasetProcessor : GmlDatasetProcessorBase<S421Feature>
 {
     private readonly S421Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public override SpecRef Spec => new("S-421", default);
     protected override string ProductDescription => "Route Plan";
@@ -80,4 +85,18 @@ public sealed class S421DatasetProcessor : GmlDatasetProcessorBase<S421Feature>
 
     protected override string BuildInfoSuffix() =>
         $"Information types: {_dataset.InformationTypes.Length}";
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S421RoutePlan.From(raw, out _),
+                S421RoutePlanRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/ValidationRunner.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ValidationRunner.cs
@@ -1,0 +1,47 @@
+using System;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Shared helper for spec-specific <see cref="IDatasetProcessor.Validate"/>
+/// overrides. Centralises projection + rule-pack invocation so each GML
+/// processor's <c>Validate</c> override stays a one-liner and so that
+/// projection failures (typically <see cref="InvalidOperationException"/>
+/// from <c>S&lt;Spec&gt;Dataset.From</c> on an empty dataset) and rule-pack
+/// exceptions never bubble out of <see cref="IDatasetProcessor.Validate"/>.
+/// </summary>
+internal static class ValidationRunner
+{
+    /// <summary>
+    /// Projects <paramref name="rawDataset"/> with <paramref name="project"/>
+    /// and runs <paramref name="ruleSet"/> against the result. Returns
+    /// <see cref="ValidationReport.Empty"/> when projection throws (e.g. an
+    /// empty dataset) or the rule pack itself throws.
+    /// </summary>
+    public static ValidationReport Run<TRaw, TTyped>(
+        TRaw rawDataset,
+        Func<TRaw, TTyped> project,
+        ValidationRuleSet<TTyped> ruleSet)
+    {
+        ArgumentNullException.ThrowIfNull(rawDataset);
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(ruleSet);
+
+        TTyped typed;
+        try
+        {
+            typed = project(rawDataset);
+        }
+        catch (Exception)
+        {
+            // Projection failures (typically "dataset is empty") leave us
+            // with no typed model to evaluate. Surface as an empty report
+            // rather than a null — the loader treats null as "no rule pack
+            // for this spec at all", which is a different condition.
+            return ValidationReport.Empty;
+        }
+
+        return ruleSet.Run(typed!);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -42,6 +42,15 @@ internal static class Strings
     public static string Pane_DatasetTab_Dataset => Get(nameof(Pane_DatasetTab_Dataset));
     public static string Pane_DatasetTab_Layers => Get(nameof(Pane_DatasetTab_Layers));
     public static string Pane_DatasetTab_NoLayers => Get(nameof(Pane_DatasetTab_NoLayers));
+    public static string Pane_DatasetTab_Validation => Get(nameof(Pane_DatasetTab_Validation));
+    public static string Pane_Validation_NoFindings => Get(nameof(Pane_Validation_NoFindings));
+    public static string Pane_Validation_NoRulePack => Get(nameof(Pane_Validation_NoRulePack));
+    public static string Pane_Validation_CountsSummaryFormat => Get(nameof(Pane_Validation_CountsSummaryFormat));
+    public static string Pane_Validation_RelatedFeatureFormat => Get(nameof(Pane_Validation_RelatedFeatureFormat));
+    public static string Pane_Validation_Severity_Error => Get(nameof(Pane_Validation_Severity_Error));
+    public static string Pane_Validation_Severity_Warning => Get(nameof(Pane_Validation_Severity_Warning));
+    public static string Pane_Validation_Severity_Info => Get(nameof(Pane_Validation_Severity_Info));
+    public static string Tooltip_ValidationBadge => Get(nameof(Tooltip_ValidationBadge));
     public static string Pane_Catalog => Get(nameof(Pane_Catalog));
     public static string Pane_Settings => Get(nameof(Pane_Settings));
     public static string Pane_Search => Get(nameof(Pane_Search));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -220,6 +220,33 @@
   <data name="Pane_DatasetTab_NoLayers" xml:space="preserve">
     <value>This dataset has no separately-controllable layers.</value>
   </data>
+  <data name="Pane_DatasetTab_Validation" xml:space="preserve">
+    <value>VALIDATION</value>
+  </data>
+  <data name="Pane_Validation_NoFindings" xml:space="preserve">
+    <value>No findings.</value>
+  </data>
+  <data name="Pane_Validation_NoRulePack" xml:space="preserve">
+    <value>Validation rules not yet defined for {0}.</value>
+  </data>
+  <data name="Pane_Validation_CountsSummaryFormat" xml:space="preserve">
+    <value>{0} findings ({1} errors, {2} warnings, {3} info)</value>
+  </data>
+  <data name="Pane_Validation_RelatedFeatureFormat" xml:space="preserve">
+    <value>Feature: {0}</value>
+  </data>
+  <data name="Pane_Validation_Severity_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Pane_Validation_Severity_Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="Pane_Validation_Severity_Info" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="Tooltip_ValidationBadge" xml:space="preserve">
+    <value>{0} validation findings ({1} errors, {2} warnings, {3} info)</value>
+  </data>
   <data name="Tooltip_TimelineSlider" xml:space="preserve">
     <value>Drag to set the global time. All loaded time-varying datasets re-render at the timestep nearest to this value.</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -259,6 +259,17 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             entry.Info = result.Info;
             entry.CurrentTime = initialTime ?? adapter?.AvailableTimes.FirstOrDefault();
 
+            // Run the spec's normative validation rule pack against
+            // the parsed dataset. Validation is a pure function of the
+            // parsed model so we only do this once per load; ECDIS
+            // / palette / time-step changes never re-run it. A null
+            // return means the spec has no rule pack defined yet —
+            // distinct from an empty report — and the Validation tab
+            // surfaces those two states with different empty-state
+            // messages.
+            var validation = await Task.Run(() => SafeValidate(processor), token);
+            entry.SetValidationReport(validation);
+
             // Dismiss the loading toast before showing the result.
             // Exchange-set entries don't show per-dataset toasts.
             if (!fromExchangeSet)
@@ -473,6 +484,29 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 list.AddRange(ls);
         }
         return list;
+    }
+
+    /// <summary>
+    /// Runs the processor's spec-specific validation rule pack and
+    /// swallows any exception so a buggy rule cannot abort a dataset
+    /// load. Returns the report on success, the processor's null on
+    /// "no rule pack for this spec", or null on exception.
+    /// </summary>
+    private static EncDotNet.S100.Validation.ValidationReport? SafeValidate(IDatasetProcessor processor)
+    {
+        try
+        {
+            return processor.Validate();
+        }
+        catch (Exception ex)
+        {
+            // Defensive — individual rule failures are already
+            // captured as synthetic Error findings by ValidationRuleSet.
+            // This catches the unlikely case where projection or rule
+            // pack construction itself throws.
+            System.Diagnostics.Debug.WriteLine($"[validation] {processor.Spec.Name}: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
     }
 
     private RenderContext CreateRenderContext(IDatasetProcessor processor, DateTime? timeStep = null)

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Validation;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
 
@@ -170,6 +171,139 @@ internal sealed class DatasetEntry : ViewModelBase
         _currentTime is { } t
             ? string.Format(CultureInfo.CurrentCulture, Strings.DatasetEntry_CurrentTimeFormat, t)
             : string.Empty;
+
+    // ── Validation report ────────────────────────────────────────────
+    //
+    // Surfaced in the Validation tab of the dataset properties panel.
+    // Populated once per load by DatasetLoaderService after Render
+    // succeeds. A null Validation means the spec has no rule pack yet
+    // (S-101 / S-102 / S-104 / S-111 / S-201 / S-57); an empty Findings
+    // collection on a non-null Validation means the rules ran and
+    // found nothing.
+
+    private ValidationReport? _validation;
+    /// <summary>
+    /// Aggregated validation findings for this dataset, or <c>null</c>
+    /// when the spec has no rule pack defined. Set once at load time
+    /// by <see cref="Services.DatasetLoaderService"/> via
+    /// <see cref="SetValidationReport"/>.
+    /// </summary>
+    public ValidationReport? Validation => _validation;
+
+    /// <summary><c>true</c> when a rule pack ran (regardless of finding count).</summary>
+    public bool HasValidationRulePack => _validation is not null;
+
+    /// <summary>
+    /// Read-only display models for the report's findings, in the
+    /// order the rules emitted them. Empty when no rule pack ran or
+    /// the report contains no findings.
+    /// </summary>
+    public IReadOnlyList<ValidationFindingViewModel> Findings { get; private set; } =
+        Array.Empty<ValidationFindingViewModel>();
+
+    /// <summary>Total findings across all severities.</summary>
+    public int ValidationFindingCount =>
+        _validation?.Findings.IsDefaultOrEmpty == false ? _validation.Findings.Length : 0;
+
+    /// <summary>Number of <see cref="ValidationSeverity.Error"/> findings.</summary>
+    public int ValidationErrorCount =>
+        _validation?.Findings.IsDefaultOrEmpty == false
+            ? _validation.Findings.Count(f => f.Severity == ValidationSeverity.Error)
+            : 0;
+
+    /// <summary>Number of <see cref="ValidationSeverity.Warning"/> findings.</summary>
+    public int ValidationWarningCount =>
+        _validation?.Findings.IsDefaultOrEmpty == false
+            ? _validation.Findings.Count(f => f.Severity == ValidationSeverity.Warning)
+            : 0;
+
+    /// <summary>Number of <see cref="ValidationSeverity.Info"/> findings.</summary>
+    public int ValidationInfoCount =>
+        _validation?.Findings.IsDefaultOrEmpty == false
+            ? _validation.Findings.Count(f => f.Severity == ValidationSeverity.Info)
+            : 0;
+
+    /// <summary><c>true</c> when the report contains at least one finding.</summary>
+    public bool HasValidationFindings => ValidationFindingCount > 0;
+
+    /// <summary>
+    /// Drives the badge severity class: <c>true</c> when at least one
+    /// Error finding exists. Wired to a <c>Classes.Error</c> binding on
+    /// the badge Border so styling stays in XAML — no value converter.
+    /// </summary>
+    public bool BadgeIsError => ValidationErrorCount > 0;
+
+    /// <summary><c>true</c> when there are warnings but no errors.</summary>
+    public bool BadgeIsWarning => ValidationErrorCount == 0 && ValidationWarningCount > 0;
+
+    /// <summary><c>true</c> when only info-severity findings are present.</summary>
+    public bool BadgeIsInfo =>
+        ValidationErrorCount == 0 && ValidationWarningCount == 0 && ValidationInfoCount > 0;
+
+    /// <summary>
+    /// Localised tooltip for the count badge, e.g.
+    /// <c>"3 validation findings (1 errors, 2 warnings, 0 info)"</c>.
+    /// </summary>
+    public string ValidationBadgeTooltip => string.Format(
+        CultureInfo.CurrentCulture,
+        Strings.Tooltip_ValidationBadge,
+        ValidationFindingCount,
+        ValidationErrorCount,
+        ValidationWarningCount,
+        ValidationInfoCount);
+
+    /// <summary>
+    /// Localised counts summary shown above the findings list when
+    /// findings are present.
+    /// </summary>
+    public string ValidationCountsSummary => string.Format(
+        CultureInfo.CurrentCulture,
+        Strings.Pane_Validation_CountsSummaryFormat,
+        ValidationFindingCount,
+        ValidationErrorCount,
+        ValidationWarningCount,
+        ValidationInfoCount);
+
+    /// <summary>
+    /// Localised message rendered when the Findings list is empty —
+    /// either "No findings." (rule pack ran clean) or
+    /// "Validation rules not yet defined for {spec}." (no rule pack).
+    /// </summary>
+    public string ValidationEmptyStateMessage =>
+        HasValidationRulePack
+            ? Strings.Pane_Validation_NoFindings
+            : string.Format(CultureInfo.CurrentCulture, Strings.Pane_Validation_NoRulePack, ProductSpec);
+
+    /// <summary>
+    /// Replaces the cached validation report and raises change
+    /// notifications for every derived property. Pass <c>null</c> to
+    /// reset (e.g. on reload), pass <see cref="ValidationReport.Empty"/>
+    /// or a report with findings to populate. Safe to call from any
+    /// thread; consumers are responsible for marshalling to the UI
+    /// thread when needed.
+    /// </summary>
+    public void SetValidationReport(ValidationReport? report)
+    {
+        _validation = report;
+        Findings = report is null || report.Findings.IsDefaultOrEmpty
+            ? Array.Empty<ValidationFindingViewModel>()
+            : report.Findings.Select(f => new ValidationFindingViewModel(f)).ToArray();
+
+        OnPropertyChanged(nameof(Validation));
+        OnPropertyChanged(nameof(Findings));
+        OnPropertyChanged(nameof(HasValidationRulePack));
+        OnPropertyChanged(nameof(ValidationFindingCount));
+        OnPropertyChanged(nameof(ValidationErrorCount));
+        OnPropertyChanged(nameof(ValidationWarningCount));
+        OnPropertyChanged(nameof(ValidationInfoCount));
+        OnPropertyChanged(nameof(HasValidationFindings));
+        OnPropertyChanged(nameof(BadgeIsError));
+        OnPropertyChanged(nameof(BadgeIsWarning));
+        OnPropertyChanged(nameof(BadgeIsInfo));
+        OnPropertyChanged(nameof(ValidationBadgeTooltip));
+        OnPropertyChanged(nameof(ValidationCountsSummary));
+        OnPropertyChanged(nameof(ValidationEmptyStateMessage));
+    }
 
     public DatasetEntry(string filePath, string productSpec)
         : this(filePath, productSpec, source: null, relativePath: null, displayName: null)

--- a/src/EncDotNet.S100.Viewer/ViewModels/ValidationFindingViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ValidationFindingViewModel.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Validation;
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Display-ready wrapper around a single <see cref="ValidationFinding"/>
+/// surfaced in the dataset properties panel's Validation tab. Immutable —
+/// findings never mutate after a dataset finishes loading.
+/// </summary>
+internal sealed class ValidationFindingViewModel
+{
+    public ValidationFindingViewModel(ValidationFinding finding)
+    {
+        Finding = finding;
+        SeverityClass = finding.Severity switch
+        {
+            ValidationSeverity.Error => "Error",
+            ValidationSeverity.Warning => "Warning",
+            _ => "Info",
+        };
+        SeverityIcon = finding.Severity switch
+        {
+            ValidationSeverity.Error => "ErrorCircle",
+            ValidationSeverity.Warning => "Warning",
+            _ => "Info",
+        };
+        SeverityLabel = finding.Severity switch
+        {
+            ValidationSeverity.Error => Strings.Pane_Validation_Severity_Error,
+            ValidationSeverity.Warning => Strings.Pane_Validation_Severity_Warning,
+            _ => Strings.Pane_Validation_Severity_Info,
+        };
+        HasRelatedFeature = !string.IsNullOrEmpty(finding.RelatedFeatureId);
+        RelatedFeatureLine = HasRelatedFeature
+            ? string.Format(CultureInfo.CurrentCulture, Strings.Pane_Validation_RelatedFeatureFormat,
+                finding.RelatedFeatureId)
+            : string.Empty;
+    }
+
+    public ValidationFinding Finding { get; }
+
+    /// <summary>Rule identifier (e.g. <c>S125-R-1.1</c>).</summary>
+    public string RuleId => Finding.RuleId;
+
+    /// <summary>Human-readable message describing the finding.</summary>
+    public string Message => Finding.Message;
+
+    /// <summary>Severity for icon / class binding.</summary>
+    public ValidationSeverity Severity => Finding.Severity;
+
+    /// <summary><c>true</c> when this finding is an Error — bound to <c>Classes.Error</c>.</summary>
+    public bool IsError => Finding.Severity == ValidationSeverity.Error;
+
+    /// <summary><c>true</c> when this finding is a Warning — bound to <c>Classes.Warning</c>.</summary>
+    public bool IsWarning => Finding.Severity == ValidationSeverity.Warning;
+
+    /// <summary><c>true</c> when this finding is Info — bound to <c>Classes.Info</c>.</summary>
+    public bool IsInfo => Finding.Severity == ValidationSeverity.Info;
+
+    /// <summary>
+    /// Localised severity label (e.g. "Error") used in tooltips and
+    /// accessibility surfaces.
+    /// </summary>
+    public string SeverityLabel { get; }
+
+    /// <summary>
+    /// XAML class name (<c>Error</c> / <c>Warning</c> / <c>Info</c>)
+    /// applied to the severity icon for colour theming.
+    /// </summary>
+    public string SeverityClass { get; }
+
+    /// <summary>
+    /// Name of the FluentIcon glyph rendered for this severity
+    /// (<c>ErrorCircle</c> / <c>Warning</c> / <c>Info</c>).
+    /// </summary>
+    public string SeverityIcon { get; }
+
+    /// <summary><c>true</c> when <see cref="ValidationFinding.RelatedFeatureId"/> is set.</summary>
+    public bool HasRelatedFeature { get; }
+
+    /// <summary>
+    /// Localised line of text describing the related feature, e.g.
+    /// "Feature: BUOYAGE.1". Empty when no related feature is set.
+    /// </summary>
+    public string RelatedFeatureLine { get; }
+
+    /// <summary>Optional point location, plumbed for future click-to-zoom (not bound in v1).</summary>
+    public GeoPosition? Point => Finding.Point;
+
+    /// <summary>Optional bounding-box location, plumbed for future click-to-zoom (not bound in v1).</summary>
+    public BoundingBox? BoundingBox => Finding.BoundingBox;
+}

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -91,6 +91,52 @@
                 </DataTemplate>
             </Setter>
         </Style>
+
+        <!--
+          Severity badge that decorates the Validation tab header when
+          findings are present. Colour comes from severity-keyed
+          classes (Error / Warning / Info) which the view model
+          toggles via three boolean properties — no value converter
+          required.
+        -->
+        <Style Selector="Border.ValidationBadge">
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="6,1,6,1" />
+            <Setter Property="MinWidth" Value="18" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="Border.ValidationBadge.Error">
+            <Setter Property="Background" Value="#D13438" />
+        </Style>
+        <Style Selector="Border.ValidationBadge.Warning">
+            <Setter Property="Background" Value="#CA5010" />
+        </Style>
+        <Style Selector="Border.ValidationBadge.Info">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="Border.ValidationBadge > TextBlock">
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
+
+        <!--
+          Severity-keyed colour for the FluentIcon glyph rendered next
+          to each finding row. The icon name is set by the view model
+          (ErrorCircle / Warning / Info) and the class drives colour.
+        -->
+        <Style Selector="ic|FluentIcon.SeverityIcon.Error">
+            <Setter Property="Foreground" Value="#D13438" />
+        </Style>
+        <Style Selector="ic|FluentIcon.SeverityIcon.Warning">
+            <Setter Property="Foreground" Value="#CA5010" />
+        </Style>
+        <Style Selector="ic|FluentIcon.SeverityIcon.Info">
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+        </Style>
     </UserControl.Styles>
 
     <DockPanel>
@@ -496,6 +542,92 @@
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
+                                </Panel>
+                            </ScrollViewer>
+                        </TabItem>
+
+                        <!-- Validation findings (per-spec rule packs;
+                             empty-state for specs with no pack). The
+                             header carries a count badge when findings
+                             are present; severity drives the badge
+                             colour via three boolean classes on the
+                             view model. -->
+                        <TabItem>
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal" Spacing="6"
+                                            VerticalAlignment="Center">
+                                    <TextBlock Text="{x:Static loc:Strings.Pane_DatasetTab_Validation}"
+                                               LetterSpacing="1"
+                                               VerticalAlignment="Center" />
+                                    <Border Classes="ValidationBadge"
+                                            Classes.Error="{Binding SelectedEntry.BadgeIsError, FallbackValue=False}"
+                                            Classes.Warning="{Binding SelectedEntry.BadgeIsWarning, FallbackValue=False}"
+                                            Classes.Info="{Binding SelectedEntry.BadgeIsInfo, FallbackValue=False}"
+                                            IsVisible="{Binding SelectedEntry.HasValidationFindings, FallbackValue=False}"
+                                            ToolTip.Tip="{Binding SelectedEntry.ValidationBadgeTooltip}">
+                                        <TextBlock Text="{Binding SelectedEntry.ValidationFindingCount}" />
+                                    </Border>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                                          VerticalScrollBarVisibility="Auto">
+                                <Panel Margin="8,8,8,8">
+                                    <!-- Empty state: either "no rule pack" or "no findings". -->
+                                    <TextBlock IsVisible="{Binding !SelectedEntry.HasValidationFindings, FallbackValue=True}"
+                                               Text="{Binding SelectedEntry.ValidationEmptyStateMessage}"
+                                               Opacity="0.6"
+                                               TextWrapping="Wrap"
+                                               HorizontalAlignment="Center"
+                                               TextAlignment="Center" />
+                                    <StackPanel Spacing="8"
+                                                IsVisible="{Binding SelectedEntry.HasValidationFindings, FallbackValue=False}">
+                                        <TextBlock Text="{Binding SelectedEntry.ValidationCountsSummary}"
+                                                   FontWeight="SemiBold"
+                                                   Opacity="0.8"
+                                                   FontSize="12" />
+                                        <ItemsControl ItemsSource="{Binding SelectedEntry.Findings}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Spacing="10" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:ValidationFindingViewModel">
+                                                    <Grid ColumnDefinitions="Auto,*"
+                                                          RowDefinitions="Auto,Auto,Auto"
+                                                          ColumnSpacing="8"
+                                                          RowSpacing="2">
+                                                        <ic:FluentIcon Grid.Row="0" Grid.Column="0"
+                                                                       Grid.RowSpan="3"
+                                                                       Icon="{Binding SeverityIcon}"
+                                                                       IconVariant="Regular"
+                                                                       FontSize="16"
+                                                                       Classes="SeverityIcon"
+                                                                       Classes.Error="{Binding IsError}"
+                                                                       Classes.Warning="{Binding IsWarning}"
+                                                                       Classes.Info="{Binding IsInfo}"
+                                                                       VerticalAlignment="Top"
+                                                                       Margin="0,2,0,0"
+                                                                       ToolTip.Tip="{Binding SeverityLabel}" />
+                                                        <TextBlock Grid.Row="0" Grid.Column="1"
+                                                                   Text="{Binding RuleId}"
+                                                                   FontFamily="Consolas,Menlo,monospace"
+                                                                   FontSize="11"
+                                                                   Opacity="0.75" />
+                                                        <TextBlock Grid.Row="1" Grid.Column="1"
+                                                                   Text="{Binding Message}"
+                                                                   TextWrapping="Wrap"
+                                                                   FontSize="12" />
+                                                        <TextBlock Grid.Row="2" Grid.Column="1"
+                                                                   Text="{Binding RelatedFeatureLine}"
+                                                                   FontSize="11"
+                                                                   Opacity="0.6"
+                                                                   IsVisible="{Binding HasRelatedFeature}" />
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
                                 </Panel>
                             </ScrollViewer>
                         </TabItem>

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetEntryValidationTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetEntryValidationTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using EncDotNet.S100.Validation;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for the validation surface added to
+/// <see cref="DatasetEntry"/> and the
+/// <see cref="ValidationFindingViewModel"/> wrapper. These tests do not
+/// touch Avalonia — they exercise pure view-model logic so they can run
+/// on any CI without a display.
+/// </summary>
+public class DatasetEntryValidationTests
+{
+    private static ValidationFinding Finding(string ruleId, ValidationSeverity severity,
+        string message = "msg", string? relatedFeatureId = null)
+        => new()
+        {
+            RuleId = ruleId,
+            Severity = severity,
+            Message = message,
+            RelatedFeatureId = relatedFeatureId,
+        };
+
+    private static ValidationReport ReportOf(params ValidationFinding[] findings)
+        => new(findings.ToImmutableArray(), RulesEvaluated: findings.Length,
+            RulesWithFindings: findings.Length);
+
+    [Fact]
+    public void Defaults_HaveNoValidationReport_AndShowNoRulePackEmptyState()
+    {
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+
+        Assert.Null(entry.Validation);
+        Assert.False(entry.HasValidationRulePack);
+        Assert.False(entry.HasValidationFindings);
+        Assert.Equal(0, entry.ValidationFindingCount);
+        Assert.Empty(entry.Findings);
+        Assert.Contains("S-125", entry.ValidationEmptyStateMessage);
+    }
+
+    [Fact]
+    public void SetValidationReport_WithErrorsAndWarnings_PopulatesCountsAndBadgeFlags()
+    {
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+        var observed = new List<string?>();
+        entry.PropertyChanged += (_, e) => observed.Add(e.PropertyName);
+
+        entry.SetValidationReport(ReportOf(
+            Finding("S125-R-1.1", ValidationSeverity.Error),
+            Finding("S125-R-1.2", ValidationSeverity.Warning),
+            Finding("S125-R-1.3", ValidationSeverity.Warning),
+            Finding("S125-R-1.4", ValidationSeverity.Info)));
+
+        Assert.True(entry.HasValidationRulePack);
+        Assert.True(entry.HasValidationFindings);
+        Assert.Equal(4, entry.ValidationFindingCount);
+        Assert.Equal(1, entry.ValidationErrorCount);
+        Assert.Equal(2, entry.ValidationWarningCount);
+        Assert.Equal(1, entry.ValidationInfoCount);
+        Assert.True(entry.BadgeIsError);
+        Assert.False(entry.BadgeIsWarning);
+        Assert.False(entry.BadgeIsInfo);
+        Assert.Equal(4, entry.Findings.Count);
+        Assert.Contains(nameof(DatasetEntry.ValidationFindingCount), observed);
+        Assert.Contains(nameof(DatasetEntry.HasValidationFindings), observed);
+    }
+
+    [Fact]
+    public void SetValidationReport_WithOnlyWarnings_SelectsWarningBadge()
+    {
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+
+        entry.SetValidationReport(ReportOf(
+            Finding("R1", ValidationSeverity.Warning),
+            Finding("R2", ValidationSeverity.Info)));
+
+        Assert.False(entry.BadgeIsError);
+        Assert.True(entry.BadgeIsWarning);
+        Assert.False(entry.BadgeIsInfo);
+    }
+
+    [Fact]
+    public void SetValidationReport_WithOnlyInfo_SelectsInfoBadge()
+    {
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+
+        entry.SetValidationReport(ReportOf(Finding("R1", ValidationSeverity.Info)));
+
+        Assert.False(entry.BadgeIsError);
+        Assert.False(entry.BadgeIsWarning);
+        Assert.True(entry.BadgeIsInfo);
+    }
+
+    [Fact]
+    public void SetValidationReport_Empty_ShowsNoFindingsEmptyState()
+    {
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+
+        entry.SetValidationReport(ValidationReport.Empty);
+
+        Assert.True(entry.HasValidationRulePack);
+        Assert.False(entry.HasValidationFindings);
+        Assert.Equal(0, entry.ValidationFindingCount);
+        // The "no findings" message must not include the spec name —
+        // that's reserved for the "no rule pack" empty state.
+        Assert.DoesNotContain("S-125", entry.ValidationEmptyStateMessage);
+    }
+
+    [Fact]
+    public void SetValidationReport_Null_ResetsToNoRulePackState()
+    {
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+        entry.SetValidationReport(ReportOf(Finding("R1", ValidationSeverity.Error)));
+        Assert.True(entry.HasValidationFindings);
+
+        entry.SetValidationReport(null);
+
+        Assert.Null(entry.Validation);
+        Assert.False(entry.HasValidationRulePack);
+        Assert.False(entry.HasValidationFindings);
+        Assert.Equal(0, entry.ValidationFindingCount);
+        Assert.Empty(entry.Findings);
+        Assert.Contains("S-125", entry.ValidationEmptyStateMessage);
+    }
+
+    [Theory]
+    [InlineData(ValidationSeverity.Error, "Error", "ErrorCircle", true, false, false)]
+    [InlineData(ValidationSeverity.Warning, "Warning", "Warning", false, true, false)]
+    [InlineData(ValidationSeverity.Info, "Info", "Info", false, false, true)]
+    public void ValidationFindingViewModel_MapsSeverityToIconAndFlags(
+        ValidationSeverity severity, string expectedClass, string expectedIcon,
+        bool isError, bool isWarning, bool isInfo)
+    {
+        var vm = new ValidationFindingViewModel(Finding("R1", severity));
+
+        Assert.Equal(expectedClass, vm.SeverityClass);
+        Assert.Equal(expectedIcon, vm.SeverityIcon);
+        Assert.Equal(isError, vm.IsError);
+        Assert.Equal(isWarning, vm.IsWarning);
+        Assert.Equal(isInfo, vm.IsInfo);
+    }
+
+    [Fact]
+    public void ValidationFindingViewModel_NoRelatedFeature_HidesRelatedLine()
+    {
+        var vm = new ValidationFindingViewModel(Finding("R1", ValidationSeverity.Error));
+
+        Assert.False(vm.HasRelatedFeature);
+        Assert.Equal(string.Empty, vm.RelatedFeatureLine);
+    }
+
+    [Fact]
+    public void ValidationFindingViewModel_WithRelatedFeature_FormatsLine()
+    {
+        var vm = new ValidationFindingViewModel(
+            Finding("R1", ValidationSeverity.Warning, relatedFeatureId: "BUOYAGE.42"));
+
+        Assert.True(vm.HasRelatedFeature);
+        Assert.Contains("BUOYAGE.42", vm.RelatedFeatureLine);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetProcessorValidationTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetProcessorValidationTests.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// End-to-end smoke tests that the spec-specific dataset processors
+/// surface a non-null <see cref="EncDotNet.S100.Validation.ValidationReport"/>
+/// from <see cref="IDatasetProcessor.Validate"/> when a rule pack is
+/// defined for the spec. These exercise the wire-up — raw GML →
+/// typed projection → rule pack — without asserting on the contents of
+/// the report itself (those are covered by the per-spec rule tests).
+/// </summary>
+public class DatasetProcessorValidationTests
+{
+    private static string TestData(params string[] parts)
+        => Path.Combine(new[] { AppContext.BaseDirectory, "TestData" }.Concat(parts).ToArray());
+
+    private static PortrayalCatalogueManager CreateCatalogueManager(string spec)
+    {
+        var manager = new PortrayalCatalogueManager();
+        manager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        return manager;
+    }
+
+    [Fact]
+    public void S125Processor_Validate_ReturnsNonNullReport()
+    {
+        var path = TestData("S125", "aton_point.gml");
+        Assert.True(File.Exists(path), $"Missing fixture: {path}");
+
+        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"));
+
+        var report = processor.Validate();
+
+        Assert.NotNull(report);
+        Assert.True(report!.RulesEvaluated > 0,
+            "S-125 rule pack should report at least one rule evaluated");
+    }
+
+    [Fact]
+    public void S125Processor_Validate_IsCachedAcrossCalls()
+    {
+        var path = TestData("S125", "aton_point.gml");
+        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"));
+
+        var first = processor.Validate();
+        var second = processor.Validate();
+
+        // Same instance — confirms the processor caches and never
+        // re-runs validation on subsequent calls.
+        Assert.Same(first, second);
+    }
+}


### PR DESCRIPTION
Surfaces per-spec validation findings in the viewer's dataset properties panel via a new **Validation** tab alongside Dataset / Layers.

## What you see

- **Tab header** carries a small count badge when findings exist:
  - red on errors, amber on warnings, accent on info-only
  - tooltip summarises counts
  - badge is hidden when there are zero findings
- **Tab body** shows a counts summary line and one row per finding with
  - severity icon (`ErrorCircle` / `Warning` / `Info` from FluentIcons),
  - rule id in monospace,
  - wrapped message,
  - optional `Feature: <gml:id>` line when `RelatedFeatureId` is set.
- **Empty states** distinguish:
  - "No findings." — rule pack ran clean.
  - "Validation rules not yet defined for *spec*." — spec has no pack.

Specs with a rule pack today: **S-122, S-124, S-125, S-127, S-128, S-129, S-131, S-411, S-421**.
Specs without one (S-101, S-102, S-104, S-111, S-201, S-57) keep the tab but show the "not yet defined" empty state.

## How it's wired

- `IDatasetProcessor.Validate()` returns `ValidationReport?` — default `null` means "no rule pack for this spec".
- Each of the 9 GML processors overrides it. They project the parsed raw dataset to the typed model and run `ValidationRuleSet<TTyped>.Default` via a new internal `ValidationRunner` helper that catches projection exceptions (e.g. empty datasets) and returns `ValidationReport.Empty`. Result is cached on the processor.
- `DatasetLoaderService.LoadAsync` invokes `processor.Validate()` once on the work thread after rendering succeeds and assigns the result to `DatasetEntry.SetValidationReport(...)`. Validation is **not** re-run on opacity / palette / time-step changes — it's a pure function of the parsed model.
- `DatasetEntry` exposes `Validation`, `Findings`, count properties (`ValidationFindingCount`, `ValidationErrorCount`, ...), `HasValidationFindings`, `BadgeIsError`/`Warning`/`Info`, tooltip / summary / empty-state strings.
- `ValidationFindingViewModel` wraps a single finding for display (severity → icon + class).

All UI strings live in `Resources/Strings.resx` per the viewer's localisation convention.

## Out of scope (kickoff said so)

- Click-to-zoom on findings (`Point` / `BoundingBox` are plumbed but not bound).
- Severity / rule filters.
- Findings map layer.
- Rule packs for S-101 / S-102 / S-104 / S-111 / S-201 / S-57.
- Persistence / export of findings.
- Background re-validation on settings changes.

## Tests

- `DatasetEntryValidationTests` (11 tests) covers count properties, empty-state selection, badge severity flags, and the `ValidationFindingViewModel` icon/class mapping.
- `DatasetProcessorValidationTests` adds an end-to-end smoke test that `S125DatasetProcessor.Validate()` returns a non-null report against an existing GML fixture and caches the result across calls.

`dotnet test --configuration Release` — **1714 passed, 0 failed, 2 skipped** across all 24 test assemblies.

## Demo

1. Open a synthetic S-125 dataset that the rule pack flags.
2. Select the dataset row → Validation tab header shows a red badge with the finding count.
3. Switch to the Validation tab → see the error icon, rule id (monospace), message, and "Feature: …" line.
4. Switch to an S-101 ENC dataset → Validation tab still present, shows "Validation rules not yet defined for S-101".