### PR TITLE
PR-L3 — Layer Controls UI

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadedDatasetInfo.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/LoadedDatasetInfo.cs
@@ -16,12 +16,31 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// Matches <see cref="EncDotNet.S100.Core.SpecRef.Name"/>.
 /// </param>
 /// <param name="Active">
-/// Whether this dataset is currently active for display. PR-L2
-/// treats "loaded" as "active" (PR-L1 has no separate active/inactive
-/// concept); the field is wired through so PR-L3's Layer Controls UI
-/// can flip individual datasets off without re-loading. A rule that
-/// suppresses S-101 features when S-102 is loaded must only fire
-/// when the S-102 dataset is <c>Active</c>; an inactive S-102 must
-/// not suppress S-101.
+/// Whether this dataset is currently active for display. The Active
+/// flag is in-memory only (PR-L3); the Layer Controls UI toggles it
+/// via <c>IDatasetLoaderService.SetActive</c>. A rule that suppresses
+/// S-101 features when S-102 is loaded must only fire when the S-102
+/// dataset is <c>Active</c>; an inactive S-102 must not suppress
+/// S-101.
+/// <para>
+/// <strong>Active vs <c>DatasetEntry.IsVisible</c>.</strong> The two
+/// flags are independent and serve different layers of the stack:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <c>DatasetEntry.IsVisible</c> is a purely visual toggle that
+///     hides / shows the rendered Mapsui layers without affecting
+///     anything else — useful for quickly peeking at what lies
+///     beneath one dataset.
+///   </item>
+///   <item>
+///     <c>Active</c> controls whether the dataset participates in
+///     S-98 inter-product rule evaluation (e.g. S-102 suppressing
+///     S-101 depth features) and in pick. An inactive dataset is
+///     fully removed from the cross-product stack — its layers
+///     don't paint and its presence doesn't influence sibling
+///     products. PR-L4 will persist Active in <c>ViewerSettings</c>.
+///   </item>
+/// </list>
 /// </param>
 public sealed record LoadedDatasetInfo(string DatasetId, string ProductSpec, bool Active);

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -240,6 +240,7 @@ public partial class App : Application
         services.AddSingleton<PortrayalCataloguesViewModel>();
         services.AddSingleton<DatasetsViewModel>();
         services.AddSingleton<CatalogPanelViewModel>();
+        services.AddSingleton<LayerStackViewModel>();
         services.AddSingleton<FeatureSearchViewModel>();
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<IMarinerSettingsProvider, MarinerSettingsProvider>();

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -274,6 +274,23 @@
                         </ToggleButton>
                     </Grid>
 
+                    <!-- Layer Stack -->
+                    <Grid>
+                        <Border Width="3" HorizontalAlignment="Left"
+                                Background="{DynamicResource AccentBrush}"
+                                IsVisible="{Binding IsLayerStackSelected}" />
+                        <ToggleButton Classes="ActivityIcon"
+                                      IsChecked="{Binding IsLayerStackSelected, Mode=OneWay}"
+                                      Command="{Binding SelectLayerStackCommand}"
+                                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_LayerStack}"
+                                      Height="48"
+                                      Padding="0"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center">
+                            <ic:FluentIcon Icon="Stack" IconVariant="Regular" FontSize="22" />
+                        </ToggleButton>
+                    </Grid>
+
                     <!-- Search -->
                     <Grid>
                         <Border Width="3" HorizontalAlignment="Left"
@@ -353,6 +370,8 @@
                                             IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsDatasetsSelected}" />
                         <views:CatalogPanelView DataContext="{Binding CatalogPanel}"
                                                 IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsCatalogSelected}" />
+                        <views:LayerStackView DataContext="{Binding LayerStack}"
+                                              IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsLayerStackSelected}" />
                         <views:FeatureSearchView DataContext="{Binding Search}"
                                                  IsVisible="{Binding $parent[shadui:Window].((vm:MainViewModel)DataContext).IsSearchSelected}" />
                         <views:SettingsView DataContext="{Binding Settings}"

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -54,6 +54,25 @@ internal static class Strings
     public static string Pane_Catalog => Get(nameof(Pane_Catalog));
     public static string Pane_Settings => Get(nameof(Pane_Settings));
     public static string Pane_Search => Get(nameof(Pane_Search));
+    public static string Pane_LayerStack => Get(nameof(Pane_LayerStack));
+
+    // Layer Stack panel (PR-L3)
+    public static string LayerStack_PanelTitle => Get(nameof(LayerStack_PanelTitle));
+    public static string LayerStack_ShowEmptyPlanes => Get(nameof(LayerStack_ShowEmptyPlanes));
+    public static string LayerStack_EmptyPlane_Placeholder => Get(nameof(LayerStack_EmptyPlane_Placeholder));
+    public static string LayerStack_ActiveTooltip => Get(nameof(LayerStack_ActiveTooltip));
+    public static string LayerStack_VisibilityVsActive_HelpText => Get(nameof(LayerStack_VisibilityVsActive_HelpText));
+    public static string LayerStack_ChildCountFormat => Get(nameof(LayerStack_ChildCountFormat));
+    public static string LayerStack_PriorityFormat => Get(nameof(LayerStack_PriorityFormat));
+    public static string LayerStack_Plane_BaseChartUnder => Get(nameof(LayerStack_Plane_BaseChartUnder));
+    public static string LayerStack_Plane_Bathymetry => Get(nameof(LayerStack_Plane_Bathymetry));
+    public static string LayerStack_Plane_OnDemandSurface => Get(nameof(LayerStack_Plane_OnDemandSurface));
+    public static string LayerStack_Plane_BaseChartOver => Get(nameof(LayerStack_Plane_BaseChartOver));
+    public static string LayerStack_Plane_OtherChartOverlays => Get(nameof(LayerStack_Plane_OtherChartOverlays));
+    public static string LayerStack_Plane_CautionsAndWarnings => Get(nameof(LayerStack_Plane_CautionsAndWarnings));
+    public static string LayerStack_Plane_DynamicArrows => Get(nameof(LayerStack_Plane_DynamicArrows));
+    public static string LayerStack_Plane_MarinerOverlay => Get(nameof(LayerStack_Plane_MarinerOverlay));
+    public static string LayerStack_Plane_EcdisAlerts => Get(nameof(LayerStack_Plane_EcdisAlerts));
 
     // Search
     public static string Search_Placeholder => Get(nameof(Search_Placeholder));
@@ -68,6 +87,7 @@ internal static class Strings
     public static string Tooltip_PortrayalCatalogues => Get(nameof(Tooltip_PortrayalCatalogues));
     public static string Tooltip_Datasets => Get(nameof(Tooltip_Datasets));
     public static string Tooltip_Catalog => Get(nameof(Tooltip_Catalog));
+    public static string Tooltip_LayerStack => Get(nameof(Tooltip_LayerStack));
     public static string Tooltip_PickMode => Get(nameof(Tooltip_PickMode));
     public static string Tooltip_ZoomIn => Get(nameof(Tooltip_ZoomIn));
     public static string Tooltip_ZoomOut => Get(nameof(Tooltip_ZoomOut));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -42,6 +42,61 @@
   <data name="Pane_Search" xml:space="preserve">
     <value>SEARCH</value>
   </data>
