### PR TITLE
V-2: S-104 validation rule pack + WaterLevelCoverage.GroupPath

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -1,17 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S104.Validation;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -56,6 +59,8 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly S104DatasetData _data;
     private readonly string _fileName;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public SpecRef Spec => new("S-104", default);
 
@@ -614,4 +619,145 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     };
 
     private static string DecodeTrend(byte code) => DecodeTrend((int)code);
+
+    /// <summary>
+    /// Runs the S-104 normative rule pack
+    /// (<see cref="S104DatasetRules.Default"/>) against the parsed
+    /// dataset and returns the cached report. Returns <c>null</c> when
+    /// the loaded HDF5 has no validatable shape (defensive — currently
+    /// unreachable because the constructor produces either a
+    /// <see cref="S104DatasetData.GriddedCoverage"/> or a
+    /// <see cref="S104DatasetData.StationSeries"/>, both of which this
+    /// method handles).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per <c>docs/design/non-gml-validation.md</c> §5.1 and §5.3,
+    /// this override surfaces reader-time projection diagnostics under
+    /// reserved rule ids:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>S104-PROJ-SCHEMA</c> — defensive try/catch for
+    /// <see cref="S100DatasetSchemaException"/>. The realistic failure
+    /// mode is the constructor itself throwing, so this only fires if
+    /// a future reader change moves schema validation later in the
+    /// pipeline.</description></item>
+    /// <item><description><c>S104-PROJ-UNSUPPORTED</c> — surfaced
+    /// proactively when the loaded dataset is a
+    /// <see cref="S104DatasetData.StationSeries"/> (S-104 dcf 8,
+    /// "time series at fixed stations") because the V-2 rule pack
+    /// operates on <see cref="S104Dataset"/> (the gridded view) and
+    /// not on the station-series shape. Also surfaced defensively if
+    /// rule evaluation ever throws an
+    /// <see cref="S100DatasetNotSupportedException"/>.</description></item>
+    /// </list>
+    /// <para>
+    /// Validation is a pure function of the parsed dataset; the
+    /// report is cached after the first call (mirroring the V-1
+    /// S-102 processor and the GML processors' pattern).
+    /// </para>
+    /// </remarks>
+    public ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ComputeValidationReport();
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
+
+    private ValidationReport? ComputeValidationReport()
+    {
+        switch (_data)
+        {
+            case S104DatasetData.GriddedCoverage g:
+                try
+                {
+                    return S104DatasetRules.Default.Run(g.Dataset);
+                }
+                catch (S100DatasetSchemaException ex)
+                {
+                    return BuildSchemaSurrogateReport(ex);
+                }
+                catch (S100DatasetNotSupportedException ex)
+                {
+                    return BuildUnsupportedSurrogateReport(ex);
+                }
+
+            case S104DatasetData.StationSeries:
+                return BuildStationSeriesUnsupportedReport();
+
+            default:
+                return null;
+        }
+    }
+
+    private static ValidationReport BuildSchemaSurrogateReport(S100DatasetSchemaException ex)
+    {
+        var details = new List<string> { $"GroupPath='{ex.GroupPath}'" };
+        if (!string.IsNullOrEmpty(ex.AttributeOrDataset))
+            details.Add($"AttributeOrDataset='{ex.AttributeOrDataset}'");
+        if (!string.IsNullOrEmpty(ex.SpecReference))
+            details.Add($"SpecReference='{ex.SpecReference}'");
+
+        var finding = new ValidationFinding
+        {
+            RuleId = "S104-PROJ-SCHEMA",
+            Severity = ValidationSeverity.Error,
+            Message = $"S104 reader raised S100DatasetSchemaException: {ex.Message} ({string.Join(", ", details)}).",
+            RelatedFeatureId = ex.GroupPath,
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+    }
+
+    private static ValidationReport BuildUnsupportedSurrogateReport(S100DatasetNotSupportedException ex)
+    {
+        var details = new List<string>();
+        if (!string.IsNullOrEmpty(ex.Feature))
+            details.Add($"Feature='{ex.Feature}'");
+        if (!string.IsNullOrEmpty(ex.SpecReference))
+            details.Add($"SpecReference='{ex.SpecReference}'");
+
+        var finding = new ValidationFinding
+        {
+            RuleId = "S104-PROJ-UNSUPPORTED",
+            Severity = ValidationSeverity.Error,
+            Message = $"S104 reader raised S100DatasetNotSupportedException: {ex.Message} ({string.Join(", ", details)}).",
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+    }
+
+    private ValidationReport BuildStationSeriesUnsupportedReport()
+    {
+        // The reader produced a StationSeries (dcf 8) variant. The V-2
+        // rule pack targets the gridded S104Dataset view (dcf 2/3) only,
+        // so surface this proactively under S104-PROJ-UNSUPPORTED per
+        // docs/design/non-gml-validation.md §5.3.
+        var finding = new ValidationFinding
+        {
+            RuleId = "S104-PROJ-UNSUPPORTED",
+            Severity = ValidationSeverity.Error,
+            Message =
+                $"S104 dataset '{_fileName}' uses data coding format 8 " +
+                "(time series at fixed stations). The V-2 S-104 rule pack " +
+                "targets the gridded (dcf 2 / dcf 3) S104Dataset shape and " +
+                "does not currently evaluate station-series datasets " +
+                "(S-100 Part 10c §10.2.1; S-104 Edition 2.0.0 §10.2.3 / §10.2.7).",
+            RelatedFeatureId = "/WaterLevel",
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+    }
 }

--- a/src/EncDotNet.S100.Datasets.S104/README.md
+++ b/src/EncDotNet.S100.Datasets.S104/README.md
@@ -36,6 +36,37 @@ If IHO publishes an official S-104 portrayal catalogue, the bundled
 `content/S104/pc/` directory (today `.gitkeep`-only by design) will be the
 landing point and this catalogue will be re-wired against it.
 
+## Validation
+
+A bundled rule pack
+(`EncDotNet.S100.Datasets.S104.Validation.S104DatasetRules.Default`)
+evaluates a typed `S104Dataset` against the S-104 Edition 2.0.0
+checklist and emits a `ValidationReport` of findings. The pack is
+invoked automatically by `S104DatasetProcessor.Validate()` and is
+also runnable directly:
+
+```csharp
+var report = S104DatasetRules.Default.Run(dataset);
+foreach (var finding in report.Findings)
+    Console.WriteLine($"{finding.RuleId} {finding.Severity}: {finding.Message}");
+```
+
+| Rule id                  | Severity | Checks                                                                                                                  |
+|--------------------------|----------|-------------------------------------------------------------------------------------------------------------------------|
+| `S104-R-1.1`             | Error    | Each coverage's `Values.Length` equals `NumPointsLatitudinal × NumPointsLongitudinal`.                                  |
+| `S104-R-1.2`             | Error    | `DataCodingFormat` is in the supported gridded set `{2, 3}`.                                                            |
+| `S104-R-2.1`             | Warning  | `Coverages` are strictly increasing by `TimePoint` (one finding at first violation; cascade suppression).               |
+| `S104-R-2.2`             | Warning  | Successive `TimePoint` deltas vary by no more than ±10% of the median delta (skipped when `Coverages.Count < 3`).       |
+| `S104-R-3.1`             | Warning  | `MethodWaterLevelProduct` is set when `Coverages.Count > 1`.                                                            |
+| `S104-R-4.1`             | Warning  | Non-NODATA water-level values lie in `[-15, 15]` m (one finding per offending coverage; `-9999f`/NaN/±Infinity skipped).|
+| `S104-R-4.2`             | Error    | Each coverage's origin and `origin + (numPoints - 1) × spacing` extent stay in WGS-84 ranges without antimeridian wrap. |
+| `S104-PROJ-SCHEMA`       | Error    | Defensive surrogate: emitted when the underlying HDF5 dataset fails schema-level parsing inside `Validate()`.           |
+| `S104-PROJ-UNSUPPORTED`  | Error    | Emitted when the loaded dataset uses an unsupported data coding format (e.g. dcf 8 station series).                     |
+
+R-2.1 and R-2.2 are the **time-axis rule patterns**; they are the
+template the S-111 (V-3) rule pack reuses against
+`SurfaceCurrentCoverage`.
+
 ## Installation
 
 ```sh

--- a/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104DatasetReader.cs
@@ -226,6 +226,7 @@ public static class S104DatasetReader
                 NumPointsLatitudinal = numLat,
                 NumPointsLongitudinal = numLon,
                 StartSequence = startSequence,
+                GroupPath = instancePath,
                 TimePoint = timePoint,
                 Values = values,
             });

--- a/src/EncDotNet.S100.Datasets.S104/Validation/S104DatasetRules.cs
+++ b/src/EncDotNet.S100.Datasets.S104/Validation/S104DatasetRules.cs
@@ -1,0 +1,515 @@
+using System.Globalization;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S104.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-104 <see cref="S104Dataset"/>. Rule identifiers follow the
+/// convention <c>S104-R-{clause}</c> for normative rules and
+/// <c>S104-PROJ-{kind}</c> for projection-diagnostic surrogates,
+/// traceable back to S-104 (Edition 2.0.0) and S-100 Part 10c.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the V-2 rule pack as defined in
+/// <c>docs/design/non-gml-validation.md</c> §6.2. Rules read off the
+/// strongly-typed <see cref="S104Dataset"/> produced by
+/// <see cref="S104DatasetReader"/>; structural-schema failures the
+/// reader cannot tolerate are thrown as
+/// <see cref="EncDotNet.S100.Hdf5.S100DatasetSchemaException"/> at
+/// read time (and unsupported data-coding-format selections as
+/// <see cref="EncDotNet.S100.Hdf5.S100DatasetNotSupportedException"/>)
+/// and (per design §5.1 and §5.3) surfaced as <c>S104-PROJ-SCHEMA</c>
+/// / <c>S104-PROJ-UNSUPPORTED</c> findings by the dataset processor's
+/// <c>Validate()</c> wrapper.
+/// </para>
+/// <para>
+/// V-2 introduces the time-axis rule pattern (R-2.1 monotonicity,
+/// R-2.2 cadence). V-3 (S-111) reuses these patterns against
+/// <c>SurfaceCurrentCoverage</c>.
+/// </para>
+/// <para>
+/// Tier-3 cross-dataset rules are out of scope; per-finding payload
+/// conventions follow design §4.3:
+/// <list type="bullet">
+/// <item><description>per-coverage finding — <c>RelatedFeatureId = "{groupPath}"</c></description></item>
+/// <item><description>per-time-step finding — <c>RelatedFeatureId = "{groupPath}#timePoint"</c></description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class S104DatasetRules
+{
+    /// <summary>
+    /// S-104 NODATA sentinel for the water-level <c>Height</c> channel
+    /// (S-100 Part 10c §11 fill convention; this codebase uses
+    /// <c>-9999.0f</c> as documented on <c>S104CoverageSource.FillValue</c>).
+    /// </summary>
+    internal const float NoDataValue = -9999.0f;
+
+    /// <summary>
+    /// Fallback <c>RelatedFeatureId</c> stem when a coverage lacks a
+    /// populated <see cref="WaterLevelCoverage.GroupPath"/> (e.g.
+    /// synthetic test fixtures). Matches the conventional S-104
+    /// container group name.
+    /// </summary>
+    private const string FallbackCoveragePath = "/WaterLevel";
+
+    /// <summary>
+    /// <c>S104-R-1.1</c> — Every <see cref="WaterLevelCoverage"/>'s
+    /// <see cref="WaterLevelCoverage.Values"/> array length equals
+    /// <see cref="WaterLevelCoverage.NumPointsLatitudinal"/> ×
+    /// <see cref="WaterLevelCoverage.NumPointsLongitudinal"/>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §10.2.1.2 (gridded coverage
+    /// shape contract) and S-104 Edition 2.0.0 §10.2 / §12
+    /// (<c>WaterLevel</c> feature). Implements the
+    /// <c>s104-water-level</c> skill review-checklist item
+    /// "values array shape matches numPointsLat × numPointsLon".
+    /// </remarks>
+    public static IValidationRule<S104Dataset> CoverageValuesLengthMatchesShape { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-1.1")
+            .WithDescription("Each WaterLevelCoverage's Values length must equal NumPointsLatitudinal × NumPointsLongitudinal.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long expected = (long)c.NumPointsLatitudinal * c.NumPointsLongitudinal;
+                    if (c.Values.LongLength == expected)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S104-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"WaterLevelCoverage at '{CoveragePath(c)}' (timePoint {FmtTime(c.TimePoint)}) has Values length {c.Values.LongLength} but " +
+                            $"expected NumPointsLatitudinal ({c.NumPointsLatitudinal}) × NumPointsLongitudinal ({c.NumPointsLongitudinal}) = {expected}.",
+                        RelatedFeatureId = CoveragePath(c),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-R-1.2</c> — <see cref="S104Dataset.DataCodingFormat"/>
+    /// is in the supported set <c>{2, 3}</c> (regular grid /
+    /// ungeorectified grid). The reader currently rejects other formats
+    /// at parse time (raising
+    /// <see cref="EncDotNet.S100.Hdf5.S100DatasetNotSupportedException"/>);
+    /// this rule documents intent so future reader changes do not
+    /// silently widen the supported set.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §10.2.1 (data coding format
+    /// enumeration); S-104 Edition 2.0.0 §10.2 (<c>dataCodingFormat</c>
+    /// root attribute on the <c>WaterLevel</c> group). Implements the
+    /// <c>s104-water-level</c> skill review-checklist item
+    /// "data coding format is the supported gridded set".
+    /// </remarks>
+    public static IValidationRule<S104Dataset> DataCodingFormatIsSupported { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-1.2")
+            .WithDescription("DataCodingFormat must be in the supported gridded set {2, 3}.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                int dcf = dataset.DataCodingFormat;
+                if (dcf == 2 || dcf == 3)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S104-R-1.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"DataCodingFormat {dcf} is not in the supported S-104 gridded set " +
+                            "{2 (regular grid), 3 (ungeorectified grid)}.",
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-R-2.1</c> — <see cref="S104Dataset.Coverages"/> ordered
+    /// by <see cref="WaterLevelCoverage.TimePoint"/> are strictly
+    /// increasing. Emits a single finding at the first violation;
+    /// later violations are usually cascade noise and are suppressed
+    /// per <c>docs/design/non-gml-validation.md</c> §7.2.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-104 Edition 2.0.0 §10.2.5 (<c>timePoint</c>
+    /// attribute on each <c>Group_NNN</c>); S-100 Part 10c §10.2.6
+    /// (time-series group sequence). Implements the
+    /// <c>s104-water-level</c> skill review-checklist item
+    /// "time-step groups are monotonic in time".
+    /// </remarks>
+    public static IValidationRule<S104Dataset> TimePointsStrictlyIncreasing { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-2.1")
+            .WithDescription("Coverage TimePoint sequence must be strictly increasing.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.Coverages.Count < 2)
+                    return Array.Empty<ValidationFinding>();
+
+                for (var i = 1; i < dataset.Coverages.Count; i++)
+                {
+                    var prev = dataset.Coverages[i - 1];
+                    var curr = dataset.Coverages[i];
+                    if (curr.TimePoint > prev.TimePoint)
+                        continue;
+
+                    return new[]
+                    {
+                        new ValidationFinding
+                        {
+                            RuleId = "S104-R-2.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Coverage TimePoint sequence is not strictly increasing at index {i}: " +
+                                $"previous = {FmtTime(prev.TimePoint)}, current = {FmtTime(curr.TimePoint)}. " +
+                                "Only the first violation is reported (later out-of-order steps are usually cascade noise).",
+                            RelatedFeatureId = $"{CoveragePath(curr)}#timePoint",
+                        },
+                    };
+                }
+
+                return Array.Empty<ValidationFinding>();
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-R-2.2</c> — Successive <see cref="WaterLevelCoverage.TimePoint"/>
+    /// deltas vary by no more than ±10% of the median delta. Skipped
+    /// when <c>Coverages.Count &lt; 3</c> (a single delta has no
+    /// comparison). One finding per offending gap.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-104 Edition 2.0.0 §10.2.5 / §12.3
+    /// (<c>timeRecordInterval</c>) — operational consumers assume
+    /// near-uniform cadence. Implements the <c>s104-water-level</c>
+    /// skill review-checklist item "time-step cadence is uniform
+    /// within tolerance". The rule deliberately uses the median
+    /// (not the mean) delta as the reference so a single missing
+    /// step does not skew the tolerance for the rest of the series.
+    /// </remarks>
+    public static IValidationRule<S104Dataset> TimeStepCadenceWithinTolerance { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-2.2")
+            .WithDescription("Successive TimePoint deltas must vary by no more than ±10% of the median delta.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.Coverages.Count < 3)
+                    return Array.Empty<ValidationFinding>();
+
+                var deltas = new TimeSpan[dataset.Coverages.Count - 1];
+                for (var i = 1; i < dataset.Coverages.Count; i++)
+                {
+                    var delta = dataset.Coverages[i].TimePoint - dataset.Coverages[i - 1].TimePoint;
+                    if (delta <= TimeSpan.Zero)
+                    {
+                        // Monotonicity is R-2.1's job; skip cadence on non-positive deltas
+                        // to avoid double-reporting the same anomaly.
+                        return Array.Empty<ValidationFinding>();
+                    }
+                    deltas[i - 1] = delta;
+                }
+
+                var sorted = (TimeSpan[])deltas.Clone();
+                Array.Sort(sorted);
+                var median = sorted[sorted.Length / 2];
+                if (median <= TimeSpan.Zero)
+                    return Array.Empty<ValidationFinding>();
+
+                double medianTicks = median.Ticks;
+                double tolerance = 0.10;
+
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < deltas.Length; i++)
+                {
+                    double ratio = deltas[i].Ticks / medianTicks;
+                    if (ratio >= 1.0 - tolerance && ratio <= 1.0 + tolerance)
+                        continue;
+
+                    var offending = dataset.Coverages[i + 1];
+                    var prev = dataset.Coverages[i];
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S104-R-2.2",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"TimePoint cadence at index {i + 1} is {FmtDelta(deltas[i])} " +
+                            $"({Fmt(ratio * 100.0)}% of median {FmtDelta(median)}); " +
+                            $"outside the ±10% tolerance (previous = {FmtTime(prev.TimePoint)}, current = {FmtTime(offending.TimePoint)}).",
+                        RelatedFeatureId = $"{CoveragePath(offending)}#timePoint",
+                    });
+                }
+
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-R-3.1</c> — <see cref="S104Dataset.MethodWaterLevelProduct"/>
+    /// is set (non-null, non-empty) when the dataset contains more than
+    /// one coverage (i.e. is itself a time series, where the method
+    /// provenance is operationally important).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-104 Edition 2.0.0 §12 / §10.2.3
+    /// (<c>methodWaterLevelProduct</c> attribute on the
+    /// <c>WaterLevel</c> container; recommended for forecast and
+    /// hindcast products). Implements the <c>s104-water-level</c>
+    /// skill review-checklist item "provenance attributes populated
+    /// on multi-step datasets".
+    /// </remarks>
+    public static IValidationRule<S104Dataset> MethodSetForTimeSeries { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-3.1")
+            .WithDescription("MethodWaterLevelProduct should be set on multi-step datasets.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.Coverages.Count <= 1)
+                    return Array.Empty<ValidationFinding>();
+                if (!string.IsNullOrWhiteSpace(dataset.MethodWaterLevelProduct))
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S104-R-3.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"MethodWaterLevelProduct is not set on a multi-step dataset " +
+                            $"({dataset.Coverages.Count} coverages); operational consumers expect this " +
+                            "provenance attribute on forecast or hindcast time series.",
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-R-4.1</c> — Non-NODATA water-level <c>Height</c> values
+    /// across each coverage lie within the plausible range [-15, 15]
+    /// metres. NODATA cells (finite values equal to
+    /// <see cref="NoDataValue"/>, plus <see cref="float.NaN"/> and
+    /// ±<see cref="float.PositiveInfinity"/>) are excluded from the
+    /// range check.
+    /// </summary>
+    /// <remarks>
+    /// Plausibility heuristic: tides, surges, and routine
+    /// meteorological forcing rarely exceed ±15 m even in extreme
+    /// estuaries; catches common producer mistakes such as a centimetre
+    /// scaling factor left applied or a missing datum subtraction.
+    /// One finding per offending coverage with the count of out-of-range
+    /// cells in the message; emitting one finding per cell on a
+    /// broken tile would drown the report in cascade noise (design §6.2).
+    /// Spec reference: S-104 Edition 2.0.0 §12 (<c>waterLevelHeight</c>
+    /// units). Implements the <c>s104-water-level</c> skill
+    /// review-checklist item "water-level values within physically
+    /// plausible range".
+    /// </remarks>
+    public static IValidationRule<S104Dataset> WaterLevelValuesInPlausibleRange { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-4.1")
+            .WithDescription("Non-NODATA water-level values must lie in [-15, 15] metres.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                const float min = -15f;
+                const float max = 15f;
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long offending = 0;
+                    float worst = 0f;
+                    for (var idx = 0; idx < c.Values.Length; idx++)
+                    {
+                        float h = c.Values[idx].Height;
+                        if (h == NoDataValue)
+                            continue;
+                        if (float.IsNaN(h) || float.IsInfinity(h))
+                            continue;
+                        if (h >= min && h <= max)
+                            continue;
+
+                        offending++;
+                        if (Math.Abs(h) > Math.Abs(worst))
+                            worst = h;
+                    }
+                    if (offending == 0)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S104-R-4.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"WaterLevelCoverage at '{CoveragePath(c)}' (timePoint {FmtTime(c.TimePoint)}) has {offending} non-NODATA " +
+                            $"value(s) outside the plausible range [-15, 15] m (worst observed: {Fmt(worst)} m).",
+                        RelatedFeatureId = CoveragePath(c),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-R-4.2</c> — Each coverage's
+    /// <see cref="WaterLevelCoverage.OriginLatitude"/> is in [-90, 90]
+    /// and <see cref="WaterLevelCoverage.OriginLongitude"/> is in
+    /// [-180, 180], and the extent
+    /// (<c>origin + (numPoints - 1) × spacing</c>) stays in range
+    /// without wrapping the antimeridian or crossing the pole.
+    /// </summary>
+    /// <remarks>
+    /// Folds the V-1 S102-R-4.1 (origin range) and S102-R-4.2 (extent
+    /// range) into a single rule because the S-104 time-series shape
+    /// already inflates the per-coverage rule count. Per-coverage
+    /// finding; populates <see cref="ValidationFinding.BoundingBox"/>
+    /// to the offending tile extent (clamped to ordered edges; values
+    /// may themselves be out of range). Spec reference: S-100 Part 10c
+    /// §10.2.1.2 (grid georeferencing). Implements the
+    /// <c>s104-water-level</c> skill review-checklist items
+    /// "georeferencing attributes within WGS-84 range" and "tile extent
+    /// stays within WGS-84 ranges".
+    /// </remarks>
+    public static IValidationRule<S104Dataset> CoverageGeoreferencingInRange { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-R-4.2")
+            .WithDescription("Coverage origin and extent must stay in WGS-84 range and not wrap the antimeridian or cross the pole.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+
+                    var problems = new List<string>();
+                    if (c.OriginLatitude < -90 || c.OriginLatitude > 90)
+                        problems.Add($"OriginLatitude {Fmt(c.OriginLatitude)} outside [-90, 90]");
+                    if (c.OriginLongitude < -180 || c.OriginLongitude > 180)
+                        problems.Add($"OriginLongitude {Fmt(c.OriginLongitude)} outside [-180, 180]");
+
+                    double latEnd = c.OriginLatitude;
+                    double lonEnd = c.OriginLongitude;
+                    if (c.NumPointsLatitudinal > 0 && c.NumPointsLongitudinal > 0)
+                    {
+                        latEnd = c.OriginLatitude + (c.NumPointsLatitudinal - 1) * c.SpacingLatitudinal;
+                        lonEnd = c.OriginLongitude + (c.NumPointsLongitudinal - 1) * c.SpacingLongitudinal;
+                        if (latEnd > 90 || latEnd < -90)
+                            problems.Add($"latitude end {Fmt(latEnd)} outside [-90, 90]");
+                        if (lonEnd > 180 || lonEnd < -180)
+                            problems.Add($"longitude end {Fmt(lonEnd)} outside [-180, 180] (antimeridian-spanning tiles are out of scope for V-2)");
+                    }
+
+                    if (problems.Count == 0)
+                        continue;
+
+                    double south = Math.Min(c.OriginLatitude, latEnd);
+                    double north = Math.Max(c.OriginLatitude, latEnd);
+                    double west = Math.Min(c.OriginLongitude, lonEnd);
+                    double east = Math.Max(c.OriginLongitude, lonEnd);
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S104-R-4.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"WaterLevelCoverage at '{CoveragePath(c)}' (timePoint {FmtTime(c.TimePoint)}) has out-of-range " +
+                            "georeferencing: " + string.Join("; ", problems) + ".",
+                        RelatedFeatureId = CoveragePath(c),
+                        BoundingBox = new BoundingBox(south, west, north, east),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S104-PROJ-SCHEMA</c> — defensive projection-diagnostic
+    /// surrogate (design §5.1, §5.3).
+    /// </summary>
+    /// <remarks>
+    /// The rule body is intentionally a no-op: by the time the rule
+    /// pack runs the dataset is already constructed, so any
+    /// <see cref="EncDotNet.S100.Hdf5.S100DatasetSchemaException"/>
+    /// has already thrown out of the reader. The rule id is reserved
+    /// in this rule set so that <c>S104DatasetProcessor.Validate()</c>
+    /// can emit a single-finding report carrying the exception's
+    /// <c>GroupPath</c>, <c>AttributeOrDataset</c>, and
+    /// <c>SpecReference</c> under this same rule id when the
+    /// defensive try/catch around the rule-pack call fires.
+    /// </remarks>
+    public static IValidationRule<S104Dataset> ProjectionSchemaSurrogate { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-PROJ-SCHEMA")
+            .WithDescription("Defensive surrogate: an S100DatasetSchemaException was caught during validation.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((_, _) => Array.Empty<ValidationFinding>())
+            .Build();
+
+    /// <summary>
+    /// <c>S104-PROJ-UNSUPPORTED</c> — projection-diagnostic surrogate
+    /// for an <see cref="EncDotNet.S100.Hdf5.S100DatasetNotSupportedException"/>
+    /// (design §5.3). In practice this fires when the underlying
+    /// HDF5 dataset uses a data coding format the reader has not
+    /// implemented (e.g. dcf 8 station-series, which lacks an
+    /// <see cref="S104Dataset"/> view), or when a future reader
+    /// change widens the rejected set.
+    /// </summary>
+    /// <remarks>
+    /// The rule body is a no-op (analogous to <see cref="ProjectionSchemaSurrogate"/>);
+    /// <c>S104DatasetProcessor.Validate()</c> emits findings under
+    /// this rule id directly when it detects the dcf8 variant or
+    /// when its defensive try/catch traps the exception.
+    /// </remarks>
+    public static IValidationRule<S104Dataset> ProjectionUnsupportedSurrogate { get; } =
+        ValidationRuleBuilder.RuleFor<S104Dataset>("S104-PROJ-UNSUPPORTED")
+            .WithDescription("Defensive surrogate: an S100DatasetNotSupportedException was caught during validation.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((_, _) => Array.Empty<ValidationFinding>())
+            .Build();
+
+    /// <summary>The canonical default rule set for S-104 water-level datasets.</summary>
+    public static ValidationRuleSet<S104Dataset> Default { get; } = new(
+        CoverageValuesLengthMatchesShape,
+        DataCodingFormatIsSupported,
+        TimePointsStrictlyIncreasing,
+        TimeStepCadenceWithinTolerance,
+        MethodSetForTimeSeries,
+        WaterLevelValuesInPlausibleRange,
+        CoverageGeoreferencingInRange,
+        ProjectionSchemaSurrogate,
+        ProjectionUnsupportedSurrogate);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S104Dataset dataset, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+
+    private static string CoveragePath(WaterLevelCoverage coverage)
+        => coverage.GroupPath ?? FallbackCoveragePath;
+
+    private static string Fmt(double value)
+        => value.ToString("0.######", CultureInfo.InvariantCulture);
+
+    private static string FmtTime(DateTime value)
+        => value.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static string FmtDelta(TimeSpan value)
+        => value.ToString("c", CultureInfo.InvariantCulture);
+}

--- a/src/EncDotNet.S100.Datasets.S104/WaterLevelCoverage.cs
+++ b/src/EncDotNet.S100.Datasets.S104/WaterLevelCoverage.cs
@@ -27,6 +27,19 @@ public sealed class WaterLevelCoverage
     public string? StartSequence { get; init; }
 
     /// <summary>
+    /// The HDF5 instance-group path this coverage was read from, e.g.
+    /// <c>"/WaterLevel/WaterLevel.01"</c>. Populated by
+    /// <see cref="S104DatasetReader"/>; nullable so synthetic test
+    /// fixtures may omit it. Validation rules surface this on
+    /// per-coverage findings via <c>RelatedFeatureId</c>, and append
+    /// <c>#timePoint</c> on per-time-step findings (per
+    /// <c>docs/design/non-gml-validation.md</c> §4.3). Multiple
+    /// time-step coverages share an instance path; the
+    /// <see cref="TimePoint"/> disambiguates them in finding messages.
+    /// </summary>
+    public string? GroupPath { get; init; }
+
+    /// <summary>
     /// The time point for this coverage, parsed from the HDF5 group's <c>timePoint</c> attribute.
     /// </summary>
     public required DateTime TimePoint { get; init; }

--- a/tests/EncDotNet.S100.Datasets.S104.Tests/Validation/S104ValidationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S104.Tests/Validation/S104ValidationTests.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Linq;
+using EncDotNet.S100.Datasets.S104;
+using EncDotNet.S100.Datasets.S104.Validation;
+using EncDotNet.S100.Validation;
+using Xunit;
+
+namespace EncDotNet.S100.Datasets.S104.Tests.Validation;
+
+/// <summary>
+/// Synthetic-fixture tests for the V-2 S-104 rule pack
+/// (<see cref="S104DatasetRules"/>). No real HDF5 files
+/// required; every fixture is constructed in-memory.
+/// </summary>
+public class S104ValidationTests
+{
+    private const float NoData = -9999.0f;
+
+    private static readonly DateTime BaseTime =
+        new(2026, 5, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    private static WaterLevelCoverage MakeCoverage(
+        int rows = 2,
+        int cols = 2,
+        double originLat = 50.0,
+        double originLon = -1.0,
+        double spacingLat = 0.01,
+        double spacingLon = 0.01,
+        DateTime? timePoint = null,
+        WaterLevelValue[]? values = null,
+        string? groupPath = "/WaterLevel/WaterLevel.01")
+        => new()
+        {
+            OriginLatitude = originLat,
+            OriginLongitude = originLon,
+            SpacingLatitudinal = spacingLat,
+            SpacingLongitudinal = spacingLon,
+            NumPointsLatitudinal = rows,
+            NumPointsLongitudinal = cols,
+            GroupPath = groupPath,
+            TimePoint = timePoint ?? BaseTime,
+            Values = values ?? FillHeights(rows * cols, 1.5f),
+        };
+
+    private static WaterLevelValue[] FillHeights(int count, float height, byte trend = 3)
+    {
+        var arr = new WaterLevelValue[count];
+        for (var i = 0; i < count; i++)
+            arr[i] = new WaterLevelValue(height, trend);
+        return arr;
+    }
+
+    private static S104Dataset MakeDataset(
+        int dcf = 2,
+        string? method = "TidalForecast",
+        params WaterLevelCoverage[] coverages)
+        => new()
+        {
+            HorizontalCRS = 4326,
+            IssueDate = "2026-05-28T00:00:00Z",
+            DataCodingFormat = dcf,
+            MethodWaterLevelProduct = method,
+            Coverages = coverages.Length == 0
+                ? new[] { MakeCoverage() }
+                : coverages,
+        };
+
+    // ----- Default rule set / clean dataset -----
+
+    [Fact]
+    public void Default_Run_On_Clean_Dataset_Is_Valid()
+    {
+        // A clean single-coverage dataset (method allowed to be null since Count == 1).
+        var dataset = new S104Dataset
+        {
+            HorizontalCRS = 4326,
+            IssueDate = "2026-05-28T00:00:00Z",
+            DataCodingFormat = 2,
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        Assert.True(report.IsValid, $"Expected clean dataset to be valid; got: {string.Join(", ", report.Findings.Select(f => f.RuleId))}");
+        Assert.Equal(9, report.RulesEvaluated);
+        Assert.Equal(0, report.RulesWithFindings);
+    }
+
+    // ----- R-1.1 -----
+
+    [Fact]
+    public void R1_1_Fires_When_Values_Length_Mismatches_Shape()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 3, values: FillHeights(5, 1.5f));
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-1.1");
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R1_1_Does_Not_Fire_When_Shape_Matches()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 3, values: FillHeights(6, 1.5f));
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-1.1");
+    }
+
+    // ----- R-1.2 -----
+
+    [Fact]
+    public void R1_2_Fires_On_Unsupported_DataCodingFormat()
+    {
+        var dataset = MakeDataset(dcf: 8, coverages: MakeCoverage());
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-1.2");
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Contains("8", f.Message);
+    }
+
+    [Fact]
+    public void R1_2_Does_Not_Fire_For_Supported_DataCodingFormats()
+    {
+        var report2 = S104DatasetRules.Default.Run(MakeDataset(dcf: 2, coverages: MakeCoverage()));
+        var report3 = S104DatasetRules.Default.Run(MakeDataset(dcf: 3, coverages: MakeCoverage()));
+
+        Assert.DoesNotContain(report2.Findings, x => x.RuleId == "S104-R-1.2");
+        Assert.DoesNotContain(report3.Findings, x => x.RuleId == "S104-R-1.2");
+    }
+
+    // ----- R-2.1 -----
+
+    [Fact]
+    public void R2_1_Fires_On_Non_Increasing_TimePoints()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime, groupPath: "/WaterLevel/WaterLevel.01");
+        var c2 = MakeCoverage(timePoint: BaseTime, groupPath: "/WaterLevel/WaterLevel.01"); // equal — not strictly increasing
+        var dataset = MakeDataset(coverages: new[] { c1, c2 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-2.1");
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal($"{c2.GroupPath}#timePoint", f.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R2_1_Does_Not_Fire_When_TimePoints_Strictly_Increase()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var c3 = MakeCoverage(timePoint: BaseTime.AddHours(2));
+        var dataset = MakeDataset(coverages: new[] { c1, c2, c3 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-2.1");
+    }
+
+    [Fact]
+    public void R2_1_Emits_Only_One_Finding_For_Multiple_Violations()
+    {
+        // Three back-to-back violations; only the first should be reported.
+        var c1 = MakeCoverage(timePoint: BaseTime.AddHours(5));
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(3));
+        var c3 = MakeCoverage(timePoint: BaseTime.AddHours(2));
+        var c4 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var dataset = MakeDataset(coverages: new[] { c1, c2, c3, c4 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var r21 = report.Findings.Where(x => x.RuleId == "S104-R-2.1").ToList();
+        Assert.Single(r21);
+    }
+
+    // ----- R-2.2 -----
+
+    [Fact]
+    public void R2_2_Fires_When_Cadence_Outside_Tolerance()
+    {
+        // Median delta = 1h. Inject a 2h gap → 200% of median → outside ±10%.
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var c3 = MakeCoverage(timePoint: BaseTime.AddHours(2));
+        var c4 = MakeCoverage(timePoint: BaseTime.AddHours(4), groupPath: "/WaterLevel/WaterLevel.04"); // 2h gap
+        var c5 = MakeCoverage(timePoint: BaseTime.AddHours(5));
+        var dataset = MakeDataset(coverages: new[] { c1, c2, c3, c4, c5 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var r22 = report.Findings.Where(x => x.RuleId == "S104-R-2.2").ToList();
+        Assert.Single(r22);
+        Assert.Equal(ValidationSeverity.Warning, r22[0].Severity);
+        Assert.Equal($"{c4.GroupPath}#timePoint", r22[0].RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R2_2_Does_Not_Fire_For_Uniform_Cadence()
+    {
+        var coverages = Enumerable.Range(0, 5)
+            .Select(i => MakeCoverage(timePoint: BaseTime.AddHours(i)))
+            .ToArray();
+        var dataset = MakeDataset(coverages: coverages);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-2.2");
+    }
+
+    [Fact]
+    public void R2_2_Is_Skipped_When_Coverages_Count_Less_Than_3()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(100)); // huge gap, no comparison possible
+        var dataset = MakeDataset(coverages: new[] { c1, c2 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-2.2");
+    }
+
+    // ----- R-3.1 -----
+
+    [Fact]
+    public void R3_1_Fires_When_Method_Missing_On_TimeSeries()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var dataset = MakeDataset(method: null, coverages: new[] { c1, c2 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-3.1");
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+    }
+
+    [Fact]
+    public void R3_1_Does_Not_Fire_When_Method_Set_On_TimeSeries()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var dataset = MakeDataset(method: "TidalForecast", coverages: new[] { c1, c2 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-3.1");
+    }
+
+    [Fact]
+    public void R3_1_Does_Not_Fire_For_Single_Coverage_Without_Method()
+    {
+        var dataset = MakeDataset(method: null, coverages: MakeCoverage());
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-3.1");
+    }
+
+    // ----- R-4.1 -----
+
+    [Fact]
+    public void R4_1_Fires_On_Implausible_Height_Values()
+    {
+        var values = FillHeights(4, 1.5f);
+        values[1] = new WaterLevelValue(50f, 3); // > 15 m
+        values[2] = new WaterLevelValue(-20f, 3); // < -15 m
+        var coverage = MakeCoverage(values: values);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-4.1");
+        Assert.Equal(ValidationSeverity.Warning, f.Severity);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+        // One finding per coverage (count in message), not per cell.
+        Assert.Contains("2 non-NODATA", f.Message);
+    }
+
+    [Fact]
+    public void R4_1_Does_Not_Fire_For_In_Range_Values()
+    {
+        var values = FillHeights(4, 1.5f);
+        values[0] = new WaterLevelValue(-15f, 3); // boundary inclusive
+        values[1] = new WaterLevelValue(15f, 3);
+        var coverage = MakeCoverage(values: values);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-4.1");
+    }
+
+    [Fact]
+    public void R4_1_Treats_Minus_9999_As_NoData()
+    {
+        var values = FillHeights(4, 1.5f);
+        values[1] = new WaterLevelValue(NoData, 0); // NODATA sentinel — must be skipped
+        values[2] = new WaterLevelValue(NoData, 0);
+        var coverage = MakeCoverage(values: values);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-4.1");
+    }
+
+    [Fact]
+    public void R4_1_Skips_NaN_Values()
+    {
+        var values = FillHeights(4, 1.5f);
+        values[1] = new WaterLevelValue(float.NaN, 0);
+        values[2] = new WaterLevelValue(float.PositiveInfinity, 0);
+        var coverage = MakeCoverage(values: values);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        // NaN / infinity are skipped (not flagged as out of plausible range).
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-4.1");
+    }
+
+    // ----- R-4.2 -----
+
+    [Fact]
+    public void R4_2_Fires_On_Out_Of_Range_Origin()
+    {
+        var coverage = MakeCoverage(originLat: 100.0, originLon: 200.0);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-4.2");
+        Assert.Equal(ValidationSeverity.Error, f.Severity);
+        Assert.Equal(coverage.GroupPath, f.RelatedFeatureId);
+        Assert.NotNull(f.BoundingBox);
+    }
+
+    [Fact]
+    public void R4_2_Fires_On_Extent_Wrapping_Antimeridian()
+    {
+        // origin lon 179, spacing 1, 5 points → end = 183 (wraps)
+        var coverage = MakeCoverage(
+            originLon: 179.0,
+            spacingLon: 1.0,
+            cols: 5,
+            values: FillHeights(10, 1.5f),
+            rows: 2);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S104-R-4.2");
+        Assert.Contains("longitude end", f.Message);
+    }
+
+    [Fact]
+    public void R4_2_Does_Not_Fire_For_In_Range_Georeferencing()
+    {
+        var dataset = MakeDataset(coverages: MakeCoverage());
+
+        var report = S104DatasetRules.Default.Run(dataset);
+        Assert.DoesNotContain(report.Findings, x => x.RuleId == "S104-R-4.2");
+    }
+
+    // ----- Multi-coverage RelatedFeatureId reflects GroupPath -----
+
+    [Fact]
+    public void Per_Coverage_Findings_Use_GroupPath_As_RelatedFeatureId()
+    {
+        var c1 = MakeCoverage(
+            rows: 2, cols: 3,
+            values: FillHeights(5, 1.5f), // shape mismatch — R-1.1 fires
+            timePoint: BaseTime,
+            groupPath: "/WaterLevel/WaterLevel.01");
+        var c2 = MakeCoverage(
+            rows: 2, cols: 3,
+            values: FillHeights(7, 1.5f), // shape mismatch — R-1.1 fires
+            timePoint: BaseTime.AddHours(1),
+            groupPath: "/WaterLevel/WaterLevel.02");
+        var dataset = MakeDataset(coverages: new[] { c1, c2 });
+
+        var report = S104DatasetRules.Default.Run(dataset);
+
+        var r11 = report.Findings.Where(x => x.RuleId == "S104-R-1.1").ToList();
+        Assert.Equal(2, r11.Count);
+        Assert.Contains(r11, f => f.RelatedFeatureId == "/WaterLevel/WaterLevel.01");
+        Assert.Contains(r11, f => f.RelatedFeatureId == "/WaterLevel/WaterLevel.02");
+    }
+}


### PR DESCRIPTION
Implements **V-2** of the non-GML validation roadmap ([`docs/design/non-gml-validation.md` §6.2](docs/design/non-gml-validation.md)): an S-104 water-level rule pack evaluated against the typed `S104Dataset`. Sibling to V-1 (S-102, #134); introduces the **time-axis rule patterns** that V-3 (S-111) will reuse.

## Rules shipped (`S104DatasetRules.Default`)

| Rule | Severity | Check |
|---|---|---|
| `S104-R-1.1` | Error | `Values.Length == NumPointsLat × NumPointsLon` per coverage |
| `S104-R-1.2` | Error | `DataCodingFormat ∈ {2, 3}` |
| `S104-R-2.1` | Warning | `Coverages` strictly increasing in `TimePoint` (cascade-suppressed — single finding at first violation) |
| `S104-R-2.2` | Warning | `TimePoint` cadence within ±10% of the median delta; skipped when `Coverages.Count < 3` |
| `S104-R-3.1` | Warning | `MethodWaterLevelProduct` set when `Coverages.Count > 1` |
| `S104-R-4.1` | Warning | Water-level values in `[-15, 15]` m; `-9999.0f`, `NaN`, `±∞` skipped (per S-100 Part 10c NODATA) |
| `S104-R-4.2` | Error | Origin in WGS-84 and extent does not antimeridian-wrap |
| `S104-PROJ-SCHEMA` | — | Defensive surrogate emitted from processor catch (§5.1) |
| `S104-PROJ-UNSUPPORTED` | — | Emitted for dcf 8 station series OR `S100DatasetNotSupportedException` (§5.3) |

R-2.1 and R-2.2 are the new time-axis patterns. **V-3 (S-111) should reuse them verbatim** — the cascade-suppression early-return in R-2.1 and the median-delta tolerance reference in R-2.2 both generalise directly to `SurfaceCurrentCoverage`.

## Framework prep (design §10 Q-cov-1)

- **`WaterLevelCoverage.GroupPath`** (nullable, init-only) — **additive, non-breaking**. Populated by `S104DatasetReader` from the iterated HDF5 instance path (e.g. `/WaterLevel/WaterLevel.01`). Rules use it as the per-coverage `RelatedFeatureId`, with `#timePoint` appended for time-axis findings. Mirrors V-1's `BathymetryCoverage.GroupPath` addition.

## Processor integration

`S104DatasetProcessor.Validate()` (`src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs`):
- Caches the report (`_validationReport` / `_validationCached`).
- Wraps `S104DatasetRules.Default.Run(_dataset)` in a defensive try/catch handling **both** `S100DatasetSchemaException` (→ `S104-PROJ-SCHEMA`) **and** `S100DatasetNotSupportedException` (→ `S104-PROJ-UNSUPPORTED`).
- Also proactively surfaces dcf 8 station-series datasets (`S104DatasetData.StationSeries`) as `S104-PROJ-UNSUPPORTED` since there is no typed `S104Dataset` to evaluate.

## Tests

22 synthetic-fixture tests in `tests/EncDotNet.S100.Datasets.S104.Tests/Validation/S104ValidationTests.cs` — no real HDF5 dependency. All pass.

Includes explicit coverage for: R-2.1 cascade suppression, R-4.1 NODATA (`-9999.0f`) skipping, R-4.1 `NaN` skipping, multi-coverage `RelatedFeatureId = GroupPath`, and a default-clean-dataset baseline.

## Build & test status

- `dotnet build` clean (no new warnings).
- `dotnet test` (Release) — all 49 S-104 dataset tests pass (27 pre-existing + 22 new). One pre-existing telemetry test failure (`VectorPipeline_emits_xslt_transform_span`) is unrelated to this PR.

## What this PR does NOT touch

- `docs/design/non-gml-validation.md` — unchanged.
- Core framework (`IValidationRule<TModel>`, `ValidationRuleSet<TModel>`, etc.) — unchanged.
- `SurfaceCurrentCoverage` / S-111 — owned by V-3.
- `S104CoverageSource`, `S104PortrayalCatalogue`, viewer, MCP — unchanged.

## Spec references

- S-100 Ed 5.2.1 Part 10c §10.2.1, §10.2.1.2 (HDF5 fill value)
- S-104 Ed 2.0.0 §10.2, §12 (water-level coverage encoding)
- Design note §6.2 (S-104 rule list), §5.1 / §5.3 (PROJ surrogates), §4.3 (`RelatedFeatureId` `#timePoint` convention), §7.2 (time-series iteration), §10 Q-cov-1 (`GroupPath` plumbing)