### PR TITLE
Validation findings: click-to-zoom + map overlay

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -38,6 +38,7 @@ public partial class MainWindow : ShadUI.Window
     private readonly IExchangeSetService _exchangeSetService;
     private readonly MainViewModel _viewModel;
     private readonly DatasetCatalogAggregator _catalogAggregator;
+    private ValidationOverlayService? _validationOverlay;
     private string? _screenshotPath;
 
     public MainWindow() : this(null) { }
@@ -117,7 +118,21 @@ public partial class MainWindow : ShadUI.Window
         // Hand the loader a map host now that the Mapsui control exists, and
         // seed catalogues / build the pipeline factory from CLI options. The
         // loader subscribes to its own settings dependencies internally.
-        _loader.Initialize(new MapsuiMapHost(MapControl), options);
+        var mapHost = new MapsuiMapHost(MapControl);
+        _loader.Initialize(mapHost, options);
+        // Wire validation finding click-to-zoom: each finding view-model
+        // routes its <c>ZoomToFindingCommand</c> through this dispatcher.
+        _viewModel.Datasets.ZoomDispatcher = mapHost.ZoomToExtent;
+        // Build the validation findings overlay layer that draws above
+        // all dataset layers for the currently-selected dataset. The
+        // service subscribes to the datasets view-model and lives for
+        // the lifetime of the window.
+        _validationOverlay = new ValidationOverlayService(mapHost, _viewModel.Datasets);
+        Closed += (_, _) =>
+        {
+            _validationOverlay?.Dispose();
+            _validationOverlay = null;
+        };
         _loader.StatusChanged += text => _viewModel.StatusText = text;
         _loader.DatasetLoaded += entry =>
         {

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -51,6 +51,8 @@ internal static class Strings
     public static string Pane_Validation_Severity_Warning => Get(nameof(Pane_Validation_Severity_Warning));
     public static string Pane_Validation_Severity_Info => Get(nameof(Pane_Validation_Severity_Info));
     public static string Tooltip_ValidationBadge => Get(nameof(Tooltip_ValidationBadge));
+    public static string Tooltip_FindingZoomTo => Get(nameof(Tooltip_FindingZoomTo));
+    public static string Tooltip_FindingNoSpatialLocation => Get(nameof(Tooltip_FindingNoSpatialLocation));
     public static string Pane_Catalog => Get(nameof(Pane_Catalog));
     public static string Pane_Settings => Get(nameof(Pane_Settings));
     public static string Pane_Search => Get(nameof(Pane_Search));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -305,6 +305,12 @@
   <data name="Tooltip_ValidationBadge" xml:space="preserve">
     <value>{0} validation findings ({1} errors, {2} warnings, {3} info)</value>
   </data>
+  <data name="Tooltip_FindingZoomTo" xml:space="preserve">
+    <value>Zoom map to finding location.</value>
+  </data>
+  <data name="Tooltip_FindingNoSpatialLocation" xml:space="preserve">
+    <value>No spatial location for this finding.</value>
+  </data>
   <data name="Tooltip_TimelineSlider" xml:space="preserve">
     <value>Drag to set the global time. All loaded time-varying datasets re-render at the timestep nearest to this value.</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
@@ -49,4 +49,16 @@ internal interface IMapHost
     /// map's navigator is unavailable).
     /// </summary>
     void ZoomToExtent(MRect extent);
+
+    /// <summary>
+    /// Adds an overlay-tier layer to the map, above all dataset
+    /// layers. Used by services such as the validation findings
+    /// overlay that need to draw above all datasets independently of
+    /// dataset ordering. Overlay layers are not tracked as dataset
+    /// layers and are never moved by <see cref="ReorderDatasetLayers"/>.
+    /// </summary>
+    void AddOverlayLayer(ILayer layer);
+
+    /// <summary>Removes a previously-added overlay layer.</summary>
+    void RemoveOverlayLayer(ILayer layer);
 }

--- a/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
@@ -25,6 +25,14 @@ internal sealed class MapsuiMapHost : IMapHost
     /// </summary>
     private readonly HashSet<ILayer> _datasetLayers = new();
 