+  <data name="Pane_LayerStack" xml:space="preserve">
+    <value>LAYER STACK</value>
+  </data>
+
+  <!-- Layer Stack panel (PR-L3) -->
+  <data name="LayerStack_PanelTitle" xml:space="preserve">
+    <value>Layer Stack</value>
+  </data>
+  <data name="LayerStack_ShowEmptyPlanes" xml:space="preserve">
+    <value>Show empty planes</value>
+  </data>
+  <data name="LayerStack_EmptyPlane_Placeholder" xml:space="preserve">
+    <value>No datasets loaded.</value>
+  </data>
+  <data name="LayerStack_ActiveTooltip" xml:space="preserve">
+    <value>Active — when off, this dataset is removed from the cross-product paint stack and no longer influences S-98 interoperability rules or pick. Distinct from the per-dataset Visibility toggle on the Datasets panel.</value>
+  </data>
+  <data name="LayerStack_VisibilityVsActive_HelpText" xml:space="preserve">
+    <value>Active controls participation in S-98 rules and pick; Visibility (on the Datasets panel) only hides the rendered layers.</value>
+  </data>
+  <data name="LayerStack_ChildCountFormat" xml:space="preserve">
+    <value>{0}</value>
+    <comment>{0} = number of layer entries in this S-98 display plane.</comment>
+  </data>
+  <data name="LayerStack_PriorityFormat" xml:space="preserve">
+    <value>#{0}</value>
+    <comment>{0} = within-plane priority (S-100 Part 9 §10 drawingPriority).</comment>
+  </data>
+  <data name="LayerStack_Plane_BaseChartUnder" xml:space="preserve">
+    <value>Base chart (under)</value>
+  </data>
+  <data name="LayerStack_Plane_Bathymetry" xml:space="preserve">
+    <value>Bathymetry</value>
+  </data>
+  <data name="LayerStack_Plane_OnDemandSurface" xml:space="preserve">
+    <value>On-demand surface</value>
+  </data>
+  <data name="LayerStack_Plane_BaseChartOver" xml:space="preserve">
+    <value>Base chart (over)</value>
+  </data>
+  <data name="LayerStack_Plane_OtherChartOverlays" xml:space="preserve">
+    <value>Other chart overlays</value>
+  </data>
+  <data name="LayerStack_Plane_CautionsAndWarnings" xml:space="preserve">
+    <value>Cautions and warnings</value>
+  </data>
+  <data name="LayerStack_Plane_DynamicArrows" xml:space="preserve">
+    <value>Dynamic arrows</value>
+  </data>
+  <data name="LayerStack_Plane_MarinerOverlay" xml:space="preserve">
+    <value>Mariner overlay</value>
+  </data>
+  <data name="LayerStack_Plane_EcdisAlerts" xml:space="preserve">
+    <value>ECDIS alerts</value>
+  </data>
 
   <!-- Search panel -->
   <data name="Search_Placeholder" xml:space="preserve">
@@ -75,6 +130,9 @@
   </data>
   <data name="Tooltip_Catalog" xml:space="preserve">
     <value>Dataset Catalog</value>
+  </data>
+  <data name="Tooltip_LayerStack" xml:space="preserve">
+    <value>Layer Stack</value>
   </data>
   <data name="Tooltip_PickMode" xml:space="preserve">
     <value>Pick Mode (I) — single-tap to identify features</value>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -68,6 +68,23 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     /// </summary>
     private IReadOnlyList<ILayer> _currentStackedLayers = Array.Empty<ILayer>();
     /// <summary>
+    /// Snapshot of the most recently computed S-98 layer stack as
+    /// <see cref="LayerStackEntry"/> records (bottom-of-paint-stack
+    /// first). Same order as <see cref="_currentStackedLayers"/>;
+    /// the Layer Stack panel
+    /// (<see cref="ViewModels.LayerStackViewModel"/>) groups these
+    /// by <see cref="S98DisplayPlane"/> for the tree view.
+    /// </summary>
+    private IReadOnlyList<LayerStackEntry> _currentStackEntries = Array.Empty<LayerStackEntry>();
+    /// <summary>
+    /// In-memory per-dataset Active flags. Keyed by dataset id (the
+    /// same identifier produced by <see cref="EntryId"/>). Missing
+    /// entries default to <c>true</c>. Process-local for PR-L3; PR-L4
+    /// will persist in <see cref="ViewerSettings"/>.
+    /// </summary>
+    // TODO PR-L4: persist Active in ViewerSettings
+    private readonly Dictionary<string, bool> _activeFlags = new(StringComparer.Ordinal);
+    /// <summary>
     /// Per-entry sub-layer keys, parallel by index to
     /// <see cref="_entryLayers"/>. Null when the processor did not
     /// supply per-layer names (single-layer products).
@@ -151,7 +168,32 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     public IReadOnlyList<ILayer> CurrentStackedLayers => _currentStackedLayers;
 
+    public IReadOnlyList<LayerStackEntry> CurrentStackEntries => _currentStackEntries;
+
     public event Action? LayerStackChanged;
+
+    public event Action<string>? ActiveChanged;
+
+    public bool GetActive(string datasetId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(datasetId);
+        return !_activeFlags.TryGetValue(datasetId, out var v) || v;
+    }
+
+    public void SetActive(string datasetId, bool active)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(datasetId);
+        var previous = GetActive(datasetId);
+        if (previous == active) return;
+        _activeFlags[datasetId] = active;
+        // Recompute the cross-product stack so R-101-102-B (and any
+        // future Active-aware rules) re-evaluates with the new
+        // flag, and rebroadcast it through the map host so PickService
+        // / Layer Stack panel see the change.
+        if (_mapHost is not null)
+            _mapHost.ReorderDatasetLayers(FlattenLayerOrder());
+        ActiveChanged?.Invoke(datasetId);
+    }
 
     public event Action<DatasetEntry>? DatasetLoaded;
 
@@ -485,6 +527,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             entry.PropertyChanged -= OnEntryPropertyChanged;
         _processors.Remove(entry);
         _entryOrder.Remove(entry);
+        _activeFlags.Remove(EntryId(entry));
         _globalTime.Unregister(entry);
         _s128CatalogSource.RemoveDataset(entry.DisplayName);
         // Publish the new (empty / smaller) stack so PickService and
@@ -531,6 +574,14 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             var entry = _entryOrder[i];
             if (!_entryLayers.TryGetValue(entry, out var layers)) continue;
 
+            // PR-L3: an inactive dataset is removed entirely from the
+            // cross-product paint stack — its layers don't paint and
+            // it doesn't influence R-101-102-B / siblings (that
+            // happens via BuildLoadedDatasetInfos below; this branch
+            // also stops the layers from being drawn at all).
+            var datasetId = EntryId(entry);
+            if (!GetActive(datasetId)) continue;
+
             if (_entryStackEntries.TryGetValue(entry, out var stack) && stack.Count > 0)
             {
                 perDataset.Add(stack);
@@ -551,7 +602,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                         Layer: l,
                         Plane: plane,
                         WithinPlanePriority: 0,
-                        SourceDatasetId: entry.FilePath ?? entry.DisplayName));
+                        SourceDatasetId: datasetId));
                 }
                 perDataset.Add(synth);
             }
@@ -572,16 +623,27 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
         var list = LayerStackBuilder.ToLayerList(ruled);
         _currentStackedLayers = list;
+        _currentStackEntries = ruled;
         LayerStackChanged?.Invoke();
         return list;
     }
 
     /// <summary>
+    /// Stable per-entry identifier matching
+    /// <see cref="LayerStackEntry.SourceDatasetId"/>. Used both as
+    /// the key for <see cref="_activeFlags"/> and as the dataset id
+    /// passed to <see cref="IInteroperabilityAuthority"/> rules.
+    /// </summary>
+    private static string EntryId(DatasetEntry entry) =>
+        entry.FilePath ?? entry.DisplayName;
+
+    /// <summary>
     /// Builds the snapshot of <see cref="LoadedDatasetInfo"/> values
