### PR TITLE
PR-D2.1: Surface dynamic feature sources in the Layer Stack

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -250,6 +250,17 @@ public partial class App : Application
         services.AddSingleton<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>(sp =>
             sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>());
 
+        // PR-D2.1: dynamic-source registry accessor. The real registry
+        // is the DynamicSourceOverlayHost constructed in MainWindow
+        // (it needs IMapHost, which only exists after the MapControl
+        // initialises). The accessor is the indirection: view-models
+        // depend on it through IDynamicFeatureSourceRegistry; MainWindow
+        // assigns Current once the host is built. Mirrors
+        // IMapHostAccessor / MapHostAccessor below.
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicFeatureSourceRegistryAccessor>();
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.IDynamicFeatureSourceRegistry>(sp =>
+            sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicFeatureSourceRegistryAccessor>());
+
         // MCP server (loopback-only, off by default). The catalog adapter
         // observes the existing dataset loader and re-opens dataset files
         // for read-only MCP queries; the host owns server lifecycle.

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -440,39 +440,6 @@
                         <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
                     </Button>
                     <!--
-                      Own-ship overlay toggle (PR-D2). Mirrors the
-                      MeasureModeButton pattern: regular Button +
-                      a state class so the styling and sizing match
-                      the rest of the toolbar.
-                    -->
-                    <Button x:Name="OwnShipButton"
-                            Classes="Icon MapOverlay"
-                            Classes.ownShipActive="{Binding IsOwnShipVisible}"
-                            Command="{Binding ToggleOwnShipCommand}"
-                            IsVisible="{Binding IsOwnShipSourceAvailable}"
-                            ToolTip.Tip="{x:Static loc:Strings.OwnShip_Toggle_Tooltip}">
-                        <Button.Styles>
-                            <Style Selector="Button#OwnShipButton.ownShipActive">
-                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                                <Setter Property="Foreground" Value="White" />
-                            </Style>
-                            <Style Selector="Button#OwnShipButton.ownShipActive /template/ ContentPresenter">
-                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                            </Style>
-                            <Style Selector="Button#OwnShipButton.ownShipActive ic|FluentIcon">
-                                <Setter Property="Foreground" Value="White" />
-                            </Style>
-                            <Style Selector="Button#OwnShipButton.ownShipActive /template/ Border#HoverBackground">
-                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                                <Setter Property="Opacity" Value="1" />
-                            </Style>
-                        </Button.Styles>
-                        <ic:FluentIcon Icon="Location" IconVariant="Regular" FontSize="16" />
-                    </Button>
-                    <!--
                       Display category pill — compact label that opens
                       a flyout to switch between ECDIS display categories.
                     -->

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -138,6 +138,9 @@ public partial class MainWindow : ShadUI.Window
             _validationOverlay = null;
             foreach (var reg in _dynamicSourceRegistrations) reg.Dispose();
             _dynamicSourceRegistrations.Clear();
+            App.Services.GetRequiredService<
+                EncDotNet.S100.Viewer.Services.DynamicSources.DynamicFeatureSourceRegistryAccessor>()
+                .Current = null;
             _dynamicSourceOverlayHost?.Dispose();
             _dynamicSourceOverlayHost = null;
         };
@@ -215,6 +218,32 @@ public partial class MainWindow : ShadUI.Window
             mapHost,
             App.Services,
             logger: App.Services.GetService<Microsoft.Extensions.Logging.ILogger<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost>>());