+    /// <summary>
+    /// Tracks overlay-tier layers added via
+    /// <see cref="AddOverlayLayer"/>. Held separately from
+    /// <see cref="_datasetLayers"/> so <see cref="ReorderDatasetLayers"/>
+    /// never moves or removes overlays.
+    /// </summary>
+    private readonly HashSet<ILayer> _overlayLayers = new();
+
     public MapsuiMapHost(MapControl mapControl)
     {
         ArgumentNullException.ThrowIfNull(mapControl);
@@ -106,6 +114,22 @@ internal sealed class MapsuiMapHost : IMapHost
         {
             nav.ZoomToBox(extent.Grow(extent.Width * 0.1, extent.Height * 0.1));
         }
+    }
+
+    public void AddOverlayLayer(ILayer layer)
+    {
+        ArgumentNullException.ThrowIfNull(layer);
+        var map = _mapControl.Map;
+        if (map is null) return;
+        if (!_overlayLayers.Add(layer)) return;
+        map.Layers.Add(layer);
+    }
+
+    public void RemoveOverlayLayer(ILayer layer)
+    {
+        ArgumentNullException.ThrowIfNull(layer);
+        _overlayLayers.Remove(layer);
+        _mapControl.Map?.Layers.Remove(layer);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Services/ValidationOverlayBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ValidationOverlayBuilder.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Validation;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Projections;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using MapsuiColor = Mapsui.Styles.Color;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Builds the Mapsui <see cref="MemoryLayer"/> overlay that renders
+/// validation findings with spatial information for the currently
+/// selected dataset. Modelled on
+/// <see cref="EncDotNet.S100.Viewer.Tools.MeasureOverlayLayer"/>: the
+/// feature list is rebuilt from scratch on every update — finding
+/// counts are small and the code stays declarative.
+/// </summary>
+internal static class ValidationOverlayBuilder
+{
+    /// <summary>Stable layer name; reused so the host can find/remove it.</summary>
+    public const string LayerName = "Validation Findings Overlay";
+
+    // Severity palette — matches the validation badge / icon colours
+    // declared in <c>Views/DatasetsView.axaml</c>.
+    private static readonly MapsuiColor ErrorColor = new(0xD1, 0x34, 0x38);
+    private static readonly MapsuiColor WarningColor = new(0xCA, 0x50, 0x10);
+    private static readonly MapsuiColor InfoColor = new(0x00, 0x7A, 0xCC);
+    private static readonly MapsuiColor HaloColor = new(0xFF, 0xFF, 0xFF);
+
+    /// <summary>Creates a fresh, empty overlay layer.</summary>
+    public static MemoryLayer Create() => new()
+    {
+        Name = LayerName,
+        Style = null,
+        Features = new List<IFeature>(),
+    };
+
+    /// <summary>
+    /// Replaces <paramref name="layer"/>'s features with a freshly
+    /// built representation of the findings in
+    /// <paramref name="findings"/> that carry spatial information.
+    /// Findings without a <c>Point</c> or <c>BoundingBox</c> are
+    /// silently skipped.
+    /// </summary>
+    public static void Update(MemoryLayer layer, IEnumerable<ValidationFindingViewModel> findings)
+    {
+        var features = new List<IFeature>();
+        foreach (var vm in findings)
+        {
+            if (!vm.HasSpatialLocation) continue;
+            var color = SeverityColor(vm.Severity);
+
+            if (vm.BoundingBox is { } bbox)
+            {
+                features.Add(BuildBoundingBoxFeature(bbox, color));
+            }
+            if (vm.Point is { } point)
+            {
+                features.Add(BuildPointFeature(point.Latitude, point.Longitude, color));
+            }
+        }
+        layer.Features = features;
+        layer.DataHasChanged();
+    }
+
+    /// <summary>
+    /// Severity → marker/stroke colour. Internal so tests can assert
+    /// the mapping without re-declaring the palette.
+    /// </summary>
+    internal static MapsuiColor SeverityColor(ValidationSeverity severity) => severity switch
+    {
+        ValidationSeverity.Error => ErrorColor,
+        ValidationSeverity.Warning => WarningColor,
+        _ => InfoColor,
+    };
+
+    private static IFeature BuildPointFeature(double latitude, double longitude, MapsuiColor color)
+    {
+        var (mx, my) = SphericalMercator.FromLonLat(longitude, latitude);
+        var feature = new GeometryFeature(new Point(mx, my));
+        feature.Styles.Add(new SymbolStyle
+        {
+            SymbolType = SymbolType.Ellipse,
+            SymbolScale = 0.7,
+            Fill = new Brush { Color = color },
+            Outline = new Pen { Color = HaloColor, Width = 2.0 },
+        });
+        return feature;
+    }
+
+    private static IFeature BuildBoundingBoxFeature(EncDotNet.S100.Pipelines.BoundingBox bbox, MapsuiColor color)
+    {
+        var (minX, minY) = SphericalMercator.FromLonLat(bbox.WestLongitude, bbox.SouthLatitude);
+        var (maxX, maxY) = SphericalMercator.FromLonLat(bbox.EastLongitude, bbox.NorthLatitude);
+
+        var ring = new LinearRing(new[]
+        {
+            new Coordinate(minX, minY),
+            new Coordinate(maxX, minY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(minX, maxY),
+            new Coordinate(minX, minY),
+        });
+        var polygon = new Polygon(ring);
+        var feature = new GeometryFeature(polygon);
+
+        // Translucent severity-coloured fill; opaque severity-coloured
+        // stroke. Alpha 64 (~25 %) keeps the underlying chart legible
+        // while still clearly marking the area.
+        var fillColor = new MapsuiColor(color.R, color.G, color.B, 64);
+        feature.Styles.Add(new VectorStyle
+        {
+            Fill = new Brush { Color = fillColor },
+            Outline = new Pen { Color = color, Width = 2.0 },
+        });
+        return feature;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/ValidationOverlayService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ValidationOverlayService.cs
@@ -1,0 +1,115 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Maintains a single overlay-tier <see cref="MemoryLayer"/> that
+/// renders validation findings with spatial information for the
+/// currently-selected dataset. Built/replaced/torn down as the user
+/// changes selection so findings never "pile up" across datasets.
+/// </summary>
+internal sealed class ValidationOverlayService : IDisposable
+{
+    private readonly IMapHost _mapHost;
+    private readonly DatasetsViewModel _datasets;
+    private DatasetEntry? _trackedEntry;
+    private MemoryLayer? _layer;
+    private bool _disposed;
+
+    public ValidationOverlayService(IMapHost mapHost, DatasetsViewModel datasets)
+    {
+        ArgumentNullException.ThrowIfNull(mapHost);
+        ArgumentNullException.ThrowIfNull(datasets);
+        _mapHost = mapHost;
+        _datasets = datasets;
+        _datasets.PropertyChanged += OnDatasetsPropertyChanged;
+        SyncSelection();
+    }
+
+    /// <summary>
+    /// Exposed for tests so they can assert layer state without
+    /// reaching into the (fake) map host.
+    /// </summary>
+    internal MemoryLayer? CurrentLayer => _layer;
+
+    private void OnDatasetsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(DatasetsViewModel.SelectedEntry))
+        {
+            SyncSelection();
+        }
+    }
+
+    private void OnEntryPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(DatasetEntry.Findings))
+        {
+            Rebuild();
+        }
+    }
+
+    private void SyncSelection()
+    {
+        var newEntry = _datasets.SelectedEntry;
+        if (ReferenceEquals(newEntry, _trackedEntry))
+        {
+            Rebuild();
+            return;
+        }
+
+        if (_trackedEntry is not null)
+        {
+            _trackedEntry.PropertyChanged -= OnEntryPropertyChanged;
+        }
+        _trackedEntry = newEntry;
+        if (_trackedEntry is not null)
+        {
+            _trackedEntry.PropertyChanged += OnEntryPropertyChanged;
+        }
+        Rebuild();
+    }
+
+    private void Rebuild()
+    {
+        var entry = _trackedEntry;
+        var spatial = entry?.Findings.Where(f => f.HasSpatialLocation).ToArray();
+        var hasSpatial = spatial is { Length: > 0 };
+
+        if (!hasSpatial)
+        {
+            TeardownLayer();
+            return;
+        }
+
+        if (_layer is null)
+        {
+            _layer = ValidationOverlayBuilder.Create();
+            _mapHost.AddOverlayLayer(_layer);
+        }
+        ValidationOverlayBuilder.Update(_layer, spatial!);
+    }
+
+    private void TeardownLayer()
+    {
+        if (_layer is null) return;
+        _mapHost.RemoveOverlayLayer(_layer);
+        _layer = null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _datasets.PropertyChanged -= OnDatasetsPropertyChanged;
+        if (_trackedEntry is not null)
+        {
+            _trackedEntry.PropertyChanged -= OnEntryPropertyChanged;
+            _trackedEntry = null;
+        }
+        TeardownLayer();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -282,12 +282,24 @@ internal sealed class DatasetEntry : ViewModelBase
     /// thread; consumers are responsible for marshalling to the UI
     /// thread when needed.
     /// </summary>
+    /// <summary>
+    /// Optional callback that zooms the live map to a finding's
+    /// extent. Set by <see cref="DatasetsViewModel"/> once the entry
+    /// is added to its <c>Entries</c> collection so finding
+    /// view-models built by <see cref="SetValidationReport"/> can
+    /// drive <see cref="Services.IMapHost.ZoomToExtent"/> through it.
+    /// Stays <c>null</c> in tests that don't construct the
+    /// view-model, in which case <see cref="ValidationFindingViewModel.ZoomToFindingCommand"/>
+    /// is disabled.
+    /// </summary>
+    internal Action<Mapsui.MRect>? ZoomDispatcher { get; set; }
+
     public void SetValidationReport(ValidationReport? report)
     {
         _validation = report;
         Findings = report is null || report.Findings.IsDefaultOrEmpty
             ? Array.Empty<ValidationFindingViewModel>()
-            : report.Findings.Select(f => new ValidationFindingViewModel(f)).ToArray();
+            : report.Findings.Select(f => new ValidationFindingViewModel(f, ZoomDispatcher)).ToArray();
 
         OnPropertyChanged(nameof(Validation));
         OnPropertyChanged(nameof(Findings));
@@ -425,6 +437,28 @@ internal sealed class DatasetsViewModel : ViewModelBase
     /// of the Properties sub-panel.</summary>
     public bool HasSelection => _selectedEntry is not null;
 
+    private Action<Mapsui.MRect>? _zoomDispatcher;
+    /// <summary>
+    /// Routes <see cref="ValidationFindingViewModel.ZoomToFindingCommand"/>
+    /// activations from individual finding view-models to the live
+    /// map's <see cref="Services.IMapHost.ZoomToExtent"/>. Set once by
+    /// the window after the map host is available; assigned to every
+    /// entry currently in <see cref="Entries"/> and to entries added
+    /// later.
+    /// </summary>
+    public Action<Mapsui.MRect>? ZoomDispatcher
+    {
+        get => _zoomDispatcher;
+        set
+        {
+            _zoomDispatcher = value;
+            foreach (var entry in Entries)
+            {
+                entry.ZoomDispatcher = value;
+            }
+        }
+    }
+
     public ICommand AddCommand { get; }
     public ICommand RemoveCommand { get; }
 
@@ -493,6 +527,15 @@ internal sealed class DatasetsViewModel : ViewModelBase
         {
             if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
                 _loader.SetEntryOrder(Entries.ToArray());
+
+            if (e.NewItems is not null && _zoomDispatcher is not null)
+            {
+                foreach (var item in e.NewItems)
+                {
+                    if (item is DatasetEntry entry)
+                        entry.ZoomDispatcher = _zoomDispatcher;
+                }
+            }
         };
 
         // Auto-unregister entries from the global time service when they

--- a/src/EncDotNet.S100.Viewer/ViewModels/ValidationFindingViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ValidationFindingViewModel.cs
@@ -1,8 +1,13 @@
+using System;
 using System.Globalization;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.DataModel;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Validation;
 using EncDotNet.S100.Viewer.Resources;
+using Mapsui;
+using Mapsui.Projections;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -13,9 +18,31 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// </summary>
 internal sealed class ValidationFindingViewModel
 {
+    /// <summary>
+    /// Half-side, in metres (EPSG:3857), of the padded square used to
+    /// zoom to a point-only finding. ~500 m gives a comfortable
+    /// feature-level view at roughly 1:50,000.
+    /// </summary>
+    internal const double PointZoomHalfMetres = 500.0;
+
+    private readonly Action<MRect>? _zoomDispatcher;
+
     public ValidationFindingViewModel(ValidationFinding finding)
+        : this(finding, zoomDispatcher: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a finding view-model that routes
+    /// <see cref="ZoomToFindingCommand"/> through
+    /// <paramref name="zoomDispatcher"/>. Pass <c>null</c> in tests or
+    /// non-map surfaces; the command will then no-op while
+    /// <see cref="HasSpatialLocation"/> still reflects the truth.
+    /// </summary>
+    public ValidationFindingViewModel(ValidationFinding finding, Action<MRect>? zoomDispatcher)
     {
         Finding = finding;
+        _zoomDispatcher = zoomDispatcher;
         SeverityClass = finding.Severity switch
         {
             ValidationSeverity.Error => "Error",
@@ -39,6 +66,7 @@ internal sealed class ValidationFindingViewModel
             ? string.Format(CultureInfo.CurrentCulture, Strings.Pane_Validation_RelatedFeatureFormat,
                 finding.RelatedFeatureId)
             : string.Empty;
+        ZoomToFindingCommand = new RelayCommand(ExecuteZoomToFinding, () => HasSpatialLocation);
     }
 
     public ValidationFinding Finding { get; }
@@ -88,9 +116,70 @@ internal sealed class ValidationFindingViewModel
     /// </summary>
     public string RelatedFeatureLine { get; }
 
-    /// <summary>Optional point location, plumbed for future click-to-zoom (not bound in v1).</summary>
+    /// <summary>Optional point location for click-to-zoom and map overlay.</summary>
     public GeoPosition? Point => Finding.Point;
 
-    /// <summary>Optional bounding-box location, plumbed for future click-to-zoom (not bound in v1).</summary>
+    /// <summary>Optional bounding-box location for click-to-zoom and map overlay.</summary>
     public BoundingBox? BoundingBox => Finding.BoundingBox;
+
+    /// <summary>
+    /// <c>true</c> when the finding carries any spatial information
+    /// (either <see cref="Point"/> or <see cref="BoundingBox"/>) that
+    /// the click-to-zoom command and the map overlay can use.
+    /// </summary>
+    public bool HasSpatialLocation => Finding.Point is not null || Finding.BoundingBox is not null;
+
+    /// <summary>
+    /// Localised tooltip for the clickable finding row: the zoom-to
+    /// hint when a spatial location is present, otherwise the
+    /// no-location explanation.
+    /// </summary>
+    public string ZoomTooltip => HasSpatialLocation
+        ? Strings.Tooltip_FindingZoomTo
+        : Strings.Tooltip_FindingNoSpatialLocation;
+
+    /// <summary>
+    /// Command that zooms the map to this finding's spatial location.
+    /// Disabled when <see cref="HasSpatialLocation"/> is <c>false</c>
+    /// or no zoom dispatcher has been supplied. When both
+    /// <see cref="Point"/> and <see cref="BoundingBox"/> are present
+    /// the bounding box wins (richer extent). A point-only finding
+    /// resolves to a small padded square (~500 m on a side) around
+    /// the point so the zoom lands at a sensible feature-level scale.
+    /// </summary>
+    public ICommand ZoomToFindingCommand { get; }
+
+    /// <summary>
+    /// Resolves the EPSG:3857 extent this finding should zoom to, or
+    /// <c>null</c> when the finding has no spatial information.
+    /// Exposed internally for tests; the command uses the same logic.
+    /// </summary>
+    internal MRect? ResolveZoomExtent()
+    {
+        if (Finding.BoundingBox is { } bbox)
+        {
+            var (minX, minY) = SphericalMercator.FromLonLat(bbox.WestLongitude, bbox.SouthLatitude);
+            var (maxX, maxY) = SphericalMercator.FromLonLat(bbox.EastLongitude, bbox.NorthLatitude);
+            return new MRect(minX, minY, maxX, maxY);
+        }
+        if (Finding.Point is { } p)
+        {
+            var (cx, cy) = SphericalMercator.FromLonLat(p.Longitude, p.Latitude);
+            return new MRect(
+                cx - PointZoomHalfMetres,
+                cy - PointZoomHalfMetres,
+                cx + PointZoomHalfMetres,
+                cy + PointZoomHalfMetres);
+        }
+        return null;
+    }
+
+    private void ExecuteZoomToFinding()
+    {
+        if (_zoomDispatcher is null) return;
+        if (ResolveZoomExtent() is { } extent)
+        {
+            _zoomDispatcher(extent);
+        }
+    }
 }

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -137,6 +137,29 @@
         <Style Selector="ic|FluentIcon.SeverityIcon.Info">
             <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
         </Style>
+
+        <!--
+          Clickable finding row: a borderless, transparent-background
+          Button that flashes a subtle hover highlight and switches to
+          the Hand cursor when enabled. Disabled rows (no spatial
+          location) stay flat with the default cursor.
+        -->
+        <Style Selector="Button.FindingRow">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="4,2,4,2" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+        </Style>
+        <Style Selector="Button.FindingRow:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}" />
+        </Style>
+        <Style Selector="Button.FindingRow:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListMediumBrush}" />
+        </Style>
+        <Style Selector="Button.FindingRow:not(:disabled)">
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
     </UserControl.Styles>
 
     <DockPanel>
@@ -593,37 +616,42 @@
                                             </ItemsControl.ItemsPanel>
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="vm:ValidationFindingViewModel">
-                                                    <Grid ColumnDefinitions="Auto,*"
-                                                          RowDefinitions="Auto,Auto,Auto"
-                                                          ColumnSpacing="8"
-                                                          RowSpacing="2">
-                                                        <ic:FluentIcon Grid.Row="0" Grid.Column="0"
-                                                                       Grid.RowSpan="3"
-                                                                       Icon="{Binding SeverityIcon}"
-                                                                       IconVariant="Regular"
-                                                                       FontSize="16"
-                                                                       Classes="SeverityIcon"
-                                                                       Classes.Error="{Binding IsError}"
-                                                                       Classes.Warning="{Binding IsWarning}"
-                                                                       Classes.Info="{Binding IsInfo}"
-                                                                       VerticalAlignment="Top"
-                                                                       Margin="0,2,0,0"
-                                                                       ToolTip.Tip="{Binding SeverityLabel}" />
-                                                        <TextBlock Grid.Row="0" Grid.Column="1"
-                                                                   Text="{Binding RuleId}"
-                                                                   FontFamily="Consolas,Menlo,monospace"
-                                                                   FontSize="11"
-                                                                   Opacity="0.75" />
-                                                        <TextBlock Grid.Row="1" Grid.Column="1"
-                                                                   Text="{Binding Message}"
-                                                                   TextWrapping="Wrap"
-                                                                   FontSize="12" />
-                                                        <TextBlock Grid.Row="2" Grid.Column="1"
-                                                                   Text="{Binding RelatedFeatureLine}"
-                                                                   FontSize="11"
-                                                                   Opacity="0.6"
-                                                                   IsVisible="{Binding HasRelatedFeature}" />
-                                                    </Grid>
+                                                    <Button Classes="FindingRow"
+                                                            Command="{Binding ZoomToFindingCommand}"
+                                                            IsEnabled="{Binding HasSpatialLocation}"
+                                                            ToolTip.Tip="{Binding ZoomTooltip}">
+                                                        <Grid ColumnDefinitions="Auto,*"
+                                                              RowDefinitions="Auto,Auto,Auto"
+                                                              ColumnSpacing="8"
+                                                              RowSpacing="2">
+                                                            <ic:FluentIcon Grid.Row="0" Grid.Column="0"
+                                                                           Grid.RowSpan="3"
+                                                                           Icon="{Binding SeverityIcon}"
+                                                                           IconVariant="Regular"
+                                                                           FontSize="16"
+                                                                           Classes="SeverityIcon"
+                                                                           Classes.Error="{Binding IsError}"
+                                                                           Classes.Warning="{Binding IsWarning}"
+                                                                           Classes.Info="{Binding IsInfo}"
+                                                                           VerticalAlignment="Top"
+                                                                           Margin="0,2,0,0"
+                                                                           ToolTip.Tip="{Binding SeverityLabel}" />
+                                                            <TextBlock Grid.Row="0" Grid.Column="1"
+                                                                       Text="{Binding RuleId}"
+                                                                       FontFamily="Consolas,Menlo,monospace"
+                                                                       FontSize="11"
+                                                                       Opacity="0.75" />
+                                                            <TextBlock Grid.Row="1" Grid.Column="1"
+                                                                       Text="{Binding Message}"
+                                                                       TextWrapping="Wrap"
+                                                                       FontSize="12" />
+                                                            <TextBlock Grid.Row="2" Grid.Column="1"
+                                                                       Text="{Binding RelatedFeatureLine}"
+                                                                       FontSize="11"
+                                                                       Opacity="0.6"
+                                                                       IsVisible="{Binding HasRelatedFeature}" />
+                                                        </Grid>
+                                                    </Button>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -575,7 +575,7 @@
                              are present; severity drives the badge
                              colour via three boolean classes on the
                              view model. -->
-                        <TabItem>
+                        <TabItem HeaderTemplate="{x:Null}">
                             <TabItem.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="6"
                                             VerticalAlignment="Center">

--- a/tests/EncDotNet.S100.Viewer.Tests/ValidationOverlayTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ValidationOverlayTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Validation;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Projections;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for the validation findings overlay: the click-to-zoom
+/// command on <see cref="ValidationFindingViewModel"/>, the
+/// <see cref="ValidationOverlayService"/> selection-driven layer
+/// lifecycle, and the severity → colour mapping in
+/// <see cref="ValidationOverlayBuilder"/>.
+/// </summary>
+public class ValidationOverlayTests
+{
+    // ── Test fakes ───────────────────────────────────────────────────
+
+    private sealed class FakeMapHost : IMapHost
+    {
+        public List<MRect> ZoomCalls { get; } = new();
+        public List<ILayer> Overlays { get; } = new();
+
+        public void AddLayer(ILayer layer) { }
+        public void RemoveLayer(ILayer layer) { }
+        public void ReorderDatasetLayers(IReadOnlyList<ILayer> orderedDatasetLayers) { }
+        public void ZoomToExtent(MRect extent) => ZoomCalls.Add(extent);
+        public void AddOverlayLayer(ILayer layer) => Overlays.Add(layer);
+        public void RemoveOverlayLayer(ILayer layer) => Overlays.Remove(layer);
+    }
+
+    private static ValidationFinding Finding(
+        ValidationSeverity severity = ValidationSeverity.Info,
+        GeoPosition? point = null,
+        BoundingBox? bbox = null)
+        => new()
+        {
+            RuleId = "TEST-1",
+            Severity = severity,
+            Message = "msg",
+            Point = point,
+            BoundingBox = bbox,
+        };
+
+    private static ValidationReport ReportOf(params ValidationFinding[] findings)
+        => new(findings.ToImmutableArray(), RulesEvaluated: findings.Length,
+            RulesWithFindings: findings.Length);
+
+    // ── ValidationFindingViewModel.HasSpatialLocation truth table ────
+
+    [Fact]
+    public void HasSpatialLocation_IsFalse_WhenNeitherPointNorBoundingBox()
+    {
+        var vm = new ValidationFindingViewModel(Finding());
+        Assert.False(vm.HasSpatialLocation);
+        Assert.False(vm.ZoomToFindingCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void HasSpatialLocation_IsTrue_WithPointOnly()
+    {
+        var vm = new ValidationFindingViewModel(Finding(point: new GeoPosition(40, -70)));
+        Assert.True(vm.HasSpatialLocation);
+    }
+
+    [Fact]
+    public void HasSpatialLocation_IsTrue_WithBoundingBoxOnly()
+    {
+        var vm = new ValidationFindingViewModel(Finding(bbox: new BoundingBox(10, 20, 30, 40)));
+        Assert.True(vm.HasSpatialLocation);
+    }
+
+    [Fact]
+    public void HasSpatialLocation_IsTrue_WithBothPointAndBoundingBox()
+    {
+        var vm = new ValidationFindingViewModel(Finding(
+            point: new GeoPosition(40, -70),
+            bbox: new BoundingBox(10, 20, 30, 40)));
+        Assert.True(vm.HasSpatialLocation);
+    }
+
+    // ── Command extent dispatch ──────────────────────────────────────
+
+    [Fact]
+    public void ZoomCommand_DispatchesBoundingBoxExtent()
+    {
+        var captured = new List<MRect>();
+        var bbox = new BoundingBox(southLatitude: 10, westLongitude: 20, northLatitude: 30, eastLongitude: 40);
+        var vm = new ValidationFindingViewModel(Finding(bbox: bbox), extent => captured.Add(extent));
+
+        vm.ZoomToFindingCommand.Execute(null);
+
+        var expected = MercatorRectOf(bbox);
+        Assert.Single(captured);
+        AssertRectClose(expected, captured[0]);
+    }
+
+    [Fact]
+    public void ZoomCommand_DispatchesBoundingBox_WhenBothFieldsPresent()
+    {
+        var captured = new List<MRect>();
+        var bbox = new BoundingBox(10, 20, 30, 40);
+        var vm = new ValidationFindingViewModel(
+            Finding(point: new GeoPosition(45, 25), bbox: bbox),
+            extent => captured.Add(extent));
+
+        vm.ZoomToFindingCommand.Execute(null);
+
+        Assert.Single(captured);
+        AssertRectClose(MercatorRectOf(bbox), captured[0]);
+    }
+
+    [Fact]
+    public void ZoomCommand_DispatchesPaddedSquare_ForPointOnly()
+    {
+        var captured = new List<MRect>();
+        var vm = new ValidationFindingViewModel(
+            Finding(point: new GeoPosition(40, -70)),
+            extent => captured.Add(extent));
+
+        vm.ZoomToFindingCommand.Execute(null);
+
+        Assert.Single(captured);
+        var (cx, cy) = SphericalMercator.FromLonLat(-70, 40);
+        var half = ValidationFindingViewModel.PointZoomHalfMetres;
+        AssertRectClose(new MRect(cx - half, cy - half, cx + half, cy + half), captured[0]);
+    }
+
+    [Fact]
+    public void ZoomCommand_NoOps_WhenNoSpatialLocation()
+    {
+        var captured = new List<MRect>();
+        var vm = new ValidationFindingViewModel(Finding(), extent => captured.Add(extent));
+
+        vm.ZoomToFindingCommand.Execute(null);
+
+        Assert.Empty(captured);
+        Assert.False(vm.ZoomToFindingCommand.CanExecute(null));
+    }
+
+    // ── ValidationOverlayService lifecycle ───────────────────────────
+
+    [Fact]
+    public void OverlayService_AddsNoLayer_WhenSelectionHasNoFindings()
+    {
+        var host = new FakeMapHost();
+        var (vm, _) = MakeDatasetsViewModelWithEntry();
+
+        using var svc = new ValidationOverlayService(host, vm);
+        Assert.Empty(host.Overlays);
+    }
+
+    [Fact]
+    public void OverlayService_AddsNoLayer_WhenFindingsHaveNoSpatialInfo()
+    {
+        var host = new FakeMapHost();
+        var (vm, entry) = MakeDatasetsViewModelWithEntry();
+        entry.SetValidationReport(ReportOf(Finding()));
+        vm.SelectedEntry = entry;
+
+        using var svc = new ValidationOverlayService(host, vm);
+        Assert.Empty(host.Overlays);
+    }
+
+    [Fact]
+    public void OverlayService_AddsLayer_WithFeaturePerSpatialFinding()
+    {
+        var host = new FakeMapHost();
+        var (vm, entry) = MakeDatasetsViewModelWithEntry();
+        entry.SetValidationReport(ReportOf(
+            Finding(point: new GeoPosition(40, -70)),
+            Finding(bbox: new BoundingBox(10, 20, 30, 40)),
+            Finding()));
+        vm.SelectedEntry = entry;
+
+        using var svc = new ValidationOverlayService(host, vm);
+
+        Assert.Single(host.Overlays);
+        var layer = Assert.IsType<MemoryLayer>(host.Overlays[0]);
+        Assert.Equal(2, CountFeatures(layer));
+    }
+
+    [Fact]
+    public void OverlayService_RebuildsLayer_OnSelectionChange()
+    {
+        var host = new FakeMapHost();
+        var loader = new FakeDatasetLoaderService();
+        var vm = new DatasetsViewModel(loader);
+        var withSpatial = new DatasetEntry("/tmp/a.gml", "S-125");
+        withSpatial.SetValidationReport(ReportOf(Finding(point: new GeoPosition(40, -70))));
+        var withoutSpatial = new DatasetEntry("/tmp/b.gml", "S-125");
+        withoutSpatial.SetValidationReport(ReportOf(Finding()));
+        vm.Entries.Add(withSpatial);
+        vm.Entries.Add(withoutSpatial);
+
+        using var svc = new ValidationOverlayService(host, vm);
+
+        vm.SelectedEntry = withSpatial;
+        Assert.Single(host.Overlays);
+
+        vm.SelectedEntry = withoutSpatial;
+        Assert.Empty(host.Overlays);
+
+        vm.SelectedEntry = withSpatial;
+        Assert.Single(host.Overlays);
+
+        vm.SelectedEntry = null;
+        Assert.Empty(host.Overlays);
+    }
+
+    [Fact]
+    public void OverlayService_RemovesLayer_OnDispose()
+    {
+        var host = new FakeMapHost();
+        var (vm, entry) = MakeDatasetsViewModelWithEntry();
+        entry.SetValidationReport(ReportOf(Finding(point: new GeoPosition(40, -70))));
+        vm.SelectedEntry = entry;
+
+        var svc = new ValidationOverlayService(host, vm);
+        Assert.Single(host.Overlays);
+
+        svc.Dispose();
+        Assert.Empty(host.Overlays);
+    }
+
+    // ── Builder severity → colour mapping ────────────────────────────
+
+    [Fact]
+    public void Builder_MapsSeveritiesToBadgePalette()
+    {
+        var error = ValidationOverlayBuilder.SeverityColor(ValidationSeverity.Error);
+        var warning = ValidationOverlayBuilder.SeverityColor(ValidationSeverity.Warning);
+        var info = ValidationOverlayBuilder.SeverityColor(ValidationSeverity.Info);
+
+        Assert.Equal((0xD1, 0x34, 0x38), (error.R, error.G, error.B));
+        Assert.Equal((0xCA, 0x50, 0x10), (warning.R, warning.G, warning.B));
+        Assert.Equal((0x00, 0x7A, 0xCC), (info.R, info.G, info.B));
+    }
+
+    [Fact]
+    public void Builder_SkipsFindings_WithoutSpatialInfo()
+    {
+        var layer = ValidationOverlayBuilder.Create();
+        var vms = new[]
+        {
+            new ValidationFindingViewModel(Finding()),
+            new ValidationFindingViewModel(Finding(point: new GeoPosition(40, -70))),
+        };
+
+        ValidationOverlayBuilder.Update(layer, vms);
+
+        Assert.Equal(1, CountFeatures(layer));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static (DatasetsViewModel vm, DatasetEntry entry) MakeDatasetsViewModelWithEntry()
+    {
+        var loader = new FakeDatasetLoaderService();
+        var vm = new DatasetsViewModel(loader);
+        var entry = new DatasetEntry("/tmp/x.gml", "S-125");
+        vm.Entries.Add(entry);
+        return (vm, entry);
+    }
+
+    private static int CountFeatures(MemoryLayer layer)
+    {
+        int n = 0;
+        foreach (var _ in layer.Features) n++;
+        return n;
+    }
+
+    private static MRect MercatorRectOf(BoundingBox bbox)
+    {
+        var (minX, minY) = SphericalMercator.FromLonLat(bbox.WestLongitude, bbox.SouthLatitude);
+        var (maxX, maxY) = SphericalMercator.FromLonLat(bbox.EastLongitude, bbox.NorthLatitude);
+        return new MRect(minX, minY, maxX, maxY);
+    }
+
+    private static void AssertRectClose(MRect expected, MRect actual, double tolerance = 1e-6)
+    {
+        Assert.InRange(actual.MinX, expected.MinX - tolerance, expected.MinX + tolerance);
+        Assert.InRange(actual.MinY, expected.MinY - tolerance, expected.MinY + tolerance);
+        Assert.InRange(actual.MaxX, expected.MaxX - tolerance, expected.MaxX + tolerance);
+        Assert.InRange(actual.MaxY, expected.MaxY - tolerance, expected.MaxY + tolerance);
+    }
+}


### PR DESCRIPTION
## Summary

Makes dataset validation findings spatially actionable (v2 of #115). Clicking a finding row in the Validation tab now zooms the map to its `Point` / `BoundingBox`, and findings carrying spatial info render as a severity-coloured overlay layer on the map so they are locatable at a glance.

**Approach.** Findings already plumbed `Point` and `BoundingBox` through `ValidationFindingViewModel`; this PR consumes them.

- `ValidationFindingViewModel` gains `HasSpatialLocation`, `ZoomTooltip`, and a `ZoomToFindingCommand` (`CommunityToolkit.Mvvm.Input.RelayCommand`). Extent resolution prefers bbox when both fields are present, falls back to a small Mercator square (~500 m half-side) for point-only findings, and disables the command otherwise.
- A `ZoomDispatcher` (`Action<MRect>?`) is threaded `MainWindow` -> `DatasetsViewModel` -> `DatasetEntry` -> finding VM so the VM never takes a direct `IMapHost` dependency.
- `IMapHost` is extended with `AddOverlayLayer` / `RemoveOverlayLayer` so overlays sit above the dataset tier without `ReorderDatasetLayers` disturbing them (rationale in `plan.md`).
- New `ValidationOverlayService` (lifecycle owner) observes selection + per-entry `Findings` changes and builds/replaces/tears down a single `MemoryLayer` via `ValidationOverlayBuilder` (severity-coloured disc markers + translucent severity-coloured polygons; palette matches the Validation badges: error `#D13438`, warning `#CA5010`, info `#007ACC`).
- The Validation tab finding row becomes a `Button` styled as a transparent row (`Classes="FindingRow"`) bound to `ZoomToFindingCommand`, disabled when no spatial info, with the appropriate tooltip.
- Drive-by fix: the `CenteredTabs` `HeaderTemplate` stringified the new `StackPanel` header (text + count badge) to `Avalonia.Controls.StackPanel`. The Validation `TabItem` now sets `HeaderTemplate="{x:Null}"` so its panel renders directly; the inner `TextBlock` keeps `LetterSpacing="1"` for typographic consistency.

**Verified.** Loaded `tests/datasets/S125/aton_chesapeake.gml` (2 spatial findings at real Chesapeake Bay coordinates from `S125-R-2.1`); rows click-to-zoom and the overlay renders. 305/305 viewer tests + full Release suite green.

## Spec alignment

- [x] N/A - change is purely infrastructural (build, CI, docs, tooling)

UI/viewer change only; no spec semantics touched. `ValidationFinding` and `Core/Validation/` untouched.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New: `tests/EncDotNet.S100.Viewer.Tests/ValidationOverlayTests.cs` (10 tests, including a reusable `FakeMapHost`) covering the truth table for `HasSpatialLocation`, command extent resolution per case, service create/teardown on selection change, and severity colour assignment.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

N/A for README/docs updates (viewer-internal feature with no public API additions outside the viewer assembly); new public-ish members carry XML doc comments.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. `IMapHost` gains two methods on top of the existing surface; existing implementations and callers are unaffected.