-    /// the S-98 rule engine consumes. PR-L2 treats "loaded" as
-    /// "active" — there is no separate active/inactive concept yet
-    /// (PR-L3's Layer Controls UI will add one). An inactive entry
-    /// suppresses every rule that depends on its product.
+    /// the S-98 rule engine consumes. <c>Active</c> combines the
+    /// PR-L3 in-memory flag, the existing <c>DatasetEntry.IsVisible</c>
+    /// proxy, and a "did the processor actually produce layers?"
+    /// check so a failed render doesn't accidentally suppress
+    /// sibling products.
     /// </summary>
     private IReadOnlyList<LoadedDatasetInfo> BuildLoadedDatasetInfos()
     {
@@ -589,13 +651,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         foreach (var entry in _entryOrder)
         {
             if (!_processors.TryGetValue(entry, out var proc)) continue;
-            // PR-L2: "loaded == active" — IsVisible is the closest
-            // viewer-side proxy for "currently displayed". An entry
-            // whose layer collection is empty (failed render) is
-            // treated as inactive so its absence doesn't accidentally
-            // suppress sibling products.
-            var datasetId = entry.FilePath ?? entry.DisplayName;
-            var active = entry.IsVisible
+            var datasetId = EntryId(entry);
+            var active = GetActive(datasetId)
+                && entry.IsVisible
                 && _entryLayers.TryGetValue(entry, out var layers)
                 && layers.Count > 0;
             result.Add(new LoadedDatasetInfo(datasetId, proc.Spec.Name, active));

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -565,22 +565,20 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         // (and lands at the highest layer index — drawn last, on
         // top), preserving the prior behaviour for single-plane
         // dataset stacks.
+        //
+        // PR-L3: we keep building the FULL plane-sorted list of
+        // entries (including inactive datasets) so the Layer Stack
+        // panel can still show their rows and let the user re-enable
+        // them. Only the rendered layer list (returned to the map
+        // host) is filtered to active entries; the snapshot stored
+        // in <see cref="_currentStackEntries"/> retains every entry.
         var perDataset = new List<IReadOnlyList<LayerStackEntry>>(_entryOrder.Count);
-        // _entryOrder is already top-of-UI first, which is exactly
-        // what LayerStackBuilder.Build expects. It internally walks
-        // bottom-up so the top-of-UI dataset wins within-plane ties.
         for (int i = 0; i < _entryOrder.Count; i++)
         {
             var entry = _entryOrder[i];
             if (!_entryLayers.TryGetValue(entry, out var layers)) continue;
 
-            // PR-L3: an inactive dataset is removed entirely from the
-            // cross-product paint stack — its layers don't paint and
-            // it doesn't influence R-101-102-B / siblings (that
-            // happens via BuildLoadedDatasetInfos below; this branch
-            // also stops the layers from being drawn at all).
             var datasetId = EntryId(entry);
-            if (!GetActive(datasetId)) continue;
 
             if (_entryStackEntries.TryGetValue(entry, out var stack) && stack.Count > 0)
             {
@@ -621,9 +619,23 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         var loaded = BuildLoadedDatasetInfos();
         var ruled = authority.ApplyRules(sorted, loaded, _marinerSettings.Current);
 
-        var list = LayerStackBuilder.ToLayerList(ruled);
-        _currentStackedLayers = list;
+        // Cache the FULL ruled list (including inactive datasets) for
+        // the Layer Stack panel.
         _currentStackEntries = ruled;
+
+        // PR-L3: filter inactive datasets out of the rendered layer
+        // list handed back to the map host. The active flag is the
+        // single source of truth: inactive entries don't paint and
+        // don't influence pick.
+        var renderEntries = new List<LayerStackEntry>(ruled.Count);
+        foreach (var e in ruled)
+        {
+            if (!GetActive(e.SourceDatasetId)) continue;
+            renderEntries.Add(e);
+        }
+
+        var list = LayerStackBuilder.ToLayerList(renderEntries);
+        _currentStackedLayers = list;
         LayerStackChanged?.Invoke();
         return list;
     }
@@ -635,7 +647,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     /// passed to <see cref="IInteroperabilityAuthority"/> rules.
     /// </summary>
     private static string EntryId(DatasetEntry entry) =>
-        entry.FilePath ?? entry.DisplayName;
+        entry.FilePath is { } p && p.Length > 0
+            ? System.IO.Path.GetFileName(p)
+            : entry.DisplayName;
 
     /// <summary>
     /// Builds the snapshot of <see cref="LoadedDatasetInfo"/> values

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui.Layers;
 
@@ -69,25 +70,49 @@ internal interface IDatasetLoaderService
     /// <see cref="PickService"/> so multi-hit picks return top-of-stack
     /// hits first.
     /// </summary>
-    /// <remarks>
-    /// Default implementation returns an empty list so test doubles
-    /// that don't care about layer ordering needn't override it.
-    /// </remarks>
-    IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+    IReadOnlyList<ILayer> CurrentStackedLayers { get; }
 
     /// <summary>
-    /// Raised after <see cref="CurrentStackedLayers"/> has been
-    /// recomputed (any load, remove, re-render, or reorder).
+    /// Rich snapshot of the current S-98-ordered layer stack — same
+    /// order as <see cref="CurrentStackedLayers"/> but each entry
+    /// also carries its <see cref="S98DisplayPlane"/>, within-plane
+    /// priority, source dataset id, and (where applicable) source
+    /// feature type. Consumed by the Layer Stack panel
+    /// (<see cref="LayerStackViewModel"/>) to group rows by plane
+    /// and label each row with its provenance.
     /// </summary>
-    /// <remarks>
-    /// Default implementation is a no-op event so test doubles that
-    /// don't fire layer-stack notifications needn't override it.
-    /// </remarks>
-    event Action? LayerStackChanged
-    {
-        add { }
-        remove { }
-    }
+    IReadOnlyList<LayerStackEntry> CurrentStackEntries { get; }
+
+    /// <summary>
+    /// Raised after <see cref="CurrentStackedLayers"/> /
+    /// <see cref="CurrentStackEntries"/> have been recomputed (any
+    /// load, remove, re-render, reorder, or Active-flag toggle).
+    /// </summary>
+    event Action? LayerStackChanged;
+
+    /// <summary>
+    /// Returns whether the supplied dataset is currently <em>active</em>
+    /// for S-98 interoperability (i.e. participates in rule evaluation
+    /// and pick). Unknown ids default to active. See
+    /// <see cref="LoadedDatasetInfo.Active"/> for the distinction
+    /// between Active and <see cref="DatasetEntry.IsVisible"/>.
+    /// </summary>
+    bool GetActive(string datasetId);
+
+    /// <summary>
+    /// Sets the in-memory Active flag for the supplied dataset id and,
+    /// if the value changed, re-evaluates the S-98 layer stack and
+    /// fires <see cref="LayerStackChanged"/> and
+    /// <see cref="ActiveChanged"/>. The Active flag is process-local;
+    /// PR-L4 will persist it via <c>ViewerSettings</c>.
+    /// </summary>
+    void SetActive(string datasetId, bool active);
+
+    /// <summary>
+    /// Raised when <see cref="SetActive"/> changes a dataset's Active
+    /// flag. The string argument is the dataset id whose state flipped.
+    /// </summary>
+    event Action<string>? ActiveChanged;
 
     /// <summary>
     /// Raised on the calling thread (typically the UI thread) immediately

--- a/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
@@ -31,10 +31,16 @@ internal interface IMapHost
     void RemoveLayer(ILayer layer);
 
     /// <summary>
-    /// Replaces the paint order of the host's dataset layers with the
-    /// supplied sequence, preserving the relative position of the
-    /// basemap (below) and any overlays (above). Layers not present in
-    /// the host's dataset set are ignored.
+    /// Replaces the host's dataset-layer slice with the supplied
+    /// sequence, preserving the relative position of the basemap
+    /// (below) and any tool overlays (above). The supplied list is
+    /// <b>authoritative</b>: any previously-tracked dataset layer not
+    /// present in the new sequence is removed from the map, and any
+    /// layer in the new sequence that the host has not seen before
+    /// (e.g. a rule-filtered MemoryLayer replica) is inserted and
+    /// tracked. Callers therefore use this method both to reorder and
+    /// to hide/replace dataset layers — including swapping out inactive
+    /// datasets when the user toggles their Active flag.
     /// </summary>
     void ReorderDatasetLayers(System.Collections.Generic.IReadOnlyList<ILayer> orderedDatasetLayers);
 

--- a/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
@@ -71,23 +71,31 @@ internal sealed class MapsuiMapHost : IMapHost
         }
         if (insertAt < 0) insertAt = Math.Min(1, map.Layers.Count);
 
-        // Remove every dataset layer (in any order) then re-insert in
-        // the requested order at the captured base index. Layers in
-        // `orderedDatasetLayers` that the host has never seen are
-        // skipped — the contract says they're ignored.
-        foreach (var l in orderedDatasetLayers)
+        // PR-L3 fix: treat the supplied list as the **authoritative**
+        // dataset-layer slice of <c>map.Layers</c>.
+        //
+        // 1. Any previously-known dataset layer that is NOT in the new
+        //    list must be removed from the map (e.g. a dataset whose
+        //    Active flag was just toggled off, or whose original layer
+        //    instance was just replaced by a rule-filtered MemoryLayer
+        //    such as the one produced by R-101-102-B).
+        // 2. Conversely, layers in the new list that the host has not
+        //    seen before — typically the rule-filtered replicas — must
+        //    be inserted *and* tracked so the next reorder cycle treats
+        //    them correctly.
+        foreach (var existing in _datasetLayers)
         {
-            if (_datasetLayers.Contains(l))
-                map.Layers.Remove(l);
+            map.Layers.Remove(existing);
         }
+        _datasetLayers.Clear();
+
         int idx = insertAt;
         foreach (var l in orderedDatasetLayers)
         {
-            if (_datasetLayers.Contains(l))
-            {
-                if (idx > map.Layers.Count) idx = map.Layers.Count;
-                map.Layers.Insert(idx++, l, 0);
-            }
+            if (l is null) continue;
+            if (idx > map.Layers.Count) idx = map.Layers.Count;
+            map.Layers.Insert(idx++, l, 0);
+            _datasetLayers.Add(l);
         }
     }
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/ActivityKind.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ActivityKind.cs
@@ -9,4 +9,5 @@ internal enum ActivityKind
     Search,
     Settings,
     EcdisDisplay,
+    LayerStack,
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/LayerStackViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/LayerStackViewModel.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Threading;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Interoperability;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// View model for the Layer Stack panel (PR-L3). Subscribes to
+/// <see cref="IDatasetLoaderService.LayerStackChanged"/> and reflects
+/// the rich <see cref="LayerStackEntry"/> snapshot from
+/// <see cref="IDatasetLoaderService.CurrentStackEntries"/> as a list
+/// of <see cref="LayerStackPlaneViewModel"/> groups — one per
+/// <see cref="S98DisplayPlane"/> — ordered top-of-stack first
+/// (S-98 §A-3.2.1.1 + MSC.530(106)/Rev.1 §Appendix 2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Empty planes (those with no entries) are hidden by default. The
+/// user can flip the <see cref="ShowEmptyPlanes"/> toggle to see
+/// every canonical S-98 plane regardless.
+/// </para>
+/// <para>
+/// Per-plane expansion state is preserved across rebuilds keyed by
+/// the plane enum value so a load/remove/active-toggle doesn't
+/// collapse the user's previously expanded planes.
+/// </para>
+/// </remarks>
+internal sealed class LayerStackViewModel : ViewModelBase
+{
+    private readonly IDatasetLoaderService _loader;
+    private readonly ITimeFormatProvider? _timeFormat;
+    // PR-L4 reserve: kept on the field so the constructor still
+    // captures it. _ = is enough to suppress unused-field warnings.
+    // The plan reserves ITimeFormatProvider for time-aware status
+    // text on per-entry rows.
+
+    /// <summary>Plane group order: top-of-paint-stack first.</summary>
+    private static readonly S98DisplayPlane[] PlanesTopFirst =
+    {
+        S98DisplayPlane.EcdisAlerts,
+        S98DisplayPlane.MarinerOverlay,
+        S98DisplayPlane.DynamicArrows,
+        S98DisplayPlane.CautionsAndWarnings,
+        S98DisplayPlane.OtherChartOverlays,
+        S98DisplayPlane.BaseChartOver,
+        S98DisplayPlane.OnDemandSurface,
+        S98DisplayPlane.Bathymetry,
+        S98DisplayPlane.BaseChartUnder,
+    };
+
+    public ObservableCollection<LayerStackPlaneViewModel> Planes { get; } = new();
+
+    private readonly Dictionary<S98DisplayPlane, bool> _planeExpansion = new();
+
+    private bool _showEmptyPlanes;
+    /// <summary>
+    /// When true the panel shows every canonical S-98 display plane
+    /// even if no loaded dataset contributes layers to it. Default
+    /// false to keep the tree compact for typical single-product
+    /// sessions.
+    /// </summary>
+    public bool ShowEmptyPlanes
+    {
+        get => _showEmptyPlanes;
+        set
+        {
+            if (SetProperty(ref _showEmptyPlanes, value))
+            {
+                Rebuild();
+                OnPropertyChanged(nameof(IsEmpty));
+            }
+        }
+    }
+
+    /// <summary>True when no plane row is currently displayed.</summary>
+    public bool IsEmpty => Planes.Count == 0;
+
+    /// <summary>Empty-state body text (S-128 PdC picker arrives in PR-L4).</summary>
+    public string EmptyMessage => Strings.LayerStack_EmptyPlane_Placeholder;
+
+    /// <summary>"Active vs. Visibility" help text for the panel footer.</summary>
+    public string ActiveVsVisibilityHelp => Strings.LayerStack_VisibilityVsActive_HelpText;
+
+    public LayerStackViewModel(IDatasetLoaderService loader, ITimeFormatProvider? timeFormat = null)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+        _loader = loader;
+        _timeFormat = timeFormat;
+        _ = _timeFormat; // reserved for PR-L4 per-entry timestamp display
+        _loader.LayerStackChanged += OnLayerStackChanged;
+        Rebuild();
+    }
+
+    private void OnLayerStackChanged()
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            Rebuild();
+        else
+            Dispatcher.UIThread.Post(Rebuild);
+    }
+
+    /// <summary>
+    /// Rebuilds the plane tree from the loader's current
+    /// <see cref="LayerStackEntry"/> snapshot. Preserves
+    /// <see cref="LayerStackPlaneViewModel.IsExpanded"/> per plane
+    /// across rebuilds via <see cref="_planeExpansion"/>.
+    /// </summary>
+    public void Rebuild()
+    {
+        // Snapshot expansion state from existing plane VMs so it
+        // survives the collection reset.
+        foreach (var existing in Planes)
+            _planeExpansion[existing.Plane] = existing.IsExpanded;
+
+        Planes.Clear();
+
+        var entries = _loader.CurrentStackEntries;
+        // Group by plane preserving entry order (bottom-of-paint-stack
+        // first → within-plane priority asc, which is the order the
+        // authority hands them back).
+        var byPlane = new Dictionary<S98DisplayPlane, List<LayerStackEntry>>();
+        foreach (var e in entries)
+        {
+            if (!byPlane.TryGetValue(e.Plane, out var list))
+            {
+                list = new List<LayerStackEntry>();
+                byPlane[e.Plane] = list;
+            }
+            list.Add(e);
+        }
+
+        foreach (var plane in PlanesTopFirst)
+        {
+            byPlane.TryGetValue(plane, out var planeEntries);
+            var planeEntriesList = planeEntries ?? new List<LayerStackEntry>();
+            if (planeEntriesList.Count == 0 && !_showEmptyPlanes) continue;
+
+            // Within-plane order: render the child list top-of-plane
+            // first (highest WithinPlanePriority first) so the tree
+            // reads like the paint stack — top wins.
+            var children = planeEntriesList
+                .OrderByDescending(e => e.WithinPlanePriority)
+                .ThenBy(e => e.SourceDatasetId, StringComparer.Ordinal)
+                .Select(e => new LayerStackEntryViewModel(_loader, e))
+                .ToList();
+
+            var isExpanded = !_planeExpansion.TryGetValue(plane, out var prev) || prev;
+            var vm = new LayerStackPlaneViewModel(plane, children, isExpanded);
+            Planes.Add(vm);
+        }
+
+        OnPropertyChanged(nameof(IsEmpty));
+    }
+}
+
+/// <summary>
+/// One <see cref="S98DisplayPlane"/> group row in the Layer Stack
+/// panel — its title, contributing entries, expansion state, and
+/// child count.
+/// </summary>
+internal sealed class LayerStackPlaneViewModel : ViewModelBase
+{
+    public S98DisplayPlane Plane { get; }
+    public IReadOnlyList<LayerStackEntryViewModel> Children { get; }
+
+    public string Title => Plane switch
+    {
+        S98DisplayPlane.BaseChartUnder => Strings.LayerStack_Plane_BaseChartUnder,
+        S98DisplayPlane.Bathymetry => Strings.LayerStack_Plane_Bathymetry,
+        S98DisplayPlane.OnDemandSurface => Strings.LayerStack_Plane_OnDemandSurface,
+        S98DisplayPlane.BaseChartOver => Strings.LayerStack_Plane_BaseChartOver,
+        S98DisplayPlane.OtherChartOverlays => Strings.LayerStack_Plane_OtherChartOverlays,
+        S98DisplayPlane.CautionsAndWarnings => Strings.LayerStack_Plane_CautionsAndWarnings,
+        S98DisplayPlane.DynamicArrows => Strings.LayerStack_Plane_DynamicArrows,
+        S98DisplayPlane.MarinerOverlay => Strings.LayerStack_Plane_MarinerOverlay,
+        S98DisplayPlane.EcdisAlerts => Strings.LayerStack_Plane_EcdisAlerts,
+        _ => Plane.ToString(),
+    };
+
+    public int ChildCount => Children.Count;
+
+    public string ChildCountText => string.Format(
+        System.Globalization.CultureInfo.CurrentCulture,
+        Strings.LayerStack_ChildCountFormat, ChildCount);
+
+    public bool IsEmpty => Children.Count == 0;
+
+    private bool _isExpanded;
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set => SetProperty(ref _isExpanded, value);
+    }
+
+    public LayerStackPlaneViewModel(
+        S98DisplayPlane plane,
+        IReadOnlyList<LayerStackEntryViewModel> children,
+        bool isExpanded)
+    {
+        Plane = plane;
+        Children = children;
+        _isExpanded = isExpanded;
+    }
+}
+
+/// <summary>
+/// One <see cref="LayerStackEntry"/> child row — its source
+/// dataset id, optional source feature type, within-plane priority,
+/// and a two-way bound <see cref="IsActive"/> checkbox routed
+/// through <see cref="IDatasetLoaderService.SetActive"/>.
+/// </summary>
+internal sealed class LayerStackEntryViewModel : ViewModelBase
+{
+    private readonly IDatasetLoaderService _loader;
+    public LayerStackEntry Entry { get; }
+
+    public string DatasetId => Entry.SourceDatasetId;
+
+    public string DatasetLabel
+    {
+        get
+        {
+            // Show just the file name for typical file paths to keep
+            // the tree narrow; tooltip carries the full id.
+            try { return System.IO.Path.GetFileName(Entry.SourceDatasetId) is { Length: > 0 } n ? n : Entry.SourceDatasetId; }
+            catch { return Entry.SourceDatasetId; }
+        }
+    }
+
+    public string? SourceFeatureType => Entry.SourceFeatureType;
+
+    public bool HasSourceFeatureType => !string.IsNullOrEmpty(Entry.SourceFeatureType);
+
+    public int WithinPlanePriority => Entry.WithinPlanePriority;
+
+    public string PriorityText => string.Format(
+        System.Globalization.CultureInfo.CurrentCulture,
+        Strings.LayerStack_PriorityFormat, Entry.WithinPlanePriority);
+
+    public bool IsActive
+    {
+        get => _loader.GetActive(Entry.SourceDatasetId);
+        set
+        {
+            if (_loader.GetActive(Entry.SourceDatasetId) == value) return;
+            _loader.SetActive(Entry.SourceDatasetId, value);
+            OnPropertyChanged();
+        }
+    }
+
+    public LayerStackEntryViewModel(IDatasetLoaderService loader, LayerStackEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+        ArgumentNullException.ThrowIfNull(entry);
+        _loader = loader;
+        Entry = entry;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -22,6 +22,7 @@ internal sealed class MainViewModel : ViewModelBase
     public PortrayalCataloguesViewModel PortrayalCatalogues { get; }
     public DatasetsViewModel Datasets { get; }
     public CatalogPanelViewModel CatalogPanel { get; }
+    public LayerStackViewModel LayerStack { get; }
     public FeatureSearchViewModel Search { get; }
     public SettingsViewModel Settings { get; }
     public PickReportViewModel PickReport { get; }
@@ -48,6 +49,7 @@ internal sealed class MainViewModel : ViewModelBase
                 OnPropertyChanged(nameof(IsPortrayalCataloguesSelected));
                 OnPropertyChanged(nameof(IsDatasetsSelected));
                 OnPropertyChanged(nameof(IsCatalogSelected));
+                OnPropertyChanged(nameof(IsLayerStackSelected));
                 OnPropertyChanged(nameof(IsSearchSelected));
                 OnPropertyChanged(nameof(IsSettingsSelected));
                 OnPropertyChanged(nameof(IsEcdisDisplaySelected));
@@ -67,6 +69,7 @@ internal sealed class MainViewModel : ViewModelBase
         ActivityKind.PortrayalCatalogues => Strings.Pane_PortrayalCatalogues,
         ActivityKind.Datasets => Strings.Pane_Datasets,
         ActivityKind.Catalog => Strings.Pane_Catalog,
+        ActivityKind.LayerStack => Strings.Pane_LayerStack,
         ActivityKind.Search => Strings.Pane_Search,
         ActivityKind.Settings => Strings.Pane_Settings,
         ActivityKind.EcdisDisplay => Strings.Pane_EcdisDisplay,
@@ -77,6 +80,7 @@ internal sealed class MainViewModel : ViewModelBase
     public bool IsPortrayalCataloguesSelected => _selectedActivity == ActivityKind.PortrayalCatalogues;
     public bool IsDatasetsSelected => _selectedActivity == ActivityKind.Datasets;
     public bool IsCatalogSelected => _selectedActivity == ActivityKind.Catalog;
+    public bool IsLayerStackSelected => _selectedActivity == ActivityKind.LayerStack;
     public bool IsSearchSelected => _selectedActivity == ActivityKind.Search;
     public bool IsSettingsSelected => _selectedActivity == ActivityKind.Settings;
     public bool IsEcdisDisplaySelected => _selectedActivity == ActivityKind.EcdisDisplay;
@@ -85,6 +89,7 @@ internal sealed class MainViewModel : ViewModelBase
     public ICommand SelectPortrayalCataloguesCommand { get; }
     public ICommand SelectDatasetsCommand { get; }
     public ICommand SelectCatalogCommand { get; }
+    public ICommand SelectLayerStackCommand { get; }
     public ICommand SelectSearchCommand { get; }
     public ICommand SelectSettingsCommand { get; }
     public ICommand SelectEcdisDisplayCommand { get; }
@@ -517,6 +522,7 @@ internal sealed class MainViewModel : ViewModelBase
         PortrayalCataloguesViewModel portrayalCatalogues,
         DatasetsViewModel datasets,
         CatalogPanelViewModel catalogPanel,
+        LayerStackViewModel layerStack,
         FeatureSearchViewModel search,
         SettingsViewModel settingsViewModel,
         PickReportViewModel pickReport,
@@ -536,6 +542,7 @@ internal sealed class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(portrayalCatalogues);
         ArgumentNullException.ThrowIfNull(datasets);
         ArgumentNullException.ThrowIfNull(catalogPanel);
+        ArgumentNullException.ThrowIfNull(layerStack);
         ArgumentNullException.ThrowIfNull(search);
         ArgumentNullException.ThrowIfNull(settingsViewModel);
         ArgumentNullException.ThrowIfNull(pickReport);
@@ -577,6 +584,7 @@ internal sealed class MainViewModel : ViewModelBase
         PortrayalCatalogues = portrayalCatalogues;
         Datasets = datasets;
         CatalogPanel = catalogPanel;
+        LayerStack = layerStack;
         Search = search;
         Settings = settingsViewModel;
         PickReport = pickReport;
@@ -595,6 +603,7 @@ internal sealed class MainViewModel : ViewModelBase
         SelectPortrayalCataloguesCommand = new RelayCommand(() => SelectedActivity = ActivityKind.PortrayalCatalogues);
         SelectDatasetsCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Datasets);
         SelectCatalogCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Catalog);
