### PR TITLE
PR-L2 — S-98 inter-product rules (R-101-102, R-101-124, R-104, R-111)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/FeatureTagKeys.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/FeatureTagKeys.cs
@@ -1,0 +1,36 @@
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Well-known keys set on Mapsui <c>IFeature</c> instances by dataset
+/// processors so that the S-98 interoperability rule engine can
+/// filter features without re-running the portrayal pipeline.
+/// </summary>
+/// <remarks>
+/// PR-L2 R-101-102-B implementation uses these tags to suppress
+/// S-101 <c>DepthArea</c> and <c>DepthContour</c> features when an
+/// S-102 dataset is loaded (S-98 Annex A §8.4.1 + Part B §B-3.1.2).
+/// Tags are written by <c>S101DatasetProcessor</c> and read by
+/// <c>S98DefaultRules.R_101_102_B_SuppressDepthFeatures</c>. Sibling
+/// processors are free to add their own tags following the same
+/// dotted-namespace convention.
+/// </remarks>
+public static class FeatureTagKeys
+{
+    /// <summary>
+    /// Feature-type code (S-100 Part 5 / ISO 19110 — e.g.
+    /// <c>"DepthArea"</c>, <c>"DepthContour"</c>) of the originating
+    /// dataset feature. Set by S-101 / S-57 processors; nullable for
+    /// features that don't trace back to a single feature type.
+    /// </summary>
+    public const string FeatureType = "S100.FeatureType";
+
+    /// <summary>
+    /// Numeric depth value, in metres, of a <c>DepthContour</c>
+    /// feature (S-101 attribute <c>VALDCO</c>). Used by R-101-102-B
+    /// to honour the MSC.232(82) §5.8 safety-contour exception:
+    /// the contour matching the mariner's
+    /// <see cref="EncDotNet.S100.Pipelines.MarinerSettings.SafetyContour"/>
+    /// must remain visible even when S-102 replaces depth shading.
+    /// </summary>
+    public const string DepthContourValue = "S100.DepthContourValue";
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/IInteroperabilityAuthority.cs
@@ -71,4 +71,47 @@ public interface IInteroperabilityAuthority
     /// load-order tiebreaker.
     /// </remarks>
     IReadOnlyList<LayerStackEntry> Sort(IEnumerable<LayerStackEntry> entries);
+
+    /// <summary>
+    /// Applies S-98 inter-product rules to a sorted layer stack.
+    /// Each rule's <see cref="S98InteroperabilityRule.Condition"/>
+    /// is checked against the supplied
+    /// <paramref name="loadedDatasets"/> (plus optional mariner
+    /// settings); rules whose condition fires invoke their
+    /// <see cref="S98InteroperabilityRule.Effect"/> on the stack.
+    /// Rules execute in the enumeration order of
+    /// <paramref name="rules"/> — each rule's output is the next
+    /// rule's input.
+    /// </summary>
+    /// <param name="sortedStack">
+    /// The layer stack as produced by <see cref="Sort"/>. The input
+    /// is not mutated; rules return new lists.
+    /// </param>
+    /// <param name="loadedDatasets">
+    /// Snapshot of every dataset currently known to the loader.
+    /// Rules inspect product specs and active flags to decide
+    /// whether to fire.
+    /// </param>
+    /// <param name="mariner">
+    /// Optional active mariner-settings snapshot. Rules that depend
+    /// on viewer settings (e.g. R-101-102-B's safety-contour
+    /// exception per MSC.232(82) §5.8) read it; rules that don't
+    /// ignore it. <c>null</c> falls back to
+    /// <see cref="EncDotNet.S100.Pipelines.MarinerSettings.Default"/>.
+    /// </param>
+    /// <param name="rules">
+    /// Optional rule collection. Defaults to
+    /// <see cref="S98DefaultRules.Default"/>. Passing an empty
+    /// collection is a deliberate no-op (rules disabled).
+    /// </param>
+    /// <returns>
+    /// The post-rule layer stack. Layers may be replaced (suppressed
+    /// features removed) but the count is monotonic per rule —
+    /// rules cannot add new entries in v1.
+    /// </returns>
+    IReadOnlyList<LayerStackEntry> ApplyRules(
+        IReadOnlyList<LayerStackEntry> sortedStack,
+        IReadOnlyList<LoadedDatasetInfo> loadedDatasets,
+        EncDotNet.S100.Pipelines.MarinerSettings? mariner = null,
+        IReadOnlyCollection<S98InteroperabilityRule>? rules = null);
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
@@ -127,4 +127,32 @@ public sealed class InteroperabilityAuthority : IInteroperabilityAuthority
             .ThenBy(e => e.WithinPlanePriority)
             .ToList();
     }
