### PR TITLE
Add MCP render_to_image tool (viewer-injected)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -75,14 +75,47 @@ npx @modelcontextprotocol/inspector
 
 Set the transport to **Streamable HTTP**, paste the endpoint from the
 viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
-**Connect**. You should see three tools:
+**Connect**. You should see the following tools:
 
 | Tool | Purpose |
 |---|---|
 | `list_datasets` | Summarises every dataset currently loaded in the viewer. |
+| `list_specs` | Lists S-100 product specifications the host can read. |
+| `list_time_steps` | Lists time steps for a time-varying dataset (S-104, S-111, S-421). |
 | `find_at` | Returns every loaded dataset whose declared bounding box contains a lat/lon point (decimal degrees, WGS-84). Bbox-only — does not check per-cell coverage or NoData masks. |
 | `describe_feature` | Returns spec, feature type, and attributes for a feature id in a given dataset. Supported specs: S-101 (RCID), S-102 (`BathymetryCoverage[.01]`), S-104 / S-111 (`WaterLevel`/`SurfaceCurrent[.NN][.Group_KKK]` or bare station identifier), S-124 (`gml:id`), and S-129 (`gml:id` of plan / plan-area / control-point / non-navigable-area). |
+| `query_features` | Returns features from loaded GML vector datasets whose geometry intersects a spatial query. |
 | `sample_coverage` | Samples a depth / water-level / current value at a lat/lon from an S-102 / S-104 / S-111 dataset. |
+| `sample_coverage_along` | Samples a coverage along a polyline / great-circle path. |
+| `render_to_image` *(viewer only)* | Captures the viewer's current map view as a PNG image, returned as an MCP `ImageContentBlock`. Lets an agent see exactly what the user sees for diagnosis of rendering issues (palette banding, NoData voids, augmented-geometry artefacts, missing features, etc.). |
+
+### Image content blocks (`render_to_image`)
+
+`render_to_image` is the first tool in this codebase to return non-text
+MCP content. The response payload is a `CallToolResult` whose
+`Content` array contains, in order:
+
+1. an `ImageContentBlock` carrying base64-encoded PNG bytes with
+   `mimeType: "image/png"` — MCP clients render this inline;
+2. a `TextContentBlock` carrying a small JSON metadata envelope
+   (`width`, `height`, `pixelDensity`, `imageFormat`, `byteLength`,
+   optional `notes`) so agents still get structured echo of the
+   rendered dimensions.
+
+The snapshot is captured from a **clone** of the live Mapsui `Map`
+that shares the layer collection but owns its own navigator. The
+live map control is never mutated, so taking a snapshot does not
+disturb the user's view or trigger a redraw on screen. Viewport,
+palette, time step, and loaded datasets reflect the user's current
+view exactly.
+
+`render_to_image` is **viewer-only**: it is injected into the hosted
+MCP server by `EncDotNet.S100.Viewer` via the
+`S100McpServerOptions.AdditionalTools` extension point. A future
+headless MCP host would need to supply its own equivalent (or
+something domain-appropriate) — the catalog-only
+`EncDotNet.S100.Mcp.Tools` library deliberately has no rendering
+dependency.
 
 ## Sample agent prompts
 

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -168,6 +168,16 @@ The five error variants implemented in this PR:
 `FeatureDescriberRegistry` keyed on `SpecRef.Name`. Each describer
 implements an internal `ISpecFeatureDescriber` strategy.
 
+## Host-injected tools
+
+The eight tools above are catalog-only and live in this assembly. A
+host (e.g. the Avalonia viewer) may inject additional tools at
+runtime via `S100McpServerOptions.AdditionalTools` in
+`EncDotNet.S100.Mcp`. The viewer uses this extension point to expose
+`render_to_image`, which captures the live map as a PNG — that tool
+necessarily depends on Mapsui / Skia and therefore deliberately does
+not live here. See `docs/mcp-server.md` for details.
+
 The registry currently wires six describers:
 
 | Spec   | Describer                  | Feature id convention                                                                                       |

--- a/src/EncDotNet.S100.Mcp/S100McpServer.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServer.cs
@@ -118,7 +118,12 @@ public sealed class S100McpServer : IAsyncDisposable
         var listTimeSteps = new ListTimeStepsTool(_catalog);
         var tools = S100McpServerToolFactory
             .CreateTools(listDatasets, describeFeature, sampleCoverage, findAt, queryFeatures, sampleCoverageAlong, listSpecs, listTimeSteps)
-            .ToArray();
+            .ToList();
+
+        if (_options.AdditionalTools is { Count: > 0 } extra)
+        {
+            tools.AddRange(extra);
+        }
 
         builder.Services
             .AddMcpServer()

--- a/src/EncDotNet.S100.Mcp/S100McpServerOptions.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerOptions.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Net;
+using ModelContextProtocol.Server;
 
 namespace EncDotNet.S100.Mcp;
 
