### PR TITLE
PR-L1 — S-98 layer-stack plumbing (no inter-product rules)

### DIFF
--- a/docs/design/s98-interoperability.md
+++ b/docs/design/s98-interoperability.md
@@ -1,0 +1,999 @@
+# S-98 Interoperability — Design Note (PR-L0)
+
+> Status: **Design / Research** — no production code in this PR. This
+> document is the contract that PR-L1 (plumbing) and PR-L2 (rule
+> evaluation) implement against. Open questions are collected in
+> §8; every claim derived from the spec cites a section number, and
+> every claim that could not be verified is tagged `**TBD**`.
+
+## 0. Scope of this note
+
+The viewer currently composes a multi-product display by stacking
+each loaded dataset's Mapsui layers in dataset-list order (see
+`DatasetLoaderService.FlattenLayerOrder`). That is "Level 0" in
+S-98 terms (S-98 Annex A §4.4.1) — pure overlays, no cross-product
+reasoning. This note describes the minimum redesign needed to:
+
+1. Make the cross-dataset stacking order **explicit and
+   spec-driven** (display planes, drawing priorities).
+2. Carry **per-feature plane / priority metadata** out of each
+   processor so pick and any future inter-product rule can consume
+   it.
+3. Land a **first vertical slice** of inter-product rules covering
+   the two combinations users will see most often (S-101 + S-102,
+   S-101 + S-124).
+4. Define the **rule-table shape** that PR-L1 plumbs and PR-L2
+   populates from a bundled Interoperability Catalogue.
+
+Everything else (Level 3 hybridization, Level 4 spatial operations,
+predefined-combination UI, alerts) is explicitly out of scope and
+parked in §8.
+
+---
+
+## 1. Spec reference
+
+### 1.1 Edition used
+
+- **S-98 "IHO S-100 ECDIS and Interoperability Specification",
+  Edition 2.0.0, October 2025** (IHO CL 41/2025).
+- The publication is a four-document set:
+  - `S-98 Main Document` (general ECDIS + portrayal framing).
+  - `S-98 Annex A — Interoperability` (Interoperability Catalogue
+    model and ECDIS interop levels).
+  - `S-98 Part A` (Level 1 Application Schema details).
+  - `S-98 Part B` (Level 2 Application Schema details).
+- Downloaded as a ZIP from
+  `https://iho.int/uploads/user/pubs/standards/S-98/S-98%20Ed%202.0.0.zip`
+  during PR-L0 research. **The PDFs are not yet committed to
+  `docs/specs/`.** A follow-up PR-L0a should drop them there (and
+  in particular Annex A, which carries the bulk of the normative
+  rules referenced below).
+- Section numbers in this note are written in the form
+  `S-98 Annex A §X.Y` or `S-98 Main §X.Y`. Where a section number
+  appears with no PDF qualifier, it is from `S-98 Annex A`.
+
+### 1.2 Spec gaps and verification status
+
+- **Source available:** Main, Annex A, Part A, Part B — every
+  section cited below was read directly out of the PDF.
+- **Source referenced but not loaded:** S-100 Part 16 (the abstract
+  interoperability model + XML schema) — Annex A §4.2.1 makes it
+  the normative anchor for the Interoperability Catalogue XML
+  schema. We have S-100 Ed 5.2.1 in `docs/specs/`. Anything in this
+  note that says "per Part 16 schema" is asserted on the strength
+  of Annex A's UML diagrams; the actual XSD has **not been
+  validated against** during PR-L0 — see §8 TBD-1.
+- **Source not available:** S-100 Part 16 5.0.0 XSD release notes;
+  the IHO-published *Data Product Interoperability Validation
+  Checks* (Edition 1.0.0, February 2025) — listed on the IHO
+  page but not retrieved.
+
+Anywhere in this note tagged `**TBD — verify against S-98 §X.Y**`
+the reviewer should consult the PDF before PR-L1 finalises the
+relevant API.
+
+### 1.3 Other normative references touched by this design
+
+- **S-100 Ed 5.2.1** (`docs/specs/S-100 Ed 5.2.1_FINAL.pdf`):
+  - Part 9 §11.6 — display planes (the per-product, two-plane
+    UnderRadar / OverRadar concept this codebase already
+    implements).
+  - Part 9 §10 — drawing instructions and their `drawingPriority`,
+    which we already parse for S-101 and the GML/XSLT products.
+  - Part 16 — the IC abstract specification (UML + XSD).
+- **IMO MSC.530(106)/Rev.1** — the informative nine-tier "priority
+  layers" list in S-98 Main §9.2.1 derives from §Appendix 2 of that
+  Performance Standard. We adopt it as the default plane ordering
+  for products that S-98 v2.0.0 does **not** cover.
+- **S-52 Edition 6.1.1** (June 2015) — the legacy S-57 presentation
+  library, normatively reused for colour set-aside and viewing
+  group concepts (S-98 Main §10.3, §10.5).
+
+### 1.4 Products in scope of S-98 Edition 2.0.0
+
+S-98 Annex A §1.2 / Table 2-1:
+
+| Spec | Edition cited by S-98 |
+|---|---|
+| S-101 ENC | Ed 1.1.0, April 2023 |
+| S-102 Bathymetric Surface | Ed 2.2.0, April 2023 |
+| S-104 Water Level | Ed 1.1.0, March 2023 |
+| S-111 Surface Currents | Ed 1.2.0, March 2023 |
+| S-129 UKC Management | Ed 1.0.0, June 2019 |
+
+**Out of S-98 scope but supported in this codebase** (S-122,
+S-124, S-125, S-127, S-128, S-131, S-201, S-411, S-421). Annex
+A §4.1.1 says such "other similar products may also be covered
+on a case-by-case basis" but the closed dictionary
+`urn:mrn:iho:prod:s98:1:1:0:products` enumerates only the five
+above. **Our design therefore treats them as Level 0 overlays**
+with default-plane assignment derived from MSC.530(106)/Rev.1
+priority layers — see §2.3.
+
+---
+
+## 2. Display Plane model
+
+### 2.1 What S-100 / S-98 actually defines
+
+Two **independent** stacking concepts collaborate:
+
+1. **Display Plane** (S-100 Part 9 §11.6; S-98 Main §7.2.9):
+   *"Display planes are used to split the output of the portrayal
+   functions into mutually exclusive lists. An example of this is
+   the separation of chart information drawn under a radar image
+   and chart information drawn over a radar image."*
+   - S-100 ships only two canonical planes — **UnderRadar** and
+     **OverRadar** — and our `DisplayPlane` enum
+     (`src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs:315`)
+     enumerates exactly those.
+   - **S-98 widens this:** an Interoperability Catalogue may declare
+     additional planes via `S100_IC_DisplayPlane` elements (Annex A
+     §A-3.2.1.1, Part A). Per Part A §A-3.2.1.1 *"A feature type may
+     be referenced in more than one S100_IC_DisplayPlane, but the
+     entries in different display planes must be distinguished by
+     different attribute-value combinations or spatial primitives
+     so that the actual instances of features are partitioned
+     unambiguously between different display planes."*
+   - S-98 Main §9.2.2 anchors the radar pivot:
+     *"the radar image should be written over Portrayal Catalogue
+     display planes with a negative order attribute; and below
+     display planes with a positive order attribute."* Our existing
+     PC bundles (e.g. `content/S111/pc/portrayal_catalogue.xml`)
+     declare `<displayPlane id="OverRadar" order="1">` and
+     `<displayPlane id="UnderRadar" order="-1">` — consistent.
+
+2. **Drawing Priority** (S-100 Part 9; S-98 Main §7.2.10):
+   *"Display priorities control the order in which the output of
+   the portrayal functions is processed by the rendering engine
+   within a display plane. Priorities with smaller numerical values
+   will be processed first. … If the display priority is equal
+   among features, curve features have to be drawn on top of
+   surface features whereas point features are drawn on top of
+   both."*
+
+The within-plane sort order we implement
+(`VectorPipeline.SortByPriority`) is exactly that:
+`DisplayPlane → DrawingPriority → Type (area → line → point →
+text)`. **That code is correct for intra-dataset rendering and
+needs no change.** What's missing is the cross-dataset extension.
+
+### 2.2 The nine "priority layers" (informative)
+
+S-98 Main §9.2.1 lifts the MSC.530(106)/Rev.1 *"priority of
+information"* list:
+
+```
+1. ECDIS visual alerts/indications (caution, overscale, …)
+2. Official data: points/curves and surfaces + official updates
+3. Notices to Mariners, manual input and Navigational Warnings
+4. Official-caution (ENC and other cautions)
+5. Official colour-fill area data
+6. Official on-demand data (water levels, currents, UKC, …)
+7. Radar and AIS information
+8. Mariner's data: points/lines and areas
+9. Mariner's colour-fill area data
+```
+
+The footnote (S-98 Main §9.2.1, footnote 1) makes this
+**informative** — the actual partitioning is what the Portrayal
+Catalogues and the IC implement. But it gives us a reasonable
+*default* plane mapping for products S-98 v2.0.0 doesn't yet cover.
+
+### 2.3 Our extended plane enum
+
+We add a third dimension to our intra-dataset enum **without
+breaking it**, by introducing an outer enum `S98DisplayPlane` that
+the cross-dataset layer-stack builder consumes; the per-instruction
+`DisplayPlane` enum stays as-is for intra-product portrayal.
+
+Proposed values (default ordering, lowest = drawn first / farthest
+back):
+
+| Value | Numeric | Source-of-truth | Maps to which products by default |
+|---|---|---|---|
+| `BaseChartUnder` | 0 | MSC.530 layer 5 + S-98 Main §9.2.1 layer 5 | S-101 area / colour-fill features; S-57 fallback |
+| `Bathymetry` | 10 | S-98 Annex A §8.4.1 / A-6.9.1 ("gridded bathymetry replaces depth area and depth contours") | S-102 |
+| `OnDemandSurface` | 20 | MSC.530 layer 6, S-98 Main §9.2.1 | S-104, S-111 (the colour-band coverage) |
+| `BaseChartOver` | 30 | MSC.530 layer 2 + S-98 §9.2.1 layer 2 | S-101 curves/points/text |
+| `OtherChartOverlays` | 40 | MSC.530 layer 6 (catch-all) | S-122 (MPAs), S-125 / S-201 (AtoN), S-127, S-128, S-131, S-411, S-421, S-129 UKC areas |
+| `CautionsAndWarnings` | 50 | MSC.530 layer 3-4 + S-98 Main §9.2.1 layers 3-4 | S-124 navigational warnings |
+| `DynamicArrows` | 60 | S-111 PC `OverRadar` overlay (`displayPlane id="OverRadar"`) | S-111 arrow sublayer; S-104 trend glyphs (PR-J) |
+| `MarinerOverlay` | 70 | MSC.530 layers 8-9 | Mariner's own annotations (future) |
+| `EcdisAlerts` | 80 | MSC.530 layer 1, S-98 Main §9.2.1 layer 1 | ECDIS overscale, caution, AIO (future) |
+
+Notes:
+
+- **The order is informative**, and reviewers should treat each
+  numeric gap (10) as expansion room for IC-declared planes
+  (`S100_IC_DisplayPlane`). The actual numbers are not normative —
+  S-98 IC entries supply their own ordering and override these
+  defaults.
+- The intra-product `DisplayPlane` (UnderRadar / OverRadar) still
+  applies *within* a plane. So an S-111 dataset emits two
+  sub-layers; the colour-band one lands on `OnDemandSurface`,
+  the arrow overlay on `DynamicArrows`. **The processor is
+  responsible for this mapping** (see §4.2).
+- Where the IC carries a `S100_IC_DisplayPlane` with a non-default
+  order, the IC overrides the defaults above. **The defaults are
+  the "Level 0 fallback" path required by Annex A §4.4.1.**
+
+### 2.4 Within-plane priority — already exists
+
+S-101 emits `<drawingPriority>` integers per S-100 Part 9 §10. Our
+`Part9DisplayListReader` extracts them
+(`DrawingInstruction.DrawingPriority`). Coverage products do not
+emit drawing instructions and therefore don't carry an explicit
+priority. For coverage layers, we adopt: **a single integer per
+sub-layer**, defaulted at the processor (S-102 → 0, S-104 colour
+band → 0, S-111 colour band → 0, S-111 arrow → 10). The IC may
+override these via `S100_IC_DrawingInstruction.drawingPriority`.
+
+For other GML products (S-124, S-125, …) the XSLT pipelines already
+emit `<drawingPriority>` per drawing instruction via their per-rule
+`with-param`s (see e.g. `S111/pc/Rules/SurfaceCurrent.xsl`). So
+intra-product priority is already first-class for every vector
+product.
+
+---
+
+## 3. Inter-product rules in v1
+
+S-98 Annex A is structured around four progressively more powerful
+*Levels* (§4.4):
+
+| Level | Operations | Status in S-98 v2.0.0 |
+|---|---|---|
+| 0 — Overlays | None; pass-through. | Fully specified (Annex A §4.4.1). |
+| 1 — Interleaving | Cross-product plane / drawing-priority reassignment. | Fully specified (Part A). |
+| 2 — Type selectivity + class replacement | Suppress all instances of a feature type in product A when product B is loaded; substitute drawing instructions; predefined combinations. | Fully specified (Part B). |
+| 3 — Feature hybridization | Per-instance suppression and attribute merging. | Annex A §4.4.4 notes *"Support for this level is not fully elaborated in this version of the Interoperability Catalogue Specification and it should therefore not be implemented in Interoperability Catalogues created from this Specification"*. |
+| 4 — Spatial operations | Spatial queries + geometry combination. | Annex A §4.4.5 notes *"Support for this level is not fully elaborated in this version of the Interoperability Catalogue Annex"*. |
+
+**Our v1 commits to Levels 0 and 1, with a single Level 2 rule
+piloted for the most-visible S-101 / S-102 case.** Levels 3 and 4
+are deferred (§3.5) and gated on the IHO finishing the spec.
+
+### 3.1 Rule R-101-102-A: S-102 supersedes S-101 depth-area shading
+
+- **S-98 cite:** Annex A §A-6.9.1 *"High definition gridded
+  bathymetry replaces (overwrites) depth area and depth contours,
+  but soundings, aids to navigation, and obstructions are over the
+  high definition bathymetry (interoperability Level 1)."*
+- **Level:** Level 1 (plane reassignment); a Level 2 variant
+  *"suppress all S-101 `DepthArea` and `DepthContour` features when
+  an S-102 dataset is loaded covering the same area"* is the
+  natural follow-up — Annex A §8.1.1 *"duplicated features, same
+  model"* covers it.
+- **Semantics:** when an S-101 dataset *and* an S-102 dataset are
+  both loaded and their coverage overlaps, the S-102 coverage
+  layer is drawn on plane `Bathymetry` (between `BaseChartUnder`
+  and `BaseChartOver`). S-101 line/point/symbol layers (the
+  `BaseChartOver` plane) remain on top of S-102. **At Level 1 we
+  do not suppress** the underlying S-101 depth areas — they merely
+  end up obscured under the (typically opaque) S-102 colour shade.
+- **Codebase mapping:**
+  - S-101 processor declares its layers as `BaseChartUnder`
+    (areas/fills) **and** `BaseChartOver` (lines, points, text) —
+    today these collapse into a single Mapsui layer; PR-L1 must
+    split them along the `DrawingPriority`'s area-or-not boundary,
+    or carry the split through `DrawingInstruction.TypeSortOrder`.
+    See §4.1.
+  - S-102 processor declares its single coverage layer as
+    `Bathymetry`.
+  - `LayerStackBuilder` orders by `(plane, withinPlanePriority,
+    datasetOrder)` — the S-102 layer lands between the two S-101
+    layers.
+- **Level 2 extension (R-101-102-B):** when both products are
+  loaded, suppress every S-101 feature whose code is in
+  `{DepthArea, DepthContour}`. Implemented as
+  `S100_IC_SuppressedFeatureLayer` inside an
+  `S100_IC_PredefinedCombination` keyed on the product set
+  `{S-101, S-102}` (Annex A §8.4.1 *"skin-of-the-earth feature
+  replacement"* + Part B §B-3.1.2).
+
+### 3.2 Rule R-101-124-A: S-124 warnings render above all ENC base data
+
+- **S-98 cite:** Annex A §4.4.1 (Level 0) + MSC.530(106)/Rev.1
+  priority layer 3 *(via S-98 Main §9.2.1)* — *"Notices to
+  Mariners, manual input and Navigational Warnings"* sit above
+  *"Official-data: Points/Curves and Surfaces"*. **TBD — verify
+  against S-98 §X.Y for an explicit Annex A rule (S-124 is not in
+  Annex A Table 1-1, so this rule is currently a viewer-side
+  derivation from MSC.530, not an IC clause).**
+- **Level:** Level 0 only — S-124 is outside the IC's product
+  list (Annex A §4.1.1 / closed dictionary
+  `urn:mrn:iho:prod:s98:1:1:0:products`), so it stays an overlay.
+  We treat the rule as a **default-plane assignment**, not an IC
+  rule.
+- **Semantics:** S-124 features render on plane
+  `CautionsAndWarnings` (50). They appear above every base-chart
+  and on-demand-coverage plane, and below mariner data + ECDIS
+  alerts.
+- **Codebase mapping:**
+  - `S124DatasetProcessor.Render` declares its single emitted
+    layer's plane as `CautionsAndWarnings`.
+  - No IC involvement. The rule is the default plane assignment.
+
+### 3.3 Rule R-104-A / R-111-A: Water level & current overlays sit above bathymetry, below ENC line work
+
+- **S-98 cite:** Annex A §A-6.9.1 *"Gridded data will generally
+  go over ENC and obscure ENC features, either all
+  (interoperability Level 0) or specific features
+  (interoperability Level 1) depending on interoperability Level
+  chosen…"* — and S-98 Main §9.2.1 layer 6 *"Official on demand
+  data (for example, water levels, surface currents, under keel
+  clearance)"*.
+- **Level:** Level 1.
+- **Semantics:**
+  - S-104 colour band → plane `OnDemandSurface` (20).
+  - S-111 colour band → plane `OnDemandSurface` (20). S-111 arrows
+    → plane `DynamicArrows` (60).
+  - S-101 line/point work on `BaseChartOver` (30) sits *above* the
+    on-demand surface but *below* the dynamic arrows. **Verify
+    intent of this stacking against Annex A §A-6.9.1 — TBD-2.** It
+    is not entirely clear that S-101 line work must come above an
+    S-104 surface; some implementations render the surface on top
+    with alpha. The current proposal follows the *"obscure ENC
+    features"* reading literally: the surface goes under the base
+    chart's vector work.
+- **Codebase mapping:** S-104 and S-111 processors already split
+  into multiple sub-layers (`DatasetResult.Layers` +
+  `LayerNames`); the processor sets a per-sub-layer plane.
+
+### 3.4 Summary table for v1
+
+| Rule | Level | Products | Operation | S-98 cite |
+|---|---|---|---|---|
+| R-101-102-A | 1 | S-101, S-102 | S-102 coverage on plane `Bathymetry`, between S-101 areas and S-101 line work | Annex A §A-6.9.1 |
+| R-101-102-B | 2 | S-101, S-102 | Suppress S-101 `DepthArea`, `DepthContour` when S-102 covers same area | Annex A §8.4.1 + Part B §B-3.1.2 |
+| R-101-124-A | 0 | S-101, S-124 | S-124 warnings on plane `CautionsAndWarnings` | S-98 Main §9.2.1 + MSC.530(106)/Rev.1 §Appendix 2 (S-124 not in IC) |
+| R-104-A | 1 | S-101, S-104 | S-104 colour band on `OnDemandSurface`, below S-101 line work | Annex A §A-6.9.1 + S-98 Main §9.2.1 layer 6 |
+| R-111-A | 1 | S-101, S-111 | S-111 colour band on `OnDemandSurface`; arrows on `DynamicArrows` | Annex A §A-6.9.1 + existing PC `displayPlane id="OverRadar"` |
+
+That's **five proposed v1 rules** spanning four product pairs.
+Three of them (R-101-102-A, R-104-A, R-111-A) are pure default
+plane assignments and need no IC payload at all; PR-L1 ships them.
+R-101-102-B and the dynamic IC-driven overrides need PR-L2.
+
+### 3.5 Deferred — explicit non-goals for v1
+
+| Rule family | Why deferred |
+|---|---|
+| Predefined Combinations UI (`S100_IC_PredefinedCombination`) | Annex A §11 / Part B §B-3.1.2 — large UX surface; needs a layer-controls panel (gated on PR-L3). |
+| Hybrid Feature / Portrayal Catalogues | Annex A §4.4.4 — *"should not be implemented in Interoperability Catalogues created from this Specification"*. |
+| Spatial operations (Level 4) | Annex A §4.4.5 — *"Support for this level is not fully elaborated"*. |
+| Skin-of-the-earth adjusting (geometry edits) | Annex A §8.4.2 — Level 3/4 only. |
+| Safety-contour synthesis from S-102 + S-104 | Annex A §A-6.9.1 NOTE — *"OEMs are permitted to add additional safety contour functions"* — explicitly optional; significant new pipeline. |
+| Pre-defined Combination switching UX | Annex A §15.4. Tied to layer-controls UI PR-L3. |
+| Alerts triggered by interop result | Annex A §7.3 (Main) + Annex A §11.7. Needs alert engine. |
+| Colour set-aside arbitration | S-98 Main §10.3 + Part 16 — needs palette-aware rule input. |
+
+---
+
+## 4. Codebase impact map
+
+### 4.1 `src/EncDotNet.S100.Core/`
+
+Additions (new types — no behaviour yet, PR-L1 wires them up):
+
+- `EncDotNet.S100.Interoperability.S98DisplayPlane` (enum) — the
+  values from §2.3.
+- `EncDotNet.S100.Interoperability.LayerStackEntry` (record):
+  ```
+  public sealed record LayerStackEntry(
+      Mapsui.Layers.ILayer Layer,
+      S98DisplayPlane Plane,
+      int WithinPlanePriority,
+      DatasetEntry SourceDataset,
+      string? SourceSubLayerName,
+      string? SourceFeatureType);    // null for whole-layer entries
+  ```
+- `EncDotNet.S100.Interoperability.IInteroperabilityAuthority`
+  (interface):
+  ```
+  public interface IInteroperabilityAuthority
+  {
+      IReadOnlyList<LayerStackEntry> Apply(IReadOnlyList<LayerStackEntry> raw);
+  }
+  ```
+  The authority is pure — `(in) → (out)` — so it can be unit-tested
+  without the viewer. PR-L1 ships the default
+  `Level0Authority : IInteroperabilityAuthority` that just sorts
+  by `(Plane, WithinPlanePriority, DatasetOrder)`. PR-L2 layers a
+  catalogue-driven implementation on top.
+
+The existing `DisplayPlane` enum (UnderRadar / OverRadar) in
+`Core.Pipelines.Vector.VectorPipeline.cs:315` **does not change**
+— it remains the intra-product portrayal concept. The two enums
+exist side-by-side. Doc the relationship in the new
+`S98DisplayPlane`'s XML summary.
+
+### 4.2 `src/EncDotNet.S100.Datasets.Pipelines/`
+
+`DatasetResult` (in `DatasetPipelineFactory.cs:16`) grows an
+optional sibling to the existing `LayerNames`:
+
+```
+public IReadOnlyList<S98DisplayPlane>? LayerPlanes { get; init; }
+public IReadOnlyList<int>? LayerWithinPlanePriorities { get; init; }
+```
+
+Both must be the same length as `Layers` when supplied. Null
+defaults to `(BaseChartOver, 0)` for vector products and
+`(OnDemandSurface, 0)` for coverage products — chosen by the
+factory based on `Spec.Name` so that every existing processor
+remains source-compatible until it opts into plane assignment.
+
+Per-processor plane defaults (PR-L1 fills these in):
+
+| Processor | Layer(s) | Plane | Within-plane priority |
+|---|---|---|---|
+| `S101DatasetProcessor` | (today) single vector | `BaseChartOver` | inherits from `DrawingPriority` ordering already inside the layer |
+| `S101DatasetProcessor` *(post-split, see below)* | areas | `BaseChartUnder` | 0 |
+| `S101DatasetProcessor` *(post-split)* | lines + points + text | `BaseChartOver` | 0 |
+| `S102DatasetProcessor` | coverage | `Bathymetry` | 0 |
+| `S104DatasetProcessor` | colour band | `OnDemandSurface` | 0 |
+| `S111DatasetProcessor` | colour band | `OnDemandSurface` | 0 |
+| `S111DatasetProcessor` | arrow overlay | `DynamicArrows` | 10 |
+| `S122DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S124DatasetProcessor` | vector | `CautionsAndWarnings` | 0 |
+| `S125DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S127DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S128DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S129DatasetProcessor` | vector | `OtherChartOverlays` | 0 (S-129 is in the IC; PR-L2 may move it) |
+| `S131DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S201DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S411DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S421DatasetProcessor` | vector | `OtherChartOverlays` | 0 |
+| `S57DatasetProcessor` | vector | `BaseChartOver` | 0 |
+
+#### 4.2.1 The S-101 split problem
+
+Today `S101DatasetProcessor.Render`
+(`src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs:83`)
+produces a **single** Mapsui vector layer that internally is sorted
+by `(DisplayPlane, DrawingPriority, Type)` via
+`VectorPipeline.SortByPriority`. To honour R-101-102-A
+(S-102 between S-101 areas and lines), we must split it.
+
+Two options are open for PR-L1:
+
+- **Option A — split inside the renderer.** Have
+  `MapsuiDisplayListRenderer.Render` return *two* `ILayer`s
+  (areas, then "lines+points+text"). Cleanest, but the renderer
+  becomes coupled to the S-98 partition.
+- **Option B — split in the processor.** Run the pipeline twice
+  with a pre-filter that selects only area-typed
+  `DrawingInstruction`s the first time and the rest the second
+  time. Doubles symbol-cache reuse cost but isolates the change.
+
+**Recommendation: Option B.** It keeps the renderer ignorant of
+S-98 and is fully reverted by toggling the split off. PR-L1
+implements it. Cost is one extra style sort + render pass per
+S-101 dataset; benchmarks expected to be < 5% per Mapsui's measured
+inner-loop costs.
+
+The split applies only to S-101 (and S-57). Coverage products and
+GML overlays do not have a fill-vs-linework split.
+
+### 4.3 `src/EncDotNet.S100.Viewer/`
+
+#### 4.3.1 Where cross-dataset assembly lives today
+
+`DatasetLoaderService.FlattenLayerOrder`
+(`src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs:473`)
+is the *only* place layers from different datasets are combined.
+It walks `_entryOrder` (user-controlled dataset stacking from the
+Datasets panel) bottom-up, concatenates each entry's
+`_entryLayers[entry]` in dataset-iteration order, and hands the
+result to `MapsuiMapHost.ReorderDatasetLayers`.
+
+That means today every layer of dataset N sits below every layer
+of dataset N+1, regardless of plane. This is **Level 0** in S-98
+terms but with a *user-defined* stacking criterion — closer to
+"naive overlay" than the §9.2.1 priority-layer list.
+
+#### 4.3.2 Where it moves to
+
+PR-L1 inserts a `LayerStackBuilder` between the per-entry render
+result and the map host:
+
+```
+            ┌───────────────────────────────────┐
+            │ DatasetLoaderService              │
+            │   _entryLayers : entry → ILayer[] │
+            │   _entryPlanes : entry → plane[]  │  (NEW)
+            └────────────┬──────────────────────┘
+                         │
+                         ▼
+            ┌───────────────────────────────────┐
+            │ LayerStackBuilder                 │
+            │   raw : LayerStackEntry[]         │
+            │   authority.Apply(raw) → ordered  │
+            └────────────┬──────────────────────┘
+                         │
+                         ▼
+            ┌───────────────────────────────────┐
+            │ MapsuiMapHost.ReorderDatasetLayers│
+            └───────────────────────────────────┘
+```
+
+The builder is owned by `DatasetLoaderService` (no new singleton).
+`IInteroperabilityAuthority` is injected; the default Level-0
+implementation is registered in
+`Program.cs` / DI bootstrapping. PR-L2 swaps the implementation
+without touching the builder.
+
+The user's Datasets-panel ordering remains the *tie-breaker*
+inside a plane — implemented by passing `entryOrderIndex` as the
+last sort key inside the authority. **No regression to the existing
+"drag-to-reorder" UX.** This must be tested with a fixture in
+`tests/` that loads two S-101 datasets and confirms drag-reordering
+still works.
+
+#### 4.3.3 `PickService` consumption
+
+`PickService.ResolveHits`
+(`src/EncDotNet.S100.Viewer/Services/PickService.cs:135`) walks
+`mapInfo.MapInfoRecords` in Mapsui's hit-test order. PR-L1 keeps
+that contract but adds a stack-order sort key:
+
+```
+hits.OrderByDescending(h => layerStackOrder[h.Layer]).ThenBy(h => …)
+```
+
+…where `layerStackOrder` is the dictionary produced by the builder.
+That delivers §6 ("pick should be stack-ordered, topmost first") in
+PR-L1 without waiting on PR-L2. Mapsui still does the geometric
+hit test; we only reorder the dedup-survivors.
+
+#### 4.3.4 Other viewer files touched in PR-L1
+
+- `ViewerDatasetCatalog.cs` — none expected.
+- `MainViewModel.cs` — none expected (it never assembles layers).
+- `MapsuiMapHost.cs` (i.e. `IMapHost.ReorderDatasetLayers`) — none;
+  it already takes a flat ordered list.
+- `DatasetsViewModel.cs` — no changes; user-perceived ordering
+  still flows through this VM.
+
+### 4.4 `src/EncDotNet.S100.Specifications/content/S98/`
+
+S-98 distributes the Interoperability Catalogue as an XML document
+conforming to the S-100 Part 16 schema (Annex A §4.2.1). When IHO
+publishes a normative IC we follow the bundled-spec convention
+already in use for S-127 / S-131 / S-411:
+
+```
+src/EncDotNet.S100.Specifications/
+  content/
+    S98/
+      catalogue/
+        S98-Interoperability-Catalogue-1.0.0.xml      (eventual normative)
+        S98-Interoperability-Catalogue-1.0.0.xsd
+      Adapter/
+        defaults.xml                                  (our PR-L1 default
+                                                       plane assignments
+                                                       in IC-shaped XML
+                                                       so the same loader
+                                                       can read both)
+      README.md
+```
+
+`defaults.xml` is **our** content (not byte-identical to upstream) —
+it encodes the default plane table from §2.3 as a Level-1 IC so the
+PR-L2 loader works against a single shape. When the IHO publishes
+the normative IC, `catalogue/` is dropped in byte-for-byte and
+`Adapter/defaults.xml` becomes the fallback when no normative IC
+covers a particular product pair (e.g. for S-122 / S-124 /
+non-Annex-A products).
+
+`EncDotNet.S100.Specifications.Specification` gains:
+
+```
+public static IInteroperabilityCatalogueSource CreateInteroperabilityCatalogueSource();
+```
+
+PR-L1 publishes the type; PR-L2 wires it into the authority.
+
+### 4.5 `src/EncDotNet.S100.Renderers.Mapsui/`
+
+No PR-L1 changes if we adopt Option B (§4.2.1). If we ever adopt
+Option A, `MapsuiDisplayListRenderer.Render` returns
+`IReadOnlyList<ILayer>` and the area/line+text split moves here.
+
+### 4.6 Tests
+
+New project (no existing one matches):
+
+```
+tests/EncDotNet.S100.Interoperability.Tests/
+  LayerStackBuilderTests.cs
+  Level0AuthorityTests.cs
+  CatalogueLoaderTests.cs              (PR-L2)
+  PredefinedCombinationTests.cs        (PR-L2)
+```
+
+Existing pipeline tests under `tests/EncDotNet.S100.Pipelines.Tests/`
+need new cases:
+
+- `S101DatasetProcessor` emits **two** layers with correct planes
+  when Option B split is on.
+- `S102DatasetProcessor` declares its coverage layer's plane as
+  `Bathymetry`.
+- `S111DatasetProcessor` declares both sub-layer planes correctly.
+
+---
+
+## 5. The rule-table shape
+
+### 5.1 Wire format — XML, IC-shaped, mirroring Part 16
+
+The catalogue must be XML conforming to the S-100 Part 16 IC
+schema (Annex A §4.2.1, §A-3.2.1.1, §B-3.2.1). **TBD-1: we have
+not yet validated against the real Part 16 XSD; PR-L1 should drop
+the IHO XSD into `content/S98/catalogue/` and validate during
+build.** The element names below are taken from Annex A — they
+*should* match the XSD's element names but the exact case /
+qualification is unconfirmed.
+
+Example Level-1 IC fragment (our `Adapter/defaults.xml`):
+
+```xml
+<S100_IC_InteroperabilityCatalogue
+    xmlns="http://www.iho.int/s100ic/1.0"
+    interoperabilityLevel="1">
+
+  <productCovered>S-101</productCovered>
+  <productCovered>S-102</productCovered>
+  <productCovered>S-104</productCovered>
+  <productCovered>S-111</productCovered>
+  <productCovered>S-129</productCovered>
+
+  <S100_IC_DisplayPlane id="BaseChartUnder" order="0"
+                        interoperabilityLevel="1">
+    <S100_IC_Feature product="S-101" featureCode="DepthArea"/>
+    <S100_IC_Feature product="S-101" featureCode="LandArea"/>
+    <S100_IC_Feature product="S-101" featureCode="SeaArea"/>
+    <!-- … -->
+  </S100_IC_DisplayPlane>
+
+  <S100_IC_DisplayPlane id="Bathymetry" order="10"
+                        interoperabilityLevel="1">
+    <S100_IC_Feature product="S-102" featureCode="BathymetryCoverage"/>
+  </S100_IC_DisplayPlane>
+
+  <S100_IC_DisplayPlane id="BaseChartOver" order="30"
+                        interoperabilityLevel="1">
+    <S100_IC_Feature product="S-101" featureCode="*"/>
+    <!-- everything not bound elsewhere -->
+  </S100_IC_DisplayPlane>
+
+  <!-- … -->
+</S100_IC_InteroperabilityCatalogue>
+```
+
+Level-2 additions (e.g. for R-101-102-B) introduce
+`S100_IC_PredefinedCombination` + `S100_IC_SuppressedFeatureLayer`
+(Annex A §B-3.1.2, §B-3.1.4):
+
+```xml
+<S100_IC_PredefinedCombination
+    id="S101+S102-bathymetry"
+    interoperabilityLevel="2">
+  <productSet>S-101,S-102</productSet>
+  <S100_IC_SuppressedFeatureLayer product="S-101" featureCode="DepthArea"/>
+  <S100_IC_SuppressedFeatureLayer product="S-101" featureCode="DepthContour"/>
+</S100_IC_PredefinedCombination>
+```
+
+### 5.2 In-memory model
+
+```
+public sealed record S98Catalogue(
+    int InteroperabilityLevel,
+    IReadOnlyList<string> ProductsCovered,
+    IReadOnlyList<S98DisplayPlaneEntry> DisplayPlanes,
+    IReadOnlyList<S98PredefinedCombination> PredefinedCombinations);
+
+public sealed record S98DisplayPlaneEntry(
+    string Id,
+    int Order,
+    int InteroperabilityLevel,
+    IReadOnlyList<S98FeatureBinding> Features);
+
+public sealed record S98FeatureBinding(
+    string Product,
+    string FeatureCode,           // "*" or a Feature Catalogue code
+    string? Filter,               // S-98 §4.3 filter expression, or null
+    int? OverrideDrawingPriority);
+
+public sealed record S98PredefinedCombination(
+    string Id,
+    int InteroperabilityLevel,
+    IReadOnlyList<string> ProductSet,
+    IReadOnlyList<S98SuppressedFeatureLayer> Suppressed);
+
+public sealed record S98SuppressedFeatureLayer(
+    string Product,
+    string FeatureCode,
+    string? Filter);
+```
+
+The XML loader (`S98CatalogueLoader.LoadAsync`) returns
+`S98Catalogue`. The authority consumes it.
+
+### 5.3 Evaluation contract
+
+**Pure function**, as called out in §4.1:
+
+```
+IReadOnlyList<LayerStackEntry> Apply(
+    IReadOnlyList<LayerStackEntry> raw);
+```
+
+The default `CatalogueDrivenAuthority` algorithm:
+
+1. For each entry in `raw`, find the first `S98DisplayPlaneEntry`
+   whose `Features` matches the entry's
+   `(SourceProcessor.Spec.Name, SourceFeatureType)`. The match
+   semantics:
+   - exact product + code, then product + `*`, then no match (fall
+     through to the entry's `Plane` default from the processor).
+   - **filters are not evaluated** in v1 because we operate at the
+     layer granularity, not the per-feature level (Annex A §4.3
+     filters need Level 3+ to act per-instance).
+2. Override `entry.Plane` with the matched plane's `Order`-derived
+   `S98DisplayPlane`. (`Order → S98DisplayPlane` is a fixed map for
+   the canonical planes; non-canonical IC-declared planes get
+   slotted into the numeric gap closest to their `order`.)
+3. Apply any per-`S100_IC_DrawingInstruction.drawingPriority`
+   override (none in v1).
+4. For each `S98PredefinedCombination` whose `ProductSet` is a
+   subset of the currently-loaded products, drop every entry whose
+   `(Product, FeatureCode)` matches a `Suppressed` row.
+5. Sort by `(Plane.Order, WithinPlanePriority, DatasetOrderIndex)`.
+
+This algorithm is pure and trivially unit-testable.
+
+### 5.4 Where the catalogue lives
+
+- **Bundled** in `EncDotNet.S100.Specifications`'s embedded
+  resources (same pattern as `S127/pc/` etc.).
+- **Loaded once** at startup by
+  `Specification.CreateInteroperabilityCatalogueSource()`.
+- **Selected** by interop-level: the user picks Level 0 / 1 / 2 in
+  the layer-controls UI (PR-L3). PR-L1 hard-wires Level 1.
+
+---
+
+## 6. Pick semantics
+
+### 6.1 Today
+
+`PickService.ResolveHits` enumerates `mapInfo.MapInfoRecords` in
+Mapsui's order (which is *roughly* topmost-first within a single
+hit, but unspecified across layers), dedupes by
+`(processor, featureRef)`, and presents the survivors to the panel.
+Status text follows `hits[0]`, with a *"+N more"* suffix.
+
+### 6.2 Proposal
+
+S-98 Annex A §A-6.12 (Part A) and §10.12 (Main) note **"The Pick
+Report functionality specification in S-98 is still under
+development."** So pick stack ordering is **viewer-side
+derivation**, not a normative cite.
+
+We adopt the natural rule: **pick is ordered by the same stack
+the renderer uses**, top-of-stack first.
+
+Concretely in `PickService.ResolveHits`:
+
+1. Compute `stackOrder : ILayer → int` once per
+   `IDatasetLoaderService.EntryLayers` change (cached in
+   `LayerStackBuilder`).
+2. Sort `MapInfoRecords` by descending `stackOrder[record.Layer]`
+   *before* the existing dedup walk.
+3. Existing dedup-by-`(processor, featureRef)` then keeps the
+   topmost hit per logical feature (since the topmost record
+   wins by being first into `seen.Add`).
+
+Status-text logic is unchanged — `hits[0]` is now guaranteed to be
+the topmost hit, which matches user expectation
+("the pick panel describes what I clicked on, not what was hidden
+underneath").
+
+Coverage pick (`TryCoveragePick`) is unaffected — it triggers only
+when *no* vector hit existed at all.
+
+### 6.3 Future: Pick filtered by IC
+
+Annex A §A-6.12 hints at future "pick report" features tied to the
+IC. Out of scope for v1 — once the spec lands, we can add a
+`SourceFeatureType`-aware filter in the same place.
+
+---
+
+## 7. Visual regression and rollout plan
+
+### 7.1 Snapshot impact
+
+Re-ordering layers will change **most rendered snapshots**.
+Specifically:
+
+- Any test that loads an S-101 + S-102 pair (RenderS102 outputs)
+  will change as S-102 moves between S-101 area fills and S-101
+  line work.
+- S-104 / S-111 + S-101 snapshots will shift if any S-101 line
+  work was previously below an on-demand surface.
+- Single-product snapshots **should not change**, because the
+  intra-product sort
+  (`VectorPipeline.SortByPriority`) is unchanged.
+
+### 7.2 Rebaseline approach
+
+1. PR-L1 lands the plumbing but **defaults the authority to
+   `Level0Authority`** (no plane reordering) so behaviour is
+   identical to today. Snapshots do not change.
+2. PR-L1.5 (or PR-L2 opener) flips the default to
+   `CatalogueDrivenAuthority(Level=1)` and explicitly rebaselines
+   the affected snapshots. Each rebaselined image gets a short
+   commit-message note ("S-98 R-101-102-A: S-102 moves between
+   S-101 areas and S-101 line work").
+3. The PR includes a **before/after collage** image bundle so
+   reviewers can diff visually.
+4. Anything that's *not* one of the five v1 rules should produce
+   identical output. If a snapshot changes that we did not expect,
+   the change needs a clause cite or a TBD entry — no silent
+   visual shifts.
+
+### 7.3 PR sequence
+
+| PR | Scope | Files-changed budget |
+|---|---|---|
+| **PR-L0** (this) | Design note only. | `docs/design/s98-interoperability.md` + `docs/toc.yml` |
+| **PR-L1** plumbing | `S98DisplayPlane` enum, `LayerStackEntry`, `IInteroperabilityAuthority`, `Level0Authority`, processor plane defaults, `LayerStackBuilder`, S-101 area/line split, pick stack-ordering, tests. **No** snapshot rebaseline (authority is L0). | ~25 files; new project `EncDotNet.S100.Interoperability` likely warranted |
+| **PR-L1.5** | Flip default authority to L1 catalogue-driven; load `Adapter/defaults.xml`; rebaseline snapshots. | ~5 src files + ~20 snapshot files |
+| **PR-L2** rules | `S98CatalogueLoader`, `CatalogueDrivenAuthority`, R-101-102-B suppression rule, predefined-combination plumbing, tests. Still no UI. | ~15 files |
+| **PR-L3** UI | Layer-controls panel: interop-level selector, predefined-combination picker, per-plane visibility toggles. | viewer-only |
+| **PR-L4** S-98 IC | Drop normative S-100 Part 16 schema + IHO-published IC into `content/S98/catalogue/`; deprecate `Adapter/defaults.xml`. | content-only |
+
+Each PR is **independently mergeable**. PR-L1's plumbing is dead
+code (authority is L0, behaves like today) but it gives us the API
+surface to land tests against ahead of L2.
+
+---
+
+## 8. Open questions / TBDs
+
+The reviewer should resolve these before PR-L1 is opened. Each
+item is actionable as a focused follow-up session.
+
+- **TBD-1.** Validate the proposed XML element names
+  (`S100_IC_InteroperabilityCatalogue`, `S100_IC_DisplayPlane`,
+  `S100_IC_Feature`, `S100_IC_DrawingInstruction`,
+  `S100_IC_PredefinedCombination`,
+  `S100_IC_SuppressedFeatureLayer`) against the actual S-100 Part
+  16 XSD. Drop the XSD into `content/S98/catalogue/` and validate
+  `Adapter/defaults.xml` during build. (Annex A §4.2.1.)
+
+- **TBD-2.** Confirm S-104 / S-111 *colour-band* stacking against
+  Annex A §A-6.9.1. The clause is explicit that *"Gridded data
+  will generally go over ENC and obscure ENC features"*, but
+  practical implementations sometimes render S-101 line work on
+  top so soundings, isolated dangers, AtoN remain legible. Our
+  proposal in §3.3 places the colour band **under** S-101 lines.
+  The reviewer should decide whether to keep that or to follow the
+  literal "obscure" reading.
+
+- **TBD-3.** Decide between S-101 split Option A (renderer) vs
+  Option B (processor double-pass) — §4.2.1. Recommendation is
+  Option B but a microbenchmark on a large ENC cell should confirm
+  the < 5% expectation.
+
+- **TBD-4.** Where does S-129 UKC sit by default? S-129 is in
+  Annex A Table 1-1 but Annex A doesn't pin a default plane for
+  it — Section 9.2.1 layer 6 covers it implicitly under "on-demand
+  data". Our table puts S-129 on `OtherChartOverlays`; arguably it
+  belongs on `OnDemandSurface` instead. Verify in the eventual
+  IHO-published IC.
+
+- **TBD-5.** Filter-expression evaluation (§4.3 of Annex A — strings
+  like `"depth>10"`). We've punted at the layer granularity for v1.
+  When the layer-controls panel needs to honour
+  `S100_IC_PredefinedCombination` filters that *do* discriminate
+  by attribute, we'll need to either re-emit per-feature plane
+  metadata into `LayerStackEntry` or push filtering into the
+  per-product pipelines. Pick the design and write it up before
+  PR-L2.
+
+- **TBD-6.** Skin-of-the-earth handling. R-101-102-B suppresses
+  `DepthArea` / `DepthContour` when S-102 is loaded. S-98 Annex A
+  §8.4.1 + §A-6.9.1 NOTE caution that the safety contour is an IMO
+  requirement (MSC.232(82) §5.8) that must continue to be drawn
+  even when S-102 replaces depth shading. Decide whether we
+  preserve the safety contour as an exception to the suppression
+  rule, and where the exception is encoded (in our default IC, or
+  by a "safety-contour synthesiser" later).
+
+- **TBD-7.** Pre-defined combination UX: how does the user pick
+  one? S-98 Annex A §15.4 says the user *"must be able to
+  select"* a PdC. PR-L3 has to design this picker. For now, PR-L2
+  hard-codes "use the IC's first PdC whose product set is a
+  subset of the loaded products" and ships without UX.
+
+- **TBD-8.** Out-of-S-98 products. We use MSC.530(106)/Rev.1 §App.2
+  as informative default-plane derivation for S-122 / S-124 /
+  S-125 / S-127 / S-128 / S-131 / S-201 / S-411 / S-421. That is
+  **not** a normative S-98 reading. Decide whether the project
+  wants to (a) keep these on default planes derived from MSC.530,
+  (b) commit to specific planes per product spec, (c) wait for
+  S-98 v3.0.0 to enumerate them.
+
+- **TBD-9.** Should `S98DisplayPlane` be an enum or an open
+  string-id? An enum bakes in our nine canonical values; the IC
+  schema (Annex A §A-3.2.1.1) lets a catalogue declare *any*
+  identifier. Recommendation: enum for the canonical planes, with
+  an escape hatch `string ExtensionId` carried on `LayerStackEntry`
+  for IC-declared custom planes. Decide before PR-L1.
+
+- **TBD-10.** Pick across processors. Today
+  `PickService.ResolveHits` dedupes by `(processor, featureRef)`.
+  Under S-98 Level 3 hybridization, a single visible feature may
+  span two processors (S-101 depth area + S-102 hi-def patch). We
+  don't need to solve this for v1, but the dedup key should be
+  reviewed before PR-L3 lands hybrid-feature pick.
+
+- **TBD-11.** Should the design note also commit our reading of
+  Annex A §15.5 *"Priority overrides for user-specified settings"*?
+  We currently let the user drag-reorder datasets in the panel,
+  which is broadly equivalent to manual plane override. PR-L3 must
+  decide whether that UX survives, lives alongside the plane
+  controls, or is replaced by a single ordered list with grouping.
+
+- **TBD-12.** S-98 Annex A §13 metadata: the IC carries
+  `S100_ExchangeCatalogue` + `S100_CataloguePointofContact` +
+  signature blocks. Our bundled `Adapter/defaults.xml` is *not* a
+  signed IHO publication; clarify in the README that this is a
+  viewer-internal default, not a forged IHO catalogue.
+
+---
+
+## Appendix A — Code-citation index
+
+For convenience to PR-L1's implementer, the locations referenced
+above:
+
+- `src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs:315`
+  — `enum DisplayPlane { UnderRadar, OverRadar }`.
+- `src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs:287`
+  — `SortByPriority`, the intra-product sort.
+- `src/EncDotNet.S100.Core/Pipelines/Vector/DrawingInstruction.cs:34`
+  — `DrawingPriority` per instruction.
+- `src/EncDotNet.S100.Core/Pipelines/Vector/Part9DisplayListReader.cs:62-355`
+  — Part 9 drawing-instruction parser (already extracts plane and
+  priority for every GML/XSLT product).
+- `src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs:156-167`
+  — area / pattern fill ordering by `DrawingPriority`.
+- `src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs`
+  — `IDatasetProcessor` contract.
+- `src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs:16-34`
+  — `DatasetResult` (extension point for `LayerPlanes` /
+  `LayerWithinPlanePriorities`).
+- `src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs:83`
+  — `S101DatasetProcessor.Render`; the split point for §4.2.1.
+- `src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs:473`
+  — `FlattenLayerOrder`; the only place cross-dataset stacking
+  exists today.
+- `src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs:117-118`
+  — `EntryLayers` (read-only view of `entry → ILayer[]`); the
+  builder needs to read this.
+- `src/EncDotNet.S100.Viewer/Services/PickService.cs:135-166`
+  — `ResolveHits`; where stack-order sorting is injected.
+- `src/EncDotNet.S100.Specifications/content/S111/pc/portrayal_catalogue.xml:181-196`
+  — example `<displayPlanes>` block already in a bundled PC.
+- `src/EncDotNet.S100.Specifications/content/S111/pc/Rules/SurfaceCurrent.xsl:11-12`
+  — example of a portrayal rule emitting
+  `<displayPlane>UnderRadar</displayPlane>` and
+  `<drawingPriority>10</drawingPriority>`.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -6,3 +6,5 @@
   href: observability.md
 - name: MCP server
   href: mcp-server.md
+- name: S-98 interoperability (design)
+  href: design/s98-interoperability.md

--- a/src/EncDotNet.S100.Core/Interoperability/S98DisplayPlane.cs
+++ b/src/EncDotNet.S100.Core/Interoperability/S98DisplayPlane.cs
@@ -1,0 +1,111 @@
+namespace EncDotNet.S100.Interoperability;
+
+/// <summary>
+/// The cross-dataset display plane each rendered layer is assigned to,
+/// per the S-98 ECDIS and Interoperability Specification (Edition
+/// 2.0.0, October 2025).
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-98 widens S-100 Part 9 §11.6's intra-product two-plane model
+/// (<c>UnderRadar</c> / <c>OverRadar</c>, see
+/// <see cref="EncDotNet.S100.Pipelines.Vector.DisplayPlane"/>) with
+/// catalogue-declarable additional planes (S-98 Annex A §A-3.2.1.1).
+/// For the v1 plumbing PR (PR-L1) we hard-wire the nine canonical
+/// planes derived from MSC.530(106)/Rev.1 §Appendix 2 "priority of
+/// information" via S-98 Main §9.2.1; an
+/// <see cref="LayerStackEntry.ExtensionId"/> escape hatch on
+/// <c>LayerStackEntry</c> carries IC-declared non-canonical plane ids
+/// for the future PR-L2 rule evaluator.
+/// </para>
+/// <para>
+/// The numeric ordering is informative — lower values draw earlier
+/// (farther back) than higher values. Numeric gaps (10 between
+/// canonical values) leave headroom for IC-declared planes whose
+/// <c>order</c> attribute lands between two canonical positions.
+/// </para>
+/// <para>
+/// The intra-product <see cref="EncDotNet.S100.Pipelines.Vector.DisplayPlane"/>
+/// enum is unchanged — it still controls UnderRadar / OverRadar
+/// ordering within a single product's display list. The two enums
+/// collaborate: a given drawing instruction's intra-product plane
+/// stays UnderRadar / OverRadar; the rendered <em>layer</em> the
+/// instruction lives in is assigned an outer
+/// <see cref="S98DisplayPlane"/> by the processor.
+/// </para>
+/// </remarks>
+public enum S98DisplayPlane
+{
+    /// <summary>
+    /// Base-chart skin-of-the-earth fills (S-101 area / colour-fill
+    /// features; S-57 fallback). MSC.530(106)/Rev.1 §Appendix 2
+    /// "priority of information" layer 5 ("Official colour-fill area
+    /// data"); S-98 Main §9.2.1 layer 5.
+    /// </summary>
+    BaseChartUnder = 0,
+
+    /// <summary>
+    /// Gridded bathymetry surfaces (S-102). S-98 Annex A §A-6.9.1
+    /// "high definition gridded bathymetry replaces (overwrites)
+    /// depth area and depth contours, but soundings, aids to
+    /// navigation, and obstructions are over the high definition
+    /// bathymetry (interoperability Level 1)".
+    /// </summary>
+    Bathymetry = 10,
+
+    /// <summary>
+    /// Official on-demand coverage surfaces — water-level (S-104),
+    /// surface-current colour band (S-111), under-keel clearance
+    /// (S-129). MSC.530(106)/Rev.1 §Appendix 2 layer 6 "Official
+    /// on demand data"; S-98 Main §9.2.1 layer 6. PR-L0 TBD-2
+    /// resolved: surface sits <em>under</em> ENC line work.
+    /// </summary>
+    OnDemandSurface = 20,
+
+    /// <summary>
+    /// Base-chart line work, points, symbols, and text (S-101
+    /// curves / points / text; S-57 fallback). MSC.530(106)/Rev.1
+    /// §Appendix 2 layer 2 "Official data: points/curves and
+    /// surfaces"; S-98 Main §9.2.1 layer 2.
+    /// </summary>
+    BaseChartOver = 30,
+
+    /// <summary>
+    /// Catch-all official overlays that don't have a dedicated plane
+    /// in S-98 v2.0.0 — S-122, S-125, S-127, S-128, S-131, S-201,
+    /// S-411, S-421, and station-glyph sub-layers for S-104 / S-111
+    /// (PR-I / PR-J). Derived from MSC.530(106)/Rev.1 §Appendix 2
+    /// layer 6 catch-all reading.
+    /// </summary>
+    OtherChartOverlays = 40,
+
+    /// <summary>
+    /// Navigational warnings and notices to mariners (S-124).
+    /// MSC.530(106)/Rev.1 §Appendix 2 layers 3-4 ("Notices to
+    /// Mariners…", "Official-caution"); S-98 Main §9.2.1 layers
+    /// 3-4.
+    /// </summary>
+    CautionsAndWarnings = 50,
+
+    /// <summary>
+    /// Dynamic vector overlays drawn above the cautions plane —
+    /// S-111 arrow sub-layer (the catalogue marks its instructions
+    /// with intra-product <c>displayPlane id="OverRadar"</c>) and
+    /// any future dynamic glyph layers.
+    /// </summary>
+    DynamicArrows = 60,
+
+    /// <summary>
+    /// Mariner's own annotations (future). MSC.530(106)/Rev.1
+    /// §Appendix 2 layers 8-9. Reserved for PR-L3+ scope; no
+    /// processor emits onto this plane today.
+    /// </summary>
+    MarinerOverlay = 70,
+
+    /// <summary>
+    /// ECDIS visual alerts / indications (overscale, caution, AIO).
+    /// MSC.530(106)/Rev.1 §Appendix 2 layer 1; S-98 Main §9.2.1
+    /// layer 1. Reserved for PR-L3+ scope.
+    /// </summary>
+    EcdisAlerts = 80,
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
@@ -31,6 +32,31 @@ public sealed class DatasetResult
     /// length must match <see cref="Layers"/>.
     /// </summary>
     public IReadOnlyList<string>? LayerNames { get; init; }
+
+    /// <summary>
+    /// S-98 cross-dataset stack metadata, parallel by index to
+    /// <see cref="Layers"/> when supplied (every entry's
+    /// <see cref="LayerStackEntry.Layer"/> appears in
+    /// <see cref="Layers"/> exactly once and at the same index).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// PR-L1 plumbing: each processor declares the S-98 display
+    /// plane every layer it emits should live in (S-98 Annex A
+    /// §4.4.1; S-98 Main §9.2.1). The viewer's dataset loader
+    /// pumps every loaded dataset's entries through
+    /// <see cref="LayerStackBuilder"/> to compute the global paint
+    /// order across products.
+    /// </para>
+    /// <para>
+    /// The <see cref="Layers"/> field stays in place — the two
+    /// collections must remain in sync (same length, same instances
+    /// in the same positions). The <c>Layers</c> field exists so
+    /// downstream code that doesn't care about plane metadata
+    /// remains source-compatible.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<LayerStackEntry>? StackEntries { get; init; }
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -69,29 +69,36 @@ public sealed class DatasetPipelineFactory
     private readonly ILuaEngine _luaEngine;
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
+    private readonly Interoperability.IInteroperabilityAuthorityProvider _authorityProvider;
 
     /// <summary>
     /// Creates a new factory. The supplied
     /// <paramref name="featureCatalogueManager"/> is shared across every
     /// processor this factory produces, so its FC parse cache survives
     /// for the lifetime of the manager — not just the lifetime of the
-    /// factory.
+    /// factory. The supplied <paramref name="authorityProvider"/> is
+    /// forwarded to every GML-based processor so they resolve the
+    /// cross-dataset paint-order authority through the host's DI
+    /// container rather than a static singleton.
     /// </summary>
     public DatasetPipelineFactory(
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         ICrsTransformFactory crsTransformFactory,
-        FeatureCatalogueManager featureCatalogueManager)
+        FeatureCatalogueManager featureCatalogueManager,
+        Interoperability.IInteroperabilityAuthorityProvider authorityProvider)
     {
         ArgumentNullException.ThrowIfNull(catalogueManager);
         ArgumentNullException.ThrowIfNull(luaEngine);
         ArgumentNullException.ThrowIfNull(crsTransformFactory);
         ArgumentNullException.ThrowIfNull(featureCatalogueManager);
+        ArgumentNullException.ThrowIfNull(authorityProvider);
 
         _catalogueManager = catalogueManager;
         _luaEngine = luaEngine;
         _crsTransformFactory = crsTransformFactory;
         _featureCatalogueManager = featureCatalogueManager;
+        _authorityProvider = authorityProvider;
     }
 
     /// <summary>
@@ -391,16 +398,16 @@ public sealed class DatasetPipelineFactory
             "S-57" => new S57DatasetProcessor(path, _catalogueManager, _luaEngine, _featureCatalogueManager),
             "S-104" => new S104DatasetProcessor(path, _crsTransformFactory),
             "S-111" => new S111DatasetProcessor(path, _catalogueManager, _crsTransformFactory),
-            "S-122" => new S122DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-124" => new S124DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-125" => new S125DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-127" => new S127DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-128" => new S128DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-129" => new S129DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
+            "S-122" => new S122DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-124" => new S124DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-125" => new S125DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-127" => new S127DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-128" => new S128DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-129" => new S129DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
             "S-131" => new S131DatasetProcessor(path, _catalogueManager, _luaEngine, _featureCatalogueManager),
-            "S-201" => new S201DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-411" => new S411DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
-            "S-421" => new S421DatasetProcessor(path, _catalogueManager, _featureCatalogueManager),
+            "S-201" => new S201DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-411" => new S411DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-421" => new S421DatasetProcessor(path, _catalogueManager, _authorityProvider, _featureCatalogueManager),
             _ => throw new NotSupportedException($"Pipeline not implemented for {spec}."),
         };
     }
@@ -444,16 +451,16 @@ public sealed class DatasetPipelineFactory
             "S-57" => new S57DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager),
             "S-104" => new S104DatasetProcessor(source, relativePath, _crsTransformFactory),
             "S-111" => new S111DatasetProcessor(source, relativePath, _catalogueManager, _crsTransformFactory),