+
+    /// <inheritdoc />
+    public IReadOnlyList<LayerStackEntry> ApplyRules(
+        IReadOnlyList<LayerStackEntry> sortedStack,
+        IReadOnlyList<LoadedDatasetInfo> loadedDatasets,
+        EncDotNet.S100.Pipelines.MarinerSettings? mariner = null,
+        IReadOnlyCollection<S98InteroperabilityRule>? rules = null)
+    {
+        ArgumentNullException.ThrowIfNull(sortedStack);
+        ArgumentNullException.ThrowIfNull(loadedDatasets);
+
+        var ruleSet = rules ?? S98DefaultRules.Default;
+        if (ruleSet.Count == 0)
+        {
+            return sortedStack;
+        }
+
+        var context = new S98RuleContext(loadedDatasets, mariner);
+        IReadOnlyList<LayerStackEntry> current = sortedStack;
+        foreach (var rule in ruleSet)
+        {
+            if (rule.Condition(context))
+            {
+                current = rule.Effect(current, context);
+            }
+        }
+        return current;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadOrderInteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadOrderInteroperabilityAuthority.cs
@@ -67,4 +67,24 @@ public sealed class LoadOrderInteroperabilityAuthority : IInteroperabilityAuthor
         System.ArgumentNullException.ThrowIfNull(entries);
         return entries.OrderBy(e => e.WithinPlanePriority).ToList();
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The load-order authority deliberately bypasses S-98
+    /// inter-product rules: the contract of this authority is
+    /// "ignore S-98 entirely", and that includes Level-2 suppression.
+    /// Returns the stack unchanged regardless of which rule
+    /// collection is supplied. Hosts that want S-98 rules should use
+    /// <see cref="InteroperabilityAuthority"/> instead.
+    /// </remarks>
+    public IReadOnlyList<LayerStackEntry> ApplyRules(
+        IReadOnlyList<LayerStackEntry> sortedStack,
+        IReadOnlyList<LoadedDatasetInfo> loadedDatasets,
+        EncDotNet.S100.Pipelines.MarinerSettings? mariner = null,
+        IReadOnlyCollection<S98InteroperabilityRule>? rules = null)
+    {
+        System.ArgumentNullException.ThrowIfNull(sortedStack);
+        System.ArgumentNullException.ThrowIfNull(loadedDatasets);
+        return sortedStack;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadedDatasetInfo.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadedDatasetInfo.cs
@@ -1,0 +1,27 @@
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Identifies a currently-loaded dataset to the S-98 interoperability
+/// rule engine. Carries the minimum information a rule needs to
+/// decide whether it should fire: which product spec the dataset
+/// conforms to and whether the dataset is currently active for
+/// display.
+/// </summary>
+/// <param name="DatasetId">
+/// Stable identifier matching <see cref="LayerStackEntry.SourceDatasetId"/>
+/// (typically the dataset's file name or exchange-set relative path).
+/// </param>
+/// <param name="ProductSpec">
+/// Product specification name (e.g. <c>"S-101"</c>, <c>"S-102"</c>).
+/// Matches <see cref="EncDotNet.S100.Core.SpecRef.Name"/>.
+/// </param>
+/// <param name="Active">
+/// Whether this dataset is currently active for display. PR-L2
+/// treats "loaded" as "active" (PR-L1 has no separate active/inactive
+/// concept); the field is wired through so PR-L3's Layer Controls UI
+/// can flip individual datasets off without re-loading. A rule that
+/// suppresses S-101 features when S-102 is loaded must only fire
+/// when the S-102 dataset is <c>Active</c>; an inactive S-102 must
+/// not suppress S-101.
+/// </param>
+public sealed record LoadedDatasetInfo(string DatasetId, string ProductSpec, bool Active);

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/S98DefaultRules.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/S98DefaultRules.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Mapsui;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// The five inter-product rules shipped in PR-L2 (S-98 Edition
+/// 2.0.0). Three rules (<see cref="R_101_102_A"/>,
+/// <see cref="R_104_A"/>, <see cref="R_111_A"/>) are pure
+/// plane-assignment properties already satisfied by PR-L1's default
+/// plane table; they carry an identity <see cref="S98InteroperabilityRule.Effect"/>
+/// and exist primarily as named property anchors for tests and for
+/// future PRs that may load real IC payloads. <see cref="R_101_124_A"/>
+/// is the analogous Level-0 derivation for S-124. The Level-2 rule
+/// <see cref="R_101_102_B_SuppressDepthFeatures"/> is the only one
+/// with a non-identity effect — it removes S-101 <c>DepthArea</c>
+/// and <c>DepthContour</c> features from the stack when an S-102
+/// dataset is loaded and active, honouring the MSC.232(82) §5.8
+/// safety-contour exception.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rules execute in the order returned by <see cref="Default"/>;
+/// declaration order is deliberate so that downstream rules can rely
+/// on upstream rules' outputs. The current set has no inter-rule
+/// dependencies (the four plane-order rules are identity functions
+/// and R-101-102-B does not depend on them), so the order is
+/// effectively cosmetic for v1 — but the contract is fixed for
+/// future extensions.
+/// </para>
+/// <para>
+/// Every IC element name introduced here is flagged with a
+/// <c>TODO PR-L2-RESYNC</c> comment so a future re-sync against
+/// the S-100 Part 16 XSD (PR-L0 TBD-1) can find them by grep.
+/// </para>
+/// </remarks>
+public static class S98DefaultRules
+{
+    private const double SafetyContourTolerance = 1e-6;
+
+    /// <summary>
+    /// R-101-102-A (Level 1) — S-102 must render between S-101 area
+    /// fills (<see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.BaseChartUnder"/>)
+    /// and S-101 line work
+    /// (<see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.BaseChartOver"/>).
+    /// </summary>
+    /// <remarks>
+    /// The property holds purely from PR-L1's default plane assignment
+    /// (S-102 lands on <see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.Bathymetry"/>
+    /// at plane order 10, between BaseChartUnder=0 and BaseChartOver=30).
+    /// The rule is shipped as an identity effect so the property is
+    /// pinned by name and citation, testable, and resilient to future
+    /// changes that might re-shuffle the plane table.
+    /// Cites S-98 Ed.2.0.0 Annex A §A-6.9.1.
+    /// </remarks>
+    // TODO PR-L2-RESYNC: confirm against S-100 Part 16 XSD
+    public static readonly S98InteroperabilityRule R_101_102_A = new(
+        RuleId: "R-101-102-A",
+        SpecCitation: "S-98 Ed.2.0.0 Annex A §A-6.9.1",
+        Condition: HasActiveProductSet("S-101", "S-102"),
+        Effect: Identity);
+
+    /// <summary>
+    /// R-101-102-B (Level 2) — when an S-102 dataset is loaded and
+    /// active, suppress every S-101 <c>DepthArea</c> and
+    /// <c>DepthContour</c> feature so the gridded bathymetric
+    /// surface replaces the legacy depth shading. The S-101 safety
+    /// contour (the contour whose <c>VALDCO</c> equals the mariner's
+    /// <see cref="EncDotNet.S100.Pipelines.MarinerSettings.SafetyContour"/>)
+    /// is preserved per MSC.232(82) §5.8 / IMO ECDIS Performance
+    /// Standard §10.5.2 / S-98 Annex A §A-6.9.1 NOTE.
+    /// </summary>
+    /// <remarks>
+    /// Implementation: the rule walks the sorted stack, finds the
+    /// S-101 area / line-work layers, and replaces each affected
+    /// <see cref="LayerStackEntry"/> with a new
+    /// <see cref="MemoryLayer"/> built from the surviving features.
+    /// Tagging is performed upstream by <c>S101DatasetProcessor</c>:
+    /// every Mapsui IFeature carries <see cref="FeatureTagKeys.FeatureType"/>
+    /// and, for depth contours, <see cref="FeatureTagKeys.DepthContourValue"/>.
+    /// Cites S-98 Ed.2.0.0 Annex A §8.4.1 + Part B §B-3.1.2 +
+    /// Annex A §A-6.9.1 NOTE + MSC.232(82) §5.8 + IMO MSC.232(82) Annex 11 §10.5.2.
+    /// </remarks>
+    // TODO PR-L2-RESYNC: confirm against S-100 Part 16 XSD
+    public static readonly S98InteroperabilityRule R_101_102_B_SuppressDepthFeatures = new(
+        RuleId: "R-101-102-B",
+        SpecCitation: "S-98 Ed.2.0.0 Annex A §8.4.1 + Part B §B-3.1.2 + MSC.232(82) §5.8",
+        Condition: HasActiveProductSet("S-101", "S-102"),
+        Effect: SuppressS101DepthFeatures);
+
+    /// <summary>
+    /// R-101-124-A (Level 0, derived) — S-124 navigational warnings
+    /// render on
+    /// <see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.CautionsAndWarnings"/>,
+    /// above ENC base data and below mariner overlays. Identity
+    /// effect — the property is satisfied by PR-L1's default plane
+    /// assignment.
+    /// </summary>
+    /// <remarks>
+    /// S-124 is outside S-98 v2.0.0 IC scope (Annex A §4.1.1 — closed
+    /// dictionary <c>urn:mrn:iho:prod:s98:1:1:0:products</c>); this
+    /// rule is a viewer-side derivation from S-98 Main §9.2.1 / IMO
+    /// MSC.530(106)/Rev.1 §Appendix 2 priority layer 3, not a
+    /// normative IC clause.
+    /// </remarks>
+    // TODO PR-L2-RESYNC: confirm against S-100 Part 16 XSD
+    public static readonly S98InteroperabilityRule R_101_124_A = new(
+        RuleId: "R-101-124-A",
+        SpecCitation: "S-98 Ed.2.0.0 Main §9.2.1 + IMO MSC.530(106)/Rev.1 §App.2 layer 3",
+        Condition: HasActiveProductSet("S-101", "S-124"),
+        Effect: Identity);
+
+    /// <summary>
+    /// R-104-A (Level 1) — S-104 colour-band surface renders on
+    /// <see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.OnDemandSurface"/>,
+    /// below S-101 line work. Identity effect — satisfied by PR-L1's
+    /// default plane assignment.
+    /// </summary>
+    // TODO PR-L2-RESYNC: confirm against S-100 Part 16 XSD
+    public static readonly S98InteroperabilityRule R_104_A = new(
+        RuleId: "R-104-A",
+        SpecCitation: "S-98 Ed.2.0.0 Annex A §A-6.9.1 + Main §9.2.1 layer 6",
+        Condition: HasActiveProductSet("S-101", "S-104"),
+        Effect: Identity);
+
+    /// <summary>
+    /// R-111-A (Level 1) — S-111 colour-band surface renders on
+    /// <see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.OnDemandSurface"/>;
+    /// the arrow overlay renders on
+    /// <see cref="EncDotNet.S100.Interoperability.S98DisplayPlane.DynamicArrows"/>.
+    /// Identity effect — satisfied by PR-L1's default plane
+    /// assignment.
+    /// </summary>
+    // TODO PR-L2-RESYNC: confirm against S-100 Part 16 XSD
+    public static readonly S98InteroperabilityRule R_111_A = new(
+        RuleId: "R-111-A",
+        SpecCitation: "S-98 Ed.2.0.0 Annex A §A-6.9.1",
+        Condition: HasActiveProductSet("S-101", "S-111"),
+        Effect: Identity);
+
+    /// <summary>
+    /// The default rule collection in evaluation order. Declaration
+    /// order is the evaluation order: <see cref="R_101_102_A"/> first
+    /// (plane-property anchor), <see cref="R_101_102_B_SuppressDepthFeatures"/>
+    /// second (the only mutating rule in v1), then the remaining
+    /// plane-property anchors. Composing rules that mutate the stack
+    /// should be added before any rule that reads attributes the
+    /// upstream rule removes; today no such dependency exists.
+    /// </summary>
+    public static readonly IReadOnlyList<S98InteroperabilityRule> Default =
+        new[]
+        {
+            R_101_102_A,
+            R_101_102_B_SuppressDepthFeatures,
+            R_101_124_A,
+            R_104_A,
+            R_111_A,
+        };
+
+    private static Func<S98RuleContext, bool> HasActiveProductSet(params string[] productSpecs)
+    {
+        ArgumentNullException.ThrowIfNull(productSpecs);
+        return context =>
+        {
+            foreach (var spec in productSpecs)
+            {
+                bool found = false;
+                foreach (var ds in context.LoadedDatasets)
+                {
+                    if (ds.Active && string.Equals(ds.ProductSpec, spec, StringComparison.Ordinal))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) return false;
+            }
+            return true;
+        };
+    }
+
+    private static IReadOnlyList<LayerStackEntry> Identity(
+        IReadOnlyList<LayerStackEntry> stack,
+        S98RuleContext context)
+        => stack;
+
+    private static IReadOnlyList<LayerStackEntry> SuppressS101DepthFeatures(
+        IReadOnlyList<LayerStackEntry> stack,
+        S98RuleContext context)
+    {
+        var mariner = context.EffectiveMariner;
+        var safetyContour = mariner.SafetyContour;
+
+        // S-101 feature codes suppressed by S-102 (Annex A §8.4.1
+        // "skin-of-the-earth feature replacement"). Held as a small
+        // ordinal-comparison set because the renderer tags are
+        // case-sensitive S-100 Part 5 codes.
+        // TODO PR-L2-RESYNC: confirm against S-100 Part 16 XSD
+        var suppressedTypes = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "DepthArea",
+            "DepthContour",
+        };
+
+        var result = new List<LayerStackEntry>(stack.Count);
+        foreach (var entry in stack)
+        {
+            // Only S-101 source datasets are subject to the rule;
+            // skip everything else (incl. S-57 — Annex A §4.1.1
+            // closes the product list to S-100 specs).
+            if (!IsS101Entry(entry, context))
+            {
+                result.Add(entry);
+                continue;
+            }
+
+            var filtered = FilterLayer(entry.Layer, suppressedTypes, safetyContour);
+            if (ReferenceEquals(filtered, entry.Layer))
+            {
+                result.Add(entry);
+            }
+            else
+            {
+                result.Add(entry with { Layer = filtered });
+            }
+        }
+        return result;
+    }
+
+    private static bool IsS101Entry(LayerStackEntry entry, S98RuleContext context)
+    {
+        // Match the entry back to its source dataset to confirm the
+        // S-101 product. We cannot use Plane alone — S-122/S-125/...
+        // also sit on overlay planes — and we cannot use Layer.Name
+        // because it is processor-formatted. SourceDatasetId is the
+        // stable join key against LoadedDatasetInfo.
+        foreach (var ds in context.LoadedDatasets)
+        {
+            if (string.Equals(ds.DatasetId, entry.SourceDatasetId, StringComparison.Ordinal))
+            {
+                return string.Equals(ds.ProductSpec, "S-101", StringComparison.Ordinal);
+            }
+        }
+        return false;
+    }
+
+    private static ILayer FilterLayer(
+        ILayer layer,
+        HashSet<string> suppressedTypes,
+        double safetyContour)
+    {
+        if (layer is not MemoryLayer memoryLayer)
+        {
+            // We only know how to rebuild MemoryLayer-shaped vector
+            // layers. Coverage layers (S-102 etc.) never reach this
+            // branch because IsS101Entry guards by product. If a
+            // future S-101 renderer emits a different ILayer type
+            // we'd need to teach this code to clone it.
+            return layer;
+        }
+
+        var src = memoryLayer.Features;
+        var kept = new List<IFeature>();
+        bool changed = false;
+        foreach (var f in src)
+        {
+            if (ShouldSuppress(f, suppressedTypes, safetyContour))
+            {
+                changed = true;
+                continue;
+            }
+            kept.Add(f);
+        }
+
+        if (!changed)
+        {
+            return layer;
+        }
+
+        // Build a new MemoryLayer that mirrors the source. We do not
+        // mutate the existing layer — DatasetLoaderService caches it
+        // for non-suppression renders and PR-L3's Layer Controls UI
+        // may toggle the suppression off, restoring the original.
+        return new MemoryLayer
+        {
+            Name = memoryLayer.Name,
+            Features = kept,
+            Style = memoryLayer.Style,
+        };
+    }
+
+    private static bool ShouldSuppress(
+        IFeature feature,
+        HashSet<string> suppressedTypes,
+        double safetyContour)
+    {
+        var typeRaw = feature[FeatureTagKeys.FeatureType] as string;
+        if (typeRaw is null || !suppressedTypes.Contains(typeRaw))
+        {
+            return false;
+        }
+
+        // Safety-contour exception (MSC.232(82) §5.8). Only depth
+        // contours have a numeric depth value; depth areas are
+        // suppressed unconditionally.
+        if (string.Equals(typeRaw, "DepthContour", StringComparison.Ordinal))
+        {
+            if (TryReadDepth(feature, out var depth) &&
+                Math.Abs(depth - safetyContour) <= SafetyContourTolerance)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryReadDepth(IFeature feature, out double depth)
+    {
+        var raw = feature[FeatureTagKeys.DepthContourValue];
+        switch (raw)
+        {
+            case double d:
+                depth = d;
+                return true;
+            case float f:
+                depth = f;
+                return true;
+            case int i:
+                depth = i;
+                return true;
+            case long l:
+                depth = l;
+                return true;
+            case string s when double.TryParse(
+                s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed):
+                depth = parsed;
+                return true;
+            default:
+                depth = double.NaN;
+                return false;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/S98InteroperabilityRule.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/S98InteroperabilityRule.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// One S-98 inter-product rule: a guarded transformation of the
+/// sorted layer stack. PR-L2 ships five rules (see
+/// <see cref="S98DefaultRules"/>); future PRs may load additional
+/// rules from a parsed Interoperability Catalogue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A rule is a pair of pure delegates: <see cref="Condition"/>
+/// decides whether the rule applies given the current set of loaded
+/// datasets, and <see cref="Effect"/> transforms the sorted stack
+/// when <see cref="Condition"/> returns <c>true</c>. Rules execute
+/// in the order they appear in
+/// <see cref="IInteroperabilityAuthority.ApplyRules"/>'s rule
+/// collection (declaration order); each rule's output is the next
+/// rule's input.
+/// </para>
+/// <para>
+/// Rules are pure functions of <c>(stack, context)</c> — they must
+/// not mutate the input list, the layers it references, or any
+/// shared state. The default implementations in
+/// <see cref="S98DefaultRules"/> follow this contract.
+/// </para>
+/// </remarks>
+/// <param name="RuleId">
+/// Stable identifier, e.g. <c>"R-101-102-B"</c>. Used in diagnostics
+/// and tests; must be unique within a rule collection.
+/// </param>
+/// <param name="SpecCitation">
+/// Free-text citation of the spec clause(s) this rule derives from,
+/// e.g. <c>"S-98 Ed.2.0.0 Annex A §8.4.1 + Part B §B-3.1.2"</c>.
+/// </param>
+/// <param name="Condition">
+/// Predicate over the rule context; <c>true</c> means the rule's
+/// <see cref="Effect"/> should be applied. Must be pure.
+/// </param>
+/// <param name="Effect">
+/// Transforms the sorted layer stack. Receives the (possibly
+/// already-transformed) stack and the rule context; must return a
+/// new list — input must not be mutated.
+/// </param>
+public sealed record S98InteroperabilityRule(
+    string RuleId,
+    string SpecCitation,
+    Func<S98RuleContext, bool> Condition,
+    Func<IReadOnlyList<LayerStackEntry>, S98RuleContext, IReadOnlyList<LayerStackEntry>> Effect);

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/S98RuleContext.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/S98RuleContext.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
+
+/// <summary>
+/// Inputs to a single <see cref="S98InteroperabilityRule"/> evaluation:
+/// the set of currently-loaded datasets plus optional mariner state
+/// (used by rules whose effect depends on viewer settings, e.g. the
+/// safety-contour exception to R-101-102-B).
+/// </summary>
+/// <param name="LoadedDatasets">
+/// Snapshot of every dataset currently known to the loader. Order is
+/// not significant — rules query by product spec / active flag.
+/// </param>
+/// <param name="Mariner">
+/// Active mariner-settings snapshot, or <c>null</c> if rules should
+/// fall back to <see cref="MarinerSettings.Default"/>. Rules that
+/// honour MSC.232(82) §5.8 (safety contour) read
+/// <see cref="MarinerSettings.SafetyContour"/> from this snapshot.
+/// </param>
+public sealed record S98RuleContext(
+    IReadOnlyList<LoadedDatasetInfo> LoadedDatasets,
+    MarinerSettings? Mariner = null)
+{
+    /// <summary>Mariner settings to use during evaluation; never <c>null</c>.</summary>
+    public MarinerSettings EffectiveMariner => Mariner ?? MarinerSettings.Default;
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -131,6 +131,13 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         var lineLayer = CreateRenderer(s101Cat, palette, context, suffix: "lines")
             .Render(otherInstructions, geometryProvider);
 
+        // PR-L2 R-101-102-B: tag every Mapsui IFeature with its S-101
+        // feature-type code and (for DepthContour) its VALDCO depth
+        // value, so the S-98 rule engine can filter without re-running
+        // portrayal. See S98DefaultRules.SuppressS101DepthFeatures.
+        TagMapsuiFeaturesWithFeatureType(areaLayer);
+        TagMapsuiFeaturesWithFeatureType(lineLayer);
+
         // Union the two layer extents (each is in EPSG:3857). Mapsui
         // returns a zero-extent rect when a layer has no features, so
         // skip such layers in the union.
@@ -176,6 +183,53 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
                     SourceFeatureType: "linework"),
             },
         };
+    }
+
+    /// <summary>
+    /// Tags every Mapsui feature on <paramref name="layer"/> with the
+    /// <see cref="EncDotNet.S100.Datasets.Pipelines.Interoperability.FeatureTagKeys.FeatureType"/>
+    /// (and, for <c>DepthContour</c>, the numeric depth value under
+    /// <see cref="EncDotNet.S100.Datasets.Pipelines.Interoperability.FeatureTagKeys.DepthContourValue"/>).
+    /// </summary>
+    /// <remarks>
+    /// The Mapsui renderer stamps each <c>IFeature</c> with the
+    /// originating S-100 feature reference under
+    /// <see cref="MapsuiDisplayListRenderer.FeatureRefKey"/>. We read
+    /// that, look up the originating <see cref="Pipelines.Vector.Feature"/>
+    /// in the lazily-built feature index, and copy the feature-type
+    /// code plus the safety-contour exception payload (VALDCO /
+    /// <c>valueOfDepthContour</c>, S-101 FC §3.1.1) onto the Mapsui
+    /// feature. This is the data the PR-L2 R-101-102-B rule consumes
+    /// to suppress depth area / contour features while preserving the
+    /// safety contour (MSC.232(82) §5.8).
+    /// </remarks>
+    private void TagMapsuiFeaturesWithFeatureType(ILayer layer)
+    {
+        if (layer is not MemoryLayer memoryLayer) return;
+
+        _featureIndex ??= BuildFeatureIndex();
+
+        foreach (var mapFeature in memoryLayer.Features)
+        {
+            if (mapFeature[MapsuiDisplayListRenderer.FeatureRefKey] is not string featureRef)
+                continue;
+
+            if (!long.TryParse(featureRef, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var id))
+                continue;
+
+            if (!_featureIndex.TryGetValue(id, out var feature))
+                continue;
+
+            mapFeature[Interoperability.FeatureTagKeys.FeatureType] = feature.FeatureType;
+
+            if (string.Equals(feature.FeatureType, "DepthContour", StringComparison.Ordinal) &&
+                feature.Attributes.TryGetValue("valueOfDepthContour", out var depthRaw) &&
+                depthRaw is not null)
+            {
+                mapFeature[Interoperability.FeatureTagKeys.DepthContourValue] = depthRaw;
+            }
+        }
     }
 
     private MapsuiDisplayListRenderer CreateRenderer(

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -557,11 +557,50 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             }
         }
 
-        var sorted = LayerStackBuilder.Build(_authorityProvider.Current, perDataset);
-        var list = LayerStackBuilder.ToLayerList(sorted);
+        var authority = _authorityProvider.Current;
+        var sorted = LayerStackBuilder.Build(authority, perDataset);
+
+        // PR-L2: apply S-98 inter-product rules (suppression, etc.)
+        // after the per-plane sort. The rule set is the default
+        // S98DefaultRules collection; rules read the mariner settings
+        // (e.g. SafetyContour for R-101-102-B's safety-contour
+        // exception per MSC.232(82) §5.8). LoadOrderInteroperabilityAuthority
+        // explicitly no-ops ApplyRules so the strict load-order mode
+        // is unaffected.
+        var loaded = BuildLoadedDatasetInfos();
+        var ruled = authority.ApplyRules(sorted, loaded, _marinerSettings.Current);
+
+        var list = LayerStackBuilder.ToLayerList(ruled);
         _currentStackedLayers = list;
         LayerStackChanged?.Invoke();
         return list;
+    }
+
+    /// <summary>
+    /// Builds the snapshot of <see cref="LoadedDatasetInfo"/> values
+    /// the S-98 rule engine consumes. PR-L2 treats "loaded" as
+    /// "active" — there is no separate active/inactive concept yet
+    /// (PR-L3's Layer Controls UI will add one). An inactive entry
+    /// suppresses every rule that depends on its product.
+    /// </summary>
+    private IReadOnlyList<LoadedDatasetInfo> BuildLoadedDatasetInfos()
+    {
+        var result = new List<LoadedDatasetInfo>(_entryOrder.Count);
+        foreach (var entry in _entryOrder)
+        {
+            if (!_processors.TryGetValue(entry, out var proc)) continue;
+            // PR-L2: "loaded == active" — IsVisible is the closest
+            // viewer-side proxy for "currently displayed". An entry
+            // whose layer collection is empty (failed render) is
+            // treated as inactive so its absence doesn't accidentally
+            // suppress sibling products.
+            var datasetId = entry.FilePath ?? entry.DisplayName;
+            var active = entry.IsVisible
+                && _entryLayers.TryGetValue(entry, out var layers)
+                && layers.Count > 0;
+            result.Add(new LoadedDatasetInfo(datasetId, proc.Spec.Name, active));
+        }
+        return result;
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Pipelines.Tests/S98DefaultRulesTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S98DefaultRulesTests.cs
@@ -1,0 +1,384 @@
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Interoperability;
+using EncDotNet.S100.Pipelines;
+using Mapsui;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Pins the five PR-L2 inter-product rules from
+/// <see cref="S98DefaultRules"/>. Three rules
+/// (R-101-102-A, R-104-A, R-111-A, R-101-124-A) are pure
+/// plane-order anchors satisfied by PR-L1's default plane table;
+/// the only mutating rule is R-101-102-B (suppress S-101 depth
+/// features when S-102 is loaded). Tests cover every gate from
+/// the briefing: condition firing, safety-contour exception, the
+/// Active flag, and rule composition declaration order.
+/// </summary>
+public class S98DefaultRulesTests
+{
+    private readonly InteroperabilityAuthority _auth = new();
+
+    // ----------------------------------------------------------------
+    // R-101-102-A — plane-order property
+    // ----------------------------------------------------------------
+
+    [Fact]
+    public void R_101_102_A_keeps_s102_between_s101_areas_and_linework()
+    {
+        var s101a = StackEntry("s101-cell.000", S98DisplayPlane.BaseChartUnder);
+        var s101l = StackEntry("s101-cell.000", S98DisplayPlane.BaseChartOver);
+        var s102 = StackEntry("s102-tile.h5", S98DisplayPlane.Bathymetry);
+
+        var sorted = _auth.Sort(new[] { s101a, s102, s101l });
+        var ruled = _auth.ApplyRules(
+            sorted,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s102-tile.h5", "S-102", Active: true),
+            });
+
+        Assert.Equal(
+            new[] { S98DisplayPlane.BaseChartUnder, S98DisplayPlane.Bathymetry, S98DisplayPlane.BaseChartOver },
+            ruled.Select(e => e.Plane).ToArray());
+    }
+
+    // ----------------------------------------------------------------
+    // R-101-102-B — suppression
+    // ----------------------------------------------------------------
+
+    [Fact]
+    public void R_101_102_B_does_not_suppress_when_only_s101_loaded()
+    {
+        var (areaLayer, lineLayer) = BuildS101LayersWithDepthFeatures();
+        var stack = new[]
+        {
+            new LayerStackEntry(areaLayer, S98DisplayPlane.BaseChartUnder, 0, "s101-cell.000", SourceFeatureType: "area"),
+            new LayerStackEntry(lineLayer, S98DisplayPlane.BaseChartOver, 0, "s101-cell.000", SourceFeatureType: "linework"),
+        };
+
+        var ruled = _auth.ApplyRules(
+            stack,
+            new[] { new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true) });
+
+        // S-101 alone: nothing changes; the same Mapsui layers come back.
+        Assert.Same(areaLayer, ruled[0].Layer);
+        Assert.Same(lineLayer, ruled[1].Layer);
+    }
+
+    [Fact]
+    public void R_101_102_B_suppresses_depth_area_and_depth_contour_when_s102_loaded()
+    {
+        var (areaLayer, lineLayer) = BuildS101LayersWithDepthFeatures();
+        var s102 = new MemoryLayer("s102");
+        var stack = new[]
+        {
+            new LayerStackEntry(areaLayer, S98DisplayPlane.BaseChartUnder, 0, "s101-cell.000", SourceFeatureType: "area"),
+            new LayerStackEntry(s102, S98DisplayPlane.Bathymetry, 0, "s102-tile.h5"),
+            new LayerStackEntry(lineLayer, S98DisplayPlane.BaseChartOver, 0, "s101-cell.000", SourceFeatureType: "linework"),
+        };
+
+        var ruled = _auth.ApplyRules(
+            stack,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s102-tile.h5", "S-102", Active: true),
+            });
+
+        // Area layer: DepthArea suppressed, LandArea retained.
+        var filteredArea = Assert.IsType<MemoryLayer>(ruled[0].Layer);
+        var areaTypes = filteredArea.Features
+            .Select(f => f[FeatureTagKeys.FeatureType] as string)
+            .ToArray();
+        Assert.DoesNotContain("DepthArea", areaTypes);
+        Assert.Contains("LandArea", areaTypes);
+
+        // Line layer: DepthContour suppressed, Coastline retained.
+        var filteredLine = Assert.IsType<MemoryLayer>(ruled[2].Layer);
+        var lineTypes = filteredLine.Features
+            .Select(f => f[FeatureTagKeys.FeatureType] as string)
+            .ToArray();
+        Assert.DoesNotContain("DepthContour", lineTypes);
+        Assert.Contains("Coastline", lineTypes);
+
+        // S-102 layer is passed through unchanged.
+        Assert.Same(s102, ruled[1].Layer);
+    }
+
+    [Fact]
+    public void R_101_102_B_preserves_safety_contour_per_msc232_5_8()
+    {
+        // S-101 line layer carries three DepthContour features at
+        // 5m, 10m (=safety), 20m. MSC.232(82) §5.8 requires the
+        // safety contour to remain visible even when S-102 replaces
+        // bathy shading.
+        var (areaLayer, lineLayer) = BuildS101LayersWithDepthFeatures(
+            depthContoursMetres: new double[] { 5.0, 10.0, 20.0 });
+
+        var s102 = new MemoryLayer("s102");
+        var stack = new[]
+        {
+            new LayerStackEntry(areaLayer, S98DisplayPlane.BaseChartUnder, 0, "s101-cell.000", SourceFeatureType: "area"),
+            new LayerStackEntry(s102, S98DisplayPlane.Bathymetry, 0, "s102-tile.h5"),
+            new LayerStackEntry(lineLayer, S98DisplayPlane.BaseChartOver, 0, "s101-cell.000", SourceFeatureType: "linework"),
+        };
+
+        var mariner = MarinerSettings.Default with { SafetyContour = 10.0 };
+        var ruled = _auth.ApplyRules(
+            stack,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s102-tile.h5", "S-102", Active: true),
+            },
+            mariner);
+
+        var filteredLine = Assert.IsType<MemoryLayer>(ruled[2].Layer);
+        var contourDepths = filteredLine.Features
+            .Where(f => (f[FeatureTagKeys.FeatureType] as string) == "DepthContour")
+            .Select(f => (double)f[FeatureTagKeys.DepthContourValue]!)
+            .ToArray();
+
+        // Only the 10m contour survives — the safety contour.
+        Assert.Equal(new[] { 10.0 }, contourDepths);
+    }
+
+    [Fact]
+    public void R_101_102_B_does_not_fire_when_s102_inactive()
+    {
+        var (areaLayer, lineLayer) = BuildS101LayersWithDepthFeatures();
+        var stack = new[]
+        {
+            new LayerStackEntry(areaLayer, S98DisplayPlane.BaseChartUnder, 0, "s101-cell.000", SourceFeatureType: "area"),
+            new LayerStackEntry(lineLayer, S98DisplayPlane.BaseChartOver, 0, "s101-cell.000", SourceFeatureType: "linework"),
+        };
+
+        var ruled = _auth.ApplyRules(
+            stack,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                // S-102 loaded but NOT active — Layer Controls UI off.
+                new LoadedDatasetInfo("s102-tile.h5", "S-102", Active: false),
+            });
+
+        // No suppression — same Mapsui layer instances come back.
+        Assert.Same(areaLayer, ruled[0].Layer);
+        Assert.Same(lineLayer, ruled[1].Layer);
+    }
+
+    // ----------------------------------------------------------------
+    // R-101-124-A, R-104-A, R-111-A — plane-order properties
+    // ----------------------------------------------------------------
+
+    [Fact]
+    public void R_101_124_A_places_s124_on_cautions_and_warnings_above_s101()
+    {
+        var s101l = StackEntry("s101-cell.000", S98DisplayPlane.BaseChartOver);
+        var s124 = StackEntry("s124-warning.gml", S98DisplayPlane.CautionsAndWarnings);
+
+        var sorted = _auth.Sort(new[] { s124, s101l });
+        var ruled = _auth.ApplyRules(
+            sorted,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s124-warning.gml", "S-124", Active: true),
+            });
+
+        Assert.Equal(
+            new[] { S98DisplayPlane.BaseChartOver, S98DisplayPlane.CautionsAndWarnings },
+            ruled.Select(e => e.Plane).ToArray());
+    }
+
+    [Fact]
+    public void R_104_A_places_s104_color_band_below_s101_line_work()
+    {
+        var s101l = StackEntry("s101-cell.000", S98DisplayPlane.BaseChartOver);
+        var s104 = StackEntry("s104.h5", S98DisplayPlane.OnDemandSurface);
+
+        var sorted = _auth.Sort(new[] { s101l, s104 });
+        var ruled = _auth.ApplyRules(
+            sorted,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s104.h5", "S-104", Active: true),
+            });
+
+        // OnDemandSurface (20) < BaseChartOver (30).
+        Assert.Equal(
+            new[] { S98DisplayPlane.OnDemandSurface, S98DisplayPlane.BaseChartOver },
+            ruled.Select(e => e.Plane).ToArray());
+    }
+
+    [Fact]
+    public void R_111_A_places_color_band_on_on_demand_and_arrows_on_dynamic_arrows()
+    {
+        var s101l = StackEntry("s101-cell.000", S98DisplayPlane.BaseChartOver);
+        var band = StackEntry("s111.h5", S98DisplayPlane.OnDemandSurface);
+        var arrows = StackEntry("s111.h5", S98DisplayPlane.DynamicArrows);
+
+        var sorted = _auth.Sort(new[] { arrows, s101l, band });
+        var ruled = _auth.ApplyRules(
+            sorted,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s111.h5", "S-111", Active: true),
+            });
+
+        // OnDemandSurface (20) < BaseChartOver (30) < DynamicArrows (60).
+        Assert.Equal(
+            new[] { S98DisplayPlane.OnDemandSurface, S98DisplayPlane.BaseChartOver, S98DisplayPlane.DynamicArrows },
+            ruled.Select(e => e.Plane).ToArray());
+    }
+
+    // ----------------------------------------------------------------
+    // Rule composition / declaration order
+    // ----------------------------------------------------------------
+
+    [Fact]
+    public void Rules_execute_in_declaration_order_with_each_output_feeding_the_next()
+    {
+        // Build a marker rule that records the layer-count it sees on
+        // input. Compose it with a marker that always halves the
+        // stack. If declaration order is honoured, the second rule
+        // sees the first rule's output, not the original.
+        var observed = new List<int>();
+
+        var firstFires = false;
+        var first = new S98InteroperabilityRule(
+            RuleId: "TEST-1",
+            SpecCitation: "test",
+            Condition: _ => { firstFires = true; return true; },
+            Effect: (stack, _) =>
+            {
+                observed.Add(stack.Count);
+                return stack.Take(stack.Count / 2).ToList();
+            });
+
+        var second = new S98InteroperabilityRule(
+            RuleId: "TEST-2",
+            SpecCitation: "test",
+            Condition: _ => true,
+            Effect: (stack, _) =>
+            {
+                observed.Add(stack.Count);
+                return stack;
+            });
+
+        var stack = Enumerable.Range(0, 8)
+            .Select(i => StackEntry($"id-{i}", S98DisplayPlane.OtherChartOverlays))
+            .ToArray();
+
+        _auth.ApplyRules(
+            stack,
+            new[] { new LoadedDatasetInfo("id-0", "S-101", Active: true) },
+            mariner: null,
+            rules: new[] { first, second });
+
+        Assert.True(firstFires);
+        Assert.Equal(new[] { 8, 4 }, observed.ToArray());
+    }
+
+    [Fact]
+    public void Default_rule_set_is_in_documented_order()
+    {
+        // S98DefaultRules.Default declaration order is part of the
+        // public contract — pin it.
+        Assert.Equal(
+            new[] { "R-101-102-A", "R-101-102-B", "R-101-124-A", "R-104-A", "R-111-A" },
+            S98DefaultRules.Default.Select(r => r.RuleId).ToArray());
+    }
+
+    [Fact]
+    public void Empty_rule_set_is_a_no_op()
+    {
+        var (areaLayer, lineLayer) = BuildS101LayersWithDepthFeatures();
+        var s102 = new MemoryLayer("s102");
+        var stack = new[]
+        {
+            new LayerStackEntry(areaLayer, S98DisplayPlane.BaseChartUnder, 0, "s101-cell.000", SourceFeatureType: "area"),
+            new LayerStackEntry(s102, S98DisplayPlane.Bathymetry, 0, "s102-tile.h5"),
+            new LayerStackEntry(lineLayer, S98DisplayPlane.BaseChartOver, 0, "s101-cell.000", SourceFeatureType: "linework"),
+        };
+
+        var ruled = _auth.ApplyRules(
+            stack,
+            new[]
+            {
+                new LoadedDatasetInfo("s101-cell.000", "S-101", Active: true),
+                new LoadedDatasetInfo("s102-tile.h5", "S-102", Active: true),
+            },
+            mariner: null,
+            rules: System.Array.Empty<S98InteroperabilityRule>());
+
+        // Same instances back — no rule fired.
+        Assert.Same(areaLayer, ruled[0].Layer);
+        Assert.Same(lineLayer, ruled[2].Layer);
+    }
+
+    // ----------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------
+
+    private static LayerStackEntry StackEntry(string id, S98DisplayPlane plane)
+        => new(new MemoryLayer(id), plane, 0, id);
+
+    /// <summary>
+    /// Builds two synthetic Mapsui layers that mirror what
+    /// <c>S101DatasetProcessor</c> produces after PR-L2 feature
+    /// tagging: an "areas" layer with a DepthArea + LandArea, and a
+    /// "linework" layer with one or more DepthContour features
+    /// plus a Coastline. Features carry only the metadata the
+    /// rule engine consults (S-100 feature type + VALDCO), not
+    /// real geometry — that's the rule contract.
+    /// </summary>
+    private static (MemoryLayer Areas, MemoryLayer Lines) BuildS101LayersWithDepthFeatures(
+        double[]? depthContoursMetres = null)
+    {
+        depthContoursMetres ??= new double[] { 10.0 };
+
+        var areaFeatures = new List<IFeature>
+        {
+            TaggedFeature("DepthArea"),
+            TaggedFeature("LandArea"),
+        };
+        var areas = new MemoryLayer
+        {
+            Name = "S-101 (areas)",
+            Features = areaFeatures,
+        };
+
+        var lineFeatures = new List<IFeature> { TaggedFeature("Coastline") };
+        foreach (var d in depthContoursMetres)
+        {
+            var f = TaggedFeature("DepthContour");
+            f[FeatureTagKeys.DepthContourValue] = d;
+            lineFeatures.Add(f);
+        }
+        var lines = new MemoryLayer
+        {
+            Name = "S-101 (lines)",
+            Features = lineFeatures,
+        };
+
+        return (areas, lines);
+    }
+
+    private static IFeature TaggedFeature(string featureType)
+    {
+        // PointFeature is the simplest IFeature in Mapsui — the rule
+        // engine only reads dictionary attributes, never geometry.
+        var f = new PointFeature(0, 0);
+        f[FeatureTagKeys.FeatureType] = featureType;
+        return f;
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -476,4 +476,66 @@ public class PickServiceTests
         Assert.Equal("fb", viewModel.PickReport.Hits[1].FeatureRef);
         Assert.Equal("fa", viewModel.PickReport.Hits[2].FeatureRef);
     }
