### PR TITLE
PR-D2: own-ship overlay (consumer of dynamic-feature-source)

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -231,6 +231,25 @@ public partial class App : Application
         services.AddSingleton<IFileDialogService, FileDialogService>();
         services.AddSingleton<IExchangeSetService, ExchangeSetService>();
 
+        // Own-ship dynamic source (PR-D2). Synthetic driver scaffolds
+        // a moving point at Solent (50.8°N 1.3°W) tracking due east
+        // at 5 m/s (~9.7 kn); a future real-GPS / NMEA-replay driver
+        // implements IOwnShipPositionProvider instead. The source is
+        // also exposed as IDynamicFeatureSource so the overlay host
+        // discovers it via GetServices&lt;IDynamicFeatureSource&gt;().
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipPositionProvider>(_ =>
+            new EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.SyntheticOwnShipPositionProvider(
+                start: new EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipPosition(
+                    Latitude: 50.8,
+                    Longitude: -1.3,
+                    CourseOverGroundDeg: 90.0,
+                    SpeedOverGroundMs: 5.0,
+                    Timestamp: DateTimeOffset.UtcNow),
+                cadence: TimeSpan.FromSeconds(1)));
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>();
+        services.AddSingleton<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>(sp =>
+            sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>());
+
         // MCP server (loopback-only, off by default). The catalog adapter
         // observes the existing dataset loader and re-opens dataset files
         // for read-only MCP queries; the host owns server lifecycle.

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -440,16 +440,38 @@
                         <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
                     </Button>
                     <!--
-                      Own-ship overlay toggle (PR-D2). Hides the
-                      synthetic own-ship glyph when off.
+                      Own-ship overlay toggle (PR-D2). Mirrors the
+                      MeasureModeButton pattern: regular Button +
+                      a state class so the styling and sizing match
+                      the rest of the toolbar.
                     -->
-                    <ToggleButton x:Name="OwnShipButton"
-                                  Classes="Icon MapOverlay"
-                                  IsChecked="{Binding IsOwnShipVisible, Mode=TwoWay}"
-                                  IsVisible="{Binding IsOwnShipSourceAvailable}"
-                                  ToolTip.Tip="{x:Static loc:Strings.OwnShip_Toggle_Tooltip}">
+                    <Button x:Name="OwnShipButton"
+                            Classes="Icon MapOverlay"
+                            Classes.ownShipActive="{Binding IsOwnShipVisible}"
+                            Command="{Binding ToggleOwnShipCommand}"
+                            IsVisible="{Binding IsOwnShipSourceAvailable}"
+                            ToolTip.Tip="{x:Static loc:Strings.OwnShip_Toggle_Tooltip}">
+                        <Button.Styles>
+                            <Style Selector="Button#OwnShipButton.ownShipActive">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#OwnShipButton.ownShipActive /template/ ContentPresenter">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                            </Style>
+                            <Style Selector="Button#OwnShipButton.ownShipActive ic|FluentIcon">
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#OwnShipButton.ownShipActive /template/ Border#HoverBackground">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Opacity" Value="1" />
+                            </Style>
+                        </Button.Styles>
                         <ic:FluentIcon Icon="Location" IconVariant="Regular" FontSize="16" />
-                    </ToggleButton>
+                    </Button>
                     <!--
                       Display category pill — compact label that opens
                       a flyout to switch between ECDIS display categories.

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -440,6 +440,17 @@
                         <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
                     </Button>
                     <!--
+                      Own-ship overlay toggle (PR-D2). Hides the
+                      synthetic own-ship glyph when off.
+                    -->
+                    <ToggleButton x:Name="OwnShipButton"
+                                  Classes="Icon MapOverlay"
+                                  IsChecked="{Binding IsOwnShipVisible, Mode=TwoWay}"
+                                  IsVisible="{Binding IsOwnShipSourceAvailable}"
+                                  ToolTip.Tip="{x:Static loc:Strings.OwnShip_Toggle_Tooltip}">
+                        <ic:FluentIcon Icon="Location" IconVariant="Regular" FontSize="16" />
+                    </ToggleButton>
+                    <!--
                       Display category pill — compact label that opens
                       a flyout to switch between ECDIS display categories.
                     -->

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -39,6 +39,8 @@ public partial class MainWindow : ShadUI.Window
     private readonly MainViewModel _viewModel;
     private readonly DatasetCatalogAggregator _catalogAggregator;
     private ValidationOverlayService? _validationOverlay;
+    private EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost? _dynamicSourceOverlayHost;
+    private readonly List<IDisposable> _dynamicSourceRegistrations = new();
     private string? _screenshotPath;
 
     public MainWindow() : this(null) { }
@@ -129,10 +131,28 @@ public partial class MainWindow : ShadUI.Window
         // service subscribes to the datasets view-model and lives for
         // the lifetime of the window.
         _validationOverlay = new ValidationOverlayService(mapHost, _viewModel.Datasets);
+
+        // PR-D2: dynamic-source overlay host. Subscribes to every
+        // registered IDynamicFeatureSource (own-ship in v1) and
+        // mounts a backing MemoryLayer on the overlay tier so the
+        // glyph paints above dataset layers.
+        _dynamicSourceOverlayHost = new EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost(
+            mapHost,
+            App.Services,
+            logger: App.Services.GetService<Microsoft.Extensions.Logging.ILogger<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost>>());
+        foreach (var source in App.Services.GetServices<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>())
+        {
+            _dynamicSourceRegistrations.Add(_dynamicSourceOverlayHost.Register(source));
+        }
+
         Closed += (_, _) =>
         {
             _validationOverlay?.Dispose();
             _validationOverlay = null;
+            foreach (var reg in _dynamicSourceRegistrations) reg.Dispose();
+            _dynamicSourceRegistrations.Clear();
+            _dynamicSourceOverlayHost?.Dispose();
+            _dynamicSourceOverlayHost = null;
         };
         _loader.StatusChanged += text => _viewModel.StatusText = text;
         _loader.DatasetLoaded += entry =>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -132,19 +132,6 @@ public partial class MainWindow : ShadUI.Window
         // the lifetime of the window.
         _validationOverlay = new ValidationOverlayService(mapHost, _viewModel.Datasets);
 