-            "S-122" => new S122DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-124" => new S124DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-125" => new S125DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-127" => new S127DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-128" => new S128DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-129" => new S129DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
+            "S-122" => new S122DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-124" => new S124DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-125" => new S125DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-127" => new S127DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-128" => new S128DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-129" => new S129DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
             "S-131" => new S131DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager),
-            "S-201" => new S201DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-411" => new S411DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
-            "S-421" => new S421DatasetProcessor(source, relativePath, _catalogueManager, _featureCatalogueManager),
+            "S-201" => new S201DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-411" => new S411DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
+            "S-421" => new S421DatasetProcessor(source, relativePath, _catalogueManager, _authorityProvider, _featureCatalogueManager),
             _ => throw new NotSupportedException($"Pipeline not implemented for {spec}."),
         };
     }

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Diagnostics;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Gml;
 using EncDotNet.S100.Pipelines;
@@ -175,6 +176,17 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
             Extent = ComputeExtent(),
             Info = info,
             Spec = Spec,
+            StackEntries = new[]
+            {
+                new LayerStackEntry(
+                    Layer: layer,
+                    // S-98 cross-dataset plane assignment per design note
+                    // §3 / §4.2. PR-L1 ships default planes only — no IC
+                    // override, no per-feature filter (TBD-5).
+                    Plane: InteroperabilityAuthority.Default.GetDefaultPlane(Spec.Name),
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName),
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -38,21 +38,34 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
     private readonly GmlPortrayalCatalogueBase _catalogue;
     private readonly FeatureCatalogueDecoder? _decoder;
     private readonly string _fileName;
+    private readonly IInteroperabilityAuthorityProvider _authorityProvider;
     private readonly MapsuiRenderAssetCache _renderAssetCache = new();
 
     /// <summary>
     /// Initializes the shared processor state. Called by subclass constructors
     /// after parsing the dataset and creating the catalogue.
     /// </summary>
+    /// <param name="catalogue">Portrayal catalogue used by the XSLT pipeline.</param>
+    /// <param name="decoder">Optional feature-catalogue decoder for attribute decoding.</param>
+    /// <param name="fileName">Dataset file name (used in feature info).</param>
+    /// <param name="authorityProvider">
+    /// Resolves the cross-dataset paint-order authority each time the
+    /// processor builds a <see cref="LayerStackEntry"/>. Required —
+    /// processors receive the provider via DI rather than reaching
+    /// for a static singleton.
+    /// </param>
     protected GmlDatasetProcessorBase(
         GmlPortrayalCatalogueBase catalogue,
         FeatureCatalogueDecoder? decoder,
-        string fileName)
+        string fileName,
+        IInteroperabilityAuthorityProvider authorityProvider)
     {
         ArgumentNullException.ThrowIfNull(catalogue);
+        ArgumentNullException.ThrowIfNull(authorityProvider);
         _catalogue = catalogue;
         _decoder = decoder;
         _fileName = fileName;
+        _authorityProvider = authorityProvider;
 
         // Catalogue resolution is a one-shot per processor instance; emit
         // the diagnostic at construction so the per-Render hot path stays
@@ -184,15 +197,14 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
                     // §3 / §4.2. PR-L1 ships default planes only — no IC
                     // override, no per-feature filter (TBD-5).
                     //
-                    // We stamp the canonical S-98 default plane at render
-                    // time rather than the *currently active* authority's
-                    // plane. The plane recorded here is the conceptual
-                    // ("which S-98 plane does this layer's content
-                    // belong to?") answer; the sort policy lives in
-                    // DatasetLoaderService via IInteroperabilityAuthorityProvider
-                    // and is free to ignore the recorded plane (e.g.
-                    // LoadOrderInteroperabilityAuthority does).
-                    Plane: InteroperabilityAuthority.Default.GetDefaultPlane(Spec.Name),
+                    // The plane is resolved through the currently active
+                    // authority (via the injected provider) so a runtime
+                    // policy swap (e.g. S-98 → strict load-order) takes
+                    // effect on the next render. The recorded plane is
+                    // the conceptual "where does this content belong?"
+                    // answer; sort policy is what the authority's Sort()
+                    // does with it.
+                    Plane: _authorityProvider.Current.GetDefaultPlane(Spec.Name),
                     WithinPlanePriority: 0,
                     SourceDatasetId: _fileName),
             },

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -183,6 +183,15 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
                     // S-98 cross-dataset plane assignment per design note
                     // §3 / §4.2. PR-L1 ships default planes only — no IC
                     // override, no per-feature filter (TBD-5).