+
+    [Fact]
+    public void HandlePick_AfterR_101_102_B_Suppression_ReturnsS102Hit()
+    {
+        // PR-L2 (S-98): when R-101-102-B suppresses S-101 DepthArea
+        // because an S-102 dataset is loaded, picking inside that area
+        // must return the S-102 feature (the now-topmost-visible hit
+        // at the pick location) — never the suppressed S-101 feature.
+        // We simulate the post-rule state: the stack contains a
+        // filtered S-101 areas layer (no DepthArea feature) and an
+        // S-102 layer above it. Mapsui consequently has no DepthArea
+        // feature to hit-test against; the pick resolves only to the
+        // S-102 record.
+        var viewModel = CreateMainViewModel();
+        var s101 = new DatasetEntry("/tmp/s101.000", "S-101");
+        var s102 = new DatasetEntry("/tmp/s102.h5", "S-102");
+
+        var procS101 = new StubProcessor("S-101", new FeatureInfo
+        {
+            FeatureRef = "land-1", FeatureType = "LandArea", FeatureTypeName = "Land Area",
+            Attributes = Array.Empty<PickAttribute>(),
+        });
+        var procS102 = new StubProcessor("S-102", new FeatureInfo
+        {
+            FeatureRef = "bathy-1", FeatureType = "BathymetryCoverage", FeatureTypeName = "Bathymetry",
+            Attributes = Array.Empty<PickAttribute>(),
+        });
+
+        var s101AreasFiltered = new MemoryLayer("s101.areas");
+        var s102Layer = new MemoryLayer("s102");
+
+        // Post-suppression stack: filtered S-101 areas (DepthArea gone)
+        // sits on plane BaseChartUnder; S-102 sits on plane Bathymetry
+        // above it.
+        var stack = new ILayer[] { s101AreasFiltered, s102Layer };
+
+        var loader = new StackAwareLoader(
+            new Dictionary<DatasetEntry, IDatasetProcessor>
+            {
+                [s101] = procS101,
+                [s102] = procS102,
+            },
+            new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>
+            {
+                [s101] = new[] { (ILayer)s101AreasFiltered },
+                [s102] = new[] { (ILayer)s102Layer },
+            },
+            stack);
+
+        var service = CreatePickService(loader, viewModel);
+
+        // Mapsui hit test produces only the S-102 record because the
+        // DepthArea feature is no longer in any visible layer.
+        service.HandlePick(BuildMapInfo(new[]
+        {
+            MakeRecord(s102Layer, "bathy-1"),
+        }));
+
+        Assert.Single(viewModel.PickReport.Hits);
+        Assert.Equal("bathy-1", viewModel.PickReport.Hits[0].FeatureRef);
+        Assert.Equal("BathymetryCoverage", viewModel.PickReport.FeatureType);
+    }
 }