+
+        // PR-D2.1: seed per-source visibility from persisted settings
+        // *before* the Register loop so each source's MemoryLayer.Enabled
+        // starts in the user's last-known state, then wire write-back so
+        // the Layer Stack panel's visibility toggle persists.
+        var viewerSettings = App.Services.GetRequiredService<ViewerSettings>();
+        foreach (var kv in viewerSettings.DynamicSourceVisibility)
+        {
+            _dynamicSourceOverlayHost.SetVisible(kv.Key, kv.Value);
+        }
+        _dynamicSourceOverlayHost.SourcesChanged += () =>
+        {
+            foreach (var info in _dynamicSourceOverlayHost.Sources)
+            {
+                viewerSettings.DynamicSourceVisibility[info.Id] = _dynamicSourceOverlayHost.GetVisible(info.Id);
+            }
+            try { viewerSettings.Save(); } catch { /* best-effort */ }
+        };
+
+        // Attach the registry to the accessor so view-models resolved
+        // before window construction (e.g. LayerStackViewModel as a
+        // singleton) start seeing dynamic sources.
+        App.Services.GetRequiredService<
+            EncDotNet.S100.Viewer.Services.DynamicSources.DynamicFeatureSourceRegistryAccessor>()
+            .Current = _dynamicSourceOverlayHost;
+
         foreach (var source in App.Services.GetServices<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>())
         {
             _dynamicSourceRegistrations.Add(_dynamicSourceOverlayHost.Register(source));

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -234,15 +234,22 @@ Architecture:
 - Rendering uses the default `DefaultDynamicFeatureRenderer` (blue
   disc + six-minute predictor). A custom `OwnShipRenderer` is
   deferred until a second dynamic source coexists.
+- Layer Stack integration (PR-D2.1) surfaces every registered
+  `IDynamicFeatureSource` as a row in the `DynamicArrows` plane of
+  the Layer Stack panel. Each row exposes the source's display name
+  and a visibility checkbox; toggling the checkbox flips the
+  underlying overlay layer's `Enabled` flag through
+  `IDynamicFeatureSourceRegistry.SetVisible` and persists into
+  `ViewerSettings.DynamicSourceVisibility` (keyed by source Id).
+  Dynamic rows sort below dataset rows in the plane and are kept in
+  registration order. The legacy `ViewerSettings.OwnShipVisible`
+  bool is migrated into the dictionary on first load and mirrored
+  back on save for downgrade compatibility.
 
 **Caveats**
 
 - The synthetic driver is scaffolding — start position, course, and
   speed are hard-coded constants, not user-configurable settings.
-- Layer Stack integration is deferred. The PR-D1 surface does not
-  yet expose a `DynamicSourceRegistration` adapter for the layer
-  panel; until it does, the toolbar toggle is the visibility
-  affordance.
 - "Centre on own-ship", picking the glyph, and time-axis integration
-  are all out of scope for PR-D2.
+  are all out of scope for PR-D2 / PR-D2.1.
 

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -63,6 +63,7 @@ internal static class Strings
     public static string LayerStack_ShowEmptyPlanes => Get(nameof(LayerStack_ShowEmptyPlanes));
     public static string LayerStack_EmptyPlane_Placeholder => Get(nameof(LayerStack_EmptyPlane_Placeholder));
     public static string LayerStack_ActiveTooltip => Get(nameof(LayerStack_ActiveTooltip));
+    public static string LayerStack_DynamicEntry_VisibilityTooltip => Get(nameof(LayerStack_DynamicEntry_VisibilityTooltip));
     public static string LayerStack_VisibilityVsActive_HelpText => Get(nameof(LayerStack_VisibilityVsActive_HelpText));
     public static string LayerStack_ChildCountFormat => Get(nameof(LayerStack_ChildCountFormat));
     public static string LayerStack_PriorityFormat => Get(nameof(LayerStack_PriorityFormat));
@@ -394,5 +395,4 @@ internal static class Strings
     // Own-ship overlay (PR-D2)
     public static string OwnShip_DisplayName => Get(nameof(OwnShip_DisplayName));
     public static string OwnShip_Description => Get(nameof(OwnShip_Description));
-    public static string OwnShip_Toggle_Tooltip => Get(nameof(OwnShip_Toggle_Tooltip));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -59,6 +59,10 @@
   <data name="LayerStack_ActiveTooltip" xml:space="preserve">
     <value>Active — when off, this dataset is removed from the cross-product paint stack and no longer influences S-98 interoperability rules or pick. Distinct from the per-dataset Visibility toggle on the Datasets panel.</value>
   </data>
+  <data name="LayerStack_DynamicEntry_VisibilityTooltip" xml:space="preserve">
+    <value>Visibility — when off, this dynamic source's overlay is hidden from the map. The source keeps tracking in the background.</value>
+    <comment>Tooltip for the visibility checkbox on a dynamic-feature-source row in the Layer Stack (PR-D2.1).</comment>
+  </data>
   <data name="LayerStack_VisibilityVsActive_HelpText" xml:space="preserve">
     <value>Active controls participation in S-98 rules and pick; Visibility (on the Datasets panel) only hides the rendered layers.</value>
   </data>
@@ -1042,9 +1046,5 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   <data name="OwnShip_Description" xml:space="preserve">
     <value>The vessel's own position (synthetic for v1).</value>
     <comment>Longer description of the own-ship source for tooltips and settings panels.</comment>
-  </data>
-  <data name="OwnShip_Toggle_Tooltip" xml:space="preserve">
-    <value>Toggle the own-ship overlay</value>
-    <comment>Tooltip for the toolbar button that hides/shows the own-ship glyph.</comment>
   </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicFeatureSourceRegistryAccessor.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicFeatureSourceRegistryAccessor.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Late-bound accessor for the dynamic-source overlay host's
+/// <see cref="IDynamicFeatureSourceRegistry"/> surface (PR-D2.1).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The overlay host is constructed by <c>MainWindow</c> after the
+/// Avalonia <c>MapControl</c> exists, which happens after DI is built
+/// and after singletons like <c>LayerStackViewModel</c> have already
+/// been resolved. This accessor bridges that ordering: services that
+/// need the registry hold the accessor and read
+/// <see cref="Current"/> (or subscribe to <see cref="SourcesChanged"/>)
+/// at invocation time. Mirrors the
+/// <c>IMapHostAccessor</c> / <c>MapHostAccessor</c> pattern already
+/// established by the MCP wiring.
+/// </para>
+/// <para>
+/// <see cref="SourcesChanged"/> on the accessor fires when (a) the
+/// inner registry's event fires, or (b) <see cref="Current"/> is
+/// assigned (the "registry just attached" transition forces a
+/// rebuild). Subscribers therefore don't need to know whether the
+/// inner registry has attached yet.
+/// </para>
+/// </remarks>
+internal sealed class DynamicFeatureSourceRegistryAccessor : IDynamicFeatureSourceRegistry
+{
+    private IDynamicFeatureSourceRegistry? _current;
+
+    /// <summary>
+    /// The attached registry, or <see langword="null"/> when no host
+    /// has been constructed yet. Assignment subscribes / unsubscribes
+    /// <see cref="SourcesChanged"/> passthrough and fires the event
+    /// once so existing subscribers rebuild against the freshly
+    /// attached registry.
+    /// </summary>
+    public IDynamicFeatureSourceRegistry? Current
+    {
+        get => _current;
+        set
+        {
+            if (ReferenceEquals(_current, value)) return;
+
+            if (_current is not null) _current.SourcesChanged -= RaiseSourcesChanged;
+            _current = value;
+            if (_current is not null) _current.SourcesChanged += RaiseSourcesChanged;
+
+            RaiseSourcesChanged();
+        }
+    }
+
+    public IReadOnlyList<DynamicSourceRegistrationInfo> Sources =>
+        _current?.Sources ?? Array.Empty<DynamicSourceRegistrationInfo>();
+
+    public bool GetVisible(string sourceId) => _current?.GetVisible(sourceId) ?? true;
+
+    public void SetVisible(string sourceId, bool visible) =>
+        _current?.SetVisible(sourceId, visible);
+
+    public event Action? SourcesChanged;
+
+    private void RaiseSourcesChanged() => SourcesChanged?.Invoke();
+}

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
@@ -36,16 +36,27 @@ namespace EncDotNet.S100.Viewer.Services.DynamicSources;
 /// <c>docs/design/dynamic-feature-source.md</c> §5 Q8.
 /// </para>
 /// </remarks>
-internal sealed class DynamicSourceOverlayHost : IDisposable
+internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSourceRegistry
 {
     private readonly IMapHost _mapHost;
     private readonly IServiceProvider _services;
     private readonly Action<Action> _marshal;
     private readonly ILogger<DynamicSourceOverlayHost> _logger;
     private readonly Dictionary<string, Registration> _byId = new(StringComparer.Ordinal);
+    // Registration order — preserved separately from _byId so the
+    // Layer Stack panel can render sources in the order they were
+    // registered (PR-D2.1 Q7). Mutated under _lock.
+    private readonly List<Registration> _ordered = new();
+    // Visibility map keyed by source id. Pre-seeded entries (set
+    // before Register) survive a later Register call so persisted
+    // visibility from ViewerSettings can be applied without a race.
+    private readonly Dictionary<string, bool> _visibility = new(StringComparer.Ordinal);
     private readonly object _lock = new();
 
     private static readonly DefaultDynamicFeatureRenderer s_defaultRenderer = new();
+
+    /// <inheritdoc />
+    public event Action? SourcesChanged;
 
     /// <summary>
     /// Creates a new overlay host.
@@ -102,6 +113,7 @@ internal sealed class DynamicSourceOverlayHost : IDisposable
         };
 
         var registration = new Registration(source, renderer, layer, this);
+        bool initialVisible;
 
         lock (_lock)
         {
@@ -111,12 +123,21 @@ internal sealed class DynamicSourceOverlayHost : IDisposable
                     $"A dynamic feature source with id '{source.Id}' is already registered.");
             }
             _byId[source.Id] = registration;