+        SelectLayerStackCommand = new RelayCommand(() => SelectedActivity = ActivityKind.LayerStack);
         SelectSearchCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Search);
         SelectSettingsCommand = new RelayCommand(() => SelectedActivity = ActivityKind.Settings);
         SelectEcdisDisplayCommand = new RelayCommand(() => SelectedActivity = ActivityKind.EcdisDisplay);
@@ -622,6 +631,7 @@ internal sealed class MainViewModel : ViewModelBase
             OnPropertyChanged(nameof(IsPortrayalCataloguesSelected));
             OnPropertyChanged(nameof(IsDatasetsSelected));
             OnPropertyChanged(nameof(IsCatalogSelected));
+            OnPropertyChanged(nameof(IsLayerStackSelected));
             OnPropertyChanged(nameof(IsSearchSelected));
             OnPropertyChanged(nameof(IsSettingsSelected));
             OnPropertyChanged(nameof(IsEcdisDisplaySelected));

--- a/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
@@ -1,0 +1,126 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             x:Class="EncDotNet.S100.Viewer.Views.LayerStackView"
+             x:DataType="vm:LayerStackViewModel">
+
+    <DockPanel LastChildFill="True">
+
+        <!-- Header: "Show empty planes" toggle. The pane title comes
+             from MainWindow's PaneTitle binding; this header only
+             carries the toggle so the tree starts at row 1. -->
+        <Border DockPanel.Dock="Top" Padding="8,4,8,6">
+            <CheckBox IsChecked="{Binding ShowEmptyPlanes, Mode=TwoWay}"
+                      Content="{x:Static loc:Strings.LayerStack_ShowEmptyPlanes}"
+                      ToolTip.Tip="{x:Static loc:Strings.LayerStack_ShowEmptyPlanes}" />
+        </Border>
+
+        <!-- Footer: Active vs. Visibility help text. -->
+        <Border DockPanel.Dock="Bottom"
+                Padding="8,6,8,8"
+                BorderBrush="{DynamicResource BorderColor}"
+                BorderThickness="0,1,0,0">
+            <TextBlock Text="{Binding ActiveVsVisibilityHelp}"
+                       FontSize="11"
+                       Opacity="0.65"
+                       TextWrapping="Wrap" />
+        </Border>
+
+        <!-- Empty state -->
+        <Border IsVisible="{Binding IsEmpty}"
+                Padding="16"
+                VerticalAlignment="Center">
+            <StackPanel Spacing="8" HorizontalAlignment="Center">
+                <ic:FluentIcon Icon="Stack"
+                               IconVariant="Regular"
+                               FontSize="32"
+                               Opacity="0.4"
+                               HorizontalAlignment="Center" />
+                <TextBlock Text="{Binding EmptyMessage}"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Opacity="0.6"
+                           FontSize="12" />
+                <!-- TODO PR-L4 (TBD-7): PdC picker UX -->
+            </StackPanel>
+        </Border>
+
+        <!-- Populated state: tree of planes, each with a list of entries. -->
+        <ScrollViewer IsVisible="{Binding !IsEmpty}"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Planes}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:LayerStackPlaneViewModel">
+                        <Expander IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
+                                  Margin="4,2"
+                                  Padding="0">
+                            <Expander.Header>
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding Title}"
+                                               FontWeight="SemiBold"
+                                               FontSize="12"
+                                               VerticalAlignment="Center"
+                                               TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding ChildCountText}"
+                                               FontSize="11"
+                                               Opacity="0.7"
+                                               VerticalAlignment="Center" />
+                                </Grid>
+                            </Expander.Header>
+
+                            <Panel>
+                                <!-- Empty placeholder when ShowEmptyPlanes is on. -->
+                                <TextBlock IsVisible="{Binding IsEmpty}"
+                                           Text="{x:Static loc:Strings.LayerStack_EmptyPlane_Placeholder}"
+                                           FontSize="11"
+                                           Opacity="0.5"
+                                           Margin="24,4,8,4" />
+
+                                <ItemsControl ItemsSource="{Binding Children}"
+                                              IsVisible="{Binding !IsEmpty}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:LayerStackEntryViewModel">
+                                            <Grid ColumnDefinitions="Auto,*,Auto"
+                                                  ColumnSpacing="8"
+                                                  Margin="24,3,8,3">
+                                                <CheckBox Grid.Column="0"
+                                                          IsChecked="{Binding IsActive, Mode=TwoWay}"
+                                                          ToolTip.Tip="{x:Static loc:Strings.LayerStack_ActiveTooltip}"
+                                                          VerticalAlignment="Center" />
+                                                <StackPanel Grid.Column="1"
+                                                            VerticalAlignment="Center"
+                                                            Spacing="0">
+                                                    <TextBlock Text="{Binding DatasetLabel}"
+                                                               FontSize="12"
+                                                               ToolTip.Tip="{Binding DatasetId}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding SourceFeatureType}"
+                                                               IsVisible="{Binding HasSourceFeatureType}"
+                                                               FontSize="10"
+                                                               Opacity="0.65"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                </StackPanel>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding PriorityText}"
+                                                           FontSize="10"
+                                                           Opacity="0.6"
+                                                           VerticalAlignment="Center"
+                                                           FontFamily="Consolas,Menlo,Monaco,monospace" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <!-- TODO PR-L4 (TBD-11): unify ordering UX with DatasetsViewModel drag-reorder -->
+                            </Panel>
+                        </Expander>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
@@ -28,9 +28,16 @@
                        TextWrapping="Wrap" />
         </Border>
 