### PR DESCRIPTION
Implements the five v1 inter-product rules from `docs/design/s98-interoperability.md` §3 on top of PR-L1's plane-assignment plumbing.

## Rules delivered

| Rule | Level | Effect | Spec |
|---|---|---|---|
| **R-101-102-A** | 1 | S-102 between S-101 area fills and line work | S-98 Main §9.2.1 |
| **R-101-102-B** | 2 | Suppress S-101 `DepthArea` + `DepthContour` when S-102 loaded and active (with safety-contour exception) | Annex A §8.4.1, Part B §B-3.1.2, MSC.232(82) §5.8 |
| **R-101-124-A** | 0 | S-124 on `CautionsAndWarnings` | Main §9.2.1, MSC.530(106)/Rev.1 |
| **R-104-A** | 1 | S-104 on `OnDemandSurface` | Annex A §A-6.9.1, Main §9.2.1 layer 6 |
| **R-111-A** | 1 | S-111 band on `OnDemandSurface`, arrows on `DynamicArrows` | Annex A §A-6.9.1 |

Four of the five are pure plane-order properties satisfied by PR-L1's default plane table; this PR pins them via tests. **R-101-102-B is the only mutating rule.**

## Suppression strategy: option (b) — feature-tag filtering

I chose option (b) (filter `IFeature`s by tag) over option (a) (re-run the portrayal pipeline with a suppression set) because:

