### PR TITLE
Add S-201 validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S201DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S201DatasetProcessor.cs
@@ -1,9 +1,12 @@
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.S201;
+using EncDotNet.S100.Datasets.S201.DataModel;
+using EncDotNet.S100.Datasets.S201.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Validation;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
@@ -16,6 +19,8 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 public sealed class S201DatasetProcessor : GmlDatasetProcessorBase<S201Feature>
 {
     private readonly S201Dataset _dataset;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     /// <inheritdoc />
     public override SpecRef Spec => new("S-201", default);
@@ -106,4 +111,18 @@ public sealed class S201DatasetProcessor : GmlDatasetProcessorBase<S201Feature>
     /// <inheritdoc />
     protected override string BuildInfoSuffix() =>
         $"Information types: {_dataset.InformationTypes.Length}";
+
+    /// <inheritdoc />
+    public override ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ValidationRunner.Run(
+                _dataset,
+                static raw => S201AtonInventory.From(raw, out _),
+                S201AtonRules.Default);
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
 }

--- a/src/EncDotNet.S100.Datasets.S201/Validation/S201AtonRules.cs
+++ b/src/EncDotNet.S100.Datasets.S201/Validation/S201AtonRules.cs
@@ -1,0 +1,611 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S201.DataModel;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S201.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-201 <see cref="S201AtonInventory"/>. Rule identifiers follow
+/// the convention <c>S201-R-{clause}</c>, where <c>{clause}</c> traces
+/// to the relevant section of the S-201 specification
+/// (Edition 2.0.0 — Aids to Navigation Information) or to the S-100
+/// framework (Part 10b §6.2 / §6.4 for coordinate and identifier
+/// encoding).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pilot rule set focuses on Tier-1 (schema-shape) and Tier-2
+/// (spec-semantic) rules that can be evaluated against a single
+/// <see cref="S201AtonInventory"/> in isolation. Tier-3 cross-dataset
+/// rules (e.g. cross-referencing an AtoN's charted position against an
+/// S-101 chart) are out of scope here — they would reach sibling
+/// datasets via <see cref="ValidationContext.Services"/>.
+/// </para>
+/// <para>
+/// <b>Audience-driven design.</b> S-201 is the IALA AtoN-authority
+/// exchange product, not an ECDIS portrayal product. Rules emphasise
+/// integrity of the inventory chain (xlink resolution, equipment ↔
+/// host-structure subordination, aggregation membership, AIS MMSI
+/// conformance) over mariner-display concerns.
+/// </para>
+/// <para>
+/// <b>Deviation from S-125.</b> Projection-time issues surfaced by
+/// <see cref="S201AtonInventory.From"/> (unresolved xlinks, attribute
+/// parse failures, duplicate ids) are reported through a
+/// <c>ProjectionDiagnostic</c> out-parameter rather than carried on
+/// the typed model, so the rule pack performs its own checks where
+/// useful (see <see cref="AggregationMembersResolved"/>).
+/// </para>
+/// </remarks>
+public static class S201AtonRules
+{
+    private static readonly ImmutableHashSet<AisAtonKind> MmsiRequiredAisKinds =
+        ImmutableHashSet.Create(AisAtonKind.Physical, AisAtonKind.Synthetic);
+
+    private static readonly ImmutableHashSet<int> ValidChangeTypes =
+        ImmutableHashSet.Create(1, 2, 3, 4);
+
+    // ── S201-R-1.1 — coordinates in WGS-84 range ─────────────────
+
+    /// <summary>
+    /// <c>S201-R-1.1</c> — Every coordinate of every AtoN geometry must
+    /// fall within the WGS-84 ranges: latitude in [-90, +90] and
+    /// longitude in [-180, +180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 — geographic coordinates for
+    /// <c>EPSG:4326</c> are bounded. AtoNs without geometry
+    /// (geometry-less container features such as <c>AtonAggregation</c>)
+    /// are ignored by this rule.
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> CoordinatesInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-1.1")
+            .WithDescription("AtoN coordinates must lie within the WGS-84 lat/lon ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var aton in inventory.AtoNs)
+                {
+                    if (aton.Coordinates.IsDefaultOrEmpty) continue;
+                    foreach (var pos in aton.Coordinates)
+                    {
+                        bool latOk = pos.Latitude is >= -90 and <= 90;
+                        bool lonOk = pos.Longitude is >= -180 and <= 180;
+                        if (latOk && lonOk) continue;
+
+                        var details = (latOk, lonOk) switch
+                        {
+                            (false, true) => $"latitude {pos.Latitude} is outside [-90, +90]",
+                            (true, false) => $"longitude {pos.Longitude} is outside [-180, +180]",
+                            _ => $"latitude {pos.Latitude} and longitude {pos.Longitude} are both out of range",
+                        };
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S201-R-1.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"{aton.FeatureClass} '{aton.Id}': {details}.",
+                            Point = pos,
+                            RelatedFeatureId = aton.Id,
+                            DatasetId = inventory.DatasetIdentifier,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S201-R-1.2 — gml:id uniqueness ───────────────────────────
+
+    /// <summary>
+    /// <c>S201-R-1.2</c> — Every AtoN, aggregation, association, and
+    /// information-type instance must carry a dataset-unique
+    /// <c>gml:id</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.4 — every GML object exposed
+    /// at the dataset level must carry a unique <c>gml:id</c> so that
+    /// <c>xlink:href</c> references resolve deterministically.
+    /// Duplicate identifiers also break the typed projection's
+    /// back-resolved <c>parent</c> / aggregation lookups.
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> GmlIdsUnique { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-1.2")
+            .WithDescription("gml:id values must be unique across AtoNs, aggregations, and information types.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var dupes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                void Track(string? id)
+                {
+                    if (string.IsNullOrEmpty(id)) return;
+                    if (!seen.Add(id)) dupes.Add(id);
+                }
+
+                foreach (var a in inventory.AtoNs) Track(a.Id);
+                foreach (var a in inventory.Aggregations) Track(a.Id);
+                foreach (var a in inventory.Associations) Track(a.Id);
+                foreach (var s in inventory.StatusInformation) Track(s.Id);
+                foreach (var p in inventory.PositioningInformation) Track(p.Id);
+                foreach (var f in inventory.FixingMethods) Track(f.Id);
+                foreach (var q in inventory.SpatialQualities) Track(q.Id);
+
+                foreach (var dup in dupes)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S201-R-1.2",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Duplicate gml:id '{dup}'.",
+                        RelatedFeatureId = dup,
+                        DatasetId = inventory.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S201-R-1.3 — navigable AtoN has geometry ─────────────────
+
+    /// <summary>
+    /// <c>S201-R-1.3</c> — Every navigable AtoN (concrete
+    /// <c>StructureObject</c>, <c>Equipment</c>, or non-virtual
+    /// <c>ElectronicAton</c>) must carry at least one coordinate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C — the FC requires a
+    /// point geometry for concrete physical AtoNs. Aggregation
+    /// containers (handled separately as
+    /// <see cref="S201AtonAggregation"/> / <see cref="S201AtonAssociation"/>)
+    /// and non-physical feature kinds (lines, areas, dataset metadata,
+    /// represented in the typed model as <see cref="S201GenericAtonObject"/>)
+    /// are exempt.
+    /// </para>
+    /// <para>
+    /// Virtual AIS AtoNs (<see cref="AisAtonKind.Virtual"/>) describe a
+    /// notional aid broadcast over AIS and may legitimately appear
+    /// without a transmitter position when the encoder elides it; the
+    /// rule fires at <see cref="ValidationSeverity.Warning"/> on
+    /// non-virtual AtoNs only.
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> NavigableAtoNHasGeometry { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-1.3")
+            .WithDescription("Concrete physical AtoNs must carry at least one coordinate.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var aton in inventory.AtoNs)
+                {
+                    if (!RequiresGeometry(aton)) continue;
+                    if (!aton.Coordinates.IsDefaultOrEmpty && aton.Coordinates.Length > 0) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S201-R-1.3",
+                        Severity = ValidationSeverity.Warning,
+                        Message = $"{aton.FeatureClass} '{aton.Id}' has no geometry.",
+                        RelatedFeatureId = aton.Id,
+                        DatasetId = inventory.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    private static bool RequiresGeometry(S201AtonObject aton) => aton switch
+    {
+        S201ElectronicAtoN { Kind: AisAtonKind.Virtual } => false,
+        S201StructureObject => true,
+        S201Equipment => true,
+        S201ElectronicAtoN => true,
+        _ => false,
+    };
+
+    // ── S201-R-2.1 — physical / synthetic AIS MMSI ───────────────
+
+    /// <summary>
+    /// <c>S201-R-2.1</c> — Every Physical or Synthetic AIS aid to
+    /// navigation must carry an <c>mMSICode</c> of exactly nine
+    /// decimal digits.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C —
+    /// §<c>PhysicalAISAidToNavigation</c> and
+    /// §<c>SyntheticAISAidToNavigation</c> declare <c>mMSICode</c>
+    /// (Maritime Mobile Service Identity) as a required attribute. The
+    /// MMSI is the nine-digit identifier broadcast in the AIS message
+    /// (ITU-R M.585).
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> PhysicalAisHasMmsi { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-2.1")
+            .WithDescription("Physical / Synthetic AIS aids to navigation must carry a 9-digit mMSICode.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var ais in inventory.ElectronicAtoNs)
+                {
+                    if (!MmsiRequiredAisKinds.Contains(ais.Kind)) continue;
+                    AddMmsiFinding(findings, inventory, ais, "S201-R-2.1", ValidationSeverity.Error, requirePresent: true);
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S201-R-2.2 — virtual AIS MMSI format ─────────────────────
+
+    /// <summary>
+    /// <c>S201-R-2.2</c> — When a Virtual AIS aid to navigation
+    /// carries an <c>mMSICode</c>, the value must be exactly nine
+    /// decimal digits.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C —
+    /// §<c>VirtualAISAidToNavigation</c>. The FC permits a virtual AIS
+    /// AtoN to be authored without an MMSI (a virtual mark may be
+    /// dropped without provisioning a dedicated identity), but when one
+    /// is supplied it must still conform to the ITU MMSI nine-digit
+    /// shape. The rule fires at <see cref="ValidationSeverity.Warning"/>
+    /// rather than <see cref="ValidationSeverity.Error"/> because the
+    /// missing-value case is permitted.
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> VirtualAisMmsiFormat { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-2.2")
+            .WithDescription("Virtual AIS aids to navigation, when carrying an mMSICode, must use the 9-digit ITU shape.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var ais in inventory.ElectronicAtoNs)
+                {
+                    if (ais.Kind != AisAtonKind.Virtual) continue;
+                    AddMmsiFinding(findings, inventory, ais, "S201-R-2.2", ValidationSeverity.Warning, requirePresent: false);
+                }
+                return findings;
+            })
+            .Build();
+
+    private static void AddMmsiFinding(
+        List<ValidationFinding> findings,
+        S201AtonInventory inventory,
+        S201ElectronicAtoN ais,
+        string ruleId,
+        ValidationSeverity severity,
+        bool requirePresent)
+    {
+        var mmsi = ais.MmsiCode;
+        var position = ais.Coordinates.IsDefaultOrEmpty ? (GeoPosition?)null : ais.Coordinates[0];
+
+        if (string.IsNullOrEmpty(mmsi))
+        {
+            if (!requirePresent) return;
+            findings.Add(new ValidationFinding
+            {
+                RuleId = ruleId,
+                Severity = severity,
+                Message = $"AIS AtoN '{ais.Id}' ({ais.FeatureClass}) is missing the required mMSICode attribute.",
+                Point = position,
+                RelatedFeatureId = ais.Id,
+                DatasetId = inventory.DatasetIdentifier,
+            });
+            return;
+        }
+
+        if (mmsi.Length != 9 || !mmsi.All(char.IsAsciiDigit))
+        {
+            findings.Add(new ValidationFinding
+            {
+                RuleId = ruleId,
+                Severity = severity,
+                Message =
+                    $"AIS AtoN '{ais.Id}' ({ais.FeatureClass}) has malformed mMSICode '{mmsi}'; " +
+                    "must be exactly 9 decimal digits.",
+                Point = position,
+                RelatedFeatureId = ais.Id,
+                DatasetId = inventory.DatasetIdentifier,
+            });
+        }
+    }
+
+    // ── S201-R-3.1 — ChangeTypes codelist ────────────────────────
+
+    /// <summary>
+    /// <c>S201-R-3.1</c> — When an <c>AtonStatusInformation</c>
+    /// carries a <c>ChangeTypes</c> code it must fall within the closed
+    /// enumeration declared by the Feature Catalogue.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C2 — <c>ChangeTypes</c>
+    /// codelist (1 Advance Notice of Change, 2 Discrepancy,
+    /// 3 Proposed Change, 4 Permanent Change). Note S-201 has only
+    /// four codelist values where S-125 has five — the spec does not
+    /// include "Temporary Change" as a distinct code under S-201.
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> ChangeTypesInEnumeration { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-3.1")
+            .WithDescription("AtonStatusInformation ChangeTypes must be one of the FC listed values 1–4.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var info in inventory.StatusInformation)
+                {
+                    if (info.ChangeTypes is not { } code) continue;
+                    if (ValidChangeTypes.Contains(code)) continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S201-R-3.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"AtonStatusInformation '{info.Id}' has ChangeTypes code {code}; " +
+                            "expected one of 1 (Advance Notice), 2 (Discrepancy), 3 (Proposed), 4 (Permanent).",
+                        RelatedFeatureId = info.Id,
+                        DatasetId = inventory.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S201-R-4.1 — date range ordering ─────────────────────────
+
+    /// <summary>
+    /// <c>S201-R-4.1</c> — When an AtoN's <c>fixedDateRange</c> or
+    /// <c>periodicDateRange</c> carries both a start and an end, the
+    /// start must not be after the end.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C — §<c>fixedDateRange</c>
+    /// and §<c>periodicDateRange</c>. The complex attribute is composed
+    /// of <c>dateStart</c> / <c>dateEnd</c>; the spec is silent on
+    /// degenerate ranges but a deployment whose validity begins after
+    /// it ends is non-actionable.
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> DateRangeOrdered { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-4.1")
+            .WithDescription("AtoN date ranges must have Start ≤ End when both bounds are present.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+
+                void CheckRange(string ownerId, string ownerClass, string label, S201DateRange? range)
+                {
+                    if (range is null) return;
+                    if (range.Start is not { } s || range.End is not { } e) return;
+                    if (s <= e) return;
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S201-R-4.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"{ownerClass} '{ownerId}' {label} has Start ({s:O}) after End ({e:O}).",
+                        RelatedFeatureId = ownerId,
+                        DatasetId = inventory.DatasetIdentifier,
+                    });
+                }
+
+                foreach (var aton in inventory.AtoNs)
+                {
+                    CheckRange(aton.Id, aton.FeatureClass, "fixedDateRange", aton.FixedDateRange);
+                    CheckRange(aton.Id, aton.FeatureClass, "periodicDateRange", aton.PeriodicDateRange);
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S201-R-5.1 — equipment has host structure ────────────────
+
+    /// <summary>
+    /// <c>S201-R-5.1</c> — Every <c>Equipment</c> instance (including
+    /// concrete <c>GenericLight</c> subclasses) should resolve to a
+    /// host <c>StructureObject</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C —
+    /// <c>StructureEquipment</c> association. The subordination chain
+    /// is back-resolved by the typed projection via
+    /// <c>theParentFeature</c> / <c>parent</c> xlinks; an equipment
+    /// instance whose <see cref="S201Equipment.HostStructure"/> is
+    /// <c>null</c> is either free-standing (rare but spec-permissible
+    /// in the operational fleet) or carries an unresolved
+    /// <c>xlink:href</c>.
+    /// </para>
+    /// <para>
+    /// The rule fires at <see cref="ValidationSeverity.Warning"/>
+    /// rather than <see cref="ValidationSeverity.Error"/> because the
+    /// FC does not strictly require the association — the warning
+    /// flags the case for downstream authority review.
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> EquipmentHasHostStructure { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-5.1")
+            .WithDescription("Equipment instances should resolve to a host structure via StructureEquipment.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var eq in inventory.Equipment)
+                {
+                    if (eq.HostStructure is not null) continue;
+                    var position = eq.Coordinates.IsDefaultOrEmpty ? (GeoPosition?)null : eq.Coordinates[0];
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S201-R-5.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"{eq.FeatureClass} '{eq.Id}' has no resolved host structure " +
+                            "(missing or unresolved StructureEquipment xlink).",
+                        Point = position,
+                        RelatedFeatureId = eq.Id,
+                        DatasetId = inventory.DatasetIdentifier,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    // ── S201-R-6.1 — aggregation has members ─────────────────────
+
+    /// <summary>
+    /// <c>S201-R-6.1</c> — Every <c>AtonAggregation</c> /
+    /// <c>AtonAssociation</c> must reference at least two AtoNs.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-201 Edition 2.0.0 Annex C — §<c>AtonAggregation</c>
+    /// and §<c>AtonAssociation</c>. These features are geometry-less
+    /// containers whose entire purpose is to group two or more AtoNs
+    /// by xlink (e.g. a leading line of two beacons). An aggregation
+    /// with fewer than two resolved peers has no semantic content.
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> AggregationHasMembers { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-6.1")
+            .WithDescription("AtonAggregation / AtonAssociation must reference at least two AtoNs.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var agg in inventory.Aggregations)
+                    CheckMemberCount(findings, inventory, agg.Id, "AtonAggregation", agg.Peers);
+                foreach (var asoc in inventory.Associations)
+                    CheckMemberCount(findings, inventory, asoc.Id, "AtonAssociation", asoc.Peers);
+                return findings;
+            })
+            .Build();
+
+    private static void CheckMemberCount(
+        List<ValidationFinding> findings,
+        S201AtonInventory inventory,
+        string id,
+        string kind,
+        ImmutableArray<S201AtonObject> peers)
+    {
+        var count = peers.IsDefaultOrEmpty ? 0 : peers.Length;
+        if (count >= 2) return;
+        findings.Add(new ValidationFinding
+        {
+            RuleId = "S201-R-6.1",
+            Severity = ValidationSeverity.Warning,
+            Message = $"{kind} '{id}' has {count} resolved peer(s); expected at least 2.",
+            RelatedFeatureId = id,
+            DatasetId = inventory.DatasetIdentifier,
+        });
+    }
+
+    // ── S201-R-6.2 — aggregation members resolved ────────────────
+
+    /// <summary>
+    /// <c>S201-R-6.2</c> — Every peer <c>xlink:href</c> on an
+    /// <c>AtonAggregation</c> or <c>AtonAssociation</c> must resolve
+    /// to an AtoN in the inventory.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Spec reference: S-100 Part 10b §6.4 — <c>xlink:href</c>
+    /// references at the dataset level must resolve. The typed
+    /// projection captures the resolved peers in
+    /// <see cref="S201AtonAggregation.Peers"/>; comparing the resolved
+    /// count to the number of <c>peer</c>-role references on the
+    /// source feature surfaces dropped references that would otherwise
+    /// hide behind the typed model's already-resolved view.
+    /// </para>
+    /// <para>
+    /// The rule fires at <see cref="ValidationSeverity.Error"/> — an
+    /// unresolved aggregation member is a structural defect in the
+    /// AtoN inventory.
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S201AtonInventory> AggregationMembersResolved { get; } =
+        ValidationRuleBuilder.RuleFor<S201AtonInventory>("S201-R-6.2")
+            .WithDescription("AtonAggregation / AtonAssociation peer xlinks must all resolve.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((inventory, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                foreach (var agg in inventory.Aggregations)
+                    CheckXlinkResolution(findings, inventory, agg.Id, "AtonAggregation", agg.Peers);
+                foreach (var asoc in inventory.Associations)
+                    CheckXlinkResolution(findings, inventory, asoc.Id, "AtonAssociation", asoc.Peers);
+                return findings;
+            })
+            .Build();
+
+    private static void CheckXlinkResolution(
+        List<ValidationFinding> findings,
+        S201AtonInventory inventory,
+        string id,
+        string kind,
+        ImmutableArray<S201AtonObject> peers)
+    {
+        var source = FindSourceFeature(inventory, id);
+        if (source is null) return;
+
+        var expected = 0;
+        foreach (var r in source.FeatureReferences)
+        {
+            if (string.Equals(r.Role, "peer", StringComparison.OrdinalIgnoreCase))
+                expected++;
+        }
+
+        var actual = peers.IsDefaultOrEmpty ? 0 : peers.Length;
+        if (actual >= expected) return;
+
+        findings.Add(new ValidationFinding
+        {
+            RuleId = "S201-R-6.2",
+            Severity = ValidationSeverity.Error,
+            Message =
+                $"{kind} '{id}' has {expected - actual} unresolved peer xlink(s) " +
+                $"({actual} of {expected} resolved).",
+            RelatedFeatureId = id,
+            DatasetId = inventory.DatasetIdentifier,
+        });
+    }
+
+    private static S201Feature? FindSourceFeature(S201AtonInventory inventory, string id)
+    {
+        if (inventory.Source.Features.IsDefaultOrEmpty) return null;
+        foreach (var f in inventory.Source.Features)
+        {
+            if (string.Equals(f.Id, id, StringComparison.Ordinal))
+                return f;
+        }
+        return null;
+    }
+
+    /// <summary>The canonical default rule set for S-201 AtoN inventories.</summary>
+    public static ValidationRuleSet<S201AtonInventory> Default { get; } = new(
+        CoordinatesInWgs84Range,
+        GmlIdsUnique,
+        NavigableAtoNHasGeometry,
+        PhysicalAisHasMmsi,
+        VirtualAisMmsiFormat,
+        ChangeTypesInEnumeration,
+        DateRangeOrdered,
+        EquipmentHasHostStructure,
+        AggregationHasMembers,
+        AggregationMembersResolved);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    /// <param name="inventory">The S-201 AtoN inventory to validate.</param>
+    /// <param name="context">Optional validation context; defaults to <see cref="ValidationContext.Default"/>.</param>
+    /// <returns>The validation report for <paramref name="inventory"/>.</returns>
+    public static ValidationReport Validate(S201AtonInventory inventory, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+        return Default.Run(inventory, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S201.Tests/Validation/S201AtonRulesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S201.Tests/Validation/S201AtonRulesTests.cs
@@ -1,0 +1,644 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.S201;
+using EncDotNet.S100.Datasets.S201.DataModel;
+using EncDotNet.S100.Datasets.S201.Validation;
+using EncDotNet.S100.Gml;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S201.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="S201AtonRules"/>. Each test constructs a
+/// minimal synthetic <see cref="S201AtonInventory"/> in memory (no GML
+/// fixtures) and asserts the rule fires (or doesn't) with the expected
+/// finding shape.
+/// </summary>
+public class S201AtonRulesTests
+{
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private const string DatasetId = "S201-DS-1";
+
+    private static S201Feature SourceFeature(
+        string id,
+        string featureType = "LateralBuoy",
+        params S201FeatureReference[] featureReferences) => new()
+    {
+        Id = id,
+        FeatureType = featureType,
+        GeometryType = GmlGeometryType.Point,
+        Points = ImmutableArray<(double, double)>.Empty,
+        Curves = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+        ExteriorRing = ImmutableArray<(double, double)>.Empty,
+        InteriorRings = ImmutableArray<ImmutableArray<(double, double)>>.Empty,
+        Attributes = ImmutableDictionary<string, string>.Empty,
+        ComplexAttributes = ImmutableArray<S201ComplexAttribute>.Empty,
+        InformationReferences = ImmutableArray<S201InformationReference>.Empty,
+        FeatureReferences = featureReferences.ToImmutableArray(),
+    };
+
+    private static S201StructureObject Structure(
+        string id,
+        string featureClass = "LateralBuoy",
+        double? lat = 0,
+        double? lon = 0,
+        S201DateRange? fixedRange = null,
+        S201DateRange? periodicRange = null)
+    {
+        var coords = (lat is null || lon is null)
+            ? ImmutableArray<GeoPosition>.Empty
+            : ImmutableArray.Create(new GeoPosition(lat.Value, lon.Value));
+        return new S201StructureObject
+        {
+            Id = id,
+            FeatureClass = featureClass,
+            Source = SourceFeature(id, featureClass),
+            GeometryKind = coords.IsEmpty ? S201GeometryKind.None : S201GeometryKind.Point,
+            Coordinates = coords,
+            FixedDateRange = fixedRange,
+            PeriodicDateRange = periodicRange,
+        };
+    }
+
+    private static S201Equipment Equipment(
+        string id,
+        string featureClass = "FogSignal",
+        double? lat = 0,
+        double? lon = 0,
+        S201StructureObject? host = null)
+    {
+        var coords = (lat is null || lon is null)
+            ? ImmutableArray<GeoPosition>.Empty
+            : ImmutableArray.Create(new GeoPosition(lat.Value, lon.Value));
+        var eq = new S201Equipment
+        {
+            Id = id,
+            FeatureClass = featureClass,
+            Source = SourceFeature(id, featureClass),
+            GeometryKind = coords.IsEmpty ? S201GeometryKind.None : S201GeometryKind.Point,
+            Coordinates = coords,
+        };
+        if (host is not null)
+            SetHostStructure(eq, host);
+        return eq;
+    }
+
+    private static readonly System.Reflection.PropertyInfo HostStructureProperty =
+        typeof(S201Equipment).GetProperty(nameof(S201Equipment.HostStructure))!;
+
+    private static void SetHostStructure(S201Equipment equipment, S201StructureObject host)
+    {
+        // HostStructure has an internal setter (resolved by the typed projection);
+        // tests live outside the S-201 assembly and use reflection to set it.
+        HostStructureProperty.SetValue(equipment, host);
+    }
+
+    private static S201ElectronicAtoN Ais(
+        string id,
+        AisAtonKind kind = AisAtonKind.Virtual,
+        string? mmsi = "992341001",
+        double? lat = 0,
+        double? lon = 0)
+    {
+        var featureClass = kind switch
+        {
+            AisAtonKind.Physical => "PhysicalAISAidToNavigation",
+            AisAtonKind.Synthetic => "SyntheticAISAidToNavigation",
+            AisAtonKind.Virtual => "VirtualAISAidToNavigation",
+            _ => "VirtualAISAidToNavigation",
+        };
+        var coords = (lat is null || lon is null)
+            ? ImmutableArray<GeoPosition>.Empty
+            : ImmutableArray.Create(new GeoPosition(lat.Value, lon.Value));
+        return new S201ElectronicAtoN
+        {
+            Id = id,
+            FeatureClass = featureClass,
+            Source = SourceFeature(id, featureClass),
+            Kind = kind,
+            MmsiCode = mmsi,
+            GeometryKind = coords.IsEmpty ? S201GeometryKind.None : S201GeometryKind.Point,
+            Coordinates = coords,
+        };
+    }
+
+    private static S201AtonStatusInformation StatusInfo(string id, int? changeTypes = 1) => new()
+    {
+        Id = id,
+        ChangeTypes = changeTypes,
+    };
+
+    private static S201AtonAggregation Aggregation(string id, params S201AtonObject[] peers) => new()
+    {
+        Id = id,
+        Peers = peers.ToImmutableArray(),
+    };
+
+    private static S201AtonAssociation Association(string id, params S201AtonObject[] peers) => new()
+    {
+        Id = id,
+        Peers = peers.ToImmutableArray(),
+    };
+
+    /// <summary>
+    /// Adds a synthetic source feature for an aggregation/association with
+    /// <paramref name="peerCount"/> <c>peer</c>-role references — used to
+    /// drive the unresolved-xlink check.
+    /// </summary>
+    private static S201Feature AggregationSource(string id, string featureType, int peerCount)
+    {
+        var refs = Enumerable.Range(0, peerCount)
+            .Select(i => new S201FeatureReference { Role = "peer", TargetRef = $"target-{id}-{i}" })
+            .ToArray();
+        return SourceFeature(id, featureType, refs);
+    }
+
+    private static S201AtonInventory Inventory(
+        ImmutableArray<S201AtonObject>? atons = null,
+        ImmutableArray<S201AtonStatusInformation>? statusInfo = null,
+        ImmutableArray<S201AtonAggregation>? aggregations = null,
+        ImmutableArray<S201AtonAssociation>? associations = null,
+        ImmutableArray<S201Feature>? sourceFeatures = null)
+    {
+        var atonArray = atons ?? ImmutableArray<S201AtonObject>.Empty;
+        var structures = atonArray.OfType<S201StructureObject>().ToImmutableArray();
+        var equipment = atonArray.OfType<S201Equipment>().ToImmutableArray();
+        var electronic = atonArray.OfType<S201ElectronicAtoN>().ToImmutableArray();
+
+        var sourceFeatureArray = sourceFeatures
+            ?? atonArray.Select(a => a.Source).ToImmutableArray();
+
+        var source = new S201Dataset
+        {
+            DatasetIdentifier = DatasetId,
+            ProductIdentifier = "S-201",
+            Features = sourceFeatureArray,
+            InformationTypes = ImmutableArray<S201InformationType>.Empty,
+        };
+
+        return new S201AtonInventory
+        {
+            DatasetIdentifier = DatasetId,
+            ProductIdentifier = "S-201",
+            AtoNs = atonArray,
+            Structures = structures,
+            Equipment = equipment,
+            ElectronicAtoNs = electronic,
+            Aggregations = aggregations ?? ImmutableArray<S201AtonAggregation>.Empty,
+            Associations = associations ?? ImmutableArray<S201AtonAssociation>.Empty,
+            StatusInformation = statusInfo ?? ImmutableArray<S201AtonStatusInformation>.Empty,
+            Source = source,
+        };
+    }
+
+    // ── S201-R-1.1 — coordinates in WGS-84 range ─────────────────
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Passes_OnValidPositions()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", lat: -89.9, lon: -179.9),
+            Structure("S2", lat: 89.9, lon: 179.9)));
+        Assert.Empty(S201AtonRules.CoordinatesInWgs84Range.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_IgnoresGeometrylessAtoNs()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", lat: null, lon: null)));
+        Assert.Empty(S201AtonRules.CoordinatesInWgs84Range.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnOutOfRangeLatitude()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("BAD", lat: 95.0, lon: 0)));
+        var f = Assert.Single(S201AtonRules.CoordinatesInWgs84Range.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-1.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("BAD", f.RelatedFeatureId);
+        Assert.Equal(DatasetId, f.DatasetId);
+        Assert.Contains("latitude", f.Message);
+    }
+
+    [Fact]
+    public void CoordinatesInWgs84Range_Fails_OnOutOfRangeLongitude()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("BAD", lat: 0, lon: 181.0)));
+        var f = Assert.Single(S201AtonRules.CoordinatesInWgs84Range.Evaluate(inv, ValidationContext.Default));
+        Assert.Contains("longitude", f.Message);
+    }
+
+    // ── S201-R-1.2 — gml:id uniqueness ───────────────────────────
+
+    [Fact]
+    public void GmlIdsUnique_Passes_OnDistinctIds()
+    {
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(Structure("S1"), Structure("S2")),
+            statusInfo: ImmutableArray.Create(StatusInfo("I1")));
+        Assert.Empty(S201AtonRules.GmlIdsUnique.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void GmlIdsUnique_Fails_OnDuplicateAtonIds()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1"), Structure("S1"), Structure("S2")));
+        var f = Assert.Single(S201AtonRules.GmlIdsUnique.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-1.2", f.RuleId);
+        Assert.Equal("S1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void GmlIdsUnique_Fails_AcrossAtonAndInformationType()
+    {
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(Structure("X1")),
+            statusInfo: ImmutableArray.Create(StatusInfo("X1")));
+        var f = Assert.Single(S201AtonRules.GmlIdsUnique.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("X1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void GmlIdsUnique_CaseInsensitive()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("Aid-1"), Structure("aid-1")));
+        Assert.Single(S201AtonRules.GmlIdsUnique.Evaluate(inv, ValidationContext.Default));
+    }
+
+    // ── S201-R-1.3 — navigable AtoN has geometry ─────────────────
+
+    [Fact]
+    public void NavigableAtoNHasGeometry_Passes_WhenStructureHasGeometry()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", lat: 10, lon: 20)));
+        Assert.Empty(S201AtonRules.NavigableAtoNHasGeometry.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void NavigableAtoNHasGeometry_Fails_WhenStructureHasNoGeometry()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S-NOPOS", lat: null, lon: null)));
+        var f = Assert.Single(S201AtonRules.NavigableAtoNHasGeometry.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-1.3", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("S-NOPOS", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void NavigableAtoNHasGeometry_IgnoresVirtualAis()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("V1", AisAtonKind.Virtual, lat: null, lon: null)));
+        Assert.Empty(S201AtonRules.NavigableAtoNHasGeometry.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void NavigableAtoNHasGeometry_FiresForPhysicalAisWithoutPosition()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("P1", AisAtonKind.Physical, lat: null, lon: null)));
+        Assert.Single(S201AtonRules.NavigableAtoNHasGeometry.Evaluate(inv, ValidationContext.Default));
+    }
+
+    // ── S201-R-2.1 — physical / synthetic AIS MMSI ───────────────
+
+    [Theory]
+    [InlineData(AisAtonKind.Physical)]
+    [InlineData(AisAtonKind.Synthetic)]
+    public void PhysicalAisHasMmsi_Passes_OnNineDigitMmsi(AisAtonKind kind)
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("A1", kind, "992341001")));
+        Assert.Empty(S201AtonRules.PhysicalAisHasMmsi.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PhysicalAisHasMmsi_IgnoresVirtualAis()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("V1", AisAtonKind.Virtual, mmsi: null)));
+        Assert.Empty(S201AtonRules.PhysicalAisHasMmsi.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PhysicalAisHasMmsi_IgnoresNonAis()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(Structure("S1")));
+        Assert.Empty(S201AtonRules.PhysicalAisHasMmsi.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void PhysicalAisHasMmsi_Fails_OnMissingMmsi()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("P1", AisAtonKind.Physical, mmsi: null)));
+        var f = Assert.Single(S201AtonRules.PhysicalAisHasMmsi.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-2.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Contains("missing", f.Message);
+    }
+
+    [Theory]
+    [InlineData("12345678")]
+    [InlineData("1234567890")]
+    [InlineData("12345678X")]
+    public void PhysicalAisHasMmsi_Fails_OnMalformedMmsi(string mmsi)
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("P1", AisAtonKind.Physical, mmsi)));
+        var f = Assert.Single(S201AtonRules.PhysicalAisHasMmsi.Evaluate(inv, ValidationContext.Default));
+        Assert.Contains("malformed", f.Message);
+    }
+
+    // ── S201-R-2.2 — virtual AIS MMSI format ─────────────────────
+
+    [Fact]
+    public void VirtualAisMmsiFormat_PassesWhenMissing()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("V1", AisAtonKind.Virtual, mmsi: null)));
+        Assert.Empty(S201AtonRules.VirtualAisMmsiFormat.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void VirtualAisMmsiFormat_PassesOnNineDigitMmsi()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("V1", AisAtonKind.Virtual, "992341001")));
+        Assert.Empty(S201AtonRules.VirtualAisMmsiFormat.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void VirtualAisMmsiFormat_FailsOnMalformedMmsi()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Ais("V1", AisAtonKind.Virtual, "12345")));
+        var f = Assert.Single(S201AtonRules.VirtualAisMmsiFormat.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-2.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+    }
+
+    // ── S201-R-3.1 — ChangeTypes codelist ────────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void ChangeTypesInEnumeration_PassesOnValidCodes(int code)
+    {
+        var inv = Inventory(statusInfo: ImmutableArray.Create(StatusInfo("I1", code)));
+        Assert.Empty(S201AtonRules.ChangeTypesInEnumeration.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void ChangeTypesInEnumeration_IgnoresNullCode()
+    {
+        var inv = Inventory(statusInfo: ImmutableArray.Create(StatusInfo("I1", null)));
+        Assert.Empty(S201AtonRules.ChangeTypesInEnumeration.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(99)]
+    public void ChangeTypesInEnumeration_FailsOnOutOfRangeCode(int code)
+    {
+        var inv = Inventory(statusInfo: ImmutableArray.Create(StatusInfo("I1", code)));
+        var f = Assert.Single(S201AtonRules.ChangeTypesInEnumeration.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-3.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("I1", f.RelatedFeatureId);
+    }
+
+    // ── S201-R-4.1 — date range ordering ─────────────────────────
+
+    [Fact]
+    public void DateRangeOrdered_PassesOnOrderedFixedRange()
+    {
+        var range = new S201DateRange
+        {
+            Start = DateTimeOffset.Parse("2025-01-01T00:00:00Z"),
+            End = DateTimeOffset.Parse("2025-12-31T00:00:00Z"),
+        };
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", fixedRange: range)));
+        Assert.Empty(S201AtonRules.DateRangeOrdered.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void DateRangeOrdered_IgnoresPartialRange()
+    {
+        var range = new S201DateRange { Start = DateTimeOffset.Parse("2025-01-01T00:00:00Z") };
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", fixedRange: range)));
+        Assert.Empty(S201AtonRules.DateRangeOrdered.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void DateRangeOrdered_FailsOnInvertedFixedRange()
+    {
+        var range = new S201DateRange
+        {
+            Start = DateTimeOffset.Parse("2025-12-31T00:00:00Z"),
+            End = DateTimeOffset.Parse("2025-01-01T00:00:00Z"),
+        };
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", fixedRange: range)));
+        var f = Assert.Single(S201AtonRules.DateRangeOrdered.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-4.1", f.RuleId);
+        Assert.Contains("fixedDateRange", f.Message);
+    }
+
+    [Fact]
+    public void DateRangeOrdered_FailsOnInvertedPeriodicRange()
+    {
+        var range = new S201DateRange
+        {
+            Start = DateTimeOffset.Parse("2025-08-01T00:00:00Z"),
+            End = DateTimeOffset.Parse("2025-06-01T00:00:00Z"),
+        };
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Structure("S1", periodicRange: range)));
+        var f = Assert.Single(S201AtonRules.DateRangeOrdered.Evaluate(inv, ValidationContext.Default));
+        Assert.Contains("periodicDateRange", f.Message);
+    }
+
+    // ── S201-R-5.1 — equipment has host structure ────────────────
+
+    [Fact]
+    public void EquipmentHasHostStructure_PassesWhenHostResolved()
+    {
+        var host = Structure("S1");
+        var eq = Equipment("E1", host: host);
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(host, eq));
+        Assert.Empty(S201AtonRules.EquipmentHasHostStructure.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void EquipmentHasHostStructure_FailsWhenHostMissing()
+    {
+        var inv = Inventory(atons: ImmutableArray.Create<S201AtonObject>(
+            Equipment("E1", host: null)));
+        var f = Assert.Single(S201AtonRules.EquipmentHasHostStructure.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-5.1", f.RuleId);
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal("E1", f.RelatedFeatureId);
+    }
+
+    // ── S201-R-6.1 — aggregation has members ─────────────────────
+
+    [Fact]
+    public void AggregationHasMembers_PassesOnTwoPeers()
+    {
+        var a = Structure("A");
+        var b = Structure("B");
+        var agg = Aggregation("AGG1", a, b);
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(a, b),
+            aggregations: ImmutableArray.Create(agg));
+        Assert.Empty(S201AtonRules.AggregationHasMembers.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AggregationHasMembers_FailsOnEmpty()
+    {
+        var inv = Inventory(aggregations: ImmutableArray.Create(Aggregation("AGG1")));
+        var f = Assert.Single(S201AtonRules.AggregationHasMembers.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-6.1", f.RuleId);
+        Assert.Equal("AGG1", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void AggregationHasMembers_FailsOnSinglePeer()
+    {
+        var a = Structure("A");
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(a),
+            associations: ImmutableArray.Create(Association("ASOC1", a)));
+        Assert.Single(S201AtonRules.AggregationHasMembers.Evaluate(inv, ValidationContext.Default));
+    }
+
+    // ── S201-R-6.2 — aggregation members resolved ────────────────
+
+    [Fact]
+    public void AggregationMembersResolved_PassesWhenAllResolved()
+    {
+        var a = Structure("A");
+        var b = Structure("B");
+        var agg = Aggregation("AGG1", a, b);
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(a, b),
+            aggregations: ImmutableArray.Create(agg),
+            sourceFeatures: ImmutableArray.Create(
+                a.Source,
+                b.Source,
+                AggregationSource("AGG1", "AtonAggregation", peerCount: 2)));
+        Assert.Empty(S201AtonRules.AggregationMembersResolved.Evaluate(inv, ValidationContext.Default));
+    }
+
+    [Fact]
+    public void AggregationMembersResolved_FailsWhenSomeDropped()
+    {
+        var a = Structure("A");
+        var b = Structure("B");
+        var agg = Aggregation("AGG1", a, b);
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(a, b),
+            aggregations: ImmutableArray.Create(agg),
+            sourceFeatures: ImmutableArray.Create(
+                a.Source,
+                b.Source,
+                AggregationSource("AGG1", "AtonAggregation", peerCount: 4)));
+        var f = Assert.Single(S201AtonRules.AggregationMembersResolved.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("S201-R-6.2", f.RuleId);
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal("AGG1", f.RelatedFeatureId);
+        Assert.Contains("2 unresolved", f.Message);
+    }
+
+    [Fact]
+    public void AggregationMembersResolved_FiresOnAssociation()
+    {
+        var a = Structure("A");
+        var asoc = Association("ASOC1", a);
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(a),
+            associations: ImmutableArray.Create(asoc),
+            sourceFeatures: ImmutableArray.Create(
+                a.Source,
+                AggregationSource("ASOC1", "AtonAssociation", peerCount: 3)));
+        var f = Assert.Single(S201AtonRules.AggregationMembersResolved.Evaluate(inv, ValidationContext.Default));
+        Assert.Equal("ASOC1", f.RelatedFeatureId);
+    }
+
+    // ── Default rule set smoke tests ──────────────────────────────
+
+    [Fact]
+    public void DefaultRuleSet_HasAllExpectedRules()
+    {
+        var ids = S201AtonRules.Default.Rules.Select(r => r.RuleId).ToHashSet();
+        Assert.Equal(10, ids.Count);
+        Assert.Contains("S201-R-1.1", ids);
+        Assert.Contains("S201-R-1.2", ids);
+        Assert.Contains("S201-R-1.3", ids);
+        Assert.Contains("S201-R-2.1", ids);
+        Assert.Contains("S201-R-2.2", ids);
+        Assert.Contains("S201-R-3.1", ids);
+        Assert.Contains("S201-R-4.1", ids);
+        Assert.Contains("S201-R-5.1", ids);
+        Assert.Contains("S201-R-6.1", ids);
+        Assert.Contains("S201-R-6.2", ids);
+    }
+
+    [Fact]
+    public void DefaultRuleSet_ProducesNoFindingsOnCleanInventory()
+    {
+        var host = Structure("HOST", lat: 10, lon: 20);
+        var eq = Equipment("EQ", lat: 10, lon: 20, host: host);
+        var ais = Ais("AIS-P", AisAtonKind.Physical, "992341001", lat: 10, lon: 20);
+        var aggSource = AggregationSource("AGG1", "AtonAggregation", peerCount: 2);
+        var agg = Aggregation("AGG1", host, eq);
+        var status = StatusInfo("STAT1", changeTypes: 2);
+
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(host, eq, ais),
+            statusInfo: ImmutableArray.Create(status),
+            aggregations: ImmutableArray.Create(agg),
+            sourceFeatures: ImmutableArray.Create(host.Source, eq.Source, ais.Source, aggSource));
+
+        var report = S201AtonRules.Validate(inv);
+        Assert.Empty(report.Findings);
+    }
+
+    [Fact]
+    public void DefaultRuleSet_SurfacesMultipleViolations()
+    {
+        var bad = Structure("BAD", lat: 95.0, lon: 0);
+        var dup = Structure("BAD");
+        var orphanEq = Equipment("ORPHAN", host: null);
+        var badAis = Ais("AIS-P", AisAtonKind.Physical, mmsi: null);
+        var badStatus = StatusInfo("STAT1", changeTypes: 99);
+
+        var inv = Inventory(
+            atons: ImmutableArray.Create<S201AtonObject>(bad, dup, orphanEq, badAis),
+            statusInfo: ImmutableArray.Create(badStatus));
+
+        var report = S201AtonRules.Validate(inv);
+        var ruleIds = report.Findings.Select(f => f.RuleId).ToHashSet();
+        Assert.Contains("S201-R-1.1", ruleIds);
+        Assert.Contains("S201-R-1.2", ruleIds);
+        Assert.Contains("S201-R-2.1", ruleIds);
+        Assert.Contains("S201-R-3.1", ruleIds);
+        Assert.Contains("S201-R-5.1", ruleIds);
+    }
+}


### PR DESCRIPTION
## Summary

S-201 was the last GML product spec returning `null` from its processor's `Validate()` method, so the viewer's new Validation tab (PR #115) showed "Validation rules not yet defined for S-201". This PR closes that gap with a ten-rule pack modelled on `S125AtonRules`, tuned for the IALA authority-to-authority exchange audience (tight conformance, inventory integrity, lifecycle correctness).

The rules consume the typed `S201AtonInventory` projection (no new model fields), and the processor wires them through the shared `ValidationRunner.Run` pattern used by the nine sibling packs. Once this lands, opening an S-201 dataset in the viewer automatically populates the Validation tab — no viewer changes required.

### Rules

| ID | Severity | Concern |
|---|---|---|
| `S201-R-1.1` `CoordinatesInWgs84Range` | Error | Lat/lon bounds on every AtoN point (S-100 Part 10b §6.2) |
| `S201-R-1.2` `GmlIdsUnique` | Error | `gml:id` uniqueness across AtoNs, aggregations, associations, info types |
| `S201-R-1.3` `NavigableAtoNHasGeometry` | Warning | Physical AtoNs carry at least one fix; exempts Virtual AIS |
| `S201-R-2.1` `PhysicalAisHasMmsi` | Error | Physical/Synthetic AIS-AtoN has a 9-digit MMSI |
| `S201-R-2.2` `VirtualAisMmsiFormat` | Warning | When present on Virtual AIS, MMSI is 9 digits |
| `S201-R-3.1` `ChangeTypesInEnumeration` | Error | Status change-type codes ∈ {1,2,3,4} |
| `S201-R-4.1` `DateRangeOrdered` | Warning | Fixed + periodic date ranges have start ≤ end |
| `S201-R-5.1` `EquipmentHasHostStructure` | Warning | Every `S201Equipment` resolves to a host structure |
| `S201-R-6.1` `AggregationHasMembers` | Warning | Aggregations carry ≥ 2 peers |
| `S201-R-6.2` `AggregationMembersResolved` | Error | Every peer xlink in the source feature resolves |

### Notes / deviations from the kickoff

A few candidates in the kickoff didn't fit the typed model and were dropped or replaced:

- The S-201 typed model has no `S201AtonStatusIndication` (that's S-125 only), so the status-indication position rule is omitted.
- Status date ranges live on `S201AtonObject` itself (`FixedDateRange` / `PeriodicDateRange`), not on `S201AtonStatusInformation`, so the "lifecycle vs removal" rule is reframed as `S201-R-4.1` against those properties.
- `ChangeTypes` is a 4-value codelist in S-201 (vs 5 in S-125) — easy trap if mirroring S-125 verbatim.
- `S201Equipment.HostStructure` is type-system-locked to `S201StructureObject?` and structures have no host, so host-of-host cycles are impossible. The slot is repurposed as `S201-R-6.2` (aggregation xlink resolution), reconstructed by comparing typed `Peers.Length` against the raw `peer`-role `FeatureReferences` to surface dropped references.

## Spec alignment

- [ ] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

S-201 (no checkbox in the template, but the `s201-aton-information` skill was consulted).

**Spec section references cited in code/docs:**

- S-100 Part 10b §6.2 (coordinate order / WGS-84 bounds) — `S201-R-1.1`
- S-100 Part 10b §6.4 (`gml:id` uniqueness) — `S201-R-1.2`
- S-201 Ed 2.0.0 codelist for `ChangeTypes` — `S201-R-3.1`

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

64 new tests in `tests/EncDotNet.S100.Datasets.S201.Tests/Validation/S201AtonRulesTests.cs` (pass + fail per rule, plus two `Default` smoke tests). S-201 test suite: 64 passed / 1 skipped (real-dataset gate) / 0 failed. Pipelines suite: 340 passed.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

`S201AtonRules` is public with full XML docs. No user-facing behaviour change beyond the Validation tab automatically populating.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

None added.

## Breaking changes

None.