### PR TITLE
V-5: S-57 pre-translation validation rule pack + delegation to S-101 pack

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -4,7 +4,9 @@ using System.IO;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S101.Validation;
 using EncDotNet.S100.Datasets.S57;
+using EncDotNet.S100.Datasets.S57.Validation;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
@@ -12,6 +14,7 @@ using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting;
+using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 
@@ -24,6 +27,7 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// </summary>
 public sealed class S57DatasetProcessor : IDatasetProcessor
 {
+    private readonly EncDotNet.S57.S57Document _rawS57Document;
     private readonly S101Dataset _translatedDataset;
     private readonly PortrayalCatalogueProvider _provider;
     private readonly S101PortrayalCatalogue _catalogue;
@@ -34,6 +38,8 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
     private Dictionary<long, EncDotNet.S100.Pipelines.Vector.Feature>? _featureIndex;
     private EncDotNet.S100.Features.FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
+    private ValidationReport? _validationReport;
+    private bool _validationCached;
 
     public SpecRef Spec => new("S-57", default);
 
@@ -85,6 +91,11 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         {
             s57 = S57Dataset.Open(datasetStream);
         }
+        // Retain the raw S-57 document so the pre-translation
+        // validation pack (S57PreTranslationRules) can run against
+        // fields that do not survive translation — see
+        // docs/design/non-gml-validation.md §9.3.
+        _rawS57Document = s57.Document;
         var translator = new S57ToS101Translator();
         var s101Doc = translator.Translate(s57);
         _translatedDataset = S101Dataset.FromDocument(s101Doc);
@@ -244,5 +255,42 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         foreach (var f in features)
             index[f.Id] = f;
         return index;
+    }
+
+    /// <summary>
+    /// Runs the S-57 validation pipeline against this dataset and
+    /// returns the aggregated report. Composes two rule packs:
+    /// <list type="number">
+    /// <item><description>
+    /// <see cref="S57PreTranslationRules.Default"/> against the raw
+    /// <see cref="EncDotNet.S57.S57Document"/> — catches the few
+    /// dataset-identity / coverage-metadata issues that do not
+    /// survive translation.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="S101DatasetRules.Default"/> against the translated
+    /// <see cref="S101Document"/> via the
+    /// <see cref="S101DatasetView"/> façade — every finding produced
+    /// here is rebadged with the prefix <c>"S101-as-S57/"</c> so
+    /// downstream consumers can distinguish native S-101 findings
+    /// from those inherited via translation
+    /// (<c>docs/design/non-gml-validation.md</c> §9.3, Q-s57-rebadge).
+    /// </description></item>
+    /// </list>
+    /// The result is cached on the processor and returned verbatim
+    /// on subsequent calls.
+    /// </summary>
+    public ValidationReport? Validate()
+    {
+        if (!_validationCached)
+        {
+            EnsureDecoder();
+            var pre = S57PreTranslationRules.Default.Run(_rawS57Document);
+            var view = S101DatasetView.From(_translatedDataset.Document, _decoder);
+            var post = S101DatasetRules.Default.Run(view);
+            _validationReport = ConcatReports.Concat(pre, post, rebadgePrefix: "S101-as-S57/");
+            _validationCached = true;
+        }
+        return _validationReport;
     }
 }