- `S101DatasetProcessor` already maintains a lazy `_featureIndex` mapping `FeatureRef` → `Feature`. Tagging the emitted `IFeature`s with their feature-type code is one dictionary lookup per feature; no pipeline change.
- Option (a) would require re-rendering the entire ENC cell every time the loaded-dataset set changes (or every render). The briefing's perf-risk caveat about caching the rebuild becomes moot under (b).
- The rule effect builds a new `MemoryLayer` per affected S-101 entry, copying only surviving features. No per-feature plane metadata is introduced (TBD-5 stays out of scope).

The R-101-102-B effect honours the **MSC.232(82) §5.8 safety-contour exception**: any `DepthContour` whose `valueOfDepthContour` matches the current mariner `SafetyContour` (tolerance 1e-6) is retained even when others are suppressed.

## Wiring

- `S98InteroperabilityRule` is a record `(RuleId, SpecCitation, Condition, Effect)` — no DSL, no Part-16 dependency. Predicates and effects are plain delegates.
- `S98DefaultRules.Default` holds the five rules in declaration order (rules run in that order; pinned by `Default_rule_set_is_in_documented_order` test).
- `IInteroperabilityAuthority.ApplyRules(stack, loadedDatasets, mariner?, rules?)` added; `LoadOrderInteroperabilityAuthority` returns the stack untouched.
- `DatasetLoaderService.FlattenLayerOrder` calls `ApplyRules` after `LayerStackBuilder.Build`.
- `LoadedDatasetInfo.Active` maps 1:1 to `entry.IsVisible && layers.Count > 0` per briefing — real active/inactive lands with PR-L3 (Layer Controls UI).

