### PR TITLE
S-101 validation pack (V-4) + spec-aligned façade

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -38,6 +38,7 @@
     <Project Path="tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.VisualRegression.Tests/EncDotNet.S100.VisualRegression.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.VisualRegression/EncDotNet.S100.VisualRegression.csproj" />
+    <Project Path="tests/EncDotNet.S100.Datasets.S101.Tests/EncDotNet.S100.Datasets.S101.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S104.Tests/EncDotNet.S100.Datasets.S104.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S111.Tests/EncDotNet.S100.Datasets.S111.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S122.Tests/EncDotNet.S100.Datasets.S122.Tests.csproj" />

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S101.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
@@ -12,6 +13,7 @@ using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting;
+using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 
@@ -29,6 +31,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
     private Dictionary<long, EncDotNet.S100.Pipelines.Vector.Feature>? _featureIndex;
     private FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public SpecRef Spec => new("S-101", default);
 
@@ -310,6 +314,44 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             _decoder = _featureCatalogueManager.GetDecoder("S-101");
             _decoderLoaded = true;
         }
+    }
+
+    /// <summary>
+    /// Runs the V-4 S-101 validation rule pack
+    /// (<see cref="S101DatasetRules.Default"/>) against the parsed
+    /// document, returning the resulting <see cref="ValidationReport"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implements the processor integration shape defined by
+    /// <c>docs/design/non-gml-validation.md</c> §9.3: the document is
+    /// projected through the spec-vocabulary
+    /// <see cref="S101DatasetView"/> façade (design §3.1, option (b))
+    /// using the bundled <see cref="FeatureCatalogueDecoder"/> for
+    /// FC-conformance rules, then handed to the cached default rule
+    /// set. The report is cached on first call; subsequent calls
+    /// return the same instance (design §9.4).
+    /// </para>
+    /// <para>
+    /// When no S-101 Feature Catalogue is available the façade is
+    /// built without a decoder; rules requiring catalogue lookup
+    /// (<c>S101-R-1.2</c>, <c>S101-R-4.1</c>) degrade to no-ops per
+    /// design §8.1. Reader-level parse failures occur in the
+    /// constructor and never reach this method; the
+    /// <c>S101-PROJ-PARSE</c> rule is a documented placeholder for
+    /// future reader diagnostics (design §5.2 Stance A).
+    /// </para>
+    /// </remarks>
+    public ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            EnsureDecoder();
+            var view = S101DatasetView.From(_dataset.Document, _decoder);
+            _validationReport = S101DatasetRules.Default.Run(view);
+            _validationCached = true;
+        }
+        return _validationReport;
     }
 
     private FeatureInfo BuildFeatureInfo(EncDotNet.S100.Pipelines.Vector.Feature feature)

--- a/src/EncDotNet.S100.Datasets.S101/Validation/S101AttributeView.cs
+++ b/src/EncDotNet.S100.Datasets.S101/Validation/S101AttributeView.cs
@@ -1,0 +1,53 @@
+namespace EncDotNet.S100.Datasets.S101.Validation;
+
+/// <summary>
+/// A spec-vocabulary view over a single <see cref="S101Attribute"/> row
+/// of a feature or information record.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implements the façade contract described in
+/// <c>docs/design/non-gml-validation.md</c> §3.1 (input model option (b),
+/// "thin spec-aligned façade"). Rule authors read attribute acronyms
+/// (e.g. <c>"DRVAL1"</c>) and string values; numeric-code-to-acronym
+/// resolution against <see cref="S101Document.AttributeTypeCatalogue"/>
+/// happens once at façade construction, not in rule bodies.
+/// </para>
+/// <para>
+/// A view with a <c>null</c> <see cref="Acronym"/> represents an
+/// attribute whose numeric code did not resolve against the dataset's
+/// embedded attribute catalogue — this is the failure mode reported by
+/// <c>S101-R-1.2</c>. The raw <see cref="NumericCode"/> remains
+/// available so the finding can cite it.
+/// </para>
+/// </remarks>
+public sealed class S101AttributeView
+{
+    /// <summary>
+    /// Attribute acronym resolved through the dataset's
+    /// <see cref="S101Document.AttributeTypeCatalogue"/> — for example
+    /// <c>"DRVAL1"</c> or <c>"OBJNAM"</c>. <c>null</c> when the numeric
+    /// code is not present in the catalogue.
+    /// </summary>
+    public string? Acronym { get; init; }
+
+    /// <summary>The raw numeric attribute code from the ATTR field (FRID record).</summary>
+    public ushort NumericCode { get; init; }
+
+    /// <summary>
+    /// Sequence index within a complex-attribute instance. The marker
+    /// row uses <c>1</c>; subsequent sub-rows belonging to the same
+    /// complex-attribute instance carry monotonically increasing
+    /// indices. Simple attributes always carry <c>1</c>.
+    /// </summary>
+    public ushort Index { get; init; }
+
+    /// <summary>
+    /// Attribute value as a string. Numeric and enumerated values are
+    /// stringified by the parser. The empty string is preserved as
+    /// <see cref="string.Empty"/> so rules can distinguish "set but
+    /// empty" from "absent". <c>null</c> only when the parser produced
+    /// no value at all.
+    /// </summary>
+    public string? Value { get; init; }
+}