+            _ordered.Add(registration);
+
+            // Apply any pre-seeded visibility (e.g. from settings
+            // restored before MainWindow constructed the host).
+            initialVisible = !_visibility.TryGetValue(source.Id, out var v) || v;
+            _visibility[source.Id] = initialVisible;
         }
+
+        layer.Enabled = initialVisible;
 
         _marshal(() =>
         {
             _mapHost.AddOverlayLayer(layer);
             Rebuild(registration);
+            SourcesChanged?.Invoke();
         });
 
         source.Changed += registration.OnChanged;
@@ -171,10 +192,77 @@ internal sealed class DynamicSourceOverlayHost : IDisposable
         Registration[] regs;
         lock (_lock)
         {
-            regs = _byId.Values.ToArray();
+            regs = _ordered.ToArray();
             _byId.Clear();
+            _ordered.Clear();
         }
         foreach (var r in regs) r.DisposeInternal();
+        SourcesChanged?.Invoke();
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<DynamicSourceRegistrationInfo> Sources
+    {
+        get
+        {
+            lock (_lock)
+            {
+                var list = new List<DynamicSourceRegistrationInfo>(_ordered.Count);
+                foreach (var r in _ordered)
+                {
+                    list.Add(new DynamicSourceRegistrationInfo(
+                        Id: r.Source.Id,
+                        DisplayName: r.Source.Metadata.DisplayName,
+                        Description: r.Source.Metadata.Description));
+                }
+                return list;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public bool GetVisible(string sourceId)
+    {
+        ArgumentNullException.ThrowIfNull(sourceId);
+        lock (_lock)
+        {
+            return !_visibility.TryGetValue(sourceId, out var v) || v;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetVisible(string sourceId, bool visible)
+    {
+        ArgumentNullException.ThrowIfNull(sourceId);
+
+        Registration? registration;
+        bool changed;
+        lock (_lock)
+        {
+            var hadEntry = _visibility.TryGetValue(sourceId, out var current);
+            changed = !hadEntry || current != visible;
+            if (changed) _visibility[sourceId] = visible;
+            _byId.TryGetValue(sourceId, out registration);
+        }
+
+        if (!changed) return;
+
+        if (registration is not null)
+        {
+            _marshal(() =>
+            {
+                registration.Layer.Enabled = visible;
+                registration.Layer.DataHasChanged();
+                SourcesChanged?.Invoke();
+            });
+        }
+        else
+        {
+            // Source not registered yet (seeding from settings).
+            // Still fire so subscribers re-render any stub VM rows
+            // that key off seeded values.
+            SourcesChanged?.Invoke();
+        }
     }
 
     /// <summary>Captured registration for one source.</summary>
@@ -213,8 +301,16 @@ internal sealed class DynamicSourceOverlayHost : IDisposable
             if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
             Source.Changed -= OnChanged;
-            lock (_host._lock) _host._byId.Remove(Source.Id);
-            _host._marshal(() => _host._mapHost.RemoveOverlayLayer(Layer));
+            lock (_host._lock)
+            {
+                _host._byId.Remove(Source.Id);
+                _host._ordered.Remove(this);
+            }
+            _host._marshal(() =>
+            {
+                _host._mapHost.RemoveOverlayLayer(Layer);
+                _host.SourcesChanged?.Invoke();
+            });
         }
 
         internal void DisposeInternal()

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceRegistrationInfo.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceRegistrationInfo.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Read-only registration view of an <see cref="EncDotNet.S100.DynamicSources.IDynamicFeatureSource"/>
+/// hosted by <see cref="DynamicSourceOverlayHost"/>. Surfaced through
+/// <see cref="IDynamicFeatureSourceRegistry"/> so view-models can
+/// render Layer Stack rows without taking a dependency on the
+/// concrete source instance.
+/// </summary>
+/// <param name="Id">Instance-unique source id.</param>
+/// <param name="DisplayName">Localised display label (PR-D2.1).</param>
+/// <param name="Description">Optional longer description for tooltips.</param>
+internal sealed record DynamicSourceRegistrationInfo(
+    string Id,
+    string DisplayName,
+    string? Description);

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/IDynamicFeatureSourceRegistry.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/IDynamicFeatureSourceRegistry.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Viewer-internal registry surface over the dynamic-source overlay
+/// host (PR-D2.1). Exposes the set of currently registered sources
+/// and a per-source visibility toggle so the Layer Stack panel can
+/// render a row per source with the same UX as dataset entries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implemented by <see cref="DynamicSourceOverlayHost"/>. The registry
+/// is the canonical read/write surface for view-models; the host's
+/// <c>Register</c> method remains the only way to add or remove a
+/// source.
+/// </para>
+/// <para>
+/// Visibility state is owned by the host. Toggling visibility flips
+/// the backing <c>MemoryLayer.Enabled</c> bit — the source itself is
+/// left alone (it keeps publishing into the hidden layer). This
+/// preserves the PR-D1 <c>IDynamicFeatureSource</c> contract (no
+/// <c>IsEnabled</c>) and avoids per-source toggle plumbing.
+/// </para>
+/// <para>
+/// All members are safe to call from the UI thread. The host marshals
+/// internal state mutations so <see cref="SourcesChanged"/> always
+/// fires on the UI thread when raised through the host's normal flow.
+/// </para>
+/// </remarks>
+internal interface IDynamicFeatureSourceRegistry
+{
+    /// <summary>
+    /// Currently registered sources in registration order. Stable
+    /// across visibility toggles; updated on Register / Dispose.
+    /// </summary>
+    IReadOnlyList<DynamicSourceRegistrationInfo> Sources { get; }
+
+    /// <summary>
+    /// Returns the current visibility for the source identified by
+    /// <paramref name="sourceId"/>. Defaults to <see langword="true"/>
+    /// for unregistered ids so seeding a not-yet-registered id is a
+    /// no-op that still round-trips its eventual default.
+    /// </summary>
+    bool GetVisible(string sourceId);
+
+    /// <summary>
+    /// Sets the visibility for the source identified by
+    /// <paramref name="sourceId"/>. May be called before the source
+    /// registers (seeding from persisted settings). Idempotent; fires
+    /// <see cref="SourcesChanged"/> only on a real transition.
+    /// </summary>
+    void SetVisible(string sourceId, bool visible);
+
+    /// <summary>
+    /// Raised when <see cref="Sources"/> changes (register / dispose)
+    /// or when <see cref="SetVisible"/> transitions a source's
+    /// visibility. Always raised on the UI thread.
+    /// </summary>
+    event Action? SourcesChanged;
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/LayerStackViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/LayerStackViewModel.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -34,6 +35,7 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 internal sealed class LayerStackViewModel : ViewModelBase
 {
     private readonly IDatasetLoaderService _loader;
+    private readonly IDynamicFeatureSourceRegistry? _dynamicSources;
     private readonly ITimeFormatProvider? _timeFormat;
     // PR-L4 reserve: kept on the field so the constructor still
     // captures it. _ = is enough to suppress unused-field warnings.
@@ -87,13 +89,19 @@ internal sealed class LayerStackViewModel : ViewModelBase
     /// <summary>"Active vs. Visibility" help text for the panel footer.</summary>
     public string ActiveVsVisibilityHelp => Strings.LayerStack_VisibilityVsActive_HelpText;
 
-    public LayerStackViewModel(IDatasetLoaderService loader, ITimeFormatProvider? timeFormat = null)
+    public LayerStackViewModel(
+        IDatasetLoaderService loader,
+        IDynamicFeatureSourceRegistry? dynamicSources = null,
+        ITimeFormatProvider? timeFormat = null)
     {
         ArgumentNullException.ThrowIfNull(loader);
         _loader = loader;
+        _dynamicSources = dynamicSources;
         _timeFormat = timeFormat;
         _ = _timeFormat; // reserved for PR-L4 per-entry timestamp display
         _loader.LayerStackChanged += OnLayerStackChanged;
+        if (_dynamicSources is not null)
+            _dynamicSources.SourcesChanged += OnLayerStackChanged;
         Rebuild();
     }
 
@@ -107,7 +115,8 @@ internal sealed class LayerStackViewModel : ViewModelBase
 
     /// <summary>
     /// Rebuilds the plane tree from the loader's current
-    /// <see cref="LayerStackEntry"/> snapshot. Preserves
+    /// <see cref="LayerStackEntry"/> snapshot plus any registered
+    /// dynamic feature sources (PR-D2.1). Preserves
     /// <see cref="LayerStackPlaneViewModel.IsExpanded"/> per plane
     /// across rebuilds via <see cref="_planeExpansion"/>.
     /// </summary>
@@ -135,20 +144,39 @@ internal sealed class LayerStackViewModel : ViewModelBase
             list.Add(e);
         }
 
+        // PR-D2.1: dynamic feature sources land in the DynamicArrows
+        // plane in registration order. Snapshot once here so the
+        // bucket sees a stable view even if the registry mutates
+        // mid-rebuild.
+        var dynamicSources = _dynamicSources?.Sources ?? Array.Empty<DynamicSourceRegistrationInfo>();
+
         foreach (var plane in PlanesTopFirst)
         {
             byPlane.TryGetValue(plane, out var planeEntries);
             var planeEntriesList = planeEntries ?? new List<LayerStackEntry>();
-            if (planeEntriesList.Count == 0 && !_showEmptyPlanes) continue;
+            var dynamicForPlane = plane == S98DisplayPlane.DynamicArrows
+                ? dynamicSources
+                : Array.Empty<DynamicSourceRegistrationInfo>();
 
-            // Within-plane order: render the child list top-of-plane
-            // first (highest WithinPlanePriority first) so the tree
-            // reads like the paint stack — top wins.
-            var children = planeEntriesList
+            if (planeEntriesList.Count == 0 && dynamicForPlane.Count == 0 && !_showEmptyPlanes)
+                continue;
+
+            // Dataset rows: highest WithinPlanePriority first so the
+            // tree reads like the paint stack — top wins.
+            var datasetChildren = planeEntriesList
                 .OrderByDescending(e => e.WithinPlanePriority)
                 .ThenBy(e => e.SourceDatasetId, StringComparer.Ordinal)
-                .Select(e => new LayerStackEntryViewModel(_loader, e))
-                .ToList();
+                .Select(e => (ViewModelBase)new LayerStackEntryViewModel(_loader, e));
+
+            // Dynamic rows: registration order (preserved by
+            // IDynamicFeatureSourceRegistry.Sources). Placed below
+            // dataset rows in the panel since datasets typically
+            // carry positive priorities; a future priority hint on
+            // DynamicSourceMetadata could change this.
+            var dynamicChildren = dynamicForPlane
+                .Select(info => (ViewModelBase)new LayerStackDynamicEntryViewModel(_dynamicSources!, info));
+
+            var children = datasetChildren.Concat(dynamicChildren).ToList();
 
             var isExpanded = !_planeExpansion.TryGetValue(plane, out var prev) || prev;
             var vm = new LayerStackPlaneViewModel(plane, children, isExpanded);
@@ -167,7 +195,7 @@ internal sealed class LayerStackViewModel : ViewModelBase
 internal sealed class LayerStackPlaneViewModel : ViewModelBase
 {
     public S98DisplayPlane Plane { get; }
-    public IReadOnlyList<LayerStackEntryViewModel> Children { get; }
+    public IReadOnlyList<ViewModelBase> Children { get; }
 
     public string Title => Plane switch
     {
@@ -200,12 +228,64 @@ internal sealed class LayerStackPlaneViewModel : ViewModelBase
 
     public LayerStackPlaneViewModel(
         S98DisplayPlane plane,
-        IReadOnlyList<LayerStackEntryViewModel> children,
+        IReadOnlyList<ViewModelBase> children,
         bool isExpanded)
     {
         Plane = plane;
         Children = children;
         _isExpanded = isExpanded;
+    }
+}
+
+/// <summary>
+/// One dynamic-feature-source child row in the Layer Stack panel
+/// (PR-D2.1) — its source id, display name, optional description,
+/// and a two-way bound <see cref="IsActive"/> checkbox routed
+/// through <see cref="IDynamicFeatureSourceRegistry.SetVisible"/>.
+/// </summary>
+/// <remarks>
+/// A sibling of <see cref="LayerStackEntryViewModel"/>: both inherit
+/// <see cref="ViewModelBase"/> so the plane VM can hold a mixed
+/// collection. XAML picks the appropriate template by runtime type
+/// via <c>ItemsControl.DataTemplates</c>.
+/// </remarks>
+internal sealed class LayerStackDynamicEntryViewModel : ViewModelBase
+{
+    private readonly IDynamicFeatureSourceRegistry _registry;
+
+    public string SourceId { get; }
+    public string DisplayName { get; }
+    public string? Description { get; }
+    public bool HasDescription => !string.IsNullOrEmpty(Description);
+
+    /// <summary>
+    /// Whether the source's overlay layer is currently visible.
+    /// Routes through
+    /// <see cref="IDynamicFeatureSourceRegistry.SetVisible"/>; the
+    /// registry's resulting <c>SourcesChanged</c> event triggers a
+    /// VM rebuild so the new state surfaces immediately.
+    /// </summary>
+    public bool IsActive
+    {
+        get => _registry.GetVisible(SourceId);
+        set
+        {
+            if (_registry.GetVisible(SourceId) == value) return;
+            _registry.SetVisible(SourceId, value);
+            OnPropertyChanged();
+        }
+    }
+
+    public LayerStackDynamicEntryViewModel(
+        IDynamicFeatureSourceRegistry registry,
+        DynamicSourceRegistrationInfo info)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(info);
+        _registry = registry;
+        SourceId = info.Id;
+        DisplayName = info.DisplayName;
+        Description = info.Description;
     }
 }
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -289,41 +289,6 @@ internal sealed class MainViewModel : ViewModelBase
 
     public ICommand ToggleStatusBarCommand { get; }
 
-    // PR-D2 own-ship overlay toggle.
-    private readonly EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource? _ownShipSource;
-    private bool _isOwnShipVisible;
-
-    /// <summary>
-    /// Whether the own-ship overlay glyph is currently published by the
-    /// dynamic source (and therefore drawn on the overlay tier). Bound
-    /// to the toolbar toggle button and persisted via
-    /// <see cref="ViewerSettings.OwnShipVisible"/>.
-    /// </summary>
-    public bool IsOwnShipVisible
-    {
-        get => _isOwnShipVisible;
-        set
-        {
-            if (SetProperty(ref _isOwnShipVisible, value))
-            {
-                if (_ownShipSource is not null) _ownShipSource.IsEnabled = value;
-                _settings.OwnShipVisible = value;
-                _settings.Save();
-            }
-        }
-    }
-
-    /// <summary>Toggle the own-ship overlay visibility.</summary>
-    public ICommand ToggleOwnShipCommand { get; }
-
-    /// <summary>
-    /// True when own-ship is wired (the synthetic source resolved
-    /// from DI). The toolbar button binds its <c>IsVisible</c> to
-    /// this so callers that construct the view-model without a
-    /// source (legacy tests) get a clean tree.
-    /// </summary>
-    public bool IsOwnShipSourceAvailable => _ownShipSource is not null;
-
     /// <summary>
     /// Toggles the bottom dock open/closed. Kept for the existing
     /// View menu binding; in PR-M4 the dock contains the Timeline tab.
@@ -699,8 +664,7 @@ internal sealed class MainViewModel : ViewModelBase
         IToastService toasts,
         IEnumerable<IActivityTab>? activityTabs = null,
         McpServerHost? mcpServerHost = null,
-        IStatusPresenter? statusPresenter = null,
-        EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource? ownShipSource = null)
+        IStatusPresenter? statusPresenter = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(featureCatalogues);
@@ -824,13 +788,6 @@ internal sealed class MainViewModel : ViewModelBase
         });
 
         _isStatusBarVisible = settings.IsStatusBarVisible;
-
-        // PR-D2 own-ship overlay. Resolve from DI; if absent (legacy
-        // test callers, design-time), the toggle hides itself.
-        _ownShipSource = ownShipSource;
-        _isOwnShipVisible = settings.OwnShipVisible;
-        if (_ownShipSource is not null) _ownShipSource.IsEnabled = _isOwnShipVisible;
-        ToggleOwnShipCommand = new RelayCommand(() => IsOwnShipVisible = !IsOwnShipVisible);
 
         ToggleStatusBarCommand = new RelayCommand(() => IsStatusBarVisible = !IsStatusBarVisible);
 

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -119,7 +119,24 @@ internal sealed class ViewerSettings
     /// driver is always running; this flag controls whether the
     /// source publishes the glyph to the dynamic-source overlay tier.
     /// </summary>
+    /// <remarks>
+    /// PR-D2.1 supersedes this field with the per-source
+    /// <see cref="DynamicSourceVisibility"/> dictionary. The field is
+    /// kept on the POCO so a downgrade still reads the user's choice;
+    /// <see cref="Load"/> migrates its value into the dictionary on
+    /// first load, and <see cref="Save"/> mirrors the dictionary
+    /// entry back so the legacy field stays in sync for one release.
+    /// </remarks>
     public bool OwnShipVisible { get; set; } = true;
+
+    /// <summary>
+    /// Per-source visibility for dynamic feature sources (PR-D2.1),
+    /// keyed by <c>IDynamicFeatureSource.Id</c>. Drives the Layer
+    /// Stack panel's visibility toggle for the
+    /// <c>DynamicArrows</c> plane.
+    /// </summary>
+    public Dictionary<string, bool> DynamicSourceVisibility { get; set; }
+        = new(StringComparer.Ordinal);
 
     /// <summary>
     /// User preference for whether the bottom timeline panel is shown.
@@ -208,6 +225,15 @@ internal sealed class ViewerSettings
                     settings.PortrayalCataloguePath = null;
                 }
 
+                // PR-D2.1: migrate legacy OwnShipVisible bool into the
+                // per-source DynamicSourceVisibility dictionary so the
+                // own-ship row in the Layer Stack picks up the user's
+                // pre-PR-D2.1 choice on first load.
+                if (!settings.DynamicSourceVisibility.ContainsKey(OwnShipVisibilityKey))
+                {
+                    settings.DynamicSourceVisibility[OwnShipVisibilityKey] = settings.OwnShipVisible;
+                }
+
                 return settings;
             }
         }