## `TODO PR-L2-RESYNC` markers

Every IC element name introduced in this PR carries the resync marker so a future S-100 Part 16 sync can find them by `grep -r "TODO PR-L2-RESYNC"`:

- All 5 rule declarations in `S98DefaultRules.cs` (rule IDs)
- The suppressed-feature-type set inside `SuppressS101DepthFeatures`

## Tests

- `S98DefaultRulesTests.cs` (Pipelines, **11 tests**): plane-order property for all four anchor rules; R-101-102-B suppression on/off; safety-contour exception; `Active` flag honoured; rule composition declaration order; empty rule set is a no-op; `Default` ordering pin.
- `PickServiceTests.cs` (Viewer, **+1 test**): `HandlePick_AfterR_101_102_B_Suppression_ReturnsS102Hit` verifies picks over a suppressed `DepthArea` resolve to the S-102 hit.
- Full suite: **0 failures**, 280 viewer / 340 pipelines / all others passing.

## Visual regression

**No snapshots rebaselined.** Verified there are no existing fixtures that load S-101 + S-102 together; the new rule's first opportunity to affect rendered output is when such a fixture is added.

## Out of scope (per briefing)

- IC XML rule pack under `content/S98/` (lands when Part 16 is in hand — PR-L2a).
- Per-feature plane metadata (Annex A §4.3) — TBD-5.
- Layer Controls UI (PR-L3), PdC picker UX, IC validation against Part 16 XSD.

Refs: #117 (PR-L0 design note), #118 (PR-L1 plumbing).