@@ -34,4 +36,21 @@ public sealed class S100McpServerOptions
     /// Time to wait before evicting an idle MCP session.
     /// </summary>
     public TimeSpan IdleTimeout { get; init; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Additional MCP tools to expose alongside the built-in catalog
+    /// tools. Hosts inject tools that need live UI / processor state
+    /// here (e.g. the viewer's <c>render_to_image</c> tool, which
+    /// snapshots the current Mapsui map). May be <see langword="null"/>
+    /// or empty when no host-supplied tools are needed.
+    /// </summary>
+    /// <remarks>
+    /// Each entry is appended verbatim to the built-in tool list before
+    /// the MCP server is started; tool names must therefore not collide
+    /// with the built-ins (<c>list_datasets</c>, <c>describe_feature</c>,
+    /// <c>sample_coverage</c>, <c>find_at</c>, <c>query_features</c>,
+    /// <c>sample_coverage_along</c>, <c>list_specs</c>,
+    /// <c>list_time_steps</c>).
+    /// </remarks>
+    public IReadOnlyList<McpServerTool>? AdditionalTools { get; init; }
 }

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -230,9 +230,11 @@ public partial class App : Application
         // observes the existing dataset loader and re-opens dataset files
         // for read-only MCP queries; the host owns server lifecycle.
         services.AddSingleton<ViewerDatasetCatalog>();
+        services.AddSingleton<IMapHostAccessor, MapHostAccessor>();
         services.AddSingleton<McpServerHost>(sp => new McpServerHost(
             sp.GetRequiredService<ViewerDatasetCatalog>(),
             sp.GetRequiredService<ViewerSettings>(),
+            sp.GetRequiredService<IMapHostAccessor>(),
             sp.GetService<ILoggerFactory>()));
 
         // View models

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -117,7 +117,9 @@ public partial class MainWindow : ShadUI.Window
         // Hand the loader a map host now that the Mapsui control exists, and
         // seed catalogues / build the pipeline factory from CLI options. The
         // loader subscribes to its own settings dependencies internally.