@@ -224,7 +250,23 @@ internal sealed class ViewerSettings
         var dir = Path.GetDirectoryName(SettingsFilePath);
         if (!string.IsNullOrEmpty(dir))
             Directory.CreateDirectory(dir);
+
+        // PR-D2.1: keep legacy OwnShipVisible in sync with the
+        // per-source visibility dictionary so a downgrade still
+        // picks up the user's current choice.
+        if (DynamicSourceVisibility.TryGetValue(OwnShipVisibilityKey, out var ownShipVisible))
+        {
+            OwnShipVisible = ownShipVisible;
+        }
+
         var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
         File.WriteAllText(SettingsFilePath, json);
     }
+
+    /// <summary>
+    /// Source id of the own-ship dynamic source (matches
+    /// <c>OwnShipSource.FeatureId</c>). Used by the PR-D2.1
+    /// migration / mirror logic.
+    /// </summary>
+    internal const string OwnShipVisibilityKey = "ownship";
 }

--- a/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
@@ -90,8 +90,8 @@
 
                                 <ItemsControl ItemsSource="{Binding Children}"
                                               IsVisible="{Binding !IsEmpty}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="vm:LayerStackEntryViewModel">
+                                    <ItemsControl.DataTemplates>
+                                        <DataTemplate DataType="vm:LayerStackEntryViewModel">
                                             <Grid ColumnDefinitions="Auto,*,Auto"
                                                   ColumnSpacing="8"
                                                   Margin="24,3,8,3">