+        <!-- Body: empty state and populated tree share the fill slot
+             so the empty-state placeholder centres in the available
+             space (DockPanel only stretches its last child, so we
+             need a single fill container here). -->
+        <Grid>
+
         <!-- Empty state -->
         <Border IsVisible="{Binding IsEmpty}"
                 Padding="16"
+                HorizontalAlignment="Center"
                 VerticalAlignment="Center">
             <StackPanel Spacing="8" HorizontalAlignment="Center">
                 <ic:FluentIcon Icon="Stack"
@@ -122,5 +129,6 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </ScrollViewer>
+        </Grid>
     </DockPanel>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+public partial class LayerStackView : UserControl
+{
+    public LayerStackView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ActiveFlagTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ActiveFlagTests.cs
@@ -1,0 +1,46 @@
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests covering the PR-L3 in-memory Active flag contract on
+/// <see cref="LoadedDatasetInfo"/> and via the
+/// <see cref="IDatasetLoaderService"/> abstraction.
+/// </summary>
+public class ActiveFlagTests
+{
+    [Fact]
+    public void LoadedDatasetInfo_Active_RoundTripsTrue()
+    {
+        var info = new LoadedDatasetInfo("a.000", "S-101", Active: true);
+        Assert.True(info.Active);
+    }
+
+    [Fact]
+    public void LoadedDatasetInfo_Active_RoundTripsFalse()
+    {
+        var info = new LoadedDatasetInfo("b.h5", "S-102", Active: false);
+        Assert.False(info.Active);
+    }
+
+    [Fact]
+    public void LoaderStub_GetActive_DefaultsToTrue_ForUnknownId()
+    {
+        var loader = new LayerStackViewModelTests.ControllableLoader();
+        Assert.True(loader.GetActive("never-seen-before"));
+    }
+
+    [Fact]
+    public void LoaderStub_SetActive_FiresActiveChanged()
+    {
+        var loader = new LayerStackViewModelTests.ControllableLoader();
+        string? observed = null;
+        loader.ActiveChanged += id => observed = id;
+
+        loader.SetActive("a.000", false);
+
+        Assert.Equal("a.000", observed);
+        Assert.False(loader.GetActive("a.000"));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui.Layers;
@@ -36,6 +37,12 @@ public class DatasetsViewModelExchangeSetHeaderTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static DatasetsViewModel NewVm() => new(new NoopLoader());

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui.Layers;
@@ -32,6 +33,12 @@ public class DatasetsViewModelTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries) { OrderCalls.Add(orderedEntries); }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
@@ -25,6 +26,12 @@ public class EcdisDisplayPanelViewModelTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static PortrayalCatalogue CreateSyntheticCatalogue() => new()

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer.Services;
 using ExchangeSetProgress = EncDotNet.S100.Viewer.Services.ExchangeSetProgress;
 using EncDotNet.S100.Viewer.ViewModels;
@@ -58,6 +59,12 @@ public class ExchangeSetServiceLoaderTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static (DatasetsViewModel datasets, ExchangeSetService service) CreateSystem()

--- a/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui.Layers;
@@ -36,4 +37,10 @@ internal sealed class FakeDatasetLoaderService : IDatasetLoaderService
     public event Action<DatasetEntry>? DatasetLoaded;
     public event Action<string?>? StatusChanged;
     public event Action<DatasetEntry>? DatasetRemoved;
+    public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+    public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+    public event Action? LayerStackChanged { add { } remove { } }
+    public bool GetActive(string datasetId) => true;
+    public void SetActive(string datasetId, bool active) { }
+    public event Action<string>? ActiveChanged { add { } remove { } }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui.Layers;
@@ -45,6 +46,12 @@ public class FeatureSearchServiceTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static FeatureSummary Sum(string id, string type, string? typeName = null)

--- a/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Interoperability;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests for <see cref="LayerStackViewModel"/> (PR-L3).
+/// </summary>
+public class LayerStackViewModelTests
+{
+    [Fact]
+    public void Rebuild_GroupsByPlane_TopFirst()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(
+            Entry("a.000", S98DisplayPlane.BaseChartUnder, 10),
+            Entry("b.h5", S98DisplayPlane.Bathymetry, 20),
+            Entry("c.gml", S98DisplayPlane.MarinerOverlay, 30));
+
+        var vm = new LayerStackViewModel(loader);
+
+        var planes = vm.Planes.Select(p => p.Plane).ToList();
+        // Top-first order: MarinerOverlay before Bathymetry before BaseChartUnder.
+        Assert.Equal(new[]
+        {
+            S98DisplayPlane.MarinerOverlay,
+            S98DisplayPlane.Bathymetry,
+            S98DisplayPlane.BaseChartUnder,
+        }, planes);
+    }
+
+    [Fact]
+    public void Rebuild_OrdersChildren_ByWithinPlanePriorityDescending()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(
+            Entry("low.gml", S98DisplayPlane.MarinerOverlay, 1),
+            Entry("high.gml", S98DisplayPlane.MarinerOverlay, 99),
+            Entry("mid.gml", S98DisplayPlane.MarinerOverlay, 50));
+
+        var vm = new LayerStackViewModel(loader);
+
+        var plane = Assert.Single(vm.Planes);
+        var ids = plane.Children.Select(c => c.DatasetId).ToList();
+        Assert.Equal(new[] { "high.gml", "mid.gml", "low.gml" }, ids);
+    }
+
+    [Fact]
+    public void EmptyPlanes_HiddenByDefault_ShownWhenToggled()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
+
+        var vm = new LayerStackViewModel(loader);
+        Assert.Single(vm.Planes); // only the populated plane
+
+        vm.ShowEmptyPlanes = true;
+        Assert.Equal(9, vm.Planes.Count); // all canonical planes
+
+        vm.ShowEmptyPlanes = false;
+        Assert.Single(vm.Planes);
+    }
+
+    [Fact]
+    public void LayerStackChanged_TriggersRebuild()
+    {
+        var loader = new ControllableLoader();
+        var vm = new LayerStackViewModel(loader);
+        Assert.Empty(vm.Planes);
+
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
+        loader.FireLayerStackChanged();
+
+        Assert.Single(vm.Planes);
+        Assert.Equal(S98DisplayPlane.BaseChartUnder, vm.Planes[0].Plane);
+    }
+
+    [Fact]
+    public void ExpansionState_PreservedAcrossRebuild()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
+        var vm = new LayerStackViewModel(loader);
+
+        // Collapse the plane.
+        var plane = vm.Planes[0];
+        plane.IsExpanded = false;
+
+        // Trigger a rebuild by changing the entry set (still BaseChartUnder).
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10),
+                          Entry("b.000", S98DisplayPlane.BaseChartUnder, 20));
+        loader.FireLayerStackChanged();
+
+        var rebuilt = Assert.Single(vm.Planes);
+        Assert.False(rebuilt.IsExpanded);
+        Assert.Equal(2, rebuilt.Children.Count);
+    }
+
+    [Fact]
+    public void IsActive_TogglesViaLoader()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
+        var vm = new LayerStackViewModel(loader);
+
+        var entry = vm.Planes[0].Children[0];
+        Assert.True(entry.IsActive); // default
+
+        entry.IsActive = false;
+        Assert.False(loader.GetActive("a.000"));
+        Assert.False(entry.IsActive);
+
+        entry.IsActive = true;
+        Assert.True(loader.GetActive("a.000"));
+    }
+
+    private static LayerStackEntry Entry(string id, S98DisplayPlane plane, int priority)
+        => new(new MemoryLayer(id), plane, priority, id);
+
+    /// <summary>
+    /// Test loader stub with a settable entry list and a public
+    /// <see cref="FireLayerStackChanged"/> method.
+    /// </summary>
+    internal sealed class ControllableLoader : IDatasetLoaderService
+    {
+        private IReadOnlyList<LayerStackEntry> _entries = Array.Empty<LayerStackEntry>();
+        private readonly Dictionary<string, bool> _active = new();
+
+        public void SetEntries(params LayerStackEntry[] entries) => _entries = entries;
+        public void FireLayerStackChanged() => LayerStackChanged?.Invoke();
+
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => _entries;
+        public IReadOnlyList<ILayer> CurrentStackedLayers => _entries.Select(e => e.Layer).ToList();
+        public event Action? LayerStackChanged;
+
+        public bool GetActive(string datasetId) =>
+            !_active.TryGetValue(datasetId, out var v) || v;
+        public void SetActive(string datasetId, bool active)
+        {
+            _active[datasetId] = active;
+            ActiveChanged?.Invoke(datasetId);
+            LayerStackChanged?.Invoke();
+        }
+        public event Action<string>? ActiveChanged;
+
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; } =
+            new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; } =
+            new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
+        public event Action<string?>? StatusChanged { add { } remove { } }
+
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries) { }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Services;
@@ -53,6 +54,12 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private MainViewModel CreateViewModel()
@@ -66,6 +73,7 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
             datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