-        // PR-D2: dynamic-source overlay host. Subscribes to every
-        // registered IDynamicFeatureSource (own-ship in v1) and
-        // mounts a backing MemoryLayer on the overlay tier so the
-        // glyph paints above dataset layers.
-        _dynamicSourceOverlayHost = new EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost(
-            mapHost,
-            App.Services,
-            logger: App.Services.GetService<Microsoft.Extensions.Logging.ILogger<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost>>());
-        foreach (var source in App.Services.GetServices<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>())
-        {
-            _dynamicSourceRegistrations.Add(_dynamicSourceOverlayHost.Register(source));
-        }
-
         Closed += (_, _) =>
         {
             _validationOverlay?.Dispose();
@@ -219,6 +206,19 @@ public partial class MainWindow : ShadUI.Window
         };
 
         MapControl.Map?.Layers.Add(OpenStreetMap.CreateTileLayer());
+
+        // PR-D2: dynamic-source overlay host. Registered *after* the
+        // basemap so MapsuiMapHost's ComputeOverlayInsertIndex places
+        // the overlay above the OSM tile layer rather than at index 0
+        // (where the subsequently-added basemap would cover it).
+        _dynamicSourceOverlayHost = new EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost(
+            mapHost,
+            App.Services,
+            logger: App.Services.GetService<Microsoft.Extensions.Logging.ILogger<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost>>());
+        foreach (var source in App.Services.GetServices<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>())
+        {
+            _dynamicSourceRegistrations.Add(_dynamicSourceOverlayHost.Register(source));
+        }
 
         // Disable Mapsui's built-in LoggingWidget — it can throw "minX > maxX" on
         // narrow viewports during resize, and the exception is raised on the

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -210,3 +210,39 @@ currently rendered at.
 - Animation (play/pause/speed) is intentionally out of scope;
   `GlobalTimeService.SetCurrentTime` is the obvious seam for a
   future timer-driven driver.
+
+## Own-ship overlay (PR-D2)
+
+A single moving point published through the dynamic-source
+abstraction (PR-D1). The toolbar **Location** toggle controls
+visibility; the setting is persisted via `ViewerSettings.OwnShipVisible`.
+
+Architecture:
+
+- `IOwnShipPositionProvider` is a thin push interface (`Current` +
+  `Updated`). The PR-D2 reference driver
+  `SyntheticOwnShipPositionProvider` dead-reckons along a fixed
+  course/speed on a 1 Hz timer (Solent — 50.8° N, 1.3° W, course
+  090° T, 5 m/s ≈ 9.7 kn). A future real-GPS / NMEA-replay driver
+  implements the same interface.
+- `OwnShipSource` is the `IDynamicFeatureSource` that converts
+  provider fixes into `DynamicFeature` snapshots (Id `"ownship"`,
+  Kind `"ownship"`, Point geometry) with an optional `DynamicMotion`
+  sidecar. SOG is converted from m/s (provider) to knots
+  (`DynamicMotion.SpeedOverGroundKn`); COG is mirrored to
+  `HeadingDeg` so the default renderer's predictor line draws.
+- Rendering uses the default `DefaultDynamicFeatureRenderer` (blue
+  disc + six-minute predictor). A custom `OwnShipRenderer` is
+  deferred until a second dynamic source coexists.
+
+**Caveats**
+
+- The synthetic driver is scaffolding — start position, course, and
+  speed are hard-coded constants, not user-configurable settings.
+- Layer Stack integration is deferred. The PR-D1 surface does not
+  yet expose a `DynamicSourceRegistration` adapter for the layer
+  panel; until it does, the toolbar toggle is the visibility
+  affordance.
+- "Centre on own-ship", picking the glyph, and time-axis integration
+  are all out of scope for PR-D2.
+

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -390,4 +390,9 @@ internal static class Strings
     public static string LoadFailureToast_NotSupportedBody => Get(nameof(LoadFailureToast_NotSupportedBody));
     public static string LoadFailureToast_SchemaBody => Get(nameof(LoadFailureToast_SchemaBody));
     public static string LoadFailureToast_CopyDetails => Get(nameof(LoadFailureToast_CopyDetails));
+
+    // Own-ship overlay (PR-D2)
+    public static string OwnShip_DisplayName => Get(nameof(OwnShip_DisplayName));
+    public static string OwnShip_Description => Get(nameof(OwnShip_Description));
+    public static string OwnShip_Toggle_Tooltip => Get(nameof(OwnShip_Toggle_Tooltip));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1033,4 +1033,18 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
     <value>Copy details</value>
     <comment>Label for the action button on the load-failure toast.</comment>
   </data>
