### PR TITLE
V-3: S-111 surface currents validation rule pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Datasets.S111.Validation;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Interoperability;
@@ -13,6 +15,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -61,6 +64,9 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly S111DatasetData _data;
     private readonly string _fileName;
+
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public SpecRef Spec => new("S-111", default);
 
@@ -836,5 +842,153 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                 },
             },
         };
+    }
+
+    /// <summary>
+    /// Runs the V-3 S-111 validation rule pack
+    /// (<see cref="S111SurfaceCurrentRules.Default"/>) against the
+    /// gridded <see cref="S111Dataset"/> view of this processor's
+    /// dataset, or returns a single-finding
+    /// <c>S111-PROJ-UNSUPPORTED</c> report when the underlying dataset
+    /// is the station-series (<see cref="S111DatasetData.StationSeries"/>)
+    /// variant (dcf 3 ungeorectified grid or dcf 8 time series at fixed
+    /// stations, both of which the rule pack does not cover).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per <c>docs/design/non-gml-validation.md</c> §5.1 and §5.3,
+    /// this override surfaces reader-time projection diagnostics under
+    /// reserved rule ids:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>S111-PROJ-SCHEMA</c> — defensive try/catch for
+    /// <see cref="S100DatasetSchemaException"/>. The realistic failure
+    /// mode is the constructor itself throwing, so this only fires if
+    /// a future reader change moves schema validation later in the
+    /// pipeline.</description></item>
+    /// <item><description><c>S111-PROJ-UNSUPPORTED</c> — surfaced
+    /// proactively when the loaded dataset is a
+    /// <see cref="S111DatasetData.StationSeries"/> (S-111 dcf 3 or
+    /// dcf 8) because the V-3 rule pack operates on
+    /// <see cref="S111Dataset"/> (the gridded view) and not on the
+    /// station-series shape. Also surfaced defensively if rule
+    /// evaluation ever throws an
+    /// <see cref="S100DatasetNotSupportedException"/>.</description></item>
+    /// </list>
+    /// <para>
+    /// Validation is a pure function of the parsed dataset; the
+    /// report is cached after the first call (mirroring the V-1
+    /// S-102 and V-2 S-104 processors).
+    /// </para>
+    /// </remarks>
+    public ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            _validationReport = ComputeValidationReport();
+            _validationCached = true;
+        }
+        return _validationReport;
+    }
+
+    private ValidationReport? ComputeValidationReport()
+    {
+        switch (_data)
+        {
+            case S111DatasetData.GriddedCoverage g:
+                try
+                {
+                    return S111SurfaceCurrentRules.Default.Run(g.Dataset);
+                }
+                catch (S100DatasetSchemaException ex)
+                {
+                    return BuildSchemaSurrogateReport(ex);
+                }
+                catch (S100DatasetNotSupportedException ex)
+                {
+                    return BuildUnsupportedSurrogateReport(ex);
+                }
+
+            case S111DatasetData.StationSeries s:
+                return BuildStationSeriesUnsupportedReport(s.Dataset.DataCodingFormat);
+
+            default:
+                return null;
+        }
+    }
+
+    private static ValidationReport BuildSchemaSurrogateReport(S100DatasetSchemaException ex)
+    {
+        var details = new List<string> { $"GroupPath='{ex.GroupPath}'" };
+        if (!string.IsNullOrEmpty(ex.AttributeOrDataset))
+            details.Add($"AttributeOrDataset='{ex.AttributeOrDataset}'");
+        if (!string.IsNullOrEmpty(ex.SpecReference))
+            details.Add($"SpecReference='{ex.SpecReference}'");
+
+        var finding = new ValidationFinding
+        {
+            RuleId = "S111-PROJ-SCHEMA",
+            Severity = ValidationSeverity.Error,
+            Message = $"S111 reader raised S100DatasetSchemaException: {ex.Message} ({string.Join(", ", details)}).",
+            RelatedFeatureId = ex.GroupPath,
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+    }
+
+    private static ValidationReport BuildUnsupportedSurrogateReport(S100DatasetNotSupportedException ex)
+    {
+        var details = new List<string>();
+        if (!string.IsNullOrEmpty(ex.Feature))
+            details.Add($"Feature='{ex.Feature}'");
+        if (!string.IsNullOrEmpty(ex.SpecReference))
+            details.Add($"SpecReference='{ex.SpecReference}'");
+
+        var finding = new ValidationFinding
+        {
+            RuleId = "S111-PROJ-UNSUPPORTED",
+            Severity = ValidationSeverity.Error,
+            Message = $"S111 reader raised S100DatasetNotSupportedException: {ex.Message} ({string.Join(", ", details)}).",
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
+    }
+
+    private ValidationReport BuildStationSeriesUnsupportedReport(int dataCodingFormat)
+    {
+        // The reader produced a StationSeries variant (dcf 3 ungeorectified
+        // grid or dcf 8 time series at fixed stations). The V-3 rule pack
+        // targets the gridded S111Dataset view (dcf 2) only, so surface
+        // this proactively under S111-PROJ-UNSUPPORTED per
+        // docs/design/non-gml-validation.md §5.3.
+        string formatLabel = dataCodingFormat switch
+        {
+            3 => "data coding format 3 (ungeorectified grid)",
+            8 => "data coding format 8 (time series at fixed stations)",
+            _ => $"data coding format {dataCodingFormat} (station-series projection)",
+        };
+
+        var finding = new ValidationFinding
+        {
+            RuleId = "S111-PROJ-UNSUPPORTED",
+            Severity = ValidationSeverity.Error,
+            Message =
+                $"S111 dataset '{_fileName}' uses {formatLabel}. The V-3 S-111 rule pack " +
+                "targets the gridded (dcf 2) S111Dataset shape and does not currently " +
+                "evaluate station-series datasets " +
+                "(S-100 Part 10c §10.2.1; S-111 Edition 2.0.0 §10.2.3 / §10.2.7).",
+            RelatedFeatureId = "/SurfaceCurrent",
+        };
+
+        return new ValidationReport(
+            ImmutableArray.Create(finding),
+            RulesEvaluated: 1,
+            RulesWithFindings: 1);
     }
 }

--- a/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111DatasetReader.cs
@@ -232,6 +232,7 @@ public static class S111DatasetReader
                 NumPointsLatitudinal = numLat,
                 NumPointsLongitudinal = numLon,
                 StartSequence = startSequence,
+                GroupPath = instancePath,
                 TimePoint = timePoint,
                 Values = values,
             });