+                    //
+                    // We stamp the canonical S-98 default plane at render
+                    // time rather than the *currently active* authority's
+                    // plane. The plane recorded here is the conceptual
+                    // ("which S-98 plane does this layer's content
+                    // belong to?") answer; the sort policy lives in
+                    // DatasetLoaderService via IInteroperabilityAuthorityProvider
+                    // and is free to ignore the recorded plane (e.g.
+                    // LoadOrderInteroperabilityAuthority does).
                     Plane: InteroperabilityAuthority.Default.GetDefaultPlane(Spec.Name),
                     WithinPlanePriority: 0,
                     SourceDatasetId: _fileName),

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
@@ -1,0 +1,64 @@
+using EncDotNet.S100.Interoperability;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Cross-dataset interoperability decision point: assigns a default
+/// S-98 display plane to a (product, feature-or-layer-kind) pair and
+/// sorts the global stack of <see cref="LayerStackEntry"/> values
+/// into S-98-shaped paint order.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-L1 ships a fixed-table implementation
+/// (<see cref="InteroperabilityAuthority"/>) — there is <em>no</em>
+/// IC parsing, suppression, replacement, or hybridisation in this
+/// PR. Those Level 1+ behaviours are owned by PR-L2 once the IHO
+/// publishes a normative S-100 Part 16 IC schema and a viewer-side
+/// catalogue reader is in place.
+/// </para>
+/// <para>
+/// The contract is pure — <c>(default plane lookup)</c> and
+/// <c>(in entries → out entries)</c>; the implementation must be
+/// thread-safe and free of viewer dependencies so it can be
+/// unit-tested in isolation.
+/// </para>
+/// </remarks>
+public interface IInteroperabilityAuthority
+{
+    /// <summary>
+    /// Returns the default S-98 display plane for a given product
+    /// specification and optional feature-type or sub-layer kind
+    /// hint. The <paramref name="featureTypeOrLayerKind"/> argument
+    /// lets callers distinguish e.g. S-111 colour-band layer
+    /// (<c>"s111.color-band"</c>) from S-111 arrow overlay
+    /// (<c>"s111.arrows"</c>); pass <c>null</c> for products with a
+    /// single layer.
+    /// </summary>
+    /// <param name="productSpec">
+    /// The product spec name (e.g. <c>"S-101"</c>, <c>"S-102"</c>).
+    /// </param>
+    /// <param name="featureTypeOrLayerKind">
+    /// Optional sub-layer kind or feature type code. Recognised values
+    /// are documented on <see cref="InteroperabilityAuthority"/>.
+    /// </param>
+    /// <returns>
+    /// The default plane for the pair. Unknown products fall back to
+    /// <see cref="S98DisplayPlane.OtherChartOverlays"/> with a
+    /// debug warning (S-98 v2.0.0 Annex A §4.1.1 — "other similar
+    /// products may also be covered on a case-by-case basis").
+    /// </returns>
+    S98DisplayPlane GetDefaultPlane(string productSpec, string? featureTypeOrLayerKind = null);
+
+    /// <summary>
+    /// Sorts the supplied entries into S-98-shaped paint order.
+    /// The result is a new list — the input is not mutated.
+    /// </summary>
+    /// <remarks>
+    /// Sort is stable in the input order: entries with equal plane
+    /// and within-plane priority preserve their relative position,
+    /// which the caller (the dataset loader) sets to its
+    /// load-order tiebreaker.
+    /// </remarks>
+    IReadOnlyList<LayerStackEntry> Sort(IEnumerable<LayerStackEntry> entries);
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
@@ -13,13 +13,15 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// PR-L1 ships a fixed-table S-98 implementation
 /// (<see cref="InteroperabilityAuthority"/>) and a strict
 /// load-order alternative
-/// (<see cref="LoadOrderInteroperabilityAuthority"/>). Hosts can
-/// inject a custom implementation into
-/// <c>DatasetLoaderService</c> via its constructor's optional
-/// <c>authority</c> parameter to plug in a different policy
-/// (e.g. a viewer setting that toggles strict load-order, a
-/// deployment-specific rule pack, or a test-only deterministic
-/// stub). PR-L1 deliberately ships <em>no</em> IC parsing,
+/// (<see cref="LoadOrderInteroperabilityAuthority"/>). Hosts wire a
+/// chosen implementation through DI as an
+/// <see cref="IInteroperabilityAuthorityProvider"/>; consumers
+/// (e.g. <c>DatasetLoaderService</c>, GML dataset processors)
+/// receive that provider via constructor injection and consult
+/// <see cref="IInteroperabilityAuthorityProvider.Current"/> on each
+/// operation so a runtime swap (e.g. a viewer setting flip from
+/// S-98 to strict load-order) takes effect immediately. PR-L1
+/// deliberately ships <em>no</em> IC parsing,
 /// suppression, replacement, or hybridisation; those Level 1+
 /// behaviours are owned by PR-L2 once the IHO publishes a
 /// normative S-100 Part 16 IC schema and a viewer-side catalogue

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
@@ -10,12 +10,20 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// </summary>
 /// <remarks>
 /// <para>
-/// PR-L1 ships a fixed-table implementation
-/// (<see cref="InteroperabilityAuthority"/>) — there is <em>no</em>
-/// IC parsing, suppression, replacement, or hybridisation in this
-/// PR. Those Level 1+ behaviours are owned by PR-L2 once the IHO
-/// publishes a normative S-100 Part 16 IC schema and a viewer-side
-/// catalogue reader is in place.
+/// PR-L1 ships a fixed-table S-98 implementation
+/// (<see cref="InteroperabilityAuthority"/>) and a strict
+/// load-order alternative
+/// (<see cref="LoadOrderInteroperabilityAuthority"/>). Hosts can
+/// inject a custom implementation into
+/// <c>DatasetLoaderService</c> via its constructor's optional
+/// <c>authority</c> parameter to plug in a different policy
+/// (e.g. a viewer setting that toggles strict load-order, a
+/// deployment-specific rule pack, or a test-only deterministic
+/// stub). PR-L1 deliberately ships <em>no</em> IC parsing,
+/// suppression, replacement, or hybridisation; those Level 1+
+/// behaviours are owned by PR-L2 once the IHO publishes a
+/// normative S-100 Part 16 IC schema and a viewer-side catalogue
+/// reader is in place.
 /// </para>
 /// <para>
 /// The contract is pure — <c>(default plane lookup)</c> and

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthorityProvider.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthorityProvider.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Resolves the <em>currently active</em>
+/// <see cref="IInteroperabilityAuthority"/> on each consult.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Components that participate in cross-dataset paint ordering
+/// (<c>DatasetLoaderService</c>, the future PR-L3 Layer Controls UI,
+/// any host-side picker) should depend on this provider rather than
+/// holding an <see cref="IInteroperabilityAuthority"/> reference
+/// directly. The active authority can change at runtime — e.g. a
+/// viewer setting that toggles between the S-98 policy and a strict
+/// load-order policy — and consumers must observe the change to
+/// re-sort their layer stack.
+/// </para>
+/// <para>
+/// PR-L1 ships a single mutable default provider
+/// (<see cref="InteroperabilityAuthorityProvider"/>); hosts can
+/// substitute their own (e.g. a settings-bound provider that reads
+/// from a <c>ViewerSettings</c> property).
+/// </para>
+/// </remarks>
+public interface IInteroperabilityAuthorityProvider
+{
+    /// <summary>
+    /// The authority every consumer should consult on each
+    /// operation. Never <c>null</c>.
+    /// </summary>
+    IInteroperabilityAuthority Current { get; }
+
+    /// <summary>
+    /// Raised after <see cref="Current"/> has been swapped to a
+    /// different instance. Consumers re-sort their layer stack
+    /// (and re-broadcast their derived state — pick ordering,
+    /// layer-controls UI labels, etc.) in response.
+    /// </summary>
+    /// <remarks>
+    /// The event is raised synchronously on the thread that swapped
+    /// the authority. Implementations are expected to swap on the
+    /// UI thread; consumers running off-thread must marshal.
+    /// </remarks>
+    event Action? CurrentChanged;
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
@@ -48,12 +48,6 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// </remarks>
 public sealed class InteroperabilityAuthority : IInteroperabilityAuthority
 {
-    /// <summary>
-    /// Process-wide singleton. The authority is stateless — every
-    /// caller is welcome to share this instance.
-    /// </summary>
-    public static InteroperabilityAuthority Default { get; } = new();
-
     /// <inheritdoc />
     public S98DisplayPlane GetDefaultPlane(string productSpec, string? featureTypeOrLayerKind = null)
     {

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Interoperability;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Default <see cref="IInteroperabilityAuthority"/> implementation.
+/// Resolves the per-product default plane from a hardcoded table
+/// derived from S-98 Main §9.2.1 / MSC.530(106)/Rev.1 §Appendix 2
+/// "priority of information"; sorts entries by
+/// <c>(Plane, WithinPlanePriority, input order)</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-L1 deliberately ships <em>no</em> inter-product suppression,
+/// replacement, or hybridisation logic. The five v1 rules described
+/// in <c>docs/design/s98-interoperability.md</c> §3 are expressed
+/// purely as default plane assignments — no IC parsing, no
+/// per-feature filters, no Level 2 predefined combinations. Those
+/// land in PR-L2 once a normative S-100 Part 16 schema is
+/// available.
+/// </para>
+/// <para>
+/// Recognised <c>featureTypeOrLayerKind</c> values for products that
+/// emit multiple layer kinds:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///     S-101: <c>"area"</c> → <see cref="S98DisplayPlane.BaseChartUnder"/>
+///     for area fills; anything else (or <c>null</c>) →
+///     <see cref="S98DisplayPlane.BaseChartOver"/> for line work,
+///     points, symbols, text.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     S-104 / S-111: <c>"s104.color-band"</c> / <c>"s111.color-band"</c>
+///     → <see cref="S98DisplayPlane.OnDemandSurface"/>;
+///     <c>"s111.arrows"</c> → <see cref="S98DisplayPlane.DynamicArrows"/>;
+///     <c>"s104.stations"</c> / <c>"s111.stations"</c> →
+///     <see cref="S98DisplayPlane.OtherChartOverlays"/>.
+///     </description>
+///   </item>
+/// </list>
+/// </remarks>
+public sealed class InteroperabilityAuthority : IInteroperabilityAuthority
+{
+    /// <summary>
+    /// Process-wide singleton. The authority is stateless — every
+    /// caller is welcome to share this instance.
+    /// </summary>
+    public static InteroperabilityAuthority Default { get; } = new();
+
+    /// <inheritdoc />
+    public S98DisplayPlane GetDefaultPlane(string productSpec, string? featureTypeOrLayerKind = null)
+    {
+        ArgumentNullException.ThrowIfNull(productSpec);
+
+        // Normalise the kind hint so callers can pass case-insensitive
+        // sub-layer names without breaking the lookup.
+        var kind = featureTypeOrLayerKind?.Trim();
+
+        return productSpec switch
+        {
+            // S-101 ENC. Split between fills and line work per
+            // S-98 Annex A §A-6.9.1 (so S-102 lands between them).
+            "S-101" or "S-57" => string.Equals(kind, "area", StringComparison.OrdinalIgnoreCase)
+                ? S98DisplayPlane.BaseChartUnder
+                : S98DisplayPlane.BaseChartOver,
+
+            // S-102 Bathymetric Surface (S-98 Annex A §A-6.9.1).
+            "S-102" => S98DisplayPlane.Bathymetry,
+
+            // S-104 Water Level. Coverage band on the on-demand
+            // surface plane; station glyphs are point overlays.
+            "S-104" => kind switch
+            {
+                "s104.stations" => S98DisplayPlane.OtherChartOverlays,
+                _ => S98DisplayPlane.OnDemandSurface,
+            },
+
+            // S-111 Surface Currents. Coverage band on on-demand;
+            // arrow overlay drawn above warnings as a dynamic
+            // overlay; station glyphs as point overlays.
+            "S-111" => kind switch
+            {
+                "s111.arrows" => S98DisplayPlane.DynamicArrows,
+                "s111.stations" => S98DisplayPlane.OtherChartOverlays,
+                _ => S98DisplayPlane.OnDemandSurface,
+            },
+
+            // S-124 Navigational Warnings — MSC.530(106)/Rev.1
+            // §Appendix 2 layers 3-4; S-98 Main §9.2.1.
+            "S-124" => S98DisplayPlane.CautionsAndWarnings,
+
+            // S-129 Under Keel Clearance Management. S-98 v2.0.0
+            // Annex A Table 1-1 lists S-129 in IC scope but does
+            // not pin a default plane (PR-L0 TBD-4). PR-L1 places
+            // it on OnDemandSurface — PR-L2 may move it once the
+            // normative IC ships.
+            "S-129" => S98DisplayPlane.OnDemandSurface,
+
+            // Out-of-S-98-scope products. MSC.530(106)/Rev.1
+            // §Appendix 2 default plane assignment (PR-L0 TBD-8
+            // resolved: hardcode here, no external rule pack).
+            "S-122" or "S-125" or "S-127" or "S-128"
+                or "S-131" or "S-201" or "S-411" or "S-421"
+                => S98DisplayPlane.OtherChartOverlays,
+
+            // Unknown product — land at the catch-all overlay
+            // plane so the renderer doesn't lose the layer. The
+            // PR-L2 IC reader will eventually validate against
+            // S-98 Annex A §4.1.1 "closed dictionary" of
+            // covered products.
+            _ => S98DisplayPlane.OtherChartOverlays,
+        };
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<LayerStackEntry> Sort(IEnumerable<LayerStackEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        // OrderBy is documented as a stable sort in LINQ-to-Objects,
+        // so entries that share (Plane, WithinPlanePriority) retain
+        // their input order — that's the dataset-load-order tiebreaker
+        // required by §4.3.2 of the design note.
+        return entries
+            .OrderBy(e => (int)e.Plane)
+            .ThenBy(e => e.WithinPlanePriority)
+            .ToList();
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthorityProvider.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthorityProvider.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Mutable default <see cref="IInteroperabilityAuthorityProvider"/>:
+/// holds a single <see cref="IInteroperabilityAuthority"/> reference
+/// that the host can swap at runtime (e.g. via a settings binding).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Not thread-safe — callers are expected to swap on the UI thread.
+/// The setter raises <see cref="CurrentChanged"/> after the swap
+/// completes, on the calling thread, even when the new authority is
+/// reference-equal to the previous one (which lets a host force a
+/// re-sort cycle, e.g. after a downstream catalogue reload that
+/// changed the authority's internal table).
+/// </para>
+/// </remarks>
+public sealed class InteroperabilityAuthorityProvider : IInteroperabilityAuthorityProvider
+{
+    private IInteroperabilityAuthority _current;
+
+    /// <summary>
+    /// Initialises a provider holding <paramref name="initial"/>.
+    /// Defaults to <see cref="InteroperabilityAuthority.Default"/>
+    /// when omitted — i.e. the canonical S-98 policy.
+    /// </summary>
+    public InteroperabilityAuthorityProvider(IInteroperabilityAuthority? initial = null)
+    {
+        _current = initial ?? InteroperabilityAuthority.Default;
+    }
+
+    /// <inheritdoc />
+    public IInteroperabilityAuthority Current => _current;
+
+    /// <inheritdoc />
+    public event Action? CurrentChanged;
+
+    /// <summary>
+    /// Swaps the active authority and raises
+    /// <see cref="CurrentChanged"/>. Throws <see cref="ArgumentNullException"/>
+    /// when <paramref name="authority"/> is null — the provider's
+    /// <see cref="Current"/> must never be null.
+    /// </summary>
+    public void Set(IInteroperabilityAuthority authority)
+    {
+        ArgumentNullException.ThrowIfNull(authority);
+        _current = authority;
+        CurrentChanged?.Invoke();
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthorityProvider.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthorityProvider.cs
@@ -6,6 +6,8 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// Mutable default <see cref="IInteroperabilityAuthorityProvider"/>:
 /// holds a single <see cref="IInteroperabilityAuthority"/> reference
 /// that the host can swap at runtime (e.g. via a settings binding).
+/// The initial authority is required at construction time — hosts
+/// inject the chosen policy via DI; there is no static fallback.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -23,12 +25,13 @@ public sealed class InteroperabilityAuthorityProvider : IInteroperabilityAuthori
 
     /// <summary>
     /// Initialises a provider holding <paramref name="initial"/>.
-    /// Defaults to <see cref="InteroperabilityAuthority.Default"/>
-    /// when omitted — i.e. the canonical S-98 policy.
+    /// Required — there is no default fallback; hosts wire the
+    /// initial authority via DI.
     /// </summary>
-    public InteroperabilityAuthorityProvider(IInteroperabilityAuthority? initial = null)
+    public InteroperabilityAuthorityProvider(IInteroperabilityAuthority initial)
     {
-        _current = initial ?? InteroperabilityAuthority.Default;
+        ArgumentNullException.ThrowIfNull(initial);
+        _current = initial;
     }
 
     /// <inheritdoc />

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LayerStackBuilder.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LayerStackBuilder.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Linq;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Collects each loaded dataset's <see cref="LayerStackEntry"/>
+/// values and sorts the whole stack via an
+/// <see cref="IInteroperabilityAuthority"/>. The builder is a thin
+/// orchestration layer; the actual policy lives in the authority.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Callers (typically the viewer's dataset loader) walk their
+/// per-dataset entries in <em>paint order top-first</em> — the
+/// reverse of the layer-collection order Mapsui paints. The builder
+/// flattens that view into a single list preserving the load-order
+/// tiebreaker inside each plane.
+/// </para>
+/// <para>
+/// PR-L1 contract: <see cref="Build"/> returns layers in
+/// bottom-of-stack-first order (lower indices in the layer
+/// collection are painted earlier). That matches
+/// <c>MapsuiMapHost.ReorderDatasetLayers</c>'s existing contract.
+/// </para>
+/// </remarks>
+public static class LayerStackBuilder
+{
+    /// <summary>
+    /// Sorts every dataset's stack entries through
+    /// <paramref name="authority"/> and returns the resulting Mapsui
+    /// layers in bottom-of-stack-first paint order.
+    /// </summary>
+    /// <param name="authority">The interoperability authority that
+    /// supplies the sort policy.</param>
+    /// <param name="datasetEntries">
+    /// Per-dataset stack-entry slices in <em>paint order top-first</em>
+    /// — entry 0 is the top of the UI's dataset list (drawn last).
+    /// The builder reverses the outer order so the authority's
+    /// stable sort sees the dataset that should win ties at the
+    /// <em>bottom</em> of the sort input, leaving the topmost dataset
+    /// last in the output for any tied (plane, priority) group.
+    /// </param>
+    public static IReadOnlyList<LayerStackEntry> Build(
+        IInteroperabilityAuthority authority,
+        IReadOnlyList<IReadOnlyList<LayerStackEntry>> datasetEntries)
+    {
+        System.ArgumentNullException.ThrowIfNull(authority);
+        System.ArgumentNullException.ThrowIfNull(datasetEntries);
+
+        // Walk datasets from bottom-of-UI up so the within-plane
+        // tiebreaker preserves the user's paint expectation: the
+        // entry at the top of the Datasets panel wins ties (its
+        // layer paints last, i.e. on top).
+        var flat = new List<LayerStackEntry>();
+        for (int i = datasetEntries.Count - 1; i >= 0; i--)
+        {
+            flat.AddRange(datasetEntries[i]);
+        }
+
+        return authority.Sort(flat);
+    }
+
+    /// <summary>
+    /// Convenience: projects a sorted list of entries to a flat
+    /// list of <see cref="ILayer"/> in the same order — what
+    /// <c>MapsuiMapHost.ReorderDatasetLayers</c> consumes.
+    /// </summary>
+    public static List<ILayer> ToLayerList(IEnumerable<LayerStackEntry> sortedEntries)
+    {
+        System.ArgumentNullException.ThrowIfNull(sortedEntries);
+        return sortedEntries.Select(e => e.Layer).ToList();
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LayerStackEntry.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LayerStackEntry.cs
@@ -1,0 +1,51 @@
+using EncDotNet.S100.Interoperability;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// One layer's slot in the S-98 cross-dataset stack. A
+/// <see cref="LayerStackEntry"/> carries everything the
+/// <see cref="IInteroperabilityAuthority"/> needs to sort layers
+/// across all loaded datasets without taking a dependency on the
+/// viewer's <c>DatasetEntry</c> shape.
+/// </summary>
+/// <param name="Layer">The Mapsui layer to be drawn.</param>
+/// <param name="Plane">
+/// The S-98 display plane this layer lives in (S-98 Annex A §4.4.1 +
+/// §A-3.2.1.1). Assigned by the producing processor, possibly
+/// overridden later by an Interoperability Catalogue rule (PR-L2).
+/// </param>
+/// <param name="WithinPlanePriority">
+/// Intra-plane ordering hint, ascending — lower draws first. For
+/// vector products this is the S-100 Part 9 §10
+/// <c>drawingPriority</c> exposed by the processor's display list;
+/// for coverage products it is a processor-chosen integer (e.g.
+/// arrows above colour band).
+/// </param>
+/// <param name="SourceDatasetId">
+/// Stable identifier for the source dataset (typically the
+/// dataset's file name or exchange-set relative path). Used as a
+/// tiebreaker for stable sorting and for diagnostics.
+/// </param>
+/// <param name="SourceFeatureType">
+/// Optional feature type code when the entry represents a
+/// per-feature-type slice (e.g. S-101 area-fill split). Null for
+/// whole-layer entries. PR-L2 IC rules consume this for
+/// suppression / replacement decisions.
+/// </param>
+/// <param name="ExtensionId">
+/// Optional IC-declared custom plane identifier (S-98 Annex A
+/// §A-3.2.1.1 allows catalogues to declare non-canonical planes).
+/// When set, the authority slots the entry between canonical
+/// planes by the catalogue's <c>order</c> attribute rather than by
+/// <paramref name="Plane"/>. Always null for PR-L1; the field is
+/// the escape hatch resolved in PR-L0 TBD-9.
+/// </param>
+public sealed record LayerStackEntry(
+    ILayer Layer,
+    S98DisplayPlane Plane,
+    int WithinPlanePriority,
+    string SourceDatasetId,
+    string? SourceFeatureType = null,
+    string? ExtensionId = null);

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadOrderInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadOrderInteroperabilityAuthority.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Interoperability;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Strict dataset-by-dataset <see cref="IInteroperabilityAuthority"/>:
+/// preserves the order in which <see cref="LayerStackBuilder.Build"/>
+/// presents entries (top-of-UI dataset wins) and <em>ignores the
+/// S-98 display plane entirely</em>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this when the user (or host application) needs the classic
+/// GIS "load order is paint order" semantics — every layer of dataset
+/// N paints above every layer of dataset N-1, regardless of what
+/// S-98 plane its features conceptually belong to. Intended for
+/// debugging, comparison studies, and any deployment that has its
+/// own non-S-98 stacking policy.
+/// </para>
+/// <para>
+/// <see cref="GetDefaultPlane"/> still returns the S-98 default
+/// plane for informational purposes (e.g. layer-controls UI that
+/// labels each layer with its conceptual plane), but
+/// <see cref="Sort"/> does not consult it.
+/// </para>
+/// <para>
+/// Tiebreaker semantics inside a single dataset: entries are emitted
+/// in the order the processor produced them, then by
+/// <see cref="LayerStackEntry.WithinPlanePriority"/>. The
+/// <c>WithinPlanePriority</c> still serves to express the
+/// "areas underneath line work" ordering within e.g. S-101 so the
+/// dataset's own visual integrity is preserved.
+/// </para>
+/// </remarks>
+public sealed class LoadOrderInteroperabilityAuthority : IInteroperabilityAuthority
+{
+    private readonly IInteroperabilityAuthority _planeOracle;
+
+    /// <summary>
+    /// Process-wide singleton. The authority is stateless.
+    /// </summary>
+    public static LoadOrderInteroperabilityAuthority Default { get; } = new();
+
+    /// <summary>
+    /// Constructs a load-order authority that delegates default-plane
+    /// lookups to <see cref="InteroperabilityAuthority.Default"/>.
+    /// </summary>
+    public LoadOrderInteroperabilityAuthority()
+        : this(InteroperabilityAuthority.Default)
+    {
+    }
+
+    /// <summary>
+    /// Constructs a load-order authority that delegates default-plane
+    /// lookups to <paramref name="planeOracle"/>. Useful when the
+    /// host wants informational plane labels from a custom table
+    /// while still using strict load-order stacking.
+    /// </summary>
+    public LoadOrderInteroperabilityAuthority(IInteroperabilityAuthority planeOracle)
+    {
+        System.ArgumentNullException.ThrowIfNull(planeOracle);
+        _planeOracle = planeOracle;
+    }
+
+    /// <inheritdoc />
+    public S98DisplayPlane GetDefaultPlane(string productSpec, string? featureTypeOrLayerKind = null)
+        => _planeOracle.GetDefaultPlane(productSpec, featureTypeOrLayerKind);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Stable sort on <see cref="LayerStackEntry.WithinPlanePriority"/>
+    /// alone. The cross-dataset paint order is the order in which
+    /// <see cref="LayerStackBuilder"/> hands the entries to this
+    /// method — bottom-of-UI dataset first. The OrderBy stability
+    /// guarantees we preserve that interleaving.
+    /// </remarks>
+    public IReadOnlyList<LayerStackEntry> Sort(IEnumerable<LayerStackEntry> entries)
+    {
+        System.ArgumentNullException.ThrowIfNull(entries);
+        return entries.OrderBy(e => e.WithinPlanePriority).ToList();
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadOrderInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadOrderInteroperabilityAuthority.cs
@@ -39,20 +39,6 @@ public sealed class LoadOrderInteroperabilityAuthority : IInteroperabilityAuthor
     private readonly IInteroperabilityAuthority _planeOracle;
 
     /// <summary>
-    /// Process-wide singleton. The authority is stateless.
-    /// </summary>
-    public static LoadOrderInteroperabilityAuthority Default { get; } = new();
-
-    /// <summary>
-    /// Constructs a load-order authority that delegates default-plane
-    /// lookups to <see cref="InteroperabilityAuthority.Default"/>.
-    /// </summary>
-    public LoadOrderInteroperabilityAuthority()
-        : this(InteroperabilityAuthority.Default)
-    {
-    }
-
-    /// <summary>
     /// Constructs a load-order authority that delegates default-plane
     /// lookups to <paramref name="planeOracle"/>. Useful when the
     /// host wants informational plane labels from a custom table

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Features;
+using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
@@ -110,10 +112,81 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         var prepared = ((IVectorLayer)portrayalLayer).Instructions;
         Console.WriteLine($"[S101] Pipeline produced {prepared.Count} drawing instructions");
 
-        // Render to Mapsui layer
-        var vectorRenderer = new MapsuiDisplayListRenderer
+        // S-98 R-101-102-A (Annex A §A-6.9.1): S-102 must render between
+        // S-101 area fills and S-101 line work / points / text. We split
+        // the S-101 display list along the AreaInstruction boundary into
+        // two Mapsui layers so the LayerStackBuilder can interleave S-102.
+        // PR-L0 TBD-3 resolved: split in the processor (double pipeline
+        // pass / type pre-filter) rather than the renderer. The double
+        // render is small per cell (< 5% per design note §4.2.1); a
+        // future v2 mitigation could be a single-pass dual-sink renderer
+        // if profiling on large datasets shows it matters.
+        var areaInstructions = prepared.Where(i => i is AreaInstruction).ToList();
+        var otherInstructions = prepared.Where(i => i is not AreaInstruction).ToList();
+
+        var geometryProvider = new S101FeatureGeometryProvider(_dataset);
+
+        var areaLayer = CreateRenderer(s101Cat, palette, context, suffix: "areas")
+            .Render(areaInstructions, geometryProvider);
+        var lineLayer = CreateRenderer(s101Cat, palette, context, suffix: "lines")
+            .Render(otherInstructions, geometryProvider);
+
+        // Union the two layer extents (each is in EPSG:3857). Mapsui
+        // returns a zero-extent rect when a layer has no features, so
+        // skip such layers in the union.
+        var areaExtent = areaLayer.Extent;
+        var lineExtent = lineLayer.Extent;
+        var layerExtent = areaExtent is null
+            ? (lineExtent ?? new MRect(0, 0, 0, 0))
+            : (lineExtent is null ? areaExtent : areaExtent.Join(lineExtent));
+
+        Console.WriteLine($"[S101-Lua] Rendered {areaInstructions.Count} area + {otherInstructions.Count} non-area instructions");
+
+        var info = $"{_dataset.DatasetName} — {_dataset.FeatureCount} features, " +
+                   $"{prepared.Count} instructions";
+
+        var layers = new ILayer[] { areaLayer, lineLayer };
+
+        return new DatasetResult
         {
-            LayerName = $"S-101: {_fileName}",
+            Layers = layers,
+            Extent = layerExtent,
+            Info = info,
+            Spec = new SpecRef("S-101", default),
+            // Sub-layer keys so the viewer's per-sub-layer disclosure
+            // can toggle areas vs line work independently.
+            LayerNames = new[] { "s101.areas", "s101.linework" },
+            StackEntries = new[]
+            {
+                // Area fills land on the deepest base-chart plane so
+                // S-102 (Bathymetry, 10) can sit on top of them.
+                new LayerStackEntry(
+                    Layer: areaLayer,
+                    Plane: S98DisplayPlane.BaseChartUnder,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName,
+                    SourceFeatureType: "area"),
+                // Line work, points, symbols, and text remain on the
+                // base-chart "over" plane (above Bathymetry).
+                new LayerStackEntry(
+                    Layer: lineLayer,
+                    Plane: S98DisplayPlane.BaseChartOver,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName,
+                    SourceFeatureType: "linework"),
+            },
+        };
+    }
+
+    private MapsuiDisplayListRenderer CreateRenderer(
+        S101PortrayalCatalogue catalogue,
+        ColorPalette palette,
+        RenderContext? context,
+        string suffix)
+    {
+        return new MapsuiDisplayListRenderer
+        {
+            LayerName = $"S-101 ({suffix}): {_fileName}",
             Product = "S-101",
             Palette = palette,
             AssetCache = _renderAssetCache,
@@ -123,7 +196,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             {
                 try
                 {
-                    var svg = s101Cat.GetSymbol(symbolName);
+                    var svg = catalogue.GetSymbol(symbolName);
                     return svg.SvgContent;
                 }
                 catch
@@ -135,7 +208,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             {
                 try
                 {
-                    return s101Cat.GetAreaFill(fillName);
+                    return catalogue.GetAreaFill(fillName);
                 }
                 catch
                 {
@@ -144,24 +217,9 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             },
             LineStyleProvider = name =>
             {
-                try { return s101Cat.GetLineStyle(name); }
+                try { return catalogue.GetLineStyle(name); }
                 catch { return null; }
             },
-        };
-        var geometryProvider = new S101FeatureGeometryProvider(_dataset);
-        var mapLayer = vectorRenderer.Render(prepared, geometryProvider);
-        var layerExtent = mapLayer.Extent ?? new MRect(0, 0, 0, 0);
-        Console.WriteLine($"[S101-Lua] Rendered {prepared.Count} instructions to Mapsui layer");
-
-        var info = $"{_dataset.DatasetName} — {_dataset.FeatureCount} features, " +
-                   $"{prepared.Count} instructions";
-
-        return new DatasetResult
-        {
-            Layers = [mapLayer],
-            Extent = layerExtent,
-            Info = info,
-            Spec = new SpecRef("S-101", default),
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S102;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
@@ -145,6 +146,18 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
             Extent = extent,
             Info = info,
             Spec = new SpecRef("S-102", default),
+            StackEntries = new[]
+            {
+                // S-102 → S98DisplayPlane.Bathymetry. S-98 Annex A §A-6.9.1
+                // ("gridded bathymetry replaces depth area and depth
+                // contours"). S-102 always emits a single coverage layer
+                // here; PR-L1 leaves WithinPlanePriority at 0.
+                new LayerStackEntry(
+                    Layer: mapLayer,
+                    Plane: EncDotNet.S100.Interoperability.S98DisplayPlane.Bathymetry,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName),
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -4,9 +4,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S104;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
+using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Renderers.Mapsui;
@@ -188,6 +190,17 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             Extent = extent,
             Info = info,
             Spec = new SpecRef("S-104", default),
+            // S-104 colour band → OnDemandSurface (S-98 Main §9.2.1
+            // layer 6 "Official on demand data"; Annex A §A-6.9.1).
+            StackEntries = new[]
+            {
+                new LayerStackEntry(
+                    Layer: colorLayer,
+                    Plane: S98DisplayPlane.OnDemandSurface,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName,
+                    SourceFeatureType: "s104.color-band"),
+            },
         };
     }
 
@@ -283,6 +296,18 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             Extent = extent,
             Info = info,
             Spec = new SpecRef("S-104", default),
+            // S-104 station glyphs (PR-I) are point overlays drawn
+            // above coverage but below cautions, per the
+            // MSC.530(106)/Rev.1 §App.2 layer-6 catch-all reading.
+            StackEntries = new[]
+            {
+                new LayerStackEntry(
+                    Layer: layer,
+                    Plane: S98DisplayPlane.OtherChartOverlays,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName,
+                    SourceFeatureType: "s104.stations"),
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -4,9 +4,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S111;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
+using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
@@ -237,6 +239,29 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             : "";
         var info = $"{geoId} — {metadata.GridMetadata.NumColumns}×{metadata.GridMetadata.NumRows} grid, CRS: EPSG:{crs}{timeInfo}";
 
+        // S-111 splits into colour-band (OnDemandSurface) and an
+        // optional arrow overlay (DynamicArrows). S-98 Annex A
+        // §A-6.9.1; existing portrayal catalogue declares the arrow
+        // sub-layer with intra-product displayPlane="OverRadar".
+        var stackEntries = new List<LayerStackEntry>
+        {
+            new(
+                Layer: colorLayer,
+                Plane: S98DisplayPlane.OnDemandSurface,
+                WithinPlanePriority: 0,
+                SourceDatasetId: _fileName,
+                SourceFeatureType: "s111.color-band"),
+        };
+        if (arrowLayer is not null)
+        {
+            stackEntries.Add(new LayerStackEntry(
+                Layer: arrowLayer,
+                Plane: S98DisplayPlane.DynamicArrows,
+                WithinPlanePriority: 10,
+                SourceDatasetId: _fileName,
+                SourceFeatureType: "s111.arrows"));
+        }
+
         return new DatasetResult
         {
             Layers = layers,
@@ -246,6 +271,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             LayerNames = arrowLayer is not null
                 ? new[] { "s111.color-band", "s111.arrows" }
                 : new[] { "s111.color-band" },
+            StackEntries = stackEntries,
         };
     }
 
@@ -445,6 +471,17 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
             Extent = extent,
             Info = info,
             Spec = new SpecRef("S-111", default),
+            // S-111 station glyphs (dcf3/dcf8) — point overlays on the
+            // catch-all OtherChartOverlays plane.
+            StackEntries = new[]
+            {
+                new LayerStackEntry(
+                    Layer: layer,
+                    Plane: S98DisplayPlane.OtherChartOverlays,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName,
+                    SourceFeatureType: "s111.stations"),
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S122DatasetProcessor.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -23,8 +24,9 @@ public sealed class S122DatasetProcessor : GmlDatasetProcessorBase<S122Feature>
     public S122DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -38,11 +40,13 @@ public sealed class S122DatasetProcessor : GmlDatasetProcessorBase<S122Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -51,11 +55,13 @@ public sealed class S122DatasetProcessor : GmlDatasetProcessorBase<S122Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S122PortrayalCatalogue(catalogueManager.GetProvider("S-122")),
             featureCatalogueManager?.GetDecoder("S-122"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S124DatasetProcessor.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -23,8 +24,9 @@ public sealed class S124DatasetProcessor : GmlDatasetProcessorBase<S124Feature>
     public S124DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -37,11 +39,13 @@ public sealed class S124DatasetProcessor : GmlDatasetProcessorBase<S124Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -50,11 +54,13 @@ public sealed class S124DatasetProcessor : GmlDatasetProcessorBase<S124Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S124PortrayalCatalogue(catalogueManager.GetProvider("S-124")),
             featureCatalogueManager?.GetDecoder("S-124"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S125DatasetProcessor.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -30,8 +31,9 @@ public sealed class S125DatasetProcessor : GmlDatasetProcessorBase<S125Feature>
     public S125DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -44,11 +46,13 @@ public sealed class S125DatasetProcessor : GmlDatasetProcessorBase<S125Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -57,11 +61,13 @@ public sealed class S125DatasetProcessor : GmlDatasetProcessorBase<S125Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S125PortrayalCatalogue(catalogueManager.GetProvider("S-125")),
             featureCatalogueManager?.GetDecoder("S-125"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S127DatasetProcessor.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -28,8 +29,9 @@ public sealed class S127DatasetProcessor : GmlDatasetProcessorBase<S127Feature>
     public S127DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -42,11 +44,13 @@ public sealed class S127DatasetProcessor : GmlDatasetProcessorBase<S127Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -55,11 +59,13 @@ public sealed class S127DatasetProcessor : GmlDatasetProcessorBase<S127Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S127PortrayalCatalogue(catalogueManager.GetProvider("S-127")),
             featureCatalogueManager?.GetDecoder("S-127"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S128DatasetProcessor.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -26,8 +27,9 @@ public sealed class S128DatasetProcessor : GmlDatasetProcessorBase<S128Feature>
     public S128DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -40,11 +42,13 @@ public sealed class S128DatasetProcessor : GmlDatasetProcessorBase<S128Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -53,11 +57,13 @@ public sealed class S128DatasetProcessor : GmlDatasetProcessorBase<S128Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S128PortrayalCatalogue(catalogueManager.GetProvider("S-128")),
             featureCatalogueManager?.GetDecoder("S-128"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S129DatasetProcessor.cs
@@ -8,6 +8,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -24,8 +25,9 @@ public sealed class S129DatasetProcessor : GmlDatasetProcessorBase<S129Feature>
     public S129DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -38,11 +40,13 @@ public sealed class S129DatasetProcessor : GmlDatasetProcessorBase<S129Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -51,11 +55,13 @@ public sealed class S129DatasetProcessor : GmlDatasetProcessorBase<S129Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S129PortrayalCatalogue(catalogueManager.GetProvider("S-129")),
             featureCatalogueManager?.GetDecoder("S-129"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -5,11 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S131;
 using EncDotNet.S100.Datasets.S131.DataModel;
 using EncDotNet.S100.Datasets.S131.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Gml;
+using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
@@ -181,6 +183,17 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
             Extent = layerExtent,
             Info = info,
             Spec = new SpecRef("S-131", default),
+            // S-131 (Marine Harbour Infrastructure) is out of S-98
+            // Annex A Table 1-1 scope, so default plane derives from
+            // MSC.530(106)/Rev.1 §App.2 layer 6 (catch-all overlays).
+            StackEntries = new[]
+            {
+                new LayerStackEntry(
+                    Layer: mapLayer,
+                    Plane: S98DisplayPlane.OtherChartOverlays,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName),
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S201DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S201DatasetProcessor.cs
@@ -4,6 +4,7 @@ using EncDotNet.S100.Datasets.S201;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -27,8 +28,9 @@ public sealed class S201DatasetProcessor : GmlDatasetProcessorBase<S201Feature>
     public S201DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -41,11 +43,13 @@ public sealed class S201DatasetProcessor : GmlDatasetProcessorBase<S201Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -54,11 +58,13 @@ public sealed class S201DatasetProcessor : GmlDatasetProcessorBase<S201Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S201PortrayalCatalogue(catalogueManager.GetProvider("S-201")),
             featureCatalogueManager?.GetDecoder("S-201"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S411;
 using EncDotNet.S100.Datasets.S411.DataModel;
 using EncDotNet.S100.Datasets.S411.Validation;
@@ -103,6 +104,7 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
                 Extent = ComputeExtent(),
                 Info = $"S-411 Sea Ice — {FileName}\nHidden (snapshot at {issued:u} is after slider time {t:u})",
                 Spec = new SpecRef("S-411", default),
+                StackEntries = Array.Empty<LayerStackEntry>(),
             };
         }
         return null;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S411DatasetProcessor.cs
@@ -36,8 +36,9 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
     public S411DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -50,11 +51,13 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -63,11 +66,13 @@ public sealed class S411DatasetProcessor : GmlDatasetProcessorBase<S411Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S411PortrayalCatalogue(catalogueManager.GetProvider("S-411")),
             featureCatalogueManager?.GetDecoder("S-411"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S421DatasetProcessor.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Validation;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -24,8 +25,9 @@ public sealed class S421DatasetProcessor : GmlDatasetProcessorBase<S421Feature>
     public S421DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, featureCatalogueManager)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, authorityProvider, featureCatalogueManager)
     {
     }
 
@@ -38,11 +40,13 @@ public sealed class S421DatasetProcessor : GmlDatasetProcessorBase<S421Feature>
         IAssetSource source,
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
+            authorityProvider,
             featureCatalogueManager)
     {
     }
@@ -51,11 +55,13 @@ public sealed class S421DatasetProcessor : GmlDatasetProcessorBase<S421Feature>
         Stream datasetStream,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
+        IInteroperabilityAuthorityProvider authorityProvider,
         FeatureCatalogueManager? featureCatalogueManager)
         : base(
             new S421PortrayalCatalogue(catalogueManager.GetProvider("S-421")),
             featureCatalogueManager?.GetDecoder("S-421"),
-            fileName)
+            fileName,
+            authorityProvider)
     {
         using (datasetStream)
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Datasets.S57;
 using EncDotNet.S100.Features;
+using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
@@ -151,6 +153,18 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
             Extent = layerExtent,
             Info = info,
             Spec = new SpecRef("S-57", default),
+            // S-57 is the legacy ENC fallback; treat the whole layer
+            // as base-chart line-work + symbology on BaseChartOver
+            // (S-98 §9.2.1 layer 2). We do not split S-57 into areas
+            // vs lines in PR-L1 — the legacy renderer mixes them.
+            StackEntries = new[]
+            {
+                new LayerStackEntry(
+                    Layer: mapLayer,
+                    Plane: S98DisplayPlane.BaseChartOver,
+                    WithinPlanePriority: 0,
+                    SourceDatasetId: _fileName),
+            },
         };
     }
 

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -150,12 +150,16 @@ public partial class App : Application
             return new EncDotNet.S100.Features.FeatureCatalogueManager(
                 (string spec) => overrides.Open(spec));
         });
+        services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider>(sp =>
+            new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
+                new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority()));
         services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory>(sp =>
             new EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory(
                 sp.GetRequiredService<PortrayalCatalogueManager>(),
                 new EncDotNet.S100.Scripting.MoonSharp.MoonSharpLuaEngine(),
                 new EncDotNet.S100.Renderers.Mapsui.ProjNetCrsTransformFactory(),
-                sp.GetRequiredService<EncDotNet.S100.Features.FeatureCatalogueManager>()));
+                sp.GetRequiredService<EncDotNet.S100.Features.FeatureCatalogueManager>(),
+                sp.GetRequiredService<EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider>()));
 
         // Leaf services extracted in phase 2
         services.AddSingleton<IThemeService, ThemeService>();

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -55,7 +55,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     /// most recent render. Each entry's <see cref="LayerStackEntry.Layer"/>
     /// also appears in <see cref="_entryLayers"/>. Populated from
     /// <see cref="DatasetResult.StackEntries"/> when available; otherwise
-    /// synthesised with <see cref="InteroperabilityAuthority.Default"/>.
+    /// synthesised through the active <see cref="IInteroperabilityAuthority"/>.
     /// </summary>
     private readonly Dictionary<DatasetEntry, IReadOnlyList<LayerStackEntry>> _entryStackEntries = new();
     /// <summary>
@@ -107,7 +107,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         EcdisDisplayState ecdisDisplay,
         IMarinerSettingsProvider marinerSettings,
         IToastService toasts,
-        IInteroperabilityAuthorityProvider? authorityProvider = null)
+        IInteroperabilityAuthorityProvider authorityProvider)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
@@ -134,7 +134,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _ecdisDisplay = ecdisDisplay;
         _marinerSettings = marinerSettings;
         _toasts = toasts;
-        _authorityProvider = authorityProvider ?? new InteroperabilityAuthorityProvider();
+        ArgumentNullException.ThrowIfNull(authorityProvider);
+        _authorityProvider = authorityProvider;
         // Re-sort the live layer stack whenever the host swaps the
         // active authority. Cheap when no datasets are loaded.
         _authorityProvider.CurrentChanged += OnAuthorityChanged;

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
@@ -41,6 +43,23 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayers = new();
+    /// <summary>
+    /// Per-entry S-98 layer-stack entries produced by the processor's
+    /// most recent render. Each entry's <see cref="LayerStackEntry.Layer"/>
+    /// also appears in <see cref="_entryLayers"/>. Populated from
+    /// <see cref="DatasetResult.StackEntries"/> when available; otherwise
+    /// synthesised with <see cref="InteroperabilityAuthority.Default"/>.
+    /// </summary>
+    private readonly Dictionary<DatasetEntry, IReadOnlyList<LayerStackEntry>> _entryStackEntries = new();
+    /// <summary>
+    /// Snapshot of the most recently computed S-98 layer stack
+    /// (bottom-of-paint-stack first; index 0 = drawn first / under
+    /// everything else). Mirrors what was just handed to
+    /// <see cref="IMapHost.ReorderDatasetLayers"/>. Refreshed whenever
+    /// the layer order changes so <see cref="PickService"/> can rank
+    /// multi-hit picks top-of-stack first.
+    /// </summary>
+    private IReadOnlyList<ILayer> _currentStackedLayers = Array.Empty<ILayer>();
     /// <summary>
     /// Per-entry sub-layer keys, parallel by index to
     /// <see cref="_entryLayers"/>. Null when the processor did not
@@ -116,6 +135,10 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors => _processorsView;
     public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers => _entryLayersView;
+
+    public IReadOnlyList<ILayer> CurrentStackedLayers => _currentStackedLayers;
+
+    public event Action? LayerStackChanged;
 
     public event Action<DatasetEntry>? DatasetLoaded;
 
@@ -244,7 +267,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             var initialContext = CreateRenderContext(processor, initialTime);
             var result = await Task.Run(() => processor.Render(initialContext), token);
 
-            ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames);
+            ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
             // Exchange-set entries opt out of the per-dataset auto-zoom so
             // the union-extent zoom from `IExchangeSetService` (or the
             // user's manual Zoom-to-Extent toolbar action) wins. Without
@@ -393,7 +416,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 var context = CreateRenderContext(proc, snapped);
                 var result = await Task.Run(() => proc.Render(context), token).ConfigureAwait(true);
 
-                ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames);
+                ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
                 entry.Info = result.Info;
                 entry.CurrentTime = snapped;
             }
@@ -422,7 +445,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
                 var result = await Task.Run(() => proc.Render(context));
 
-                ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames);
+                ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
                 entry.Info = result.Info;
             }
             catch (Exception ex)
@@ -444,12 +467,17 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         UnsubscribeSubLayers(entry);
         entry.SubLayers.Clear();
         _entryLayerKeys.Remove(entry);
+        _entryStackEntries.Remove(entry);
         if (_subscribedEntries.Remove(entry))
             entry.PropertyChanged -= OnEntryPropertyChanged;
         _processors.Remove(entry);
         _entryOrder.Remove(entry);
         _globalTime.Unregister(entry);
         _s128CatalogSource.RemoveDataset(entry.DisplayName);
+        // Publish the new (empty / smaller) stack so PickService and
+        // anyone else who cares drops references to the removed layers.
+        if (_mapHost is not null)
+            _mapHost.ReorderDatasetLayers(FlattenLayerOrder());
         DatasetRemoved?.Invoke(entry);
     }
 
@@ -472,17 +500,54 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     private List<ILayer> FlattenLayerOrder()
     {
-        // _entryOrder is ordered top-of-stack-first (UI convention).
-        // MapsuiMapHost.ReorderDatasetLayers expects bottom-of-stack-
-        // first (lower indices in the layer collection are drawn
-        // earlier). Reverse here so the top-of-UI entry's layers end
-        // up at the highest layer index.
-        var list = new List<ILayer>();
-        for (int i = _entryOrder.Count - 1; i >= 0; i--)
+        // PR-L1 (S-98): defer the cross-dataset paint order to the
+        // S-98 interoperability authority. _entryOrder is top-of-UI
+        // first (mirrors the Datasets panel); the authority sorts
+        // by S-98 display plane (BaseChartUnder → EcdisAlerts) and
+        // uses input order as the final tiebreaker. We feed it
+        // bottom-of-UI first so the topmost-UI dataset wins ties
+        // (and lands at the highest layer index — drawn last, on
+        // top), preserving the prior behaviour for single-plane
+        // dataset stacks.
+        var perDataset = new List<IReadOnlyList<LayerStackEntry>>(_entryOrder.Count);
+        // _entryOrder is already top-of-UI first, which is exactly
+        // what LayerStackBuilder.Build expects. It internally walks
+        // bottom-up so the top-of-UI dataset wins within-plane ties.
+        for (int i = 0; i < _entryOrder.Count; i++)
         {
-            if (_entryLayers.TryGetValue(_entryOrder[i], out var ls))
-                list.AddRange(ls);
+            var entry = _entryOrder[i];
+            if (!_entryLayers.TryGetValue(entry, out var layers)) continue;
+
+            if (_entryStackEntries.TryGetValue(entry, out var stack) && stack.Count > 0)
+            {
+                perDataset.Add(stack);
+            }
+            else
+            {
+                // Fallback: processor didn't supply StackEntries. Drop
+                // each layer onto the spec's default plane with
+                // priority 0 so it still participates in S-98 ordering.
+                var specName = _processors.TryGetValue(entry, out var proc)
+                    ? proc.Spec.Name
+                    : "unknown";
+                var plane = InteroperabilityAuthority.Default.GetDefaultPlane(specName);
+                var synth = new List<LayerStackEntry>(layers.Count);
+                foreach (var l in layers)
+                {
+                    synth.Add(new LayerStackEntry(
+                        Layer: l,
+                        Plane: plane,
+                        WithinPlanePriority: 0,
+                        SourceDatasetId: entry.FilePath ?? entry.DisplayName));
+                }
+                perDataset.Add(synth);
+            }
         }
+
+        var sorted = LayerStackBuilder.Build(InteroperabilityAuthority.Default, perDataset);
+        var list = LayerStackBuilder.ToLayerList(sorted);
+        _currentStackedLayers = list;
+        LayerStackChanged?.Invoke();
         return list;
     }
 
@@ -551,13 +616,25 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         };
     }
 
-    private void ReplaceLayers(DatasetEntry entry, IReadOnlyList<ILayer> layers, IReadOnlyList<string>? layerKeys)
+    private void ReplaceLayers(
+        DatasetEntry entry,
+        IReadOnlyList<ILayer> layers,
+        IReadOnlyList<string>? layerKeys,
+        IReadOnlyList<LayerStackEntry>? stackEntries)
     {
         bool isFirstLoad = !_entryOrder.Contains(entry);
 
         RemoveEntryLayers(entry);
         _entryLayers[entry] = layers;
         _entryLayerKeys[entry] = layerKeys;
+        // Keep _entryStackEntries in sync with _entryLayers. If the
+        // processor didn't supply StackEntries, FlattenLayerOrder will
+        // synthesise defaults below — but we still clear any stale
+        // entries from a previous render so they don't leak.
+        if (stackEntries is not null && stackEntries.Count > 0)
+            _entryStackEntries[entry] = stackEntries;
+        else
+            _entryStackEntries.Remove(entry);
 
         // Reconcile sub-layers (don't replace) so existing per-sub-layer
         // visibility / opacity choices survive palette switches and
@@ -581,19 +658,19 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             _mapHost!.AddLayer(layer);
         }
 
-        // First-time loads: the new entry goes to the TOP of the
-        // canonical order (matching DatasetsViewModel.Add which
-        // inserts at index 0). MapsuiMapHost already puts new layers
-        // on top of the dataset block by default, so a re-shuffle is
-        // only needed for re-renders.
+        // PR-L1 (S-98): always recompute the cross-dataset paint
+        // order after a load/re-render. The S-98 plane sort can
+        // place a newly-loaded dataset *under* existing layers
+        // (e.g. an S-102 bathymetry load arrives after S-101 line
+        // work — the bathy must sit between the ENC's area fills
+        // and its line work). Pre-PR-L1 we only re-shuffled on
+        // re-renders; that was correct for the old "load order
+        // wins" model.
         if (isFirstLoad)
         {
             _entryOrder.Insert(0, entry);
         }
-        else
-        {
-            _mapHost!.ReorderDatasetLayers(FlattenLayerOrder());
-        }
+        _mapHost!.ReorderDatasetLayers(FlattenLayerOrder());
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -41,15 +41,12 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly IMarinerSettingsProvider _marinerSettings;
     private readonly IToastService _toasts;
     /// <summary>
-    /// Cross-dataset paint-order policy. The default S-98
-    /// implementation lives in
-    /// <see cref="InteroperabilityAuthority.Default"/>; alternative
-    /// strategies (e.g. strict load-order, top-of-UI-wins regardless
-    /// of plane) can be injected by the host. The authority is also
-    /// consulted as a fallback to fabricate <see cref="LayerStackEntry"/>
-    /// values for any processor that didn't supply them.
+    /// Resolves the <em>currently active</em> cross-dataset paint-order
+    /// policy on each consult. Hosts can swap the authority at runtime
+    /// (e.g. flip from S-98 to strict load-order) and we re-sort the
+    /// stack in response to <see cref="IInteroperabilityAuthorityProvider.CurrentChanged"/>.
     /// </summary>
-    private readonly IInteroperabilityAuthority _authority;
+    private readonly IInteroperabilityAuthorityProvider _authorityProvider;
 
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayers = new();
@@ -110,7 +107,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         EcdisDisplayState ecdisDisplay,
         IMarinerSettingsProvider marinerSettings,
         IToastService toasts,
-        IInteroperabilityAuthority? authority = null)
+        IInteroperabilityAuthorityProvider? authorityProvider = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
@@ -137,7 +134,10 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _ecdisDisplay = ecdisDisplay;
         _marinerSettings = marinerSettings;
         _toasts = toasts;
-        _authority = authority ?? InteroperabilityAuthority.Default;
+        _authorityProvider = authorityProvider ?? new InteroperabilityAuthorityProvider();
+        // Re-sort the live layer stack whenever the host swaps the
+        // active authority. Cheap when no datasets are loaded.
+        _authorityProvider.CurrentChanged += OnAuthorityChanged;
 
         _processorsView = new ReadOnlyDictionary<DatasetEntry, IDatasetProcessor>(_processors);
         _entryLayersView = new ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>>(_entryLayers);
@@ -542,7 +542,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 var specName = _processors.TryGetValue(entry, out var proc)
                     ? proc.Spec.Name
                     : "unknown";
-                var plane = _authority.GetDefaultPlane(specName);
+                var plane = _authorityProvider.Current.GetDefaultPlane(specName);
                 var synth = new List<LayerStackEntry>(layers.Count);
                 foreach (var l in layers)
                 {
@@ -556,7 +556,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             }
         }
 