--- a/src/EncDotNet.S100.Datasets.S101/Validation/S101DatasetRules.cs
+++ b/src/EncDotNet.S100.Datasets.S101/Validation/S101DatasetRules.cs
@@ -1,0 +1,764 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Validation;
+
+namespace EncDotNet.S100.Datasets.S101.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of normative rules
+/// for an S-101 dataset, evaluated through the spec-vocabulary
+/// <see cref="S101DatasetView"/> façade. Rule identifiers follow
+/// <c>S101-R-{clause}</c> for normative rules and
+/// <c>S101-PROJ-{kind}</c> for projection-diagnostic surrogates.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the V-4 rule pack as defined in
+/// <c>docs/design/non-gml-validation.md</c> §6.4. The pack reads from
+/// the thin façade introduced in the same PR (input model option (b),
+/// design §3.1); rules cite the relevant spec clause and the
+/// <c>s101-enc</c> skill review checklist item they implement.
+/// </para>
+/// <para>
+/// Per-finding payload conventions follow design §4.3:
+/// <list type="bullet">
+/// <item><description>S-101 feature findings — <c>RelatedFeatureId = "{agency}:{FIDN}.{FIDS}"</c></description></item>
+/// <item><description>Spatial record findings — <c>RelatedFeatureId = "surf:{RCID}"</c> / <c>"curve:{RCID}"</c> / <c>"point:{RCID}"</c></description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class S101DatasetRules
+{
+    /// <summary>
+    /// <c>S101-R-1.1</c> — Every feature record's
+    /// <see cref="S101FeatureRecord.FeatureTypeCode"/> must resolve to
+    /// a Feature Catalogue acronym through the dataset's embedded
+    /// <see cref="S101Document.FeatureTypeCatalogue"/>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-101 Edition 1.2.0 §6 (Encoding) and S-100
+    /// Part 10a §4.3 — the FRID record's feature type code is a
+    /// numeric reference into the embedded feature-type catalogue.
+    /// Implements the <c>s101-enc</c> skill review checklist item
+    /// "feature type code resolves to FC acronym".
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> FeatureTypeResolves { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-1.1")
+            .WithDescription("Every feature record's feature type code must resolve to an FC acronym.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>();
+                foreach (var f in view.UnresolvedFeatures)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S101-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Feature (RCID {f.Raw.RecordId}) has feature type code " +
+                            $"{f.Raw.FeatureTypeCode} which is not declared in the dataset's " +
+                            "feature type catalogue.",
+                        DatasetId = datasetId,
+                        RelatedFeatureId = f.FoidKey,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-1.2</c> — Every attribute on every feature must
+    /// resolve through <see cref="S101Document.AttributeTypeCatalogue"/>
+    /// AND its acronym must be a permitted attribute of the host
+    /// feature class per the Feature Catalogue (including inherited
+    /// bindings from any super-type chain).
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-101 Edition 1.2.0 §6, S-100 Part 5 (ISO
+    /// 19110) — feature-type attribute bindings define the set of
+    /// attributes a feature instance may carry. Implements the
+    /// <c>s101-enc</c> skill review checklist items "attribute codes
+    /// resolve" and "attribute bindings match FC for feature class".
+    /// Degrades to a no-op when no <see cref="FeatureCatalogueDecoder"/>
+    /// is available (the decoder lookup returned <c>null</c>).
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> AttributeBindingsValid { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-1.2")
+            .WithDescription("Every attribute's numeric code must resolve and its acronym must be a permitted attribute of the host feature class.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((view, _) =>
+            {
+                var findings = new List<ValidationFinding>();
+                var datasetId = view.Raw.Identification.DatasetName;
+
+                foreach (var f in view.Features)
+                {
+                    foreach (var a in f.Attributes)
+                    {
+                        if (a.Acronym is null)
+                        {
+                            findings.Add(new ValidationFinding
+                            {
+                                RuleId = "S101-R-1.2",
+                                Severity = ValidationSeverity.Error,
+                                Message = $"Feature '{f.FeatureTypeAcronym ?? f.Raw.FeatureTypeCode.ToString(CultureInfo.InvariantCulture)}' " +
+                                    $"(RCID {f.Raw.RecordId}) carries attribute code {a.NumericCode} " +
+                                    "which is not declared in the dataset's attribute type catalogue.",
+                                DatasetId = datasetId,
+                                RelatedFeatureId = f.FoidKey,
+                            });
+                        }
+                    }
+
+                    if (view.Decoder is null || f.FeatureTypeAcronym is null)
+                        continue;
+
+                    var permitted = CollectPermittedAttributes(view.Decoder, f.FeatureTypeAcronym);
+                    if (permitted is null)
+                        continue; // Unknown feature class; R-1.1 already fires.
+
+                    foreach (var a in f.Attributes)
+                    {
+                        if (a.Acronym is null) continue;
+                        if (permitted.Contains(a.Acronym)) continue;
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S101-R-1.2",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"Feature '{f.FeatureTypeAcronym}' (RCID {f.Raw.RecordId}) carries " +
+                                $"attribute '{a.Acronym}' which is not bound to that feature class in the " +
+                                "S-101 Feature Catalogue.",
+                            DatasetId = datasetId,
+                            RelatedFeatureId = f.FoidKey,
+                        });
+                    }
+                }
+
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-2.1</c> — Feature Object Identifier (FOID) triples
+    /// (<c>producingAgency</c>, <c>FIDN</c>, <c>FIDS</c>) must be
+    /// unique across <see cref="S101DatasetView.Features"/>. Each
+    /// duplicate occurrence emits one finding; the first occurrence
+    /// is the anchor and is not flagged.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-101 Edition 1.2.0 §6 / S-100 Part 10a §4.3.2
+    /// — the FOID composite key uniquely identifies a feature
+    /// instance within an exchange set. Implements the design
+    /// note §8.4 ("FOID uniqueness — one finding per duplicate;
+    /// first occurrence is the anchor") and the <c>s101-enc</c>
+    /// skill review checklist item "FOID uniqueness".
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> FoidUniqueness { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-2.1")
+            .WithDescription("Feature Object Identifier triples must be unique within the dataset.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var anchors = new Dictionary<string, S101FeatureView>(StringComparer.Ordinal);
+                var findings = new List<ValidationFinding>();
+                foreach (var f in view.Features)
+                {
+                    var key = f.FoidKey;
+                    if (anchors.TryGetValue(key, out var anchor))
+                    {
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S101-R-2.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"Duplicate FOID '{key}': feature RCID {f.Raw.RecordId} repeats the " +
+                                $"identifier first used by feature RCID {anchor.Raw.RecordId}.",
+                            DatasetId = datasetId,
+                            RelatedFeatureId = key,
+                        });
+                    }
+                    else
+                    {
+                        anchors[key] = f;
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-3.1</c> — Every spatial association on every feature
+    /// must reference a record present in the matching
+    /// <c>(RecordName, RecordId)</c> dictionary of the document.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10a §4.3.3 — the SPAS field carries
+    /// (RCNM, RCID, orientation) tuples that must resolve to a point
+    /// (110), multipoint (115), curve (120), composite curve (125),
+    /// or surface (130) record present in the same dataset.
+    /// Implements the <c>s101-enc</c> skill review checklist item
+    /// "spatial association referential integrity".
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> SpatialAssociationsResolve { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-3.1")
+            .WithDescription("Every spatial association must reference an existing spatial record.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>();
+                foreach (var f in view.Features)
+                {
+                    foreach (var sa in f.SpatialAssociations)
+                    {
+                        if (view.TryGetSpatial(sa, out var _record)) continue;
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S101-R-3.1",
+                            Severity = ValidationSeverity.Error,
+                            Message = $"Feature '{f.FeatureTypeAcronym ?? f.Raw.FeatureTypeCode.ToString(CultureInfo.InvariantCulture)}' " +
+                                $"(RCID {f.Raw.RecordId}) references spatial record " +
+                                $"(RCNM={sa.RecordName}, RCID={sa.RecordId}) which is not present in the dataset.",
+                            DatasetId = datasetId,
+                            RelatedFeatureId = f.FoidKey,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-3.2</c> — Every surface record's rings (exterior and
+    /// interior) must be closed and contain at least three distinct
+    /// vertices. A ring is closed when its constituent curves form a
+    /// cycle (end of the last curve equals start of the first); a
+    /// degenerate ring (fewer than three distinct points) is reported
+    /// regardless of closure per the design note §8.2.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10a §4.3.3 (Surface records) and
+    /// ISO 19107 — a polygon boundary is a closed simple ring.
+    /// Implements the <c>s101-enc</c> skill review checklist item
+    /// "surface ring closure".
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> SurfaceRingsClosed { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-3.2")
+            .WithDescription("Surface rings must be closed and contain at least three distinct vertices.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>();
+                foreach (var surface in view.Raw.Surfaces.Values)
+                {
+                    EvaluateSurface(view, surface, datasetId, findings);
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-3.3</c> — Composite curve continuity: when iterating
+    /// a composite curve's component curves in their declared order
+    /// (and honouring per-component orientation), the end point of
+    /// each curve segment must equal the start point of the next.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10a §4.3.3 (Composite curve
+    /// records) and ISO 19107 — a composite curve is a connected
+    /// sequence of curve segments.
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> CompositeCurveContinuity { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-3.3")
+            .WithDescription("Composite curve component endpoints must be continuous.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>();
+                foreach (var composite in view.Raw.CompositeCurves.Values)
+                {
+                    EvaluateComposite(view, composite, datasetId, findings);
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-4.1</c> — Enumerated simple-attribute values must be
+    /// one of the listed values declared for that attribute by the
+    /// Feature Catalogue. Issued as a warning because authoring tools
+    /// sometimes carry out-of-domain codes that are nonetheless
+    /// renderable.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 5 (ISO 19110) — listed-value
+    /// attributes constrain values to a closed code list.
+    /// Implements the <c>s101-enc</c> skill review checklist item
+    /// "enumerated attribute domain conformance". Degrades to a
+    /// no-op when no decoder is available.
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> EnumeratedAttributeDomain { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-4.1")
+            .WithDescription("Enumerated attribute values must be one of the listed values declared by the Feature Catalogue.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((view, _) =>
+            {
+                if (view.Decoder is null) return Array.Empty<ValidationFinding>();
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>();
+                foreach (var f in view.Features)
+                {
+                    foreach (var a in f.Attributes)
+                    {
+                        if (a.Acronym is null) continue;
+                        if (string.IsNullOrEmpty(a.Value)) continue;
+                        if (!view.Decoder.IsEnumeratedAttribute(a.Acronym)) continue;
+                        if (view.Decoder.ResolveListedValue(a.Acronym, a.Value) is not null) continue;
+
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S101-R-4.1",
+                            Severity = ValidationSeverity.Warning,
+                            Message = $"Feature '{f.FeatureTypeAcronym ?? "?"}' (RCID {f.Raw.RecordId}) " +
+                                $"attribute '{a.Acronym}' value '{a.Value}' is not a listed value of the " +
+                                "S-101 Feature Catalogue.",
+                            DatasetId = datasetId,
+                            RelatedFeatureId = f.FoidKey,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-5.1</c> — Every resolved coordinate (latitude /
+    /// longitude after applying the dataset's coordinate
+    /// multiplication factors) on every point, multi-point,
+    /// curve-segment intermediate coordinate, and composite-curve
+    /// vertex must lie within the WGS-84 bounds: latitude in
+    /// <c>[-90, 90]</c>, longitude in <c>[-180, 180]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10b §6.2 (geographic coordinates
+    /// for <c>EPSG:4326</c>) — the same bounds the GML packs apply.
+    /// Issued as a warning because some chart compilers permit
+    /// dateline-crossing geometry whose normalised form falls
+    /// slightly outside the canonical range.
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> CoordinatesInWgs84Range { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-5.1")
+            .WithDescription("Resolved coordinates must lie within the WGS-84 latitude/longitude ranges.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var (cmfX, cmfY) = EffectiveCmf(view.Raw.StructureInfo);
+                var findings = new List<ValidationFinding>();
+
+                foreach (var p in view.Raw.Points.Values)
+                {
+                    var (lat, lon) = ToLatLon(p.Y, p.X, cmfY, cmfX);
+                    EmitIfOutOfRange(findings, datasetId, $"point:{p.RecordId}", "Point", lat, lon);
+                }
+                foreach (var mp in view.Raw.MultiPoints.Values)
+                {
+                    foreach (var pt in mp.Points)
+                    {
+                        var (lat, lon) = ToLatLon(pt.Y, pt.X, cmfY, cmfX);
+                        EmitIfOutOfRange(findings, datasetId, $"multipoint:{mp.RecordId}", "MultiPoint", lat, lon);
+                    }
+                }
+                foreach (var cs in view.Raw.CurveSegments.Values)
+                {
+                    foreach (var ic in cs.IntermediateCoordinates)
+                    {
+                        var (lat, lon) = ToLatLon(ic.Y, ic.X, cmfY, cmfX);
+                        EmitIfOutOfRange(findings, datasetId, $"curve:{cs.RecordId}", "CurveSegment", lat, lon);
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-R-5.2</c> — Every information association on every
+    /// feature must reference an information-type record present in
+    /// <see cref="S101Document.InformationTypes"/>. Issued as a
+    /// warning because unresolved information associations degrade
+    /// gracefully (the feature still renders) but lose the linked
+    /// information content.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: S-100 Part 10a §4.3.3 (INAS field on feature
+    /// records) — the association references an information record
+    /// by RCID. Implements the <c>s101-enc</c> skill review checklist
+    /// item "information association referential integrity".
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> InformationAssociationsResolve { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-R-5.2")
+            .WithDescription("Information associations must reference an existing information-type record.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((view, _) =>
+            {
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>();
+                foreach (var f in view.Features)
+                {
+                    foreach (var ia in f.InformationAssociations)
+                    {
+                        if (view.Raw.InformationTypes.ContainsKey(ia.RecordId)) continue;
+                        findings.Add(new ValidationFinding
+                        {
+                            RuleId = "S101-R-5.2",
+                            Severity = ValidationSeverity.Warning,
+                            Message = $"Feature '{f.FeatureTypeAcronym ?? "?"}' (RCID {f.Raw.RecordId}) " +
+                                $"references information record RCID {ia.RecordId} which is not present in " +
+                                "the dataset.",
+                            DatasetId = datasetId,
+                            RelatedFeatureId = f.FoidKey,
+                        });
+                    }
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S101-PROJ-PARSE</c> — Placeholder for parser warnings
+    /// emitted by <see cref="S101DocumentReader"/>. The rule body is
+    /// intentionally empty in v1; this entry commits the rule-id
+    /// namespace so a future change that surfaces non-fatal reader
+    /// diagnostics can populate findings without breaking
+    /// downstream consumers.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: design note §5.2 (Stance A) — the reader does
+    /// not yet surface non-fatal warnings; promoting Stance B is a
+    /// separate PR. Until then the rule reads
+    /// <see cref="S101DatasetView.Diagnostics"/> (always empty) and
+    /// emits one warning per diagnostic.
+    /// </remarks>
+    public static IValidationRule<S101DatasetView> ParserDiagnosticPlaceholder { get; } =
+        ValidationRuleBuilder.RuleFor<S101DatasetView>("S101-PROJ-PARSE")
+            .WithDescription("S-101 parser warnings (placeholder for future reader diagnostics surface).")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((view, _) =>
+            {
+                if (view.Diagnostics.Count == 0) return Array.Empty<ValidationFinding>();
+                var datasetId = view.Raw.Identification.DatasetName;
+                var findings = new List<ValidationFinding>(view.Diagnostics.Count);
+                foreach (var d in view.Diagnostics)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S101-PROJ-PARSE",
+                        Severity = ValidationSeverity.Warning,
+                        Message = $"[{d.Code}] {d.Message}",
+                        DatasetId = datasetId,
+                    });
+                }
+                return findings;
+            })
+            .Build();
+
+    /// <summary>The canonical default rule set for S-101 datasets.</summary>
+    public static ValidationRuleSet<S101DatasetView> Default { get; } = new(
+        FeatureTypeResolves,
+        AttributeBindingsValid,
+        FoidUniqueness,
+        SpatialAssociationsResolve,
+        SurfaceRingsClosed,
+        CompositeCurveContinuity,
+        EnumeratedAttributeDomain,
+        CoordinatesInWgs84Range,
+        InformationAssociationsResolve,
+        ParserDiagnosticPlaceholder);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S101DatasetView view, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+        return Default.Run(view, context);
+    }
+
+    // ----- helpers -----
+
+    /// <summary>
+    /// Collects the set of attribute acronyms permitted on a feature
+    /// class, walking the super-type chain to gather inherited
+    /// bindings. Returns <c>null</c> when the feature class itself
+    /// is not present in the catalogue (so R-1.1 owns the report).
+    /// </summary>
+    private static HashSet<string>? CollectPermittedAttributes(FeatureCatalogueDecoder decoder, string acronym)
+    {
+        var fc = decoder.Catalogue;
+        var byCode = new Dictionary<string, FeatureType>(StringComparer.OrdinalIgnoreCase);
+        foreach (var ft in fc.FeatureTypes) byCode[ft.Code] = ft;
+        if (!byCode.TryGetValue(acronym, out var current))
+            return null;
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var permitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (current is not null && seen.Add(current.Code))
+        {
+            foreach (var binding in current.AttributeBindings)
+            {
+                if (!string.IsNullOrEmpty(binding.AttributeRef))
+                    permitted.Add(binding.AttributeRef);
+            }
+            if (string.IsNullOrEmpty(current.SuperType)) break;
+            byCode.TryGetValue(current.SuperType, out current);
+        }
+        return permitted;
+    }
+
+    private static (uint cmfX, uint cmfY) EffectiveCmf(S101DatasetStructureInfo si)
+    {
+        // S-100 Part 10a §4.3.1 — CMF defaults to 10^7 when the DSSI
+        // value is zero (i.e. unset).
+        var cmfX = si.CoordinateMultiplicationFactorX == 0 ? 10_000_000u : si.CoordinateMultiplicationFactorX;
+        var cmfY = si.CoordinateMultiplicationFactorY == 0 ? 10_000_000u : si.CoordinateMultiplicationFactorY;
+        return (cmfX, cmfY);
+    }
+
+    private static (double lat, double lon) ToLatLon(int y, int x, uint cmfY, uint cmfX)
+        => ((double)y / cmfY, (double)x / cmfX);
+
+    private static void EmitIfOutOfRange(
+        List<ValidationFinding> sink, string? datasetId, string relatedId, string kind, double lat, double lon)
+    {
+        bool latOk = lat is >= -90 and <= 90;
+        bool lonOk = lon is >= -180 and <= 180;
+        if (latOk && lonOk) return;
+        sink.Add(new ValidationFinding
+        {
+            RuleId = "S101-R-5.1",
+            Severity = ValidationSeverity.Warning,
+            Message = $"{kind} (RCID from {relatedId}) coordinate (lat={lat}, lon={lon}) is outside the WGS-84 range.",
+            Point = new GeoPosition(Latitude: lat, Longitude: lon),
+            DatasetId = datasetId,
+            RelatedFeatureId = relatedId,
+        });
+    }
+
+    private static void EvaluateSurface(
+        S101DatasetView view,
+        S101SurfaceRecord surface,
+        string? datasetId,
+        List<ValidationFinding> findings)
+    {
+        var relatedId = $"surf:{surface.RecordId}";
+        var (cmfX, cmfY) = EffectiveCmf(view.Raw.StructureInfo);
+
+        var rings = GroupRings(surface);
+        foreach (var ring in rings)
+        {
+            var pts = ResolveRingPoints(view, surface, ring, cmfX, cmfY, datasetId, relatedId, findings);
+            if (pts is null) continue;
+
+            var distinct = CountDistinct(pts);
+            if (distinct < 3)
+            {
+                findings.Add(new ValidationFinding
+                {
+                    RuleId = "S101-R-3.2",
+                    Severity = ValidationSeverity.Error,
+                    Message = $"Surface (RCID {surface.RecordId}) ring has only {distinct} distinct vertex/vertices; " +
+                        "a ring requires at least three.",
+                    DatasetId = datasetId,
+                    RelatedFeatureId = relatedId,
+                });
+                continue;
+            }
+
+            var first = pts[0];
+            var last = pts[^1];
+            if (Math.Abs(first.X - last.X) > 0 || Math.Abs(first.Y - last.Y) > 0)
+            {
+                findings.Add(new ValidationFinding
+                {
+                    RuleId = "S101-R-3.2",
+                    Severity = ValidationSeverity.Error,
+                    Message = $"Surface (RCID {surface.RecordId}) ring is not closed: first vertex " +
+                        $"({first.Y}, {first.X}) ≠ last vertex ({last.Y}, {last.X}).",
+                    DatasetId = datasetId,
+                    RelatedFeatureId = relatedId,
+                });
+            }
+        }
+    }
+
+    private static List<List<S101RingAssociation>> GroupRings(S101SurfaceRecord surface)
+    {
+        // RIAS lists ring associations consecutively, exterior (USAG=1)
+        // first followed by interior (USAG=2) rings; each ring is a
+        // contiguous run sharing the same Usage value. We don't have
+        // an explicit per-ring delimiter so the simplest grouping is
+        // "split whenever Usage transitions from 1 → 2"; multiple
+        // interior rings (USAG=2) belonging to the same surface would
+        // be encoded by repeated curves in the same run. For ring
+        // closure analysis we evaluate the whole run as one boundary
+        // path — sufficient for v1.
+        var groups = new List<List<S101RingAssociation>>();
+        List<S101RingAssociation>? current = null;
+        byte previousUsage = 0;
+        foreach (var ra in surface.RingAssociations)
+        {
+            if (current is null || ra.Usage != previousUsage)
+            {
+                current = new List<S101RingAssociation>();
+                groups.Add(current);
+                previousUsage = ra.Usage;
+            }
+            current.Add(ra);
+        }
+        return groups;
+    }
+
+    private static List<(int Y, int X)>? ResolveRingPoints(
+        S101DatasetView view,
+        S101SurfaceRecord surface,
+        List<S101RingAssociation> ring,
+        uint cmfX,
+        uint cmfY,
+        string? datasetId,
+        string relatedId,
+        List<ValidationFinding> findings)
+    {
+        var pts = new List<(int Y, int X)>();
+        foreach (var ra in ring)
+        {
+            var curve = ResolveCurveSegments(view, ra.RecordName, ra.RecordId);
+            if (curve is null)
+            {
+                // Dangling spatial reference — R-3.1 owns this finding;
+                // skip the ring entirely to avoid a duplicate report.
+                return null;
+            }
+            AppendCurvePoints(view, curve, ra.Orientation == 2, pts);
+        }
+        _ = (cmfX, cmfY, datasetId, relatedId, findings);
+        return pts;
+    }
+
+    private static IReadOnlyList<S101CurveSegmentRecord>? ResolveCurveSegments(
+        S101DatasetView view, byte recordName, uint recordId)
+    {
+        // A ring component is either a curve (RCNM=120) or a composite
+        // curve (RCNM=125). For composite curves, recursively gather
+        // the underlying curve segments in declared order.
+        if (recordName == 120)
+        {
+            return view.Raw.CurveSegments.TryGetValue(recordId, out var c)
+                ? new[] { c }
+                : null;
+        }
+        if (recordName == 125)
+        {
+            if (!view.Raw.CompositeCurves.TryGetValue(recordId, out var composite)) return null;
+            var list = new List<S101CurveSegmentRecord>();
+            foreach (var cu in composite.CurveComponents)
+            {
+                if (!view.Raw.CurveSegments.TryGetValue(cu.RecordId, out var c)) return null;
+                list.Add(c);
+            }
+            return list;
+        }
+        return null;
+    }
+
+    private static void AppendCurvePoints(
+        S101DatasetView view,
+        IReadOnlyList<S101CurveSegmentRecord> segments,
+        bool reverseRing,
+        List<(int Y, int X)> sink)
+    {
+        // We walk each curve segment in begin→end order and append
+        // begin point, intermediate coordinates, and end point. Per-
+        // segment orientation (forward/reverse) is encoded at the
+        // ring level; for v1 we honour the ring orientation by
+        // reversing the final point sequence if requested. The
+        // segment-level orientation flag is not surfaced through
+        // S101RingAssociation, so segment-level reversal is left to
+        // a v-next refinement.
+        foreach (var seg in segments)
+        {
+            (int Y, int X)? begin = null, end = null;
+            foreach (var pa in seg.PointAssociations)
+            {
+                if (!view.Raw.Points.TryGetValue(pa.RecordId, out var p)) continue;
+                if (pa.Topology == 1) begin = (p.Y, p.X);
+                else if (pa.Topology == 2) end = (p.Y, p.X);
+            }
+            if (begin is { } b) sink.Add(b);
+            foreach (var ic in seg.IntermediateCoordinates) sink.Add((ic.Y, ic.X));
+            if (end is { } e) sink.Add(e);
+        }
+        if (reverseRing) sink.Reverse();
+    }
+
+    private static int CountDistinct(List<(int Y, int X)> pts)
+    {
+        var set = new HashSet<(int, int)>();
+        foreach (var p in pts) set.Add(p);
+        return set.Count;
+    }
+
+    private static void EvaluateComposite(
+        S101DatasetView view,
+        S101CompositeCurveRecord composite,
+        string? datasetId,
+        List<ValidationFinding> findings)
+    {
+        var relatedId = $"composite:{composite.RecordId}";
+        (int Y, int X)? previousEnd = null;
+        int index = 0;
+        foreach (var cu in composite.CurveComponents)
+        {
+            if (!view.Raw.CurveSegments.TryGetValue(cu.RecordId, out var seg))
+            {
+                // R-3.1 handles dangling references; skip continuity
+                // analysis for this composite.
+                return;
+            }
+            (int Y, int X)? begin = null, end = null;
+            foreach (var pa in seg.PointAssociations)
+            {
+                if (!view.Raw.Points.TryGetValue(pa.RecordId, out var p)) continue;
+                if (pa.Topology == 1) begin = (p.Y, p.X);
+                else if (pa.Topology == 2) end = (p.Y, p.X);
+            }
+
+            // Honour the per-component orientation flag.
+            if (cu.Orientation == 2) (begin, end) = (end, begin);
+
+            if (previousEnd is { } pe && begin is { } b && (pe.Y != b.Y || pe.X != b.X))
+            {
+                findings.Add(new ValidationFinding
+                {
+                    RuleId = "S101-R-3.3",
+                    Severity = ValidationSeverity.Error,
+                    Message = $"Composite curve (RCID {composite.RecordId}) is not continuous at " +
+                        $"component index {index}: previous endpoint ({pe.Y}, {pe.X}) ≠ next start " +
+                        $"({b.Y}, {b.X}).",
+                    DatasetId = datasetId,
+                    RelatedFeatureId = relatedId,
+                });
+            }
+            previousEnd = end;
+            index++;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S101/Validation/S101DatasetView.cs
+++ b/src/EncDotNet.S100.Datasets.S101/Validation/S101DatasetView.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using EncDotNet.S100.Features;
+
+namespace EncDotNet.S100.Datasets.S101.Validation;
+
+/// <summary>
+/// Spec-aligned façade over an <see cref="S101Document"/>, exposing
+/// feature-type acronyms, attribute acronyms, and spatial-record
+/// lookup helpers in the vocabulary used by the S-101 Feature
+/// Catalogue rather than the numeric codes of the ISO 8211 encoding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implements the input-model decision recorded in
+/// <c>docs/design/non-gml-validation.md</c> §3.1 — option (b),
+/// "thin spec-aligned façade". The façade is constructed once per
+/// dataset by <see cref="From(S101Document, FeatureCatalogueDecoder?)"/>;
+/// rule packs (e.g. <see cref="S101DatasetRules"/>) read from
+/// <see cref="Features"/>, <see cref="OfType(string)"/>, and
+/// <see cref="TryGetSpatial(S101SpatialAssociation, out object?)"/>.
+/// </para>
+/// <para>
+/// The underlying <see cref="S101Document"/> is reachable through
+/// <see cref="Raw"/> for the rare rule that needs to dive below the
+/// façade. By design (§3.1 closing paragraph) the façade does NOT
+/// expose <see cref="S101FeatureRecord"/> as part of its surface,
+/// keeping the door open for a future fully typed projection
+/// (option (d)) without breaking existing rule code.
+/// </para>
+/// </remarks>
+public sealed class S101DatasetView
+{
+    private readonly Dictionary<string, List<S101FeatureView>> _byType;
+
+    private S101DatasetView(
+        S101Document raw,
+        ImmutableArray<S101FeatureView> features,
+        ImmutableArray<S101FeatureView> unresolvedFeatures,
+        ImmutableArray<S101DiagnosticView> diagnostics,
+        FeatureCatalogueDecoder? decoder)
+    {
+        Raw = raw;
+        Features = features;
+        UnresolvedFeatures = unresolvedFeatures;
+        Diagnostics = diagnostics;
+        Decoder = decoder;
+        _byType = new Dictionary<string, List<S101FeatureView>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in features)
+        {
+            if (f.FeatureTypeAcronym is null) continue;
+            if (!_byType.TryGetValue(f.FeatureTypeAcronym, out var list))
+            {
+                list = new List<S101FeatureView>();
+                _byType[f.FeatureTypeAcronym] = list;
+            }
+            list.Add(f);
+        }
+    }
+
+    /// <summary>The underlying parsed S-101 document.</summary>
+    public S101Document Raw { get; }
+
+    /// <summary>
+    /// The bundled <see cref="FeatureCatalogueDecoder"/> the façade
+    /// was constructed with, or <c>null</c> when no catalogue was
+    /// available. Rule packs use the decoder to enumerate attribute
+    /// bindings and listed values for FC-conformance rules
+    /// (<c>S101-R-1.2</c>, <c>S101-R-4.1</c>).
+    /// </summary>
+    public FeatureCatalogueDecoder? Decoder { get; }
+
+    /// <summary>
+    /// Every feature in the document, in dataset order, including
+    /// features whose <see cref="S101FeatureView.FeatureTypeAcronym"/>
+    /// did not resolve. Use <see cref="UnresolvedFeatures"/> to
+    /// enumerate only the unresolved subset.
+    /// </summary>
+    public ImmutableArray<S101FeatureView> Features { get; }
+
+    /// <summary>
+    /// Sidecar view of every feature in the document whose feature
+    /// type code did not resolve through
+    /// <see cref="S101Document.FeatureTypeCatalogue"/>. Used by
+    /// <c>S101-R-1.1</c>.
+    /// </summary>
+    public ImmutableArray<S101FeatureView> UnresolvedFeatures { get; }
+
+    /// <summary>
+    /// Parse-time diagnostics surfaced by <see cref="S101DocumentReader"/>.
+    /// Always empty for v1 per the design note §5.2 Stance A; the
+    /// surface is present so a future reader change can populate it
+    /// without breaking the façade contract.
+    /// </summary>
+    public IReadOnlyList<S101DiagnosticView> Diagnostics { get; }
+
+    /// <summary>
+    /// Returns every resolved feature whose
+    /// <see cref="S101FeatureView.FeatureTypeAcronym"/> matches
+    /// <paramref name="acronym"/> (case-insensitive). Returns an
+    /// empty sequence when no features of that type exist.
+    /// </summary>
+    public IEnumerable<S101FeatureView> OfType(string acronym)
+    {
+        if (string.IsNullOrEmpty(acronym))
+            return Array.Empty<S101FeatureView>();
+        return _byType.TryGetValue(acronym, out var list)
+            ? list
+            : Array.Empty<S101FeatureView>();
+    }
+
+    /// <summary>
+    /// Resolves a <see cref="S101SpatialAssociation"/> into the
+    /// matching spatial record. Returns <c>true</c> with the record
+    /// boxed as <see cref="object"/> when the
+    /// <c>(RecordName, RecordId)</c> pair maps into one of the
+    /// document's spatial dictionaries (RCNM 110 = Point, 115 =
+    /// MultiPoint, 120 = Curve, 125 = CompositeCurve, 130 = Surface);
+    /// returns <c>false</c> when the reference is dangling.
+    /// </summary>
+    /// <remarks>
+    /// Surfaces are returned as <see cref="S101SurfaceRecord"/>,
+    /// composite curves as <see cref="S101CompositeCurveRecord"/>,
+    /// curves as <see cref="S101CurveSegmentRecord"/>, points as
+    /// <see cref="S101PointRecord"/>, and multi-points as
+    /// <see cref="S101MultiPointRecord"/>. Rule code that needs a
+    /// specific shape pattern-matches the returned <c>object</c>.
+    /// </remarks>
+    public bool TryGetSpatial(S101SpatialAssociation association, out object? record)
+    {
+        record = null;
+        switch (association.RecordName)
+        {
+            case 110:
+                if (Raw.Points.TryGetValue(association.RecordId, out var p))
+                {
+                    record = p; return true;
+                }
+                break;
+            case 115:
+                if (Raw.MultiPoints.TryGetValue(association.RecordId, out var mp))
+                {
+                    record = mp; return true;
+                }
+                break;
+            case 120:
+                if (Raw.CurveSegments.TryGetValue(association.RecordId, out var cs))
+                {
+                    record = cs; return true;
+                }
+                break;
+            case 125:
+                if (Raw.CompositeCurves.TryGetValue(association.RecordId, out var cc))
+                {
+                    record = cc; return true;
+                }
+                break;
+            case 130:
+                if (Raw.Surfaces.TryGetValue(association.RecordId, out var s))
+                {
+                    record = s; return true;
+                }
+                break;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the canonical <c>RelatedFeatureId</c> string for a
+    /// spatial association per design §4.3 — e.g. <c>"surf:42"</c>,
+    /// <c>"curve:17"</c>, <c>"point:9"</c>. Includes the tagged
+    /// prefix so RCIDs (which are NOT unique across record-name
+    /// buckets) remain disambiguated.
+    /// </summary>
+    public static string SpatialRelatedId(S101SpatialAssociation association)
+    {
+        var prefix = association.RecordName switch
+        {
+            110 => "point",
+            115 => "multipoint",
+            120 => "curve",
+            125 => "composite",
+            130 => "surf",
+            _ => $"rcnm{association.RecordName}",
+        };
+        return $"{prefix}:{association.RecordId}";
+    }
+
+    /// <summary>
+    /// Builds a façade for the supplied document, resolving every
+    /// feature's type code and attribute codes once against the
+    /// embedded catalogues. The <paramref name="decoder"/> is
+    /// retained for FC-conformance rules; pass <c>null</c> when no
+    /// Feature Catalogue is available (in which case
+    /// <c>S101-R-1.2</c> and <c>S101-R-4.1</c> degrade to no-ops).
+    /// </summary>
+    /// <param name="document">The parsed S-101 document.</param>
+    /// <param name="decoder">
+    /// The bundled <see cref="FeatureCatalogueDecoder"/> for S-101,
+    /// or <c>null</c> when validation runs without a catalogue.
+    /// </param>
+    public static S101DatasetView From(S101Document document, FeatureCatalogueDecoder? decoder)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var featuresBuilder = ImmutableArray.CreateBuilder<S101FeatureView>(document.Features.Length);
+        var unresolvedBuilder = ImmutableArray.CreateBuilder<S101FeatureView>();
+        var attrCatalogue = document.AttributeTypeCatalogue;
+
+        foreach (var record in document.Features)
+        {
+            document.FeatureTypeCatalogue.TryGetValue(record.FeatureTypeCode, out var typeAcronym);
+
+            var attributeBuilder = ImmutableArray.CreateBuilder<S101AttributeView>(record.Attributes.Length);
+            foreach (var attr in record.Attributes)
+            {
+                attrCatalogue.TryGetValue(attr.NumericCode, out var acronym);
+                attributeBuilder.Add(new S101AttributeView
+                {
+                    Acronym = acronym,
+                    NumericCode = attr.NumericCode,
+                    Index = attr.Index,
+                    Value = attr.Value,
+                });
+            }
+
+            var view = new S101FeatureView(record, typeAcronym, attributeBuilder.ToImmutable(), attrCatalogue);
+            featuresBuilder.Add(view);
+            if (typeAcronym is null)
+                unresolvedBuilder.Add(view);
+        }
+
+        return new S101DatasetView(
+            document,
+            featuresBuilder.MoveToImmutable(),
+            unresolvedBuilder.ToImmutable(),
+            ImmutableArray<S101DiagnosticView>.Empty,
+            decoder);
+    }
+}
+
+/// <summary>
+/// A parse-time diagnostic surfaced by the S-101 reader. Present as
+/// part of the façade contract so the <c>S101-PROJ-PARSE</c> rule
+/// (design §5.2) has a stable shape to iterate; always empty in v1
+/// per the Stance A decision documented in the design note.
+/// </summary>
+/// <remarks>
+/// Promote to a non-empty surface only once
+/// <see cref="S101DocumentReader"/> is changed to emit warnings
+/// alongside the parsed document (Stance B).
+/// </remarks>
+public sealed class S101DiagnosticView
+{
+    /// <summary>A stable, machine-readable code identifying the diagnostic.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Human-readable description of the diagnostic.</summary>
+    public required string Message { get; init; }
+}

--- a/src/EncDotNet.S100.Datasets.S101/Validation/S101FeatureView.cs
+++ b/src/EncDotNet.S100.Datasets.S101/Validation/S101FeatureView.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Datasets.S101.Validation;
+
+/// <summary>
+/// A spec-vocabulary view over a single <see cref="S101FeatureRecord"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implements the façade contract described in
+/// <c>docs/design/non-gml-validation.md</c> §3.1 (input model option (b)).
+/// Rules read feature-type acronyms and attribute acronyms; the
+/// raw record (with numeric codes, complex-attribute marker rows,
+/// spatial-record references, etc.) is reachable through the
+/// underlying <see cref="S101DatasetView.Raw"/> when needed.
+/// </para>
+/// <para>
+/// Per the design note's closing paragraph of §3.1, this façade is
+/// deliberately a strict superset of what a future fully typed
+/// projection (option (d)) would expose. Rules MUST NOT introduce
+/// dependencies on <see cref="S101FeatureRecord"/> through this view
+/// type — anything that requires raw-record access goes via
+/// <see cref="S101DatasetView.Raw"/>.
+/// </para>
+/// </remarks>
+public sealed class S101FeatureView
+{
+    private readonly Dictionary<string, List<S101AttributeView>> _byAcronym;
+    private readonly Dictionary<string, List<IReadOnlyList<S101AttributeView>>> _complexByAcronym;
+
+    internal S101FeatureView(
+        S101FeatureRecord raw,
+        string? featureTypeAcronym,
+        ImmutableArray<S101AttributeView> attributes,
+        IReadOnlyDictionary<ushort, string> attributeTypeCatalogue)
+    {
+        Raw = raw;
+        FeatureTypeAcronym = featureTypeAcronym;
+        Attributes = attributes;
+        _byAcronym = new Dictionary<string, List<S101AttributeView>>(System.StringComparer.OrdinalIgnoreCase);
+        foreach (var a in attributes)
+        {
+            if (a.Acronym is null) continue;
+            if (!_byAcronym.TryGetValue(a.Acronym, out var list))
+            {
+                list = new List<S101AttributeView>();
+                _byAcronym[a.Acronym] = list;
+            }
+            list.Add(a);
+        }
+
+        _complexByAcronym = new Dictionary<string, List<IReadOnlyList<S101AttributeView>>>(
+            System.StringComparer.OrdinalIgnoreCase);
+        BuildComplexIndex(raw, attributeTypeCatalogue);
+    }
+
+    private void BuildComplexIndex(
+        S101FeatureRecord raw,
+        IReadOnlyDictionary<ushort, string> attributeTypeCatalogue)
+    {
+        // S-101 complex attributes (S-100 Part 10a §4.4) encode each
+        // instance as a marker row (Index == 1, empty Value) followed
+        // by sub-attribute rows carrying Index > 1. We slice each
+        // marker-plus-children run and index it by the parent acronym
+        // so rules can iterate instances without re-walking the
+        // record.
+        var rows = raw.Attributes;
+        for (int i = 0; i < rows.Length; i++)
+        {
+            var row = rows[i];
+            if (row.Index != 1 || !string.IsNullOrEmpty(row.Value))
+                continue;
+            if (!attributeTypeCatalogue.TryGetValue(row.NumericCode, out var acronym))
+                continue;
+
+            var slice = new List<S101AttributeView>();
+            int j = i + 1;
+            while (j < rows.Length && rows[j].Index > 1)
+            {
+                attributeTypeCatalogue.TryGetValue(rows[j].NumericCode, out var subAcronym);
+                slice.Add(new S101AttributeView
+                {
+                    Acronym = subAcronym,
+                    NumericCode = rows[j].NumericCode,
+                    Index = rows[j].Index,
+                    Value = rows[j].Value,
+                });
+                j++;
+            }
+
+            if (!_complexByAcronym.TryGetValue(acronym, out var instances))
+            {
+                instances = new List<IReadOnlyList<S101AttributeView>>();
+                _complexByAcronym[acronym] = instances;
+            }
+            instances.Add(slice);
+        }
+    }
+
+    /// <summary>The underlying ISO 8211 feature record this view wraps.</summary>
+    public S101FeatureRecord Raw { get; }
+
+    /// <summary>
+    /// Feature-type acronym resolved through
+    /// <see cref="S101Document.FeatureTypeCatalogue"/> — for example
+    /// <c>"DepthArea"</c>. <c>null</c> when
+    /// <see cref="S101FeatureRecord.FeatureTypeCode"/> does not appear
+    /// in the catalogue (the failure mode reported by <c>S101-R-1.1</c>).
+    /// </summary>
+    public string? FeatureTypeAcronym { get; }
+
+    /// <summary>
+    /// FOID triple (producing agency, FIDN, FIDS) projected into the
+    /// canonical string form used by the design note §4.3:
+    /// <c>"{producingAgency}:{FIDN}.{FIDS}"</c>. This is the value
+    /// rule authors attach to <c>RelatedFeatureId</c> on findings.
+    /// </summary>
+    public string FoidKey =>
+        $"{Raw.ProducingAgency}:{Raw.FeatureIdentificationNumber}.{Raw.FeatureIdentificationSubdivision}";
+
+    /// <summary>
+    /// Flat list of attribute rows for the feature, one view per ISO
+    /// 8211 ATTR row. Complex-attribute marker rows are preserved so
+    /// rule authors who need the raw ordering can iterate them.
+    /// </summary>
+    public ImmutableArray<S101AttributeView> Attributes { get; }
+
+    /// <summary>
+    /// Returns every complex-attribute instance whose parent acronym
+    /// matches <paramref name="acronym"/>. Each instance is the
+    /// (possibly empty) slice of sub-attribute rows that followed its
+    /// marker row in the original record.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<S101AttributeView>> ComplexAttributes(string acronym)
+    {
+        if (string.IsNullOrEmpty(acronym))
+            return System.Array.Empty<IReadOnlyList<S101AttributeView>>();
+        return _complexByAcronym.TryGetValue(acronym, out var list)
+            ? list
+            : System.Array.Empty<IReadOnlyList<S101AttributeView>>();
+    }
+
+    /// <summary>
+    /// Convenience accessor for a simple attribute identified by
+    /// <paramref name="acronym"/>. Returns the value of the first
+    /// matching row, or <c>null</c> when the attribute is absent.
+    /// </summary>
+    /// <remarks>
+    /// Multi-valued simple attributes (the rare case where the same
+    /// acronym appears more than once on a feature) require rule
+    /// authors to iterate <see cref="Attributes"/> directly; this
+    /// method is shaped for the dominant single-valued case.
+    /// </remarks>
+    public string? GetSimple(string acronym)
+    {
+        if (string.IsNullOrEmpty(acronym)) return null;
+        return _byAcronym.TryGetValue(acronym, out var list) && list.Count > 0
+            ? list[0].Value
+            : null;
+    }
+
+    /// <summary>
+    /// Returns every simple-attribute row whose acronym matches
+    /// <paramref name="acronym"/>. Useful for rules that need to
+    /// inspect every value of a repeating simple attribute.
+    /// </summary>
+    public IEnumerable<S101AttributeView> GetAllSimple(string acronym)
+    {
+        if (string.IsNullOrEmpty(acronym))
+            return System.Array.Empty<S101AttributeView>();
+        return _byAcronym.TryGetValue(acronym, out var list)
+            ? list
+            : System.Array.Empty<S101AttributeView>();
+    }
+
+    /// <summary>Spatial associations attached to the feature, in record order.</summary>
+    public ImmutableArray<S101SpatialAssociation> SpatialAssociations => Raw.SpatialAssociations;
+
+    /// <summary>Feature-to-feature associations attached to the feature, in record order.</summary>
+    public ImmutableArray<S101FeatureAssociation> FeatureAssociations => Raw.FeatureAssociations;
+
+    /// <summary>Feature-to-information-type associations attached to the feature, in record order.</summary>
+    public ImmutableArray<S101InformationAssociation> InformationAssociations => Raw.InformationAssociations;
+}

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/EncDotNet.S100.Datasets.S101.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/EncDotNet.S100.Datasets.S101.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/Validation/S101ValidationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/Validation/S101ValidationTests.cs
@@ -1,0 +1,658 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S101.Validation;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Validation;
+using Xunit;
+
+namespace EncDotNet.S100.Datasets.S101.Tests.Validation;
+
+/// <summary>
+/// Synthetic-fixture tests for the V-4 S-101 rule pack
+/// (<see cref="S101DatasetRules"/>). Fixtures are built in-memory by
+/// composing <see cref="S101Document"/> instances directly; no real
+/// ENC datasets are required.
+/// </summary>
+public class S101ValidationTests
+{
+    // ---------------------------------------------------------------
+    // Fixture helpers
+    // ---------------------------------------------------------------
+
+    private const ushort DepthAreaCode = 1;       // FC acronym "DepthArea"
+    private const ushort SoundingCode = 2;        // FC acronym "Sounding"
+    private const ushort ObstrCode = 3;           // FC acronym "Obstruction"
+    private const ushort UnknownFeatureCode = 99; // intentionally not in any catalogue
+
+    private const ushort Drval1Code = 10;   // FC acronym "DRVAL1"
+    private const ushort Drval2Code = 11;   // FC acronym "DRVAL2"
+    private const ushort Objnam = 12;       // FC acronym "OBJNAM"
+    private const ushort CatpibCode = 13;   // FC acronym "CATPIB" (enumerated)
+    private const ushort UnknownAttrCode = 999;
+
+    private static S101DatasetIdentification Identification(string name = "TESTDS") => new()
+    {
+        RecordName = 10,
+        RecordId = 1,
+        EncodingSpecification = "S-100 Part 10a",
+        EncodingSpecificationEdition = "1.0",
+        ProductSpecification = "INT.IHO.S-101.1.0",
+        ProductSpecificationEdition = "1.0",
+        ApplicationProfile = "",
+        DatasetName = name,
+        DatasetTitle = name,
+        DatasetReferenceDate = "2026-05-28",
+        DatasetLanguage = "eng",
+    };
+
+    private static S101DatasetStructureInfo StructureInfo(uint cmf = 10_000_000) => new()
+    {
+        CoordinateMultiplicationFactorX = cmf,
+        CoordinateMultiplicationFactorY = cmf,
+        CoordinateMultiplicationFactorZ = cmf,
+    };
+
+    private static ImmutableDictionary<ushort, string> FeatureCatalogueByDefault =>
+        new Dictionary<ushort, string>
+        {
+            [DepthAreaCode] = "DepthArea",
+            [SoundingCode] = "Sounding",
+            [ObstrCode] = "Obstruction",
+        }.ToImmutableDictionary();
+
+    private static ImmutableDictionary<ushort, string> AttributeCatalogueByDefault =>
+        new Dictionary<ushort, string>
+        {
+            [Drval1Code] = "DRVAL1",
+            [Drval2Code] = "DRVAL2",
+            [Objnam] = "OBJNAM",
+            [CatpibCode] = "CATPIB",
+        }.ToImmutableDictionary();
+
+    private static S101Document Document(
+        IEnumerable<S101FeatureRecord>? features = null,
+        IEnumerable<S101PointRecord>? points = null,
+        IEnumerable<S101CurveSegmentRecord>? curves = null,
+        IEnumerable<S101CompositeCurveRecord>? composites = null,
+        IEnumerable<S101SurfaceRecord>? surfaces = null,
+        IEnumerable<S101InformationRecord>? information = null,
+        ImmutableDictionary<ushort, string>? featureCatalogue = null,
+        ImmutableDictionary<ushort, string>? attributeCatalogue = null)
+        => new()
+        {
+            Identification = Identification(),
+            StructureInfo = StructureInfo(),
+            FeatureTypeCatalogue = featureCatalogue ?? FeatureCatalogueByDefault,
+            AttributeTypeCatalogue = attributeCatalogue ?? AttributeCatalogueByDefault,
+            Points = (points ?? Array.Empty<S101PointRecord>()).ToImmutableDictionary(p => p.RecordId),
+            CurveSegments = (curves ?? Array.Empty<S101CurveSegmentRecord>()).ToImmutableDictionary(c => c.RecordId),
+            CompositeCurves = (composites ?? Array.Empty<S101CompositeCurveRecord>()).ToImmutableDictionary(c => c.RecordId),
+            Surfaces = (surfaces ?? Array.Empty<S101SurfaceRecord>()).ToImmutableDictionary(s => s.RecordId),
+            Features = (features ?? Array.Empty<S101FeatureRecord>()).ToImmutableArray(),
+            InformationTypes = (information ?? Array.Empty<S101InformationRecord>()).ToImmutableDictionary(i => i.RecordId),
+            InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            FeatureAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
+        };
+
+    private static S101FeatureRecord Feature(
+        uint rcid,
+        ushort typeCode = DepthAreaCode,
+        ushort agency = 1,
+        uint fidn = 1,
+        ushort fids = 1,
+        ImmutableArray<S101Attribute>? attributes = null,
+        ImmutableArray<S101SpatialAssociation>? spatial = null,
+        ImmutableArray<S101InformationAssociation>? info = null)
+        => new()
+        {
+            RecordId = rcid,
+            FeatureTypeCode = typeCode,
+            ProducingAgency = agency,
+            FeatureIdentificationNumber = fidn,
+            FeatureIdentificationSubdivision = fids,
+            Attributes = attributes ?? ImmutableArray<S101Attribute>.Empty,
+            SpatialAssociations = spatial ?? ImmutableArray<S101SpatialAssociation>.Empty,
+            FeatureAssociations = ImmutableArray<S101FeatureAssociation>.Empty,
+            InformationAssociations = info ?? ImmutableArray<S101InformationAssociation>.Empty,
+        };
+
+    private static S101DatasetView ViewOf(S101Document doc, FeatureCatalogueDecoder? decoder = null)
+        => S101DatasetView.From(doc, decoder);
+
+    /// <summary>
+    /// Synthesises an in-memory <see cref="FeatureCatalogueDecoder"/>
+    /// matching the synthetic feature-type / attribute catalogues used
+    /// by these tests. Keeps the test suite independent of bundled FC
+    /// XML.
+    /// </summary>
+    private static FeatureCatalogueDecoder BuildDecoder()
+    {
+        var fc = new FeatureCatalogue
+        {
+            Name = "Test",
+            VersionNumber = "0.0",
+            VersionDate = "2026-05-28",
+            ProductId = "S-101",
+            SimpleAttributes = new SimpleAttribute[]
+            {
+                new() { Code = "DRVAL1", Name = "Depth range value 1", ValueType = "Real" },
+                new() { Code = "DRVAL2", Name = "Depth range value 2", ValueType = "Real" },
+                new() { Code = "OBJNAM", Name = "Object name", ValueType = "Text" },
+                new() {
+                    Code = "CATPIB", Name = "Category of pilot boarding place", ValueType = "Enumeration",
+                    ListedValues = new ListedValue[]
+                    {
+                        new() { Code = "1", Label = "Helicopter" },
+                        new() { Code = "2", Label = "Boat" },
+                    },
+                },
+            },
+            FeatureTypes = new FeatureType[]
+            {
+                new() {
+                    Code = "DepthArea", Name = "Depth area",
+                    AttributeBindings = new AttributeBinding[]
+                    {
+                        new() { AttributeRef = "DRVAL1", Multiplicity = new Multiplicity { Lower = 0, Upper = 1 } },
+                        new() { AttributeRef = "DRVAL2", Multiplicity = new Multiplicity { Lower = 0, Upper = 1 } },
+                        new() { AttributeRef = "OBJNAM", Multiplicity = new Multiplicity { Lower = 0, Upper = 1 } },
+                    },
+                },
+                new() {
+                    Code = "Sounding", Name = "Sounding",
+                    AttributeBindings = new AttributeBinding[]
+                    {
+                        new() { AttributeRef = "OBJNAM", Multiplicity = new Multiplicity { Lower = 0, Upper = 1 } },
+                    },
+                },
+                new() {
+                    Code = "Obstruction", Name = "Obstruction",
+                    AttributeBindings = new AttributeBinding[]
+                    {
+                        new() { AttributeRef = "CATPIB", Multiplicity = new Multiplicity { Lower = 0, Upper = 1 } },
+                    },
+                },
+            },
+        };
+        return new FeatureCatalogueDecoder(fc);
+    }
+
+    // ---------------------------------------------------------------
+    // Default / all-green
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Default_RuleSet_Has_Ten_Rules()
+    {
+        Assert.Equal(10, S101DatasetRules.Default.Rules.Length);
+    }
+
+    [Fact]
+    public void Clean_Dataset_Produces_No_Findings()
+    {
+        var doc = Document(features: new[] { Feature(1) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+
+        Assert.True(report.IsValid,
+            $"Expected no findings; got: {string.Join(", ", report.Findings.Select(f => f.RuleId + ": " + f.Message))}");
+        Assert.Equal(10, report.RulesEvaluated);
+        Assert.Equal(0, report.RulesWithFindings);
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-1.1  Feature type code resolves
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R1_1_Fires_When_Feature_Type_Code_Not_In_Catalogue()
+    {
+        var doc = Document(features: new[] { Feature(1, typeCode: UnknownFeatureCode) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-1.1");
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Contains(UnknownFeatureCode.ToString(), finding.Message);
+        Assert.Equal("1:1.1", finding.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R1_1_Passes_When_All_Feature_Type_Codes_Resolve()
+    {
+        var doc = Document(features: new[]
+        {
+            Feature(1, typeCode: DepthAreaCode),
+            Feature(2, typeCode: SoundingCode, fidn: 2),
+        });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-1.1");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-1.2  Attribute code resolution + FC binding
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R1_2_Fires_When_Attribute_Code_Not_In_Catalogue()
+    {
+        var attrs = ImmutableArray.Create(new S101Attribute(UnknownAttrCode, 1, "x"));
+        var doc = Document(features: new[] { Feature(1, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-1.2");
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Contains(UnknownAttrCode.ToString(), finding.Message);
+    }
+
+    [Fact]
+    public void R1_2_Fires_When_Attribute_Not_Bound_To_Feature_Class()
+    {
+        // DRVAL1 is bound to DepthArea, not to Sounding.
+        var attrs = ImmutableArray.Create(new S101Attribute(Drval1Code, 1, "5.0"));
+        var doc = Document(features: new[] { Feature(1, typeCode: SoundingCode, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-1.2");
+        Assert.Contains("DRVAL1", finding.Message);
+        Assert.Contains("Sounding", finding.Message);
+    }
+
+    [Fact]
+    public void R1_2_Passes_When_Attribute_Bound_To_Feature_Class()
+    {
+        var attrs = ImmutableArray.Create(new S101Attribute(Drval1Code, 1, "5.0"));
+        var doc = Document(features: new[] { Feature(1, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-1.2");
+    }
+
+    [Fact]
+    public void R1_2_Skipped_When_Decoder_Unavailable()
+    {
+        // Attribute not bound to feature class — without a decoder the
+        // FC-conformance half of the rule is silently skipped.
+        var attrs = ImmutableArray.Create(new S101Attribute(Drval1Code, 1, "5.0"));
+        var doc = Document(features: new[] { Feature(1, typeCode: SoundingCode, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, decoder: null));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-1.2");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-2.1  FOID uniqueness
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R2_1_Fires_Once_Per_Duplicate_With_First_As_Anchor()
+    {
+        // Anchor (rcid 1) + two duplicates (rcid 2, 3) all share FOID 1:1.1
+        var doc = Document(features: new[]
+        {
+            Feature(rcid: 1, agency: 1, fidn: 1, fids: 1),
+            Feature(rcid: 2, agency: 1, fidn: 1, fids: 1),
+            Feature(rcid: 3, agency: 1, fidn: 1, fids: 1),
+        });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        var foid = report.Findings.Where(f => f.RuleId == "S101-R-2.1").ToList();
+        Assert.Equal(2, foid.Count);
+        Assert.All(foid, f => Assert.Equal("1:1.1", f.RelatedFeatureId));
+        Assert.Contains(foid, f => f.Message.Contains("RCID 2") && f.Message.Contains("RCID 1"));
+        Assert.Contains(foid, f => f.Message.Contains("RCID 3") && f.Message.Contains("RCID 1"));
+    }
+
+    [Fact]
+    public void R2_1_Passes_When_Foids_Are_Unique()
+    {
+        var doc = Document(features: new[]
+        {
+            Feature(1, fidn: 1),
+            Feature(2, fidn: 2),
+            Feature(3, fidn: 3),
+        });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-2.1");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-3.1  Spatial associations resolve
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R3_1_Fires_When_Spatial_Reference_Is_Dangling()
+    {
+        var spas = ImmutableArray.Create(new S101SpatialAssociation(RecordName: 110, RecordId: 999, Orientation: 1));
+        var doc = Document(features: new[] { Feature(1, spatial: spas) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-3.1");
+        Assert.Contains("RCID=999", finding.Message);
+        Assert.Contains("RCNM=110", finding.Message);
+    }
+
+    [Fact]
+    public void R3_1_Passes_When_Spatial_Reference_Resolves()
+    {
+        var pt = new S101PointRecord { RecordId = 5, Y = 500_000_000, X = 100_000_000 };
+        var spas = ImmutableArray.Create(new S101SpatialAssociation(110, 5, 1));
+        var doc = Document(
+            features: new[] { Feature(1, spatial: spas) },
+            points: new[] { pt });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-3.1");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-3.2  Surface ring closure
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R3_2_Fires_When_Surface_Ring_Does_Not_Close()
+    {
+        var p1 = new S101PointRecord { RecordId = 1, Y = 0, X = 0 };
+        var p2 = new S101PointRecord { RecordId = 2, Y = 10, X = 0 };
+        var p3 = new S101PointRecord { RecordId = 3, Y = 10, X = 10 };
+        var p4 = new S101PointRecord { RecordId = 4, Y = 99, X = 99 }; // does NOT match p1
+
+        // Curve A: p1 → p2; Curve B: p2 → p3; Curve C: p3 → p4
+        var curveA = MakeCurve(rcid: 11, beginPoint: 1, endPoint: 2);
+        var curveB = MakeCurve(rcid: 12, beginPoint: 2, endPoint: 3);
+        var curveC = MakeCurve(rcid: 13, beginPoint: 3, endPoint: 4);
+
+        var surface = new S101SurfaceRecord
+        {
+            RecordId = 20,
+            RingAssociations = ImmutableArray.Create(
+                new S101RingAssociation(RecordName: 120, RecordId: 11, Orientation: 1, Usage: 1),
+                new S101RingAssociation(120, 12, 1, 1),
+                new S101RingAssociation(120, 13, 1, 1)),
+        };
+
+        var doc = Document(
+            points: new[] { p1, p2, p3, p4 },
+            curves: new[] { curveA, curveB, curveC },
+            surfaces: new[] { surface });
+
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        var f = Assert.Single(report.Findings, x => x.RuleId == "S101-R-3.2");
+        Assert.Equal("surf:20", f.RelatedFeatureId);
+        Assert.Contains("not closed", f.Message);
+    }
+
+    [Fact]
+    public void R3_2_Fires_When_Ring_Has_Fewer_Than_Three_Distinct_Vertices()
+    {
+        var p1 = new S101PointRecord { RecordId = 1, Y = 0, X = 0 };
+        var p2 = new S101PointRecord { RecordId = 2, Y = 10, X = 10 };
+        var curveA = MakeCurve(11, 1, 2);
+        var curveB = MakeCurve(12, 2, 1);
+        var surface = new S101SurfaceRecord
+        {
+            RecordId = 30,
+            RingAssociations = ImmutableArray.Create(
+                new S101RingAssociation(120, 11, 1, 1),
+                new S101RingAssociation(120, 12, 1, 1)),
+        };
+        var doc = Document(
+            points: new[] { p1, p2 },
+            curves: new[] { curveA, curveB },
+            surfaces: new[] { surface });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.Contains(report.Findings, f => f.RuleId == "S101-R-3.2" && f.Message.Contains("distinct"));
+    }
+
+    [Fact]
+    public void R3_2_Passes_For_Closed_Triangle_Ring()
+    {
+        var p1 = new S101PointRecord { RecordId = 1, Y = 0, X = 0 };
+        var p2 = new S101PointRecord { RecordId = 2, Y = 10, X = 0 };
+        var p3 = new S101PointRecord { RecordId = 3, Y = 5, X = 10 };
+
+        var cA = MakeCurve(11, 1, 2);
+        var cB = MakeCurve(12, 2, 3);
+        var cC = MakeCurve(13, 3, 1);
+
+        var surface = new S101SurfaceRecord
+        {
+            RecordId = 40,
+            RingAssociations = ImmutableArray.Create(
+                new S101RingAssociation(120, 11, 1, 1),
+                new S101RingAssociation(120, 12, 1, 1),
+                new S101RingAssociation(120, 13, 1, 1)),
+        };
+
+        var doc = Document(
+            points: new[] { p1, p2, p3 },
+            curves: new[] { cA, cB, cC },
+            surfaces: new[] { surface });
+
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-3.2");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-3.3  Composite curve continuity
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R3_3_Fires_When_Composite_Curve_Components_Discontinuous()
+    {
+        var p1 = new S101PointRecord { RecordId = 1, Y = 0, X = 0 };
+        var p2 = new S101PointRecord { RecordId = 2, Y = 10, X = 0 };
+        var p3 = new S101PointRecord { RecordId = 3, Y = 50, X = 50 }; // discontinuity
+        var p4 = new S101PointRecord { RecordId = 4, Y = 60, X = 60 };
+
+        var cA = MakeCurve(11, 1, 2);
+        var cB = MakeCurve(12, 3, 4); // begin (3) != previous end (2)
+
+        var composite = new S101CompositeCurveRecord
+        {
+            RecordId = 50,
+            CurveComponents = ImmutableArray.Create(
+                new S101CurveUsage(RecordName: 120, RecordId: 11, Orientation: 1),
+                new S101CurveUsage(120, 12, 1)),
+        };
+
+        var doc = Document(
+            points: new[] { p1, p2, p3, p4 },
+            curves: new[] { cA, cB },
+            composites: new[] { composite });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-3.3");
+        Assert.Equal("composite:50", finding.RelatedFeatureId);
+    }
+
+    [Fact]
+    public void R3_3_Passes_For_Continuous_Composite_Curve()
+    {
+        var p1 = new S101PointRecord { RecordId = 1, Y = 0, X = 0 };
+        var p2 = new S101PointRecord { RecordId = 2, Y = 10, X = 0 };
+        var p3 = new S101PointRecord { RecordId = 3, Y = 20, X = 0 };
+        var cA = MakeCurve(11, 1, 2);
+        var cB = MakeCurve(12, 2, 3);
+        var composite = new S101CompositeCurveRecord
+        {
+            RecordId = 60,
+            CurveComponents = ImmutableArray.Create(
+                new S101CurveUsage(120, 11, 1),
+                new S101CurveUsage(120, 12, 1)),
+        };
+        var doc = Document(
+            points: new[] { p1, p2, p3 },
+            curves: new[] { cA, cB },
+            composites: new[] { composite });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-3.3");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-4.1  Enumerated attribute domain
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R4_1_Fires_When_Enumerated_Value_Out_Of_Domain()
+    {
+        // CATPIB listed values are "1" and "2"; "9" is out of domain.
+        var attrs = ImmutableArray.Create(new S101Attribute(CatpibCode, 1, "9"));
+        var doc = Document(features: new[] { Feature(1, typeCode: ObstrCode, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-4.1");
+        Assert.Equal(ValidationSeverity.Warning, finding.Severity);
+        Assert.Contains("CATPIB", finding.Message);
+        Assert.Contains("'9'", finding.Message);
+    }
+
+    [Fact]
+    public void R4_1_Passes_When_Enumerated_Value_In_Domain()
+    {
+        var attrs = ImmutableArray.Create(new S101Attribute(CatpibCode, 1, "1"));
+        var doc = Document(features: new[] { Feature(1, typeCode: ObstrCode, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-4.1");
+    }
+
+    [Fact]
+    public void R4_1_Skipped_For_Non_Enumerated_Attribute()
+    {
+        var attrs = ImmutableArray.Create(new S101Attribute(Objnam, 1, "anything"));
+        var doc = Document(features: new[] { Feature(1, attributes: attrs) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-4.1");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-5.1  Coordinates within WGS-84 range
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R5_1_Fires_When_Point_Latitude_Out_Of_Range()
+    {
+        // CMF default = 10^7; Y = 100*10^7 = 100 degrees, out of [-90, 90].
+        var pt = new S101PointRecord { RecordId = 1, Y = 1_000_000_000, X = 0 };
+        var doc = Document(points: new[] { pt });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.Contains(report.Findings, f => f.RuleId == "S101-R-5.1");
+    }
+
+    [Fact]
+    public void R5_1_Passes_For_In_Range_Coordinates()
+    {
+        var pt = new S101PointRecord { RecordId = 1, Y = 500_000_000, X = 0 };
+        var doc = Document(points: new[] { pt });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-5.1");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-R-5.2  Information associations resolve
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void R5_2_Fires_When_Information_Association_Dangling()
+    {
+        var info = ImmutableArray.Create(new S101InformationAssociation(0, 999, 0));
+        var doc = Document(features: new[] { Feature(1, info: info) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S101-R-5.2");
+        Assert.Equal(ValidationSeverity.Warning, finding.Severity);
+        Assert.Contains("999", finding.Message);
+    }
+
+    [Fact]
+    public void R5_2_Passes_When_Information_Association_Resolves()
+    {
+        var iRec = new S101InformationRecord { RecordId = 7, InformationTypeCode = 1, Attributes = ImmutableArray<S101Attribute>.Empty };
+        var info = ImmutableArray.Create(new S101InformationAssociation(0, 7, 0));
+        var doc = Document(
+            features: new[] { Feature(1, info: info) },
+            information: new[] { iRec });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc));
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-R-5.2");
+    }
+
+    // ---------------------------------------------------------------
+    // S101-PROJ-PARSE  Placeholder rule
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void ProjParse_Rule_Is_Registered_But_Emits_No_Findings_For_Stance_A()
+    {
+        var doc = Document(features: new[] { Feature(1) });
+        var report = S101DatasetRules.Default.Run(ViewOf(doc, BuildDecoder()));
+
+        // The rule is in the set (so consumers can see / filter by its
+        // id) but Stance A keeps the body empty.
+        Assert.Contains(S101DatasetRules.Default.Rules, r => r.RuleId == "S101-PROJ-PARSE");
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S101-PROJ-PARSE");
+    }
+
+    // ---------------------------------------------------------------
+    // Façade smoke tests
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void View_OfType_Returns_Matching_Features()
+    {
+        var doc = Document(features: new[]
+        {
+            Feature(1, typeCode: DepthAreaCode, fidn: 1),
+            Feature(2, typeCode: SoundingCode, fidn: 2),
+            Feature(3, typeCode: DepthAreaCode, fidn: 3),
+        });
+        var view = ViewOf(doc);
+        Assert.Equal(2, view.OfType("DepthArea").Count());
+        Assert.Single(view.OfType("Sounding"));
+        Assert.Empty(view.OfType("Bogus"));
+    }
+
+    [Fact]
+    public void Feature_GetSimple_Returns_Attribute_Value()
+    {
+        var attrs = ImmutableArray.Create(
+            new S101Attribute(Drval1Code, 1, "5.0"),
+            new S101Attribute(Drval2Code, 1, "10.0"));
+        var doc = Document(features: new[] { Feature(1, attributes: attrs) });
+        var feature = ViewOf(doc).Features[0];
+        Assert.Equal("5.0", feature.GetSimple("DRVAL1"));
+        Assert.Equal("10.0", feature.GetSimple("DRVAL2"));
+        Assert.Null(feature.GetSimple("OBJNAM"));
+    }
+
+    [Fact]
+    public void Feature_FoidKey_Follows_Design_Note_Convention()
+    {
+        var doc = Document(features: new[] { Feature(1, agency: 7, fidn: 42, fids: 3) });
+        var feature = ViewOf(doc).Features[0];
+        Assert.Equal("7:42.3", feature.FoidKey);
+    }
+
+    [Fact]
+    public void View_TryGetSpatial_Routes_By_RecordName()
+    {
+        var pt = new S101PointRecord { RecordId = 1, Y = 0, X = 0 };
+        var sur = new S101SurfaceRecord { RecordId = 10, RingAssociations = ImmutableArray<S101RingAssociation>.Empty };
+        var doc = Document(points: new[] { pt }, surfaces: new[] { sur });
+        var view = ViewOf(doc);
+
+        Assert.True(view.TryGetSpatial(new S101SpatialAssociation(110, 1, 1), out var p) && p is S101PointRecord);
+        Assert.True(view.TryGetSpatial(new S101SpatialAssociation(130, 10, 1), out var s) && s is S101SurfaceRecord);
+        Assert.False(view.TryGetSpatial(new S101SpatialAssociation(110, 999, 1), out _));
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static S101CurveSegmentRecord MakeCurve(uint rcid, uint beginPoint, uint endPoint)
+        => new()
+        {
+            RecordId = rcid,
+            PointAssociations = ImmutableArray.Create(
+                new S101PointAssociation(RecordName: 110, RecordId: beginPoint, Topology: 1),
+                new S101PointAssociation(110, endPoint, 2)),
+            IntermediateCoordinates = ImmutableArray<(int, int)>.Empty,
+        };
+}


### PR DESCRIPTION
Fourth pack in the non-GML validation series. Ships an S-101 ENC rule pack plus the spec-aligned façade it reads from (option (b) per `docs/design/non-gml-validation.md` §3.1). Mirrors the merged V-1/V-2/V-3 coverage packs (S-102 #134, S-104 #135, S-111 #137) and the S-124 GML gold-standard rule style.

## Façade (public surface)

New types under `src/EncDotNet.S100.Datasets.S101/Validation/`:

| Type | Purpose |
|---|---|
| `S101DatasetView` | Entry point `From(S101Document, FeatureCatalogueDecoder?)`. Exposes `Raw`, `Features`, `OfType(acronym)`, `TryGetSpatial(association, out object?)`, `Diagnostics` (empty in v1 per §5.2 Stance A). |
| `S101FeatureView` | `FeatureTypeAcronym`, `FoidKey` (per §4.3), `Attributes`, `ComplexAttributes(acronym)`, `GetSimple(acronym)`, `SpatialAssociations`, `FeatureAssociations`, `InformationAssociations`, `Raw`. |
| `S101AttributeView` | Per-row view over `S101Attribute`. |
| `S101DiagnosticView` | Parser-diagnostic shape (always empty until reader grows a diagnostics surface). |

Per §3.1 the façade never exposes `S101FeatureRecord` through normal accessors — `Raw` is the escape hatch, keeping the door open for option (d) without breaking rule code.

## Rules (S101DatasetRules.Default, 10 rules)

| Rule | Severity | Check |
|---|---|---|
| `S101-R-1.1` | Error | Feature type code resolves to an FC acronym. |
| `S101-R-1.2` | Error | Attribute code resolves AND is bound to host feature class (walks `SuperType` chain). |
| `S101-R-2.1` | Error | FOID uniqueness — one finding per duplicate; first occurrence is anchor (§8.4). |
| `S101-R-3.1` | Error | Spatial associations resolve into the correct record dictionary. |
| `S101-R-3.2` | Error | Surface ring closure + reject rings of <3 distinct points (§8.2). |
| `S101-R-3.3` | Error | Composite curve continuity (end-of-N = start-of-N+1). |
| `S101-R-4.1` | Warning | Enumerated attribute values in FC-declared domain. |
| `S101-R-5.1` | Warning | Resolved (lat, lon) in WGS-84 ranges. |
| `S101-R-5.2` | Warning | Information associations resolve. |
| `S101-PROJ-PARSE` | — | Placeholder per §5.2 Stance A (body empty; commits the namespace). |

## Processor integration

`S101DatasetProcessor.Validate()` builds the view via the existing `EnsureDecoder()` plumbing and caches the report (`_validationReport` / `_validationCached`) — identical shape to V-1/V-2/V-3:

```csharp
public override ValidationReport? Validate()
{
    if (!_validationCached)
    {
        var view = S101DatasetView.From(_dataset.Document, EnsureDecoder());
        _validationReport = S101DatasetRules.Default.Run(view);
        _validationCached = true;
    }
    return _validationReport;
}
```

## Tests

`tests/EncDotNet.S100.Datasets.S101.Tests/Validation/S101ValidationTests.cs` — **29 tests, all pass**. In-memory synthetic `S101Document` fixtures (no real ENC dataset dependency). Covers:

- Clean-document all-green + rule-set shape.
- Each rule's pass + fail paths.
- FOID uniqueness one-finding-per-duplicate with first occurrence as anchor.
- Spatial association dangling reference.
- Surface ring closure failure + <3-distinct-vertex rejection.
- Composite curve discontinuity.
- Enumerated value out-of-domain + non-enumerated skip.
- Information association unresolved.
- Façade smoke: `OfType`, `GetSimple`, `FoidKey`, `TryGetSpatial` routing.

## Build / test

- `dotnet build -c Release` — clean.
- `dotnet test -c Release` — all suites pass, no regressions.

## Out of scope (explicit)

- No edits to: `docs/design/non-gml-validation.md`, the validation framework (`EncDotNet.S100.Core/Validation/`), `ConcatReports` (still `internal` from V-1), S-102/S-104/S-111/S-57 code, the viewer, MCP, the portrayal pipeline.
- No edits to `S101DocumentReader` (Stance A — `S101-PROJ-PARSE` ships as a documented placeholder).
- No full typed `DataModel` projection — façade stays option (b).
- No new package dependencies.

## Design references

- `docs/design/non-gml-validation.md` (PR #133)
  - §3.1 — façade option (b)
  - §4.3 — `RelatedFeatureId` conventions
  - §5.2 — Stance A for parser diagnostics
  - §6.4 — the 10 rules
  - §8 — vector-specific topics (FC conformance, topology, FOID uniqueness)
  - §9.1 / §9.2 / §9.3 — file layout, public surface, processor integration

## Notes for V-5 (S-57)

`S101DatasetRules.Default.Run(view)` is the same entry point V-5 will invoke from `S57DatasetProcessor.Validate()` against a translated `S101Document`. To rebadge with `"S101-as-S57/"` per §9.3, run normally then project findings through a `ValidationFinding` rewrite that prefixes `RuleId`. The façade resolves FC binding through whatever `FeatureCatalogueDecoder` is passed in — V-5 can pass either the S-101 catalogue (if translation preserves codes) or an S-57-derived one. No new public hook needed on the rule set.