--- a/src/EncDotNet.S100.Datasets.S111/SurfaceCurrentCoverage.cs
+++ b/src/EncDotNet.S100.Datasets.S111/SurfaceCurrentCoverage.cs
@@ -27,6 +27,19 @@ public sealed class SurfaceCurrentCoverage
     public string? StartSequence { get; init; }
 
     /// <summary>
+    /// The HDF5 instance-group path this coverage was read from, e.g.
+    /// <c>"/SurfaceCurrent/SurfaceCurrent.01"</c>. Populated by
+    /// <see cref="S111DatasetReader"/>; nullable so synthetic test
+    /// fixtures may omit it. Validation rules surface this on
+    /// per-coverage findings via <c>RelatedFeatureId</c>, and append
+    /// <c>#timePoint</c> on per-time-step findings (per
+    /// <c>docs/design/non-gml-validation.md</c> §4.3). Multiple
+    /// time-step coverages share an instance path; the
+    /// <see cref="TimePoint"/> disambiguates them in finding messages.
+    /// </summary>
+    public string? GroupPath { get; init; }
+
+    /// <summary>
     /// The time point for this coverage, parsed from the HDF5 group's <c>timePoint</c> attribute.
     /// </summary>
     public required DateTime TimePoint { get; init; }

--- a/src/EncDotNet.S100.Datasets.S111/Validation/S111SurfaceCurrentRules.cs
+++ b/src/EncDotNet.S100.Datasets.S111/Validation/S111SurfaceCurrentRules.cs
@@ -1,0 +1,568 @@
+using System.Globalization;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S111.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-111 <see cref="S111Dataset"/>. Rule identifiers follow the
+/// convention <c>S111-R-{clause}</c> for normative rules and
+/// <c>S111-PROJ-{kind}</c> for projection-diagnostic surrogates,
+/// traceable back to S-111 (Edition 2.0.0) and S-100 Part 10c.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the V-3 rule pack as defined in
+/// <c>docs/design/non-gml-validation.md</c> §6.3. Rules read off the
+/// strongly-typed <see cref="S111Dataset"/> produced by
+/// <see cref="S111DatasetReader"/>; structural-schema failures the
+/// reader cannot tolerate are thrown as
+/// <see cref="EncDotNet.S100.Hdf5.S100DatasetSchemaException"/> at
+/// read time (and unsupported data-coding-format selections — e.g.
+/// dcf 3 ungeorectified grid or dcf 8 time series at fixed stations,
+/// which are projected onto <see cref="S111StationSeriesDataset"/>
+/// instead of <see cref="S111Dataset"/> — as
+/// <see cref="EncDotNet.S100.Hdf5.S100DatasetNotSupportedException"/>)
+/// and (per design §5.1 and §5.3) surfaced as <c>S111-PROJ-SCHEMA</c>
+/// / <c>S111-PROJ-UNSUPPORTED</c> findings by the dataset processor's
+/// <c>Validate()</c> wrapper.
+/// </para>
+/// <para>
+/// V-3 mirrors V-2 (S-104) almost exactly: the time-axis rule pattern
+/// from V-2's <c>S104-R-2.1</c> / <c>S104-R-2.2</c> is folded into a
+/// single <c>S111-R-2.1</c> (monotonicity-then-cadence) per design §6.3.
+/// </para>
+/// <para>
+/// Tier-3 cross-dataset rules are out of scope; per-finding payload
+/// conventions follow design §4.3:
+/// <list type="bullet">
+/// <item><description>per-coverage finding — <c>RelatedFeatureId = "{groupPath}"</c></description></item>
+/// <item><description>per-time-step finding — <c>RelatedFeatureId = "{groupPath}#timePoint"</c></description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class S111SurfaceCurrentRules
+{
+    /// <summary>
+    /// S-111 NODATA sentinel for the surface-current value channels
+    /// (S-100 Part 10c §11 fill convention; this codebase uses
+    /// <c>-9999.0f</c> as documented on
+    /// <see cref="S111CoverageSource.FillValue"/>). Applies to both
+    /// <see cref="SurfaceCurrentValue.Speed"/> and
+    /// <see cref="SurfaceCurrentValue.Direction"/>.
+    /// </summary>
+    internal const float NoDataValue = -9999.0f;
+
+    /// <summary>
+    /// Conversion factor from knots to metres per second
+    /// (1 international nautical mile per hour = 1852 / 3600 m/s).
+    /// S-111 stores <see cref="SurfaceCurrentValue.Speed"/> in knots
+    /// (S-111 Edition 2.0.0 §12; <c>surfaceCurrentSpeed</c> compound
+    /// member), but the plausibility bound in design §6.3 is expressed
+    /// in m/s, so the rule converts on the fly.
+    /// </summary>
+    internal const float KnotsToMetresPerSecond = 0.5144444f;
+
+    /// <summary>
+    /// Fallback <c>RelatedFeatureId</c> stem when a coverage lacks a
+    /// populated <see cref="SurfaceCurrentCoverage.GroupPath"/> (e.g.
+    /// synthetic test fixtures). Matches the conventional S-111
+    /// container group name.
+    /// </summary>
+    private const string FallbackCoveragePath = "/SurfaceCurrent";
+
+    /// <summary>
+    /// <c>S111-R-1.1</c> — Every <see cref="SurfaceCurrentCoverage"/>'s
+    /// <see cref="SurfaceCurrentCoverage.Values"/> array length equals
+    /// <see cref="SurfaceCurrentCoverage.NumPointsLatitudinal"/> ×
+    /// <see cref="SurfaceCurrentCoverage.NumPointsLongitudinal"/>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10c §10.2.1.2 (gridded coverage
+    /// shape contract) and S-111 Edition 2.0.0 §12 (<c>SurfaceCurrent</c>
+    /// feature). Implements the <c>s111-surface-currents</c> skill
+    /// review-checklist item "HDF5 layout under
+    /// <c>/SurfaceCurrent/SurfaceCurrent.NN/Group_NNN/values</c>
+    /// matches spec".
+    /// </remarks>
+    public static IValidationRule<S111Dataset> CoverageValuesLengthMatchesShape { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-R-1.1")
+            .WithDescription("Each SurfaceCurrentCoverage's Values length must equal NumPointsLatitudinal × NumPointsLongitudinal.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long expected = (long)c.NumPointsLatitudinal * c.NumPointsLongitudinal;
+                    if (c.Values.LongLength == expected)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S111-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"SurfaceCurrentCoverage at '{CoveragePath(c)}' (timePoint {FmtTime(c.TimePoint)}) has Values length {c.Values.LongLength} but " +
+                            $"expected NumPointsLatitudinal ({c.NumPointsLatitudinal}) × NumPointsLongitudinal ({c.NumPointsLongitudinal}) = {expected}.",
+                        RelatedFeatureId = CoveragePath(c),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S111-R-2.1</c> — <see cref="S111Dataset.Coverages"/> ordered
+    /// by <see cref="SurfaceCurrentCoverage.TimePoint"/> are strictly
+    /// increasing <em>and</em> their successive deltas vary by no more
+    /// than ±10% of the median delta. Per design §6.3 the S-111
+    /// time-axis check folds the V-2 monotonicity (<c>S104-R-2.1</c>)
+    /// and cadence (<c>S104-R-2.2</c>) into a single rule.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Walks the time-point sequence in two passes:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>Monotonicity — emits a single finding at the
+    /// first non-strictly-increasing step and returns immediately;
+    /// later violations are usually cascade noise (design §7.2).</description></item>
+    /// <item><description>Cadence — only entered when the sequence
+    /// is monotonic. Skipped when <c>Coverages.Count &lt; 3</c> (a
+    /// single delta has no comparison). The median (not the mean)
+    /// delta is the reference so a single missing step does not skew
+    /// the tolerance for the rest of the series.</description></item>
+    /// </list>
+    /// <para>
+    /// Spec reference: S-111 Edition 2.0.0 §12 (per-<c>Group_NNN</c>
+    /// <c>timePoint</c> attribute) and §10 (<c>timeRecordInterval</c>);
+    /// S-100 Part 10c §10.2.6 (time-series group sequence). Implements
+    /// the <c>s111-surface-currents</c> skill review-checklist item
+    /// "times derived from <c>dateTimeOfFirstRecord</c> +
+    /// <c>timeRecordInterval</c>".
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S111Dataset> TimePointMonotonicityAndCadence { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-R-2.1")
+            .WithDescription("Coverage TimePoint sequence must be strictly increasing with cadence within ±10% of the median delta.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.Coverages.Count < 2)
+                    return Array.Empty<ValidationFinding>();
+
+                // Pass 1: monotonicity. Early-return on the first violation
+                // to suppress cascade noise per design §7.2.
+                for (var i = 1; i < dataset.Coverages.Count; i++)
+                {
+                    var prev = dataset.Coverages[i - 1];
+                    var curr = dataset.Coverages[i];
+                    if (curr.TimePoint > prev.TimePoint)
+                        continue;
+
+                    return new[]
+                    {
+                        new ValidationFinding
+                        {
+                            RuleId = "S111-R-2.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message =
+                                $"Coverage TimePoint sequence is not strictly increasing at index {i}: " +
+                                $"previous = {FmtTime(prev.TimePoint)}, current = {FmtTime(curr.TimePoint)}. " +
+                                "Only the first violation is reported (later out-of-order steps are usually cascade noise); " +
+                                "cadence is not evaluated until monotonicity holds.",
+                            RelatedFeatureId = $"{CoveragePath(curr)}#timePoint",
+                        },
+                    };
+                }
+
+                // Pass 2: cadence. Requires ≥ 3 coverages (≥ 2 deltas) for
+                // a meaningful comparison.
+                if (dataset.Coverages.Count < 3)
+                    return Array.Empty<ValidationFinding>();
+
+                var deltas = new TimeSpan[dataset.Coverages.Count - 1];
+                for (var i = 1; i < dataset.Coverages.Count; i++)
+                {
+                    var delta = dataset.Coverages[i].TimePoint - dataset.Coverages[i - 1].TimePoint;
+                    if (delta <= TimeSpan.Zero)
+                    {
+                        // Defensive — monotonicity pass above should have caught this.
+                        return Array.Empty<ValidationFinding>();
+                    }
+                    deltas[i - 1] = delta;
+                }
+
+                var sorted = (TimeSpan[])deltas.Clone();
+                Array.Sort(sorted);
+                var median = sorted[sorted.Length / 2];
+                if (median <= TimeSpan.Zero)
+                    return Array.Empty<ValidationFinding>();
+
+                double medianTicks = median.Ticks;
+                const double tolerance = 0.10;
+
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < deltas.Length; i++)
+                {
+                    double ratio = deltas[i].Ticks / medianTicks;
+                    if (ratio >= 1.0 - tolerance && ratio <= 1.0 + tolerance)
+                        continue;
+
+                    var offending = dataset.Coverages[i + 1];
+                    var prev = dataset.Coverages[i];
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S111-R-2.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"TimePoint cadence at index {i + 1} is {FmtDelta(deltas[i])} " +
+                            $"({Fmt(ratio * 100.0)}% of median {FmtDelta(median)}); " +
+                            $"outside the ±10% tolerance (previous = {FmtTime(prev.TimePoint)}, current = {FmtTime(offending.TimePoint)}).",
+                        RelatedFeatureId = $"{CoveragePath(offending)}#timePoint",
+                    });
+                }
+
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S111-R-3.1</c> — <see cref="S111Dataset.SurfaceCurrentDepth"/>,
+    /// <em>when present</em>, lies in the plausible range [0, 1500]
+    /// metres below the surface. Skipped entirely when the attribute is
+    /// absent / null (it is optional on the <c>/SurfaceCurrent</c>
+    /// container).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-111 Edition 2.0.0 §10 / §12
+    /// (<c>surfaceCurrentDepth</c> root attribute on the
+    /// <c>SurfaceCurrent</c> container). The 1500 m upper bound is a
+    /// plausibility heuristic (currents reported as "surface" are
+    /// typically tens of metres deep at most; operational depths beyond
+    /// 1500 m almost certainly indicate a unit error). Implements the
+    /// "root-attribute completeness" conditional pattern in design §7.5.
+    /// </remarks>
+    public static IValidationRule<S111Dataset> SurfaceCurrentDepthInRange { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-R-3.1")
+            .WithDescription("SurfaceCurrentDepth, when present, must lie in [0, 1500] metres.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.SurfaceCurrentDepth is not float depth)
+                    return Array.Empty<ValidationFinding>();
+                if (float.IsNaN(depth) || float.IsInfinity(depth))
+                {
+                    return new[]
+                    {
+                        new ValidationFinding
+                        {
+                            RuleId = "S111-R-3.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message = $"SurfaceCurrentDepth is non-finite ({depth}); expected a value in [0, 1500] metres.",
+                            RelatedFeatureId = FallbackCoveragePath,
+                        },
+                    };
+                }
+                if (depth >= 0f && depth <= 1500f)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S111-R-3.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"SurfaceCurrentDepth {Fmt(depth)} m is outside the plausible range [0, 1500] m; " +
+                            "verify the producer is reporting metres below the surface.",
+                        RelatedFeatureId = FallbackCoveragePath,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// Documented members of the <see cref="S111Dataset.TypeOfCurrentData"/>
+    /// enumeration (S-111 Edition 2.0.0 §10 / §12; S-100 GI Registry
+    /// <c>typeOfCurrentData</c> enumerated domain). Used by
+    /// <see cref="TypeOfCurrentDataInEnumeratedSet"/>.
+    /// </summary>
+    /// <remarks>
+    /// The members are:
+    /// <list type="number">
+    /// <item><description>1 — History</description></item>
+    /// <item><description>2 — Real-time</description></item>
+    /// <item><description>3 — Astronomical prediction</description></item>
+    /// <item><description>4 — Analysis or hybrid method</description></item>
+    /// <item><description>5 — Hydrodynamic model hindcast</description></item>
+    /// <item><description>6 — Hydrodynamic model forecast</description></item>
+    /// </list>
+    /// </remarks>
+    internal static readonly int[] ValidTypeOfCurrentData = { 1, 2, 3, 4, 5, 6 };
+
+    /// <summary>
+    /// <c>S111-R-3.2</c> — <see cref="S111Dataset.TypeOfCurrentData"/>,
+    /// <em>when present</em>, is a member of the S-111 enumerated set
+    /// (see <see cref="ValidTypeOfCurrentData"/>). Skipped entirely
+    /// when the attribute is absent / null.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-111 Edition 2.0.0 §10 / §12 (root attribute
+    /// <c>typeOfCurrentData</c> on the <c>/SurfaceCurrent</c>
+    /// container); enumeration values published in the S-100 GI
+    /// Registry. Implements the <c>s111-surface-currents</c> skill
+    /// review-checklist item "root attributes include
+    /// <c>typeOfCurrentData</c>".
+    /// </remarks>
+    public static IValidationRule<S111Dataset> TypeOfCurrentDataInEnumeratedSet { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-R-3.2")
+            .WithDescription("TypeOfCurrentData, when present, must be a member of the S-111 enumerated set {1..6}.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                if (dataset.TypeOfCurrentData is not int t)
+                    return Array.Empty<ValidationFinding>();
+                if (Array.IndexOf(ValidTypeOfCurrentData, t) >= 0)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S111-R-3.2",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"TypeOfCurrentData {t} is not in the S-111 enumerated set " +
+                            "{1=History, 2=Real-time, 3=Astronomical prediction, 4=Analysis or hybrid, " +
+                            "5=Hydrodynamic model hindcast, 6=Hydrodynamic model forecast}.",
+                        RelatedFeatureId = FallbackCoveragePath,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S111-R-4.1</c> — Non-NODATA surface current speeds across each
+    /// coverage lie within the plausible range [0, 15] metres per second.
+    /// NODATA cells (finite values equal to <see cref="NoDataValue"/>,
+    /// plus <see cref="float.NaN"/> and ±<see cref="float.PositiveInfinity"/>)
+    /// are excluded from the range check.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// S-111 stores <see cref="SurfaceCurrentValue.Speed"/> in
+    /// <strong>knots</strong> (S-111 Edition 2.0.0 §12; compound member
+    /// <c>surfaceCurrentSpeed</c>). The plausibility bound in design
+    /// §6.3 is expressed in m/s; this rule converts each value via
+    /// <see cref="KnotsToMetresPerSecond"/> before comparing. 15 m/s
+    /// (~29.2 knots) comfortably accommodates strong tidal currents
+    /// and the fastest western-boundary currents while catching the
+    /// common producer mistake of reporting cm/s where m/s was assumed
+    /// (a 100x scale error) or vice versa.
+    /// </para>
+    /// <para>
+    /// One finding per offending coverage with the count of out-of-range
+    /// cells in the message; emitting one finding per cell on a broken
+    /// tile would drown the report in cascade noise (design §6.3 / §7.2).
+    /// </para>
+    /// <para>
+    /// Implements the <c>s111-surface-currents</c> skill known pitfall
+    /// "Speed units vary by producer".
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S111Dataset> SurfaceCurrentSpeedsInPlausibleRange { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-R-4.1")
+            .WithDescription("Non-NODATA surface current speeds must lie in [0, 15] m/s after knots→m/s conversion.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((dataset, _) =>
+            {
+                const float minMps = 0f;
+                const float maxMps = 15f;
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long offending = 0;
+                    float worstMps = 0f;
+                    float worstKnots = 0f;
+                    for (var idx = 0; idx < c.Values.Length; idx++)
+                    {
+                        float knots = c.Values[idx].Speed;
+                        if (knots == NoDataValue)
+                            continue;
+                        if (float.IsNaN(knots) || float.IsInfinity(knots))
+                            continue;
+
+                        float mps = knots * KnotsToMetresPerSecond;
+                        if (mps >= minMps && mps <= maxMps)
+                            continue;
+
+                        offending++;
+                        if (Math.Abs(mps - 7.5f) > Math.Abs(worstMps - 7.5f))
+                        {
+                            worstMps = mps;
+                            worstKnots = knots;
+                        }
+                    }
+                    if (offending == 0)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S111-R-4.1",
+                        Severity = ValidationSeverity.Warning,
+                        Message =
+                            $"SurfaceCurrentCoverage at '{CoveragePath(c)}' (timePoint {FmtTime(c.TimePoint)}) has {offending} non-NODATA " +
+                            $"speed(s) outside the plausible range [0, 15] m/s (worst observed: {Fmt(worstKnots)} knots = {Fmt(worstMps)} m/s).",
+                        RelatedFeatureId = CoveragePath(c),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S111-R-4.2</c> — Non-NODATA surface current directions across
+    /// each coverage lie within the <em>half-open</em> range
+    /// <c>[0, 360)</c> degrees true. Note the upper bound is exclusive:
+    /// <c>360.0</c> is invalid (per spec convention it must wrap to
+    /// <c>0</c>). NODATA cells (<see cref="NoDataValue"/>,
+    /// <see cref="float.NaN"/>, ±infinity) are skipped.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-111 Edition 2.0.0 §12; <c>surfaceCurrentDirection</c>
+    /// compound member, degrees true, "going to" oceanographic
+    /// convention (also documented on
+    /// <see cref="SurfaceCurrentValue.Direction"/>). Implements the
+    /// <c>s111-surface-currents</c> skill review-checklist item
+    /// "<c>surfaceCurrentDirection</c> (float32, degrees true, 0–360)"
+    /// and the known pitfall "Wrap-around at 360° must be handled".
+    /// </remarks>
+    public static IValidationRule<S111Dataset> SurfaceCurrentDirectionsInRange { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-R-4.2")
+            .WithDescription("Non-NODATA surface current directions must lie in [0, 360) degrees (upper bound exclusive).")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((dataset, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                for (var i = 0; i < dataset.Coverages.Count; i++)
+                {
+                    var c = dataset.Coverages[i];
+                    long offending = 0;
+                    float worst = 0f;
+                    for (var idx = 0; idx < c.Values.Length; idx++)
+                    {
+                        float dir = c.Values[idx].Direction;
+                        if (dir == NoDataValue)
+                            continue;
+                        if (float.IsNaN(dir) || float.IsInfinity(dir))
+                            continue;
+                        // Half-open [0, 360) — 360.0 itself is invalid and
+                        // should wrap to 0 per the spec convention.
+                        if (dir >= 0f && dir < 360f)
+                            continue;
+
+                        offending++;
+                        if (Math.Abs(dir - 180f) > Math.Abs(worst - 180f))
+                            worst = dir;
+                    }
+                    if (offending == 0)
+                        continue;
+
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S111-R-4.2",
+                        Severity = ValidationSeverity.Error,
+                        Message =
+                            $"SurfaceCurrentCoverage at '{CoveragePath(c)}' (timePoint {FmtTime(c.TimePoint)}) has {offending} non-NODATA " +
+                            $"direction(s) outside the half-open range [0, 360) degrees (worst observed: {Fmt(worst)}°); " +
+                            "360° should wrap to 0°.",
+                        RelatedFeatureId = CoveragePath(c),
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S111-PROJ-SCHEMA</c> — defensive projection-diagnostic
+    /// surrogate (design §5.1, §5.3).
+    /// </summary>
+    /// <remarks>
+    /// The rule body is intentionally a no-op: by the time the rule
+    /// pack runs the dataset is already constructed, so any
+    /// <see cref="EncDotNet.S100.Hdf5.S100DatasetSchemaException"/>
+    /// has already thrown out of the reader. The rule id is reserved
+    /// in this rule set so that <c>S111DatasetProcessor.Validate()</c>
+    /// can emit a single-finding report carrying the exception's
+    /// <c>GroupPath</c>, <c>AttributeOrDataset</c>, and
+    /// <c>SpecReference</c> under this same rule id when the
+    /// defensive try/catch around the rule-pack call fires.
+    /// </remarks>
+    public static IValidationRule<S111Dataset> ProjectionSchemaSurrogate { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-PROJ-SCHEMA")
+            .WithDescription("Defensive surrogate: an S100DatasetSchemaException was caught during validation.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((_, _) => Array.Empty<ValidationFinding>())
+            .Build();
+
+    /// <summary>
+    /// <c>S111-PROJ-UNSUPPORTED</c> — projection-diagnostic surrogate
+    /// for an <see cref="EncDotNet.S100.Hdf5.S100DatasetNotSupportedException"/>
+    /// (design §5.3). In practice this fires when the underlying
+    /// HDF5 dataset uses a data coding format the gridded
+    /// <see cref="S111Dataset"/> view does not cover — currently dcf 3
+    /// (ungeorectified grid) and dcf 8 (time series at fixed stations),
+    /// both of which the reader projects onto
+    /// <see cref="S111StationSeriesDataset"/> instead — or when a
+    /// future reader change rejects an additional format.
+    /// </summary>
+    /// <remarks>
+    /// The rule body is a no-op (analogous to <see cref="ProjectionSchemaSurrogate"/>);
+    /// <c>S111DatasetProcessor.Validate()</c> emits findings under
+    /// this rule id directly when it observes the station-series
+    /// variant or when its defensive try/catch traps the exception.
+    /// </remarks>
+    public static IValidationRule<S111Dataset> ProjectionUnsupportedSurrogate { get; } =
+        ValidationRuleBuilder.RuleFor<S111Dataset>("S111-PROJ-UNSUPPORTED")
+            .WithDescription("Defensive surrogate: an S100DatasetNotSupportedException was caught during validation.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((_, _) => Array.Empty<ValidationFinding>())
+            .Build();
+
+    /// <summary>The canonical default rule set for S-111 surface-current datasets.</summary>
+    public static ValidationRuleSet<S111Dataset> Default { get; } = new(
+        CoverageValuesLengthMatchesShape,
+        TimePointMonotonicityAndCadence,
+        SurfaceCurrentDepthInRange,
+        TypeOfCurrentDataInEnumeratedSet,
+        SurfaceCurrentSpeedsInPlausibleRange,
+        SurfaceCurrentDirectionsInRange,
+        ProjectionSchemaSurrogate,
+        ProjectionUnsupportedSurrogate);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S111Dataset dataset, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Default.Run(dataset, context);
+    }
+
+    private static string CoveragePath(SurfaceCurrentCoverage coverage)
+        => coverage.GroupPath ?? FallbackCoveragePath;
+
+    private static string Fmt(double value)
+        => value.ToString("0.######", CultureInfo.InvariantCulture);
+
+    private static string FmtTime(DateTime value)
+        => value.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static string FmtDelta(TimeSpan value)
+        => value.ToString("c", CultureInfo.InvariantCulture);
+}

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/Validation/S111ValidationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/Validation/S111ValidationTests.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Linq;
+using EncDotNet.S100.Datasets.S111;
+using EncDotNet.S100.Datasets.S111.Validation;
+using EncDotNet.S100.Validation;
+using Xunit;
+
+namespace EncDotNet.S100.Datasets.S111.Tests.Validation;
+
+/// <summary>
+/// Synthetic-fixture unit tests for the V-3 S-111 surface-current
+/// validation rule pack (<see cref="S111SurfaceCurrentRules"/>).
+/// Mirrors the structure of <c>S104ValidationTests</c> from V-2 PR #135.
+/// </summary>
+public class S111ValidationTests
+{
+    private const float NoData = -9999.0f;
+    private const float KnotsToMps = 0.5144444f;
+
+    private static readonly DateTime BaseTime =
+        new(2026, 5, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    private static SurfaceCurrentCoverage MakeCoverage(
+        int rows = 2,
+        int cols = 2,
+        double originLat = 50.0,
+        double originLon = -1.0,
+        double spacingLat = 0.01,
+        double spacingLon = 0.01,
+        DateTime? timePoint = null,
+        SurfaceCurrentValue[]? values = null,
+        string? groupPath = "/SurfaceCurrent/SurfaceCurrent.01")
+        => new()
+        {
+            OriginLatitude = originLat,
+            OriginLongitude = originLon,
+            SpacingLatitudinal = spacingLat,
+            SpacingLongitudinal = spacingLon,
+            NumPointsLatitudinal = rows,
+            NumPointsLongitudinal = cols,
+            GroupPath = groupPath,
+            TimePoint = timePoint ?? BaseTime,
+            Values = values ?? FillValues(rows * cols, speedKnots: 2.0f, direction: 90.0f),
+        };
+
+    private static SurfaceCurrentValue[] FillValues(int count, float speedKnots, float direction)
+    {
+        var arr = new SurfaceCurrentValue[count];
+        for (var i = 0; i < count; i++)
+            arr[i] = new SurfaceCurrentValue(speedKnots, direction);
+        return arr;
+    }
+
+    private static S111Dataset MakeDataset(
+        int dcf = 2,
+        float? depth = 2.0f,
+        int? typeOfCurrentData = 6,
+        params SurfaceCurrentCoverage[] coverages)
+        => new()
+        {
+            HorizontalCRS = 4326,
+            IssueDate = "2026-05-28T00:00:00Z",
+            DataCodingFormat = dcf,
+            SurfaceCurrentDepth = depth,
+            TypeOfCurrentData = typeOfCurrentData,
+            Coverages = coverages.Length == 0
+                ? new[] { MakeCoverage() }
+                : coverages,
+        };
+
+    // ----- Default rule set / clean dataset -----
+
+    [Fact]
+    public void Default_Run_On_Clean_Dataset_Is_Valid()
+    {
+        var dataset = new S111Dataset
+        {
+            HorizontalCRS = 4326,
+            IssueDate = "2026-05-28T00:00:00Z",
+            DataCodingFormat = 2,
+            SurfaceCurrentDepth = 2.0f,
+            TypeOfCurrentData = 6,
+            Coverages = new[] { MakeCoverage() },
+        };
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.True(report.IsValid, $"Expected clean dataset to be valid; got: {string.Join("; ", report.Findings.Select(f => f.Message))}");
+        Assert.Equal(8, report.RulesEvaluated); // 6 normative + 2 PROJ surrogates
+        Assert.Equal(0, report.RulesWithFindings);
+        Assert.Empty(report.Findings);
+    }
+
+    // ----- R-1.1: Values length matches shape -----
+
+    [Fact]
+    public void R1_1_Fires_When_Values_Length_Mismatches_Shape()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 3, values: FillValues(5, 1.0f, 45.0f));
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r11 = report.Findings.Where(f => f.RuleId == "S111-R-1.1").ToList();
+        Assert.Single(r11);
+        Assert.Equal(ValidationSeverity.Error, r11[0].Severity);
+        Assert.Equal("/SurfaceCurrent/SurfaceCurrent.01", r11[0].RelatedFeatureId);
+        Assert.Contains("expected", r11[0].Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void R1_1_Does_Not_Fire_When_Shape_Matches()
+    {
+        var coverage = MakeCoverage(rows: 2, cols: 3, values: FillValues(6, 1.0f, 45.0f));
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-1.1");
+    }
+
+    // ----- R-2.1: TimePoint monotonicity + cadence (folded) -----
+
+    [Fact]
+    public void R2_1_Fires_On_Non_Increasing_TimePoints()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime); // equal — not strictly increasing
+        var dataset = MakeDataset(coverages: new[] { c1, c2 });
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r21 = report.Findings.Where(f => f.RuleId == "S111-R-2.1").ToList();
+        Assert.Single(r21);
+        Assert.Equal(ValidationSeverity.Warning, r21[0].Severity);
+        Assert.EndsWith("#timePoint", r21[0].RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R2_1_Does_Not_Fire_When_TimePoints_Strictly_Increase_With_Steady_Cadence()
+    {
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var c3 = MakeCoverage(timePoint: BaseTime.AddHours(2));
+        var dataset = MakeDataset(coverages: new[] { c1, c2, c3 });
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-2.1");
+    }
+
+    [Fact]
+    public void R2_1_Emits_Only_One_Finding_On_Multiple_Monotonicity_Violations()
+    {
+        // Descending sequence — every step violates; rule should early-return after first.
+        var c1 = MakeCoverage(timePoint: BaseTime.AddHours(5));
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(3));
+        var c3 = MakeCoverage(timePoint: BaseTime.AddHours(2));
+        var c4 = MakeCoverage(timePoint: BaseTime.AddHours(1));
+        var dataset = MakeDataset(coverages: new[] { c1, c2, c3, c4 });
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r21 = report.Findings.Where(f => f.RuleId == "S111-R-2.1").ToList();
+        Assert.Single(r21);
+        Assert.Contains("index 1", r21[0].Message);
+    }
+
+    [Fact]
+    public void R2_1_Fires_On_Cadence_Outside_Tolerance()
+    {
+        // Three coverages with a 5x cadence outlier — well beyond ±10%.
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddMinutes(60));
+        var c3 = MakeCoverage(timePoint: BaseTime.AddMinutes(60 + 60));
+        var c4 = MakeCoverage(timePoint: BaseTime.AddMinutes(60 + 60 + 300)); // 5-hour gap
+        var dataset = MakeDataset(coverages: new[] { c1, c2, c3, c4 });
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r21 = report.Findings.Where(f => f.RuleId == "S111-R-2.1").ToList();
+        Assert.NotEmpty(r21);
+        Assert.All(r21, f => Assert.Equal(ValidationSeverity.Warning, f.Severity));
+        Assert.Contains(r21, f => f.Message.Contains("cadence", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void R2_1_Skips_Cadence_When_Fewer_Than_Three_Coverages()
+    {
+        // Two coverages → one delta → cadence cannot be assessed; rule must not fire.
+        var c1 = MakeCoverage(timePoint: BaseTime);
+        var c2 = MakeCoverage(timePoint: BaseTime.AddHours(99));
+        var dataset = MakeDataset(coverages: new[] { c1, c2 });
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-2.1");
+    }
+
+    // ----- R-3.1: SurfaceCurrentDepth in [0, 1500] when present -----
+
+    [Fact]
+    public void R3_1_Fires_When_Depth_Is_Negative()
+    {
+        var dataset = MakeDataset(depth: -1.0f, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r31 = report.Findings.Where(f => f.RuleId == "S111-R-3.1").ToList();
+        Assert.Single(r31);
+        Assert.Equal(ValidationSeverity.Warning, r31[0].Severity);
+    }
+
+    [Fact]
+    public void R3_1_Fires_When_Depth_Exceeds_1500m()
+    {
+        var dataset = MakeDataset(depth: 2000.0f, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.Single(report.Findings, f => f.RuleId == "S111-R-3.1");
+    }
+
+    [Fact]
+    public void R3_1_Does_Not_Fire_When_Depth_Is_Null()
+    {
+        var dataset = MakeDataset(depth: null, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-3.1");
+    }
+
+    [Fact]
+    public void R3_1_Does_Not_Fire_When_Depth_Is_In_Range()
+    {
+        var dataset = MakeDataset(depth: 750.0f, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-3.1");
+    }
+
+    // ----- R-3.2: TypeOfCurrentData in {1..6} when present -----
+
+    [Fact]
+    public void R3_2_Fires_When_TypeOfCurrentData_Out_Of_Set()
+    {
+        var dataset = MakeDataset(typeOfCurrentData: 99, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r32 = report.Findings.Where(f => f.RuleId == "S111-R-3.2").ToList();
+        Assert.Single(r32);
+        Assert.Equal(ValidationSeverity.Warning, r32[0].Severity);
+    }
+
+    [Fact]
+    public void R3_2_Does_Not_Fire_When_TypeOfCurrentData_Is_Null()
+    {
+        var dataset = MakeDataset(typeOfCurrentData: null, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-3.2");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    public void R3_2_Does_Not_Fire_For_Each_Enumerated_Value(int value)
+    {
+        var dataset = MakeDataset(typeOfCurrentData: value, coverages: MakeCoverage());
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-3.2");
+    }
+
+    // ----- R-4.1: Speed in [0, 15] m/s after knots→m/s conversion -----
+
+    [Fact]
+    public void R4_1_Fires_When_Speed_Exceeds_15_Mps()
+    {
+        // 40 knots ≈ 20.58 m/s — exceeds 15 m/s cap.
+        var bad = new[]
+        {
+            new SurfaceCurrentValue(2.0f, 90.0f),
+            new SurfaceCurrentValue(40.0f, 90.0f),
+            new SurfaceCurrentValue(2.0f, 90.0f),
+            new SurfaceCurrentValue(2.0f, 90.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: bad));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r41 = report.Findings.Where(f => f.RuleId == "S111-R-4.1").ToList();
+        Assert.Single(r41);
+        Assert.Equal(ValidationSeverity.Warning, r41[0].Severity);
+        Assert.Equal("/SurfaceCurrent/SurfaceCurrent.01", r41[0].RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R4_1_Fires_When_Speed_Is_Negative()
+    {
+        var bad = new[]
+        {
+            new SurfaceCurrentValue(2.0f, 90.0f),
+            new SurfaceCurrentValue(-1.0f, 90.0f),
+            new SurfaceCurrentValue(2.0f, 90.0f),
+            new SurfaceCurrentValue(2.0f, 90.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: bad));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.Single(report.Findings, f => f.RuleId == "S111-R-4.1");
+    }
+
+    [Fact]
+    public void R4_1_Skips_NoData_NaN_And_Infinity_Speeds()
+    {
+        // All four cells are sentinels — should be excluded from the range check.
+        var values = new[]
+        {
+            new SurfaceCurrentValue(NoData, NoData),
+            new SurfaceCurrentValue(float.NaN, 90.0f),
+            new SurfaceCurrentValue(float.PositiveInfinity, 90.0f),
+            new SurfaceCurrentValue(float.NegativeInfinity, 90.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: values));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-4.1");
+    }
+
+    [Fact]
+    public void R4_1_Does_Not_Fire_For_Speeds_Just_Below_15_Mps()
+    {
+        // 14.9 m/s / 0.5144444 ≈ 28.96 knots — at the very edge but inside.
+        const float justBelow = 14.9f / KnotsToMps;
+        var values = new[]
+        {
+            new SurfaceCurrentValue(justBelow, 90.0f),
+            new SurfaceCurrentValue(justBelow, 90.0f),
+            new SurfaceCurrentValue(justBelow, 90.0f),
+            new SurfaceCurrentValue(justBelow, 90.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: values));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-4.1");
+    }
+
+    // ----- R-4.2: Direction in [0, 360) (half-open) -----
+
+    [Fact]
+    public void R4_2_Fires_When_Direction_Equals_360()
+    {
+        // 360.0 is the spec wrap-around boundary and must be reported as invalid.
+        var values = new[]
+        {
+            new SurfaceCurrentValue(1.0f, 0.0f),
+            new SurfaceCurrentValue(1.0f, 360.0f),
+            new SurfaceCurrentValue(1.0f, 180.0f),
+            new SurfaceCurrentValue(1.0f, 270.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: values));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r42 = report.Findings.Where(f => f.RuleId == "S111-R-4.2").ToList();
+        Assert.Single(r42);
+        Assert.Equal(ValidationSeverity.Error, r42[0].Severity);
+        Assert.Equal("/SurfaceCurrent/SurfaceCurrent.01", r42[0].RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R4_2_Fires_When_Direction_Is_Negative()
+    {
+        var values = new[]
+        {
+            new SurfaceCurrentValue(1.0f, -10.0f),
+            new SurfaceCurrentValue(1.0f, 90.0f),
+            new SurfaceCurrentValue(1.0f, 180.0f),
+            new SurfaceCurrentValue(1.0f, 270.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: values));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.Single(report.Findings, f => f.RuleId == "S111-R-4.2");
+    }
+
+    [Fact]
+    public void R4_2_Does_Not_Fire_For_Boundaries_0_And_Almost_360()
+    {
+        var values = new[]
+        {
+            new SurfaceCurrentValue(1.0f, 0.0f),
+            new SurfaceCurrentValue(1.0f, 359.999f),
+            new SurfaceCurrentValue(1.0f, 90.0f),
+            new SurfaceCurrentValue(1.0f, 180.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: values));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-4.2");
+    }
+
+    [Fact]
+    public void R4_2_Skips_NoData_NaN_And_Infinity_Directions()
+    {
+        var values = new[]
+        {
+            new SurfaceCurrentValue(1.0f, NoData),
+            new SurfaceCurrentValue(1.0f, float.NaN),
+            new SurfaceCurrentValue(1.0f, float.PositiveInfinity),
+            new SurfaceCurrentValue(1.0f, 90.0f),
+        };
+        var dataset = MakeDataset(coverages: MakeCoverage(values: values));
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S111-R-4.2");
+    }
+
+    // ----- GroupPath propagation across multiple coverages -----
+
+    [Fact]
+    public void Findings_Carry_Per_Coverage_GroupPath_On_Multi_Coverage_Dataset()
+    {
+        // Two distinct coverages, each broken in a different way to trigger
+        // a per-coverage finding; verify each finding's RelatedFeatureId is
+        // the offending coverage's GroupPath rather than a shared fallback.
+        var bad1 = MakeCoverage(
+            rows: 2, cols: 2,
+            timePoint: BaseTime,
+            values: FillValues(4, 200.0f /* ~102.9 m/s — out of range */, 90.0f),
+            groupPath: "/SurfaceCurrent/SurfaceCurrent.01");
+        var bad2 = MakeCoverage(
+            rows: 2, cols: 2,
+            timePoint: BaseTime.AddHours(1),
+            values: new[]
+            {
+                new SurfaceCurrentValue(1.0f, 400.0f), // out-of-range direction
+                new SurfaceCurrentValue(1.0f, 90.0f),
+                new SurfaceCurrentValue(1.0f, 90.0f),
+                new SurfaceCurrentValue(1.0f, 90.0f),
+            },
+            groupPath: "/SurfaceCurrent/SurfaceCurrent.02");
+        var dataset = MakeDataset(coverages: new[] { bad1, bad2 });
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r41 = Assert.Single(report.Findings, f => f.RuleId == "S111-R-4.1");
+        Assert.Equal("/SurfaceCurrent/SurfaceCurrent.01", r41.RelatedFeatureId);
+
+        var r42 = Assert.Single(report.Findings, f => f.RuleId == "S111-R-4.2");
+        Assert.Equal("/SurfaceCurrent/SurfaceCurrent.02", r42.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void Findings_Fall_Back_To_SurfaceCurrent_When_GroupPath_Is_Null()
+    {
+        var coverage = MakeCoverage(
+            rows: 2, cols: 3,
+            values: FillValues(5, 1.0f, 90.0f),
+            groupPath: null);
+        var dataset = MakeDataset(coverages: coverage);
+
+        var report = S111SurfaceCurrentRules.Default.Run(dataset);
+
+        var r11 = Assert.Single(report.Findings, f => f.RuleId == "S111-R-1.1");
+        Assert.Equal("/SurfaceCurrent", r11.RelatedFeatureId);
+    }
+
+    // ----- Validate() helper -----
+
+    [Fact]
+    public void Validate_Helper_Throws_On_Null_Dataset()
+    {
+        Assert.Throws<ArgumentNullException>(() => S111SurfaceCurrentRules.Validate(null!));
+    }
+}


### PR DESCRIPTION
Ships V-3 of the non-GML validation roadmap (`docs/design/non-gml-validation.md` §6.3): the S-111 Surface Currents validation rule pack. Mirrors V-2 (S-104, #135) almost exactly — same time-axis grid shape, same processor-dispatch shape.

## Rules shipped

| Id | Severity | What it checks |
|---|---|---|
| `S111-R-1.1` | Error   | Coverage `Values.Length == NumPointsLatitudinal × NumPointsLongitudinal` |
| `S111-R-2.1` | Warning | TimePoint monotonicity **+** cadence (folded per design §6.3): early-return on first non-strictly-increasing step, then ±10% of median delta (skipped when `Coverages.Count < 3`) |
| `S111-R-3.1` | Warning | `SurfaceCurrentDepth ∈ [0, 1500]` m **when present** |
| `S111-R-3.2` | Warning | `TypeOfCurrentData ∈ {1..6}` **when present** |
| `S111-R-4.1` | Warning | Non-NODATA speeds ∈ `[0, 15]` m/s (converts S-111 knots → m/s on the fly via `0.5144444`) |
| `S111-R-4.2` | Error   | Non-NODATA directions ∈ half-open `[0, 360)` — `360.0` is invalid (must wrap to `0`) |
| `S111-PROJ-SCHEMA`     | Error | Surrogate emitted by the processor on `S100DatasetSchemaException` |
| `S111-PROJ-UNSUPPORTED`| Error | Surrogate emitted by the processor on `S100DatasetNotSupportedException` **and** proactively when the reader produced a station-series variant (dcf 3 / dcf 8) |

## `GroupPath` plumbing

Additive, non-breaking, only on `SurfaceCurrentCoverage`:

- `SurfaceCurrentCoverage.GroupPath { get; init; }` — nullable string
- `S111DatasetReader.ReadInstance` populates it from the iterated HDF5 instance path (e.g. `/SurfaceCurrent/SurfaceCurrent.01`), exactly as V-2 did for `WaterLevelCoverage`
- Per-coverage findings carry `RelatedFeatureId = GroupPath`
- Per-time-step findings append `#timePoint` (design §4.3)
- Other S-111 coverage / value types are **not** touched

## Processor dispatch (`S111DatasetProcessor.Validate()`)

Three-way dispatch off the `S111DatasetData` discriminated union, cached via `_validationReport` / `_validationCached` exactly like V-2:

- `GriddedCoverage` (dcf 2) → run `S111SurfaceCurrentRules.Default.Run(dataset)` inside try/catch for both reader exception types (`S100DatasetSchemaException` → `S111-PROJ-SCHEMA`; `S100DatasetNotSupportedException` → `S111-PROJ-UNSUPPORTED`)
- `StationSeries` (dcf 3 ungeorectified grid / dcf 8 time series at fixed stations) → proactive single-finding `S111-PROJ-UNSUPPORTED` report (the V-3 rule pack targets the gridded `S111Dataset` view only — same pattern V-2 used for S-104 dcf 8)

## Tests

`tests/EncDotNet.S100.Datasets.S111.Tests/Validation/S111ValidationTests.cs` — **31 tests** (25 `[Fact]` + 6 `[Theory]` cases via `R3_2_Does_Not_Fire_For_Each_Enumerated_Value`). Mirrors V-2's coverage density. No real HDF5 dependency. Covers: clean-dataset green; per-rule pass/fail; R-2.1 monotonicity early-return + cadence + skip-when-<3; R-3.1 / R-3.2 skip-null + boundary; R-4.1 knots→m/s boundary + NODATA/NaN/±Inf skip; R-4.2 half-open `360.0` invalid; multi-coverage `GroupPath` propagation; fallback to `/SurfaceCurrent` when `GroupPath` is null.

## Build / test status

- `dotnet build` — clean (one pre-existing CS8602 warning at S111DatasetProcessor.cs:414 unrelated to V-3; pre-existing viewer warnings in `SplitterPersistence.cs` and `LatLonFormatterTests.cs`)
- `dotnet test --configuration Release` — all green across the full solution. The previously flagged `VectorPipeline_emits_xslt_transform_span` is also passing on this branch (Pipelines.Tests: **389/389**)
- S-111 tests: **31/31** pass

## Out of scope (explicit)

- No edits to `docs/design/non-gml-validation.md`, the validation framework (`src/EncDotNet.S100.Core/Validation/`), `ConcatReports`, S-101 / S-102 / S-104 / S-57 code, the viewer, MCP, the portrayal catalogue, or `ICoverageSource`
- `GroupPath` added **only** to `SurfaceCurrentCoverage`; not propagated to other coverage types
- No new dependencies, no central package version bumps
- No real S-111 fixture files added (rules are exercised against synthetic in-memory `S111Dataset` instances)
- Station-series rule pack is deliberately not in scope — the dcf 3 / dcf 8 path goes directly to `S111-PROJ-UNSUPPORTED`