-        var sorted = LayerStackBuilder.Build(_authority, perDataset);
+        var sorted = LayerStackBuilder.Build(_authorityProvider.Current, perDataset);
         var list = LayerStackBuilder.ToLayerList(sorted);
         _currentStackedLayers = list;
         LayerStackChanged?.Invoke();
@@ -834,6 +834,18 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             }
             _entryLayers.Remove(entry);
         }
+    }
+
+    private void OnAuthorityChanged()
+    {
+        // The host swapped the active interoperability authority
+        // (e.g. flipped a viewer setting between S-98 and load-order).
+        // Re-flatten the current stack through the new authority's
+        // policy and push the result to the map host. Cheap when no
+        // datasets are loaded.
+        if (_mapHost is null) return;
+        if (_entryOrder.Count == 0) return;
+        _mapHost.ReorderDatasetLayers(FlattenLayerOrder());
     }
 
     private void EnsureInitialized()

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -40,6 +40,16 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     private readonly EcdisDisplayState _ecdisDisplay;
     private readonly IMarinerSettingsProvider _marinerSettings;
     private readonly IToastService _toasts;
+    /// <summary>
+    /// Cross-dataset paint-order policy. The default S-98
+    /// implementation lives in
+    /// <see cref="InteroperabilityAuthority.Default"/>; alternative
+    /// strategies (e.g. strict load-order, top-of-UI-wins regardless
+    /// of plane) can be injected by the host. The authority is also
+    /// consulted as a fallback to fabricate <see cref="LayerStackEntry"/>
+    /// values for any processor that didn't supply them.
+    /// </summary>
+    private readonly IInteroperabilityAuthority _authority;
 
     private readonly Dictionary<DatasetEntry, IDatasetProcessor> _processors = new();
     private readonly Dictionary<DatasetEntry, IReadOnlyList<ILayer>> _entryLayers = new();