+
+  <!-- Own-ship overlay (PR-D2) -->
+  <data name="OwnShip_DisplayName" xml:space="preserve">
+    <value>Own ship</value>
+    <comment>Display name of the own-ship dynamic source. Appears in Layer Stack rows and tooltips.</comment>
+  </data>
+  <data name="OwnShip_Description" xml:space="preserve">
+    <value>The vessel's own position (synthetic for v1).</value>
+    <comment>Longer description of the own-ship source for tooltips and settings panels.</comment>
+  </data>
+  <data name="OwnShip_Toggle_Tooltip" xml:space="preserve">
+    <value>Toggle the own-ship overlay</value>
+    <comment>Tooltip for the toolbar button that hides/shows the own-ship glyph.</comment>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/IOwnShipPositionProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/IOwnShipPositionProvider.cs
@@ -1,0 +1,32 @@
+namespace EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+
+/// <summary>
+/// Push-driven source of own-ship position fixes. Implementations
+/// are deliberately small — the synthetic driver shipped in PR-D2
+/// produces a deterministic dead-reckoned track; a future real-GPS
+/// or NMEA-replay driver implements the same contract.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Current"/> may be <see langword="null"/> until the
+/// first fix is produced. <see cref="Updated"/> fires whenever a
+/// new fix is available — possibly on a background thread.
+/// <see cref="OwnShipSource"/> performs no marshalling itself; the
+/// viewer-side overlay host is the single UI-thread boundary.
+/// </para>
+/// </remarks>
+internal interface IOwnShipPositionProvider
+{
+    /// <summary>
+    /// Most recent fix produced by this provider, or
+    /// <see langword="null"/> if no fix has been produced yet.
+    /// Safe to read from any thread.
+    /// </summary>
+    OwnShipPosition? Current { get; }
+
+    /// <summary>
+    /// Raised whenever <see cref="Current"/> changes. May be raised
+    /// on any thread.
+    /// </summary>
+    event EventHandler<OwnShipPosition>? Updated;
+}

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/OwnShipPosition.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/OwnShipPosition.cs
@@ -1,0 +1,44 @@
+namespace EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+
+/// <summary>
+/// One own-ship position fix published by an
+/// <see cref="IOwnShipPositionProvider"/>. Geometry-agnostic record;
+/// adapted into a
+/// <c>EncDotNet.S100.DynamicSources.DynamicFeature</c> by
+/// <see cref="OwnShipSource"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SpeedOverGroundMs"/> is in metres per second — the SI
+/// convention used internally throughout the viewer's dynamic-source
+/// stack. <see cref="OwnShipSource"/> converts to knots when
+/// populating the public
+/// <c>DynamicMotion.SpeedOverGroundKn</c> field (which is the
+/// contractual unit on that record).
+/// </para>
+/// <para>
+/// All motion fields are nullable so that a stationary or
+/// motion-less provider can publish position alone. When both
+/// <see cref="CourseOverGroundDeg"/> and <see cref="SpeedOverGroundMs"/>
+/// are <see langword="null"/>, the source emits a
+/// <c>DynamicFeature</c> with no motion sidecar and the default
+/// renderer omits the predictor line.
+/// </para>
+/// </remarks>
+/// <param name="Latitude">WGS-84 latitude in decimal degrees.</param>
+/// <param name="Longitude">WGS-84 longitude in decimal degrees.</param>
+/// <param name="CourseOverGroundDeg">
+/// Course over ground in degrees true (0–360), or
+/// <see langword="null"/> when no course is known.
+/// </param>
+/// <param name="SpeedOverGroundMs">
+/// Speed over ground in metres per second, or
+/// <see langword="null"/> when no speed is known.
+/// </param>
+/// <param name="Timestamp">UTC instant the fix was observed.</param>
+internal sealed record OwnShipPosition(
+    double Latitude,
+    double Longitude,
+    double? CourseOverGroundDeg,
+    double? SpeedOverGroundMs,
+    DateTimeOffset Timestamp);

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/OwnShipSource.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/OwnShipSource.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+
+/// <summary>
+/// Concrete <see cref="IDynamicFeatureSource"/> publishing the
+/// vessel's own position as a single <c>DynamicFeature</c>
+/// (Id <c>"ownship"</c>, Kind <c>"ownship"</c>). Bridges a thin
+/// position provider (<see cref="IOwnShipPositionProvider"/>) — the
+/// PR-D2 reference driver is the synthetic dead-reckoner; a future
+/// real-GPS / NMEA-replay driver implements the same interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The source always exposes either zero features (no fix yet, or
+/// the toggle is off) or exactly one feature. Aging /
+/// <c>DynamicFeatureTracker</c> is intentionally not used — a
+/// singleton feature has no aging surface.
+/// </para>
+/// <para>
+/// <c>RendererKey</c> is <see langword="null"/>: PR-D2 deliberately
+/// uses <see cref="EncDotNet.S100.Renderers.Mapsui.DynamicSources.DefaultDynamicFeatureRenderer"/>,
+/// whose disc + COG/SOG predictor is acceptable as an ECDIS-style
+/// own-ship indicator. A custom <c>OwnShipRenderer</c> is deferred
+/// until a second dynamic source coexists and demands visual
+/// differentiation.
+/// </para>
+/// <para>
+/// Speed conversion: the provider supplies SOG in metres per second
+/// (the SI convention). The published
+/// <c>DynamicMotion.SpeedOverGroundKn</c> field is in knots —
+/// converted with the maritime factor 1 m/s ≈ 1.9438444924406
+/// kn (3600 / 1852).
+/// </para>
+/// <para>
+/// <see cref="IsEnabled"/> is the toggle backing the viewer toolbar
+/// button. When set to <see langword="false"/> the source raises a
+/// <see cref="DynamicSourceChangeKind.Reset"/> with an empty
+/// <see cref="CurrentFeatures"/>; when flipped back on the cached
+/// most-recent fix (if any) is republished as <c>Added</c>.
+/// </para>
+/// </remarks>
+internal sealed class OwnShipSource : IDynamicFeatureSource, INotifyPropertyChanged, IDisposable
+{
+    /// <summary>Stable singleton feature id.</summary>
+    public const string FeatureId = "ownship";
+
+    /// <summary>Renderer-dispatch hint published on the feature.</summary>
+    public const string FeatureKind = "ownship";
+
+    /// <summary>1 m/s expressed in knots (3600 / 1852).</summary>
+    internal const double MetresPerSecondToKnots = 3600.0 / 1852.0;
+
+    private static readonly IReadOnlyList<DynamicFeature> EmptyFeatures = Array.Empty<DynamicFeature>();
+
+    private readonly IOwnShipPositionProvider _provider;
+    private readonly object _gate = new();
+    private IReadOnlyList<DynamicFeature> _current = EmptyFeatures;
+    private bool _isEnabled = true;
+    private int _disposed;
+
+    public OwnShipSource(IOwnShipPositionProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        _provider = provider;
+
+        Metadata = new DynamicSourceMetadata
+        {
+            DisplayName = Strings.OwnShip_DisplayName,
+            Description = Strings.OwnShip_Description,
+            RendererKey = null,
+        };
+
+        _provider.Updated += OnProviderUpdated;
+
+        // If the provider already has a fix at construction time
+        // (e.g. a test stub that was seeded synchronously) surface
+        // it immediately so the first Changed-after-Register rebuild
+        // paints something.
+        if (_provider.Current is { } seed)
+        {
+            ApplyFix(seed, raise: false);
+        }
+    }
+
+    /// <inheritdoc />
+    public string Id => FeatureId;
+
+    /// <inheritdoc />
+    public DynamicSourceMetadata Metadata { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<DynamicFeature> CurrentFeatures
+    {
+        get
+        {
+            lock (_gate) return _current;
+        }
+    }
+
+    /// <inheritdoc />
+    public event EventHandler<DynamicFeaturesChanged>? Changed;
+
+    /// <summary>
+    /// Whether the source is currently publishing the own-ship
+    /// feature. Setting to <see langword="false"/> empties
+    /// <see cref="CurrentFeatures"/> and raises
+    /// <see cref="DynamicSourceChangeKind.Reset"/>; setting back to
+    /// <see langword="true"/> republishes the most-recent fix as
+    /// <see cref="DynamicSourceChangeKind.Added"/> (if one exists).
+    /// </summary>
+    public bool IsEnabled
+    {
+        get
+        {
+            lock (_gate) return _isEnabled;
+        }
+        set
+        {
+            DynamicFeaturesChanged? toRaise = null;
+            lock (_gate)
+            {
+                if (_isEnabled == value) return;
+                _isEnabled = value;
+
+                if (!value)
+                {
+                    if (_current.Count > 0)
+                    {
+                        _current = EmptyFeatures;
+                        toRaise = new DynamicFeaturesChanged
+                        {
+                            Kind = DynamicSourceChangeKind.Reset,
+                            ChangedIds = Array.Empty<string>(),
+                        };
+                    }
+                }
+                else if (_provider.Current is { } fix)
+                {
+                    _current = new[] { Project(fix) };
+                    toRaise = new DynamicFeaturesChanged
+                    {
+                        Kind = DynamicSourceChangeKind.Added,
+                        ChangedIds = new[] { FeatureId },
+                    };
+                }
+            }
+
+            OnPropertyChanged();
+            if (toRaise is not null) Changed?.Invoke(this, toRaise);
+        }
+    }
+
+    private void OnProviderUpdated(object? sender, OwnShipPosition fix)
+    {
+        ApplyFix(fix, raise: true);
+    }
+
+    private void ApplyFix(OwnShipPosition fix, bool raise)
+    {
+        DynamicFeaturesChanged? toRaise = null;
+        lock (_gate)
+        {
+            if (!_isEnabled) return;
+
+            var wasEmpty = _current.Count == 0;
+            _current = new[] { Project(fix) };
+
+            if (raise)
+            {
+                toRaise = new DynamicFeaturesChanged
+                {
+                    Kind = wasEmpty
+                        ? DynamicSourceChangeKind.Added
+                        : DynamicSourceChangeKind.Updated,
+                    ChangedIds = new[] { FeatureId },
+                };
+            }
+        }
+
+        if (toRaise is not null) Changed?.Invoke(this, toRaise);
+    }
+
+    private static DynamicFeature Project(OwnShipPosition fix)
+    {
+        // Synthetic / GPS-only drivers expose Course Over Ground but
+        // not a separate gyro Heading. Default renderer keys the
+        // predictor line off Heading, so we mirror COG → Heading so
+        // the predictor draws for v1. A future driver that
+        // distinguishes the two will populate them separately.
+        var motion =
+            fix.CourseOverGroundDeg is null && fix.SpeedOverGroundMs is null
+                ? null
+                : new DynamicMotion
+                {
+                    CourseOverGroundDeg = fix.CourseOverGroundDeg,
+                    HeadingDeg = fix.CourseOverGroundDeg,
+                    SpeedOverGroundKn = fix.SpeedOverGroundMs is { } ms
+                        ? ms * MetresPerSecondToKnots
+                        : null,
+                };
+
+        return new DynamicFeature
+        {
+            Id = FeatureId,
+            Kind = FeatureKind,
+            GeometryType = GeometryType.Point,
+            Coordinates = new[] { (fix.Latitude, fix.Longitude) },
+            Motion = motion,
+            LastUpdated = fix.Timestamp,
+        };
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _provider.Updated -= OnProviderUpdated;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/SyntheticOwnShipPositionProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/SyntheticOwnShipPositionProvider.cs
@@ -1,0 +1,177 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+
+/// <summary>
+/// Synthetic <see cref="IOwnShipPositionProvider"/> that
+/// dead-reckons a single vessel along a fixed course at a fixed
+/// speed using a great-circle solution. Used as scaffolding by
+/// PR-D2 until a real GPS / NMEA driver lands.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constructor parameters define the initial state. The provider
+/// drives itself on a <see cref="Timer"/>-backed cadence and
+/// publishes a fresh fix per tick. Tests use the
+/// <see cref="Tick(TimeSpan)"/> seam to advance the simulation
+/// deterministically without depending on wall-clock timing.
+/// </para>
+/// <para>
+/// The dead-reckoning uses the WGS-84 mean Earth radius
+/// (6 371 008.8 m). Accuracy is sufficient for the scaffolding role
+/// — a future real driver replaces this implementation rather than
+/// improving its numerics.
+/// </para>
+/// </remarks>
+internal sealed class SyntheticOwnShipPositionProvider : IOwnShipPositionProvider, IDisposable
+{
+    /// <summary>WGS-84 mean Earth radius in metres.</summary>
+    private const double EarthRadiusMetres = 6_371_008.8;
+
+    private readonly object _gate = new();
+    private readonly TimeProvider _time;
+    private readonly Timer? _timer;
+    private readonly double _courseDeg;
+    private readonly double _speedMs;
+    private OwnShipPosition _current;
+    private int _disposed;
+
+    /// <summary>
+    /// Creates a synthetic provider with the supplied initial fix
+    /// and an internal timer ticking at <paramref name="cadence"/>.
+    /// </summary>
+    /// <param name="start">
+    /// Initial fix. <c>CourseOverGroundDeg</c> and
+    /// <c>SpeedOverGroundMs</c> must be non-null — the synthetic
+    /// driver always has motion. <c>Timestamp</c> seeds the clock.
+    /// </param>
+    /// <param name="cadence">
+    /// Time between simulated fixes. Defaults to 1 second.
+    /// </param>
+    /// <param name="time">
+    /// Optional time provider; defaults to
+    /// <see cref="TimeProvider.System"/>. Tests pass a fake to keep
+    /// the wall clock out of the loop.
+    /// </param>
+    public SyntheticOwnShipPositionProvider(
+        OwnShipPosition start,
+        TimeSpan? cadence = null,
+        TimeProvider? time = null)
+        : this(start, cadence, time, startTimer: true) { }
+
+    private SyntheticOwnShipPositionProvider(
+        OwnShipPosition start,
+        TimeSpan? cadence,
+        TimeProvider? time,
+        bool startTimer)
+    {
+        if (start.CourseOverGroundDeg is null)
+            throw new ArgumentException(
+                "Synthetic provider requires an initial course over ground.",
+                nameof(start));
+        if (start.SpeedOverGroundMs is null)
+            throw new ArgumentException(
+                "Synthetic provider requires an initial speed over ground.",
+                nameof(start));
+
+        _time = time ?? TimeProvider.System;
+        _courseDeg = start.CourseOverGroundDeg.Value;
+        _speedMs = start.SpeedOverGroundMs.Value;
+        _current = start;
+
+        if (startTimer)
+        {
+            var period = cadence ?? TimeSpan.FromSeconds(1);
+            _timer = new Timer(_ => TickInternal(period), state: null, period, period);
+        }
+    }
+
+    /// <summary>
+    /// Factory that creates a manual-tick provider for tests — no
+    /// internal timer; tests drive the simulation via
+    /// <see cref="Tick(TimeSpan)"/>.
+    /// </summary>
+    public static SyntheticOwnShipPositionProvider CreateManual(
+        OwnShipPosition start,
+        TimeProvider? time = null)
+        => new(start, cadence: null, time, startTimer: false);
+
+    /// <inheritdoc />
+    public OwnShipPosition? Current
+    {
+        get
+        {
+            lock (_gate) return _current;
+        }
+    }
+
+    /// <inheritdoc />
+    public event EventHandler<OwnShipPosition>? Updated;
+
+    /// <summary>
+    /// Advances the simulation by <paramref name="elapsed"/> and
+    /// raises <see cref="Updated"/> with the new fix. Used by the
+    /// internal timer; also callable from tests when the provider
+    /// was constructed via <see cref="CreateManual"/>.
+    /// </summary>
+    public void Tick(TimeSpan elapsed) => TickInternal(elapsed);
+
+    private void TickInternal(TimeSpan elapsed)
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        if (elapsed <= TimeSpan.Zero) return;
+
+        OwnShipPosition next;
+        lock (_gate)
+        {
+            var distanceMetres = _speedMs * elapsed.TotalSeconds;
+            var (lat, lon) = GeodeticDestination(
+                _current.Latitude, _current.Longitude, _courseDeg, distanceMetres);
+            next = new OwnShipPosition(
+                Latitude: lat,
+                Longitude: lon,
+                CourseOverGroundDeg: _courseDeg,
+                SpeedOverGroundMs: _speedMs,
+                Timestamp: _time.GetUtcNow());
+            _current = next;
+        }
+
+        Updated?.Invoke(this, next);
+    }
+
+    /// <summary>
+    /// Great-circle destination given a start point (degrees),
+    /// bearing (degrees true), and distance (metres). Same shape
+    /// the default renderer uses for its predictor line.
+    /// </summary>
+    internal static (double Latitude, double Longitude) GeodeticDestination(
+        double latDeg, double lonDeg, double bearingDeg, double distanceMetres)
+    {
+        var δ = distanceMetres / EarthRadiusMetres;
+        var θ = bearingDeg * Math.PI / 180.0;
+        var φ1 = latDeg * Math.PI / 180.0;
+        var λ1 = lonDeg * Math.PI / 180.0;
+
+        var sinφ1 = Math.Sin(φ1);
+        var cosφ1 = Math.Cos(φ1);
+        var sinδ = Math.Sin(δ);
+        var cosδ = Math.Cos(δ);
+
+        var sinφ2 = sinφ1 * cosδ + cosφ1 * sinδ * Math.Cos(θ);
+        var φ2 = Math.Asin(sinφ2);
+        var y = Math.Sin(θ) * sinδ * cosφ1;
+        var x = cosδ - sinφ1 * sinφ2;
+        var λ2 = λ1 + Math.Atan2(y, x);
+
+        var latOut = φ2 * 180.0 / Math.PI;
+        var lonOut = ((λ2 * 180.0 / Math.PI) + 540.0) % 360.0 - 180.0;
+        return (latOut, lonOut);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _timer?.Dispose();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -289,6 +289,41 @@ internal sealed class MainViewModel : ViewModelBase
 
     public ICommand ToggleStatusBarCommand { get; }
 
+    // PR-D2 own-ship overlay toggle.
+    private readonly EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource? _ownShipSource;
+    private bool _isOwnShipVisible;
+
+    /// <summary>
+    /// Whether the own-ship overlay glyph is currently published by the
+    /// dynamic source (and therefore drawn on the overlay tier). Bound
+    /// to the toolbar toggle button and persisted via
+    /// <see cref="ViewerSettings.OwnShipVisible"/>.
+    /// </summary>
+    public bool IsOwnShipVisible
+    {
+        get => _isOwnShipVisible;
+        set
+        {
+            if (SetProperty(ref _isOwnShipVisible, value))
+            {
+                if (_ownShipSource is not null) _ownShipSource.IsEnabled = value;
+                _settings.OwnShipVisible = value;
+                _settings.Save();
+            }
+        }
+    }
+
+    /// <summary>Toggle the own-ship overlay visibility.</summary>
+    public ICommand ToggleOwnShipCommand { get; }
+
+    /// <summary>
+    /// True when own-ship is wired (the synthetic source resolved
+    /// from DI). The toolbar button binds its <c>IsVisible</c> to
+    /// this so callers that construct the view-model without a
+    /// source (legacy tests) get a clean tree.
+    /// </summary>
+    public bool IsOwnShipSourceAvailable => _ownShipSource is not null;
+
     /// <summary>
     /// Toggles the bottom dock open/closed. Kept for the existing
     /// View menu binding; in PR-M4 the dock contains the Timeline tab.
@@ -664,7 +699,8 @@ internal sealed class MainViewModel : ViewModelBase
         IToastService toasts,
         IEnumerable<IActivityTab>? activityTabs = null,
         McpServerHost? mcpServerHost = null,
-        IStatusPresenter? statusPresenter = null)
+        IStatusPresenter? statusPresenter = null,
+        EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource? ownShipSource = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(featureCatalogues);
@@ -788,6 +824,13 @@ internal sealed class MainViewModel : ViewModelBase
         });
 
         _isStatusBarVisible = settings.IsStatusBarVisible;
+
+        // PR-D2 own-ship overlay. Resolve from DI; if absent (legacy
+        // test callers, design-time), the toggle hides itself.
+        _ownShipSource = ownShipSource;
+        _isOwnShipVisible = settings.OwnShipVisible;
+        if (_ownShipSource is not null) _ownShipSource.IsEnabled = _isOwnShipVisible;
+        ToggleOwnShipCommand = new RelayCommand(() => IsOwnShipVisible = !IsOwnShipVisible);
 
         ToggleStatusBarCommand = new RelayCommand(() => IsStatusBarVisible = !IsStatusBarVisible);
 

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -115,6 +115,13 @@ internal sealed class ViewerSettings
     public bool IsStatusBarVisible { get; set; } = true;
 
     /// <summary>
+    /// Whether the own-ship overlay (PR-D2) is visible. The synthetic
+    /// driver is always running; this flag controls whether the
+    /// source publishes the glyph to the dynamic-source overlay tier.
+    /// </summary>
+    public bool OwnShipVisible { get; set; } = true;
+
+    /// <summary>
     /// User preference for whether the bottom timeline panel is shown.
     /// When true the panel surfaces (in either an empty state or with
     /// a global slider, depending on whether any time-varying dataset

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/OwnShipSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/OwnShipSourceTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources.OwnShip;
+
+public sealed class OwnShipSourceTests
+{
+    private static OwnShipPosition Fix(
+        double lat = 50.8, double lon = -1.3,
+        double? cog = 90.0, double? sogMs = 5.0)
+        => new(lat, lon, cog, sogMs, DateTimeOffset.UnixEpoch);
+
+    [Fact]
+    public void Construction_NoFix_HasEmptyCurrentFeatures()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+
+        Assert.Empty(src.CurrentFeatures);
+    }
+
+    [Fact]
+    public void Construction_WhenProviderHasSeed_SnapshotIsPopulated_AndDoesNotRaise()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        stub.Push(Fix());
+
+        var events = new List<DynamicFeaturesChanged>();
+        using var src = new OwnShipSource(stub);
+        src.Changed += (_, e) => events.Add(e);
+
+        Assert.Single(src.CurrentFeatures);
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void FirstUpdate_RaisesAdded_WithOwnShipId()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        DynamicFeaturesChanged? captured = null;
+        src.Changed += (_, e) => captured = e;
+
+        stub.Push(Fix());
+
+        Assert.NotNull(captured);
+        Assert.Equal(DynamicSourceChangeKind.Added, captured!.Kind);
+        Assert.Equal(new[] { OwnShipSource.FeatureId }, captured.ChangedIds);
+        Assert.Single(src.CurrentFeatures);
+        Assert.Equal(OwnShipSource.FeatureId, src.CurrentFeatures[0].Id);
+        Assert.Equal(OwnShipSource.FeatureKind, src.CurrentFeatures[0].Kind);
+        Assert.Equal(GeometryType.Point, src.CurrentFeatures[0].GeometryType);
+    }
+
+    [Fact]
+    public void SecondUpdate_RaisesUpdated()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        stub.Push(Fix());
+
+        var events = new List<DynamicFeaturesChanged>();
+        src.Changed += (_, e) => events.Add(e);
+        stub.Push(Fix(lat: 50.81));
+
+        Assert.Single(events);
+        Assert.Equal(DynamicSourceChangeKind.Updated, events[0].Kind);
+        Assert.Equal(new[] { OwnShipSource.FeatureId }, events[0].ChangedIds);
+    }
+
+    [Fact]
+    public void Projection_PopulatesPositionAndMotion()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        stub.Push(Fix(lat: 50.5, lon: -1.0, cog: 123.4, sogMs: 5.144));
+
+        var f = Assert.Single(src.CurrentFeatures);
+        var pt = Assert.Single(f.Coordinates);
+        Assert.Equal(50.5, pt.Latitude, 6);
+        Assert.Equal(-1.0, pt.Longitude, 6);
+        Assert.NotNull(f.Motion);
+        Assert.Equal(123.4, f.Motion!.CourseOverGroundDeg);
+        Assert.Equal(123.4, f.Motion.HeadingDeg);
+        Assert.NotNull(f.Motion.SpeedOverGroundKn);
+        Assert.InRange(f.Motion.SpeedOverGroundKn!.Value, 9.99, 10.01);
+    }
+
+    [Fact]
+    public void Projection_WithoutMotion_LeavesDynamicMotionNull()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        stub.Push(Fix(cog: null, sogMs: null));
+
+        var f = Assert.Single(src.CurrentFeatures);
+        Assert.Null(f.Motion);
+    }
+
+    [Fact]
+    public void Disable_RaisesReset_AndEmptiesCurrentFeatures()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        stub.Push(Fix());
+
+        var events = new List<DynamicFeaturesChanged>();
+        src.Changed += (_, e) => events.Add(e);
+        src.IsEnabled = false;
+
+        Assert.Empty(src.CurrentFeatures);
+        Assert.Single(events);
+        Assert.Equal(DynamicSourceChangeKind.Reset, events[0].Kind);
+    }
+
+    [Fact]
+    public void Reenable_AfterDisable_RaisesAdded_AndRepublishes()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        stub.Push(Fix());
+        src.IsEnabled = false;
+
+        var events = new List<DynamicFeaturesChanged>();
+        src.Changed += (_, e) => events.Add(e);
+        src.IsEnabled = true;
+
+        Assert.Single(events);
+        Assert.Equal(DynamicSourceChangeKind.Added, events[0].Kind);
+        Assert.Single(src.CurrentFeatures);
+    }
+
+    [Fact]
+    public void WhileDisabled_ProviderUpdatesAreIgnored()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+        src.IsEnabled = false;
+
+        var events = new List<DynamicFeaturesChanged>();
+        src.Changed += (_, e) => events.Add(e);
+        stub.Push(Fix());
+
+        Assert.Empty(events);
+        Assert.Empty(src.CurrentFeatures);
+    }
+
+    [Fact]
+    public void Metadata_HasExpectedShape()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub);
+
+        Assert.False(string.IsNullOrWhiteSpace(src.Metadata.DisplayName));
+        Assert.Null(src.Metadata.RendererKey);
+        Assert.Equal("ownship", src.Id);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0)]
+    [InlineData(1.0, 1.9438444924406)]
+    [InlineData(10.0, 19.438444924406)]
+    public void MetresPerSecondToKnots_MatchesMaritimeFactor(double ms, double expectedKn)
+    {
+        Assert.Equal(expectedKn, ms * OwnShipSource.MetresPerSecondToKnots, 4);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/StubOwnShipPositionProvider.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/StubOwnShipPositionProvider.cs
@@ -1,0 +1,22 @@
+using System;
+using EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources.OwnShip;
+
+/// <summary>
+/// Push-driven test double: no timer, no math. Tests call
+/// <see cref="Push"/> to drive <see cref="OwnShipSource"/>
+/// state-machine transitions deterministically.
+/// </summary>
+internal sealed class StubOwnShipPositionProvider : IOwnShipPositionProvider
+{
+    public OwnShipPosition? Current { get; private set; }
+
+    public event EventHandler<OwnShipPosition>? Updated;
+
+    public void Push(OwnShipPosition fix)
+    {
+        Current = fix;
+        Updated?.Invoke(this, fix);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/SyntheticOwnShipPositionProviderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/SyntheticOwnShipPositionProviderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources.OwnShip;
+
+public sealed class SyntheticOwnShipPositionProviderTests
+{
+    private static OwnShipPosition Start(double cog, double sogMs)
+        => new(Latitude: 0.0, Longitude: 0.0,
+            CourseOverGroundDeg: cog, SpeedOverGroundMs: sogMs,
+            Timestamp: DateTimeOffset.UnixEpoch);
+
+    [Fact]
+    public void Constructor_RejectsMissingCourse()
+    {
+        var start = new OwnShipPosition(0, 0, null, 5.0, DateTimeOffset.UnixEpoch);
+        Assert.Throws<ArgumentException>(() =>
+            SyntheticOwnShipPositionProvider.CreateManual(start));
+    }
+
+    [Fact]
+    public void Constructor_RejectsMissingSpeed()
+    {
+        var start = new OwnShipPosition(0, 0, 90.0, null, DateTimeOffset.UnixEpoch);
+        Assert.Throws<ArgumentException>(() =>
+            SyntheticOwnShipPositionProvider.CreateManual(start));
+    }
+
+    [Fact]
+    public void Tick_DueEast_MovesEastButNotNorth()
+    {
+        using var provider = SyntheticOwnShipPositionProvider.CreateManual(
+            Start(cog: 90.0, sogMs: 1.0));
+
+        provider.Tick(TimeSpan.FromHours(1));
+
+        var c = provider.Current!;
+        Assert.InRange(c.Latitude, -1e-6, 1e-6);
+        // 3600 m at the equator ≈ 0.03237° of longitude.
+        Assert.InRange(c.Longitude, 0.032, 0.033);
+    }
+
+    [Fact]
+    public void Tick_DueNorth_MovesNorthButNotEast()
+    {
+        using var provider = SyntheticOwnShipPositionProvider.CreateManual(
+            Start(cog: 0.0, sogMs: 1.0));
+
+        provider.Tick(TimeSpan.FromHours(1));
+
+        var c = provider.Current!;
+        Assert.InRange(c.Latitude, 0.032, 0.033);
+        Assert.InRange(c.Longitude, -1e-6, 1e-6);
+    }
+
+    [Fact]
+    public void Tick_RaisesUpdatedWithNewFix()
+    {
+        using var provider = SyntheticOwnShipPositionProvider.CreateManual(
+            Start(cog: 90.0, sogMs: 1.0));
+
+        var fixes = new List<OwnShipPosition>();
+        provider.Updated += (_, p) => fixes.Add(p);
+
+        provider.Tick(TimeSpan.FromSeconds(1));
+        provider.Tick(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, fixes.Count);
+        Assert.True(fixes[1].Longitude > fixes[0].Longitude);
+    }
+
+    [Fact]
+    public void Tick_PreservesCourseAndSpeed()
+    {
+        using var provider = SyntheticOwnShipPositionProvider.CreateManual(
+            Start(cog: 45.0, sogMs: 7.5));
+
+        provider.Tick(TimeSpan.FromMinutes(5));
+
+        var c = provider.Current!;
+        Assert.Equal(45.0, c.CourseOverGroundDeg);
+        Assert.Equal(7.5, c.SpeedOverGroundMs);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var provider = SyntheticOwnShipPositionProvider.CreateManual(
+            Start(cog: 90.0, sogMs: 1.0));
+        provider.Dispose();
+        provider.Dispose(); // must not throw
+    }
+}


### PR DESCRIPTION
First concrete consumer of the `IDynamicFeatureSource` abstraction landed in PR-D1 (#124). Publishes a single `"ownship"` `DynamicFeature` through the existing `DynamicSourceOverlayHost` and renders via the default Mapsui renderer (disc + COG/SOG predictor).

## What's new

**Source (all internal to the Viewer per design Q1):**
- `IOwnShipPositionProvider` + `OwnShipPosition` record (SOG in m/s, the SI convention).
- `SyntheticOwnShipPositionProvider` — dead-reckons on a 1 Hz `Timer` using a great-circle solution. Exposes a `Tick(TimeSpan)` seam and `CreateManual` factory so tests are wall-clock-free.
- `OwnShipSource : IDynamicFeatureSource` — converts provider fixes to `DynamicFeature` snapshots, maps COG → `HeadingDeg` so the default renderer's predictor draws, converts m/s → knots, honours an `IsEnabled` toggle (Reset on disable, Added on re-enable with the cached fix). No `DynamicFeatureTracker` (singleton has no aging surface).

**Viewer wiring:**
- DI registration in `App.ConfigureServices` (provider, source, source-as-`IDynamicFeatureSource`).
- `MainWindow` constructs `DynamicSourceOverlayHost` (not constructed anywhere before this PR) immediately after `MapsuiMapHost`, registers each `IDynamicFeatureSource` from DI, and disposes everything on `Closed`.
- Toolbar `ToggleButton` (Location icon) bound to `MainViewModel.IsOwnShipVisible`, persisted via `ViewerSettings.OwnShipVisible` (default true). All strings via `Resources/Strings.resx`.

## Design decisions (per kickoff Q1–Q9)

| Q | Decision |
|---|---|
| Q1 project | Viewer-internal (no new project) |
| Q2 provider | `IOwnShipPositionProvider`, m/s canonical |
| Q3 motion | populated when present; null leaves `DynamicMotion` null |
| Q4 init pos | Solent 50.8°N, 1.3°W, course 090°T, 5 m/s |
| Q5 lifecycle | no tracker (always singleton) |
| Q6 renderer | default (disc + predictor) — custom deferred |
| Q7 wiring | DI + host construction in `MainWindow` |
| Q8 settings | visibility persists; driver knobs are scaffolding |
| Q9 tests | 20 headless xunit tests |

## Deferred / open

- **Layer Stack integration** — PR-D1 never landed the `DynamicSourceRegistration` adapter sketched in design §4.3 / §6.3. The kickoff's preferred "via existing Layer Stack visibility toggle" surface therefore doesn't exist yet. The toolbar toggle is v1; the layer-panel adapter remains an open follow-up. Documented in the README.
- Custom `OwnShipRenderer`, "Centre on own-ship", NMEA/GPS, recorded-log replay — all explicit out-of-scope items in the kickoff.

## Verification

- `dotnet build` green.
- `dotnet test --configuration Release` green across **all 24 test projects**; own-ship adds **20 new passing tests** in `EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/`.

## PR-D1 surface

Untouched. The only PR-D1 type instantiated for the first time at runtime is `DynamicSourceOverlayHost` — that's viewer wiring of an already-shipped type, not a surface change.