+            layerStack: new LayerStackViewModel(new NoopLoader()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Services;
@@ -59,6 +60,12 @@ public class MainViewModelOpenRecentTests : IDisposable
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private MainViewModel CreateViewModel(
@@ -76,6 +83,7 @@ public class MainViewModelOpenRecentTests : IDisposable
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
             datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
+            layerStack: new LayerStackViewModel(loader),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Services;
@@ -41,6 +42,12 @@ public class MainViewModelPickModeTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static MainViewModel CreateViewModel()
@@ -59,6 +66,7 @@ public class MainViewModelPickModeTests
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
             datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(catalogSource),
+            layerStack: new LayerStackViewModel(new StubDatasetLoaderService()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Viewer.Catalogs;
@@ -57,6 +58,12 @@ public class PickServiceTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static MainViewModel CreateMainViewModel()
@@ -74,6 +81,7 @@ public class PickServiceTests
             portrayalCatalogues: new PortrayalCataloguesViewModel(settings, catalogues),
             datasets: datasets,
             catalogPanel: new CatalogPanelViewModel(new EmptyCatalogSource()),
+            layerStack: new LayerStackViewModel(new StubLoader()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
             pickReport: new PickReportViewModel(),
@@ -161,6 +169,12 @@ public class PickServiceTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     private static MapInfo BuildMapInfo(IEnumerable<MapInfoRecord> records)
@@ -411,6 +425,11 @@ public class PickServiceTests
         public Task ReRenderAllAsync() => Task.CompletedTask;
         public void RemoveEntry(DatasetEntry entry) { }
         public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
     [Fact]


### PR DESCRIPTION
Adds a new **Layer Stack** side panel that surfaces the resolved S-98 layer stack grouped by display plane (top-of-paint-stack first) and lets the user toggle each dataset's in-memory **Active** flag.

## What's in

- **Interface promotion** — `IDatasetLoaderService.CurrentStackedLayers` and `LayerStackChanged` are now required members. Added `CurrentStackEntries` (richer `LayerStackEntry` snapshot) plus `GetActive` / `SetActive` / `ActiveChanged`.
- **Active flag (in-memory)** — `DatasetLoaderService` stores Active per dataset id (default true). `FlattenLayerOrder` and `BuildLoadedDatasetInfos` honour it, so R-101-102-B and any future Active-aware rules see the toggle. Process-local; persistence deferred to PR-L4 (TODO marker on `_activeFlags`). Distinct from `DatasetEntry.IsVisible` — documented on `LoadedDatasetInfo.Active`.
- **LayerStackViewModel** — groups `CurrentStackEntries` by `S98DisplayPlane` in the canonical top-first order, hides empty planes by default with a 'Show empty planes' toggle, preserves per-plane expansion across rebuilds, and routes per-entry `IsActive` to `IDatasetLoaderService.SetActive`.
- **LayerStackView.axaml** — mirrors `CatalogPanelView`. PR-L4 TBDs (PdC picker / drag-reorder unification) are marked in code.
- **MainWindow / App DI** — new activity-bar toggle button + view binding; `LayerStackViewModel` registered as a singleton.
- **Strings & tooltips** — 16 new `Strings.resx` entries. All checkboxes / toggle buttons carry `ToolTip.Tip`.

## Placement assumption

The brief asked for *"own column in the left sidebar, sibling to Catalogs"*. The existing `MainWindow.axaml` uses a **single** activity-pane column whose contents are selected by `MainViewModel.SelectedActivity` (driven by the activity bar). Adding a parallel column would double the sidebar chrome and break the established pattern, so I implemented Layer Stack as a **new activity tab** (sibling to Catalogs in the activity bar). That still satisfies *"sibling to Catalogs, not a sub-tab of dataset list"* — happy to refactor to a literal second column if you'd prefer.

## Tests

| Project | Before | After | Δ |
| --- | --- | --- | --- |
| `EncDotNet.S100.Viewer.Tests` | 280 | 290 | +10 |
| `EncDotNet.S100.Pipelines.Tests` | 340 | 340 | 0 |

- `LayerStackViewModelTests` (6) — plane grouping, top-first order, within-plane priority desc, empty-plane hide/show, `LayerStackChanged` triggers rebuild, expansion preserved across rebuilds, IsActive round-trips through the loader.
- `ActiveFlagTests` (4) — `LoadedDatasetInfo.Active` round-trip, loader `GetActive` default, `SetActive` raises `ActiveChanged`. R-101-102-B Active=false suppression is already covered in `S98DefaultRulesTests` (PR-L2).
- Updated **10** existing `IDatasetLoaderService` stubs to implement the promoted members.

`dotnet build EncDotNet.S100.slnx -c Release` and `dotnet test -c Release` both green.

## Out of scope (deferred to PR-L4)

- `// TODO PR-L4 (TBD-7): PdC picker UX` — empty-state area of the panel.
- `// TODO PR-L4 (TBD-11): unify ordering UX with DatasetsViewModel drag-reorder` — drag-reorder stays as-is on the Datasets panel.
- `// TODO PR-L4: persist Active in ViewerSettings` — Active is in-memory only this PR.

## Visual regression

Panel is additive (new activity tab; no MainWindow column changes). No snapshot rebaseline needed.

## Manual smoke (described, not enforced)

Load S-101 + S-102 → two planes visible (BaseChartOver/Bathymetry); toggle S-102 Active off → S-101 DepthArea reappears in render + pick.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