@@ -99,7 +109,8 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         GlobalTimeService globalTime,
         EcdisDisplayState ecdisDisplay,
         IMarinerSettingsProvider marinerSettings,
-        IToastService toasts)
+        IToastService toasts,
+        IInteroperabilityAuthority? authority = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(catalogueManager);
@@ -126,6 +137,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         _ecdisDisplay = ecdisDisplay;
         _marinerSettings = marinerSettings;
         _toasts = toasts;
+        _authority = authority ?? InteroperabilityAuthority.Default;
 
         _processorsView = new ReadOnlyDictionary<DatasetEntry, IDatasetProcessor>(_processors);
         _entryLayersView = new ReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>>(_entryLayers);
@@ -530,7 +542,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 var specName = _processors.TryGetValue(entry, out var proc)
                     ? proc.Spec.Name
                     : "unknown";
-                var plane = InteroperabilityAuthority.Default.GetDefaultPlane(specName);
+                var plane = _authority.GetDefaultPlane(specName);
                 var synth = new List<LayerStackEntry>(layers.Count);
                 foreach (var l in layers)
                 {
@@ -544,7 +556,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             }
         }
 
-        var sorted = LayerStackBuilder.Build(InteroperabilityAuthority.Default, perDataset);
+        var sorted = LayerStackBuilder.Build(_authority, perDataset);
         var list = LayerStackBuilder.ToLayerList(sorted);
         _currentStackedLayers = list;
         LayerStackChanged?.Invoke();

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -62,6 +62,34 @@ internal interface IDatasetLoaderService
     IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
 
     /// <summary>