@@ -120,7 +120,33 @@
                                                            FontFamily="Consolas,Menlo,Monaco,monospace" />
                                             </Grid>
                                         </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
+                                        <!-- PR-D2.1: dynamic-feature-source row. Same chrome
+                                             as a dataset row but the checkbox toggles overlay
+                                             visibility via IDynamicFeatureSourceRegistry. -->
+                                        <DataTemplate DataType="vm:LayerStackDynamicEntryViewModel">
+                                            <Grid ColumnDefinitions="Auto,*"
+                                                  ColumnSpacing="8"
+                                                  Margin="24,3,8,3">
+                                                <CheckBox Grid.Column="0"
+                                                          IsChecked="{Binding IsActive, Mode=TwoWay}"
+                                                          ToolTip.Tip="{x:Static loc:Strings.LayerStack_DynamicEntry_VisibilityTooltip}"
+                                                          VerticalAlignment="Center" />
+                                                <StackPanel Grid.Column="1"
+                                                            VerticalAlignment="Center"
+                                                            Spacing="0">
+                                                    <TextBlock Text="{Binding DisplayName}"
+                                                               FontSize="12"
+                                                               ToolTip.Tip="{Binding SourceId}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding Description}"
+                                                               IsVisible="{Binding HasDescription}"
+                                                               FontSize="10"
+                                                               Opacity="0.65"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                </StackPanel>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.DataTemplates>
                                 </ItemsControl>
                                 <!-- TODO PR-L4 (TBD-11): unify ordering UX with DatasetsViewModel drag-reorder -->
                             </Panel>

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostRegistryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostRegistryTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
+using Mapsui.Layers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources;
+
+/// <summary>
+/// PR-D2.1: <see cref="DynamicSourceOverlayHost"/> as
+/// <see cref="IDynamicFeatureSourceRegistry"/>.
+/// </summary>
+public class DynamicSourceOverlayHostRegistryTests
+{
+    [Fact]
+    public void Sources_ReturnsRegisteredInOrder_AndFiresEventOnRegister()
+    {
+        var host = new FakeMapHost();
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        IDynamicFeatureSourceRegistry registry = sut;
+        int events = 0;
+        registry.SourcesChanged += () => events++;
+
+        sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
+        sut.Register(new FakeDynamicFeatureSource("b", new DynamicSourceMetadata { DisplayName = "B" }));
+
+        Assert.Equal(new[] { "a", "b" }, registry.Sources.Select(s => s.Id));
+        Assert.Equal(new[] { "A", "B" }, registry.Sources.Select(s => s.DisplayName));
+        Assert.Equal(2, events);
+    }
+
+    [Fact]
+    public void DisposeRegistration_RemovesFromSources_AndFiresEvent()
+    {
+        var host = new FakeMapHost();
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        var reg = sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
+        IDynamicFeatureSourceRegistry registry = sut;
+        int events = 0;
+        registry.SourcesChanged += () => events++;
+
+        reg.Dispose();
+
+        Assert.Empty(registry.Sources);
+        Assert.Equal(1, events);
+    }
+
+    [Fact]
+    public void SetVisible_TogglesMemoryLayerEnabled_AndFiresEvent()
+    {
+        var host = new FakeMapHost();
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
+        IDynamicFeatureSourceRegistry registry = sut;
+        var layer = (MemoryLayer)host.OverlayLayers[0];
+        int events = 0;
+        registry.SourcesChanged += () => events++;
+
+        Assert.True(layer.Enabled);
+        registry.SetVisible("a", false);
+
+        Assert.False(layer.Enabled);
+        Assert.False(registry.GetVisible("a"));
+        Assert.Equal(1, events);
+    }
+
+    [Fact]
+    public void SetVisible_BeforeRegister_SeedsInitialEnabledState()
+    {
+        var host = new FakeMapHost();
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        IDynamicFeatureSourceRegistry registry = sut;
+
+        registry.SetVisible("a", false);
+        sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
+
+        var layer = (MemoryLayer)host.OverlayLayers[0];
+        Assert.False(layer.Enabled);
+        Assert.False(registry.GetVisible("a"));
+    }
+
+    [Fact]
+    public void GetVisible_UnknownId_DefaultsToTrue()
+    {
+        var host = new FakeMapHost();
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+
+        Assert.True(((IDynamicFeatureSourceRegistry)sut).GetVisible("missing"));
+    }
+
+    private static void SyncMarshal(Action a) => a();
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
@@ -51,7 +51,9 @@ public class LayerStackViewModelTests
         var vm = new LayerStackViewModel(loader);
 
         var plane = Assert.Single(vm.Planes);
-        var ids = plane.Children.Select(c => c.DatasetId).ToList();
+        var ids = plane.Children
+            .OfType<LayerStackEntryViewModel>()
+            .Select(c => c.DatasetId).ToList();
         Assert.Equal(new[] { "high.gml", "mid.gml", "low.gml" }, ids);
     }
 