-        _loader.Initialize(new MapsuiMapHost(MapControl), options);
+        var mapHost = new MapsuiMapHost(MapControl);
+        App.Services.GetRequiredService<IMapHostAccessor>().Current = mapHost;
+        _loader.Initialize(mapHost, options);
         _loader.StatusChanged += text => _viewModel.StatusText = text;
         _loader.DatasetLoaded += entry =>
         {

--- a/src/EncDotNet.S100.Viewer/McpTools/MapNotReady.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/MapNotReady.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+using EncDotNet.S100.Mcp.Tools;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// The viewer's map control has not been initialised yet (or the
+/// snapshot path failed). Returned by <see cref="RenderToImageTool"/>
+/// when no PNG can be produced. Distinguished from
+/// <see cref="InvalidArgument"/> in that the caller's request is
+/// well-formed; the host environment is simply not ready.
+/// </summary>
+/// <param name="Reason">Single-sentence description of which aspect of the host is unavailable.</param>
+[Description("Raised when the viewer's map control has not been initialised yet (or has been torn down) and a render snapshot cannot be produced.")]
+internal sealed record MapNotReady(
+    [property: Description("Single-sentence description of which aspect of the host is unavailable.")] string Reason)
+    : ToolError("map_not_ready", $"The viewer's map is not ready: {Reason}.");

--- a/src/EncDotNet.S100.Viewer/McpTools/RenderToImageMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RenderToImageMcpAdapter.cs
@@ -25,6 +25,7 @@ internal static class RenderToImageMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/RenderToImageMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RenderToImageMcpAdapter.cs
@@ -1,0 +1,167 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Wraps a <see cref="RenderToImageTool"/> as an <see cref="McpServerTool"/>
+/// so the viewer's <c>McpServerHost</c> can inject it into the hosted
+/// <c>EncDotNet.S100.Mcp.S100McpServer</c>. The wrapper returns the
+/// PNG as a first-class <see cref="ImageContentBlock"/> (the first
+/// MCP tool in this codebase to do so), followed by a
+/// <see cref="TextContentBlock"/> carrying JSON metadata so agents
+/// still see echoed dimensions.
+/// </summary>
+internal static class RenderToImageMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Captures the viewer's current map view as a PNG image and returns it as an MCP " +
+        "ImageContentBlock alongside a JSON metadata block. Primary use case: agent-driven " +
+        "diagnosis of rendering issues — palette banding, NoData voids, augmented-geometry " +
+        "artefacts, missing features, etc. The snapshot reflects exactly what the user sees: " +
+        "viewport, palette, time step, loaded datasets. Read-only and side-effect free; the " +
+        "live map control is not mutated. Viewer-injected tool — not available from a headless " +
+        "MCP host until that host supplies its own equivalent.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(RenderToImageTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+
+        var del = (
+            [Description("Output image width in pixels; null defaults to 1024. Clamped to [64, 4096].")] int? width = null,
+            [Description("Output image height in pixels; null defaults to 768. Clamped to [64, 4096].")] int? height = null,
+            [Description("Display pixel-density multiplier (1.0 = device-independent pixels; 2.0 = HiDPI). Null defaults to 1.0. Clamped to [0.5, 3.0].")] double? pixelDensity = null,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(
+                new RenderToImageRequest(width, height, pixelDensity),
+                ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = RenderToImageTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<RenderToImageResult>>> resultFactory)
+    {
+        try
+        {
+            var result = await resultFactory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return InternalError(ex);
+        }
+    }
+
+    /// <summary>
+    /// Test seam: translates an already-completed <see cref="ToolResult{T}"/>
+    /// into a <see cref="CallToolResult"/> using the same shape this
+    /// adapter produces in production. Lets tests assert that successes
+    /// surface as <see cref="ImageContentBlock"/> + <see cref="TextContentBlock"/>
+    /// (in that order) without standing up an MCP server.
+    /// </summary>
+    internal static CallToolResult TranslateResult(ToolResult<RenderToImageResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            return Success(value);
+        }
+        result.TryGetError(out var err);
+        return Failure(err!);
+    }
+
+    private static CallToolResult Success(RenderToImageResult value)
+    {
+        var metadata = new JsonObject
+        {
+            ["width"] = value.Width,
+            ["height"] = value.Height,
+            ["pixelDensity"] = value.PixelDensity,
+            ["imageFormat"] = value.ImageFormat,
+            ["byteLength"] = value.ImageBytes.Length,
+        };
+        if (value.Notes is not null)
+        {
+            metadata["notes"] = value.Notes;
+        }
+
+        return new CallToolResult
+        {
+            Content =
+            [
+                ImageContentBlock.FromBytes(value.ImageBytes, "image/png"),
+                new TextContentBlock { Text = metadata.ToJsonString(JsonOptions) },
+            ],
+            IsError = false,
+        };
+    }
+
+    private static CallToolResult Failure(ToolError error)
+    {
+        var details = JsonSerializer.SerializeToNode(error, error.GetType(), JsonOptions) as JsonObject
+            ?? new JsonObject();
+        details.Remove("code");
+        details.Remove("message");
+        details.Remove("Code");
+        details.Remove("Message");
+
+        var payload = new JsonObject
+        {
+            ["code"] = error.Code,
+            ["message"] = error.Message,
+            ["details"] = details,
+        };
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = payload.ToJsonString(JsonOptions) },
+            ],
+            IsError = true,
+        };
+    }
+
+    private static CallToolResult InternalError(Exception ex)
+    {
+        var payload = new JsonObject
+        {
+            ["code"] = "internal_error",
+            ["message"] = ex.Message,
+            ["details"] = new JsonObject
+            {
+                ["exceptionType"] = ex.GetType().FullName,
+            },
+        };
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = payload.ToJsonString(JsonOptions) },
+            ],
+            IsError = true,
+        };
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/RenderToImageTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RenderToImageTool.cs
@@ -1,0 +1,178 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Request payload for <see cref="RenderToImageTool"/>.
+/// </summary>
+[Description("Request for render_to_image: optional output dimensions and pixel-density multiplier; the snapshot otherwise mirrors the viewer's current map state exactly.")]
+internal sealed record RenderToImageRequest(
+    [property: Description("Output image width in pixels; null defaults to 1024. Clamped to [64, 4096].")] int? Width = null,
+    [property: Description("Output image height in pixels; null defaults to 768. Clamped to [64, 4096].")] int? Height = null,
+    [property: Description("Display pixel-density multiplier (1.0 = device-independent pixels; 2.0 = HiDPI). Null defaults to 1.0. Clamped to [0.5, 3.0].")] double? PixelDensity = null);
+
+/// <summary>Result of <see cref="RenderToImageTool"/>.</summary>
+[Description("Result of render_to_image: echoed dimensions/density plus PNG bytes; agents receive the image as a separate MCP ImageContentBlock alongside this JSON metadata.")]
+internal sealed record RenderToImageResult(
+    [property: Description("Image width in pixels actually rendered (post-clamp / default-resolution).")] int Width,
+    [property: Description("Image height in pixels actually rendered (post-clamp / default-resolution).")] int Height,
+    [property: Description("Pixel-density multiplier actually applied (post-clamp / default-resolution).")] double PixelDensity,
+    [property: Description("Image format identifier; always \"png\" in v1.")] string ImageFormat,
+    [property: Description("PNG-encoded image bytes; surfaced separately as a MCP ImageContentBlock with mimeType image/png at the wire layer.")] byte[] ImageBytes,
+    [property: Description("Optional human-readable note (e.g. \"applied default 1024x768 size\").")] string? Notes);
+
+/// <summary>
+/// Captures the viewer's current map view as a PNG image so that MCP
+/// agents can visually inspect what the user sees. Primary use case:
+/// diagnosis of rendering issues (palette banding, NoData voids,
+/// augmented-geometry artefacts, missing features, etc.).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tool snapshots the live Mapsui map managed by the viewer's
+/// <see cref="IMapHost"/>: current viewport, palette, time step, and
+/// loaded datasets are reflected exactly. Nothing in the live map is
+/// mutated; the snapshot uses a clone Map that shares the layer
+/// collection but owns its own navigator.
+/// </para>
+/// <para>
+/// This tool is viewer-injected — the catalog-only MCP tool surface
+/// in <c>EncDotNet.S100.Mcp.Tools</c> deliberately has no rendering
+/// dependency. A future headless MCP host would need to provide its
+/// own equivalent.
+/// </para>
+/// </remarks>
+internal sealed class RenderToImageTool
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "render_to_image";
+
+    internal const int DefaultWidth = 1024;
+    internal const int DefaultHeight = 768;
+    internal const double DefaultPixelDensity = 1.0;
+
+    internal const int MinDimension = 64;
+    internal const int MaxDimension = 4096;
+    internal const double MinPixelDensity = 0.5;
+    internal const double MaxPixelDensity = 3.0;
+
+    private readonly IMapHostAccessor _accessor;
+
+    /// <summary>Creates a new <see cref="RenderToImageTool"/>.</summary>
+    public RenderToImageTool(IMapHostAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        _accessor = accessor;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public async Task<ToolResult<RenderToImageResult>> InvokeAsync(
+        RenderToImageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (request.PixelDensity is { } d && (double.IsNaN(d) || double.IsInfinity(d)))
+        {
+            return ToolResult<RenderToImageResult>.Err(
+                new InvalidArgument(nameof(request.PixelDensity),
+                    $"value {d} is not a finite number"));
+        }
+
+        var (width, widthClamped) = ResolveDimension(request.Width, DefaultWidth);
+        var (height, heightClamped) = ResolveDimension(request.Height, DefaultHeight);
+        var (density, densityClamped) = ResolveDensity(request.PixelDensity);
+
+        var host = _accessor.Current;
+        if (host is null)
+        {
+            return ToolResult<RenderToImageResult>.Err(
+                new MapNotReady("the viewer's map control has not been initialised yet"));
+        }
+
+        byte[]? bytes;
+        try
+        {
+            bytes = await host.RenderCurrentViewToPngAsync(width, height, density, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<RenderToImageResult>.Err(
+                new MapNotReady($"render failed: {ex.GetType().Name}: {ex.Message}"));
+        }
+
+        if (bytes is null || bytes.Length == 0)
+        {
+            return ToolResult<RenderToImageResult>.Err(
+                new MapNotReady("no current viewport (map has no size yet)"));
+        }
+
+        var notes = BuildNotes(
+            request.Width is null, widthClamped,
+            request.Height is null, heightClamped,
+            request.PixelDensity is null, densityClamped);
+
+        return ToolResult<RenderToImageResult>.Ok(new RenderToImageResult(
+            width, height, density, "png", bytes, notes));
+    }
+
+    private static (int Value, bool Clamped) ResolveDimension(int? requested, int @default)
+    {
+        if (requested is null) return (@default, false);
+        var raw = requested.Value;
+        var clamped = Math.Clamp(raw, MinDimension, MaxDimension);
+        return (clamped, clamped != raw);
+    }
+
+    private static (double Value, bool Clamped) ResolveDensity(double? requested)
+    {
+        if (requested is null) return (DefaultPixelDensity, false);
+        var raw = requested.Value;
+        var clamped = Math.Clamp(raw, MinPixelDensity, MaxPixelDensity);
+        return (clamped, clamped != raw);
+    }
+
+    private static string? BuildNotes(
+        bool widthDefaulted, bool widthClamped,
+        bool heightDefaulted, bool heightClamped,
+        bool densityDefaulted, bool densityClamped)
+    {
+        if (!widthDefaulted && !widthClamped
+            && !heightDefaulted && !heightClamped
+            && !densityDefaulted && !densityClamped)
+        {
+            return null;
+        }
+
+        var parts = new System.Collections.Generic.List<string>(3);
+        if (widthDefaulted || heightDefaulted)
+        {
+            var which = (widthDefaulted, heightDefaulted) switch
+            {
+                (true, true) => "width/height",
+                (true, false) => "width",
+                _ => "height",
+            };
+            parts.Add($"defaulted {which}");
+        }
+        if (widthClamped || heightClamped)
+        {
+            parts.Add("clamped dimensions to [64, 4096]");
+        }
+        if (densityDefaulted) parts.Add("defaulted pixelDensity to 1.0");
+        else if (densityClamped) parts.Add("clamped pixelDensity to [0.5, 3.0]");
+
+        return string.Join("; ", parts);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
@@ -49,4 +49,28 @@ internal interface IMapHost
     /// map's navigator is unavailable).
     /// </summary>
     void ZoomToExtent(MRect extent);
+
+    /// <summary>
+    /// Captures the current map view as a PNG byte array.
+    /// </summary>
+    /// <param name="widthPx">Output image width in pixels (caller-clamped).</param>
+    /// <param name="heightPx">Output image height in pixels (caller-clamped).</param>
+    /// <param name="pixelDensity">Display pixel density multiplier (1.0 = device-independent pixels).</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// PNG-encoded bytes of the current map state at the requested
+    /// size, or <see langword="null"/> when the underlying map has not
+    /// been initialised yet. The snapshot mirrors the user's current
+    /// viewport, palette, time step, and loaded datasets exactly —
+    /// nothing in the live map is mutated by this call.
+    /// </returns>
+    /// <remarks>
+    /// Implementations must be safe to call from any thread; they
+    /// marshal to the UI thread as needed.
+    /// </remarks>
+    System.Threading.Tasks.Task<byte[]?> RenderCurrentViewToPngAsync(
+        int widthPx,
+        int heightPx,
+        double pixelDensity,
+        System.Threading.CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Viewer/Services/IMapHostAccessor.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IMapHostAccessor.cs
@@ -1,0 +1,32 @@
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Late-bound accessor for the viewer's <see cref="IMapHost"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The map host is constructed by <c>MainWindow</c> after the Avalonia
+/// <see cref="Mapsui.UI.Avalonia.MapControl"/> exists, which happens
+/// after DI is built and after singletons like
+/// <see cref="McpServerHost"/> have already been resolved. This
+/// accessor bridges that ordering: services that need the host (for
+/// snapshotting the current map, etc.) hold the accessor and read
+/// <see cref="Current"/> at invocation time.
+/// </para>
+/// <para>
+/// Implementations are expected to be thread-safe — readers may run
+/// off the UI thread (e.g. MCP request handlers); the host itself is
+/// responsible for marshalling.
+/// </para>
+/// </remarks>
+internal interface IMapHostAccessor
+{
+    /// <summary>The current map host, or <see langword="null"/> when not yet attached.</summary>
+    IMapHost? Current { get; set; }
+}
+
+/// <summary>Default in-memory implementation of <see cref="IMapHostAccessor"/>.</summary>
+internal sealed class MapHostAccessor : IMapHostAccessor
+{
+    public IMapHost? Current { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
@@ -1,8 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
 using Mapsui;
 using Mapsui.Extensions;
 using Mapsui.Layers;
+using Mapsui.Rendering;
+using Mapsui.Rendering.Skia;
 using Mapsui.UI.Avalonia;
 
 namespace EncDotNet.S100.Viewer.Services;
@@ -106,6 +112,63 @@ internal sealed class MapsuiMapHost : IMapHost
         {
             nav.ZoomToBox(extent.Grow(extent.Width * 0.1, extent.Height * 0.1));
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]?> RenderCurrentViewToPngAsync(
+        int widthPx,
+        int heightPx,
+        double pixelDensity,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Marshal to the UI thread: Mapsui's Map/Navigator state must
+        // not be read or mutated concurrently with the live control's
+        // own render loop, and Avalonia layers are UI-affine.
+        return await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var liveMap = _mapControl.Map;
+            if (liveMap is null) return null;
+
+            var liveNav = liveMap.Navigator;
+            var liveViewport = liveNav.Viewport;
+            if (liveViewport.Width <= 0 || liveViewport.Height <= 0) return null;
+
+            // Build a snapshot Map that shares the live Layers list (so
+            // styles, time-step content, palette switches, and any other
+            // mutable per-layer state mirror the user's current view
+            // exactly) but owns its own Navigator. The live map is
+            // therefore untouched: setting size / zoom on the clone
+            // does not trigger a redraw on screen.
+            var snapshot = new Map { CRS = liveMap.CRS, BackColor = liveMap.BackColor };
+            foreach (var layer in liveMap.Layers)
+            {
+                snapshot.Layers.Add(layer);
+            }
+
+            snapshot.Navigator.SetSize(widthPx, heightPx);
+
+            // Match the world-extent the user currently sees. With
+            // MBoxFit.Fit, aspect-ratio mismatches show slightly more
+            // area rather than cropping — acceptable for diagnostic
+            // snapshots; the requested pixel dimensions are exact.
+            var extent = liveViewport.ToExtent();
+            if (extent is not null && extent.Width > 0 && extent.Height > 0)
+            {
+                snapshot.Navigator.ZoomToBox(extent, MBoxFit.Fit);
+            }
+
+            using var stream = new MapRenderer().RenderToBitmapStream(
+                snapshot,
+                pixelDensity: (float)pixelDensity,
+                renderFormat: RenderFormat.Png,
+                quality: 100);
+            stream.Position = 0;
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }).GetTask().ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -5,7 +5,9 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Mcp;
+using EncDotNet.S100.Viewer.McpTools;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
 
 namespace EncDotNet.S100.Viewer.Services;
 
@@ -25,6 +27,7 @@ internal sealed class McpServerHost : IAsyncDisposable
 {
     private readonly EncDotNet.S100.Mcp.Tools.Catalog.IDatasetCatalog _catalog;
     private readonly ViewerSettings _settings;
+    private readonly IMapHostAccessor? _mapHostAccessor;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -34,12 +37,14 @@ internal sealed class McpServerHost : IAsyncDisposable
     public McpServerHost(
         EncDotNet.S100.Mcp.Tools.Catalog.IDatasetCatalog catalog,
         ViewerSettings settings,
+        IMapHostAccessor? mapHostAccessor = null,
         ILoggerFactory? loggers = null)
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(settings);
         _catalog = catalog;
         _settings = settings;
+        _mapHostAccessor = mapHostAccessor;
         _loggers = loggers;
     }
 
@@ -107,10 +112,12 @@ internal sealed class McpServerHost : IAsyncDisposable
             await StopCurrentAsync(cancellationToken).ConfigureAwait(false);
         }
 
+        var additionalTools = BuildAdditionalTools();
         var options = new S100McpServerOptions
         {
             BindAddress = bindAddress,
             Port = port,
+            AdditionalTools = additionalTools,
         };
         var next = new S100McpServer(_catalog, options, _loggers);
         try
@@ -201,6 +208,13 @@ internal sealed class McpServerHost : IAsyncDisposable
     /// <see cref="SocketError.AddressAlreadyInUse"/> as well as the
     /// .NET 10 <c>AddressInUseException</c> wrapper.
     /// </summary>
+    private System.Collections.Generic.IReadOnlyList<McpServerTool>? BuildAdditionalTools()
+    {
+        if (_mapHostAccessor is null) return null;
+        var renderTool = new RenderToImageTool(_mapHostAccessor);
+        return new[] { RenderToImageMcpAdapter.Create(renderTool) };
+    }
+
     private static bool IsPortInUse(Exception ex)
     {
         for (var e = ex; e is not null; e = e.InnerException!)

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerAdditionalToolsTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerAdditionalToolsTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Mcp.Tests;
+
+public class S100McpServerAdditionalToolsTests
+{
+    [Fact]
+    public async Task AdditionalTools_are_advertised_alongside_built_ins()
+    {
+        var catalog = McpTestHelpers.NewCatalog();
+        var extra = McpServerTool.Create(
+            ([Description("Anything")] string echo) => echo,
+            new McpServerToolCreateOptions { Name = "extra_echo", Description = "test-only tool" });
+
+        await using var server = new S100McpServer(catalog, new S100McpServerOptions
+        {
+            BindAddress = IPAddress.Loopback,
+            Port = 0,
+            AdditionalTools = new[] { extra },
+        });
+        await server.StartAsync();
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var tools = await client.ListToolsAsync();
+        Assert.Contains(tools, t => t.Name == "extra_echo");
+        Assert.Contains(tools, t => t.Name == "list_datasets");
+    }
+
+    [Fact]
+    public async Task Null_AdditionalTools_does_not_break_built_ins()
+    {
+        var catalog = McpTestHelpers.NewCatalog();
+        await using var server = new S100McpServer(catalog, new S100McpServerOptions
+        {
+            BindAddress = IPAddress.Loopback,
+            Port = 0,
+            AdditionalTools = null,
+        });
+        await server.StartAsync();
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var tools = await client.ListToolsAsync();
+        Assert.Contains(tools, t => t.Name == "list_datasets");
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RenderToImageToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RenderToImageToolTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using Mapsui;
+using Mapsui.Layers;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RenderToImageToolTests
+{
+    private static readonly byte[] PngSignature = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    private static readonly byte[] StubPng = MakeStubPng();
+
+    private static byte[] MakeStubPng()
+    {
+        // Caller doesn't care that this isn't a real PNG body; only the
+        // signature is checked.
+        var b = new byte[16];
+        Array.Copy(PngSignature, b, PngSignature.Length);
+        return b;
+    }
+
+    private sealed class FakeMapHost : IMapHost
+    {
+        public int ObservedWidth, ObservedHeight;
+        public double ObservedDensity;
+        public byte[]? Result = StubPng;
+        public Exception? Throw;
+
+        public void AddLayer(ILayer layer) { }
+        public void RemoveLayer(ILayer layer) { }
+        public void ReorderDatasetLayers(System.Collections.Generic.IReadOnlyList<ILayer> orderedDatasetLayers) { }
+        public void ZoomToExtent(MRect extent) { }
+
+        public Task<byte[]?> RenderCurrentViewToPngAsync(int widthPx, int heightPx, double pixelDensity, CancellationToken ct = default)
+        {
+            ObservedWidth = widthPx;
+            ObservedHeight = heightPx;
+            ObservedDensity = pixelDensity;
+            if (Throw is not null) throw Throw;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class FakeAccessor : IMapHostAccessor
+    {
+        public IMapHost? Current { get; set; }
+    }
+
+    [Fact]
+    public async Task Applies_defaults_when_request_is_blank()
+    {
+        var host = new FakeMapHost();
+        var accessor = new FakeAccessor { Current = host };
+        var tool = new RenderToImageTool(accessor);
+
+        var result = await tool.InvokeAsync(new RenderToImageRequest());
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal(1024, ok!.Width);
+        Assert.Equal(768, ok.Height);
+        Assert.Equal(1.0, ok.PixelDensity);
+        Assert.Equal("png", ok.ImageFormat);
+        Assert.Same(StubPng, ok.ImageBytes);
+        Assert.Equal(1024, host.ObservedWidth);
+        Assert.Equal(768, host.ObservedHeight);
+        Assert.Equal(1.0, host.ObservedDensity);
+        Assert.NotNull(ok.Notes); // defaulted dimensions/density
+    }
+
+    [Theory]
+    [InlineData(32, 64)]
+    [InlineData(8192, 4096)]
+    [InlineData(64, 64)]
+    [InlineData(4096, 4096)]
+    [InlineData(1000, 1000)]
+    public async Task Clamps_dimensions(int requested, int expected)
+    {
+        var host = new FakeMapHost();
+        var tool = new RenderToImageTool(new FakeAccessor { Current = host });
+        var r = await tool.InvokeAsync(new RenderToImageRequest(Width: requested, Height: requested, PixelDensity: 1.0));
+        Assert.True(r.TryGetValue(out var ok));
+        Assert.Equal(expected, ok!.Width);
+        Assert.Equal(expected, ok.Height);
+    }
+
+    [Theory]
+    [InlineData(0.1, 0.5)]
+    [InlineData(5.0, 3.0)]
+    [InlineData(1.5, 1.5)]
+    public async Task Clamps_pixel_density(double requested, double expected)
+    {
+        var host = new FakeMapHost();
+        var tool = new RenderToImageTool(new FakeAccessor { Current = host });
+        var r = await tool.InvokeAsync(new RenderToImageRequest(PixelDensity: requested));
+        Assert.True(r.TryGetValue(out var ok));
+        Assert.Equal(expected, ok!.PixelDensity);
+    }
+
+    [Fact]
+    public async Task NaN_density_returns_invalid_argument()
+    {
+        var tool = new RenderToImageTool(new FakeAccessor { Current = new FakeMapHost() });
+        var r = await tool.InvokeAsync(new RenderToImageRequest(PixelDensity: double.NaN));
+        Assert.True(r.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Missing_host_returns_map_not_ready()
+    {
+        var tool = new RenderToImageTool(new FakeAccessor { Current = null });
+        var r = await tool.InvokeAsync(new RenderToImageRequest());
+        Assert.True(r.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public async Task Null_bytes_returns_map_not_ready()
+    {
+        var host = new FakeMapHost { Result = null };
+        var tool = new RenderToImageTool(new FakeAccessor { Current = host });
+        var r = await tool.InvokeAsync(new RenderToImageRequest());
+        Assert.True(r.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public async Task Host_exception_returns_map_not_ready()
+    {
+        var host = new FakeMapHost { Throw = new InvalidOperationException("no map") };
+        var tool = new RenderToImageTool(new FakeAccessor { Current = host });
+        var r = await tool.InvokeAsync(new RenderToImageRequest());
+        Assert.True(r.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public void Adapter_produces_image_content_block_first()
+    {
+        var host = new FakeMapHost();
+        var tool = new RenderToImageTool(new FakeAccessor { Current = host });
+        var mcpTool = RenderToImageMcpAdapter.Create(tool);
+        Assert.Equal("render_to_image", mcpTool.ProtocolTool.Name);
+    }
+
+    [Fact]
+    public void Adapter_success_emits_image_then_text()
+    {
+        var ok = ToolResult<RenderToImageResult>.Ok(new RenderToImageResult(
+            Width: 256, Height: 256, PixelDensity: 1.0,
+            ImageFormat: "png", ImageBytes: StubPng, Notes: null));
+        var call = RenderToImageMcpAdapter.TranslateResult(ok);
+        Assert.False(call.IsError);
+        Assert.Collection(call.Content,
+            c => Assert.IsType<ImageContentBlock>(c),
+            c => Assert.IsType<TextContentBlock>(c));
+        var img = (ImageContentBlock)call.Content[0];
+        Assert.Equal("image/png", img.MimeType);
+    }
+
+    [Fact]
+    public void Adapter_error_emits_structured_text()
+    {
+        var err = ToolResult<RenderToImageResult>.Err(new MapNotReady("no map"));
+        var call = RenderToImageMcpAdapter.TranslateResult(err);
+        Assert.True(call.IsError);
+        var single = Assert.Single(call.Content);
+        var text = Assert.IsType<TextContentBlock>(single);
+        Assert.Contains("map_not_ready", text.Text);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `render_to_image` MCP tool that returns the viewer's current map view as a PNG, surfaced as an MCP `ImageContentBlock`, so agents can see exactly what the user sees. Primary motivation is agent-driven diagnosis of rendering issues: palette banding, NoData voids, augmented-geometry artefacts, missing features, and so on.

The tool is deliberately viewer-injected. `EncDotNet.S100.Mcp.Tools` stays catalog-only with no Mapsui/Skia dependency; the viewer extends the hosted server through a new `S100McpServerOptions.AdditionalTools` plug point. A future headless MCP host would supply its own equivalent.

### Approach

- `S100McpServerOptions.AdditionalTools` lets a host inject extra `McpServerTool` instances alongside the eight built-in catalog tools. `S100McpServer.StartAsync` merges them before `WithTools(...)`.
- `IMapHost.RenderCurrentViewToPngAsync` snapshots a **clone** Mapsui `Map` that shares the live layer collection but owns its own `Navigator`. The live map control is never mutated; viewport / palette / time step / loaded datasets reflect the user's view exactly. UI-thread marshalled via Avalonia `Dispatcher.UIThread`.
- `IMapHostAccessor` late-binds the map host: `McpServerHost` is a DI singleton built at startup, but `MapsuiMapHost` is constructed inside `MainWindow` after the `MapControl` exists. The accessor bridges that ordering.
- `RenderToImageTool` exposes a minimal request surface — optional `Width`/`Height` (clamped 64..4096) and `PixelDensity` (clamped 0.5..3.0). Everything else is read live from the map so the snapshot mirrors the user's view rather than imposing synthetic overrides.
- `RenderToImageMcpAdapter` returns `CallToolResult { Content = [ImageContentBlock(png), TextContentBlock(json metadata)] }`, the first non-text MCP content block in this codebase. A new `MapNotReady` `ToolError` variant covers "host not attached" / "render failed" cleanly.

### Notes for reviewers

- One bug surfaced during the end-to-end smoke test and is included as a follow-up commit: `JsonSerializerOptions` for the adapter must specify a `TypeInfoResolver` up front (the MCP SDK marks the options read-only via reflection). Caught by launching the viewer with MCP enabled and calling the tool; without the fix `McpServerHost.Apply` throws.
- Aspect-ratio mismatches between the requested pixel dimensions and the live viewport are handled with `MBoxFit.Fit` — the snapshot shows slightly more area rather than cropping. Acceptable for diagnostics; requested pixel dimensions are exact.
- All new viewer-side types are `internal` (the viewer assembly has `InternalsVisibleTo` for its test project).

## Spec alignment

- [x] N/A — change is purely infrastructural (MCP server / tooling / viewer integration)

**Spec section references cited in code/docs:** N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (none required here; fakes only)
- [x] `dotnet test --configuration Release` passes locally

New coverage:

- `tests/EncDotNet.S100.Viewer.Tests/RenderToImageToolTests.cs` — defaults, dimension clamping (32 -> 64, 8192 -> 4096), density clamping (0.1 -> 0.5, 5.0 -> 3.0), NaN density rejection, missing host / null bytes / host exception -> `MapNotReady`, adapter content-block ordering (`ImageContentBlock` then `TextContentBlock`), structured error text.
- `tests/EncDotNet.S100.Mcp.Tests/S100McpServerAdditionalToolsTests.cs` — round-trips through the live server confirming `AdditionalTools` are advertised by `ListToolsAsync` alongside built-ins, and that `null` still works.

End-to-end verified by launching the viewer with MCP enabled and calling the tool over JSON-RPC; the response carried a 95 KB PNG `ImageContentBlock` plus echoed metadata.

## Documentation

- [x] Updated `src/EncDotNet.S100.Mcp.Tools/README.md` (host-injected tools section)
- [x] Updated `docs/mcp-server.md` (tool inventory + new "Image content blocks" section explaining the pattern)
- [x] New public/internal APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new deps)

## Breaking changes

None. `S100McpServerOptions.AdditionalTools` is a new optional nullable property; existing callers are unaffected.