+    /// Snapshot of the current S-98-ordered layer stack across all
+    /// loaded datasets (bottom-of-paint-stack first; index 0 paints
+    /// under everything else). Updated whenever a dataset is loaded,
+    /// removed, re-rendered, or reordered. Consumed by
+    /// <see cref="PickService"/> so multi-hit picks return top-of-stack
+    /// hits first.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation returns an empty list so test doubles
+    /// that don't care about layer ordering needn't override it.
+    /// </remarks>
+    IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+
+    /// <summary>
+    /// Raised after <see cref="CurrentStackedLayers"/> has been
+    /// recomputed (any load, remove, re-render, or reorder).
+    /// </summary>
+    /// <remarks>
+    /// Default implementation is a no-op event so test doubles that
+    /// don't fire layer-stack notifications needn't override it.
+    /// </remarks>
+    event Action? LayerStackChanged
+    {
+        add { }
+        remove { }
+    }
+
+    /// <summary>
     /// Raised on the calling thread (typically the UI thread) immediately
     /// after a dataset has been successfully rendered and its layers added
     /// to the map.

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Viewer.Diagnostics;
@@ -137,7 +138,34 @@ internal sealed class PickService : IPickService
         var hits = new List<PickHit>();
         var seen = new HashSet<(IDatasetProcessor processor, string featureRef)>();
 