@@ -113,7 +115,7 @@ public class LayerStackViewModelTests
         loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
         var vm = new LayerStackViewModel(loader);
 
-        var entry = vm.Planes[0].Children[0];
+        var entry = (LayerStackEntryViewModel)vm.Planes[0].Children[0];
         Assert.True(entry.IsActive); // default
 
         entry.IsActive = false;

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewModels/LayerStackViewModelDynamicSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewModels/LayerStackViewModelDynamicSourceTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Interoperability;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+using ControllableLoader = EncDotNet.S100.Viewer.Tests.LayerStackViewModelTests.ControllableLoader;
+
+namespace EncDotNet.S100.Viewer.Tests.ViewModels;
+
+/// <summary>
+/// PR-D2.1: dynamic-source rows in <see cref="LayerStackViewModel"/>.
+/// </summary>
+public class LayerStackViewModelDynamicSourceTests
+{
+    [Fact]
+    public void Rebuild_NoDynamicSources_NoDynamicArrowsPlane()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
+        var registry = new FakeRegistry();
+
+        var vm = new LayerStackViewModel(loader, registry);
+
+        Assert.DoesNotContain(vm.Planes, p => p.Plane == S98DisplayPlane.DynamicArrows);
+    }
+
+    [Fact]
+    public void Rebuild_DynamicSources_AppearInDynamicArrowsPlane_InRegistrationOrder()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
+        var registry = new FakeRegistry();
+        registry.Add(new DynamicSourceRegistrationInfo("ownship", "Own Ship", null));
+        registry.Add(new DynamicSourceRegistrationInfo("ais", "AIS", "Other vessels"));
+
+        var vm = new LayerStackViewModel(loader, registry);
+
+        var plane = vm.Planes.Single(p => p.Plane == S98DisplayPlane.DynamicArrows);
+        var dyn = plane.Children.OfType<LayerStackDynamicEntryViewModel>().ToList();
+        Assert.Equal(new[] { "ownship", "ais" }, dyn.Select(d => d.SourceId));
+        Assert.Equal("Own Ship", dyn[0].DisplayName);
+    }
+
+    [Fact]
+    public void DynamicEntry_IsActive_TogglesThroughRegistry()
+    {
+        var loader = new ControllableLoader();
+        var registry = new FakeRegistry();
+        registry.Add(new DynamicSourceRegistrationInfo("ownship", "Own Ship", null));
+
+        var vm = new LayerStackViewModel(loader, registry);
+        var entry = vm.Planes.Single(p => p.Plane == S98DisplayPlane.DynamicArrows)
+            .Children.OfType<LayerStackDynamicEntryViewModel>().Single();
+
+        Assert.True(entry.IsActive);
+        entry.IsActive = false;
+        Assert.False(registry.GetVisible("ownship"));
+        Assert.False(entry.IsActive);
+    }
+
+    [Fact]
+    public void SourcesChanged_TriggersRebuild_AddingNewRow()
+    {
+        var loader = new ControllableLoader();
+        var registry = new FakeRegistry();
+        var vm = new LayerStackViewModel(loader, registry);
+
+        Assert.DoesNotContain(vm.Planes, p => p.Plane == S98DisplayPlane.DynamicArrows);
+
+        registry.Add(new DynamicSourceRegistrationInfo("ownship", "Own Ship", null));
+
+        var plane = vm.Planes.Single(p => p.Plane == S98DisplayPlane.DynamicArrows);
+        Assert.Single(plane.Children.OfType<LayerStackDynamicEntryViewModel>());
+    }
+
+    [Fact]
+    public void SourcesChanged_TriggersRebuild_RemovingRow()
+    {
+        var loader = new ControllableLoader();
+        var registry = new FakeRegistry();
+        registry.Add(new DynamicSourceRegistrationInfo("ownship", "Own Ship", null));
+        var vm = new LayerStackViewModel(loader, registry);
+
+        registry.RemoveAt(0);
+
+        Assert.DoesNotContain(vm.Planes, p => p.Plane == S98DisplayPlane.DynamicArrows);
+    }
+
+    [Fact]
+    public void MixedPlane_DatasetAndDynamicRowsCoexist_DatasetsFirst()
+    {
+        var loader = new ControllableLoader();
+        loader.SetEntries(Entry("s111-arrows", S98DisplayPlane.DynamicArrows, 50));
+        var registry = new FakeRegistry();
+        registry.Add(new DynamicSourceRegistrationInfo("ownship", "Own Ship", null));
+
+        var vm = new LayerStackViewModel(loader, registry);
+        var plane = vm.Planes.Single(p => p.Plane == S98DisplayPlane.DynamicArrows);
+
+        Assert.Equal(2, plane.Children.Count);
+        Assert.IsType<LayerStackEntryViewModel>(plane.Children[0]);
+        Assert.IsType<LayerStackDynamicEntryViewModel>(plane.Children[1]);
+    }
+
+    private static LayerStackEntry Entry(string id, S98DisplayPlane plane, int priority)
+        => new(new MemoryLayer(id), plane, priority, id);
+
+    private sealed class FakeRegistry : IDynamicFeatureSourceRegistry
+    {
+        private readonly List<DynamicSourceRegistrationInfo> _list = new();
+        private readonly Dictionary<string, bool> _visible = new(StringComparer.Ordinal);
+
+        public IReadOnlyList<DynamicSourceRegistrationInfo> Sources => _list;
+        public event Action? SourcesChanged;
+
+        public bool GetVisible(string sourceId) =>
+            !_visible.TryGetValue(sourceId, out var v) || v;
+
+        public void SetVisible(string sourceId, bool visible)
+        {
+            _visible[sourceId] = visible;
+            SourcesChanged?.Invoke();
+        }
+
+        public void Add(DynamicSourceRegistrationInfo info)
+        {
+            _list.Add(info);
+            SourcesChanged?.Invoke();
+        }
+
+        public void RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+            SourcesChanged?.Invoke();
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewerSettingsMigrationTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewerSettingsMigrationTests.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using EncDotNet.S100.Viewer;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// PR-D2.1: legacy <c>OwnShipVisible</c> bool migrates into the
+/// <see cref="ViewerSettings.DynamicSourceVisibility"/> dictionary
+/// on first load, and downgrade compat is preserved on save.
+/// </summary>
+public class ViewerSettingsMigrationTests
+{
+    [Fact]
+    public void Load_LegacyOwnShipVisibleFalse_MigratesIntoDict()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"viewer-settings-{Path.GetRandomFileName()}.json");
+        File.WriteAllText(path, "{\"OwnShipVisible\":false}");
+
+        try
+        {
+            var s = ViewerSettings.Load(path);
+
+            Assert.True(s.DynamicSourceVisibility.TryGetValue(
+                ViewerSettings.OwnShipVisibilityKey, out var v));
+            Assert.False(v);
+            Assert.False(s.OwnShipVisible);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NewFormatPresent_PreservesDictAndDoesNotOverwrite()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"viewer-settings-{Path.GetRandomFileName()}.json");
+        File.WriteAllText(path,
+            "{\"OwnShipVisible\":true,\"DynamicSourceVisibility\":{\"ownship\":false,\"ais\":true}}");
+
+        try
+        {
+            var s = ViewerSettings.Load(path);
+
+            Assert.False(s.DynamicSourceVisibility["ownship"]);
+            Assert.True(s.DynamicSourceVisibility["ais"]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Save_MirrorsDictBackToLegacyField()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"viewer-settings-{Path.GetRandomFileName()}.json");
+        try
+        {
+            var s = ViewerSettings.Load(path);
+            s.DynamicSourceVisibility[ViewerSettings.OwnShipVisibilityKey] = false;
+            s.Save();
+
+            var reloaded = ViewerSettings.Load(path);
+            Assert.False(reloaded.OwnShipVisible);
+            Assert.False(reloaded.DynamicSourceVisibility[ViewerSettings.OwnShipVisibilityKey]);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
Closes the gap PR-D1 left (the `DynamicSourceRegistration` sketch never shipped) and PR-D2 surfaced (own-ship sat on a toolbar toggle because there was nowhere for it in the layer panel).

Every registered `IDynamicFeatureSource` now appears as a row in the `DynamicArrows` plane of the Layer Stack panel with a visibility checkbox that persists through `ViewerSettings`. The interim toolbar own-ship toggle is gone.

## Design (Q1–Q9 from kickoff)

- **Q1/Q2**: New internal `IDynamicFeatureSourceRegistry` (Sources / Get|SetVisible / SourcesChanged) implemented by `DynamicSourceOverlayHost`. Late-binding `DynamicFeatureSourceRegistryAccessor` mirrors the existing `IMapHostAccessor` pattern so the view-model can subscribe before the host (which needs `IMapHost`) is constructed. The PR-D1 `IDynamicFeatureSource` Core contract is untouched.
- **Q3 (a)**: New sibling `LayerStackDynamicEntryViewModel`; `LayerStackPlaneViewModel.Children` widens to `IReadOnlyList<ViewModelBase>`; XAML resolves per-row template via `ItemsControl.DataTemplates` with two type-keyed entries.
- **Q4 (a)**: Toolbar `OwnShipButton`, `IsOwnShipVisible`, `ToggleOwnShipCommand`, `IsOwnShipSourceAvailable`, and `OwnShip_Toggle_Tooltip` resx all removed.
- **Q5**: `ViewerSettings.DynamicSourceVisibility` dict keyed by source Id. Legacy `OwnShipVisible` bool migrates into the dict on Load and is mirrored back on Save for downgrade compatibility.
- **Q6**: One new resx key: `LayerStack_DynamicEntry_VisibilityTooltip`.
- **Q7**: Registration order inside the bucket (datasets first by `WithinPlanePriority` DESC, then dynamic rows in `Sources` order).
- **Q8**: `ShowEmptyPlanes` semantics untouched.

## Visibility wiring

The host owns a `Dictionary<string,bool> _visibility` and flips `MemoryLayer.Enabled` (Mapsui standard). The source's `IsEnabled` is no longer driven by the viewer (kept on the class for source-internal use). `SetVisible` works both before and after `Register` — pre-seeding a value lets persisted settings apply on host startup without races.

## Tests (14 new)

- **`LayerStackViewModelDynamicSourceTests`** — 0/1/2 dynamic sources, registration order, toggle round-trip, `SourcesChanged`-driven add/remove, mixed plane (dataset + dynamic in `DynamicArrows`).
- **`DynamicSourceOverlayHostRegistryTests`** — `Sources` order, `SourcesChanged` on register / dispose / SetVisible, `MemoryLayer.Enabled` toggle, pre-seed survives `Register`, unknown-id defaults to visible.
- **`ViewerSettingsMigrationTests`** — legacy `OwnShipVisible:false` migrates into the dict, new-format dict is preserved, Save mirrors back for downgrade compat.

## Verification

- `dotnet build` — 0 errors, 0 new warnings.
- `dotnet test --configuration Release` — all 24 test projects green; viewer tests 387/387.
- Manual smoke: launched the viewer; Own Ship row visible in the `DynamicArrows` plane, toolbar toggle gone, S-101 chart loads and renders normally.

## Out of scope

Per kickoff: centre-on-own-ship, custom `OwnShipRenderer`, AIS / multi-vessel, time-axis integration, MCP exposure, hit-testing, drag-reordering, per-source opacity, any change to `IDynamicFeatureSource` / `DynamicFeature` / `DynamicMotion`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>