### PR TITLE
Fix S-101 area & point feature name labels not rendering

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -119,6 +119,13 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     /// </summary>
     private const string FeatureNamePatch = """
         function GetFeatureName(feature, contextParameters)
+            -- Match upstream featurePortrayal:GetFeatureName side effect so
+            -- main.lua's fallback PortrayFeatureName guard sees this call and
+            -- does not re-emit the name with a different default offset.
+            if feature._featurePortrayal then
+                feature._featurePortrayal.GetFeatureNameCalled = true
+            end
+
             if not feature['!featureName'] or #feature.featureName == 0 then
                 return nil
             end

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -102,6 +102,57 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
         end
         """;
 
+    /// <summary>
+    /// Lua patch that corrects the upstream <c>GetFeatureName</c> and
+    /// <c>PortrayFeatureName</c> functions in <c>PortrayalModel.lua</c>. The
+    /// upstream implementation requires both <c>name</c> AND <c>nameUsage</c>
+    /// on every <c>featureName</c> entry, but the S-101 Feature Catalogue
+    /// (Edition 1.x) declares <c>nameUsage</c> with multiplicity <c>0..1</c>
+    /// — it is optional. FC-conformant ENCs that omit <c>nameUsage</c> for
+    /// a single default-display name currently get no label rendered at all.
+    /// <para/>
+    /// This patch reimplements the global <c>GetFeatureName</c> (and the
+    /// <c>PortrayFeatureName</c> helper that wraps it) so a missing
+    /// <c>nameUsage</c> is treated as <c>1</c> (Default Name Display),
+    /// matching the FC's optional semantics. When <c>nameUsage</c> is
+    /// present, the original <c>1</c>/<c>2</c> branching is preserved.
+    /// </summary>
+    private const string FeatureNamePatch = """
+        function GetFeatureName(feature, contextParameters)
+            if not feature['!featureName'] or #feature.featureName == 0 then
+                return nil
+            end
+
+            local defaultName
+            for _, featureName in ipairs(feature.featureName) do
+                if featureName.name then
+                    local nameUsage = featureName.nameUsage
+                    local languageMatches = (featureName.language and featureName.language == contextParameters.NationalLanguage)
+
+                    if nameUsage == nil or nameUsage == 1 then
+                        if languageMatches then
+                            return featureName.name
+                        end
+                        defaultName = defaultName or featureName.name
+                    elseif nameUsage == 2 and languageMatches then
+                        return featureName.name
+                    end
+                end
+            end
+
+            return defaultName
+        end
+
+        function PortrayFeatureName(feature, featurePortrayal, contextParameters, textViewingGroup, textPriority, viewingGroup, priority, textStyleInstructions)
+            local name = GetFeatureName(feature, contextParameters)
+            if name then
+                local textStyle = textStyleInstructions or 'FontColor:CHBLK'
+                featurePortrayal:AddInstructions(textStyle)
+                featurePortrayal:AddTextInstruction(EncodeString(name, '%s'), textViewingGroup, textPriority, viewingGroup, priority)
+            end
+        end
+        """;
+
     public S101LuaRuleExecutor(
         ILuaEngine luaEngine,
         S101Dataset dataset,
@@ -246,6 +297,11 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
                 return _orig_contains(value, array)
             end
             """);
+
+        // 3d. Patch GetFeatureName / PortrayFeatureName so feature names
+        //     without an explicit nameUsage sub-attribute still render. See
+        //     the FeatureNamePatch comment for the spec rationale.
+        lua.Execute(FeatureNamePatch);
 
         // 4. Build context parameter array using the Lua-side factory function
         //    PortrayalCreateContextParameter(name, type, default) → ContextParameter table

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs
@@ -66,6 +66,38 @@ public class S101FeatureNameTextTests
             $"found 0 of {namedPoints.Count} named point features.");
     }
 
+    [SkippableFact]
+    public void NamedFeatures_EmitTextInstruction_AtMostOncePerFeature()
+    {
+        // Regression guard: main.lua falls back to PortrayFeatureName when
+        // featurePortrayal.GetFeatureNameCalled was not set. If the adapter
+        // patch forgets to set that flag, every named feature emits its
+        // label twice with different offsets (visible as duplicated, slightly
+        // offset text in the viewer).
+        var (emitted, namedSurfaces, namedPoints) = RunPipelineAndClassify();
+        Skip.If(namedSurfaces.Count == 0 && namedPoints.Count == 0,
+            "Fixture has no named features.");
+
+        var named = namedSurfaces.Concat(namedPoints)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        var perFeatureTextCounts = new Dictionary<uint, int>();
+        foreach (var e in emitted)
+        {
+            if (!uint.TryParse(e.FeatureRef, out var id)) continue;
+            if (!named.TryGetValue(id, out var name)) continue;
+            if (!e.InstructionString.Contains("TextInstruction:" + name, StringComparison.Ordinal)) continue;
+            perFeatureTextCounts[id] = perFeatureTextCounts.GetValueOrDefault(id) + 1;
+        }
+
+        var duplicates = perFeatureTextCounts.Where(kv => kv.Value > 1).ToList();
+        Assert.True(
+            duplicates.Count == 0,
+            $"Expected each named feature to emit its label at most once; " +
+            $"found {duplicates.Count} feature(s) with duplicate labels. " +
+            $"First offender: feature {duplicates.FirstOrDefault().Key} emitted {duplicates.FirstOrDefault().Value} times.");
+    }
+
     private static (IReadOnlyList<EmittedInstruction> Emitted,
                     IReadOnlyDictionary<uint, string> NamedSurfaces,
                     IReadOnlyDictionary<uint, string> NamedPoints) RunPipelineAndClassify()

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Regression tests for the S-101 feature name labelling fix.
+/// <para/>
+/// The upstream Lua portrayal model's <c>GetFeatureName</c> requires both
+/// <c>name</c> AND <c>nameUsage</c> on every <c>featureName</c> sub-attribute,
+/// but the S-101 Feature Catalogue (Edition 1.x) declares <c>nameUsage</c>
+/// with multiplicity <c>0..1</c> — it is optional. FC-conformant ENCs that
+/// omit <c>nameUsage</c> previously rendered no label. The
+/// <see cref="S101LuaRuleExecutor"/> adapter patch corrects this.
+/// </summary>
+public class S101FeatureNameTextTests
+{
+    /// <summary>
+    /// The S-101 IHO V12 fixture <c>101AA00DS0008.000</c> contains many
+    /// surface and point features with a <c>featureName</c> attribute whose
+    /// <c>nameUsage</c> sub-attribute is omitted (FC-conformant). Without
+    /// the adapter patch, none of these emit a <c>TextInstruction:</c>.
+    /// </summary>
+    private const string FixtureFile = "101AA00DS0008.000";
+
+    [SkippableFact]
+    public void NamedSurfaceFeatures_EmitTextInstruction()
+    {
+        var (emitted, namedSurfaces, _) = RunPipelineAndClassify();
+        Skip.If(namedSurfaces.Count == 0, "Fixture has no named surface features.");
+
+        var withText = emitted
+            .Where(e => uint.TryParse(e.FeatureRef, out var id)
+                && namedSurfaces.TryGetValue(id, out var name)
+                && e.InstructionString.Contains("TextInstruction:" + name, StringComparison.Ordinal))
+            .Select(e => e.FeatureRef)
+            .ToHashSet();
+
+        Assert.True(
+            withText.Count > 0,
+            $"Expected at least one surface featureName label to be emitted as TextInstruction; " +
+            $"found 0 of {namedSurfaces.Count} named surface features.");
+    }
+
+    [SkippableFact]
+    public void NamedPointFeatures_EmitTextInstruction()
+    {
+        var (emitted, _, namedPoints) = RunPipelineAndClassify();
+        Skip.If(namedPoints.Count == 0, "Fixture has no named point features.");
+
+        var withText = emitted
+            .Where(e => uint.TryParse(e.FeatureRef, out var id)
+                && namedPoints.TryGetValue(id, out var name)
+                && e.InstructionString.Contains("TextInstruction:" + name, StringComparison.Ordinal))
+            .Select(e => e.FeatureRef)
+            .ToHashSet();
+
+        Assert.True(
+            withText.Count > 0,
+            $"Expected at least one point featureName label to be emitted as TextInstruction; " +
+            $"found 0 of {namedPoints.Count} named point features.");
+    }
+
+    private static (IReadOnlyList<EmittedInstruction> Emitted,
+                    IReadOnlyDictionary<uint, string> NamedSurfaces,
+                    IReadOnlyDictionary<uint, string> NamedPoints) RunPipelineAndClassify()
+    {
+        var fixturePath = ResolveFixturePath(FixtureFile);
+        Skip.IfNot(File.Exists(fixturePath),
+            $"S-101 fixture not found at expected path: {fixturePath}");
+
+        var dataset = S101Dataset.Open(fixturePath);
+
+        using var fcStream = Specification.TryOpenFeatureCatalogue("S-101")
+            ?? throw new InvalidOperationException("S-101 feature catalogue not bundled.");
+        var fc = FeatureCatalogueReader.Read(fcStream);
+
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var pcProvider = PortrayalCatalogueProvider.OpenAsync(pcSource).GetAwaiter().GetResult();
+        var luaEngine = new MoonSharpLuaEngine();
+        var catalogue = new S101PortrayalCatalogue(pcProvider, luaEngine);
+        catalogue.SwitchPalette(PaletteType.Day);
+
+        var executor = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
+        var emitted = executor.ExecuteRaw(MarinerSettings.Default);
+
+        // Classify named features: featureName (NATC=48) holds an empty
+        // top-level marker followed by a `name` sibling sub-attribute
+        // (NATC=49) per S-100 Part 10a ISO 8211 layout.
+        var doc = dataset.Document;
+        ushort? featureNameCode = null;
+        ushort? nameCode = null;
+        foreach (var (code, attrName) in doc.AttributeTypeCatalogue)
+        {
+            if (string.Equals(attrName, "featureName", StringComparison.OrdinalIgnoreCase))
+                featureNameCode = code;
+            if (string.Equals(attrName, "name", StringComparison.OrdinalIgnoreCase))
+                nameCode = code;
+        }
+        Skip.IfNot(featureNameCode is not null && nameCode is not null,
+            "Fixture catalogue does not define featureName/name attributes.");
+
+        var namedSurfaces = new Dictionary<uint, string>();
+        var namedPoints = new Dictionary<uint, string>();
+        foreach (var feat in doc.Features)
+        {
+            if (feat.SpatialAssociations.Length == 0) continue;
+            if (!feat.Attributes.Any(a => a.NumericCode == featureNameCode))
+                continue;
+
+            // Find the `name` sub-attribute value (first instance).
+            string? value = null;
+            foreach (var attr in feat.Attributes)
+            {
+                if (attr.NumericCode == nameCode && !string.IsNullOrEmpty(attr.Value))
+                {
+                    value = attr.Value;
+                    break;
+                }
+            }
+            if (value is null) continue;
+
+            // RCNM 130 = Surface; 110 = Point (S-100 Part 10a).
+            var rcnm = feat.SpatialAssociations[0].RecordName;
+            if (rcnm == 130) namedSurfaces[feat.RecordId] = value;
+            else if (rcnm == 110) namedPoints[feat.RecordId] = value;
+        }
+
+        return (emitted, namedSurfaces, namedPoints);
+    }
+
+    /// <summary>
+    /// Resolves the bundled S-101 test dataset by walking up from the test
+    /// assembly's base directory until the <c>tests/datasets/S101</c>
+    /// folder is found.
+    /// </summary>
+    private static string ResolveFixturePath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "tests", "datasets", "S101", "S-101", "DATASET_FILES", fileName);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return Path.Combine("tests", "datasets", "S101", "S-101", "DATASET_FILES", fileName);
+    }
+}


### PR DESCRIPTION
## Problem

S-101 ENCs were rendering no `featureName` labels for **area** features (BuiltUpArea, SeaAreaNamedWaterArea, LandRegion, …) and many **point** features. Only text driven by *other* attributes (e.g. `verticalClearanceFixed` → "V.clr 1.8") was appearing.

## Root cause

`content/S101/pc/Rules/PortrayalModel.lua` (upstream, byte-identical) gates name selection on **both** `name` AND `nameUsage`:

```lua
if featureName.name and featureName.nameUsage then
    ...
end
```

But the S-101 Feature Catalogue declares `nameUsage` with multiplicity `0..1` — it is **optional**. ENCs that omit it (most real-world cells) are fully FC-conformant, but the upstream guard fails, `GetFeatureName` returns `nil`, and `AddTextInstruction(nil, …)` no-ops.

Host-side attribute resolution (`S101LuaDataProvider`), `DrawingInstructionParser`, and the `MapsuiDisplayListRenderer` Surface text path were all confirmed correct via diagnostic dumps. The break was entirely inside upstream Lua catalogue logic.

## Fix

Per `s101-enc.instructions.md`, `content/S101/pc/` must remain byte-identical to upstream. Following the existing `contains` adapter-patch convention in `S101LuaRuleExecutor`, I added a small Lua patch that replaces the global `GetFeatureName` and `PortrayFeatureName` with versions that treat a missing `nameUsage` as `1` (default name display). The original `nameUsage == 1` / `nameUsage == 2` language-matching semantics are preserved verbatim.

## Verification

- Diagnostic dump against `101GB00502038.000` (the user's reproducing dataset): before — 0 `TextInstruction:` segments for 112 named surfaces + 90 named points; after — names emit correctly (Frostlane, THE SOLENT, All Saints Church, …).
- New regression test in `tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs` against bundled fixture `101AA00DS0008.000` (42 named surfaces, 121 named points). Confirmed failing without the patch, passing with it.
- Full `EncDotNet.S100.Pipelines.Tests` suite: **361/361 pass** in Release.

## Out of scope

- Renderer, parser, host attribute provider — unchanged (all verified correct).
- Multi-instance `featureName` handling — pre-existing `Index == 1` filter in `CountComplexAttributes` is not exercised by this bug and is left for a separate change.