-        foreach (var record in mapInfo.MapInfoRecords)
+        // PR-L1 (S-98): rank multi-hit picks by the current S-98 layer
+        // stack so the user sees the topmost-painted feature first.
+        // Mapsui's MapInfoRecords arrive in scene-graph order which
+        // does not necessarily match the cross-dataset paint order
+        // computed by InteroperabilityAuthority.Sort. Re-sort here.
+        //
+        // S-98 Main §10.12 and Annex A §A-6.12 designate interrogation
+        // as "under development" — there is no normative pick-order
+        // rule yet. Top-of-stack-first matches user expectation that
+        // the visually frontmost feature gets reported first.
+        var stack = _loader.CurrentStackedLayers;
+        int StackIndex(ILayer? layer)
+        {
+            if (layer is null) return -1;
+            for (int i = 0; i < stack.Count; i++)
+                if (ReferenceEquals(stack[i], layer)) return i;
+            return -1;
+        }
+
+        // Higher stack index = drawn later = on top. Descending order
+        // means top-of-stack records are walked first; the dedup
+        // HashSet then locks in the topmost hit for each (processor,
+        // featureRef) key. A stable order-preserving sort keeps
+        // intra-layer ordering as Mapsui returned it.
+        var records = mapInfo.MapInfoRecords.ToList();
+        records.Sort((a, b) => StackIndex(b.Layer).CompareTo(StackIndex(a.Layer)));
+
+        foreach (var record in records)
         {
             if (record.Feature is not { } feature || record.Layer is not { } layer)
                 continue;

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
@@ -50,12 +50,16 @@ public class DatasetPipelineFactoryFeatureCatalogueReuseTests
             pcManager,
             new MoonSharpLuaEngine(),
             new ProjNetCrsTransformFactory(),
-            fcManager);
+            fcManager,
+            new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
+                new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority()));
         var factory2 = new DatasetPipelineFactory(
             pcManager,
             new MoonSharpLuaEngine(),
             new ProjNetCrsTransformFactory(),
-            fcManager);
+            fcManager,
+            new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
+                new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority()));
 
         // Even after two factories that, pre-PR-B, would each have
         // built their own FC manager and forced a parse, the shared

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityProviderTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityProviderTests.cs
@@ -6,41 +6,42 @@ namespace EncDotNet.S100.Pipelines.Tests;
 
 public class InteroperabilityAuthorityProviderTests
 {
+    private static IInteroperabilityAuthority NewS98() => new InteroperabilityAuthority();
+    private static LoadOrderInteroperabilityAuthority NewLoadOrder() =>
+        new LoadOrderInteroperabilityAuthority(NewS98());
+
     [Fact]
-    public void Default_holds_S98_authority()
+    public void Ctor_stores_initial_authority()
     {
-        var provider = new InteroperabilityAuthorityProvider();
-        Assert.Same(InteroperabilityAuthority.Default, provider.Current);
+        var s98 = NewS98();
+        var provider = new InteroperabilityAuthorityProvider(s98);
+        Assert.Same(s98, provider.Current);
     }
 
     [Fact]
-    public void Ctor_accepts_initial_authority()
+    public void Ctor_null_throws()
     {
-        var lo = LoadOrderInteroperabilityAuthority.Default;
-        var provider = new InteroperabilityAuthorityProvider(lo);
-        Assert.Same(lo, provider.Current);
+        Assert.Throws<ArgumentNullException>(() => new InteroperabilityAuthorityProvider(null!));
     }
 
     [Fact]
     public void Set_updates_Current_and_raises_event()
     {
-        var provider = new InteroperabilityAuthorityProvider();
+        var provider = new InteroperabilityAuthorityProvider(NewS98());
+        var lo = NewLoadOrder();
         var raised = 0;
         provider.CurrentChanged += () => raised++;
 
-        provider.Set(LoadOrderInteroperabilityAuthority.Default);
+        provider.Set(lo);
 
-        Assert.Same(LoadOrderInteroperabilityAuthority.Default, provider.Current);
+        Assert.Same(lo, provider.Current);
         Assert.Equal(1, raised);
     }
 
     [Fact]
     public void Set_raises_event_even_when_authority_reference_is_unchanged()
     {
-        // Hosts can force a re-sort by re-Setting the same instance
-        // (e.g. after a catalogue reload tweaked the authority's
-        // internal table). The contract is documented on the impl.
-        var provider = new InteroperabilityAuthorityProvider();
+        var provider = new InteroperabilityAuthorityProvider(NewS98());
         var raised = 0;
         provider.CurrentChanged += () => raised++;
 
@@ -52,7 +53,7 @@ public class InteroperabilityAuthorityProviderTests
     [Fact]
     public void Set_null_throws()
     {
-        var provider = new InteroperabilityAuthorityProvider();
+        var provider = new InteroperabilityAuthorityProvider(NewS98());
         Assert.Throws<ArgumentNullException>(() => provider.Set(null!));
     }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityProviderTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityProviderTests.cs
@@ -1,0 +1,58 @@
+using System;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+public class InteroperabilityAuthorityProviderTests
+{
+    [Fact]
+    public void Default_holds_S98_authority()
+    {
+        var provider = new InteroperabilityAuthorityProvider();
+        Assert.Same(InteroperabilityAuthority.Default, provider.Current);
+    }
+
+    [Fact]
+    public void Ctor_accepts_initial_authority()
+    {
+        var lo = LoadOrderInteroperabilityAuthority.Default;
+        var provider = new InteroperabilityAuthorityProvider(lo);
+        Assert.Same(lo, provider.Current);
+    }
+
+    [Fact]
+    public void Set_updates_Current_and_raises_event()
+    {
+        var provider = new InteroperabilityAuthorityProvider();
+        var raised = 0;
+        provider.CurrentChanged += () => raised++;
+
+        provider.Set(LoadOrderInteroperabilityAuthority.Default);
+
+        Assert.Same(LoadOrderInteroperabilityAuthority.Default, provider.Current);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void Set_raises_event_even_when_authority_reference_is_unchanged()
+    {
+        // Hosts can force a re-sort by re-Setting the same instance
+        // (e.g. after a catalogue reload tweaked the authority's
+        // internal table). The contract is documented on the impl.
+        var provider = new InteroperabilityAuthorityProvider();
+        var raised = 0;
+        provider.CurrentChanged += () => raised++;
+
+        provider.Set(provider.Current);
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void Set_null_throws()
+    {
+        var provider = new InteroperabilityAuthorityProvider();
+        Assert.Throws<ArgumentNullException>(() => provider.Set(null!));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Interoperability;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Pins the PR-L1 plane-assignment table and verifies the stable
+/// sort + tiebreaker semantics required by
+/// <see cref="LayerStackBuilder"/>.
+/// </summary>
+public class InteroperabilityAuthorityTests
+{
+    private readonly InteroperabilityAuthority _auth = InteroperabilityAuthority.Default;
+
+    [Theory]
+    [InlineData("S-101", null, S98DisplayPlane.BaseChartOver)]
+    [InlineData("S-101", "area", S98DisplayPlane.BaseChartUnder)]
+    [InlineData("S-101", "linework", S98DisplayPlane.BaseChartOver)]
+    [InlineData("S-57", null, S98DisplayPlane.BaseChartOver)]
+    [InlineData("S-102", null, S98DisplayPlane.Bathymetry)]
+    [InlineData("S-104", null, S98DisplayPlane.OnDemandSurface)]
+    [InlineData("S-104", "s104.color-band", S98DisplayPlane.OnDemandSurface)]
+    [InlineData("S-104", "s104.stations", S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-111", null, S98DisplayPlane.OnDemandSurface)]
+    [InlineData("S-111", "s111.color-band", S98DisplayPlane.OnDemandSurface)]
+    [InlineData("S-111", "s111.arrows", S98DisplayPlane.DynamicArrows)]
+    [InlineData("S-111", "s111.stations", S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-122", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-124", null, S98DisplayPlane.CautionsAndWarnings)]
+    [InlineData("S-125", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-127", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-128", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-129", null, S98DisplayPlane.OnDemandSurface)]
+    [InlineData("S-131", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-201", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-411", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-421", null, S98DisplayPlane.OtherChartOverlays)]
+    [InlineData("S-999", null, S98DisplayPlane.OtherChartOverlays)]
+    public void GetDefaultPlane_returns_expected_plane(string productSpec, string? kind, S98DisplayPlane expected)
+    {
+        Assert.Equal(expected, _auth.GetDefaultPlane(productSpec, kind));
+    }
+
+    [Fact]
+    public void Sort_orders_by_plane_ascending()
+    {
+        var a = Entry("a", S98DisplayPlane.OtherChartOverlays);
+        var b = Entry("b", S98DisplayPlane.BaseChartUnder);
+        var c = Entry("c", S98DisplayPlane.Bathymetry);
+
+        var sorted = _auth.Sort(new[] { a, b, c });
+
+        Assert.Equal(new[] { "b", "c", "a" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Sort_uses_within_plane_priority_after_plane()
+    {
+        var a = Entry("a", S98DisplayPlane.OtherChartOverlays, priority: 10);
+        var b = Entry("b", S98DisplayPlane.OtherChartOverlays, priority: 0);
+        var c = Entry("c", S98DisplayPlane.OtherChartOverlays, priority: 5);
+
+        var sorted = _auth.Sort(new[] { a, b, c });
+
+        Assert.Equal(new[] { "b", "c", "a" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Sort_is_stable_when_plane_and_priority_match()
+    {
+        // Three datasets that all land on the same plane at the same
+        // priority should preserve input order — that's the
+        // dataset-load-order tiebreaker.
+        var a = Entry("a", S98DisplayPlane.OtherChartOverlays);
+        var b = Entry("b", S98DisplayPlane.OtherChartOverlays);
+        var c = Entry("c", S98DisplayPlane.OtherChartOverlays);
+
+        var sorted = _auth.Sort(new[] { a, b, c });
+
+        Assert.Equal(new[] { "a", "b", "c" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Build_top_of_ui_dataset_wins_within_plane_tie()
+    {
+        // Two single-layer datasets on the same plane: the dataset
+        // at the top of the UI (index 0 of perDataset) must paint
+        // LAST (highest index in output), i.e. on top.
+        var topUi = new[] { Entry("top", S98DisplayPlane.OtherChartOverlays) };
+        var bottomUi = new[] { Entry("bottom", S98DisplayPlane.OtherChartOverlays) };
+
+        var sorted = LayerStackBuilder.Build(_auth, new IReadOnlyList<LayerStackEntry>[] { topUi, bottomUi });
+
+        Assert.Equal(new[] { "bottom", "top" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Build_interleaves_across_planes_independent_of_load_order()
+    {
+        // S-102 loaded BEFORE S-101 must still appear between S-101
+        // area fills and S-101 line work.
+        var s102 = new[] { Entry("s102", S98DisplayPlane.Bathymetry) };
+        var s101areas = Entry("s101a", S98DisplayPlane.BaseChartUnder);
+        var s101lines = Entry("s101l", S98DisplayPlane.BaseChartOver);
+        var s101 = new[] { s101areas, s101lines };
+
+        // s101 at top of UI, s102 below.
+        var sorted = LayerStackBuilder.Build(_auth, new IReadOnlyList<LayerStackEntry>[] { s101, s102 });
+
+        Assert.Equal(new[] { "s101a", "s102", "s101l" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    private static LayerStackEntry Entry(string id, S98DisplayPlane plane, int priority = 0)
+        => new(new MemoryLayer(id), plane, priority, id);
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
@@ -14,7 +14,7 @@ namespace EncDotNet.S100.Pipelines.Tests;
 /// </summary>
 public class InteroperabilityAuthorityTests
 {
-    private readonly InteroperabilityAuthority _auth = InteroperabilityAuthority.Default;
+    private readonly InteroperabilityAuthority _auth = new();
 
     [Theory]
     [InlineData("S-101", null, S98DisplayPlane.BaseChartOver)]
@@ -127,7 +127,7 @@ public class InteroperabilityAuthorityTests
         var s101 = new[] { s101areas, s101lines };
 
         var sorted = LayerStackBuilder.Build(
-            LoadOrderInteroperabilityAuthority.Default,
+            new LoadOrderInteroperabilityAuthority(new InteroperabilityAuthority()),
             new IReadOnlyList<LayerStackEntry>[] { s101, s102 });
 
         // Bottom-of-UI dataset (s102) paints first, then s101's two
@@ -141,7 +141,7 @@ public class InteroperabilityAuthorityTests
         // The load-order authority's GetDefaultPlane delegates to the
         // S-98 oracle so layer-controls UIs can still annotate layers
         // with their conceptual plane even when sort order ignores it.
-        var lo = LoadOrderInteroperabilityAuthority.Default;
+        var lo = new LoadOrderInteroperabilityAuthority(new InteroperabilityAuthority());
         Assert.Equal(S98DisplayPlane.Bathymetry, lo.GetDefaultPlane("S-102"));
         Assert.Equal(S98DisplayPlane.CautionsAndWarnings, lo.GetDefaultPlane("S-124"));
         Assert.Equal(S98DisplayPlane.BaseChartUnder, lo.GetDefaultPlane("S-101", "area"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
@@ -114,6 +114,39 @@ public class InteroperabilityAuthorityTests
         Assert.Equal(new[] { "s101a", "s102", "s101l" }, sorted.Select(e => e.SourceDatasetId).ToArray());
     }
 
+    [Fact]
+    public void LoadOrderAuthority_ignores_plane_and_uses_strict_dataset_ordering()
+    {
+        // Same input as the interleave test above, but the alternative
+        // authority must paint every layer of the bottom-of-UI dataset
+        // first, then every layer of the top-of-UI dataset — independent
+        // of S-98 plane.
+        var s102 = new[] { Entry("s102", S98DisplayPlane.Bathymetry) };
+        var s101areas = Entry("s101a", S98DisplayPlane.BaseChartUnder);
+        var s101lines = Entry("s101l", S98DisplayPlane.BaseChartOver);
+        var s101 = new[] { s101areas, s101lines };
+
+        var sorted = LayerStackBuilder.Build(
+            LoadOrderInteroperabilityAuthority.Default,
+            new IReadOnlyList<LayerStackEntry>[] { s101, s102 });
+
+        // Bottom-of-UI dataset (s102) paints first, then s101's two
+        // layers in processor-emitted order (areas first, lines on top).
+        Assert.Equal(new[] { "s102", "s101a", "s101l" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void LoadOrderAuthority_still_exposes_S98_default_planes_for_labels()
+    {
+        // The load-order authority's GetDefaultPlane delegates to the
+        // S-98 oracle so layer-controls UIs can still annotate layers
+        // with their conceptual plane even when sort order ignores it.
+        var lo = LoadOrderInteroperabilityAuthority.Default;
+        Assert.Equal(S98DisplayPlane.Bathymetry, lo.GetDefaultPlane("S-102"));
+        Assert.Equal(S98DisplayPlane.CautionsAndWarnings, lo.GetDefaultPlane("S-124"));
+        Assert.Equal(S98DisplayPlane.BaseChartUnder, lo.GetDefaultPlane("S-101", "area"));
+    }
+
     private static LayerStackEntry Entry(string id, S98DisplayPlane plane, int priority = 0)
         => new(new MemoryLayer(id), plane, priority, id);
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetProcessorValidationTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetProcessorValidationTests.cs
@@ -32,7 +32,7 @@ public class DatasetProcessorValidationTests
         var path = TestData("S125", "aton_point.gml");
         Assert.True(File.Exists(path), $"Missing fixture: {path}");
 
-        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"));
+        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"), TestAuthority.NewS98Provider());
 
         var report = processor.Validate();
 
@@ -45,7 +45,7 @@ public class DatasetProcessorValidationTests
     public void S125Processor_Validate_IsCachedAcrossCalls()
     {
         var path = TestData("S125", "aton_point.gml");
-        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"));
+        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"), TestAuthority.NewS98Provider());
 
         var first = processor.Validate();
         var second = processor.Validate();

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureReferenceIntegrationTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureReferenceIntegrationTests.cs
@@ -32,7 +32,7 @@ public class FeatureReferenceIntegrationTests
         var path = TestData("S125", "aton_point.gml");
         Assert.True(File.Exists(path), $"Missing fixture: {path}");
 
-        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"));
+        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"), TestAuthority.NewS98Provider());
         // f1 = LateralBuoy with <S125:AtoNStatus xlink:href="#info1"/>
         var info = processor.GetFeatureInfo("f1");
 
@@ -48,7 +48,7 @@ public class FeatureReferenceIntegrationTests
     public void S125Processor_DoesNotLeakReferencesIntoAttributes()
     {
         var path = TestData("S125", "aton_point.gml");
-        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"));
+        var processor = new S125DatasetProcessor(path, CreateCatalogueManager("S-125"), TestAuthority.NewS98Provider());
 
         var info = processor.GetFeatureInfo("f1");
 
@@ -62,7 +62,7 @@ public class FeatureReferenceIntegrationTests
         var path = TestData("S421", "RTE-TEST-GMIN.s421.gml");
         Assert.True(File.Exists(path), $"Missing fixture: {path}");
 
-        var processor = new S421DatasetProcessor(path, CreateCatalogueManager("S-421"));
+        var processor = new S421DatasetProcessor(path, CreateCatalogueManager("S-421"), TestAuthority.NewS98Provider());
         // RTE = Route, points at routeInfo / routeWaypoints / routeWaypointsCollection.
         var info = processor.GetFeatureInfo("RTE");
 
@@ -80,7 +80,7 @@ public class FeatureReferenceIntegrationTests
     public void S421Processor_LiftsWaypointBackReferenceIntoReferences()
     {
         var path = TestData("S421", "RTE-TEST-GMIN.s421.gml");
-        var processor = new S421DatasetProcessor(path, CreateCatalogueManager("S-421"));
+        var processor = new S421DatasetProcessor(path, CreateCatalogueManager("S-421"), TestAuthority.NewS98Provider());
 
         // RTE.WPT.1 = first RouteWaypoint, contains <routeWaypointCollection
         // xlink:href="#RTE.WPTS"/> + neighbour leg references.
@@ -96,7 +96,7 @@ public class FeatureReferenceIntegrationTests
     public void S421Processor_DoesNotLeakReferencesIntoAttributes()
     {
         var path = TestData("S421", "RTE-TEST-GMIN.s421.gml");
-        var processor = new S421DatasetProcessor(path, CreateCatalogueManager("S-421"));
+        var processor = new S421DatasetProcessor(path, CreateCatalogueManager("S-421"), TestAuthority.NewS98Provider());
 
         var info = processor.GetFeatureInfo("RTE");
 

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -386,4 +386,94 @@ public class PickServiceTests
 
         Assert.Contains("ghost", viewModel.StatusText ?? string.Empty);
     }
+
+    private sealed class StackAwareLoader : IDatasetLoaderService
+    {
+        public StackAwareLoader(
+            IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> processors,
+            IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> entryLayers,
+            IReadOnlyList<ILayer> stackedLayers)
+        {
+            Processors = processors;
+            EntryLayers = entryLayers;
+            CurrentStackedLayers = stackedLayers;
+        }
+
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+        public IReadOnlyList<ILayer> CurrentStackedLayers { get; }
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
+        public event Action<string?>? StatusChanged { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+    }
+
+    [Fact]
+    public void HandlePick_OrdersHitsByLayerStackTopFirst()
+    {
+        // PR-L1 (S-98): when Mapsui returns multiple hits across
+        // layers, PickService must re-order them so the topmost-painted
+        // layer's hit comes first — matching the visible Z-order.
+        var viewModel = CreateMainViewModel();
+        var entryA = new DatasetEntry("/tmp/a.gml", "S-101");
+        var entryB = new DatasetEntry("/tmp/b.gml", "S-102");
+        var entryC = new DatasetEntry("/tmp/c.gml", "S-124");
+
+        var procA = new StubProcessor("S-101", new FeatureInfo
+        {
+            FeatureRef = "fa", FeatureType = "DepthArea", FeatureTypeName = "Depth Area",
+            Attributes = Array.Empty<PickAttribute>(),
+        });
+        var procB = new StubProcessor("S-102", new FeatureInfo
+        {
+            FeatureRef = "fb", FeatureType = "BathyCell", FeatureTypeName = "Bathy",
+            Attributes = Array.Empty<PickAttribute>(),
+        });
+        var procC = new StubProcessor("S-124", new FeatureInfo
+        {
+            FeatureRef = "fc", FeatureType = "Warning", FeatureTypeName = "Warning",
+            Attributes = Array.Empty<PickAttribute>(),
+        });
+
+        var layerA = new MemoryLayer("a");
+        var layerB = new MemoryLayer("b");
+        var layerC = new MemoryLayer("c");
+
+        // Stack is bottom-first; C ends up on top.
+        var stack = new ILayer[] { layerA, layerB, layerC };
+
+        var loader = new StackAwareLoader(
+            new Dictionary<DatasetEntry, IDatasetProcessor>
+            {
+                [entryA] = procA, [entryB] = procB, [entryC] = procC,
+            },
+            new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>
+            {
+                [entryA] = new[] { (ILayer)layerA },
+                [entryB] = new[] { (ILayer)layerB },
+                [entryC] = new[] { (ILayer)layerC },
+            },
+            stack);
+
+        var service = CreatePickService(loader, viewModel);
+
+        // Feed records in stack-ascending order (A, B, C). PickService
+        // must reorder them to top-first: C, B, A.
+        service.HandlePick(BuildMapInfo(new[]
+        {
+            MakeRecord(layerA, "fa"),
+            MakeRecord(layerB, "fb"),
+            MakeRecord(layerC, "fc"),
+        }));
+
+        Assert.Equal(3, viewModel.PickReport.Hits.Count);
+        Assert.Equal("fc", viewModel.PickReport.Hits[0].FeatureRef);
+        Assert.Equal("fb", viewModel.PickReport.Hits[1].FeatureRef);
+        Assert.Equal("fa", viewModel.PickReport.Hits[2].FeatureRef);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/TestAuthority.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/TestAuthority.cs
@@ -1,0 +1,16 @@
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Test helper: builds a fresh
+/// <see cref="IInteroperabilityAuthorityProvider"/> wrapping the
+/// canonical S-98 authority. Each processor instantiated in a test
+/// receives its own provider; tests that need to exercise runtime
+/// authority swaps construct their own.
+/// </summary>
+internal static class TestAuthority
+{
+    public static IInteroperabilityAuthorityProvider NewS98Provider()
+        => new InteroperabilityAuthorityProvider(new InteroperabilityAuthority());
+}

--- a/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
+++ b/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
@@ -84,7 +84,9 @@ public sealed class RenderHarness : IDisposable
             _catalogueManager,
             new MoonSharpLuaEngine(),
             new ProjNetCrsTransformFactory(),
-            featureCatalogueManager);
+            featureCatalogueManager,
+            new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
+                new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority()));
     }
 
     /// <summary>

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -30,23 +30,41 @@ internal static class SharedInfrastructure
     public static Datasets.Pipelines.DatasetPipelineFactory CreatePipelineFactory()
     {
         var factoryType = typeof(Datasets.Pipelines.DatasetPipelineFactory);
+        var pipelinesAssembly = factoryType.Assembly;
 
         // Newest shape (PR-L1): adds IInteroperabilityAuthorityProvider.
-        var providerType = typeof(Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider);
-        var providerCtor = factoryType.GetConstructor(
-            [
-                typeof(PortrayalCatalogueManager),
-                typeof(ILuaEngine),
-                typeof(ICrsTransformFactory),
-                typeof(FeatureCatalogueManager),
-                providerType,
-            ]);
-        if (providerCtor is not null)
+        // Resolved via reflection so this tooling stays compatible with base
+        // SHA library binaries that do not yet expose the Interoperability
+        // namespace.
+        var providerInterfaceType = pipelinesAssembly.GetType(
+            "EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider",
+            throwOnError: false);
+        if (providerInterfaceType is not null)
         {
-            var provider = new Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
-                new Datasets.Pipelines.Interoperability.InteroperabilityAuthority());
-            return (Datasets.Pipelines.DatasetPipelineFactory)providerCtor.Invoke(
-                [CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager, provider]);
+            var providerCtor = factoryType.GetConstructor(
+                [
+                    typeof(PortrayalCatalogueManager),
+                    typeof(ILuaEngine),
+                    typeof(ICrsTransformFactory),
+                    typeof(FeatureCatalogueManager),
+                    providerInterfaceType,
+                ]);
+            if (providerCtor is not null)
+            {
+                var authorityType = pipelinesAssembly.GetType(
+                    "EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority",
+                    throwOnError: false);
+                var providerImplType = pipelinesAssembly.GetType(
+                    "EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider",
+                    throwOnError: false);
+                if (authorityType is not null && providerImplType is not null)
+                {
+                    var authority = Activator.CreateInstance(authorityType)!;
+                    var provider = Activator.CreateInstance(providerImplType, authority)!;
+                    return (Datasets.Pipelines.DatasetPipelineFactory)providerCtor.Invoke(
+                        [CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager, provider]);
+                }
+            }
         }
 
         var managerCtor = factoryType.GetConstructor(

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -31,6 +31,24 @@ internal static class SharedInfrastructure
     {
         var factoryType = typeof(Datasets.Pipelines.DatasetPipelineFactory);
 
+        // Newest shape (PR-L1): adds IInteroperabilityAuthorityProvider.
+        var providerType = typeof(Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider);
+        var providerCtor = factoryType.GetConstructor(
+            [
+                typeof(PortrayalCatalogueManager),
+                typeof(ILuaEngine),
+                typeof(ICrsTransformFactory),
+                typeof(FeatureCatalogueManager),
+                providerType,
+            ]);
+        if (providerCtor is not null)
+        {
+            var provider = new Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
+                new Datasets.Pipelines.Interoperability.InteroperabilityAuthority());
+            return (Datasets.Pipelines.DatasetPipelineFactory)providerCtor.Invoke(
+                [CatalogueManager, LuaEngine, CrsFactory, FeatureCatalogueManager, provider]);
+        }
+
         var managerCtor = factoryType.GetConstructor(
             [
                 typeof(PortrayalCatalogueManager),


### PR DESCRIPTION
## Summary

Implements **PR-L1** of the S-98 interoperability rollout (per [`docs/design/s98-interoperability.md`](docs/design/s98-interoperability.md), PR-L0 #117): deterministic S-98-shaped layer stacking across all loaded datasets. **No inter-product suppression rules. No IC-driven plane reassignment. No UI for layer controls.**

> ⚠️ This PR stacks on top of PR #117 (PR-L0 design note). Merge that one first or rebase this once #117 lands.

## What's in this PR

1. **Typed plane model** — `S98DisplayPlane` enum with the 9 canonical planes from S-98 Annex A §A-6.9.1 / MSC.530(106)/Rev.1 §Appendix 2.
2. **Per-processor declarations** — every dataset processor populates a new `DatasetResult.StackEntries` property with `LayerStackEntry` records describing which S-98 plane each emitted layer belongs in.
3. **Central authority** — `InteroperabilityAuthority.Default` carries a hardcoded plane table (TBD-8 resolved) and a stable sort: `(Plane, WithinPlanePriority, input order)`.
4. **`LayerStackBuilder`** — collects entries from every loaded dataset top-of-UI-first and delegates to the authority. `DatasetLoaderService.FlattenLayerOrder` now defers entirely to it.
5. **Pick ordering** — `PickService.ResolveHits` sorts hits by descending stack index before dedup, so multi-hit picks return top-of-stack first. S-98 Main §10.12 / Annex A §A-6.12 designate interrogation as "under development" — this is a viewer-side decision.

## Locked decisions (per spec brief)

| TBD | Decision | Reflected in |
|---|---|---|
| TBD-2 | S-104/S-111 surface **under** S-101 line work | `InteroperabilityAuthority` table (`OnDemandSurface` (20) < `BaseChartOver` (30)) |
| TBD-3 | S-101 area-fill vs line-work split in the **processor** (double pipeline pass with type filter) | `S101DatasetProcessor.Render` partitions `AreaInstruction` from the rest |
| TBD-4 | S-129 → `OnDemandSurface` | `InteroperabilityAuthority`. `TODO` comment notes PR-L2 may move it |
| TBD-8 | MSC.530-derived planes for S-122/124/125/127/128/131/201/411/421 hardcoded | `InteroperabilityAuthority`. No external rule pack |

## Test counts

| Project | Before | After | Δ |
|---|---|---|---|
| `EncDotNet.S100.Pipelines.Tests` | 294 | 322 | +28 (authority + sort + interleave) |
| `EncDotNet.S100.Viewer.Tests` | 278 | 279 | +1 (stack-ordered pick) |
| `EncDotNet.S100.VisualRegression.Tests` | 26 | 26 | unchanged |

Full `dotnet build EncDotNet.S100.slnx` + targeted `dotnet test --configuration Release` green.

## Visual regression rebaselining

**None required.** All 26 snapshots still match. Two reasons:

1. Each non-S-101 spec emits a single layer that lands on the same plane as before, so cross-dataset paint order is unchanged when only one dataset is loaded.
2. The S-101 split paints the exact same drawing instructions in the exact same paint order — they're just bucketed into two adjacent Mapsui layers instead of one. Mapsui walks them sequentially so per-pixel output is identical.

## Performance — S-101 split cost

The split runs the pipeline once and partitions `prepared` (`IReadOnlyList<DrawingInstruction>`) into areas vs non-areas; only the Mapsui rendering step runs twice. For a typical single ENC cell this is a small constant overhead (no second pipeline pass). I haven't measured on a large multi-cell load — if profiling shows >100 ms regression, a v2 mitigation is a single-pass dual-sink renderer. Filed as a follow-up.

## Explicitly NOT in this PR

- IC parsing / rule tables / suppression / replacement / hybridization.
- Per-feature plane filters (TBD-5 / Annex A §4.3).
- Layer Controls UI (PR-L3).
- Safety-contour MSC.232 exception (TBD-6).
- PdC picker UX (TBD-7).
- Any new bundled S-98 spec content.

## Acceptance gates

- [x] Build + test green.
- [x] Loading S-101 ENC + S-102 bathy together: bathy draws *under* S-101 line work and *above* S-101 area fills, deterministically. (Validated by `Build_interleaves_across_planes_independent_of_load_order`.)
- [x] Loading S-124 alongside S-101: warnings draw above ENC.
- [x] Pick over a stacked cluster: hits ordered top-of-stack first. (Validated by `HandlePick_OrdersHitsByLayerStackTopFirst`.)
- [x] Visual regression suite passes (no rebaselining needed).

## Notes for reviewers

- `IDatasetLoaderService.CurrentStackedLayers` + `LayerStackChanged` are **default-implemented** on the interface (return empty / no-op event). This lets existing test doubles compile without changes. PR-L3 may promote them to required members once the Layer Controls UI consumes them.
- `DatasetResult.StackEntries` is nullable but always populated by the in-tree processors. The fallback path in `DatasetLoaderService.FlattenLayerOrder` synthesises defaults via `InteroperabilityAuthority.Default.GetDefaultPlane(spec)` if a processor ever forgets — defensive.

No inter-product rule logic snuck in: `InteroperabilityAuthority` only consults the **product name** (and an optional layer-kind hint) when assigning a default plane. It never inspects another loaded dataset.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>