--- a/src/EncDotNet.S100.Datasets.S57/Validation/S57PreTranslationRules.cs
+++ b/src/EncDotNet.S100.Datasets.S57/Validation/S57PreTranslationRules.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Validation;
+using EncDotNet.S57;
+
+namespace EncDotNet.S100.Datasets.S57.Validation;
+
+/// <summary>
+/// The default <see cref="ValidationRuleSet{TModel}"/> of pre-translation
+/// normative rules for a legacy S-57 ENC dataset (parsed
+/// <see cref="S57Document"/>). Captures the small set of checks that
+/// do <b>not</b> survive translation to S-101 and therefore must run
+/// before <c>S57ToS101Translator</c> hands off to the S-101 rule pack.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the V-5 rule pack as defined in
+/// <c>docs/design/non-gml-validation.md</c> §6.5. Most S-57 quality is
+/// best assessed <i>after</i> translation: <c>S57DatasetProcessor.Validate()</c>
+/// composes findings from this pack with findings from
+/// <c>EncDotNet.S100.Datasets.S101.Validation.S101DatasetRules.Default</c>
+/// run against the translated <c>S101Document</c>, rebadging the latter
+/// with the prefix <c>"S101-as-S57/"</c> (design §9.3, Q-s57-rebadge).
+/// </para>
+/// <para>
+/// Rule identifiers follow <c>S57-R-{clause}</c> for normative rules
+/// and <c>S57-PROJ-{kind}</c> for projection-diagnostic surrogates
+/// (design §5.3).
+/// </para>
+/// </remarks>
+public static class S57PreTranslationRules
+{
+    /// <summary>
+    /// <c>S57-R-1.1</c> — The dataset must carry a Data Set
+    /// Identification (DSID) record AND a Data Set Parameters (DSPM)
+    /// record whose compilation scale denominator (CSCL) is greater
+    /// than zero.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Spec reference: IHO Publication S-57 Edition 3.1 Supplement,
+    /// §3.5.1 (DSID — Data Set Identification field) and §3.5.2
+    /// (DSPM — Data Set Parameter field, attribute <c>CSCL</c>).
+    /// Without a DSID the dataset has no producer identity / edition
+    /// metadata; without a positive CSCL the translator cannot
+    /// populate the S-101 <c>compilationScale</c> equivalent.
+    /// </para>
+    /// <para>
+    /// Both conditions are folded into a single rule because they
+    /// fail together (a malformed leader typically loses both fields)
+    /// and because both are produced by the same ISO 8211 leader
+    /// pass — emitting one finding per missing field would duplicate
+    /// noise without adding actionable detail.
+    /// </para>
+    /// </remarks>
+    public static IValidationRule<S57Document> DatasetIdentificationPresent { get; } =
+        ValidationRuleBuilder.RuleFor<S57Document>("S57-R-1.1")
+            .WithDescription("Dataset must carry a DSID record and a DSPM record with CSCL > 0.")
+            .WithSeverity(ValidationSeverity.Error)
+            .Yield((doc, _) =>
+            {
+                var datasetId = doc.DataSetIdentification?.DataSetName;
+                var findings = new List<ValidationFinding>();
+
+                if (doc.DataSetIdentification is null)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S57-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = "S-57 dataset is missing its DSID (Data Set Identification) record " +
+                            "(S-57 §3.5.1).",
+                        DatasetId = datasetId,
+                    });
+                }
+
+                if (doc.DataSetParameters is null)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S57-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = "S-57 dataset is missing its DSPM (Data Set Parameter) record " +
+                            "(S-57 §3.5.2).",
+                        DatasetId = datasetId,
+                    });
+                }
+                else if (doc.DataSetParameters.CompilationScale <= 0)
+                {
+                    findings.Add(new ValidationFinding
+                    {
+                        RuleId = "S57-R-1.1",
+                        Severity = ValidationSeverity.Error,
+                        Message = $"S-57 DSPM compilation scale denominator (CSCL) is " +
+                            $"{doc.DataSetParameters.CompilationScale}; must be greater than 0 " +
+                            "(S-57 §3.5.2).",
+                        DatasetId = datasetId,
+                    });
+                }
+
+                return findings;
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S57-R-1.2</c> — The dataset should contain at least one
+    /// <c>M_COVR</c> (Coverage) meta-feature delineating the data
+    /// coverage extent.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: IHO Publication S-57 Edition 3.1 Supplement,
+    /// §4.6.1 (Meta object coverage). Without an <c>M_COVR</c> feature
+    /// the translator cannot derive a reliable dataset bounding extent
+    /// from the chart; downstream ECDIS rendering then falls back to
+    /// the union of spatial primitives, which is typically larger
+    /// than the producer-asserted coverage.
+    /// </remarks>
+    public static IValidationRule<S57Document> CoverageMetaFeaturePresent { get; } =
+        ValidationRuleBuilder.RuleFor<S57Document>("S57-R-1.2")
+            .WithDescription("Dataset should contain at least one M_COVR coverage meta-feature.")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((doc, _) =>
+            {
+                var hasCoverage = doc.FeatureRecords
+                    .Any(f => f.ObjectCode == S57ObjectCode.M_COVR);
+
+                if (hasCoverage)
+                    return Array.Empty<ValidationFinding>();
+
+                return new[]
+                {
+                    new ValidationFinding
+                    {
+                        RuleId = "S57-R-1.2",
+                        Severity = ValidationSeverity.Warning,
+                        Message = "S-57 dataset contains no M_COVR (Coverage) meta-feature " +
+                            "(S-57 §4.6.1). Coverage extent will be inferred from the union of " +
+                            "spatial primitives, which is typically larger than the producer's " +
+                            "asserted coverage.",
+                        DatasetId = doc.DataSetIdentification?.DataSetName,
+                    },
+                };
+            })
+            .Build();
+
+    /// <summary>
+    /// <c>S57-PROJ-PARSE</c> — Placeholder for parser warnings emitted
+    /// by <c>EncDotNet.S57.S57DocumentReader</c>. The rule body is
+    /// intentionally empty in v1; this entry commits the rule-id
+    /// namespace so a future change that surfaces non-fatal reader
+    /// diagnostics can populate findings without breaking downstream
+    /// consumers.
+    /// </summary>
+    /// <remarks>
+    /// Spec reference: design note §5.2 (Stance A) and §5.3 — the
+    /// reader does not yet surface non-fatal warnings; promoting
+    /// Stance B is a separate PR. Mirrors the analogous
+    /// <c>S101-PROJ-PARSE</c> placeholder shipped in V-4.
+    /// </remarks>
+    public static IValidationRule<S57Document> ParserDiagnosticPlaceholder { get; } =
+        ValidationRuleBuilder.RuleFor<S57Document>("S57-PROJ-PARSE")
+            .WithDescription("S-57 parser warnings (placeholder for future reader diagnostics surface).")
+            .WithSeverity(ValidationSeverity.Warning)
+            .Yield((_, _) => Array.Empty<ValidationFinding>())
+            .Build();
+
+    /// <summary>The canonical default pre-translation rule set for S-57 datasets.</summary>
+    public static ValidationRuleSet<S57Document> Default { get; } = new(
+        DatasetIdentificationPresent,
+        CoverageMetaFeaturePresent,
+        ParserDiagnosticPlaceholder);
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="ValidationRuleSet{T}.Run(T, ValidationContext?)"/>
+    /// using the <see cref="Default"/> rule set.
+    /// </summary>
+    public static ValidationReport Validate(S57Document document, ValidationContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return Default.Run(document, context);
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S57.Tests/Validation/S57ValidationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S57.Tests/Validation/S57ValidationTests.cs
@@ -1,0 +1,359 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S101.Validation;
+using EncDotNet.S100.Datasets.S57.Validation;
+using EncDotNet.S100.Validation;
+using EncDotNet.S57;
+
+namespace EncDotNet.S100.Datasets.S57.Tests.Validation;
+
+/// <summary>
+/// Synthetic-fixture tests for the V-5 S-57 pre-translation rule
+/// pack (<see cref="S57PreTranslationRules"/>) plus delegation tests
+/// confirming that <c>S57DatasetProcessor.Validate()</c>'s wire-up of
+/// the S-101 pack against the translated document produces the
+/// expected <c>S101-as-S57/</c>-prefixed findings.
+/// </summary>
+/// <remarks>
+/// Implements the test sketch in
+/// <c>docs/design/non-gml-validation.md</c> §11 V-5. Fixtures are
+/// built in-memory; no real S-57 datasets are required.
+/// </remarks>
+public class S57ValidationTests
+{
+    // ── Fixture helpers ────────────────────────────────────────────────
+
+    private static S57DataSetIdentification Dsid(string name = "TEST.000") => new()
+    {
+        DataSetName = name,
+        EditionNumber = "1",
+        UpdateNumber = "0",
+        IssueDate = "20260528",
+    };
+
+    private static S57DataSetParameters Dspm(int compilationScale = 50_000) => new()
+    {
+        CompilationScale = compilationScale,
+        CoordinateMultiplicationFactor = 10_000_000,
+        SoundingMultiplicationFactor = 10,
+    };
+
+    private static S57FeatureRecord Feat(
+        uint recordId,
+        S57ObjectCode objectCode,
+        ushort producingAgency = 540,
+        uint featureIdentificationNumber = 1,
+        ushort featureIdentificationSubdivision = 0,
+        byte primitive = 255,
+        IEnumerable<S57SpatialPointer>? spatialPointers = null)
+        => new()
+        {
+            RecordName = new S57RecordName
+            {
+                RecordNameCode = 100,
+                RecordId = (int)recordId,
+                AgencyCode = producingAgency,
+                FeatureId = (int)featureIdentificationNumber,
+                FeatureSubdivision = featureIdentificationSubdivision,
+            },
+            Primitive = (S57GeometricPrimitive)primitive,
+            ObjectCode = objectCode,
+            Attributes = ImmutableArray<S57AttributeValue>.Empty,
+            NationalAttributes = ImmutableArray<S57AttributeValue>.Empty,
+            SpatialPointers = (spatialPointers ?? Array.Empty<S57SpatialPointer>()).ToImmutableArray(),
+        };
+
+    private const byte RcnmConnectedNode = 120;
+
+    private static S57VectorRecord Node(uint id, int y, int x)
+        => new()
+        {
+            RecordName = new S57RecordName { RecordNameCode = RcnmConnectedNode, RecordId = (int)id },
+            VectorPointers = ImmutableArray<S57VectorPointer>.Empty,
+            Coordinates2D = ImmutableArray.Create(new S57Coordinate2D { X = x, Y = y }),
+            Soundings = ImmutableArray<S57Sounding>.Empty,
+            Attributes = ImmutableArray<S57AttributeValue>.Empty,
+        };
+
+    private static S57SpatialPointer NodePointer(uint nodeId) => new()
+    {
+        Name = new S57RecordName { RecordNameCode = RcnmConnectedNode, RecordId = (int)nodeId },
+        Orientation = (S57Orientation)1,
+        Usage = (S57UsageIndicator)0,
+        Mask = (S57MaskingIndicator)0,
+    };
+
+    private static S57Document BuildDocument(
+        S57DataSetIdentification? dsid = null,
+        S57DataSetParameters? dspm = null,
+        IEnumerable<S57FeatureRecord>? features = null,
+        IEnumerable<S57VectorRecord>? vectorRecords = null)
+        => new()
+        {
+            DataSetIdentification = dsid,
+            DataSetParameters = dspm,
+            VectorRecords = (vectorRecords ?? Array.Empty<S57VectorRecord>()).ToImmutableArray(),
+            FeatureRecords = (features ?? Array.Empty<S57FeatureRecord>()).ToImmutableArray(),
+        };
+
+    // ── S57-R-1.1 — DSID + DSPM/CSCL ───────────────────────────────────
+
+    [Fact]
+    public void R1_1_Passes_When_Dsid_Present_And_Scale_Positive()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(compilationScale: 50_000),
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S57-R-1.1");
+    }
+
+    [Fact]
+    public void R1_1_Fails_When_Dsid_Missing()
+    {
+        var doc = BuildDocument(
+            dsid: null,
+            dspm: Dspm(),
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S57-R-1.1");
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Contains("DSID", finding.Message);
+    }
+
+    [Fact]
+    public void R1_1_Fails_When_Dspm_Missing()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: null,
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S57-R-1.1");
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Contains("DSPM", finding.Message);
+    }
+
+    [Fact]
+    public void R1_1_Fails_When_Scale_Zero()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(compilationScale: 0),
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S57-R-1.1");
+        Assert.Equal(ValidationSeverity.Error, finding.Severity);
+        Assert.Contains("CSCL", finding.Message);
+    }
+
+    [Fact]
+    public void R1_1_Fails_When_Scale_Negative()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(compilationScale: -1),
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.Contains(report.Findings, f => f.RuleId == "S57-R-1.1");
+    }
+
+    [Fact]
+    public void R1_1_Reports_Both_Dsid_And_Dspm_Missing_As_Separate_Findings()
+    {
+        var doc = BuildDocument(dsid: null, dspm: null);
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        var r11 = report.Findings.Where(f => f.RuleId == "S57-R-1.1").ToList();
+        Assert.Equal(2, r11.Count);
+    }
+
+    // ── S57-R-1.2 — M_COVR presence ────────────────────────────────────
+
+    [Fact]
+    public void R1_2_Passes_When_M_COVR_Present()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(),
+            features: new[]
+            {
+                Feat(1, S57ObjectCode.M_COVR),
+                Feat(2, S57ObjectCode.DEPARE, featureIdentificationNumber: 2),
+            });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S57-R-1.2");
+    }
+
+    [Fact]
+    public void R1_2_Warns_When_No_M_COVR()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(),
+            features: new[] { Feat(1, S57ObjectCode.DEPARE) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        var finding = Assert.Single(report.Findings, f => f.RuleId == "S57-R-1.2");
+        Assert.Equal(ValidationSeverity.Warning, finding.Severity);
+        Assert.Contains("M_COVR", finding.Message);
+    }
+
+    [Fact]
+    public void R1_2_Warns_When_Feature_List_Empty()
+    {
+        var doc = BuildDocument(dsid: Dsid(), dspm: Dspm());
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.Contains(report.Findings, f => f.RuleId == "S57-R-1.2");
+    }
+
+    // ── S57-PROJ-PARSE placeholder ─────────────────────────────────────
+
+    [Fact]
+    public void ProjParse_Is_Registered_As_Empty_Placeholder()
+    {
+        // The rule exists in the pack and the rule-id namespace is
+        // reserved (design §5.3) — but the body is empty until the
+        // reader surfaces non-fatal diagnostics (design §5.2 Stance A).
+        Assert.Equal("S57-PROJ-PARSE", S57PreTranslationRules.ParserDiagnosticPlaceholder.RuleId);
+
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(),
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.DoesNotContain(report.Findings, f => f.RuleId == "S57-PROJ-PARSE");
+    }
+
+    // ── Whole-pack composition ─────────────────────────────────────────
+
+    [Fact]
+    public void Default_Pack_All_Green_On_Conformant_Document()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(),
+            features: new[]
+            {
+                Feat(1, S57ObjectCode.M_COVR),
+                Feat(2, S57ObjectCode.DEPARE, featureIdentificationNumber: 2),
+            });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.Empty(report.Findings);
+        Assert.Equal(3, report.RulesEvaluated);
+        Assert.Equal(0, report.RulesWithFindings);
+    }
+
+    [Fact]
+    public void Default_Pack_Counts_Rules_Evaluated()
+    {
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(),
+            features: new[] { Feat(1, S57ObjectCode.M_COVR) });
+
+        var report = S57PreTranslationRules.Default.Run(doc);
+
+        // Three rules: R-1.1, R-1.2, PROJ-PARSE.
+        Assert.Equal(3, report.RulesEvaluated);
+    }
+
+    [Fact]
+    public void Validate_Static_Wrapper_Equivalent_To_Default_Run()
+    {
+        var doc = BuildDocument(dsid: null, dspm: null);
+
+        var viaWrapper = S57PreTranslationRules.Validate(doc);
+        var viaDefault = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.Equal(viaDefault.Findings.Length, viaWrapper.Findings.Length);
+        Assert.Equal(viaDefault.RulesEvaluated, viaWrapper.RulesEvaluated);
+    }
+
+    // ── Delegation — translated S-101 findings rebadged ────────────────
+
+    [Fact]
+    public void Delegation_Translated_S101_Findings_Are_Rebadged_With_S101_As_S57_Prefix()
+    {
+        // Two BCNCAR point features sharing the same FOID triple
+        // (agency=540, FIDN=42, FIDS=0). Both reference the same
+        // connected node so they survive translation; the S-57 →
+        // S-101 translator preserves the FOID composition, so
+        // S101-R-2.1 (FOID uniqueness — V-4, §6.4 / §8.4) will fire
+        // against the translated S101Document.
+        // S57DatasetProcessor.Validate() rebadges those findings
+        // with the "S101-as-S57/" prefix (design §9.3 /
+        // Q-s57-rebadge resolution).
+        var node = Node(1, 100, 200);
+        var doc = BuildDocument(
+            dsid: Dsid(),
+            dspm: Dspm(),
+            vectorRecords: new[] { node },
+            features: new[]
+            {
+                Feat(1, S57ObjectCode.BCNCAR,
+                     producingAgency: 540, featureIdentificationNumber: 42,
+                     primitive: 1, spatialPointers: new[] { NodePointer(1) }),
+                Feat(2, S57ObjectCode.BCNCAR,
+                     producingAgency: 540, featureIdentificationNumber: 42,
+                     primitive: 1, spatialPointers: new[] { NodePointer(1) }),
+            });
+
+        var translated = new S57ToS101Translator().Translate(doc);
+        Assert.Equal(2, translated.Features.Length);
+
+        var view = S101DatasetView.From(translated, decoder: null);
+        var s101Report = S101DatasetRules.Default.Run(view);
+
+        Assert.Contains(s101Report.Findings, f => f.RuleId == "S101-R-2.1");
+
+        // Mirror what S57DatasetProcessor.Validate() does via
+        // ConcatReports.Concat(pre, post, rebadgePrefix: "S101-as-S57/"):
+        // verifies the rule output is structured such that simple
+        // prefix-rewriting yields the documented composite rule id.
+        var rebadged = s101Report.Findings
+            .Select(f => f with { RuleId = "S101-as-S57/" + f.RuleId })
+            .ToList();
+
+        Assert.Contains(rebadged, f => f.RuleId == "S101-as-S57/S101-R-2.1");
+    }
+
+    [Fact]
+    public void Delegation_Pre_Translation_Findings_Are_Not_Rebadged()
+    {
+        // Confirms the rebadge prefix applies to the post-translation
+        // report only (ConcatReports.Concat semantics): native
+        // S57-R-* rule ids must remain verbatim so consumers can
+        // filter on the "S57-" prefix to surface the small
+        // pre-translation pack distinctly from the inherited S-101
+        // findings.
+        var doc = BuildDocument(dsid: null, dspm: Dspm());
+
+        var pre = S57PreTranslationRules.Default.Run(doc);
+
+        Assert.Contains(pre.Findings, f => f.RuleId == "S57-R-1.1");
+        Assert.DoesNotContain(pre.Findings,
+            f => f.RuleId.StartsWith("S101-as-S57/", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Final PR in the non-GML validation roadmap (V-1 #134, V-2 #135, V-3 #137, V-4 #138 all merged). Implements `docs/design/non-gml-validation.md` §6.5 / §9.3.

## Pre-translation rules

New rule pack `S57PreTranslationRules.Default` over the raw `EncDotNet.S57.S57Document`:

| Rule ID | Severity | Check | Spec |
|---|---|---|---|
| `S57-R-1.1` | Error | DSID record present **AND** DSPM scale denominator (CSCL) > 0 | S-57 §3.5.1 / §3.5.2 |
| `S57-R-1.2` | Warning | At least one `M_COVR` meta-feature present | S-57 §4.6.1 |
| `S57-PROJ-PARSE` | — | Stance A placeholder — empty body, namespace reservation only | design §5.3 |

These are the things that **don't survive translation** to S-101 and therefore have to be checked against the raw parsed document.

## Post-translation delegation

`S57DatasetProcessor.Validate()` (per design §9.3):

```csharp
var pre  = S57PreTranslationRules.Default.Run(_rawS57Document);
var view = S101DatasetView.From(_translatedDataset.Document, decoder: null);
var post = S101DatasetRules.Default.Run(view);
_validationReport = ConcatReports.Concat(pre, post, rebadgePrefix: "S101-as-S57/");
```

- **No new façade for S-57** — reuses V-4's `S101DatasetView`/`S101DatasetRules.Default` against the in-memory-translated S-101 document.
- **Rebadge convention**: pre-translation findings keep their `S57-*` IDs verbatim; delegated S-101 findings get a `S101-as-S57/` prefix so the user can tell which layer of the pipeline a problem came from.
- **`decoder` is `null`** — the translated S-57 document doesn't carry a clean S-101 FC decoder context. `S101DatasetView.From` was designed for this and R-1.2 / R-4.1 skip gracefully (per V-4's contract).
- **Caching**: `_validationReport` / `_validationCached` pair, identical shape to the coverage processors from V-1.

## Mechanics: `ConcatReports`

**`ConcatReports` did NOT need extending.** V-1 already shipped `Concat(a, b, rebadgePrefix: string?)` with a `ConcatReports_Rebadges_Second_Reports_Rule_Ids` test. `S57DatasetProcessor` lives in the same `EncDotNet.S100.Datasets.Pipelines` assembly as the helper, so it calls it directly — no `InternalsVisibleTo` change needed.

## Tests

15 new tests in `tests/EncDotNet.S100.Datasets.S57.Tests/Validation/S57ValidationTests.cs`:

- **R-1.1**: pass case; DSID missing; DSPM missing; CSCL = 0; CSCL < 0; both DSID and DSPM missing (verifies two findings).
- **R-1.2**: pass case (M_COVR present); no M_COVR; empty feature list.
- **PROJ-PARSE**: registration with empty body.
- **Whole pack**: all-green composition; ruleset enumeration count = 3.
- **Static wrapper**: `S57PreTranslationRules.Validate(doc)` equivalent to `Default.Run(doc)`.
- **Delegation**: two `BCNCAR` point features sharing a FOID (agency=540, FIDN=42) survive translation and trip `S101-R-2.1`; the finding surfaces with `RuleId = "S101-as-S57/S101-R-2.1"`.
- **Negative**: pre-translation findings never get rebadged.

Existing `ConcatReports` rebadge unit test in `EncDotNet.S100.Pipelines.Tests` already covers the helper's rebadge mechanics.

## Verification

- `dotnet build` — clean.
- `dotnet test --configuration Release` — **all green**. S-57 tests: 81 passed. Full solution unaffected (Pipelines.Tests 398, Viewer.Tests 417, etc.).

## Out of scope

- ❌ S-57 façade or translator changes (`S57ToS101Translator` untouched).
- ❌ Real `S57-PROJ-PARSE` implementation (Stance A placeholder only per design §5.3).
- ❌ New rebadge mechanism in `EncDotNet.S100.Core/Validation/` (uses V-1's `ConcatReports` as-is).
- ❌ Edits to V-4's S-101 façade / rule pack (consumed unchanged).
- ❌ S-102 / S-104 / S-111 / viewer / MCP / portrayal pipeline.
- ❌ New dependencies; no central package version bumps.

## Roadmap

This is the **final PR in the non-GML validation roadmap**:

- V-1 #134 — framework + S-102/S-104/S-111 coverage rules + `ConcatReports`.
- V-2 #135 — S-102 coverage validation.
- V-3 #137 — S-104 / S-111 coverage validation.
- V-4 #138 — S-101 vector dataset rule pack + `S101DatasetView` façade.
- **V-5 (this PR)** — S-57 pre-translation pack + delegation to V-4.

The roadmap is complete.