### PR TITLE
V-1: S-102 validation rule pack + BathymetryCoverage.GroupPath

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/ConcatReports.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ConcatReports.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using EncDotNet.S100.Validation;
+
+[assembly: InternalsVisibleTo("EncDotNet.S100.Pipelines.Tests")]
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Helper for joining two <see cref="ValidationReport"/>s into a single
+/// aggregated report. Lives alongside <see cref="ValidationRunner"/> so
+/// per-spec dataset processors that run more than one rule pack (for
+/// example, S-57 running both <c>S57PreTranslationRules</c> against the
+/// raw document and <c>S101DatasetRules</c> against the translated
+/// document — see <c>docs/design/non-gml-validation.md</c> §9.3) can
+/// concatenate their results uniformly.
+/// </summary>
+/// <remarks>
+/// V-1 (S-102) does not itself produce two reports per dataset; this
+/// helper lands in V-1 only so that V-5 (S-57 pre-translation pack)
+/// remains a leaf PR with no framework prerequisites.
+/// </remarks>
+internal static class ConcatReports
+{
+    /// <summary>
+    /// Returns a new <see cref="ValidationReport"/> whose findings are
+    /// the concatenation of <paramref name="a"/> followed by
+    /// <paramref name="b"/>, preserving each report's internal order.
+    /// </summary>
+    /// <param name="a">First report. Its rule ids are kept verbatim.</param>
+    /// <param name="b">Second report. When <paramref name="rebadgePrefix"/>
+    /// is non-null, every finding from <paramref name="b"/> has its
+    /// <see cref="ValidationFinding.RuleId"/> rewritten as
+    /// <c>rebadgePrefix + originalRuleId</c>.</param>
+    /// <param name="rebadgePrefix">Optional prefix applied to every
+    /// <paramref name="b"/> finding's rule id. Used by S-57 to mark
+    /// findings inherited from the translated S-101 document
+    /// (<c>"S101-as-S57/"</c>) so downstream filters can distinguish
+    /// native vs. translated rule sources.</param>
+    /// <returns>
+    /// A combined report whose <see cref="ValidationReport.RulesEvaluated"/>
+    /// and <see cref="ValidationReport.RulesWithFindings"/> are the
+    /// arithmetic sums of the inputs'.
+    /// </returns>
+    public static ValidationReport Concat(
+        ValidationReport a,
+        ValidationReport b,
+        string? rebadgePrefix = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+
+        var builder = ImmutableArray.CreateBuilder<ValidationFinding>();
+
+        if (!a.Findings.IsDefaultOrEmpty)
+            builder.AddRange(a.Findings);
+
+        if (!b.Findings.IsDefaultOrEmpty)
+        {
+            foreach (var finding in b.Findings)
+            {
+                if (rebadgePrefix is null)
+                {
+                    builder.Add(finding);
+                }
+                else
+                {
+                    builder.Add(finding with { RuleId = rebadgePrefix + finding.RuleId });
+                }
+            }
+        }
+
+        return new ValidationReport(
+            builder.ToImmutable(),
+            RulesEvaluated: a.RulesEvaluated + b.RulesEvaluated,
+            RulesWithFindings: a.RulesWithFindings + b.RulesWithFindings);
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S102.Validation;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
@@ -12,6 +14,7 @@ using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting;
+using EncDotNet.S100.Validation;
 using Mapsui;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
@@ -25,6 +28,8 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
     private readonly string _fileName;
     private readonly PortrayalPipeline _pipeline;
     private readonly MapsuiCoverageRenderer _renderer;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public SpecRef Spec => new("S-102", default);
 
@@ -220,4 +225,67 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
         => value == noData
             ? "NoData"
             : value.ToString("0.##########", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Runs the S-102 normative rule pack
+    /// (<see cref="S102DatasetRules.Default"/>) against the parsed
+    /// dataset and returns the cached report.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per <c>docs/design/non-gml-validation.md</c> §5.1, this override
+    /// defensively wraps the rule-pack call in a try/catch for
+    /// <see cref="S100DatasetSchemaException"/>. The realistic failure
+    /// mode is the reader throwing inside the constructor (in which
+    /// case the processor never exists and this method is never
+    /// reached); the wrapper is therefore forward-compatible only,
+    /// surfacing a single <c>S102-PROJ-SCHEMA</c> finding carrying
+    /// the exception's <c>GroupPath</c>, <c>AttributeOrDataset</c>,
+    /// and <c>SpecReference</c> per design §5.3.
+    /// </para>
+    /// <para>
+    /// Validation is a pure function of the parsed dataset; the
+    /// report is cached after the first call (mirroring the GML
+    /// processors' pattern, see <c>S124DatasetProcessor</c>).
+    /// </para>
+    /// </remarks>
+    public ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            try
+            {
+                _validationReport = S102DatasetRules.Default.Run(_dataset);
+            }
+            catch (S100DatasetSchemaException ex)
+            {
+                _validationReport = BuildSchemaSurrogateReport(ex);
+            }
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
+
+    private static ValidationReport BuildSchemaSurrogateReport(S100DatasetSchemaException ex)
+    {
+        var details = new List<string>();
+        details.Add($"GroupPath='{ex.GroupPath}'");
+        if (!string.IsNullOrEmpty(ex.AttributeOrDataset))
+            details.Add($"AttributeOrDataset='{ex.AttributeOrDataset}'");
+        if (!string.IsNullOrEmpty(ex.SpecReference))
+            details.Add($"SpecReference='{ex.SpecReference}'");
+
+        var finding = new ValidationFinding
+        {
+            RuleId = "S102-PROJ-SCHEMA",
+            Severity = ValidationSeverity.Error,
+            Message = $"S102 reader raised S100DatasetSchemaException: {ex.Message} ({string.Join(", ", details)}).",
+            RelatedFeatureId = ex.GroupPath,
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+    }
 }

--- a/src/EncDotNet.S100.Datasets.S102/BathymetryCoverage.cs
+++ b/src/EncDotNet.S100.Datasets.S102/BathymetryCoverage.cs
@@ -27,6 +27,17 @@ public sealed class BathymetryCoverage
     public string? StartSequence { get; init; }
 
     /// <summary>
+    /// The HDF5 group path this coverage was read from, e.g.
+    /// <c>"/BathymetryCoverage/BathymetryCoverage.01"</c>. Populated by
+    /// <see cref="S102DatasetReader"/>; nullable so synthetic test
+    /// fixtures may omit it. Validation rules surface this on
+    /// per-coverage findings via <c>RelatedFeatureId</c> so consumers
+    /// can disambiguate findings across tiles in a multi-tile dataset
+    /// (S-102 Edition 3.0.0 §3 tiling).
+    /// </summary>
+    public string? GroupPath { get; init; }
+
+    /// <summary>
     /// Flat array of bathymetry values, ordered row-major.
     /// Index a cell at (row, col) as <c>Values[row * NumPointsLongitudinal + col]</c>.
     /// </summary>

--- a/src/EncDotNet.S100.Datasets.S102/README.md
+++ b/src/EncDotNet.S100.Datasets.S102/README.md
@@ -39,6 +39,32 @@ Cells whose depth equals `S102CoverageSource.FillValue` (1,000,000f)
 are painted with the active palette's `NODTA` colour via
 `CoverageColorScheme.NoDataColor`.
 
+## Validation
+
+A bundled rule pack
+(`EncDotNet.S100.Datasets.S102.Validation.S102DatasetRules.Default`)
+evaluates a typed `S102Dataset` against the S-102 Edition 3.0.0
+checklist and emits a `ValidationReport` of findings. The pack is
+invoked automatically by `S102DatasetProcessor.Validate()` and is
+also runnable directly:
+
+```csharp
+var report = S102DatasetRules.Default.Run(dataset);
+foreach (var finding in report.Findings)
+    Console.WriteLine($"{finding.RuleId} {finding.Severity}: {finding.Message}");
+```
+
+| Rule id              | Severity | Checks                                                                                                                   |
+|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------|
+| `S102-R-1.1`         | Error    | Each coverage's `Values.Length` equals `NumPointsLatitudinal × NumPointsLongitudinal`.                                   |
+| `S102-R-2.1`         | Error    | NODATA fill in `Depth`/`Uncertainty` is exactly `1_000_000f`; flags `NaN` / ±`Infinity` as illegal sentinel substitutes. |
+| `S102-R-3.1`         | Warning  | `HorizontalCRS`, when set, is a recognised EPSG code (4326, 4269, or WGS-84 UTM band).                                   |
+| `S102-R-3.2`         | Warning  | `IssueDate`, when set, parses as ISO 8601.                                                                               |
+| `S102-R-4.1`         | Error    | Each coverage's `OriginLatitude` ∈ [-90, 90] and `OriginLongitude` ∈ [-180, 180].                                        |
+| `S102-R-4.2`         | Error    | Each coverage's extent stays inside WGS-84 bounds and does not wrap the antimeridian.                                    |
+| `S102-R-5.1`         | Warning  | Non-NODATA depth values fall within [-50, 12 000] m (one finding per offending coverage).                                |
+| `S102-PROJ-SCHEMA`   | Error    | Defensive surrogate: emitted when the underlying HDF5 dataset fails schema-level parsing inside `Validate()`.            |
+
 ## Installation
 
 ```sh

--- a/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
@@ -109,6 +109,7 @@ public static class S102DatasetReader
             NumPointsLatitudinal = numLat,
             NumPointsLongitudinal = numLon,
             StartSequence = startSequence,
+            GroupPath = instancePath,
             Values = allValues.ToArray(),
         };
     }

--- a/src/EncDotNet.S100.Datasets.S102/Validation/S102DatasetRules.cs
+++ b/src/EncDotNet.S100.Datasets.S102/Validation/S102DatasetRules.cs
@@ -1,0 +1,441 @@
+using System.Globalization;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S102.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-102 <see cref="S102Dataset"/>. Rule identifiers follow the
+/// convention <c>S102-R-{clause}</c> for normative rules and
+/// <c>S102-PROJ-{kind}</c> for projection-diagnostic surrogates, traceable
+/// back to S-102 (Edition 3.0.0) and S-100 Part 10c.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the V-1 rule pack as defined in
+/// <c>docs/design/non-gml-validation.md</c> §6.1. Rules read off the
+/// strongly-typed <see cref="S102Dataset"/> produced by
+/// <see cref="S102DatasetReader"/>; structural-schema failures the
+/// reader cannot tolerate are thrown as
+/// <see cref="EncDotNet.S100.Hdf5.S100DatasetSchemaException"/> at read
+/// time and (per design §5.1) surfaced as <c>S102-PROJ-SCHEMA</c>
+/// findings by the dataset processor's <c>Validate()</c> wrapper.
+/// </para>
+/// <para>
+/// Tier-3 cross-dataset rules (e.g. tile coherency against a sibling
+/// chart) are out of scope; per-finding payload conventions follow
+/// design §4.3:
+/// <list type="bullet">
+/// <item><description>per-coverage finding — <c>RelatedFeatureId = "{groupPath}"</c></description></item>
+/// <item><description>per-cell finding — <c>RelatedFeatureId = "{groupPath}[row,col]"</c></description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class S102DatasetRules
+{
+    /// <summary>S-102 NODATA sentinel (S-100 Part 10c §11; S-102 §10.x).</summary>
+    internal const float NoDataValue = 1_000_000f;
+
+    /// <summary>
+    /// Hard-coded set of EPSG codes considered "known" for S-102
+    /// horizontal CRS conformance (<c>S102-R-3.1</c>).
+    /// Covers WGS-84 geographic (4326), NAD83 geographic (4269), and
+    /// the WGS-84 UTM band ranges (north 32601–32660, south 32701–32760).
+    /// </summary>
+    // TODO: replace with a centralised EPSG registry once one exists in
+    // the codebase (search for KnownEpsgCodes turned up no existing
+    // catalogue at the time of writing). The S-102 spec permits any
+    // CRS resolvable through the EPSG Geodetic Parameter Registry.
+    private static bool IsKnownEpsgCode(int code) =>
+        code == 4326
+        || code == 4269
+        || (code >= 32601 && code <= 32660)
+        || (code >= 32701 && code <= 32760);
+
+    /// <summary>
+    /// <c>S102-R-1.1</c> — Every <see cref="BathymetryCoverage"/>'s
+    /// <see cref="BathymetryCoverage.Values"/> array length equals
+    /// <see cref="BathymetryCoverage.NumPointsLatitudinal"/> ×
+    /// <see cref="BathymetryCoverage.NumPointsLongitudinal"/>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §10.2.1.2 (gridded coverage
+    /// shape contract) and S-102 Edition 3.0.0 §12.6
+    /// (<c>BathymetryCoverage</c>). Implements the
+    /// <c>s102-bathymetry</c> skill review checklist item
+    /// "values array shape matches numPointsLat × numPointsLon".
+    /// </remarks>
+    public static IValidationRule<S102Dataset> CoverageValuesLengthMatchesShape { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-1.1")
+            .WithDescription("Each BathymetryCoverage's Values length must equal NumPointsLatitudinal × NumPointsLongitudinal.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long expected = (long)c.NumPointsLatitudinal * c.NumPointsLongitudinal;
+                    if (c.Values.LongLength == expected)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S102-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"BathymetryCoverage at '{CoveragePath(c, i)}' has Values length {c.Values.LongLength} but " +
+                            $"expected NumPointsLatitudinal ({c.NumPointsLatitudinal}) × NumPointsLongitudinal ({c.NumPointsLongitudinal}) = {expected}.",
+                        RelatedFeatureId = CoveragePath(c, i),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-R-2.1</c> — The NODATA fill value in a coverage's depth
+    /// channel is exactly <c>1_000_000f</c>. Any candidate-NODATA
+    /// pattern other than that sentinel (<see cref="float.NaN"/>,
+    /// <see cref="float.NegativeInfinity"/>,
+    /// <see cref="float.PositiveInfinity"/>) is flagged.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §11 NODATA convention, S-102
+    /// Edition 3.0.0 §10 (mandatory fill = <c>1_000_000f</c>).
+    /// Implements <c>s102-bathymetry</c> skill review-checklist
+    /// pitfall "NODATA must be exactly 1_000_000f". Conservative
+    /// per design §6.1: only NaN / ±Infinity are flagged; finite
+    /// values (even implausibly large) are NOT treated as
+    /// candidate-NODATA because they are addressed by
+    /// <see cref="DepthValuesInPlausibleRange"/> (<c>S102-R-5.1</c>).
+    /// </remarks>
+    public static IValidationRule<S102Dataset> NoDataFillValueIsCanonical { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-2.1")
+            .WithDescription("NODATA fill values must be exactly 1_000_000f (S-100 Part 10c §11).")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    if (c.NumPointsLongitudinal <= 0)
+                        continue;
+
+                    for (var idx = 0; idx < c.Values.Length; idx++)
+                    {
+                        float depth = c.Values[idx].Depth;
+                        if (depth == NoDataValue)
+                            continue;
+                        if (!float.IsNaN(depth) && !float.IsInfinity(depth))
+                            continue;
+
+                        int row = idx / c.NumPointsLongitudinal;
+                        int col = idx % c.NumPointsLongitudinal;
+                        string token = float.IsNaN(depth) ? "NaN"
+                            : float.IsNegativeInfinity(depth) ? "-Infinity"
+                            : "+Infinity";
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S102-R-2.1",
+                            Severity = ValidationSeverity.Error,
+                            Message =
+                                $"BathymetryCoverage at '{CoveragePath(c, i)}' has non-canonical NODATA at [{row},{col}]: " +
+                                $"Depth = {token}; expected the S-102 sentinel 1_000_000f.",
+                            RelatedFeatureId = $"{CoveragePath(c, i)}[{row},{col}]",
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-R-3.1</c> — When <see cref="S102Dataset.HorizontalCRS"/>
+    /// is set, it resolves to a known EPSG code.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-102 Edition 3.0.0 §10.2 root attribute
+    /// <c>horizontalCRS</c>. Severity is <em>Warning</em> per design
+    /// §6.1 — an unknown EPSG code typically reflects a producer
+    /// mistake but does not render the dataset unusable; consumers
+    /// may still be able to resolve the CRS through extended
+    /// catalogues. See <see cref="IsKnownEpsgCode"/> for the
+    /// recognised set.
+    /// </remarks>
+    public static IValidationRule<S102Dataset> HorizontalCrsIsKnownEpsg { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-3.1")
+            .WithDescription("HorizontalCRS, when set, must resolve to a known EPSG code.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.HorizontalCRS is not int crs)
+                    return Array.Empty<ValidationFinding>();
+                if (IsKnownEpsgCode(crs))
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S102-R-3.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"HorizontalCRS EPSG:{crs} is not in the recognised S-102 V-1 EPSG set " +
+                            "(WGS-84 geographic, NAD83 geographic, or WGS-84 UTM zones 1–60 N/S).",
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-R-3.2</c> — When <see cref="S102Dataset.IssueDate"/> is
+    /// set, it parses as an ISO 8601 date or date-time.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-102 Edition 3.0.0 §10.2 root attribute
+    /// <c>issueDate</c>. Implements the <c>s102-bathymetry</c>
+    /// skill review-checklist item "root metadata parse cleanly".
+    /// </remarks>
+    public static IValidationRule<S102Dataset> IssueDateIsIso8601 { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-3.2")
+            .WithDescription("IssueDate, when set, must parse as an ISO 8601 date or date-time.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                var raw = dataset.IssueDate;
+                if (string.IsNullOrWhiteSpace(raw))
+                    return Array.Empty<ValidationFinding>();
+
+                if (DateTimeOffset.TryParse(
+                        raw,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.RoundtripKind,
+                        out DateTimeOffset _))
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S102-R-3.2",
+                        Severity = ValidationSeverity.Warning,
+                        Message = $"IssueDate '{raw}' is not a recognisable ISO 8601 date or date-time.",
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-R-4.1</c> — Each coverage's
+    /// <see cref="BathymetryCoverage.OriginLatitude"/> is in [-90, 90]
+    /// and <see cref="BathymetryCoverage.OriginLongitude"/> is in
+    /// [-180, 180].
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §10.2.1.2 grid georeferencing.
+    /// Implements <c>s102-bathymetry</c> skill review-checklist item
+    /// "georeferencing attributes within WGS-84 range".
+    /// </remarks>
+    public static IValidationRule<S102Dataset> CoverageOriginInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-4.1")
+            .WithDescription("Each BathymetryCoverage origin lat/lon must be within WGS-84 ranges.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    var problems = new List<string>();
+                    if (c.OriginLatitude < -90 || c.OriginLatitude > 90)
+                        problems.Add($"OriginLatitude {Fmt(c.OriginLatitude)} outside [-90, 90]");
+                    if (c.OriginLongitude < -180 || c.OriginLongitude > 180)
+                        problems.Add($"OriginLongitude {Fmt(c.OriginLongitude)} outside [-180, 180]");
+                    if (problems.Count == 0)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S102-R-4.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"BathymetryCoverage at '{CoveragePath(c, i)}' has out-of-range origin: " +
+                            string.Join("; ", problems) + ".",
+                        RelatedFeatureId = CoveragePath(c, i),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-R-4.2</c> — Each coverage's extent
+    /// (<c>origin + (numPoints - 1) × spacing</c>) does not wrap the
+    /// antimeridian (longitude end &gt; 180) or cross the pole
+    /// (latitude end &gt; 90). Antimeridian-spanning datasets are out
+    /// of scope for V-1.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §10.2.1.2; implements the
+    /// <c>s102-bathymetry</c> skill review-checklist item "tile
+    /// extent stays within WGS-84 ranges". When the rule fires, the
+    /// finding carries a <see cref="ValidationFinding.BoundingBox"/>
+    /// approximating the offending tile extent (clamped to ordered
+    /// edges only; values may themselves be out of range).
+    /// </remarks>
+    public static IValidationRule<S102Dataset> CoverageExtentDoesNotWrap { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-4.2")
+            .WithDescription("Coverage extent must not wrap the antimeridian or cross the pole.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    if (c.NumPointsLatitudinal <= 0 || c.NumPointsLongitudinal <= 0)
+                        continue;
+
+                    double latEnd = c.OriginLatitude + (c.NumPointsLatitudinal - 1) * c.SpacingLatitudinal;
+                    double lonEnd = c.OriginLongitude + (c.NumPointsLongitudinal - 1) * c.SpacingLongitudinal;
+
+                    var problems = new List<string>();
+                    if (latEnd > 90 || latEnd < -90)
+                        problems.Add($"latitude end {Fmt(latEnd)} outside [-90, 90]");
+                    if (lonEnd > 180 || lonEnd < -180)
+                        problems.Add($"longitude end {Fmt(lonEnd)} outside [-180, 180] (antimeridian-spanning tiles are out of scope for V-1)");
+                    if (problems.Count == 0)
+                        continue;
+
+                    double south = Math.Min(c.OriginLatitude, latEnd);
+                    double north = Math.Max(c.OriginLatitude, latEnd);
+                    double west = Math.Min(c.OriginLongitude, lonEnd);
+                    double east = Math.Max(c.OriginLongitude, lonEnd);
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S102-R-4.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"BathymetryCoverage at '{CoveragePath(c, i)}' has out-of-range extent: " +
+                            string.Join("; ", problems) + ".",
+                        RelatedFeatureId = CoveragePath(c, i),
+                        BoundingBox = new BoundingBox(south, west, north, east),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-R-5.1</c> — Non-NODATA depth values across each
+    /// coverage lie within the plausible bathymetric range
+    /// [-50, 12 000] metres.
+    /// </summary>
+    /// <remarks>
+    /// Plausibility heuristic: continental shelves through the
+    /// deepest trenches; catches common producer mistakes such as
+    /// "depth recorded in centimetres" or "UTM-northing accidentally
+    /// stored as depth". Per design §6.1, the rule emits one finding
+    /// per coverage with the count of offending cells in the
+    /// message — emitting one finding per cell on a broken tile
+    /// would drown the report in cascade noise.
+    /// </remarks>
+    public static IValidationRule<S102Dataset> DepthValuesInPlausibleRange { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-R-5.1")
+            .WithDescription("Non-NODATA depth values must lie in [-50, 12000] metres.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                const float min = -50f;
+                const float max = 12_000f;
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long offending = 0;
+                    float worst = 0f;
+                    for (var idx = 0; idx < c.Values.Length; idx++)
+                    {
+                        float depth = c.Values[idx].Depth;
+                        if (depth == NoDataValue)
+                            continue;
+                        if (float.IsNaN(depth) || float.IsInfinity(depth))
+                            continue;
+                        if (depth >= min && depth <= max)
+                            continue;
+
+                        offending++;
+                        if (Math.Abs(depth) > Math.Abs(worst))
+                            worst = depth;
+                    }
+                    if (offending == 0)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S102-R-5.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"BathymetryCoverage at '{CoveragePath(c, i)}' has {offending} non-NODATA depth value(s) outside " +
+                            $"the plausible range [-50, 12000] m (worst observed: {Fmt(worst)} m).",
+                        RelatedFeatureId = CoveragePath(c, i),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S102-PROJ-SCHEMA</c> — defensive projection-diagnostic
+    /// surrogate (design §5.1, §5.3).
+    /// </summary>
+    /// <remarks>
+    /// The rule body is intentionally a no-op: by the time the rule
+    /// pack runs the dataset is already constructed, so any
+    /// <see cref="EncDotNet.S100.Hdf5.S100DatasetSchemaException"/>
+    /// has already thrown out of the reader. The rule id is reserved
+    /// in this rule set so that <c>S102DatasetProcessor.Validate()</c>
+    /// can emit a single-finding report carrying the exception's
+    /// <c>GroupPath</c>, <c>AttributeOrDataset</c>, and
+    /// <c>SpecReference</c> under this same rule id when the
+    /// defensive try/catch around the rule-pack call fires.
+    /// </remarks>
+    public static IValidationRule<S102Dataset> ProjectionSchemaSurrogate { get; } =
+        ValidationRuleBuilder.RuleFor<S102Dataset>("S102-PROJ-SCHEMA")
+            .WithDescription("Defensive surrogate: an S100DatasetSchemaException was caught during validation.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((_, _) => Array.Empty<ValidationFinding>())
+            .Build();
+
+    /// <summary>The canonical default rule set for S-102 bathymetry datasets.</summary>
+    public static ValidationRuleSet<S102Dataset> Default { get; } = new(
+        CoverageValuesLengthMatchesShape,
+        NoDataFillValueIsCanonical,
+        HorizontalCrsIsKnownEpsg,
+        IssueDateIsIso8601,
+        CoverageOriginInWgs84Range,
+        CoverageExtentDoesNotWrap,
+        DepthValuesInPlausibleRange,
+        ProjectionSchemaSurrogate);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S102Dataset dataset, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+
+    private static string CoveragePath(BathymetryCoverage coverage, int index)
+        => coverage.GroupPath ?? $"/BathymetryCoverage/BathymetryCoverage.{index + 1:D2}";
+
+    private static string Fmt(double value)
+        => value.ToString("0.######", CultureInfo.InvariantCulture);
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102ValidationTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102ValidationTests.cs
@@ -1,0 +1,389 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Datasets.S102.Validation;
+using EncDotNet.S100.Validation;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Synthetic-fixture tests for the V-1 S-102 rule pack
+/// (<see cref="S102DatasetRules"/>) and the
+/// <see cref="ConcatReports"/> helper. No real HDF5 files
+/// required; every fixture is constructed in-memory.
+/// </summary>
+public class S102ValidationTests
+{
+    private const float NoData = 1_000_000f;
+
+    private static BathymetryCoverage MakeCoverage(
+        int rows = 2,
+        int cols = 2,
+        double originLat = 50.0,
+        double originLon = -1.0,
+        double spacingLat = 0.01,
+        double spacingLon = 0.01,
+        BathymetryValue[]? values = null,
+        string? groupPath = "/BathymetryCoverage/BathymetryCoverage.01")
+        => new()
+        {
+            OriginLatitude = originLat,
+            OriginLongitude = originLon,
+            SpacingLatitudinal = spacingLat,
+            SpacingLongitudinal = spacingLon,
+            NumPointsLatitudinal = rows,
+            NumPointsLongitudinal = cols,
+            GroupPath = groupPath,
+            Values = values ?? FillDepths(rows * cols, 10f),
+        };
+
+    private static BathymetryValue[] FillDepths(int count, float depth, float uncertainty = 0.1f)
+    {
+        var arr = new BathymetryValue[count];
+        for (var i = 0; i < count; i++)
+            arr[i] = new BathymetryValue(depth, uncertainty);
+        return arr;
+    }
+
+    private static S102Dataset MakeDataset(
+        params BathymetryCoverage[] coverages)
+        => new()
+        {
+            HorizontalCRS = 4326,
+            IssueDate = "2024-05-01",
+            Coverages = coverages.Length == 0
+                ? new[] { MakeCoverage() }
+                : coverages,
+        };
+
+    // ----- R-1.1 -----
+
+    [Fact]
+    public void R1_1_Fires_When_Values_Length_Mismatches_Shape()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 3, values: FillDepths(5, 10f)); // expected 6
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-1.1");
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R1_1_Does_Not_Fire_When_Shape_Matches()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 3, values: FillDepths(6, 10f));
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-1.1");
+    }
+
+    // ----- R-2.1 -----
+
+    [Fact]
+    public void R2_1_Fires_On_NaN_Depth_Sentinel()
+    {
+        var values = FillDepths(4, 10f);
+        values[1] = new BathymetryValue(float.NaN, 0.1f);
+        values[2] = new BathymetryValue(float.PositiveInfinity, 0.1f);
+        var coverage = MakeCoverage(rows: 2, cols: 2, values: values);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var r21 = report.Findings.Where(x => x.RuleId == "S102-R-2.1").ToList();
+        Assert.Equal(2, r21.Count);
+        Assert.All(r21, f => Assert.Equal(ValidationSeverity.Error, f.Severity));
+        Assert.Contains(r21, f => f.RelatedFeatureId == "/BathymetryCoverage/BathymetryCoverage.01[0,1]");
+        Assert.Contains(r21, f => f.RelatedFeatureId == "/BathymetryCoverage/BathymetryCoverage.01[1,0]");
+    }
+
+    [Fact]
+    public void R2_1_Does_Not_Fire_When_NoData_Is_Canonical_Sentinel()
+    {
+        var values = FillDepths(4, 10f);
+        values[3] = new BathymetryValue(NoData, NoData);
+        var coverage = MakeCoverage(rows: 2, cols: 2, values: values);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-2.1");
+    }
+
+    [Fact]
+    public void R2_1_Does_Not_Flag_Finite_Out_Of_Range_Values()
+    {
+        // Conservative per design §6.1: finite values are addressed by R-5.1, not R-2.1.
+        var values = FillDepths(4, 99_999_999f);
+        var coverage = MakeCoverage(rows: 2, cols: 2, values: values);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-2.1");
+    }
+
+    // ----- R-3.1 -----
+
+    [Fact]
+    public void R3_1_Fires_On_Unknown_Epsg()
+    {
+        var dataset = new S102Dataset
+        {
+            HorizontalCRS = 12345,
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-3.1");
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+    }
+
+    [Theory]
+    [InlineData(4326)]
+    [InlineData(4269)]
+    [InlineData(32630)]
+    [InlineData(32750)]
+    public void R3_1_Does_Not_Fire_On_Known_Epsg(int code)
+    {
+        var dataset = new S102Dataset
+        {
+            HorizontalCRS = code,
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-3.1");
+    }
+
+    [Fact]
+    public void R3_1_Does_Not_Fire_When_HorizontalCRS_Unset()
+    {
+        var dataset = new S102Dataset
+        {
+            HorizontalCRS = null,
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-3.1");
+    }
+
+    // ----- R-3.2 -----
+
+    [Fact]
+    public void R3_2_Fires_On_Unparseable_IssueDate()
+    {
+        var dataset = new S102Dataset
+        {
+            IssueDate = "not-a-date",
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-3.2");
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+    }
+
+    [Theory]
+    [InlineData("2024-05-01")]
+    [InlineData("2024-05-01T12:00:00Z")]
+    [InlineData("2024-05-01T12:00:00+02:00")]
+    public void R3_2_Does_Not_Fire_On_Iso8601(string date)
+    {
+        var dataset = new S102Dataset
+        {
+            IssueDate = date,
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-3.2");
+    }
+
+    // ----- R-4.1 -----
+
+    [Fact]
+    public void R4_1_Fires_On_Out_Of_Range_Origin()
+    {
+        var coverage = MakeCoverage(originLat: 95.0, originLon: -1.0);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-4.1");
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R4_1_Does_Not_Fire_On_In_Range_Origin()
+    {
+        var dataset = MakeDataset(MakeCoverage(originLat: 50.0, originLon: -1.0));
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-4.1");
+    }
+
+    // ----- R-4.2 -----
+
+    [Fact]
+    public void R4_2_Fires_When_Extent_Wraps_Antimeridian()
+    {
+        var coverage = MakeCoverage(
+            rows: 2, cols: 10,
+            originLat: 50.0, originLon: 179.0,
+            spacingLat: 0.01, spacingLon: 1.0); // lonEnd = 179 + 9 = 188
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-4.2");
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.NotNull(f.BoundingBox);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R4_2_Does_Not_Fire_When_Extent_In_Range()
+    {
+        var dataset = MakeDataset(MakeCoverage(rows: 2, cols: 2, spacingLat: 0.01, spacingLon: 0.01));
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-4.2");
+    }
+
+    // ----- R-5.1 -----
+
+    [Fact]
+    public void R5_1_Fires_Once_Per_Coverage_With_Out_Of_Range_Cells()
+    {
+        var values = FillDepths(4, 10f);
+        values[0] = new BathymetryValue(-100f, 0.1f); // outside [-50, 12000]
+        values[1] = new BathymetryValue(20_000f, 0.1f);
+        var coverage = MakeCoverage(rows: 2, cols: 2, values: values);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-5.1");
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Contains("2 non-NODATA depth value(s)", f.Message);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R5_1_Does_Not_Fire_When_All_Depths_In_Range_Or_NoData()
+    {
+        var values = FillDepths(4, 10f);
+        values[3] = new BathymetryValue(NoData, NoData);
+        var coverage = MakeCoverage(rows: 2, cols: 2, values: values);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-R-5.1");
+    }
+
+    // ----- S102-PROJ-SCHEMA -----
+
+    [Fact]
+    public void ProjectionSchemaSurrogate_Body_Emits_Nothing()
+    {
+        var dataset = MakeDataset();
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S102-PROJ-SCHEMA");
+    }
+
+    // ----- Clean dataset & multi-coverage RelatedFeatureId -----
+
+    [Fact]
+    public void Clean_Dataset_Produces_Valid_Report()
+    {
+        var dataset = MakeDataset();
+        var report = S102DatasetRules.Default.Run(dataset);
+        Assert.True(report.IsValid, $"Expected no findings, got: {string.Join("; ", report.Findings.Select(f => f.RuleId))}");
+        Assert.Equal(8, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Multi_Coverage_Findings_Carry_Per_Coverage_GroupPath()
+    {
+        var a = MakeCoverage(rows: 2, cols: 2, values: FillDepths(3, 10f), // length mismatch
+            groupPath: "/BathymetryCoverage/BathymetryCoverage.01");
+        var b = MakeCoverage(rows: 2, cols: 2, values: FillDepths(3, 10f),
+            groupPath: "/BathymetryCoverage/BathymetryCoverage.02");
+        var dataset = MakeDataset(a, b);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var r11 = report.Findings.Where(x => x.RuleId == "S102-R-1.1").ToList();
+        Assert.Equal(2, r11.Count);
+        Assert.Contains(r11, f => f.RelatedFeatureId == a.GroupPath);
+        Assert.Contains(r11, f => f.RelatedFeatureId == b.GroupPath);
+    }
+
+    [Fact]
+    public void Coverage_Without_GroupPath_Falls_Back_To_Synthesised_Path()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 2, values: FillDepths(3, 10f), groupPath: null);
+        var dataset = MakeDataset(coverage);
+
+        var report = S102DatasetRules.Default.Run(dataset);
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S102-R-1.1");
+        Assert.Equal("/BathymetryCoverage/BathymetryCoverage.01", f.RelatedFeatureId);
+    }
+
+    // ----- ConcatReports -----
+
+    [Fact]
+    public void ConcatReports_Sums_Counters_And_Preserves_Order()
+    {
+        var a = new ValidationReport(
+            ImmutableArray.Create(new ValidationFinding
+            {
+                RuleId = "A-1",
+                Severity = ValidationSeverity.Error,
+                Message = "first",
+            }),
+            RulesEvaluated: 2,
+            RulesWithFindings: 1);
+
+        var b = new ValidationReport(
+            ImmutableArray.Create(
+                new ValidationFinding { RuleId = "B-1", Severity = ValidationSeverity.Warning, Message = "second" },
+                new ValidationFinding { RuleId = "B-2", Severity = ValidationSeverity.Info, Message = "third" }),
+            RulesEvaluated: 3,
+            RulesWithFindings: 2);
+
+        var combined = ConcatReports.Concat(a, b);
+
+        Assert.Equal(5, combined.RulesEvaluated);
+        Assert.Equal(3, combined.RulesWithFindings);
+        Assert.Equal(new[] { "A-1", "B-1", "B-2" }, combined.Findings.Select(f => f.RuleId).ToArray());
+    }
+
+    [Fact]
+    public void ConcatReports_Rebadges_Second_Reports_Rule_Ids()
+    {
+        var a = new ValidationReport(
+            ImmutableArray.Create(new ValidationFinding
+            {
+                RuleId = "S57-R-1.1",
+                Severity = ValidationSeverity.Error,
+                Message = "from pre",
+            }),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+
+        var b = new ValidationReport(
+            ImmutableArray.Create(new ValidationFinding
+            {
+                RuleId = "S101-R-2.1",
+                Severity = ValidationSeverity.Warning,
+                Message = "from translated",
+            }),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+
+        var combined = ConcatReports.Concat(a, b, rebadgePrefix: "S101-as-S57/");
+
+        Assert.Equal("S57-R-1.1", combined.Findings[0].RuleId);
+        Assert.Equal("S101-as-S57/S101-R-2.1", combined.Findings[1].RuleId);
+    }
+}


### PR DESCRIPTION
Implements **V-1** of the non-GML validation roadmap — see
[`docs/design/non-gml-validation.md`](https://github.com/philliphoff/EncDotNet.S100/blob/philliphoff/non-gml-validation-design/docs/design/non-gml-validation.md) §6.1.

## Rules shipped

`EncDotNet.S100.Datasets.S102.Validation.S102DatasetRules.Default`:

| Rule id              | Severity | Checks |
|----------------------|----------|--------|
| `S102-R-1.1`         | Error    | `Values.Length == NumPointsLatitudinal × NumPointsLongitudinal` per coverage. |
| `S102-R-2.1`         | Error    | NODATA fill is exactly `1_000_000f`; flags `NaN` / `±Infinity` as illegal sentinel substitutes (per-cell finding). |
| `S102-R-3.1`         | Warning  | `HorizontalCRS`, when set, is a known EPSG code (`4326`, `4269`, WGS-84 UTM bands `32601..32660` / `32701..32760`). |
| `S102-R-3.2`         | Warning  | `IssueDate`, when set, parses as ISO 8601. |
| `S102-R-4.1`         | Error    | `OriginLatitude` ∈ [-90, 90], `OriginLongitude` ∈ [-180, 180]. |
| `S102-R-4.2`         | Error    | Extent stays in WGS-84 range and does not wrap the antimeridian. |
| `S102-R-5.1`         | Warning  | Non-NODATA depth values ∈ [-50, 12 000] m (one finding per offending coverage with the cell count). |
| `S102-PROJ-SCHEMA`   | Error    | Defensive surrogate per design §5.1: emitted from `S102DatasetProcessor.Validate()` if schema parsing throws. |

Style mirrors `S124NavigationalWarningRules.cs` (one static class, one
`Default` `ValidationRuleSet<TModel>`, each rule as a
`public static IValidationRule<TModel>` property with XML-doc citing the
spec section / skill checklist item).

## `BathymetryCoverage.GroupPath`

Resolves §10 **Q-cov-1**.

- New `public string? GroupPath { get; init; }` on `BathymetryCoverage`.
- Populated by `S102DatasetReader` from the HDF5 instance path
  (e.g. `/BathymetryCoverage/BathymetryCoverage.01`).
- Rules use it as the per-coverage `RelatedFeatureId`.

**Compat:** additive — `init`-only and nullable, no migration required
for existing fixtures/tests. Not a breaking change.

## `ConcatReports` helper

`internal static class ConcatReports` lands in
`EncDotNet.S100.Datasets.Pipelines` alongside `ValidationRunner`. V-1
does not itself produce multiple reports per dataset; the helper ships
now so V-5 (S-57 pre-translation pack) remains a leaf PR. It joins two
`ValidationReport`s, preserves finding order, sums counters, and
optionally rebadges the second report's rule ids with a prefix.

`[InternalsVisibleTo("EncDotNet.S100.Pipelines.Tests")]` is set on the
Pipelines assembly so the helper can be unit-tested directly.

## `S102DatasetProcessor.Validate()`

- Caches the report (`_validationReport` / `_validationCached`) matching
  the `S124DatasetProcessor` pattern.
- Wraps `S102DatasetRules.Default.Run(dataset)` in a defensive
  `try`/`catch (S100DatasetSchemaException ex)` that returns a single
  `S102-PROJ-SCHEMA` finding carrying `GroupPath` / `AttributeOrDataset`
  / `SpecReference` from the exception.

## Tests

`tests/EncDotNet.S100.Pipelines.Tests/S102ValidationTests.cs`: **27**
synthetic-fixture tests — pass/fail case for each of the 8 rules, a
clean-dataset assertion, a multi-coverage `GroupPath` assertion, plus
two `ConcatReports` tests covering counter aggregation and rebadging.
No real HDF5 dependency.

## Build / test status

- `dotnet build` — ✅
- `dotnet test --configuration Release` — ✅ all suites pass.

## Spec references

- S-100 Ed 5.2.1 Part 10c §10.2.1.2, §11
- S-102 Ed 3.0.0 §10, §12.6
- `docs/design/non-gml-validation.md` §3.2, §4.3, §5.1, §5.3, §6.1, §7, §9, §10 Q-cov-1