### PR TITLE
PR-D3: AIS dynamic feature source via aisstream.io

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj" />
     <Project Path="src/EncDotNet.S100.Diagnostics.Export/EncDotNet.S100.Diagnostics.Export.csproj" />
     <Project Path="src/EncDotNet.S100.DynamicSources.Ais/EncDotNet.S100.DynamicSources.Ais.csproj" />
+    <Project Path="src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S104/EncDotNet.S100.Datasets.S104.csproj" />
@@ -54,6 +55,7 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S411.Tests/EncDotNet.S100.Datasets.S411.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S421.Tests/EncDotNet.S100.Datasets.S421.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.DynamicSources.Ais.Tests/EncDotNet.S100.DynamicSources.Ais.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Features.Tests/EncDotNet.S100.Features.Tests.csproj" />

--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -68,4 +68,7 @@
     <Project Path="tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj" />
     <Project Path="tools/EncDotNet.S100.PerfReport/EncDotNet.S100.PerfReport.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/EncDotNet.S100.Samples.Ais/EncDotNet.S100.Samples.Ais.csproj" />
+  </Folder>
 </Solution>

--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj" />
     <Project Path="src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj" />
     <Project Path="src/EncDotNet.S100.Diagnostics.Export/EncDotNet.S100.Diagnostics.Export.csproj" />
+    <Project Path="src/EncDotNet.S100.DynamicSources.Ais/EncDotNet.S100.DynamicSources.Ais.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S104/EncDotNet.S100.Datasets.S104.csproj" />
@@ -52,6 +53,7 @@
     <Project Path="tests/EncDotNet.S100.Datasets.S201.Tests/EncDotNet.S100.Datasets.S201.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S411.Tests/EncDotNet.S100.Datasets.S411.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S421.Tests/EncDotNet.S100.Datasets.S421.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.DynamicSources.Ais.Tests/EncDotNet.S100.DynamicSources.Ais.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Features.Tests/EncDotNet.S100.Features.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ OpenStreetMap basemap. Headline features:
 - **Validation panel** with click-to-zoom, severity colouring, and
   an overlay marker layer.
 - **Live overlays** through the dynamic-feature-source abstraction —
-  today an own-ship glyph with true-scale hull + arrowhead + CCRP
-  cross at zoom; an AIS-target adapter is the next consumer.
+  an own-ship glyph with true-scale hull + arrowhead + CCRP cross at
+  zoom, plus an **AIS-target overlay** (PR-D3) backed by the
+  [aisstream.io](https://aisstream.io) WebSocket service and rendered
+  with a per-class palette using the same hull/arrowhead vocabulary.
 - **Optional MCP server** (off by default) exposing the loaded
   datasets to AI agents.
 
@@ -163,7 +165,14 @@ split into focused packages:
 | Package | Description |
 |---|---|
 | **EncDotNet.S100.Renderers.Skia** | Coverage and vector rendering to [SkiaSharp](https://github.com/mono/SkiaSharp) bitmaps. |
-| **EncDotNet.S100.Renderers.Mapsui** | Rendering of S-100 data into [Mapsui](https://mapsui.com/) map layers with CRS projection, plus dynamic-feature-source renderers (own-ship hull + arrowhead, default disc/line/polygon fallback). |
+| **EncDotNet.S100.Renderers.Mapsui** | Rendering of S-100 data into [Mapsui](https://mapsui.com/) map layers with CRS projection, plus dynamic-feature-source renderers (own-ship hull + arrowhead, AIS-target hull + per-class palette, default disc/line/polygon fallback). |
+
+### Dynamic feature sources
+
+| Package | Description |
+|---|---|
+| **EncDotNet.S100.DynamicSources.Ais** | Decoder-agnostic AIS dynamic feature source: per-MMSI cache, ITU-R M.1371-aligned aging, projection to `DynamicFeature` with sentinel-collapsed motion. See [its README](src/EncDotNet.S100.DynamicSources.Ais/README.md). |
+| **EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo** | Production driver implementing `IAisMessageSource` over [aisstream.io](https://aisstream.io)'s WebSocket service. BCL-only (no third-party AIS or WebSocket deps). See [its README](src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/README.md). |
 
 ### MCP server
 

--- a/docs/design/ais-source.md
+++ b/docs/design/ais-source.md
@@ -1,0 +1,699 @@
+# AIS dynamic feature source — Design Note
+
+> Status: **Design accepted** — implementation lands in the same PR
+> as this note (PR-D3). Closes the dynamic-feature-source thread
+> opened by PR-D1 (#124), continued in PR-D2 (#130, own-ship singleton
+> source), PR-D2.1 (#131, layer-stack wiring), and PR-D2/Q2 (#136,
+> own-ship symbology).
+
+## 0. Scope
+
+Ship the **second concrete `IDynamicFeatureSource`** — AIS targets
+streamed from [aisstream.io](https://aisstream.io) — and prove the
+`DynamicVesselGeometry` sidecar that the own-ship work pre-staged
+against its primary intended use case.
+
+This is a single PR against `main`, branch
+`philliphoff/pr-d3-ais-sample`.
+
+In scope:
+
+1. A push-driven AIS abstraction (`IAisMessageSource`,
+   subscription-based, with optional bounding-box filtering and
+   in-place subscription updates).
+2. A concrete driver targeting aisstream.io's WebSocket service.
+3. A concrete `AisDynamicFeatureSource` projecting AIS reports onto
+   `DynamicFeature` with per-MMSI static-data merging and stale-target
+   aging.
+4. An AIS-specific renderer (`AisVesselRenderer`) sharing hull-outline,
+   arrowhead, and CCRP-cross logic with `OwnShipRenderer` via a new
+   internal `VesselSymbology` helper.
+5. Viewer integration behind a `ViewerSettings.AisOverlay` flag.
+6. A new `samples/EncDotNet.S100.Samples.Ais` Avalonia mini-app.
+
+Out of scope (each captured in §13):
+
+- Local antenna / serial / TCP NMEA-0183.
+- Replay-from-recorded-JSON driver (offline mode for the sample).
+- AIS message families beyond `PositionReport` and `ShipStaticData`.
+- S-52 sleeping / lost / dangerous-target pictogram variants.
+- CPA / TCPA computations.
+- MCP-server exposure of the AIS overlay.
+- Any change to `DynamicFeature` / `DynamicMotion` /
+  `DynamicVesselGeometry` shapes.
+
+---
+
+## 1. Why aisstream.io for the first integration
+
+The PR's request originally framed the first integration as a
+recorded-AIVDM-log driver. After scouting the .NET AIS landscape
+(`dotMorten/NmeaParser` does not decode AIVDM payloads;
+`ais-dotnet/Ais.Net` does but is itself BETA-quality and adds a
+non-trivial dep), the user redirected this PR to target
+aisstream.io directly. The resulting design is materially simpler:
+
+| Property | Recorded AIVDM log | aisstream.io WebSocket |
+|---|---|---|
+| Wire decoder needed | Yes (`Ais.Net` or hand-rolled) | **No** — service ships JSON |
+| Bounding-box filtering | Client-side after decode | **Native protocol feature** |
+| Sentinel-value handling (511/360/102.3/128) | Decoder must surface | **Live at the JSON boundary** |
+| Multi-vessel demo data | Synthetic, ~30 KB | **Live, real-world** |
+| Test isolation | Inject AIVDM bytes | Inject decoded JSON via transport seam |
+| Live demo viability | None | **Yes** (with API key) |
+
+The trade is that the live-service path requires authentication (an
+aisstream.io API key) and has a BETA SLA caveat. The middle
+abstraction (`IAisMessageSource`) insulates callers from that
+specific service so a future swap to a self-hosted decoder, a local
+antenna, or another aggregator is mechanical.
+
+---
+
+## 2. Architectural shape
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ aisstream.io WebSocket | future antenna | future aggregator │
+│                  driver-native wire protocol                │
+└─────────────────────────────┬───────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo      │
+│  ─ ClientWebSocket + System.Text.Json (BCL only)            │
+│  ─ IAisStreamIoTransport seam (testability)                 │
+│  ─ Sentinel-to-null collapse at this layer                  │
+│  ─ Reconnect with exponential backoff                       │
+│  ─ API-key redaction in logging                             │
+└─────────────────────────────┬───────────────────────────────┘
+                              │ IAisMessageSource (our abstraction)
+                              │ Subscribe(AisSubscriptionRequest)
+                              │     → IAisSubscription
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EncDotNet.S100.DynamicSources.Ais                          │
+│  ─ AisDynamicFeatureSource : IDynamicFeatureSource          │
+│  ─ DynamicFeatureTracker<AisPositionReport> for snapshots   │
+│  ─ Per-MMSI ShipStaticData cache merged at projection time  │
+│  ─ 6-min aging sweep (ITU-R M.1371 longest interval)        │
+│  ─ UpdateArea(BoundingBox?) → TryUpdateArea or resubscribe  │
+└─────────────────────────────┬───────────────────────────────┘
+                              │ IDynamicFeatureSource
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EncDotNet.S100.Viewer.Services.DynamicSources              │
+│  ─ DynamicSourceOverlayHost (existing — unchanged)          │
+│  ─ Resolves AisVesselRenderer via RendererKey "vessel.ais"  │
+└─────────────────────────────┬───────────────────────────────┘
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EncDotNet.S100.Renderers.Mapsui.DynamicSources             │
+│  ─ AisVesselRenderer + OwnShipRenderer  (both call into…)   │
+│  ─ VesselSymbology helper (extracted hull/arrow/CCRP/COG)   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Three responsibilities, three libraries:
+
+| Library | Knows about |
+|---|---|
+| `EncDotNet.S100.DynamicSources.Ais` | AIS records, subscription contract, DynamicFeature projection, aging |
+| `EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo` | Only aisstream.io's wire protocol |
+| `EncDotNet.S100.Renderers.Mapsui` (extended) | Only how to draw vessels, given dimensions and motion |
+
+The **viewer** never sees AIS-specific records — it sees only
+`IDynamicFeatureSource`, exactly as it does for own-ship. This is
+the design contract.
+
+---
+
+## 3. Q1 — Where does the sample live?
+
+**Decision: (c) both.** A new `EncDotNet.S100.Samples.Ais` Avalonia
+mini-app under a new `/samples/` solution folder, *and* an in-viewer
+flag (`ViewerSettings.AisOverlay`) that registers the same source
+behind a UI toggle.
+
+The shared abstraction (`IAisMessageSource`) makes this duplication a
+single line of DI plumbing on each side. The standalone sample is
+the demonstration vehicle for AI / route-planning agents that don't
+want to spin up the viewer; the in-viewer integration is the
+contract test that the abstraction composes with the existing
+overlay host.
+
+The sample reads its API key from the `ENCDOTNET_AIS_STREAM_KEY`
+environment variable. With no key it surfaces a clear error and
+exits — there is **no offline mode in this PR**. Adding a
+`LocalRecordedJsonSource` for offline replay is a sibling future PR
+(see §13).
+
+---
+
+## 4. Q2 — Source library shape
+
+**Decision: a standalone class library** —
+`EncDotNet.S100.DynamicSources.Ais` — referenced by the viewer, the
+sample, and any future agent / MCP host. Following the same pattern
+as the dataset libraries.
+
+Rationale: own-ship was viewer-internal because the synthetic
+dead-reckoner is a viewer toy. AIS is reusable across many hosts; a
+dedicated library is the right granularity.
+
+Dependencies:
+
+- `EncDotNet.S100.Core` (for `BoundingBox`, `DynamicFeature`,
+  `DynamicFeatureTracker`, `IDynamicFeatureSource`, etc.).
+- Nothing else — no Mapsui, no Avalonia, no JSON, no WebSockets.
+
+The driver library
+(`EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo`) takes the
+WebSocket / JSON deps and depends on the abstraction library plus
+BCL only.
+
+---
+
+## 5. Q3 — Wire decoder
+
+**Decision: none.** aisstream.io publishes already-decoded JSON over
+a WebSocket. The driver is built on `System.Net.WebSockets.ClientWebSocket`
++ `System.Text.Json` (both in the BCL). No `Ais.Net`. No
+`NmeaParser`. No third-party dep.
+
+We deliberately do not take a dep on the upstream
+`aisstream/ais-message-models` C# package. Hand-rolled JSON contract
+types for the two message families we consume (`PositionReport` and
+`ShipStaticData`) total under 100 lines and decouple us from the
+service's BETA-stage versioning churn.
+
+---
+
+## 6. Q4 — Test fixtures
+
+**Decision: synthetic JSON-lines fixtures replayed through a
+transport seam.** No live aisstream.io traffic in CI under any
+circumstance.
+
+The driver factors its WebSocket I/O behind a small interface:
+
+```csharp
+internal interface IAisStreamIoTransport : IAsyncDisposable
+{
+    Task ConnectAsync(Uri endpoint, CancellationToken ct);
+    Task SendTextAsync(string text, CancellationToken ct);
+    IAsyncEnumerable<string> ReceiveTextAsync(CancellationToken ct);
+}
+```
+
+The production implementation wraps `ClientWebSocket`. Tests inject a
+deterministic in-process fake that replays a JSON-lines fixture and
+captures sent frames for assertion.
+
+Driver tests cover:
+
+1. Connect → send subscribe within 3 s of `ConnectAsync` returning.
+2. Replay a fixture of ~15 messages (2-3 vessels, including one
+   `ShipStaticData` per vessel) → assert the decoded
+   `AisPositionReport` / `AisStaticVoyageData` sequence.
+3. `TryUpdateArea` sends a fresh subscribe frame on the same
+   connection (per aisstream.io's documented "swap and replace, not
+   merge" semantics).
+4. Reconnect after transport fault re-sends subscribe.
+5. Malformed JSON line is dropped without taking the connection
+   down.
+6. API key never appears in any log line emitted by the driver
+   (assert against an `ITestLoggerProvider`).
+
+---
+
+## 7. Q5 — AIS → DynamicFeature mapping
+
+The driver decodes aisstream.io JSON into our typed records. The
+source layer projects records onto `DynamicFeature` at publish time.
+Sentinel handling lives in the driver — the source never sees
+sentinels.
+
+### 7.1 Identity and kind
+
+| Field | Mapping |
+|---|---|
+| `DynamicFeature.Id` | `"ais:" + Mmsi.ToString(CultureInfo.InvariantCulture)` |
+| `DynamicFeature.Kind` | `"vessel.ais." + class` where `class` is one of `cargo`, `tanker`, `passenger`, `highspeedcraft`, `pleasure`, `fishing`, `tug`, `sar`, `lawenforcement`, `military`, `sailing`, `pilot`, `other`, `unknown` |
+| `DynamicFeature.GeometryType` | `Point` |
+| `DynamicFeature.Coordinates` | `[(Latitude, Longitude)]` |
+| `DynamicFeature.LastUpdated` | aisstream.io `Metadata.time_utc` (UTC) |
+
+The `class` bucket is derived from AIS shiptype code per ITU-R
+M.1371-5 Table 53 (cited in `AisShipTypeClass` XML doc comments).
+Until a `ShipStaticData` arrives for a given MMSI the bucket is
+`unknown`.
+
+### 7.2 Motion
+
+```csharp
+Motion = new DynamicMotion
+{
+    CourseOverGroundDeg = positionReport.CourseOverGroundDeg,  // null if 360 sentinel
+    HeadingDeg          = positionReport.HeadingDeg,           // null if 511 sentinel
+    SpeedOverGroundKn   = positionReport.SpeedOverGroundKn,    // null if 102.3 sentinel
+};
+```
+
+Sentinels are collapsed to `null` at the **driver** layer, so the
+source layer's `DynamicMotion` projection is a straight copy. The
+nullability of the existing `DynamicMotion` fields handles the
+already-absent case correctly.
+
+### 7.3 Vessel geometry
+
+When a `ShipStaticData` arrives for an MMSI, the driver caches it
+internally and the source merges it into every subsequent
+`DynamicFeature` for that MMSI:
+
+```csharp
+VesselGeometry = staticData is { Dimensions: { } d } d.LengthMetres > 0 && d.BeamMetres > 0
+    ? new DynamicVesselGeometry
+      {
+          LengthMetres     = d.LengthMetres,      // A + B
+          BeamMetres       = d.BeamMetres,        // C + D
+          BowOffsetMetres  = d.BowOffsetMetres,   // A
+          PortOffsetMetres = d.PortOffsetMetres,  // C
+      }
+    : null;
+```
+
+A vessel that has not yet emitted a Type-5 / Type-24 part-A is
+rendered with the pictogram fallback (no hull, classic AIS triangle).
+
+### 7.4 Aging
+
+`DynamicFeatureTracker.Sweep` runs on a `PeriodicTimer`-driven loop
+inside `AisDynamicFeatureSource`. Default retention is **6 minutes**
+— covers ITU-R M.1371-5's longest at-anchor reporting interval
+(3 minutes) with comfortable margin. Configurable via constructor
+for tests and aggressive deployments. Aisstream.io has no explicit
+"vessel left coverage" signal; aging is the only retirement
+mechanism for this driver. (A future aggregator-with-coverage
+driver could raise `AisTargetLost` events to short-circuit aging.)
+
+---
+
+## 8. Q6 — Renderer
+
+**Decision: refactor first, then add `AisVesselRenderer`.**
+
+Today, `OwnShipRenderer` contains four bits of vessel-rendering
+logic that are not own-ship-specific:
+
+1. Hull-outline polygon construction (5-vertex, parameterised by
+   `DynamicVesselGeometry` and heading).
+2. Arrowhead at the COG-vector tip.
+3. CCRP cross at the GPS antenna position.
+4. COG / heading vector itself (6-min predictor, capped at 10 nm).
+
+Extract those into an internal helper class
+`VesselSymbology` in `EncDotNet.S100.Renderers.Mapsui.DynamicSources`,
+parameterised by:
+
+- `Coordinate` (lat/lon).
+- `DynamicVesselGeometry?` (null → no hull / no CCRP cross).
+- `DynamicMotion?` (null → no COG vector).
+- `Mapsui.Styles.Color stroke / fill / hullFill`.
+- `double minVesselPixels` (per S-52 §7.4.5; default 22 px / 6 mm).
+
+`OwnShipRenderer` becomes a ~30-line wrapper that picks the
+own-ship palette and forwards. Existing `OwnShipRendererTests` stay
+green without modification — that's the regression contract.
+
+`AisVesselRenderer` is a parallel ~50-line wrapper that:
+
+- Picks a colour by `Kind` suffix lookup (`vessel.ais.cargo` →
+  cargo palette, `vessel.ais.tanker` → tanker palette, etc.).
+  Default palette for `unknown` and any unmapped kind.
+- Draws the classic AIS pictogram (small filled triangle pointing
+  along COG / heading) when no `DynamicVesselGeometry` is present
+  or when zoomed too far out. The own-ship pictogram (filled disc)
+  remains own-ship-only.
+
+We deliberately do **not** wrap `AisVesselRenderer` in
+`KindMatchingRenderer`. Per-kind dispatch is a one-line palette
+lookup inside the renderer; spinning up N small renderers and a
+matcher would be heavier and would mean each renderer has to
+duplicate the hull / arrowhead / CCRP shared logic anyway.
+
+### 8.1 Palette
+
+S-52 (Annex A) does not specify per-shiptype colours; vendor
+implementations differ. We pick a small, accessible palette inspired
+by common ECDIS conventions, keyed on `AisShipTypeClass`. Colours
+are listed in `VesselSymbology.AisPalette` with their hex codes and
+WCAG contrast ratios against the chart background documented
+inline. This is intentionally a *renderer* concern, not a *catalogue*
+concern — there is no S-100 portrayal catalogue for AIS overlays.
+
+---
+
+## 9. Q7 — Layer plane
+
+**Decision: same `S98DisplayPlane.DynamicArrows` plane as own-ship.**
+
+Per-source visibility already works through PR-D2.1's layer-stack
+panel — each `IDynamicFeatureSource` gets its own row regardless of
+plane. Splitting AIS into its own plane would be an arbitrary
+distinction that buys nothing for the user.
+
+If a future requirement wants AIS targets *under* own-ship in z-order
+(say, for an ECDIS-style "always paint own-ship on top"), the
+`DynamicSourceOverlayHost` already preserves registration order;
+register the AIS source first, the own-ship source last.
+
+---
+
+## 10. Q8 — Live timing and viewport binding
+
+**Decision: live wall-clock; no replay knob in this PR.**
+
+The driver pushes events as the upstream socket delivers them. The
+source's aging sweep runs on a 1 Hz `PeriodicTimer`. There is no
+"playback speed" concept — that idea was a recorded-log artefact and
+is properly the responsibility of a future
+`LocalRecordedJsonSource`.
+
+### 10.1 Viewport binding
+
+The viewer creates one `AisDynamicFeatureSource` whose subscription's
+`Area` is bound to the map viewport's bbox. Pan / zoom calls
+`AisDynamicFeatureSource.UpdateArea(BoundingBox?)`, which forwards
+to `IAisSubscription.TryUpdateArea` (the aisstream.io driver
+returns `true` here — the protocol explicitly supports in-place
+updates). If `TryUpdateArea` returns `false` the source disposes the
+subscription and opens a fresh one.
+
+Viewport updates are debounced to 300 ms. Below that we'd hammer the
+upstream service every frame while the user pans; above that the
+visible-but-not-yet-subscribed gap becomes uncomfortable. The
+debounce interval is a constructor parameter for tests.
+
+When the bbox changes, we **do not** clear out-of-bbox MMSIs from
+the tracker eagerly — the aging sweep handles them in due course.
+This avoids a flicker if the user pans back within the retention
+window.
+
+---
+
+## 11. Interface specifications
+
+Authoritative shapes for the public API. Implementations follow the
+same xunit-based test conventions used elsewhere in the repo.
+
+### 11.1 Subscription request
+
+```csharp
+public sealed record AisSubscriptionRequest
+{
+    /// <summary>Spatial filter (EPSG:4326). null = no filter.</summary>
+    public BoundingBox? Area { get; init; }
+
+    /// <summary>Optional MMSI allow-list. null = all.</summary>
+    public IReadOnlyCollection<uint>? Mmsis { get; init; }
+
+    /// <summary>Optional ship-type class allow-list. null = all.</summary>
+    public IReadOnlyCollection<AisShipTypeClass>? ShipTypeClasses { get; init; }
+
+    /// <summary>Which message families to receive. Defaults to both.</summary>
+    public AisMessageKinds Include { get; init; }
+        = AisMessageKinds.PositionReports | AisMessageKinds.StaticVoyageData;
+}
+
+[Flags]
+public enum AisMessageKinds
+{
+    None = 0,
+    PositionReports = 1,
+    StaticVoyageData = 2,
+}
+```
+
+### 11.2 Subscription handle
+
+```csharp
+public interface IAisSubscription : IAsyncDisposable
+{
+    AisSubscriptionRequest ActiveRequest { get; }
+
+    event EventHandler<AisPositionReport>? PositionReportReceived;
+    event EventHandler<AisStaticVoyageData>? StaticVoyageDataReceived;
+    event EventHandler<AisTargetLost>? TargetLost;
+
+    /// <summary>
+    /// Updates the spatial filter without tearing the subscription
+    /// down. Returns false when the driver cannot perform an
+    /// in-place update; callers must dispose and resubscribe.
+    /// </summary>
+    bool TryUpdateArea(BoundingBox? area);
+}
+```
+
+### 11.3 Source
+
+```csharp
+public interface IAisMessageSource
+{
+    AisSourceMetadata Metadata { get; }
+    IAisSubscription Subscribe(AisSubscriptionRequest request);
+}
+
+public sealed record AisSourceMetadata
+{
+    public required string DisplayName { get; init; }
+    public string? Description { get; init; }
+    /// <summary>True if the driver supports concurrent subscriptions
+    /// without renegotiating upstream.</summary>
+    public bool SupportsMultipleSubscriptions { get; init; }
+}
+```
+
+### 11.4 Payload records
+
+```csharp
+public abstract record AisMessage
+{
+    public required uint Mmsi { get; init; }
+    public required DateTimeOffset Timestamp { get; init; }
+}
+
+public sealed record AisPositionReport : AisMessage
+{
+    public required double Latitude { get; init; }
+    public required double Longitude { get; init; }
+    public double? CourseOverGroundDeg { get; init; }
+    public double? HeadingDeg { get; init; }
+    public double? SpeedOverGroundKn { get; init; }
+    public AisNavigationStatus? NavigationStatus { get; init; }
+    public double? RateOfTurnDegPerMin { get; init; }
+}
+
+public sealed record AisStaticVoyageData : AisMessage
+{
+    public uint? ImoNumber { get; init; }
+    public string? CallSign { get; init; }
+    public string? VesselName { get; init; }
+    public AisShipType ShipType { get; init; }
+    public AisShipTypeClass ShipTypeClass { get; init; }
+    public AisDimensions? Dimensions { get; init; }
+    public double? DraughtMetres { get; init; }
+    public string? Destination { get; init; }
+    public DateTimeOffset? Eta { get; init; }
+}
+
+public sealed record AisTargetLost
+{
+    public required uint Mmsi { get; init; }
+    public required DateTimeOffset Timestamp { get; init; }
+}
+
+public sealed record AisDimensions
+{
+    public required double LengthMetres { get; init; }
+    public required double BeamMetres { get; init; }
+    public required double BowOffsetMetres { get; init; }
+    public required double PortOffsetMetres { get; init; }
+}
+```
+
+### 11.5 Enumerations
+
+```csharp
+/// <summary>Raw AIS shiptype code (0–99) per ITU-R M.1371-5 Table 53.</summary>
+public enum AisShipType { /* 0..99 */ }
+
+/// <summary>Display-bucketing of AIS shiptype codes.</summary>
+public enum AisShipTypeClass
+{
+    Unknown, Cargo, Tanker, Passenger, HighSpeedCraft,
+    Pleasure, Fishing, Tug, SearchAndRescue, LawEnforcement,
+    Military, Sailing, PilotVessel, Other,
+}
+
+/// <summary>AIS navigation-status codes per ITU-R M.1371-5.</summary>
+public enum AisNavigationStatus
+{
+    UnderWayUsingEngine = 0, AtAnchor = 1, NotUnderCommand = 2,
+    RestrictedManoeuvrability = 3, ConstrainedByDraught = 4,
+    Moored = 5, Aground = 6, EngagedInFishing = 7,
+    UnderWaySailing = 8, /* 9..13 reserved */
+    AisSart = 14, NotDefined = 15,
+}
+```
+
+---
+
+## 12. aisstream.io protocol notes
+
+Authoritative reference: <https://aisstream.io/documentation>.
+Re-stated here so the design doc is self-contained against future
+service drift.
+
+| Property | Value |
+|---|---|
+| Endpoint | `wss://stream.aisstream.io/v0/stream` |
+| Auth | API key, sent in subscribe message |
+| Subscribe format | JSON: `{ "APIKey", "BoundingBoxes": [[[lat, lon], [lat, lon]]], "FiltersShipMMSI"?, "FilterMessageTypes"? }` |
+| Subscribe deadline | 3 s after connect |
+| Subscribe semantics | Swap-and-replace (not merge) |
+| Update mechanism | Resend full subscribe frame on same socket |
+| Cross-origin | **Blocked** — server-side use only (matches our model) |
+| Message types in scope | `PositionReport`, `ShipStaticData` |
+| Decoded format | JSON `{ MessageType, Metadata, Message: { <key>: {…} } }` |
+| SLA | **BETA — none stated** |
+| Throughput ceiling | ~300 msg/s at global scope |
+
+### 12.1 JSON contract subset we hand-roll
+
+Only the fields we actually consume. Every other property in the
+upstream message is ignored (`JsonSerializerOptions.UnknownTypeHandling`
+defaults are fine — `System.Text.Json` ignores unknown JSON fields
+by default).
+
+```jsonc
+// PositionReport
+{
+  "MessageType": "PositionReport",
+  "MetaData": {
+    "MMSI": 123456789,
+    "ShipName": "EXAMPLE",
+    "latitude": 37.81234,
+    "longitude": -122.43210,
+    "time_utc": "2026-05-29 14:23:01.234567 +0000 UTC"
+  },
+  "Message": {
+    "PositionReport": {
+      "Cog": 045.0,           // 360 sentinel → null
+      "TrueHeading": 511,     // 511 sentinel → null
+      "Sog": 12.3,            // 102.3 sentinel → null
+      "RateOfTurn": -127,     // -128 sentinel → null
+      "NavigationalStatus": 0
+    }
+  }
+}
+
+// ShipStaticData
+{
+  "MessageType": "ShipStaticData",
+  "MetaData": { "MMSI": 123456789, "time_utc": "…" },
+  "Message": {
+    "ShipStaticData": {
+      "ImoNumber": 9876543,
+      "CallSign": "EXMPL",
+      "Name": "EXAMPLE",
+      "Type": 70,
+      "Dimension": { "A": 100, "B": 30, "C": 5, "D": 12 },
+      "MaximumStaticDraught": 8.5,
+      "Destination": "USOAK",
+      "Eta": { "Month": 6, "Day": 1, "Hour": 14, "Minute": 30 }
+    }
+  }
+}
+```
+
+### 12.2 Reconnect strategy
+
+On any transport-level disconnect (`WebSocketException`, server-side
+close, network error), the driver:
+
+1. Releases the existing `ClientWebSocket`.
+2. Waits with truncated exponential backoff (250 ms, 500 ms, 1 s,
+   2 s, 4 s, 8 s, capped at 30 s).
+3. Reconnects.
+4. Re-sends the subscribe frame for the most recent active request
+   within the 3 s deadline.
+
+Active subscriptions remain valid across reconnects from the
+caller's perspective — the `IAisSubscription` instance does not
+change, only its underlying socket.
+
+---
+
+## 13. Out of scope (explicit deferrals)
+
+| Item | Why deferred | Future PR shape |
+|---|---|---|
+| Local antenna / NMEA-0183 / serial / TCP | Different driver entirely; aisstream.io covers the demo case | `EncDotNet.S100.DynamicSources.Ais.Drivers.LocalAntenna` |
+| Recorded-JSON replay (offline mode for sample) | Sample's "no API key" UX is a clear-fail in this PR | `EncDotNet.S100.DynamicSources.Ais.Drivers.LocalRecordedJson` |
+| AIS msg families beyond Position / StaticVoyage (SAR, Aids-to-Nav, Base-Station, Safety, BinaryBroadcast…) | Each needs its own DynamicFeature shape | Per-family follow-ups |
+| S-52 sleeping / lost / dangerous-target variants | Needs more design + integration with NavigationStatus + a stale-target threshold | Future PR-D4 |
+| CPA / TCPA computations | Needs route-vs-AIS interaction logic; heavyweight | Future feature work |
+| MCP-server exposure | Intentionally — keeps secrets out of MCP surface | Future PR if requested |
+| `DynamicFeature` shape changes | None needed; pre-staged sidecars already AIS-shaped | — |
+
+---
+
+## 14. Test surface
+
+| Test project | Coverage |
+|---|---|
+| `EncDotNet.S100.Pipelines.Tests` (new files) | `AisDynamicFeatureSource` (subscription lifecycle, Type-5 cache merging, sentinel pass-through, aging sweep, IsEnabled toggle parity with OwnShipSource), `AisVesselRenderer` (palette dispatch, hull / pictogram switching, CCRP cross presence) |
+| `EncDotNet.S100.Pipelines.Tests` | `VesselSymbology` helper (the underlying logic — both renderers re-call after refactor; existing OwnShipRendererTests stay green as the regression contract) |
+| New `EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests` | Driver behaviour against the `IAisStreamIoTransport` fake (subscribe within 3 s, swap-and-replace updates, reconnect re-subscribes, malformed JSON drop, **API-key redaction**) |
+| `EncDotNet.S100.Viewer.Tests` | Layer-stack integration (AIS source surfaces under DynamicArrows when overlay flag is on); settings round-trip for the new flag and masked API-key field |
+
+CI **must not** make any live aisstream.io connections under any
+test path. The transport seam is the load-bearing test boundary.
+
+---
+
+## 15. Security & privacy
+
+- The aisstream.io API key is a secret. It is stored in
+  `ViewerSettings` alongside other persisted settings. The settings
+  control uses a masked input. The key is **never** included in:
+  - Log output (the driver actively redacts it from any structured
+    log call — there is a regression test for this).
+  - Diagnostic export bundles.
+  - Crash dumps that the user might share.
+  - Any file the agent / CLI writes outside the user profile dir.
+- The sample app reads the key from `ENCDOTNET_AIS_STREAM_KEY`
+  environment variable only. Never from the repo.
+- Test fixtures contain only invented MMSIs (real-world MMSI 000000000
+  and 999999999 are reserved per ITU-R M.1371; we use values in the
+  reserved range to make this unambiguous).
+- AIS data itself is not personal data under most jurisdictions, but
+  the driver README cross-references aisstream.io's terms of service
+  (the consumer is responsible for compliance).
+
+---
+
+## 16. Open items (not blocking)
+
+1. **Multiple bbox per subscription** — aisstream.io supports an
+   array of bboxes. Our abstraction takes a single `BoundingBox`. If
+   the viewer ever needs split-screen viewports, expand the
+   abstraction's `Area` field to `IReadOnlyList<BoundingBox>?` and
+   adapt drivers. Out of scope for v1.
+2. **MMSI / ship-type filters in viewer UI** — the abstraction
+   supports them but the v1 viewer does not surface controls for
+   them. Add later if requested.
+3. **Renderer per-NavigationStatus styling** — at-anchor / aground /
+   not-under-command etc. are hinted at by S-52 but not wired in
+   v1 (would land with PR-D4 sleeping-target work).

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,4 +41,5 @@ than current-state behaviour (which lives in the per-library READMEs).
 
 - [Dynamic feature sources](design/dynamic-feature-source.md) — push-driven point/track/area features (own-ship, AIS, route preview, sensor overlays) that sit alongside static datasets in the rendering surface.
 - [Own-ship vessel symbology](design/own-ship-symbology.md) — true-scale hull + arrowhead + CCRP cross renderer that consumes the dynamic-feature-source abstraction.
+- [AIS dynamic feature source](design/ais-source.md) — three-layer split (driver → `IAisMessageSource` → `AisDynamicFeatureSource`), aisstream.io WebSocket driver, and per-class AIS target rendering.
 - [S-98 interoperability](design/s98-interoperability.md) — display-plane plumbing and inter-product rules that make multi-product paint stacks deterministic and spec-driven.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -12,5 +12,7 @@
       href: design/dynamic-feature-source.md
     - name: Own-ship vessel symbology
       href: design/own-ship-symbology.md
+    - name: AIS dynamic feature source
+      href: design/ais-source.md
     - name: S-98 interoperability
       href: design/s98-interoperability.md

--- a/samples/EncDotNet.S100.Samples.Ais/EncDotNet.S100.Samples.Ais.csproj
+++ b/samples/EncDotNet.S100.Samples.Ais/EncDotNet.S100.Samples.Ais.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>EncDotNet.S100.Samples.Ais</RootNamespace>
+    <AssemblyName>EncDotNet.S100.Samples.Ais</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.DynamicSources.Ais\EncDotNet.S100.DynamicSources.Ais.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo\EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/EncDotNet.S100.Samples.Ais/Program.cs
+++ b/samples/EncDotNet.S100.Samples.Ais/Program.cs
@@ -1,0 +1,112 @@
+// PR-D3 sample app: connects to aisstream.io, prints decoded AIS
+// messages projected through AisDynamicFeatureSource. Demonstrates
+// the three-layer split (driver → IAisMessageSource → dynamic
+// feature source) without a UI dependency.
+//
+// Usage:
+//   export ENCDOTNET_AIS_STREAM_KEY=<your-aisstream.io-key>
+//   dotnet run --project samples/EncDotNet.S100.Samples.Ais
+//
+// Optional: pass "minLat,minLon,maxLat,maxLon" as the first arg to
+// constrain the area (default = world).
+
+using System.Globalization;
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.DynamicSources.Ais;
+using EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+using EncDotNet.S100.Pipelines;
+
+const string EnvVarName = "ENCDOTNET_AIS_STREAM_KEY";
+
+var apiKey = Environment.GetEnvironmentVariable(EnvVarName);
+if (string.IsNullOrWhiteSpace(apiKey))
+{
+    Console.Error.WriteLine($"error: environment variable '{EnvVarName}' is not set.");
+    Console.Error.WriteLine($"Get a free API key from https://aisstream.io and run:");
+    Console.Error.WriteLine($"  export {EnvVarName}=<key>");
+    return 1;
+}
+
+BoundingBox? area = null;
+if (args.Length > 0)
+{
+    var parts = args[0].Split(',', StringSplitOptions.TrimEntries);
+    var inv = CultureInfo.InvariantCulture;
+    if (parts.Length != 4
+        || !double.TryParse(parts[0], NumberStyles.Float, inv, out var minLat)
+        || !double.TryParse(parts[1], NumberStyles.Float, inv, out var minLon)
+        || !double.TryParse(parts[2], NumberStyles.Float, inv, out var maxLat)
+        || !double.TryParse(parts[3], NumberStyles.Float, inv, out var maxLon))
+    {
+        Console.Error.WriteLine("error: bbox must be 'minLat,minLon,maxLat,maxLon' (decimal degrees).");
+        return 1;
+    }
+    area = new BoundingBox(minLat, minLon, maxLat, maxLon);
+}
+
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cts.Cancel();
+};
+
+var driver = new AisStreamIoMessageSource(new AisStreamIoOptions { ApiKey = apiKey });
+await using var source = new AisDynamicFeatureSource(
+    id: "ais",
+    messageSource: driver,
+    request: new AisSubscriptionRequest { Area = area });
+
+var seen = new HashSet<string>();
+source.Changed += (sender, change) =>
+{
+    var src = (IDynamicFeatureSource)sender!;
+    var byId = src.CurrentFeatures.ToDictionary(f => f.Id);
+
+    foreach (var id in change.ChangedIds)
+    {
+        switch (change.Kind)
+        {
+            case DynamicSourceChangeKind.Added:
+                seen.Add(id);
+                if (byId.TryGetValue(id, out var addedFeat))
+                    Console.WriteLine($"+ {Format(addedFeat)}");
+                break;
+
+            case DynamicSourceChangeKind.Updated:
+                if (byId.TryGetValue(id, out var updatedFeat))
+                    Console.WriteLine($"  {Format(updatedFeat)}");
+                break;
+
+            case DynamicSourceChangeKind.Removed:
+                seen.Remove(id);
+                Console.WriteLine($"- {id}");
+                break;
+        }
+    }
+};
+
+var bboxLabel = area is null ? "world" : $"[{area.SouthLatitude:F2},{area.WestLongitude:F2} → {area.NorthLatitude:F2},{area.EastLongitude:F2}]";
+Console.WriteLine($"Connected to aisstream.io, listening on {bboxLabel}. Press Ctrl+C to exit.");
+
+try
+{
+    await Task.Delay(Timeout.Infinite, cts.Token);
+}
+catch (OperationCanceledException)
+{
+    // graceful exit
+}
+
+Console.WriteLine();
+Console.WriteLine($"Disconnected. Saw {seen.Count} unique vessels.");
+return 0;
+
+static string Format(DynamicFeature f)
+{
+    var (lat, lon) = f.Coordinates.Count > 0 ? f.Coordinates[0] : (0.0, 0.0);
+    var sog = f.Motion?.SpeedOverGroundKn?.ToString("0.0") ?? "?";
+    var cog = f.Motion?.CourseOverGroundDeg?.ToString("0") ?? "?";
+    var kind = f.Kind ?? "?";
+    return $"{f.Id,-16} {kind,-22} {lat,8:F4},{lon,9:F4} SOG={sog,5}kn COG={cog,3}°";
+}

--- a/samples/EncDotNet.S100.Samples.Ais/README.md
+++ b/samples/EncDotNet.S100.Samples.Ais/README.md
@@ -1,0 +1,55 @@
+# EncDotNet.S100.Samples.Ais
+
+A small console sample demonstrating PR-D3's AIS dynamic feature
+source. Connects to [aisstream.io](https://aisstream.io)'s free
+WebSocket service via `EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo`
+and prints decoded position / static-voyage messages projected
+through `AisDynamicFeatureSource`.
+
+## Prerequisites
+
+* A free API key from <https://aisstream.io>.
+
+## Run
+
+```bash
+export ENCDOTNET_AIS_STREAM_KEY=<your-key>
+dotnet run --project samples/EncDotNet.S100.Samples.Ais
+```
+
+To constrain the subscription to a bounding box (helps stay inside
+aisstream.io's reasonable-use envelope):
+
+```bash
+# San Francisco Bay area
+dotnet run --project samples/EncDotNet.S100.Samples.Ais -- 37.4,-123.0,38.2,-122.0
+```
+
+## Output
+
+* `+` first sighting of a vessel.
+* (two leading spaces) subsequent updates of a known vessel.
+* `-` aged-out target (no message in 6 minutes).
+
+A typical line looks like:
+
+```
++ ais:367123450  vessel.ais.cargo       37.7785,-122.3850 SOG= 12.4kn COG=270°
+```
+
+## Architecture
+
+The sample composes the three layers documented in
+[`docs/design/ais-source.md`](../../docs/design/ais-source.md):
+
+```
+AisStreamIoMessageSource (driver)
+   ↓ IAisMessageSource
+AisDynamicFeatureSource (per-MMSI cache, aging, projection)
+   ↓ IDynamicFeatureSource
+this sample's Console.WriteLine sink
+```
+
+The same `AisDynamicFeatureSource` is reused by the viewer's AIS
+overlay (gated on `ViewerSettings.AisOverlay.Enabled` and the same
+environment variable).

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoJson.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoJson.cs
@@ -1,0 +1,363 @@
+using System.Globalization;
+using System.Text.Json;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+/// <summary>
+/// JSON contract for the small subset of aisstream.io messages we
+/// consume. Expressed as static methods rather than POCOs to keep
+/// the API surface small (every field is consumed in exactly one
+/// place anyway).
+/// </summary>
+internal static class AisStreamIoJson
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Builds the subscribe frame per
+    /// <c>https://aisstream.io/documentation</c>. Bounding boxes
+    /// are sent as <c>[[ [lat, lon], [lat, lon] ]]</c> (south-west
+    /// then north-east).
+    /// </summary>
+    public static string BuildSubscribeFrame(string apiKey, AisSubscriptionRequest request)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(apiKey);
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var ms = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(ms))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("APIKey", apiKey);
+
+            writer.WritePropertyName("BoundingBoxes");
+            writer.WriteStartArray();
+            writer.WriteStartArray();
+            if (request.Area is { } box)
+            {
+                writer.WriteStartArray();
+                writer.WriteNumberValue(box.SouthLatitude);
+                writer.WriteNumberValue(box.WestLongitude);
+                writer.WriteEndArray();
+                writer.WriteStartArray();
+                writer.WriteNumberValue(box.NorthLatitude);
+                writer.WriteNumberValue(box.EastLongitude);
+                writer.WriteEndArray();
+            }
+            else
+            {
+                // Service requires at least one outer bbox; -90/-180/90/180 ≈ "global".
+                writer.WriteStartArray();
+                writer.WriteNumberValue(-90.0);
+                writer.WriteNumberValue(-180.0);
+                writer.WriteEndArray();
+                writer.WriteStartArray();
+                writer.WriteNumberValue(90.0);
+                writer.WriteNumberValue(180.0);
+                writer.WriteEndArray();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndArray();
+
+            if (request.Mmsis is { Count: > 0 })
+            {
+                writer.WritePropertyName("FiltersShipMMSI");
+                writer.WriteStartArray();
+                foreach (var mmsi in request.Mmsis)
+                {
+                    // aisstream.io expects MMSIs as strings.
+                    writer.WriteStringValue(mmsi.ToString(CultureInfo.InvariantCulture));
+                }
+                writer.WriteEndArray();
+            }
+
+            var include = request.Include;
+            if (include != (AisMessageKinds.PositionReports | AisMessageKinds.StaticVoyageData))
+            {
+                writer.WritePropertyName("FilterMessageTypes");
+                writer.WriteStartArray();
+                if (include.HasFlag(AisMessageKinds.PositionReports))
+                {
+                    writer.WriteStringValue("PositionReport");
+                }
+                if (include.HasFlag(AisMessageKinds.StaticVoyageData))
+                {
+                    writer.WriteStringValue("ShipStaticData");
+                }
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndObject();
+        }
+        return System.Text.Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    /// <summary>
+    /// Parses one inbound JSON frame. Returns <see langword="null"/>
+    /// for unknown / malformed frames; the driver logs and drops
+    /// those.
+    /// </summary>
+    public static AisMessage? ParseInbound(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!root.TryGetProperty("MessageType", out var messageTypeProp)
+                || messageTypeProp.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            var messageType = messageTypeProp.GetString();
+            return messageType switch
+            {
+                "PositionReport" => ParsePositionReport(root),
+                "ShipStaticData" => ParseShipStaticData(root),
+                _ => null,
+            };
+        }
+    }
+
+    private static (uint Mmsi, DateTimeOffset Timestamp)? ReadMetadata(JsonElement root)
+    {
+        if (!root.TryGetProperty("MetaData", out var meta) || meta.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        if (!meta.TryGetProperty("MMSI", out var mmsiProp) || mmsiProp.ValueKind != JsonValueKind.Number)
+        {
+            return null;
+        }
+        if (!mmsiProp.TryGetUInt32(out var mmsi)) return null;
+
+        var timestamp = DateTimeOffset.UtcNow;
+        if (meta.TryGetProperty("time_utc", out var timeProp)
+            && timeProp.ValueKind == JsonValueKind.String
+            && timeProp.GetString() is { } timeString
+            && TryParseAisStreamTimestamp(timeString, out var parsed))
+        {
+            timestamp = parsed;
+        }
+        return (mmsi, timestamp);
+    }
+
+    /// <summary>
+    /// aisstream.io emits timestamps in Go's <c>"2006-01-02 15:04:05.000000000 -0700 MST"</c> form
+    /// (e.g. <c>"2026-05-29 14:23:01.234567 +0000 UTC"</c>). Strip the trailing zone-name token
+    /// before handing to <see cref="DateTimeOffset.TryParseExact"/>.
+    /// </summary>
+    internal static bool TryParseAisStreamTimestamp(string text, out DateTimeOffset value)
+    {
+        var trimmed = text.AsSpan().TrimEnd();
+        var lastSpace = trimmed.LastIndexOf(' ');
+        if (lastSpace > 0)
+        {
+            // If the trailing token isn't a numeric offset, drop it (Go's MST-style label).
+            var tail = trimmed[(lastSpace + 1)..];
+            if (tail.Length > 0 && tail[0] != '+' && tail[0] != '-')
+            {
+                trimmed = trimmed[..lastSpace];
+            }
+        }
+        var candidate = trimmed.ToString();
+        var formats = new[]
+        {
+            "yyyy-MM-dd HH:mm:ss.ffffff zzz",
+            "yyyy-MM-dd HH:mm:ss.fffffff zzz",
+            "yyyy-MM-dd HH:mm:ss.fff zzz",
+            "yyyy-MM-dd HH:mm:ss zzz",
+        };
+        return DateTimeOffset.TryParseExact(candidate, formats,
+            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out value)
+            || DateTimeOffset.TryParse(candidate, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal, out value);
+    }
+
+    private static AisPositionReport? ParsePositionReport(JsonElement root)
+    {
+        var meta = ReadMetadata(root);
+        if (meta is null) return null;
+        if (!root.TryGetProperty("Message", out var message)
+            || !message.TryGetProperty("PositionReport", out var pr))
+        {
+            return null;
+        }
+
+        // Position can come either from the inner PositionReport block
+        // (Latitude / Longitude) or from the MetaData block — aisstream
+        // is inconsistent across message families. Prefer the inner.
+        var lat = TryGetDouble(pr, "Latitude")
+                  ?? TryGetDouble(root.GetProperty("MetaData"), "latitude");
+        var lon = TryGetDouble(pr, "Longitude")
+                  ?? TryGetDouble(root.GetProperty("MetaData"), "longitude");
+        if (lat is null || lon is null) return null;
+
+        var cog = CollapseSentinel(TryGetDouble(pr, "Cog"), 360.0);
+        var hdg = CollapseSentinel(TryGetDouble(pr, "TrueHeading"), 511.0);
+        var sog = CollapseSentinel(TryGetDouble(pr, "Sog"), 102.3);
+        var rot = CollapseSentinelSigned(TryGetDouble(pr, "RateOfTurn"), -128.0);
+
+        AisNavigationStatus? nav = null;
+        if (TryGetInt(pr, "NavigationalStatus") is { } navInt
+            && navInt >= 0 && navInt <= 15)
+        {
+            nav = (AisNavigationStatus)navInt;
+        }
+
+        return new AisPositionReport
+        {
+            Mmsi = meta.Value.Mmsi,
+            Timestamp = meta.Value.Timestamp,
+            Latitude = lat.Value,
+            Longitude = lon.Value,
+            CourseOverGroundDeg = cog,
+            HeadingDeg = hdg,
+            SpeedOverGroundKn = sog,
+            RateOfTurnDegPerMin = rot,
+            NavigationStatus = nav,
+        };
+    }
+
+    private static AisStaticVoyageData? ParseShipStaticData(JsonElement root)
+    {
+        var meta = ReadMetadata(root);
+        if (meta is null) return null;
+        if (!root.TryGetProperty("Message", out var message)
+            || !message.TryGetProperty("ShipStaticData", out var ssd))
+        {
+            return null;
+        }
+
+        var typeCode = TryGetInt(ssd, "Type") ?? 0;
+        AisDimensions? dims = null;
+        if (ssd.TryGetProperty("Dimension", out var dim) && dim.ValueKind == JsonValueKind.Object)
+        {
+            var a = TryGetDouble(dim, "A") ?? 0;
+            var b = TryGetDouble(dim, "B") ?? 0;
+            var c = TryGetDouble(dim, "C") ?? 0;
+            var d = TryGetDouble(dim, "D") ?? 0;
+            var length = a + b;
+            var beam = c + d;
+            if (length > 0 && beam > 0)
+            {
+                dims = new AisDimensions
+                {
+                    LengthMetres = length,
+                    BeamMetres = beam,
+                    BowOffsetMetres = a,
+                    PortOffsetMetres = c,
+                };
+            }
+        }
+
+        return new AisStaticVoyageData
+        {
+            Mmsi = meta.Value.Mmsi,
+            Timestamp = meta.Value.Timestamp,
+            ImoNumber = TryGetUInt(ssd, "ImoNumber"),
+            CallSign = TryGetTrimmedString(ssd, "CallSign"),
+            VesselName = TryGetTrimmedString(ssd, "Name")
+                          ?? TryGetTrimmedString(root.GetProperty("MetaData"), "ShipName"),
+            ShipType = (AisShipType)typeCode,
+            ShipTypeClass = AisShipTypeClassExtensions.ToClass(typeCode),
+            Dimensions = dims,
+            DraughtMetres = TryGetDouble(ssd, "MaximumStaticDraught"),
+            Destination = TryGetTrimmedString(ssd, "Destination"),
+            Eta = TryReadEta(ssd),
+        };
+    }
+
+    private static DateTimeOffset? TryReadEta(JsonElement ssd)
+    {
+        if (!ssd.TryGetProperty("Eta", out var eta) || eta.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        var month = TryGetInt(eta, "Month");
+        var day = TryGetInt(eta, "Day");
+        var hour = TryGetInt(eta, "Hour");
+        var minute = TryGetInt(eta, "Minute");
+        if (month is null || day is null || hour is null || minute is null) return null;
+        if (month is 0 || day is 0) return null;
+        try
+        {
+            // AIS ETA has no year — pin to current UTC year.
+            var year = DateTime.UtcNow.Year;
+            return new DateTimeOffset(year, month.Value, day.Value, hour.Value, minute.Value, 0, TimeSpan.Zero);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    private static double? CollapseSentinel(double? value, double sentinel)
+    {
+        if (value is null) return null;
+        return Math.Abs(value.Value - sentinel) < 0.01 ? null : value.Value;
+    }
+
+    private static double? CollapseSentinelSigned(double? value, double sentinel)
+    {
+        if (value is null) return null;
+        // AIS ROT sentinel is -128 / +128; both indicate "not available".
+        return Math.Abs(value.Value) >= Math.Abs(sentinel) - 0.01 ? null : value.Value;
+    }
+
+    private static double? TryGetDouble(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var prop)) return null;
+        return prop.ValueKind switch
+        {
+            JsonValueKind.Number => prop.TryGetDouble(out var d) ? d : null,
+            _ => null,
+        };
+    }
+
+    private static int? TryGetInt(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var prop)) return null;
+        return prop.ValueKind == JsonValueKind.Number && prop.TryGetInt32(out var i) ? i : null;
+    }
+
+    private static uint? TryGetUInt(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var prop)) return null;
+        return prop.ValueKind == JsonValueKind.Number && prop.TryGetUInt32(out var u) ? u : null;
+    }
+
+    private static string? TryGetTrimmedString(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var prop)) return null;
+        if (prop.ValueKind != JsonValueKind.String) return null;
+        var text = prop.GetString();
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        return text.TrimEnd().TrimEnd('@', ' ');
+    }
+
+    /// <summary>
+    /// Replaces the API key in a logged subscribe frame with a
+    /// fixed redaction marker so the key never lands in logs.
+    /// </summary>
+    public static string RedactApiKey(string frame, string apiKey)
+    {
+        if (string.IsNullOrEmpty(apiKey)) return frame;
+        return frame.Replace(apiKey, "***REDACTED***", StringComparison.Ordinal);
+    }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoMessageSource.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoMessageSource.cs
@@ -1,0 +1,76 @@
+using EncDotNet.S100.Pipelines;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+/// <summary>
+/// <see cref="IAisMessageSource"/> backed by the aisstream.io
+/// WebSocket service. Each call to <see cref="Subscribe"/> opens an
+/// independent transport and runs its own receive loop.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reconnect is automatic — on any transport-level disconnect the
+/// driver waits with truncated exponential backoff, reconnects, and
+/// re-sends the active subscribe frame within the 3 s deadline. The
+/// returned <see cref="IAisSubscription"/> instance survives across
+/// reconnects.
+/// </para>
+/// <para>
+/// API keys are never written to logs — every outgoing frame is
+/// passed through <see cref="AisStreamIoJson.RedactApiKey"/> before
+/// emission, and a regression test pins this behaviour.
+/// </para>
+/// </remarks>
+public sealed class AisStreamIoMessageSource : IAisMessageSource
+{
+    private readonly AisStreamIoOptions _options;
+    private readonly Func<IAisStreamIoTransport> _transportFactory;
+    private readonly ILoggerFactory _loggerFactory;
+
+    /// <summary>
+    /// Convenience constructor wiring the production
+    /// <see cref="ClientWebSocketTransport"/>.
+    /// </summary>
+    public AisStreamIoMessageSource(AisStreamIoOptions options, ILoggerFactory? loggerFactory = null)
+        : this(options, () => new ClientWebSocketTransport(), loggerFactory)
+    {
+    }
+
+    /// <summary>
+    /// Test constructor — caller supplies a transport factory.
+    /// </summary>
+    public AisStreamIoMessageSource(
+        AisStreamIoOptions options,
+        Func<IAisStreamIoTransport> transportFactory,
+        ILoggerFactory? loggerFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrEmpty(options.ApiKey);
+        ArgumentNullException.ThrowIfNull(transportFactory);
+        _options = options;
+        _transportFactory = transportFactory;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+    }
+
+    /// <inheritdoc />
+    public AisSourceMetadata Metadata { get; } = new()
+    {
+        DisplayName = "aisstream.io",
+        Description = "AIS targets streamed live from aisstream.io (BETA service).",
+    };
+
+    /// <inheritdoc />
+    public IAisSubscription Subscribe(AisSubscriptionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var subscription = new AisStreamIoSubscription(
+            _options,
+            _transportFactory,
+            request,
+            _loggerFactory.CreateLogger<AisStreamIoSubscription>());
+        subscription.Start();
+        return subscription;
+    }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoOptions.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoOptions.cs
@@ -1,0 +1,42 @@
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+/// <summary>
+/// Configuration for an <see cref="AisStreamIoMessageSource"/>.
+/// </summary>
+public sealed record AisStreamIoOptions
+{
+    /// <summary>
+    /// API key issued by aisstream.io. Required.
+    /// </summary>
+    /// <remarks>
+    /// The key is sensitive — it MUST be redacted from logs and
+    /// exception messages. Loggers wired by this driver run every
+    /// outgoing JSON frame through the redactor before emission.
+    /// </remarks>
+    public required string ApiKey { get; init; }
+
+    /// <summary>
+    /// WebSocket endpoint. Defaults to the documented production
+    /// URL <c>wss://stream.aisstream.io/v0/stream</c>; tests
+    /// override.
+    /// </summary>
+    public Uri Endpoint { get; init; } = new("wss://stream.aisstream.io/v0/stream");
+
+    /// <summary>
+    /// Hard deadline within which the subscribe frame must be sent
+    /// after connect (aisstream.io closes the socket on timeout).
+    /// Defaults to 3 s per the documentation.
+    /// </summary>
+    public TimeSpan SubscribeDeadline { get; init; } = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// Initial backoff between reconnect attempts. Doubles up to
+    /// <see cref="MaxReconnectBackoff"/> on consecutive failures.
+    /// </summary>
+    public TimeSpan InitialReconnectBackoff { get; init; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Maximum backoff between reconnect attempts.
+    /// </summary>
+    public TimeSpan MaxReconnectBackoff { get; init; } = TimeSpan.FromSeconds(30);
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoSubscription.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/AisStreamIoSubscription.cs
@@ -1,0 +1,203 @@
+using EncDotNet.S100.Pipelines;
+using Microsoft.Extensions.Logging;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+/// <summary>
+/// One running aisstream.io subscription. Owns a transport, a
+/// background receive loop, and a reconnect controller.
+/// </summary>
+internal sealed class AisStreamIoSubscription : IAisSubscription
+{
+    private readonly AisStreamIoOptions _options;
+    private readonly Func<IAisStreamIoTransport> _transportFactory;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly object _stateLock = new();
+
+    private AisSubscriptionRequest _activeRequest;
+    private IAisStreamIoTransport? _transport;
+    private Task? _loop;
+    private bool _resubscribePending;
+
+    public AisStreamIoSubscription(
+        AisStreamIoOptions options,
+        Func<IAisStreamIoTransport> transportFactory,
+        AisSubscriptionRequest initialRequest,
+        ILogger logger)
+    {
+        _options = options;
+        _transportFactory = transportFactory;
+        _logger = logger;
+        _activeRequest = initialRequest;
+    }
+
+    public AisSubscriptionRequest ActiveRequest
+    {
+        get { lock (_stateLock) return _activeRequest; }
+    }
+
+    public event EventHandler<AisPositionReport>? PositionReportReceived;
+    public event EventHandler<AisStaticVoyageData>? StaticVoyageDataReceived;
+    public event EventHandler<AisTargetLost>? TargetLost;
+
+    /// <summary>
+    /// aisstream.io maps swap-and-replace cleanly to in-place
+    /// updates — we always return <see langword="true"/>. The
+    /// receive loop notices the change on its next iteration and
+    /// resends the subscribe frame.
+    /// </summary>
+    public bool TryUpdateArea(BoundingBox? area)
+    {
+        lock (_stateLock)
+        {
+            _activeRequest = _activeRequest with { Area = area };
+            _resubscribePending = true;
+        }
+        return true;
+    }
+
+    internal void Start()
+    {
+        _loop = Task.Run(() => RunLoopAsync(_cts.Token));
+    }
+
+    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    {
+        var backoff = _options.InitialReconnectBackoff;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                var transport = _transportFactory();
+                lock (_stateLock) _transport = transport;
+                try
+                {
+                    await transport.ConnectAsync(_options.Endpoint, connectCts.Token).ConfigureAwait(false);
+
+                    await SendSubscribeAsync(transport, connectCts.Token).ConfigureAwait(false);
+                    backoff = _options.InitialReconnectBackoff;
+
+                    await ReceiveUntilDoneAsync(transport, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    lock (_stateLock) _transport = null;
+                    await transport.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "aisstream.io transport error; reconnecting after {Backoff}.", backoff);
+            }
+
+            try
+            {
+                await Task.Delay(backoff, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { return; }
+
+            backoff = TimeSpan.FromMilliseconds(
+                Math.Min(backoff.TotalMilliseconds * 2, _options.MaxReconnectBackoff.TotalMilliseconds));
+        }
+    }
+
+    private async Task SendSubscribeAsync(IAisStreamIoTransport transport, CancellationToken cancellationToken)
+    {
+        AisSubscriptionRequest snapshot;
+        lock (_stateLock) snapshot = _activeRequest;
+
+        var frame = AisStreamIoJson.BuildSubscribeFrame(_options.ApiKey, snapshot);
+        using var deadlineCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadlineCts.CancelAfter(_options.SubscribeDeadline);
+        await transport.SendTextAsync(frame, deadlineCts.Token).ConfigureAwait(false);
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("aisstream.io subscribe sent: {Frame}", AisStreamIoJson.RedactApiKey(frame, _options.ApiKey));
+        }
+    }
+
+    private async Task ReceiveUntilDoneAsync(IAisStreamIoTransport transport, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            // If a TryUpdateArea call has flagged a resubscribe, send a fresh frame
+            // before the next receive.
+            bool needsResubscribe;
+            lock (_stateLock)
+            {
+                needsResubscribe = _resubscribePending;
+                _resubscribePending = false;
+            }
+            if (needsResubscribe)
+            {
+                await SendSubscribeAsync(transport, cancellationToken).ConfigureAwait(false);
+            }
+
+            var frame = await transport.ReceiveTextAsync(cancellationToken).ConfigureAwait(false);
+            if (frame is null) return; // peer closed
+            DispatchFrame(frame);
+        }
+    }
+
+    private void DispatchFrame(string frame)
+    {
+        var message = AisStreamIoJson.ParseInbound(frame);
+        switch (message)
+        {
+            case AisPositionReport pr:
+                if (PassesFilter(pr.Mmsi))
+                {
+                    PositionReportReceived?.Invoke(this, pr);
+                }
+                break;
+            case AisStaticVoyageData sd:
+                if (PassesFilter(sd.Mmsi))
+                {
+                    StaticVoyageDataReceived?.Invoke(this, sd);
+                }
+                break;
+            default:
+                _logger.LogTrace("Ignoring inbound aisstream.io frame ({Length} bytes).", frame.Length);
+                break;
+        }
+        _ = TargetLost; // suppress unused-event warning; populated only by future drivers.
+    }
+
+    private bool PassesFilter(uint mmsi)
+    {
+        AisSubscriptionRequest active;
+        lock (_stateLock) active = _activeRequest;
+        if (active.Mmsis is { Count: > 0 } mmsis && !mmsis.Contains(mmsi)) return false;
+        return true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        try
+        {
+            if (_loop is not null) await _loop.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { /* normal shutdown */ }
+        IAisStreamIoTransport? transport;
+        lock (_stateLock)
+        {
+            transport = _transport;
+            _transport = null;
+        }
+        if (transport is not null)
+        {
+            await transport.DisposeAsync().ConfigureAwait(false);
+        }
+        _cts.Dispose();
+    }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/ClientWebSocketTransport.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/ClientWebSocketTransport.cs
@@ -100,15 +100,23 @@ public sealed class ClientWebSocketTransport : IAisStreamIoTransport
         {
             if (_socket.State == WebSocketState.Open)
             {
+                // Bound the close handshake — if the peer is wedged
+                // we don't want Dispose to hang the host process.
+                using var closeCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
                 await _socket.CloseAsync(
                     WebSocketCloseStatus.NormalClosure,
                     statusDescription: null,
-                    CancellationToken.None).ConfigureAwait(false);
+                    closeCts.Token).ConfigureAwait(false);
             }
         }
         catch (WebSocketException)
         {
             // Already-broken sockets — drop quietly on dispose.
+        }
+        catch (OperationCanceledException)
+        {
+            // Close-handshake timed out — drop into Dispose() below
+            // which will Abort the underlying socket.
         }
         _socket.Dispose();
         _socket = null;

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/ClientWebSocketTransport.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/ClientWebSocketTransport.cs
@@ -1,0 +1,116 @@
+using System.Net.WebSockets;
+using System.Text;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+/// <summary>
+/// Production transport — a thin wrapper around
+/// <see cref="ClientWebSocket"/>. Reassembles fragmented text
+/// frames before yielding them.
+/// </summary>
+public sealed class ClientWebSocketTransport : IAisStreamIoTransport
+{
+    private readonly Func<ClientWebSocket> _factory;
+    private ClientWebSocket? _socket;
+
+    /// <summary>
+    /// Creates a transport that produces a new
+    /// <see cref="ClientWebSocket"/> on each
+    /// <see cref="ConnectAsync"/>.
+    /// </summary>
+    public ClientWebSocketTransport()
+        : this(() => new ClientWebSocket())
+    {
+    }
+
+    /// <summary>
+    /// Creates a transport with a caller-supplied factory — used
+    /// by tests that want to set proxies, headers, or fault
+    /// injection.
+    /// </summary>
+    public ClientWebSocketTransport(Func<ClientWebSocket> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factory = factory;
+    }
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        if (_socket is { State: WebSocketState.Open or WebSocketState.Connecting })
+        {
+            throw new InvalidOperationException("Transport is already connected.");
+        }
+        var socket = _factory();
+        await socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+        _socket = socket;
+    }
+
+    /// <inheritdoc />
+    public async Task SendTextAsync(string payload, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        var socket = _socket ?? throw new InvalidOperationException("Not connected.");
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await socket.SendAsync(
+            new ArraySegment<byte>(bytes),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> ReceiveTextAsync(CancellationToken cancellationToken)
+    {
+        var socket = _socket ?? throw new InvalidOperationException("Not connected.");
+        var buffer = new byte[8192];
+        using var ms = new MemoryStream();
+        while (true)
+        {
+            WebSocketReceiveResult result;
+            try
+            {
+                result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (WebSocketException)
+            {
+                return null;
+            }
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return null;
+            }
+
+            ms.Write(buffer, 0, result.Count);
+            if (result.EndOfMessage)
+            {
+                return Encoding.UTF8.GetString(ms.ToArray());
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_socket is null) return;
+        try
+        {
+            if (_socket.State == WebSocketState.Open)
+            {
+                await _socket.CloseAsync(
+                    WebSocketCloseStatus.NormalClosure,
+                    statusDescription: null,
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+        catch (WebSocketException)
+        {
+            // Already-broken sockets — drop quietly on dispose.
+        }
+        _socket.Dispose();
+        _socket = null;
+    }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.DynamicSources.Ais\EncDotNet.S100.DynamicSources.Ais.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/IAisStreamIoTransport.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/IAisStreamIoTransport.cs
@@ -1,0 +1,25 @@
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+/// <summary>
+/// Test seam over <see cref="System.Net.WebSockets.ClientWebSocket"/>.
+/// Production wraps a real WebSocket; tests inject an in-process
+/// fake that exchanges JSON frames without a network.
+/// </summary>
+public interface IAisStreamIoTransport : IAsyncDisposable
+{
+    /// <summary>
+    /// Opens a transport connection to the supplied endpoint.
+    /// </summary>
+    Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends a single text frame (one JSON object).
+    /// </summary>
+    Task SendTextAsync(string payload, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reads one inbound text frame. Returns <see langword="null"/>
+    /// when the peer has closed the connection cleanly.
+    /// </summary>
+    Task<string?> ReceiveTextAsync(CancellationToken cancellationToken);
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/README.md
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/README.md
@@ -1,0 +1,37 @@
+# EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo
+
+`IAisMessageSource` driver targeting [aisstream.io](https://aisstream.io)'s
+free WebSocket AIS streaming service.
+
+## What ships here
+
+| Type | Purpose |
+| --- | --- |
+| `AisStreamIoOptions` | API key, endpoint URI, subscribe deadline, reconnect backoff settings. |
+| `IAisStreamIoTransport` | Test seam over `ClientWebSocket`; exchanges JSON text frames. |
+| `ClientWebSocketTransport` | Production transport — wraps `System.Net.WebSockets.ClientWebSocket`, reassembles fragmented frames. |
+| `AisStreamIoMessageSource` | `IAisMessageSource` backed by aisstream.io. |
+| (internal) `AisStreamIoSubscription` | Per-call subscription with automatic reconnect (truncated exponential backoff, 250 ms → 30 s) and swap-and-replace `TryUpdateArea`. |
+| (internal) `AisStreamIoJson` | Hand-rolled JSON contract for `PositionReport` and `ShipStaticData`; sentinel collapse (511 / 360 / 102.3 / -128); API-key redaction for logs. |
+
+## Dependencies
+
+BCL-only — `System.Net.WebSockets.ClientWebSocket` plus
+`System.Text.Json`. No third-party AIS / WebSocket libraries.
+
+## Notes
+
+- aisstream.io is a BETA service with no published SLA. Treat as
+  best-effort; the driver reconnects transparently on disconnect.
+- The service requires the subscribe frame within 3 s of connect.
+- Updating the spatial filter is by **resending** the subscribe
+  frame on the same socket — `TryUpdateArea` does this and always
+  returns `true`.
+- API keys are sensitive. The driver never logs them — every
+  outgoing frame goes through `AisStreamIoJson.RedactApiKey` before
+  emission, and a regression test pins this behaviour.
+
+## See also
+
+- `docs/design/ais-source.md` §12.
+- `EncDotNet.S100.DynamicSources.Ais` for the abstraction layer.

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisDimensions.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisDimensions.cs
@@ -1,0 +1,31 @@
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Vessel hull dimensions decoded from an AIS Type-5 / Type-24 part-A
+/// "reference for position" payload. The four fields A/B/C/D from the
+/// AIS message are folded into the same shape as
+/// <see cref="DynamicSources.DynamicVesselGeometry"/>:
+/// <see cref="LengthMetres"/> = A + B,
+/// <see cref="BeamMetres"/> = C + D,
+/// <see cref="BowOffsetMetres"/> = A,
+/// <see cref="PortOffsetMetres"/> = C.
+/// </summary>
+/// <remarks>
+/// All values are in metres. Producers are expected to drop
+/// dimension blocks that violate the AIS spec's positivity / range
+/// constraints.
+/// </remarks>
+public sealed record AisDimensions
+{
+    /// <summary>Bow-to-stern length in metres (A + B).</summary>
+    public required double LengthMetres { get; init; }
+
+    /// <summary>Port-to-starboard beam in metres (C + D).</summary>
+    public required double BeamMetres { get; init; }
+
+    /// <summary>Distance aft of bow to the GPS antenna in metres (A).</summary>
+    public required double BowOffsetMetres { get; init; }
+
+    /// <summary>Distance starboard of port side to the GPS antenna in metres (C).</summary>
+    public required double PortOffsetMetres { get; init; }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisDynamicFeatureSource.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisDynamicFeatureSource.cs
@@ -50,6 +50,7 @@ public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDispo
     private readonly DynamicFeatureTracker<AisPositionReport> _tracker;
     private readonly object _staticLock = new();
     private readonly Dictionary<uint, AisStaticVoyageData> _staticByMmsi = new();
+    private readonly IReadOnlySet<AisShipTypeClass>? _shipTypeAllowList;
     private readonly TimeSpan _retain;
     private bool _disposed;
 
@@ -78,6 +79,11 @@ public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDispo
         _retain = retain ?? DefaultRetainWindow;
         _tracker = new DynamicFeatureTracker<AisPositionReport>(Project);
 
+        var resolved = request ?? new AisSubscriptionRequest();
+        _shipTypeAllowList = resolved.ShipTypes is null
+            ? null
+            : new HashSet<AisShipTypeClass>(resolved.ShipTypes);
+
         Metadata = new DynamicSourceMetadata
         {
             DisplayName = messageSource.Metadata.DisplayName,
@@ -85,7 +91,7 @@ public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDispo
             RendererKey = "vessel.ais",
         };
 
-        _subscription = messageSource.Subscribe(request ?? new AisSubscriptionRequest());
+        _subscription = messageSource.Subscribe(resolved);
         _subscription.PositionReportReceived += OnPositionReportReceived;
         _subscription.StaticVoyageDataReceived += OnStaticVoyageDataReceived;
         _subscription.TargetLost += OnTargetLost;
@@ -155,6 +161,7 @@ public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDispo
     private void OnPositionReportReceived(object? sender, AisPositionReport report)
     {
         if (_disposed) return;
+        if (!IsClassAllowed(report.Mmsi)) return;
         var change = _tracker.Apply(report);
         Changed?.Invoke(this, change);
     }
@@ -164,10 +171,30 @@ public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDispo
         if (_disposed) return;
 
         bool refresh;
+        bool evict = false;
         lock (_staticLock)
         {
             _staticByMmsi[data.Mmsi] = data;
             refresh = _tracker.Current.Any(f => f.Id == FeatureIdForMmsi(data.Mmsi));
+            if (_shipTypeAllowList is not null
+                && !_shipTypeAllowList.Contains(data.ShipTypeClass))
+            {
+                evict = refresh;
+                refresh = false;
+            }
+        }
+
+        if (evict)
+        {
+            // Static data revealed this MMSI is in a class the
+            // caller filtered out — remove the already-projected
+            // feature so per-class subscriptions converge.
+            var removal = _tracker.Remove(FeatureIdForMmsi(data.Mmsi));
+            if (removal.Kind == DynamicSourceChangeKind.Removed)
+            {
+                Changed?.Invoke(this, removal);
+            }
+            return;
         }
 
         if (!refresh) return;
@@ -195,6 +222,24 @@ public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDispo
         {
             Changed?.Invoke(this, change);
         }
+    }
+
+    /// <summary>
+    /// Whether a position report for <paramref name="mmsi"/> should be
+    /// admitted under the active <see cref="AisSubscriptionRequest.ShipTypes"/>
+    /// allow-list. When no static data is yet cached for the MMSI the
+    /// report is admitted optimistically; if subsequent
+    /// <see cref="AisStaticVoyageData"/> classifies the vessel into a
+    /// disallowed class the feature is evicted in
+    /// <see cref="OnStaticVoyageDataReceived"/>.
+    /// </summary>
+    private bool IsClassAllowed(uint mmsi)
+    {
+        if (_shipTypeAllowList is null) return true;
+        AisStaticVoyageData? cached;
+        lock (_staticLock) _staticByMmsi.TryGetValue(mmsi, out cached);
+        if (cached is null) return true;
+        return _shipTypeAllowList.Contains(cached.ShipTypeClass);
     }
 
     private DynamicFeature Project(AisPositionReport report)

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisDynamicFeatureSource.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisDynamicFeatureSource.cs
@@ -1,0 +1,312 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Concrete <see cref="IDynamicFeatureSource"/> that consumes an
+/// <see cref="IAisMessageSource"/>, projects every position report
+/// to a <see cref="DynamicFeature"/>, merges in the most recent
+/// <see cref="AisStaticVoyageData"/> per MMSI, and ages stale
+/// targets out via a caller-driven sweep.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The source is intentionally driver-agnostic. Tests and the
+/// future "replay a captured aisstream.io JSON-lines fixture"
+/// driver use exactly the same code path as the production
+/// aisstream.io driver — the abstraction seam is
+/// <see cref="IAisMessageSource"/>.
+/// </para>
+/// <para>
+/// <b>Aging.</b> AIS reports per ITU-R M.1371-5 §4.2.1 vary from
+/// 2 s (high-speed Class A) to 3 min (anchored Class A) to 3 min
+/// (Class B "still"). A 6-minute default retain window covers all
+/// nominal cases with margin; callers may override via the
+/// constructor. The source itself does not run a timer — the host
+/// (viewer or sample) calls <see cref="Sweep(DateTimeOffset)"/> on
+/// its own cadence.
+/// </para>
+/// <para>
+/// <b>Threading.</b> Snapshot reads on
+/// <see cref="CurrentFeatures"/> and <see cref="Metadata"/> are
+/// thread-safe via <see cref="DynamicFeatureTracker{TInbound}"/>.
+/// <see cref="Changed"/> is raised on whatever thread the inbound
+/// AIS event arrived on.
+/// </para>
+/// </remarks>
+public sealed class AisDynamicFeatureSource : IDynamicFeatureSource, IAsyncDisposable
+{
+    /// <summary>
+    /// Default retention window for stale targets — 6 minutes.
+    /// Covers ITU-R M.1371-5 §4.2.1's longest nominal reporting
+    /// interval (3 min, anchored Class A and Class B "still") with
+    /// 2× margin for transmission gaps.
+    /// </summary>
+    public static readonly TimeSpan DefaultRetainWindow = TimeSpan.FromMinutes(6);
+
+    private readonly IAisMessageSource _messageSource;
+    private readonly IAisSubscription _subscription;
+    private readonly DynamicFeatureTracker<AisPositionReport> _tracker;
+    private readonly object _staticLock = new();
+    private readonly Dictionary<uint, AisStaticVoyageData> _staticByMmsi = new();
+    private readonly TimeSpan _retain;
+    private bool _disposed;
+
+    /// <summary>
+    /// Wraps an <see cref="IAisMessageSource"/> as a
+    /// <see cref="IDynamicFeatureSource"/>.
+    /// </summary>
+    /// <param name="id">Stable instance id (e.g. <c>"ais"</c>).</param>
+    /// <param name="messageSource">Driver supplying decoded AIS messages.</param>
+    /// <param name="request">Initial subscription filters.</param>
+    /// <param name="retain">
+    /// Stale-target retention window. <see langword="null"/> uses
+    /// <see cref="DefaultRetainWindow"/>.
+    /// </param>
+    public AisDynamicFeatureSource(
+        string id,
+        IAisMessageSource messageSource,
+        AisSubscriptionRequest? request = null,
+        TimeSpan? retain = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        ArgumentNullException.ThrowIfNull(messageSource);
+
+        Id = id;
+        _messageSource = messageSource;
+        _retain = retain ?? DefaultRetainWindow;
+        _tracker = new DynamicFeatureTracker<AisPositionReport>(Project);
+
+        Metadata = new DynamicSourceMetadata
+        {
+            DisplayName = messageSource.Metadata.DisplayName,
+            Description = messageSource.Metadata.Description,
+            RendererKey = "vessel.ais",
+        };
+
+        _subscription = messageSource.Subscribe(request ?? new AisSubscriptionRequest());
+        _subscription.PositionReportReceived += OnPositionReportReceived;
+        _subscription.StaticVoyageDataReceived += OnStaticVoyageDataReceived;
+        _subscription.TargetLost += OnTargetLost;
+    }
+
+    /// <inheritdoc />
+    public string Id { get; }
+
+    /// <inheritdoc />
+    public DynamicSourceMetadata Metadata { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<DynamicFeature> CurrentFeatures => _tracker.Current;
+
+    /// <inheritdoc />
+    public event EventHandler<DynamicFeaturesChanged>? Changed;
+
+    /// <summary>
+    /// Updates the spatial filter on the underlying subscription.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the underlying driver could
+    /// update its filter in place; <see langword="false"/> when the
+    /// caller must dispose this source and create a new one with a
+    /// new <see cref="AisSubscriptionRequest"/>.
+    /// </returns>
+    public bool UpdateArea(BoundingBox? area)
+    {
+        ThrowIfDisposed();
+        return _subscription.TryUpdateArea(area);
+    }
+
+    /// <summary>
+    /// Removes feature entries whose last position report is older
+    /// than the configured retention window. The host calls this on
+    /// its own cadence (typically 1 Hz).
+    /// </summary>
+    public void Sweep(DateTimeOffset now)
+    {
+        ThrowIfDisposed();
+        var change = _tracker.Sweep(now, _retain);
+        if (change.Kind == DynamicSourceChangeKind.Removed)
+        {
+            // Drop static cache entries for swept MMSIs to keep the
+            // dictionary bounded; an MMSI that comes back will get a
+            // fresh ShipStaticData record before its next position.
+            lock (_staticLock)
+            {
+                foreach (var id in change.ChangedIds)
+                {
+                    var mmsi = TryParseMmsiFromFeatureId(id);
+                    if (mmsi is not null)
+                    {
+                        _staticByMmsi.Remove(mmsi.Value);
+                    }
+                }
+            }
+            Changed?.Invoke(this, change);
+        }
+    }
+
+    /// <summary>
+    /// Constructs the stable feature id for a given MMSI.
+    /// </summary>
+    public static string FeatureIdForMmsi(uint mmsi) => $"ais:{mmsi}";
+
+    private void OnPositionReportReceived(object? sender, AisPositionReport report)
+    {
+        if (_disposed) return;
+        var change = _tracker.Apply(report);
+        Changed?.Invoke(this, change);
+    }
+
+    private void OnStaticVoyageDataReceived(object? sender, AisStaticVoyageData data)
+    {
+        if (_disposed) return;
+
+        bool refresh;
+        lock (_staticLock)
+        {
+            _staticByMmsi[data.Mmsi] = data;
+            refresh = _tracker.Current.Any(f => f.Id == FeatureIdForMmsi(data.Mmsi));
+        }
+
+        if (!refresh) return;
+
+        // Re-project the most recent feature for this MMSI so the
+        // static-data merge takes effect immediately. We don't have
+        // the original AisPositionReport at hand, so reconstruct one
+        // from the snapshot's lat/lon/motion/timestamp — sufficient
+        // for the projection.
+        var existing = _tracker.Current.FirstOrDefault(f => f.Id == FeatureIdForMmsi(data.Mmsi));
+        if (existing is null) return;
+
+        var synthetic = ReconstructPositionReport(existing, data.Mmsi);
+        var change = _tracker.Apply(synthetic);
+        Changed?.Invoke(this, change);
+    }
+
+    private void OnTargetLost(object? sender, AisTargetLost lost)
+    {
+        if (_disposed) return;
+        var featureId = FeatureIdForMmsi(lost.Mmsi);
+        var change = _tracker.Remove(featureId);
+        lock (_staticLock) _staticByMmsi.Remove(lost.Mmsi);
+        if (change.Kind == DynamicSourceChangeKind.Removed)
+        {
+            Changed?.Invoke(this, change);
+        }
+    }
+
+    private DynamicFeature Project(AisPositionReport report)
+    {
+        AisStaticVoyageData? staticData;
+        lock (_staticLock) _staticByMmsi.TryGetValue(report.Mmsi, out staticData);
+
+        var cls = staticData?.ShipTypeClass ?? AisShipTypeClass.Unknown;
+        var attributes = new Dictionary<string, object?>
+        {
+            ["mmsi"] = report.Mmsi,
+        };
+        if (report.NavigationStatus is { } navStatus)
+        {
+            attributes["navigationStatus"] = navStatus;
+        }
+        if (report.RateOfTurnDegPerMin is { } rot)
+        {
+            attributes["rateOfTurnDegPerMin"] = rot;
+        }
+        if (staticData is not null)
+        {
+            if (staticData.VesselName is { } name) attributes["vesselName"] = name;
+            if (staticData.CallSign is { } callSign) attributes["callSign"] = callSign;
+            if (staticData.ImoNumber is { } imo) attributes["imoNumber"] = imo;
+            if (staticData.Destination is { } destination) attributes["destination"] = destination;
+            if (staticData.Eta is { } eta) attributes["eta"] = eta;
+            if (staticData.DraughtMetres is { } draught) attributes["draughtMetres"] = draught;
+            attributes["shipType"] = (int)staticData.ShipType;
+            attributes["shipTypeClass"] = cls;
+        }
+
+        DynamicVesselGeometry? geometry = null;
+        if (staticData?.Dimensions is { } dims
+            && dims.LengthMetres > 0 && dims.BeamMetres > 0)
+        {
+            geometry = new DynamicVesselGeometry
+            {
+                LengthMetres = dims.LengthMetres,
+                BeamMetres = dims.BeamMetres,
+                BowOffsetMetres = dims.BowOffsetMetres,
+                PortOffsetMetres = dims.PortOffsetMetres,
+            };
+        }
+
+        return new DynamicFeature
+        {
+            Id = FeatureIdForMmsi(report.Mmsi),
+            Kind = $"vessel.ais.{cls.ToKindToken()}",
+            GeometryType = GeometryType.Point,
+            Coordinates = new[] { (report.Latitude, report.Longitude) },
+            Motion = new DynamicMotion
+            {
+                CourseOverGroundDeg = report.CourseOverGroundDeg,
+                HeadingDeg = report.HeadingDeg,
+                SpeedOverGroundKn = report.SpeedOverGroundKn,
+            },
+            VesselGeometry = geometry,
+            Attributes = attributes,
+            LastUpdated = report.Timestamp,
+        };
+    }
+
+    private static AisPositionReport ReconstructPositionReport(DynamicFeature feature, uint mmsi)
+    {
+        var (lat, lon) = feature.Coordinates[0];
+        AisNavigationStatus? navStatus = null;
+        double? rot = null;
+        if (feature.Attributes.TryGetValue("navigationStatus", out var navObj)
+            && navObj is AisNavigationStatus n)
+        {
+            navStatus = n;
+        }
+        if (feature.Attributes.TryGetValue("rateOfTurnDegPerMin", out var rotObj)
+            && rotObj is double r)
+        {
+            rot = r;
+        }
+        return new AisPositionReport
+        {
+            Mmsi = mmsi,
+            Timestamp = feature.LastUpdated,
+            Latitude = lat,
+            Longitude = lon,
+            CourseOverGroundDeg = feature.Motion?.CourseOverGroundDeg,
+            HeadingDeg = feature.Motion?.HeadingDeg,
+            SpeedOverGroundKn = feature.Motion?.SpeedOverGroundKn,
+            NavigationStatus = navStatus,
+            RateOfTurnDegPerMin = rot,
+        };
+    }
+
+    private static uint? TryParseMmsiFromFeatureId(string id)
+    {
+        const string prefix = "ais:";
+        if (!id.StartsWith(prefix, StringComparison.Ordinal)) return null;
+        return uint.TryParse(id.AsSpan(prefix.Length), out var mmsi) ? mmsi : null;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _subscription.PositionReportReceived -= OnPositionReportReceived;
+        _subscription.StaticVoyageDataReceived -= OnStaticVoyageDataReceived;
+        _subscription.TargetLost -= OnTargetLost;
+        await _subscription.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisMessage.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisMessage.cs
@@ -1,0 +1,111 @@
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Base type for decoded AIS messages exposed by an
+/// <see cref="IAisMessageSource"/>. Concrete subtypes
+/// (<see cref="AisPositionReport"/>, <see cref="AisStaticVoyageData"/>)
+/// carry the family-specific payload.
+/// </summary>
+/// <remarks>
+/// The shape is intentionally "denormalised" — consumers do not see
+/// the underlying AIS message-type number (1, 2, 3, 5, 18, 19, 24).
+/// Drivers fold all position-bearing messages into
+/// <see cref="AisPositionReport"/> and all static / voyage messages
+/// into <see cref="AisStaticVoyageData"/>.
+/// </remarks>
+public abstract record AisMessage
+{
+    /// <summary>The reporting vessel's MMSI.</summary>
+    public required uint Mmsi { get; init; }
+
+    /// <summary>UTC timestamp at which the source received the message.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+}
+
+/// <summary>
+/// Decoded AIS position report (Class A messages 1/2/3, Class B
+/// 18/19). Sentinel values from the wire (511 heading, 360 COG,
+/// 102.3 SOG, -128 ROT) are collapsed to <see langword="null"/> at
+/// the driver boundary so this record never carries them.
+/// </summary>
+public sealed record AisPositionReport : AisMessage
+{
+    /// <summary>WGS-84 latitude in degrees.</summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>WGS-84 longitude in degrees.</summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>Course over ground in degrees true (0–359.9), or
+    /// <see langword="null"/> when the report carried the 360.0
+    /// "not available" sentinel.</summary>
+    public double? CourseOverGroundDeg { get; init; }
+
+    /// <summary>True heading in degrees (0–359), or
+    /// <see langword="null"/> when the report carried the 511
+    /// "not available" sentinel.</summary>
+    public double? HeadingDeg { get; init; }
+
+    /// <summary>Speed over ground in knots, or
+    /// <see langword="null"/> when the report carried the 102.3
+    /// "not available" sentinel.</summary>
+    public double? SpeedOverGroundKn { get; init; }
+
+    /// <summary>Navigation status, or <see langword="null"/> when
+    /// the message family does not carry one (Class B Type 18).</summary>
+    public AisNavigationStatus? NavigationStatus { get; init; }
+
+    /// <summary>Rate of turn in degrees per minute, or
+    /// <see langword="null"/> when the report carried the -128 / 128
+    /// "not available" sentinel or when the family does not carry
+    /// ROT.</summary>
+    public double? RateOfTurnDegPerMin { get; init; }
+}
+
+/// <summary>
+/// Decoded AIS static and voyage-related data (Class A message 5,
+/// Class B message 24 parts A and B combined when both have arrived).
+/// </summary>
+public sealed record AisStaticVoyageData : AisMessage
+{
+    /// <summary>IMO ship identification number, when reported.</summary>
+    public uint? ImoNumber { get; init; }
+
+    /// <summary>Call sign, when reported.</summary>
+    public string? CallSign { get; init; }
+
+    /// <summary>Vessel name, when reported.</summary>
+    public string? VesselName { get; init; }
+
+    /// <summary>Raw AIS shiptype code (Table 53). 0 = not available.</summary>
+    public AisShipType ShipType { get; init; }
+
+    /// <summary>Display-bucketed form of <see cref="ShipType"/>.</summary>
+    public AisShipTypeClass ShipTypeClass { get; init; }
+
+    /// <summary>Hull dimensions, when reported.</summary>
+    public AisDimensions? Dimensions { get; init; }
+
+    /// <summary>Maximum static draught in metres, when reported.</summary>
+    public double? DraughtMetres { get; init; }
+
+    /// <summary>Voyage destination, when reported.</summary>
+    public string? Destination { get; init; }
+
+    /// <summary>Voyage ETA, when reported.</summary>
+    public DateTimeOffset? Eta { get; init; }
+}
+
+/// <summary>
+/// Optional event raised by drivers that have an explicit
+/// "vessel left coverage" signal. The aisstream.io driver does not
+/// raise this — local-antenna and aggregator drivers may.
+/// </summary>
+public sealed record AisTargetLost
+{
+    /// <summary>The vanished vessel's MMSI.</summary>
+    public required uint Mmsi { get; init; }
+
+    /// <summary>UTC timestamp of the loss event.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisNavigationStatus.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisNavigationStatus.cs
@@ -1,0 +1,55 @@
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// AIS navigation-status codes per ITU-R M.1371-5 §3.3.7.2.1.
+/// </summary>
+public enum AisNavigationStatus
+{
+    /// <summary>0 — under way using engine.</summary>
+    UnderWayUsingEngine = 0,
+
+    /// <summary>1 — at anchor.</summary>
+    AtAnchor = 1,
+
+    /// <summary>2 — not under command.</summary>
+    NotUnderCommand = 2,
+
+    /// <summary>3 — restricted manoeuvrability.</summary>
+    RestrictedManoeuvrability = 3,
+
+    /// <summary>4 — constrained by her draught.</summary>
+    ConstrainedByDraught = 4,
+
+    /// <summary>5 — moored.</summary>
+    Moored = 5,
+
+    /// <summary>6 — aground.</summary>
+    Aground = 6,
+
+    /// <summary>7 — engaged in fishing.</summary>
+    EngagedInFishing = 7,
+
+    /// <summary>8 — under way sailing.</summary>
+    UnderWaySailing = 8,
+
+    /// <summary>9 — reserved for future amendment of navigational status for ships carrying DG, HS, MP, or IMO HSC.</summary>
+    Reserved9 = 9,
+
+    /// <summary>10 — reserved for future amendment of navigational status for ships carrying DG, HS, MP.</summary>
+    Reserved10 = 10,
+
+    /// <summary>11 — power-driven vessel towing astern (regional use).</summary>
+    PowerDrivenTowingAstern = 11,
+
+    /// <summary>12 — power-driven vessel pushing ahead or towing alongside (regional use).</summary>
+    PowerDrivenPushingAhead = 12,
+
+    /// <summary>13 — reserved for future use.</summary>
+    Reserved13 = 13,
+
+    /// <summary>14 — AIS-SART (active), MOB-AIS, EPIRB-AIS.</summary>
+    AisSart = 14,
+
+    /// <summary>15 — undefined / default.</summary>
+    NotDefined = 15,
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisShipType.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisShipType.cs
@@ -1,0 +1,91 @@
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Raw AIS shiptype code per ITU-R M.1371-5 Table 53. Carried
+/// verbatim from the upstream message for callers that need the
+/// original code; <see cref="AisShipTypeClass"/> exposes the
+/// display-bucketed form used by renderers.
+/// </summary>
+/// <remarks>
+/// Codes are nominally 0–99. The enum lists only the buckets used
+/// by the Table 53 mapping; any unmapped numeric value is preserved
+/// by casting an arbitrary <see cref="int"/> to the enum (the type
+/// is intentionally non-strict).
+/// </remarks>
+public enum AisShipType
+{
+    /// <summary>Not available (default).</summary>
+    NotAvailable = 0,
+
+    /// <summary>Reserved (1–19) — should not be used.</summary>
+    ReservedFutureUse = 1,
+
+    /// <summary>Wing in ground (WIG) — generic.</summary>
+    WingInGround = 20,
+
+    /// <summary>Fishing.</summary>
+    Fishing = 30,
+
+    /// <summary>Towing.</summary>
+    Towing = 31,
+
+    /// <summary>Towing — length exceeds 200 m or breadth exceeds 25 m.</summary>
+    TowingLargeOrWide = 32,
+
+    /// <summary>Dredging or underwater operations.</summary>
+    DredgingOrUnderwaterOps = 33,
+
+    /// <summary>Diving operations.</summary>
+    DivingOps = 34,
+
+    /// <summary>Military operations.</summary>
+    MilitaryOps = 35,
+
+    /// <summary>Sailing.</summary>
+    Sailing = 36,
+
+    /// <summary>Pleasure craft.</summary>
+    PleasureCraft = 37,
+
+    /// <summary>High speed craft (HSC) — generic.</summary>
+    HighSpeedCraft = 40,
+
+    /// <summary>Pilot vessel.</summary>
+    PilotVessel = 50,
+
+    /// <summary>Search and rescue vessel.</summary>
+    SearchAndRescue = 51,
+
+    /// <summary>Tug.</summary>
+    Tug = 52,
+
+    /// <summary>Port tender.</summary>
+    PortTender = 53,
+
+    /// <summary>Anti-pollution equipment.</summary>
+    AntiPollution = 54,
+
+    /// <summary>Law enforcement.</summary>
+    LawEnforcement = 55,
+
+    /// <summary>Spare — local vessel (56, 57).</summary>
+    SpareLocalVessel = 56,
+
+    /// <summary>Medical transport.</summary>
+    MedicalTransport = 58,
+
+    /// <summary>Non-combatant ship per RR Resolution No. 18.</summary>
+    NonCombatant = 59,
+
+    /// <summary>Passenger — generic.</summary>
+    Passenger = 60,
+
+    /// <summary>Cargo — generic.</summary>
+    Cargo = 70,
+
+    /// <summary>Tanker — generic.</summary>
+    Tanker = 80,
+
+    /// <summary>Other type — generic.</summary>
+    Other = 90,
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisShipTypeClass.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisShipTypeClass.cs
@@ -1,0 +1,143 @@
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Display-bucketed form of the AIS shiptype code, used by renderers
+/// for palette dispatch and by the dynamic-source layer to compose
+/// <see cref="DynamicFeature.Kind"/> as <c>"vessel.ais.{class}"</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mapping table (per ITU-R M.1371-5 Table 53):
+/// </para>
+/// <list type="bullet">
+///   <item><description>0 → <see cref="Unknown"/></description></item>
+///   <item><description>1–19, 56–57 → <see cref="Other"/></description></item>
+///   <item><description>20–29 → <see cref="HighSpeedCraft"/> (WIG behaves like HSC)</description></item>
+///   <item><description>30 → <see cref="Fishing"/></description></item>
+///   <item><description>31, 32 → <see cref="Tug"/></description></item>
+///   <item><description>33–34 → <see cref="Other"/></description></item>
+///   <item><description>35 → <see cref="Military"/></description></item>
+///   <item><description>36 → <see cref="Sailing"/></description></item>
+///   <item><description>37 → <see cref="Pleasure"/></description></item>
+///   <item><description>40–49 → <see cref="HighSpeedCraft"/></description></item>
+///   <item><description>50 → <see cref="PilotVessel"/></description></item>
+///   <item><description>51 → <see cref="SearchAndRescue"/></description></item>
+///   <item><description>52, 53 → <see cref="Tug"/></description></item>
+///   <item><description>55 → <see cref="LawEnforcement"/></description></item>
+///   <item><description>54, 58, 59 → <see cref="Other"/></description></item>
+///   <item><description>60–69 → <see cref="Passenger"/></description></item>
+///   <item><description>70–79 → <see cref="Cargo"/></description></item>
+///   <item><description>80–89 → <see cref="Tanker"/></description></item>
+///   <item><description>90–99, anything else → <see cref="Other"/></description></item>
+/// </list>
+/// </remarks>
+public enum AisShipTypeClass
+{
+    /// <summary>No shiptype data received yet (no Type-5 / Type-24 part-A).</summary>
+    Unknown = 0,
+
+    /// <summary>Cargo vessels (codes 70-79).</summary>
+    Cargo,
+
+    /// <summary>Tankers (codes 80-89).</summary>
+    Tanker,
+
+    /// <summary>Passenger vessels (codes 60-69).</summary>
+    Passenger,
+
+    /// <summary>High speed craft and WIG (codes 20-29, 40-49).</summary>
+    HighSpeedCraft,
+
+    /// <summary>Pleasure craft (code 37).</summary>
+    Pleasure,
+
+    /// <summary>Fishing (code 30).</summary>
+    Fishing,
+
+    /// <summary>Tugs and towing vessels (codes 31, 32, 52, 53).</summary>
+    Tug,
+
+    /// <summary>Search and rescue (code 51).</summary>
+    SearchAndRescue,
+
+    /// <summary>Law enforcement (code 55).</summary>
+    LawEnforcement,
+
+    /// <summary>Military operations (code 35).</summary>
+    Military,
+
+    /// <summary>Sailing vessels (code 36).</summary>
+    Sailing,
+
+    /// <summary>Pilot vessels (code 50).</summary>
+    PilotVessel,
+
+    /// <summary>Any other / unmapped code.</summary>
+    Other,
+}
+
+/// <summary>
+/// Maps raw AIS shiptype codes to display buckets.
+/// </summary>
+public static class AisShipTypeClassExtensions
+{
+    /// <summary>
+    /// Bucket the supplied raw AIS shiptype code per ITU-R M.1371-5
+    /// Table 53. Unknown / out-of-range codes map to
+    /// <see cref="AisShipTypeClass.Other"/>.
+    /// </summary>
+    public static AisShipTypeClass ToClass(this AisShipType type) => ToClass((int)type);
+
+    /// <summary>
+    /// Bucket a numeric AIS shiptype code per ITU-R M.1371-5
+    /// Table 53.
+    /// </summary>
+    public static AisShipTypeClass ToClass(int code) => code switch
+    {
+        0 => AisShipTypeClass.Unknown,
+        >= 1 and <= 19 => AisShipTypeClass.Other,
+        >= 20 and <= 29 => AisShipTypeClass.HighSpeedCraft,
+        30 => AisShipTypeClass.Fishing,
+        31 or 32 => AisShipTypeClass.Tug,
+        33 or 34 => AisShipTypeClass.Other,
+        35 => AisShipTypeClass.Military,
+        36 => AisShipTypeClass.Sailing,
+        37 => AisShipTypeClass.Pleasure,
+        38 or 39 => AisShipTypeClass.Other,
+        >= 40 and <= 49 => AisShipTypeClass.HighSpeedCraft,
+        50 => AisShipTypeClass.PilotVessel,
+        51 => AisShipTypeClass.SearchAndRescue,
+        52 or 53 => AisShipTypeClass.Tug,
+        54 => AisShipTypeClass.Other,
+        55 => AisShipTypeClass.LawEnforcement,
+        56 or 57 => AisShipTypeClass.Other,
+        58 or 59 => AisShipTypeClass.Other,
+        >= 60 and <= 69 => AisShipTypeClass.Passenger,
+        >= 70 and <= 79 => AisShipTypeClass.Cargo,
+        >= 80 and <= 89 => AisShipTypeClass.Tanker,
+        _ => AisShipTypeClass.Other,
+    };
+
+    /// <summary>
+    /// Lower-case, hyphen-free token used as the suffix in
+    /// <see cref="DynamicFeature.Kind"/> (e.g. <c>"cargo"</c>,
+    /// <c>"highspeedcraft"</c>).
+    /// </summary>
+    public static string ToKindToken(this AisShipTypeClass cls) => cls switch
+    {
+        AisShipTypeClass.Cargo => "cargo",
+        AisShipTypeClass.Tanker => "tanker",
+        AisShipTypeClass.Passenger => "passenger",
+        AisShipTypeClass.HighSpeedCraft => "highspeedcraft",
+        AisShipTypeClass.Pleasure => "pleasure",
+        AisShipTypeClass.Fishing => "fishing",
+        AisShipTypeClass.Tug => "tug",
+        AisShipTypeClass.SearchAndRescue => "sar",
+        AisShipTypeClass.LawEnforcement => "lawenforcement",
+        AisShipTypeClass.Military => "military",
+        AisShipTypeClass.Sailing => "sailing",
+        AisShipTypeClass.PilotVessel => "pilot",
+        AisShipTypeClass.Other => "other",
+        _ => "unknown",
+    };
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/AisSubscriptionRequest.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/AisSubscriptionRequest.cs
@@ -1,0 +1,65 @@
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Filters supplied by a caller when opening a subscription to an
+/// <see cref="IAisMessageSource"/>. All filters are optional;
+/// <see langword="null"/> means "no filter on this axis".
+/// </summary>
+/// <remarks>
+/// Drivers apply what they can upstream — aggregator services
+/// (aisstream.io, AISHub, Spire) push the bounding box into their
+/// subscribe call; antenna and recorded-log drivers apply the filter
+/// client-side after decode. Either way the end-result delivered to
+/// the caller is the same: only matching messages are raised.
+/// </remarks>
+public sealed record AisSubscriptionRequest
+{
+    /// <summary>
+    /// Spatial filter in EPSG:4326 (WGS-84). When
+    /// <see langword="null"/> the subscription is unfiltered. The
+    /// existing Core <see cref="BoundingBox"/> primitive is reused
+    /// so this fits the rest of the pipeline vocabulary.
+    /// </summary>
+    public BoundingBox? Area { get; init; }
+
+    /// <summary>
+    /// Optional MMSI allow-list. When <see langword="null"/> or
+    /// empty, all vessels are accepted.
+    /// </summary>
+    public IReadOnlyCollection<uint>? Mmsis { get; init; }
+
+    /// <summary>
+    /// Optional ship-type-class allow-list. When
+    /// <see langword="null"/> or empty, all classes are accepted.
+    /// Filtering by class requires the driver to have already seen
+    /// a matching <see cref="AisStaticVoyageData"/> for the vessel.
+    /// </summary>
+    public IReadOnlyCollection<AisShipTypeClass>? ShipTypes { get; init; }
+
+    /// <summary>
+    /// Which message families to receive. Defaults to both. Useful
+    /// for callers that only want positions (no static / voyage
+    /// merge step) or only static data (catalogue building).
+    /// </summary>
+    public AisMessageKinds Include { get; init; }
+        = AisMessageKinds.PositionReports | AisMessageKinds.StaticVoyageData;
+}
+
+/// <summary>
+/// Bit flags selecting which AIS message families to deliver on a
+/// subscription.
+/// </summary>
+[Flags]
+public enum AisMessageKinds
+{
+    /// <summary>No messages.</summary>
+    None = 0,
+
+    /// <summary>Class A (1/2/3) and Class B (18/19) position reports.</summary>
+    PositionReports = 1,
+
+    /// <summary>Class A (5) and Class B (24A+24B) static / voyage data.</summary>
+    StaticVoyageData = 2,
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/EncDotNet.S100.DynamicSources.Ais.csproj
+++ b/src/EncDotNet.S100.DynamicSources.Ais/EncDotNet.S100.DynamicSources.Ais.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/EncDotNet.S100.DynamicSources.Ais/IAisMessageSource.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/IAisMessageSource.cs
@@ -1,0 +1,35 @@
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// Display metadata exposed by an <see cref="IAisMessageSource"/>
+/// for use by the dynamic-source layer when constructing its own
+/// <see cref="DynamicSourceMetadata"/>.
+/// </summary>
+public sealed record AisSourceMetadata
+{
+    /// <summary>Human-readable name (e.g. "aisstream.io", "Local antenna").</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Optional longer description (origin, license, etc.).</summary>
+    public string? Description { get; init; }
+}
+
+/// <summary>
+/// Abstraction over a producer of decoded AIS messages — recorded
+/// log replay, local-antenna NMEA decoder, aggregator-service
+/// WebSocket feed, in-process test fake. Implementations live in
+/// driver-specific assemblies; the dynamic-source layer
+/// (<see cref="AisDynamicFeatureSource"/>) consumes only this
+/// interface and the typed records, never AIVDM bytes.
+/// </summary>
+public interface IAisMessageSource
+{
+    /// <summary>Display metadata for layer-stack labelling.</summary>
+    AisSourceMetadata Metadata { get; }
+
+    /// <summary>
+    /// Opens a subscription. Drivers multiplex multiple concurrent
+    /// subscriptions internally where needed.
+    /// </summary>
+    IAisSubscription Subscribe(AisSubscriptionRequest request);
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/IAisSubscription.cs
+++ b/src/EncDotNet.S100.DynamicSources.Ais/IAisSubscription.cs
@@ -1,0 +1,58 @@
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.DynamicSources.Ais;
+
+/// <summary>
+/// A long-lived subscription to an <see cref="IAisMessageSource"/>.
+/// Disposing tears down the upstream stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Threading.</b> Events may be raised on any thread; consumers
+/// that update UI state must marshal themselves.
+/// </para>
+/// <para>
+/// <b>Lifetimes.</b> Drivers may transparently reconnect across the
+/// lifetime of a single subscription (e.g. aisstream.io WebSocket
+/// disconnect → exponential-backoff reconnect → resend subscribe).
+/// The <see cref="IAisSubscription"/> instance survives those
+/// reconnects.
+/// </para>
+/// </remarks>
+public interface IAisSubscription : IAsyncDisposable
+{
+    /// <summary>
+    /// The active filter — may differ from the
+    /// <see cref="AisSubscriptionRequest"/> originally passed to
+    /// <see cref="IAisMessageSource.Subscribe"/> if the driver had
+    /// to widen it (e.g. service-side spatial quantisation).
+    /// </summary>
+    AisSubscriptionRequest ActiveRequest { get; }
+
+    /// <summary>Raised for every position report matching the active filter.</summary>
+    event EventHandler<AisPositionReport>? PositionReportReceived;
+
+    /// <summary>Raised for every static / voyage record matching the active filter.</summary>
+    event EventHandler<AisStaticVoyageData>? StaticVoyageDataReceived;
+
+    /// <summary>
+    /// Optional disappearance signal. Drivers without an explicit
+    /// "vessel left coverage" message (aisstream.io, antennas,
+    /// recorded logs) leave this silent and rely on the caller's
+    /// aging sweep.
+    /// </summary>
+    event EventHandler<AisTargetLost>? TargetLost;
+
+    /// <summary>
+    /// Updates the spatial filter without tearing the subscription
+    /// down. A driver that cannot update in-place returns
+    /// <see langword="false"/>; the caller should then dispose this
+    /// subscription and open a new one.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the active filter has been
+    /// updated; <see langword="false"/> when the driver does not
+    /// support in-place updates.
+    /// </returns>
+    bool TryUpdateArea(BoundingBox? area);
+}

--- a/src/EncDotNet.S100.DynamicSources.Ais/README.md
+++ b/src/EncDotNet.S100.DynamicSources.Ais/README.md
@@ -1,0 +1,48 @@
+# EncDotNet.S100.DynamicSources.Ais
+
+Concrete `IDynamicFeatureSource` for AIS targets, plus the
+driver-agnostic `IAisMessageSource` abstraction.
+
+## What ships here
+
+| Type | Purpose |
+| --- | --- |
+| `IAisMessageSource` / `IAisSubscription` | Subscription-based contract over a producer of decoded AIS messages. Drivers (aisstream.io WebSocket, local antenna NMEA, recorded-log replay) implement this interface. |
+| `AisSubscriptionRequest` / `AisMessageKinds` | Spatial / MMSI / ship-type-class filters and message-family selector. |
+| `AisPositionReport` / `AisStaticVoyageData` / `AisTargetLost` | Decoded AIS payloads — denormalised so callers don't see message-type numbers. |
+| `AisShipType` / `AisShipTypeClass` (+ `ToClass`, `ToKindToken`) | Raw shiptype codes and the ITU-R M.1371-5 Table 53 display buckets used in `DynamicFeature.Kind`. |
+| `AisNavigationStatus` | Navigation status enum per ITU-R M.1371-5 §3.3.7.2.1. |
+| `AisDimensions` | Hull dimensions (A/B/C/D) folded into length/beam/bow-offset/port-offset. |
+| `AisDynamicFeatureSource` | The actual `IDynamicFeatureSource` — projects each position report to a `DynamicFeature`, merges per-MMSI static / voyage data, and ages stale targets. |
+
+## Architecture
+
+Three-layer split with the wire format isolated to driver assemblies:
+
+```text
+[recorded log | local antenna | aggregator service]
+   │   wire bytes
+   ▼
+[driver assembly (e.g. .Drivers.AisStreamIo)]
+   │   IAisMessageSource (this assembly)
+   ▼
+[AisDynamicFeatureSource]
+   │   IDynamicFeatureSource
+   ▼
+[viewer / sample]
+```
+
+`AisDynamicFeatureSource` consumes only typed records and is
+unit-testable without any wire-format fixtures.
+
+## Renderer key
+
+The source advertises `RendererKey = "vessel.ais"`. Register a matching
+`IDynamicFeatureRenderer` in `EncDotNet.S100.Renderers.Mapsui` (the
+`AisVesselRenderer`, ships separately).
+
+## See also
+
+- `docs/design/ais-source.md` — full design notes.
+- `docs/design/dynamic-feature-source.md` — base abstractions.
+- `EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo` — production driver.

--- a/src/EncDotNet.S100.Renderers.Mapsui/DynamicSources/AisVesselRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/DynamicSources/AisVesselRenderer.cs
@@ -1,0 +1,92 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using Mapsui;
+using MapsuiColor = Mapsui.Styles.Color;
+
+namespace EncDotNet.S100.Renderers.Mapsui.DynamicSources;
+
+/// <summary>
+/// AIS-target renderer. Mirrors <see cref="OwnShipRenderer"/>'s
+/// hull / pictogram / CCRP-cross / heading-vector vocabulary via the
+/// shared <see cref="VesselSymbology"/> helper, dispatched off the
+/// AIS ship-type bucket encoded in <see cref="DynamicFeature.Kind"/>
+/// (suffix produced by <c>AisShipTypeClass.ToKindToken()</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Dispatches via a small per-class palette table — not via
+/// <c>KindMatchingRenderer</c>, since the rendering is structurally
+/// the same shape and only the colours differ. AIS targets share
+/// the <c>S98DisplayPlane.DynamicArrows</c> plane with own-ship; the
+/// per-source visibility toggles in the layer-stack panel
+/// (PR-D2.1) keep the two independently controllable.
+/// </para>
+/// <para>
+/// Default colour is green per the S-52 convention for active AIS
+/// targets (SY(AISDEF01) family). Tanker uses red (hazardous-cargo
+/// convention), passenger uses dark teal, and unknown-class targets
+/// use a neutral grey.
+/// </para>
+/// </remarks>
+public sealed class AisVesselRenderer : IDynamicFeatureRenderer
+{
+    private const string KindPrefix = "vessel.ais.";
+
+    private static readonly VesselSymbology.Palette DefaultPalette = new(
+        Stroke: new MapsuiColor(0x00, 0xA0, 0x40),
+        Fill: new MapsuiColor(0x66, 0xCC, 0x88),
+        HullFill: new MapsuiColor(0x66, 0xCC, 0x88, 160));
+
+    private static readonly VesselSymbology.Palette TankerPalette = new(
+        Stroke: new MapsuiColor(0xCC, 0x33, 0x33),
+        Fill: new MapsuiColor(0xE6, 0x99, 0x99),
+        HullFill: new MapsuiColor(0xE6, 0x99, 0x99, 160));
+
+    private static readonly VesselSymbology.Palette PassengerPalette = new(
+        Stroke: new MapsuiColor(0x00, 0x80, 0x80),
+        Fill: new MapsuiColor(0x66, 0xC2, 0xC2),
+        HullFill: new MapsuiColor(0x66, 0xC2, 0xC2, 160));
+
+    private static readonly VesselSymbology.Palette HighSpeedPalette = new(
+        Stroke: new MapsuiColor(0x80, 0x33, 0xCC),
+        Fill: new MapsuiColor(0xC2, 0x99, 0xE6),
+        HullFill: new MapsuiColor(0xC2, 0x99, 0xE6, 160));
+
+    private static readonly VesselSymbology.Palette UnknownPalette = new(
+        Stroke: new MapsuiColor(0x66, 0x66, 0x66),
+        Fill: new MapsuiColor(0xB3, 0xB3, 0xB3),
+        HullFill: new MapsuiColor(0xB3, 0xB3, 0xB3, 160));
+
+    /// <inheritdoc />
+    public bool CanRender(DynamicFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        return feature.GeometryType == GeometryType.Point
+            && feature.Kind is { } kind
+            && kind.StartsWith(KindPrefix, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<IFeature> Render(DynamicFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        return VesselSymbology.Render(feature, PaletteFor(feature.Kind));
+    }
+
+    internal static VesselSymbology.Palette PaletteFor(string? kind)
+    {
+        if (kind is null || !kind.StartsWith(KindPrefix, StringComparison.Ordinal))
+            return UnknownPalette;
+        var token = kind[KindPrefix.Length..];
+        return token switch
+        {
+            "tanker" => TankerPalette,
+            "passenger" => PassengerPalette,
+            "highspeedcraft" => HighSpeedPalette,
+            "cargo" or "fishing" or "tug" or "pleasure" or "sailing"
+                or "pilot" or "sar" or "lawenforcement" or "military"
+                or "other" => DefaultPalette,
+            _ => UnknownPalette,
+        };
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/DynamicSources/OwnShipRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/DynamicSources/OwnShipRenderer.cs
@@ -1,10 +1,6 @@
 using EncDotNet.S100.DynamicSources;
 using EncDotNet.S100.Pipelines.Vector;
 using Mapsui;
-using Mapsui.Nts;
-using Mapsui.Projections;
-using Mapsui.Styles;
-using NetTopologySuite.Geometries;
 using MapsuiColor = Mapsui.Styles.Color;
 
 namespace EncDotNet.S100.Renderers.Mapsui.DynamicSources;
@@ -19,122 +15,38 @@ namespace EncDotNet.S100.Renderers.Mapsui.DynamicSources;
 /// </summary>
 /// <remarks>
 /// <para>
+/// The actual symbol-emission logic is shared with
+/// <c>AisVesselRenderer</c> via the internal
+/// <see cref="VesselSymbology"/> helper — own-ship simply binds the
+/// helper to the S-52 own-ship blue palette.
+/// </para>
+/// <para>
 /// Standards alignment (see <c>docs/design/own-ship-symbology.md</c>
-/// §1 for citations):
-/// </para>
-/// <list type="bullet">
-///   <item><description>
-///     <b>Hull</b> — IHO S-52 Annex A SY(OWNSHP02) "scaled" symbol;
-///     small-vertex polygon parameterised by length + beam, rotated
-///     by heading, origin at the CCRP. We use 5 vertices with a
-///     0.7 bow-taper.
-///   </description></item>
-///   <item><description>
-///     <b>Pictogram</b> — IHO S-52 SY(OWNSHP01) "simple" symbol;
-///     drawn when the on-screen length would be below 6 mm
-///     (≈ <see cref="MinVesselPixels"/> px @ 96 dpi).
-///   </description></item>
-///   <item><description>
-///     <b>Course / speed vector</b> — single <see cref="LineString"/>
-///     sourced from <see cref="DynamicMotion.CourseOverGroundDeg"/>
-///     (mirrored to <see cref="DynamicMotion.HeadingDeg"/> in the
-///     v1 own-ship source). Styled per S-52's COG-vector convention
-///     (arrowhead at tip, no tick marks). A true heading line
-///     (no arrowhead) and a tick-marked speed vector are out of
-///     scope for v1; a future PR with a real gyro heading source
-///     should add the arrowless heading line per S-52.
-///   </description></item>
-///   <item><description>
-///     <b>CCRP cross</b> — IHO S-52 §8.3.1; small <c>+</c> at the
-///     GPS antenna, rendered as a single fixed-pixel inline-SVG
-///     <see cref="ImageStyle"/> that rotates with vessel heading.
-///     Gated identically to the hull.
-///   </description></item>
-/// </list>
-/// <para>
-/// Output features (in emission order):
-/// </para>
-/// <list type="number">
-///   <item><description>
-///     Course / speed vector (<see cref="LineString"/> from antenna
-///     to the 6-minute predictor endpoint) plus an arrowhead at the
-///     endpoint. Emitted when <see cref="DynamicMotion.HeadingDeg"/>
-///     is present and SOG &gt; 0. Visible at all zooms.
-///   </description></item>
-///   <item><description>
-///     <b>Hull outline</b> (5-vertex <see cref="Polygon"/>) gated to
-///     show when the on-screen vessel length is at least
-///     <see cref="MinVesselPixels"/>. Only emitted when the feature
-///     carries a non-null <see cref="DynamicFeature.VesselGeometry"/>.
-///   </description></item>
-///   <item><description>
-///     <b>CCRP cross</b> — a single <see cref="Point"/> with an
-///     inline-SVG <see cref="ImageStyle"/>, gated identically to the
-///     hull (only visible when zoomed in to outline mode). Pixel-fixed
-///     so the cross does not scale with zoom.
-///   </description></item>
-///   <item><description>
-///     <b>Pictogram</b> (coloured disc) gated to show when the
-///     on-screen vessel length is below <see cref="MinVesselPixels"/>,
-///     or unconditionally when <see cref="DynamicFeature.VesselGeometry"/>
-///     is <see langword="null"/>.
-///   </description></item>
-/// </list>
-/// <para>
-/// The outline / pictogram switch is implemented via mutually
-/// exclusive <see cref="VectorStyle.MinVisible"/> /
-/// <see cref="VectorStyle.MaxVisible"/> gates on the emitted Mapsui
-/// styles, so the renderer signature stays viewport-agnostic and
-/// Mapsui filters per-frame. The crossover resolution at latitude φ
-/// is <c>LengthMetres · cos(φ) / MinVesselPixels</c>.
+/// §1 for citations): hull = SY(OWNSHP02), pictogram = SY(OWNSHP01),
+/// CCRP cross = §8.3.1, COG vector convention from S-52 Annex A.
 /// </para>
 /// </remarks>
 public sealed class OwnShipRenderer : IDynamicFeatureRenderer
 {
     /// <summary>Pixel size at which the hull outline begins to display
-    /// (≈ 6 mm at 96 dpi — per IHO S-52 Ed 6.1 Presentation Library
-    /// §§7.4.5 / 13.2.7, which specify a 6 mm minimum on-screen
-    /// dimension for the own-ship symbol). 6 mm × 96 dpi ÷ 25.4 mm/in
-    /// = 22.68 px, rounded down.</summary>
-    public const double MinVesselPixels = 22.0;
+    /// (≈ 6 mm at 96 dpi — IHO S-52 Ed 6.1 §§7.4.5 / 13.2.7).</summary>
+    public const double MinVesselPixels = VesselSymbology.MinVesselPixels;
 
     /// <summary>Pixel size of the arrowhead on the course / speed
-    /// vector (S-52 COG vector convention; see remarks on
-    /// <see cref="OwnShipRenderer"/>).</summary>
-    public const double HeadingArrowPx = 10.0;
+    /// vector (S-52 COG vector convention).</summary>
+    public const double HeadingArrowPx = VesselSymbology.HeadingArrowPx;
 
-    /// <summary>Pixel size of each arm of the CCRP cross (half-span,
-    /// from centre to tip). The cross is rendered as a fixed-pixel
-    /// inline-SVG <c>+</c> glyph that does not scale with zoom.
-    /// Per IHO S-52 §8.3.1.</summary>
-    public const double CcrpCrossPx = 6.0;
+    /// <summary>Pixel half-span of each arm of the CCRP cross
+    /// (per IHO S-52 §8.3.1).</summary>
+    public const double CcrpCrossPx = VesselSymbology.CcrpCrossPx;
 
-    /// <summary>Bow-taper ratio: shoulders sit at this fraction of
-    /// the hull length forward of the stern. 0.7 reads as a typical
-    /// merchant-vessel silhouette without being too aggressive.</summary>
-    public const double BowTaperRatio = 0.7;
+    /// <summary>Bow-taper ratio.</summary>
+    public const double BowTaperRatio = VesselSymbology.BowTaperRatio;
 
-    /// <summary>Six-minute predictor in seconds (AIS-style).</summary>
-    private const double HeadingPredictorSeconds = 360.0;
-
-    /// <summary>Cap the heading line at 10 nautical miles regardless of speed.</summary>
-    private const double HeadingMaxMetres = 18_520.0;
-
-    private static readonly MapsuiColor Stroke = new(0x00, 0x7A, 0xCC);
-    private static readonly MapsuiColor Fill = new(0x66, 0xB3, 0xE6);
-    private static readonly MapsuiColor HullFill = new(0x66, 0xB3, 0xE6, 160);
-
-    // Inline SVG for the CCRP cross — a centred "+" of total span
-    // 2 × CcrpCrossPx pixels. Rendered via Mapsui v5's "svg-content://"
-    // ImageStyle scheme (no asset registration needed). Stroke colour
-    // matches the renderer's primary Stroke (#007ACC); arms are
-    // 1.5 px wide for visual parity with the hull outline.
-    private const string CcrpCrossSvg =
-        """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-8 -8 16 16">""" +
-        """<line x1="-6" y1="0" x2="6" y2="0" stroke="#007ACC" stroke-width="1.5"/>""" +
-        """<line x1="0" y1="-6" x2="0" y2="6" stroke="#007ACC" stroke-width="1.5"/>""" +
-        """</svg>""";
-    private static readonly string CcrpCrossImageSource = "svg-content://" + CcrpCrossSvg;
+    private static readonly VesselSymbology.Palette OwnShipPalette = new(
+        Stroke: new MapsuiColor(0x00, 0x7A, 0xCC),
+        Fill: new MapsuiColor(0x66, 0xB3, 0xE6),
+        HullFill: new MapsuiColor(0x66, 0xB3, 0xE6, 160));
 
     /// <inheritdoc />
     public bool CanRender(DynamicFeature feature)
@@ -145,203 +57,5 @@ public sealed class OwnShipRenderer : IDynamicFeatureRenderer
 
     /// <inheritdoc />
     public IEnumerable<IFeature> Render(DynamicFeature feature)
-    {
-        ArgumentNullException.ThrowIfNull(feature);
-        if (feature.Coordinates.Count == 0) yield break;
-
-        var (lat, lon) = feature.Coordinates[0];
-        var (ax, ay) = SphericalMercator.FromLonLat(lon, lat);
-
-        // Heading falls back to course-over-ground when no gyro
-        // heading is available; if both are absent we still draw the
-        // hull aligned to north (better than nothing) but skip the
-        // predictor + arrowhead.
-        var headingDeg =
-            feature.Motion?.HeadingDeg
-            ?? feature.Motion?.CourseOverGroundDeg;
-
-        var sogKn = feature.Motion?.SpeedOverGroundKn ?? 0.0;
-
-        // 1. Course / speed vector + arrowhead (no resolution gate —
-        //    visible at all zooms). Per IHO S-52, this single line
-        //    follows the COG-vector convention (arrowhead at tip, no
-        //    ticks). The v1 own-ship source mirrors COG → HDG, so we
-        //    cannot distinguish a true heading line (which would be
-        //    arrowless) from the COG vector — drawn as one combined
-        //    line per the design doc §5.
-        if (headingDeg is { } heading && sogKn > 0.0)
-        {
-            var distanceMetres = Math.Min(
-                sogKn * 1852.0 / 3600.0 * HeadingPredictorSeconds,
-                HeadingMaxMetres);
-
-            var (endLat, endLon) = GeodeticDestination(lat, lon, heading, distanceMetres);
-            var (ex, ey) = SphericalMercator.FromLonLat(endLon, endLat);
-
-            var line = new GeometryFeature(new LineString(new[]
-            {
-                new Coordinate(ax, ay),
-                new Coordinate(ex, ey),
-            }));
-            line.Styles.Add(new VectorStyle
-            {
-                Line = new Pen { Color = Stroke, Width = 1.5 },
-            });
-            yield return line;
-
-            var arrow = new GeometryFeature(new Point(ex, ey));
-            arrow.Styles.Add(new SymbolStyle
-            {
-                SymbolType = SymbolType.Triangle,
-                SymbolScale = HeadingArrowPx / 32.0, // Mapsui Triangle base is ~32 px
-                Fill = new Brush { Color = Stroke },
-                Outline = new Pen { Color = Stroke, Width = 1.0 },
-                // Mapsui SymbolRotation is degrees clockwise; Triangle
-                // points up at rotation 0 which is exactly north —
-                // matches our heading convention.
-                SymbolRotation = heading,
-            });
-            yield return arrow;
-        }
-
-        // 2. Vessel-geometry-aware features (hull + CCRP cross).
-        if (feature.VesselGeometry is { } geom
-            && geom.LengthMetres > 0
-            && geom.BeamMetres > 0)
-        {
-            // Switch resolution: outline visible when current
-            // map resolution (m/px at equator in Web Mercator) is
-            // <= LengthMetres * cos(lat) / MinVesselPixels.
-            var rSwitch = geom.LengthMetres
-                * Math.Cos(lat * Math.PI / 180.0)
-                / MinVesselPixels;
-
-            // Hull rotated by heading (or 0° if unknown) and
-            // georeferenced from the GPS antenna using the CCRP offsets.
-            var theta = (headingDeg ?? 0.0) * Math.PI / 180.0;
-            var sinT = Math.Sin(theta);
-            var cosT = Math.Cos(theta);
-
-            // Antenna position in vessel-local frame (x=starboard, y=forward).
-            // Hull rectangle spans x ∈ [-B/2, +B/2], y ∈ [0, L].
-            var antX = -geom.BeamMetres / 2.0 + geom.PortOffsetMetres;
-            var antY = geom.LengthMetres - geom.BowOffsetMetres;
-
-            var halfBeam = geom.BeamMetres / 2.0;
-            var taperY = geom.LengthMetres * BowTaperRatio;
-
-            // 5 hull vertices in local frame.
-            var local = new (double X, double Y)[]
-            {
-                (         0,  geom.LengthMetres),   // bow tip
-                (+halfBeam,   taperY),              // starboard shoulder
-                (+halfBeam,             0),          // starboard stern
-                (-halfBeam,             0),          // port stern
-                (-halfBeam,   taperY),              // port shoulder
-            };
-
-            var ring = new Coordinate[local.Length + 1];
-            for (var i = 0; i < local.Length; i++)
-            {
-                // Translate so antenna is at origin, then rotate.
-                var dx = local[i].X - antX;
-                var dy = local[i].Y - antY;
-                // Heading rotation: heading θ means bow points along
-                // bearing θ (clockwise from north). In a local
-                // (east=x, north=y) frame the rotation that maps
-                // vessel-y (forward) onto bearing θ is:
-                //   east  =  dx·cos θ + dy·sin θ
-                //   north = -dx·sin θ + dy·cos θ
-                var east = dx * cosT + dy * sinT;
-                var north = -dx * sinT + dy * cosT;
-                var (mx, my) = MercatorOffset.ToMercator(lat, lon, east, north);
-                ring[i] = new Coordinate(mx, my);
-            }
-            ring[^1] = ring[0];
-
-            var hull = new GeometryFeature(new Polygon(new LinearRing(ring)));
-            hull.Styles.Add(new VectorStyle
-            {
-                Fill = new Brush { Color = HullFill },
-                Outline = new Pen { Color = Stroke, Width = 1.5 },
-                MaxVisible = rSwitch,
-            });
-            yield return hull;
-
-            // CCRP cross at antenna position — same gate as the hull.
-            // Per IHO S-52 §8.3.1, a "+" mark at the CCRP / GPS antenna
-            // shown only when the scaled outline is visible. We render
-            // it as a single Point feature carrying an inline-SVG
-            // ImageStyle so the cross is pixel-fixed (does not scale
-            // with zoom) — this matches the S-52 intent (CCRP is a
-            // bridge-symbol indicator, not a vessel-scaled feature)
-            // and reads cleanly at every zoom level. SymbolRotation
-            // aligns the arms with the vessel's longitudinal /
-            // lateral axes so the cross visually communicates the
-            // vessel's reference frame.
-            var cross = new GeometryFeature(new Point(ax, ay));
-            cross.Styles.Add(new ImageStyle
-            {
-                Image = new Image { Source = CcrpCrossImageSource, RasterizeSvg = true },
-                SymbolScale = 1.0,
-                SymbolRotation = headingDeg ?? 0.0,
-                MaxVisible = rSwitch,
-            });
-            yield return cross;
-
-            // Pictogram only when zoomed out enough that the hull
-            // would be smaller than MinVesselPixels.
-            var disc = new GeometryFeature(new Point(ax, ay));
-            disc.Styles.Add(new SymbolStyle
-            {
-                SymbolType = SymbolType.Ellipse,
-                SymbolScale = 0.7,
-                Fill = new Brush { Color = Fill },
-                Outline = new Pen { Color = Stroke, Width = 1.5 },
-                MinVisible = rSwitch,
-            });
-            yield return disc;
-        }
-        else
-        {
-            // Pictogram-only fallback when no vessel geometry is known.
-            var disc = new GeometryFeature(new Point(ax, ay));
-            disc.Styles.Add(new SymbolStyle
-            {
-                SymbolType = SymbolType.Ellipse,
-                SymbolScale = 0.7,
-                Fill = new Brush { Color = Fill },
-                Outline = new Pen { Color = Stroke, Width = 1.5 },
-            });
-            yield return disc;
-        }
-    }
-
-    /// <summary>
-    /// Great-circle destination given start lat/lon (degrees),
-    /// bearing (degrees true), and distance in metres. WGS-84 mean
-    /// Earth radius.
-    /// </summary>
-    private static (double Latitude, double Longitude) GeodeticDestination(
-        double latDeg, double lonDeg, double bearingDeg, double distanceMetres)
-    {
-        const double R = 6_371_008.8;
-        var δ = distanceMetres / R;
-        var θ = bearingDeg * Math.PI / 180.0;
-        var φ1 = latDeg * Math.PI / 180.0;
-        var λ1 = lonDeg * Math.PI / 180.0;
-
-        var sinφ1 = Math.Sin(φ1);
-        var cosφ1 = Math.Cos(φ1);
-        var sinδ = Math.Sin(δ);
-        var cosδ = Math.Cos(δ);
-
-        var sinφ2 = sinφ1 * cosδ + cosφ1 * sinδ * Math.Cos(θ);
-        var φ2 = Math.Asin(sinφ2);
-        var y = Math.Sin(θ) * sinδ * cosφ1;
-        var x = cosδ - sinφ1 * sinφ2;
-        var λ2 = λ1 + Math.Atan2(y, x);
-
-        return (φ2 * 180.0 / Math.PI, ((λ2 * 180.0 / Math.PI) + 540.0) % 360.0 - 180.0);
-    }
+        => VesselSymbology.Render(feature, OwnShipPalette);
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/DynamicSources/VesselSymbology.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/DynamicSources/VesselSymbology.cs
@@ -1,0 +1,250 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using Mapsui;
+using Mapsui.Nts;
+using Mapsui.Projections;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using MapsuiColor = Mapsui.Styles.Color;
+
+namespace EncDotNet.S100.Renderers.Mapsui.DynamicSources;
+
+/// <summary>
+/// Shared vessel-symbology helper. Produces the four symbol elements
+/// used by both <see cref="OwnShipRenderer"/> (own ship, IHO S-52
+/// Annex A SY(OWNSHP01/02)) and <c>AisVesselRenderer</c> (AIS targets
+/// — the same hull / CCRP-cross / heading-vector vocabulary, just in
+/// a different colour palette):
+/// </summary>
+/// <remarks>
+/// <list type="number">
+///   <item><description>
+///     Course / speed vector + arrowhead (visible at all zooms when
+///     heading and SOG are known).
+///   </description></item>
+///   <item><description>
+///     Hull outline (5-vertex polygon, beam-tapered) — emitted when
+///     the feature carries a <see cref="DynamicVesselGeometry"/> and
+///     the on-screen length would be at least
+///     <see cref="MinVesselPixels"/>.
+///   </description></item>
+///   <item><description>
+///     CCRP cross at the GPS antenna, gated identically to the hull
+///     (per IHO S-52 §8.3.1).
+///   </description></item>
+///   <item><description>
+///     Pictogram (coloured disc) — gated to show below the hull
+///     threshold, or unconditionally when no vessel geometry is
+///     known.
+///   </description></item>
+/// </list>
+/// </remarks>
+internal static class VesselSymbology
+{
+    /// <summary>Pixel size at which the hull outline begins to display
+    /// (≈ 6 mm at 96 dpi; IHO S-52 Ed 6.1 §§7.4.5 / 13.2.7).</summary>
+    public const double MinVesselPixels = 22.0;
+
+    /// <summary>Pixel size of the arrowhead on the course / speed
+    /// vector (S-52 COG-vector convention).</summary>
+    public const double HeadingArrowPx = 10.0;
+
+    /// <summary>Pixel half-span of each arm of the CCRP cross
+    /// (per IHO S-52 §8.3.1).</summary>
+    public const double CcrpCrossPx = 6.0;
+
+    /// <summary>Bow-taper ratio: shoulders sit at this fraction of
+    /// the hull length forward of the stern.</summary>
+    public const double BowTaperRatio = 0.7;
+
+    /// <summary>Six-minute predictor in seconds (AIS-style).</summary>
+    private const double HeadingPredictorSeconds = 360.0;
+
+    /// <summary>Cap the heading line at 10 nautical miles regardless of speed.</summary>
+    private const double HeadingMaxMetres = 18_520.0;
+
+    /// <summary>
+    /// Colour palette controlling the produced symbology. Three
+    /// colours map onto S-52 / vendor convention slots: outline /
+    /// vector stroke, pictogram fill, hull fill (typically a
+    /// translucent variant of the pictogram fill).
+    /// </summary>
+    public sealed record Palette(MapsuiColor Stroke, MapsuiColor Fill, MapsuiColor HullFill);
+
+    /// <summary>
+    /// Emits the symbology features for <paramref name="feature"/>
+    /// using <paramref name="palette"/>. Mirrors the legacy
+    /// <c>OwnShipRenderer.Render</c> emission order so existing
+    /// regression tests stay green when own-ship is rewired through
+    /// this helper.
+    /// </summary>
+    public static IEnumerable<IFeature> Render(DynamicFeature feature, Palette palette)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        ArgumentNullException.ThrowIfNull(palette);
+        if (feature.Coordinates.Count == 0) yield break;
+
+        var (lat, lon) = feature.Coordinates[0];
+        var (ax, ay) = SphericalMercator.FromLonLat(lon, lat);
+
+        var headingDeg =
+            feature.Motion?.HeadingDeg
+            ?? feature.Motion?.CourseOverGroundDeg;
+
+        var sogKn = feature.Motion?.SpeedOverGroundKn ?? 0.0;
+
+        // 1. Course / speed vector + arrowhead.
+        if (headingDeg is { } heading && sogKn > 0.0)
+        {
+            var distanceMetres = Math.Min(
+                sogKn * 1852.0 / 3600.0 * HeadingPredictorSeconds,
+                HeadingMaxMetres);
+
+            var (endLat, endLon) = GeodeticDestination(lat, lon, heading, distanceMetres);
+            var (ex, ey) = SphericalMercator.FromLonLat(endLon, endLat);
+
+            var line = new GeometryFeature(new LineString(new[]
+            {
+                new Coordinate(ax, ay),
+                new Coordinate(ex, ey),
+            }));
+            line.Styles.Add(new VectorStyle
+            {
+                Line = new Pen { Color = palette.Stroke, Width = 1.5 },
+            });
+            yield return line;
+
+            var arrow = new GeometryFeature(new Point(ex, ey));
+            arrow.Styles.Add(new SymbolStyle
+            {
+                SymbolType = SymbolType.Triangle,
+                SymbolScale = HeadingArrowPx / 32.0,
+                Fill = new Brush { Color = palette.Stroke },
+                Outline = new Pen { Color = palette.Stroke, Width = 1.0 },
+                SymbolRotation = heading,
+            });
+            yield return arrow;
+        }
+
+        // 2. Vessel-geometry-aware features (hull + CCRP cross + zoom-gated pictogram).
+        if (feature.VesselGeometry is { } geom
+            && geom.LengthMetres > 0
+            && geom.BeamMetres > 0)
+        {
+            var rSwitch = geom.LengthMetres
+                * Math.Cos(lat * Math.PI / 180.0)
+                / MinVesselPixels;
+
+            var theta = (headingDeg ?? 0.0) * Math.PI / 180.0;
+            var sinT = Math.Sin(theta);
+            var cosT = Math.Cos(theta);
+
+            var antX = -geom.BeamMetres / 2.0 + geom.PortOffsetMetres;
+            var antY = geom.LengthMetres - geom.BowOffsetMetres;
+
+            var halfBeam = geom.BeamMetres / 2.0;
+            var taperY = geom.LengthMetres * BowTaperRatio;
+
+            var local = new (double X, double Y)[]
+            {
+                (         0,  geom.LengthMetres),
+                (+halfBeam,   taperY),
+                (+halfBeam,             0),
+                (-halfBeam,             0),
+                (-halfBeam,   taperY),
+            };
+
+            var ring = new Coordinate[local.Length + 1];
+            for (var i = 0; i < local.Length; i++)
+            {
+                var dx = local[i].X - antX;
+                var dy = local[i].Y - antY;
+                var east = dx * cosT + dy * sinT;
+                var north = -dx * sinT + dy * cosT;
+                var (mx, my) = MercatorOffset.ToMercator(lat, lon, east, north);
+                ring[i] = new Coordinate(mx, my);
+            }
+            ring[^1] = ring[0];
+
+            var hull = new GeometryFeature(new Polygon(new LinearRing(ring)));
+            hull.Styles.Add(new VectorStyle
+            {
+                Fill = new Brush { Color = palette.HullFill },
+                Outline = new Pen { Color = palette.Stroke, Width = 1.5 },
+                MaxVisible = rSwitch,
+            });
+            yield return hull;
+
+            var cross = new GeometryFeature(new Point(ax, ay));
+            cross.Styles.Add(new ImageStyle
+            {
+                Image = new Image { Source = CcrpCrossImageSource(palette.Stroke), RasterizeSvg = true },
+                SymbolScale = 1.0,
+                SymbolRotation = headingDeg ?? 0.0,
+                MaxVisible = rSwitch,
+            });
+            yield return cross;
+
+            var disc = new GeometryFeature(new Point(ax, ay));
+            disc.Styles.Add(new SymbolStyle
+            {
+                SymbolType = SymbolType.Ellipse,
+                SymbolScale = 0.7,
+                Fill = new Brush { Color = palette.Fill },
+                Outline = new Pen { Color = palette.Stroke, Width = 1.5 },
+                MinVisible = rSwitch,
+            });
+            yield return disc;
+        }
+        else
+        {
+            var disc = new GeometryFeature(new Point(ax, ay));
+            disc.Styles.Add(new SymbolStyle
+            {
+                SymbolType = SymbolType.Ellipse,
+                SymbolScale = 0.7,
+                Fill = new Brush { Color = palette.Fill },
+                Outline = new Pen { Color = palette.Stroke, Width = 1.5 },
+            });
+            yield return disc;
+        }
+    }
+
+    private static string CcrpCrossImageSource(MapsuiColor stroke)
+    {
+        var hex = $"#{stroke.R:X2}{stroke.G:X2}{stroke.B:X2}";
+        var svg =
+            """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-8 -8 16 16">""" +
+            $"""<line x1="-6" y1="0" x2="6" y2="0" stroke="{hex}" stroke-width="1.5"/>""" +
+            $"""<line x1="0" y1="-6" x2="0" y2="6" stroke="{hex}" stroke-width="1.5"/>""" +
+            """</svg>""";
+        return "svg-content://" + svg;
+    }
+
+    /// <summary>
+    /// Great-circle destination given start lat/lon (degrees), bearing
+    /// (degrees true), and distance in metres. WGS-84 mean Earth radius.
+    /// </summary>
+    public static (double Latitude, double Longitude) GeodeticDestination(
+        double latDeg, double lonDeg, double bearingDeg, double distanceMetres)
+    {
+        const double R = 6_371_008.8;
+        var δ = distanceMetres / R;
+        var θ = bearingDeg * Math.PI / 180.0;
+        var φ1 = latDeg * Math.PI / 180.0;
+        var λ1 = lonDeg * Math.PI / 180.0;
+
+        var sinφ1 = Math.Sin(φ1);
+        var cosφ1 = Math.Cos(φ1);
+        var sinδ = Math.Sin(δ);
+        var cosδ = Math.Cos(δ);
+
+        var sinφ2 = sinφ1 * cosδ + cosφ1 * sinδ * Math.Cos(θ);
+        var φ2 = Math.Asin(sinφ2);
+        var y = Math.Sin(θ) * sinδ * cosφ1;
+        var x = cosδ - sinφ1 * sinφ2;
+        var λ2 = λ1 + Math.Atan2(y, x);
+
+        return (φ2 * 180.0 / Math.PI, ((λ2 * 180.0 / Math.PI) + 540.0) % 360.0 - 180.0);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/AisOverlaySettings.cs
+++ b/src/EncDotNet.S100.Viewer/AisOverlaySettings.cs
@@ -1,0 +1,53 @@
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// User-configurable AIS-overlay settings (PR-D3). Persisted under
+/// <c>ViewerSettings.AisOverlay</c>. The API key is **not** stored
+/// in <c>settings.json</c> — it is read at startup from the
+/// environment variable named in
+/// <see cref="ApiKeyEnvironmentVariable"/> (default
+/// <c>ENCDOTNET_AIS_STREAM_KEY</c>) so users can enable the overlay
+/// without committing their key into a shared config file.
+/// </summary>
+internal sealed class AisOverlaySettings
+{
+    /// <summary>
+    /// When <see langword="true"/> and the configured API-key
+    /// environment variable is set, the viewer registers the AIS
+    /// dynamic feature source on startup. When <see langword="false"/>
+    /// (the default), the overlay stays inactive even if the env var
+    /// is set — the toggle is the user's explicit opt-in.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Name of the environment variable holding the user's
+    /// aisstream.io API key. Defaults to
+    /// <c>ENCDOTNET_AIS_STREAM_KEY</c>.
+    /// </summary>
+    public string ApiKeyEnvironmentVariable { get; set; } = "ENCDOTNET_AIS_STREAM_KEY";
+
+    /// <summary>
+    /// Optional initial bounding box (minLat, minLon, maxLat, maxLon)
+    /// pushed to aisstream.io as the subscription's spatial filter.
+    /// When <see langword="null"/>, the driver uses the world bbox
+    /// (which aisstream.io treats as "all global traffic" — heavy).
+    /// The viewer is expected to override this with the live viewport
+    /// bbox via <c>UpdateArea</c>; this seed value just bounds the
+    /// initial subscribe before the user has panned the map.
+    /// </summary>
+    public AisOverlayBoundingBox? InitialArea { get; set; }
+}
+
+/// <summary>
+/// Plain-data bounding box for <see cref="AisOverlaySettings.InitialArea"/>.
+/// Mirrored separately from <see cref="EncDotNet.S100.Core.BoundingBox"/>
+/// so the settings POCO has no dependency on Core types.
+/// </summary>
+internal sealed class AisOverlayBoundingBox
+{
+    public double MinLatitude { get; set; }
+    public double MinLongitude { get; set; }
+    public double MaxLatitude { get; set; }
+    public double MaxLongitude { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/AisOverlaySettings.cs
+++ b/src/EncDotNet.S100.Viewer/AisOverlaySettings.cs
@@ -2,21 +2,31 @@ namespace EncDotNet.S100.Viewer;
 
 /// <summary>
 /// User-configurable AIS-overlay settings (PR-D3). Persisted under
-/// <c>ViewerSettings.AisOverlay</c>. The API key is **not** stored
-/// in <c>settings.json</c> — it is read at startup from the
-/// environment variable named in
-/// <see cref="ApiKeyEnvironmentVariable"/> (default
-/// <c>ENCDOTNET_AIS_STREAM_KEY</c>) so users can enable the overlay
-/// without committing their key into a shared config file.
+/// <c>ViewerSettings.AisOverlay</c>. The aisstream.io API key may
+/// come from one of two sources, in priority order:
+///
+/// <list type="number">
+///   <item>The environment variable named in
+///   <see cref="ApiKeyEnvironmentVariable"/> (default
+///   <c>ENCDOTNET_AIS_STREAM_KEY</c>) — preferred for users who
+///   don't want their key sitting in <c>settings.json</c>.</item>
+///   <item><see cref="ApiKey"/> — set via the Settings panel for
+///   convenience. Stored in plaintext in the user's
+///   <c>settings.json</c>; treat the file with the usual care for
+///   single-user secrets.</item>
+/// </list>
+///
+/// If neither yields a value the overlay stays inactive even when
+/// <see cref="Enabled"/> is <see langword="true"/>.
 /// </summary>
 internal sealed class AisOverlaySettings
 {
     /// <summary>
-    /// When <see langword="true"/> and the configured API-key
-    /// environment variable is set, the viewer registers the AIS
+    /// When <see langword="true"/> and an API key is available (env
+    /// var or <see cref="ApiKey"/>), the viewer registers the AIS
     /// dynamic feature source on startup. When <see langword="false"/>
-    /// (the default), the overlay stays inactive even if the env var
-    /// is set — the toggle is the user's explicit opt-in.
+    /// (the default) the overlay stays inactive — the toggle is the
+    /// user's explicit opt-in.
     /// </summary>
     public bool Enabled { get; set; } = false;
 
@@ -26,6 +36,15 @@ internal sealed class AisOverlaySettings
     /// <c>ENCDOTNET_AIS_STREAM_KEY</c>.
     /// </summary>
     public string ApiKeyEnvironmentVariable { get; set; } = "ENCDOTNET_AIS_STREAM_KEY";
+
+    /// <summary>
+    /// Optional aisstream.io API key persisted directly in
+    /// <c>settings.json</c>. Used only when the env var named in
+    /// <see cref="ApiKeyEnvironmentVariable"/> is unset or blank.
+    /// Stored in plaintext — for shared environments prefer the
+    /// env-var path. Default <see langword="null"/>.
+    /// </summary>
+    public string? ApiKey { get; set; }
 
     /// <summary>
     /// Optional initial bounding box (minLat, minLon, maxLat, maxLon)

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -277,6 +277,18 @@ public partial class App : Application
                 services,
                 rendererKey: EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource.FeatureKind);
 
+        // PR-D3: AIS overlay. The renderer is always registered (idempotent
+        // and harmless when no AIS source is active). The dynamic source
+        // itself is constructed lazily via Services.DynamicSources.Ais.
+        // AisOverlayServiceCollectionExtensions.AddAisOverlay so it can
+        // be conditioned on settings + the API-key environment variable.
+        EncDotNet.S100.Renderers.Mapsui.DynamicSources.DynamicFeatureRendererServiceCollectionExtensions
+            .AddDynamicFeatureRenderer<EncDotNet.S100.Renderers.Mapsui.DynamicSources.AisVesselRenderer>(
+                services,
+                rendererKey: "vessel.ais");
+        EncDotNet.S100.Viewer.Services.DynamicSources.Ais.AisOverlayServiceCollectionExtensions
+            .AddAisOverlay(services);
+
         // PR-D2.1: dynamic-source registry accessor. The real registry
         // is the DynamicSourceOverlayHost constructed in MainWindow
         // (it needs IMapHost, which only exists after the MapControl

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -85,6 +85,8 @@
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S201\EncDotNet.S100.Datasets.S201.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S421\EncDotNet.S100.Datasets.S421.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.DynamicSources.Ais\EncDotNet.S100.DynamicSources.Ais.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo\EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.ExchangeSets\EncDotNet.S100.ExchangeSets.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Hdf5.PureHdf\EncDotNet.S100.Hdf5.PureHdf.csproj" />

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -406,4 +406,14 @@ internal static class Strings
     public static string Settings_OwnVessel_BowOffset_Tooltip => Get(nameof(Settings_OwnVessel_BowOffset_Tooltip));
     public static string Settings_OwnVessel_PortOffset => Get(nameof(Settings_OwnVessel_PortOffset));
     public static string Settings_OwnVessel_PortOffset_Tooltip => Get(nameof(Settings_OwnVessel_PortOffset_Tooltip));
+
+    // AIS overlay (PR-D3)
+    public static string Settings_AisSection => Get(nameof(Settings_AisSection));
+    public static string Settings_AisSection_Help => Get(nameof(Settings_AisSection_Help));
+    public static string Settings_AisEnabled => Get(nameof(Settings_AisEnabled));
+    public static string Settings_AisEnabledTooltip => Get(nameof(Settings_AisEnabledTooltip));
+    public static string Settings_AisApiKey => Get(nameof(Settings_AisApiKey));
+    public static string Settings_AisApiKeyTooltip => Get(nameof(Settings_AisApiKeyTooltip));
+    public static string Settings_AisApiKey_EnvVarHint => Get(nameof(Settings_AisApiKey_EnvVarHint));
+    public static string Settings_AisApiKey_EnvVarPresent => Get(nameof(Settings_AisApiKey_EnvVarPresent));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1077,4 +1077,30 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   <data name="Settings_OwnVessel_PortOffset_Tooltip" xml:space="preserve">
     <value>Distance from the port side to the GPS / reference point, in metres. Must be between 0 and the vessel beam.</value>
   </data>
+  <data name="Settings_AisSection" xml:space="preserve">
+    <value>AIS Overlay</value>
+  </data>
+  <data name="Settings_AisSection_Help" xml:space="preserve">
+    <value>Live AIS targets streamed from aisstream.io. Requires a free API key from https://aisstream.io. Changes take effect on next viewer restart.</value>
+  </data>
+  <data name="Settings_AisEnabled" xml:space="preserve">
+    <value>Enable AIS overlay</value>
+  </data>
+  <data name="Settings_AisEnabledTooltip" xml:space="preserve">
+    <value>When enabled, register the AIS dynamic-feature source on startup. The source stays inactive until an API key is supplied (env var or below).</value>
+  </data>
+  <data name="Settings_AisApiKey" xml:space="preserve">
+    <value>API key</value>
+  </data>
+  <data name="Settings_AisApiKeyTooltip" xml:space="preserve">
+    <value>Your aisstream.io API key. Stored in plaintext in settings.json — leave blank to read from the environment variable instead. The env-var value (when set) takes precedence over this field.</value>
+  </data>
+  <data name="Settings_AisApiKey_EnvVarHint" xml:space="preserve">
+    <value>Or set the {0} environment variable; the env var takes precedence when set.</value>
+    <comment>{0} = environment variable name (e.g. ENCDOTNET_AIS_STREAM_KEY).</comment>
+  </data>
+  <data name="Settings_AisApiKey_EnvVarPresent" xml:space="preserve">
+    <value>Environment variable {0} is set; it will be used.</value>
+    <comment>{0} = environment variable name.</comment>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/Ais/AisOverlayServiceCollectionExtensions.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/Ais/AisOverlayServiceCollectionExtensions.cs
@@ -47,8 +47,12 @@ internal static class AisOverlayServiceCollectionExtensions
         if (overlaySettings is null || !overlaySettings.Enabled)
             return new DisabledAisFeatureSource();
 
+        // Env var wins over the persisted key so users who care
+        // about not committing secrets to settings.json have a path.
         var apiKey = Environment.GetEnvironmentVariable(
             overlaySettings.ApiKeyEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(apiKey))
+            apiKey = overlaySettings.ApiKey;
         if (string.IsNullOrWhiteSpace(apiKey))
             return new DisabledAisFeatureSource();
 

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/Ais/AisOverlayServiceCollectionExtensions.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/Ais/AisOverlayServiceCollectionExtensions.cs
@@ -1,0 +1,101 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.DynamicSources.Ais;
+using EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+using EncDotNet.S100.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources.Ais;
+
+/// <summary>
+/// PR-D3 AIS-overlay DI registration. Wires the
+/// <c>AisStreamIoMessageSource</c> driver and an
+/// <c>AisDynamicFeatureSource</c> over it into the viewer's service
+/// provider, but only when both
+/// <see cref="AisOverlaySettings.Enabled"/> is <see langword="true"/>
+/// and the configured API-key environment variable is non-empty.
+/// In every other configuration the overlay stays silently inactive
+/// — registering the renderer is harmless because no source emits
+/// features keyed for it.
+/// </summary>
+internal static class AisOverlayServiceCollectionExtensions
+{
+    public static IServiceCollection AddAisOverlay(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IDynamicFeatureSource>(sp =>
+        {
+            var settings = sp.GetRequiredService<ViewerSettings>();
+            var loggerFactory = sp.GetService<ILoggerFactory>();
+            return BuildSource(settings.AisOverlay, loggerFactory);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Internal factory exposed for tests: builds either a real
+    /// <c>AisDynamicFeatureSource</c> or the
+    /// <see cref="DisabledAisFeatureSource"/> sentinel based on
+    /// <paramref name="overlaySettings"/> and the environment.
+    /// </summary>
+    internal static IDynamicFeatureSource BuildSource(
+        AisOverlaySettings? overlaySettings,
+        ILoggerFactory? loggerFactory)
+    {
+        if (overlaySettings is null || !overlaySettings.Enabled)
+            return new DisabledAisFeatureSource();
+
+        var apiKey = Environment.GetEnvironmentVariable(
+            overlaySettings.ApiKeyEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(apiKey))
+            return new DisabledAisFeatureSource();
+
+        var driver = new AisStreamIoMessageSource(
+            new AisStreamIoOptions { ApiKey = apiKey },
+            loggerFactory);
+
+        var request = new AisSubscriptionRequest
+        {
+            Area = ToBoundingBox(overlaySettings.InitialArea),
+        };
+
+        return new AisDynamicFeatureSource(
+            id: "ais",
+            messageSource: driver,
+            request: request);
+    }
+
+    private static BoundingBox? ToBoundingBox(AisOverlayBoundingBox? box)
+    {
+        if (box is null) return null;
+        return new BoundingBox(
+            box.MinLatitude, box.MinLongitude,
+            box.MaxLatitude, box.MaxLongitude);
+    }
+}
+
+/// <summary>
+/// No-op <see cref="IDynamicFeatureSource"/> registered when the AIS
+/// overlay is disabled. Surfaces in the layer-stack panel as an
+/// inactive sibling so toggling its visibility has no effect.
+/// </summary>
+internal sealed class DisabledAisFeatureSource : IDynamicFeatureSource, IAsyncDisposable
+{
+    public string Id => "ais.disabled";
+
+    public DynamicSourceMetadata Metadata { get; } = new()
+    {
+        DisplayName = "AIS targets (disabled)",
+        RendererKey = "vessel.ais",
+    };
+
+    public IReadOnlyList<DynamicFeature> CurrentFeatures => Array.Empty<DynamicFeature>();
+
+#pragma warning disable CS0067 // never raised — overlay is disabled
+    public event EventHandler<DynamicFeaturesChanged>? Changed;
+#pragma warning restore CS0067
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
@@ -42,6 +42,17 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
     private readonly IServiceProvider _services;
     private readonly Action<Action> _marshal;
     private readonly ILogger<DynamicSourceOverlayHost> _logger;
+    /// <summary>
+    /// Minimum time between full layer rebuilds for a single source.
+    /// PR-D3 made this matter: high-frequency sources (AIS at world
+    /// scale = 10–100+ events/sec, each touching 100s of features)
+    /// would otherwise pin the UI thread. The throttle is leading-
+    /// edge (first event in a quiet window rebuilds immediately) plus
+    /// trailing-edge (subsequent bursts collapse to one rebuild at
+    /// the end of the window) so own-ship's ~1 Hz cadence still
+    /// renders without perceptible delay.
+    /// </summary>
+    private readonly TimeSpan _coalesceWindow;
     private readonly Dictionary<string, Registration> _byId = new(StringComparer.Ordinal);
     // Registration order — preserved separately from _byId so the
     // Layer Stack panel can render sources in the order they were
@@ -77,11 +88,19 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
     /// or test-dispatcher-backed implementation.
     /// </param>
     /// <param name="logger">Optional logger.</param>
+    /// <param name="coalesceWindow">
+    /// Minimum interval between full rebuilds of a single source's
+    /// layer. <see langword="null"/> uses the default 100 ms (≈10 fps,
+    /// well above human perception threshold and far below AIS
+    /// burst rates). Tests pass <see cref="TimeSpan.Zero"/> to disable
+    /// the throttle and keep rebuilds synchronous.
+    /// </param>
     public DynamicSourceOverlayHost(
         IMapHost mapHost,
         IServiceProvider services,
         Action<Action>? marshal = null,
-        ILogger<DynamicSourceOverlayHost>? logger = null)
+        ILogger<DynamicSourceOverlayHost>? logger = null,
+        TimeSpan? coalesceWindow = null)
     {
         ArgumentNullException.ThrowIfNull(mapHost);
         ArgumentNullException.ThrowIfNull(services);
@@ -89,6 +108,7 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
         _services = services;
         _marshal = marshal ?? DispatcherMarshal;
         _logger = logger ?? NullLogger<DynamicSourceOverlayHost>.Instance;
+        _coalesceWindow = coalesceWindow ?? TimeSpan.FromMilliseconds(100);
     }
 
     /// <summary>
@@ -289,11 +309,52 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
         public void OnChanged(object? sender, DynamicFeaturesChanged e)
         {
             if (Volatile.Read(ref _disposed) != 0) return;
-            _host._marshal(() =>
+            _host._marshal(HandleChangeOnUiThread);
+        }
+
+        // UI-thread only; _trailingScheduled and _lastRebuildUtc are
+        // not synchronised because all reads/writes happen here after
+        // the _marshal hop.
+        private bool _trailingScheduled;
+        private DateTime _lastRebuildUtc = DateTime.MinValue;
+
+        private void HandleChangeOnUiThread()
+        {
+            if (Volatile.Read(ref _disposed) != 0) return;
+
+            var window = _host._coalesceWindow;
+            if (window <= TimeSpan.Zero)
             {
-                if (Volatile.Read(ref _disposed) != 0) return;
-                _host.Rebuild(this);
-            });
+                DoRebuild();
+                return;
+            }
+
+            var elapsed = DateTime.UtcNow - _lastRebuildUtc;
+            if (elapsed >= window)
+            {
+                // Leading edge — quiet window, rebuild now.
+                DoRebuild();
+                return;
+            }
+
+            // Inside an active window. Collapse this event into the
+            // already-pending trailing rebuild, or schedule one.
+            if (_trailingScheduled) return;
+            _trailingScheduled = true;
+            var delay = window - elapsed;
+            _ = Task.Delay(delay).ContinueWith(_ =>
+                _host._marshal(() =>
+                {
+                    _trailingScheduled = false;
+                    if (Volatile.Read(ref _disposed) != 0) return;
+                    DoRebuild();
+                }), TaskScheduler.Default);
+        }
+
+        private void DoRebuild()
+        {
+            _lastRebuildUtc = DateTime.UtcNow;
+            _host.Rebuild(this);
         }
 
         public void Dispose()

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
@@ -90,10 +90,11 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
     /// <param name="logger">Optional logger.</param>
     /// <param name="coalesceWindow">
     /// Minimum interval between full rebuilds of a single source's
-    /// layer. <see langword="null"/> uses the default 100 ms (≈10 fps,
-    /// well above human perception threshold and far below AIS
-    /// burst rates). Tests pass <see cref="TimeSpan.Zero"/> to disable
-    /// the throttle and keep rebuilds synchronous.
+    /// layer. <see langword="null"/> uses the default 250 ms (AIS
+    /// at world scale streams 10–100+ events/sec; the default keeps
+    /// the UI responsive while still feeling live for own-ship's
+    /// ~1 Hz cadence). Tests pass <see cref="TimeSpan.Zero"/> to
+    /// disable the throttle and keep rebuilds synchronous.
     /// </param>
     public DynamicSourceOverlayHost(
         IMapHost mapHost,
@@ -108,7 +109,7 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
         _services = services;
         _marshal = marshal ?? DispatcherMarshal;
         _logger = logger ?? NullLogger<DynamicSourceOverlayHost>.Instance;
-        _coalesceWindow = coalesceWindow ?? TimeSpan.FromMilliseconds(100);
+        _coalesceWindow = coalesceWindow ?? TimeSpan.FromMilliseconds(250);
     }
 
     /// <summary>
@@ -183,6 +184,20 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
 
     private void Rebuild(Registration registration)
     {
+        // Synchronous rebuild — used for the initial Register() build
+        // and by tests with throttle disabled. Cheap when the source
+        // has few features (own-ship == 1).
+        var features = RenderSnapshot(registration);
+        registration.Layer.Features = features;
+        registration.Layer.DataHasChanged();
+    }
+
+    // Pure-CPU helper; safe to call off the UI thread because the
+    // renderer contract is pure (no Avalonia / Mapsui state mutation
+    // beyond constructing GeometryFeature/Style objects, which are
+    // POCOs until added to a layer).
+    private static List<IFeature> RenderSnapshot(Registration registration)
+    {
         var snapshot = registration.Source.CurrentFeatures;
         var features = new List<IFeature>(snapshot.Count);
         foreach (var feature in snapshot)
@@ -193,8 +208,7 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
                 features.Add(rendered);
             }
         }
-        registration.Layer.Features = features;
-        registration.Layer.DataHasChanged();
+        return features;
     }
 
     private static void DispatcherMarshal(Action action)
@@ -312,10 +326,11 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
             _host._marshal(HandleChangeOnUiThread);
         }
 
-        // UI-thread only; _trailingScheduled and _lastRebuildUtc are
-        // not synchronised because all reads/writes happen here after
-        // the _marshal hop.
+        // UI-thread only; _trailingScheduled, _backgroundInFlight, and
+        // _lastRebuildUtc are not synchronised because all reads/
+        // writes happen here after the _marshal hop.
         private bool _trailingScheduled;
+        private bool _backgroundInFlight;
         private DateTime _lastRebuildUtc = DateTime.MinValue;
 
         private void HandleChangeOnUiThread()
@@ -325,36 +340,84 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
             var window = _host._coalesceWindow;
             if (window <= TimeSpan.Zero)
             {
-                DoRebuild();
+                // Synchronous path for tests and the initial seed.
+                _host.Rebuild(this);
+                _lastRebuildUtc = DateTime.UtcNow;
                 return;
             }
 
             var elapsed = DateTime.UtcNow - _lastRebuildUtc;
-            if (elapsed >= window)
+            if (elapsed >= window && !_backgroundInFlight)
             {
-                // Leading edge — quiet window, rebuild now.
-                DoRebuild();
+                ScheduleBackgroundRebuild();
                 return;
             }
 
-            // Inside an active window. Collapse this event into the
-            // already-pending trailing rebuild, or schedule one.
+            // Inside an active window or rebuild already running.
+            // Collapse this event into the trailing rebuild.
             if (_trailingScheduled) return;
             _trailingScheduled = true;
-            var delay = window - elapsed;
+            var delay = elapsed >= window ? TimeSpan.Zero : window - elapsed;
             _ = Task.Delay(delay).ContinueWith(_ =>
                 _host._marshal(() =>
                 {
                     _trailingScheduled = false;
                     if (Volatile.Read(ref _disposed) != 0) return;
-                    DoRebuild();
+                    if (_backgroundInFlight)
+                    {
+                        // Re-queue once the in-flight rebuild lands —
+                        // its completion will check this flag.
+                        _trailingScheduled = true;
+                        return;
+                    }
+                    ScheduleBackgroundRebuild();
                 }), TaskScheduler.Default);
         }
 
-        private void DoRebuild()
+        // UI thread → background thread for the heavy render loop →
+        // UI thread to assign the result. Keeps long-running renders
+        // (AIS at world scale: 1000s of features × multiple styles
+        // each) off the UI thread so panning / zoom stay responsive.
+        private void ScheduleBackgroundRebuild()
         {
+            _backgroundInFlight = true;
             _lastRebuildUtc = DateTime.UtcNow;
-            _host.Rebuild(this);
+            _ = Task.Run(() =>
+            {
+                List<IFeature>? features = null;
+                try
+                {
+                    if (Volatile.Read(ref _disposed) == 0)
+                    {
+                        features = RenderSnapshot(this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _host._logger.LogError(
+                        ex,
+                        "Dynamic source '{SourceId}' renderer threw during rebuild.",
+                        Source.Id);
+                }
+                _host._marshal(() =>
+                {
+                    _backgroundInFlight = false;
+                    if (Volatile.Read(ref _disposed) != 0) return;
+                    if (features is not null)
+                    {
+                        Layer.Features = features;
+                        Layer.DataHasChanged();
+                        _lastRebuildUtc = DateTime.UtcNow;
+                    }
+                    if (_trailingScheduled)
+                    {
+                        // A burst event landed mid-rebuild and was
+                        // deferred above; honour it now.
+                        _trailingScheduled = false;
+                        ScheduleBackgroundRebuild();
+                    }
+                });
+            });
         }
 
         public void Dispose()

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -468,6 +468,10 @@ internal sealed class SettingsViewModel : ViewModelBase
         _ownShipBeam = own.BeamMetres;
         _ownShipBowOffset = own.BowOffsetMetres;
         _ownShipPortOffset = own.PortOffsetMetres;
+
+        var ais = settings.AisOverlay ?? new AisOverlaySettings();
+        _aisEnabled = ais.Enabled;
+        _aisApiKey = ais.ApiKey;
     }
 
     /// <summary>
@@ -616,6 +620,88 @@ internal sealed class SettingsViewModel : ViewModelBase
                 _settings.Save();
                 OwnShipGeometryChanged?.Invoke();
             }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // AIS overlay (PR-D3). Changes don't take effect until restart;
+    // the source is registered as a singleton at app startup.
+    // ---------------------------------------------------------------
+
+    private void EnsureAisOverlaySettings()
+    {
+        _settings.AisOverlay ??= new AisOverlaySettings();
+    }
+
+    private bool _aisEnabled;
+    /// <summary>
+    /// User opt-in for the AIS overlay. Persisted to
+    /// <see cref="AisOverlaySettings.Enabled"/>. Effective on next
+    /// viewer restart.
+    /// </summary>
+    public bool AisEnabled
+    {
+        get => _aisEnabled;
+        set
+        {
+            if (SetProperty(ref _aisEnabled, value))
+            {
+                EnsureAisOverlaySettings();
+                _settings.AisOverlay!.Enabled = value;
+                _settings.Save();
+            }
+        }
+    }
+
+    private string? _aisApiKey;
+    /// <summary>
+    /// aisstream.io API key persisted in <c>settings.json</c>. The
+    /// env var named in
+    /// <see cref="AisOverlaySettings.ApiKeyEnvironmentVariable"/>
+    /// takes precedence when set; this field is the convenience
+    /// fallback for users who don't want to manage env vars.
+    /// </summary>
+    public string? AisApiKey
+    {
+        get => _aisApiKey;
+        set
+        {
+            // Treat blank/whitespace as null so the env-var fallback
+            // path is taken cleanly when the user clears the field.
+            var normalised = string.IsNullOrWhiteSpace(value) ? null : value;
+            if (SetProperty(ref _aisApiKey, normalised))
+            {
+                EnsureAisOverlaySettings();
+                _settings.AisOverlay!.ApiKey = normalised;
+                _settings.Save();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Name of the env var that, when set, supplies the API key in
+    /// preference to <see cref="AisApiKey"/>. Read-only in the UI;
+    /// surfaced as a hint so users know which variable to set.
+    /// </summary>
+    public string AisApiKeyEnvironmentVariable =>
+        _settings.AisOverlay?.ApiKeyEnvironmentVariable
+        ?? new AisOverlaySettings().ApiKeyEnvironmentVariable;
+
+    /// <summary>
+    /// Localised hint shown beneath the API-key field. Renders the
+    /// "env var is set, will be used" copy when the env var resolves
+    /// at viewmodel-construction time, otherwise the "or set ENV"
+    /// reminder.
+    /// </summary>
+    public string AisApiKeyHint
+    {
+        get
+        {
+            var envVar = AisApiKeyEnvironmentVariable;
+            var envVal = Environment.GetEnvironmentVariable(envVar);
+            return string.IsNullOrWhiteSpace(envVal)
+                ? string.Format(CultureInfo.CurrentCulture, Strings.Settings_AisApiKey_EnvVarHint, envVar)
+                : string.Format(CultureInfo.CurrentCulture, Strings.Settings_AisApiKey_EnvVarPresent, envVar);
         }
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -176,6 +176,16 @@ internal sealed class ViewerSettings
     public OwnShipSettings? OwnShip { get; set; }
 
     /// <summary>
+    /// Optional AIS overlay configuration (PR-D3). When present and
+    /// <see cref="AisOverlaySettings.Enabled"/> is <see langword="true"/>,
+    /// the viewer registers an <c>AisDynamicFeatureSource</c> backed
+    /// by the aisstream.io WebSocket driver. <see langword="null"/>
+    /// — and the matching environment variable being unset — means
+    /// the overlay is silently disabled. Pure additive; no migration.
+    /// </summary>
+    public AisOverlaySettings? AisOverlay { get; set; }
+
+    /// <summary>
     /// User preference for whether the bottom timeline panel is shown.
     /// When true the panel surfaces (in either an empty state or with
     /// a global slider, depending on whether any time-varying dataset

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -332,6 +332,34 @@
                             VerticalAlignment="Center" />
                 </StackPanel>
             </StackPanel>
+
+            <!-- AIS overlay (PR-D3) -->
+            <Separator Margin="0,8,0,0" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_AisSection}"
+                       FontSize="14"
+                       FontWeight="SemiBold"
+                       Opacity="0.7" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_AisSection_Help}"
+                       FontSize="11"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_AisEnabled}"
+                      IsChecked="{Binding AisEnabled}"
+                      ToolTip.Tip="{x:Static loc:Strings.Settings_AisEnabledTooltip}" />
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_AisApiKey}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding AisApiKey, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                         PasswordChar="•"
+                         ToolTip.Tip="{x:Static loc:Strings.Settings_AisApiKeyTooltip}"
+                         MinWidth="280"
+                         HorizontalAlignment="Left" />
+                <TextBlock Text="{Binding AisApiKeyHint}"
+                           FontSize="11"
+                           Opacity="0.6"
+                           TextWrapping="Wrap" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/AisStreamIoJsonTests.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/AisStreamIoJsonTests.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using EncDotNet.S100.DynamicSources.Ais;
+using EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests;
+
+public class AisStreamIoJsonTests
+{
+    [Fact]
+    public void Subscribe_frame_uses_explicit_bbox_in_lat_lon_order()
+    {
+        var request = new AisSubscriptionRequest
+        {
+            Area = new BoundingBox(southLatitude: 30, westLongitude: -120, northLatitude: 40, eastLongitude: -110),
+        };
+
+        var frame = AisStreamIoJson.BuildSubscribeFrame("KEY", request);
+
+        using var doc = JsonDocument.Parse(frame);
+        var bboxes = doc.RootElement.GetProperty("BoundingBoxes");
+        var pair = bboxes[0];
+        Assert.Equal(30, pair[0][0].GetDouble());
+        Assert.Equal(-120, pair[0][1].GetDouble());
+        Assert.Equal(40, pair[1][0].GetDouble());
+        Assert.Equal(-110, pair[1][1].GetDouble());
+        Assert.Equal("KEY", doc.RootElement.GetProperty("APIKey").GetString());
+    }
+
+    [Fact]
+    public void Subscribe_frame_uses_world_box_when_area_is_null()
+    {
+        var frame = AisStreamIoJson.BuildSubscribeFrame("KEY", new AisSubscriptionRequest());
+        using var doc = JsonDocument.Parse(frame);
+        var pair = doc.RootElement.GetProperty("BoundingBoxes")[0];
+        Assert.Equal(-90, pair[0][0].GetDouble());
+        Assert.Equal(-180, pair[0][1].GetDouble());
+        Assert.Equal(90, pair[1][0].GetDouble());
+        Assert.Equal(180, pair[1][1].GetDouble());
+    }
+
+    [Fact]
+    public void Subscribe_frame_writes_filter_message_types_when_subset_selected()
+    {
+        var frame = AisStreamIoJson.BuildSubscribeFrame("KEY", new AisSubscriptionRequest
+        {
+            Include = AisMessageKinds.PositionReports,
+        });
+        using var doc = JsonDocument.Parse(frame);
+        var filters = doc.RootElement.GetProperty("FilterMessageTypes");
+        Assert.Equal(1, filters.GetArrayLength());
+        Assert.Equal("PositionReport", filters[0].GetString());
+    }
+
+    [Fact]
+    public void Subscribe_frame_writes_mmsi_filter_as_strings()
+    {
+        var frame = AisStreamIoJson.BuildSubscribeFrame("KEY", new AisSubscriptionRequest
+        {
+            Mmsis = new uint[] { 1, 2, 3 },
+        });
+        using var doc = JsonDocument.Parse(frame);
+        var mmsis = doc.RootElement.GetProperty("FiltersShipMMSI");
+        Assert.Equal(3, mmsis.GetArrayLength());
+        Assert.Equal("1", mmsis[0].GetString());
+        Assert.Equal("3", mmsis[2].GetString());
+    }
+
+    [Fact]
+    public void Position_report_parses_with_sentinel_collapse()
+    {
+        const string json = """
+        {
+          "MessageType": "PositionReport",
+          "MetaData": {
+            "MMSI": 123456789,
+            "ShipName": "EXAMPLE",
+            "time_utc": "2026-05-29 14:23:01.234567 +0000 UTC"
+          },
+          "Message": {
+            "PositionReport": {
+              "Latitude": 37.81234,
+              "Longitude": -122.43210,
+              "Cog": 360.0,
+              "TrueHeading": 511,
+              "Sog": 102.3,
+              "RateOfTurn": -128,
+              "NavigationalStatus": 5
+            }
+          }
+        }
+        """;
+
+        var msg = AisStreamIoJson.ParseInbound(json);
+        var pr = Assert.IsType<AisPositionReport>(msg);
+        Assert.Equal(123456789u, pr.Mmsi);
+        Assert.Equal(37.81234, pr.Latitude);
+        Assert.Equal(-122.4321, pr.Longitude);
+        Assert.Null(pr.CourseOverGroundDeg);
+        Assert.Null(pr.HeadingDeg);
+        Assert.Null(pr.SpeedOverGroundKn);
+        Assert.Null(pr.RateOfTurnDegPerMin);
+        Assert.Equal(AisNavigationStatus.Moored, pr.NavigationStatus);
+    }
+
+    [Fact]
+    public void Position_report_keeps_real_values_through_parse()
+    {
+        const string json = """
+        {
+          "MessageType": "PositionReport",
+          "MetaData": { "MMSI": 1, "time_utc": "2026-01-01 00:00:00 +0000 UTC" },
+          "Message": { "PositionReport": { "Latitude": 1.5, "Longitude": 2.5, "Cog": 90.5, "TrueHeading": 92, "Sog": 12.3, "NavigationalStatus": 0 } }
+        }
+        """;
+
+        var pr = Assert.IsType<AisPositionReport>(AisStreamIoJson.ParseInbound(json));
+        Assert.Equal(90.5, pr.CourseOverGroundDeg);
+        Assert.Equal(92, pr.HeadingDeg);
+        Assert.Equal(12.3, pr.SpeedOverGroundKn);
+    }
+
+    [Fact]
+    public void Ship_static_data_folds_dimensions_into_length_beam_offsets()
+    {
+        const string json = """
+        {
+          "MessageType": "ShipStaticData",
+          "MetaData": { "MMSI": 42, "time_utc": "2026-01-01 00:00:00 +0000 UTC", "ShipName": "META NAME" },
+          "Message": {
+            "ShipStaticData": {
+              "ImoNumber": 9876543,
+              "CallSign": "EXMPL ",
+              "Name": "EXAMPLE@@@@",
+              "Type": 70,
+              "Dimension": { "A": 100, "B": 30, "C": 5, "D": 12 },
+              "MaximumStaticDraught": 8.5,
+              "Destination": "USOAK"
+            }
+          }
+        }
+        """;
+
+        var sd = Assert.IsType<AisStaticVoyageData>(AisStreamIoJson.ParseInbound(json));
+        Assert.Equal(42u, sd.Mmsi);
+        Assert.Equal(9876543u, sd.ImoNumber);
+        Assert.Equal("EXMPL", sd.CallSign);
+        Assert.Equal("EXAMPLE", sd.VesselName);
+        Assert.Equal(AisShipType.Cargo, sd.ShipType);
+        Assert.Equal(AisShipTypeClass.Cargo, sd.ShipTypeClass);
+        Assert.NotNull(sd.Dimensions);
+        Assert.Equal(130, sd.Dimensions!.LengthMetres);
+        Assert.Equal(17, sd.Dimensions.BeamMetres);
+        Assert.Equal(100, sd.Dimensions.BowOffsetMetres);
+        Assert.Equal(5, sd.Dimensions.PortOffsetMetres);
+        Assert.Equal(8.5, sd.DraughtMetres);
+        Assert.Equal("USOAK", sd.Destination);
+    }
+
+    [Fact]
+    public void Ship_static_data_drops_zero_dimensions()
+    {
+        const string json = """
+        {
+          "MessageType": "ShipStaticData",
+          "MetaData": { "MMSI": 42, "time_utc": "2026-01-01 00:00:00 +0000 UTC" },
+          "Message": { "ShipStaticData": { "Type": 70, "Dimension": { "A": 0, "B": 0, "C": 0, "D": 0 } } }
+        }
+        """;
+        var sd = Assert.IsType<AisStaticVoyageData>(AisStreamIoJson.ParseInbound(json));
+        Assert.Null(sd.Dimensions);
+    }
+
+    [Fact]
+    public void Unknown_message_types_yield_null()
+    {
+        Assert.Null(AisStreamIoJson.ParseInbound("""{"MessageType":"UnknownEverything"}"""));
+    }
+
+    [Fact]
+    public void Malformed_json_yields_null()
+    {
+        Assert.Null(AisStreamIoJson.ParseInbound("not json"));
+    }
+
+    [Fact]
+    public void Redact_api_key_replaces_every_occurrence()
+    {
+        var frame = """{"APIKey":"super-secret","BoundingBoxes":[]}""";
+        var redacted = AisStreamIoJson.RedactApiKey(frame, "super-secret");
+        Assert.DoesNotContain("super-secret", redacted, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", redacted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Timestamp_parser_handles_go_format_with_zone_label()
+    {
+        Assert.True(AisStreamIoJson.TryParseAisStreamTimestamp(
+            "2026-05-29 14:23:01.234567 +0000 UTC", out var value));
+        Assert.Equal(new DateTimeOffset(2026, 5, 29, 14, 23, 1, TimeSpan.Zero).AddTicks(2345670),
+            value);
+    }
+}

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/AisStreamIoMessageSourceTests.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/AisStreamIoMessageSourceTests.cs
@@ -1,0 +1,165 @@
+using EncDotNet.S100.DynamicSources.Ais;
+using EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests;
+
+public class AisStreamIoMessageSourceTests
+{
+    private static AisStreamIoOptions Options() => new()
+    {
+        ApiKey = "TEST-KEY",
+        Endpoint = new Uri("ws://test.invalid/v0/stream"),
+        SubscribeDeadline = TimeSpan.FromSeconds(5),
+        InitialReconnectBackoff = TimeSpan.FromMilliseconds(10),
+        MaxReconnectBackoff = TimeSpan.FromMilliseconds(50),
+    };
+
+    private static async Task WaitForAsync(Func<bool> predicate, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(20).ConfigureAwait(false);
+        }
+        throw new TimeoutException("Predicate did not become true.");
+    }
+
+    [Fact]
+    public async Task Subscribe_sends_subscribe_frame_and_dispatches_position()
+    {
+        FakeAisStreamIoTransport? captured = null;
+        var source = new AisStreamIoMessageSource(Options(), () => captured = new FakeAisStreamIoTransport());
+
+        var positions = new List<AisPositionReport>();
+        await using var sub = source.Subscribe(new AisSubscriptionRequest
+        {
+            Area = new BoundingBox(30, -120, 40, -110),
+        });
+        sub.PositionReportReceived += (_, p) => positions.Add(p);
+
+        await WaitForAsync(() => captured?.OutboundFrames.Count == 1);
+        Assert.Contains("\"APIKey\":\"TEST-KEY\"", captured!.OutboundFrames[0]);
+
+        captured.EnqueueInbound("""
+        {"MessageType":"PositionReport","MetaData":{"MMSI":1,"time_utc":"2026-01-01 00:00:00 +0000 UTC"},
+        "Message":{"PositionReport":{"Latitude":35,"Longitude":-115,"Cog":90,"TrueHeading":92,"Sog":10,"NavigationalStatus":0}}}
+        """);
+
+        await WaitForAsync(() => positions.Count == 1);
+        Assert.Equal(1u, positions[0].Mmsi);
+    }
+
+    [Fact]
+    public async Task TryUpdateArea_resends_subscribe_with_new_bbox()
+    {
+        FakeAisStreamIoTransport? captured = null;
+        var source = new AisStreamIoMessageSource(Options(), () => captured = new FakeAisStreamIoTransport());
+
+        await using var sub = source.Subscribe(new AisSubscriptionRequest
+        {
+            Area = new BoundingBox(0, 0, 1, 1),
+        });
+        await WaitForAsync(() => captured?.OutboundFrames.Count == 1);
+
+        Assert.True(sub.TryUpdateArea(new BoundingBox(10, 20, 30, 40)));
+
+        // The receive loop sends the new subscribe frame just before its
+        // next receive. Trigger one inbound message so the loop iterates.
+        captured!.EnqueueInbound("{}");
+        await WaitForAsync(() => captured.OutboundFrames.Count >= 2);
+        var second = captured.OutboundFrames[1];
+        Assert.Contains("\"APIKey\":\"TEST-KEY\"", second);
+        Assert.Contains("10", second);
+        Assert.Contains("40", second);
+    }
+
+    [Fact]
+    public async Task Driver_reconnects_after_peer_close()
+    {
+        var transports = new List<FakeAisStreamIoTransport>();
+        var source = new AisStreamIoMessageSource(Options(), () =>
+        {
+            var t = new FakeAisStreamIoTransport();
+            transports.Add(t);
+            return t;
+        });
+
+        await using var sub = source.Subscribe(new AisSubscriptionRequest());
+        await WaitForAsync(() => transports.Count >= 1 && transports[0].OutboundFrames.Count >= 1);
+
+        // First transport closes; loop should reconnect via factory.
+        transports[0].ScriptClose();
+        await WaitForAsync(() => transports.Count >= 2 && transports[1].OutboundFrames.Count >= 1);
+
+        Assert.True(transports[0].Disposed);
+        Assert.NotEmpty(transports[1].OutboundFrames);
+    }
+
+    [Fact]
+    public async Task Subscribe_filters_messages_by_mmsi_allowlist()
+    {
+        FakeAisStreamIoTransport? captured = null;
+        var source = new AisStreamIoMessageSource(Options(), () => captured = new FakeAisStreamIoTransport());
+        await using var sub = source.Subscribe(new AisSubscriptionRequest
+        {
+            Mmsis = new uint[] { 7 },
+        });
+        var positions = new List<AisPositionReport>();
+        sub.PositionReportReceived += (_, p) => positions.Add(p);
+
+        await WaitForAsync(() => captured?.OutboundFrames.Count == 1);
+
+        captured!.EnqueueInbound("""
+        {"MessageType":"PositionReport","MetaData":{"MMSI":1,"time_utc":"2026-01-01 00:00:00 +0000 UTC"},
+        "Message":{"PositionReport":{"Latitude":1,"Longitude":1,"Cog":0,"TrueHeading":0,"Sog":0,"NavigationalStatus":0}}}
+        """);
+        captured.EnqueueInbound("""
+        {"MessageType":"PositionReport","MetaData":{"MMSI":7,"time_utc":"2026-01-01 00:00:00 +0000 UTC"},
+        "Message":{"PositionReport":{"Latitude":2,"Longitude":2,"Cog":0,"TrueHeading":0,"Sog":0,"NavigationalStatus":0}}}
+        """);
+
+        await WaitForAsync(() => positions.Count == 1);
+        Assert.Equal(7u, positions[0].Mmsi);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_stops_loop_and_cleans_up_transport()
+    {
+        FakeAisStreamIoTransport? captured = null;
+        var source = new AisStreamIoMessageSource(Options(), () => captured = new FakeAisStreamIoTransport());
+        var sub = source.Subscribe(new AisSubscriptionRequest());
+        await WaitForAsync(() => captured?.OutboundFrames.Count == 1);
+
+        await sub.DisposeAsync();
+
+        Assert.True(captured!.Disposed);
+    }
+
+    [Fact]
+    public void Constructor_rejects_missing_api_key()
+    {
+        Assert.Throws<ArgumentException>(() => new AisStreamIoMessageSource(new AisStreamIoOptions
+        {
+            ApiKey = "",
+        }));
+    }
+
+    [Fact]
+    public async Task Outgoing_frames_never_log_api_key_in_redacted_form()
+    {
+        // Sanity test paralleling docs/design/ais-source.md §15: the redactor must hide the key.
+        FakeAisStreamIoTransport? captured = null;
+        var options = Options();
+        var source = new AisStreamIoMessageSource(options, () => captured = new FakeAisStreamIoTransport());
+        await using var sub = source.Subscribe(new AisSubscriptionRequest());
+        await WaitForAsync(() => captured?.OutboundFrames.Count == 1);
+
+        var raw = captured!.OutboundFrames[0];
+        Assert.Contains(options.ApiKey, raw, StringComparison.Ordinal);
+
+        var redacted = AisStreamIoJson.RedactApiKey(raw, options.ApiKey);
+        Assert.DoesNotContain(options.ApiKey, redacted, StringComparison.Ordinal);
+    }
+}

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests.csproj
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.DynamicSources.Ais\EncDotNet.S100.DynamicSources.Ais.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo\EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/FakeAisStreamIoTransport.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/FakeAisStreamIoTransport.cs
@@ -1,0 +1,53 @@
+using System.Threading.Channels;
+using EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests;
+
+/// <summary>
+/// In-process <see cref="IAisStreamIoTransport"/> for tests. Records
+/// every outgoing JSON frame and yields scripted inbound frames in
+/// order. Closes (yields <see langword="null"/>) when the script
+/// runs out and <see cref="ScriptClose"/> has been called.
+/// </summary>
+internal sealed class FakeAisStreamIoTransport : IAisStreamIoTransport
+{
+    private readonly Channel<string?> _inbound = Channel.CreateUnbounded<string?>();
+    public List<string> OutboundFrames { get; } = new();
+    public List<Uri> Connections { get; } = new();
+    public bool Disposed { get; private set; }
+
+    public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+    {
+        Connections.Add(endpoint);
+        return Task.CompletedTask;
+    }
+
+    public Task SendTextAsync(string payload, CancellationToken cancellationToken)
+    {
+        OutboundFrames.Add(payload);
+        return Task.CompletedTask;
+    }
+
+    public async Task<string?> ReceiveTextAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _inbound.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (ChannelClosedException)
+        {
+            return null;
+        }
+    }
+
+    public void EnqueueInbound(string frame) => _inbound.Writer.TryWrite(frame);
+
+    public void ScriptClose() => _inbound.Writer.TryComplete();
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        _inbound.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Tests/AisDynamicFeatureSourceTests.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Tests/AisDynamicFeatureSourceTests.cs
@@ -1,0 +1,274 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.DynamicSources.Ais;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Tests;
+
+public class AisDynamicFeatureSourceTests
+{
+    private static AisPositionReport Pos(uint mmsi, double lat, double lon,
+        DateTimeOffset? timestamp = null,
+        double? cog = null, double? hdg = null, double? sog = null,
+        AisNavigationStatus? nav = null) =>
+        new()
+        {
+            Mmsi = mmsi,
+            Timestamp = timestamp ?? DateTimeOffset.UnixEpoch,
+            Latitude = lat,
+            Longitude = lon,
+            CourseOverGroundDeg = cog,
+            HeadingDeg = hdg,
+            SpeedOverGroundKn = sog,
+            NavigationStatus = nav,
+        };
+
+    private static AisStaticVoyageData Static(uint mmsi,
+        AisShipType shipType = AisShipType.Cargo,
+        AisDimensions? dims = null,
+        string? name = null) =>
+        new()
+        {
+            Mmsi = mmsi,
+            Timestamp = DateTimeOffset.UnixEpoch,
+            ShipType = shipType,
+            ShipTypeClass = AisShipTypeClassExtensions.ToClass(shipType),
+            Dimensions = dims,
+            VesselName = name,
+        };
+
+    [Fact]
+    public void Initial_state_is_empty_with_renderer_key_set()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+
+        Assert.Equal("ais", source.Inner.Id);
+        Assert.Equal("vessel.ais", source.Inner.Metadata.RendererKey);
+        Assert.Empty(source.Inner.CurrentFeatures);
+        Assert.Single(fake.Subscriptions);
+    }
+
+    [Fact]
+    public void First_position_report_is_added()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+        var changes = new List<DynamicFeaturesChanged>();
+        source.Inner.Changed += (_, e) => changes.Add(e);
+
+        fake.Subscriptions[0].EmitPosition(Pos(123, 47.6, -122.3, DateTimeOffset.UnixEpoch, cog: 90, sog: 12));
+
+        var feature = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("ais:123", feature.Id);
+        Assert.Equal("vessel.ais.unknown", feature.Kind);
+        Assert.Equal(GeometryType.Point, feature.GeometryType);
+        Assert.Equal(47.6, feature.Coordinates[0].Latitude);
+        Assert.Equal(-122.3, feature.Coordinates[0].Longitude);
+        Assert.Equal(90, feature.Motion?.CourseOverGroundDeg);
+        Assert.Equal(12, feature.Motion?.SpeedOverGroundKn);
+        Assert.Null(feature.VesselGeometry);
+        Assert.Equal(123u, feature.Attributes["mmsi"]);
+        var change = Assert.Single(changes);
+        Assert.Equal(DynamicSourceChangeKind.Added, change.Kind);
+    }
+
+    [Fact]
+    public void Static_voyage_data_merges_into_subsequent_position()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+
+        var dims = new AisDimensions
+        {
+            LengthMetres = 200,
+            BeamMetres = 30,
+            BowOffsetMetres = 50,
+            PortOffsetMetres = 15,
+        };
+        fake.Subscriptions[0].EmitStatic(Static(7, AisShipType.Tanker, dims, "TANKER ONE"));
+        fake.Subscriptions[0].EmitPosition(Pos(7, 0, 0));
+
+        var feature = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("vessel.ais.tanker", feature.Kind);
+        Assert.NotNull(feature.VesselGeometry);
+        Assert.Equal(200, feature.VesselGeometry!.LengthMetres);
+        Assert.Equal(30, feature.VesselGeometry.BeamMetres);
+        Assert.Equal(50, feature.VesselGeometry.BowOffsetMetres);
+        Assert.Equal(15, feature.VesselGeometry.PortOffsetMetres);
+        Assert.Equal("TANKER ONE", feature.Attributes["vesselName"]);
+    }
+
+    [Fact]
+    public void Late_static_data_re_projects_existing_feature()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+
+        fake.Subscriptions[0].EmitPosition(Pos(42, 1, 2, DateTimeOffset.UnixEpoch, cog: 45, hdg: 50, sog: 5));
+        var before = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("vessel.ais.unknown", before.Kind);
+        Assert.Null(before.VesselGeometry);
+
+        var dims = new AisDimensions
+        {
+            LengthMetres = 50, BeamMetres = 10,
+            BowOffsetMetres = 25, PortOffsetMetres = 5,
+        };
+        fake.Subscriptions[0].EmitStatic(Static(42, AisShipType.Cargo, dims, "CARGO 42"));
+
+        var after = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("vessel.ais.cargo", after.Kind);
+        Assert.Equal("CARGO 42", after.Attributes["vesselName"]);
+        Assert.NotNull(after.VesselGeometry);
+        // Position / motion preserved across re-projection.
+        Assert.Equal(1, after.Coordinates[0].Latitude);
+        Assert.Equal(45, after.Motion?.CourseOverGroundDeg);
+        Assert.Equal(50, after.Motion?.HeadingDeg);
+        Assert.Equal(5, after.Motion?.SpeedOverGroundKn);
+    }
+
+    [Fact]
+    public void Static_data_with_no_position_is_cached_silently()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+        var changes = new List<DynamicFeaturesChanged>();
+        source.Inner.Changed += (_, e) => changes.Add(e);
+
+        fake.Subscriptions[0].EmitStatic(Static(99, AisShipType.PilotVessel));
+
+        Assert.Empty(source.Inner.CurrentFeatures);
+        Assert.Empty(changes);
+    }
+
+    [Fact]
+    public void Sentinel_collapse_is_a_driver_concern_so_nulls_round_trip_to_motion()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+
+        fake.Subscriptions[0].EmitPosition(Pos(1, 0, 0,
+            cog: null, hdg: null, sog: null));
+
+        var feature = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Null(feature.Motion?.CourseOverGroundDeg);
+        Assert.Null(feature.Motion?.HeadingDeg);
+        Assert.Null(feature.Motion?.SpeedOverGroundKn);
+    }
+
+    [Fact]
+    public void Sweep_removes_targets_older_than_retention_window()
+    {
+        var fake = new FakeAisMessageSource();
+        var retain = TimeSpan.FromMinutes(2);
+        using var source = new AisDynamicFeatureSource("ais", fake, retain: retain).AsSyncDisposable();
+
+        var t0 = DateTimeOffset.UnixEpoch;
+        fake.Subscriptions[0].EmitPosition(Pos(1, 0, 0, t0));
+        fake.Subscriptions[0].EmitPosition(Pos(2, 0, 0, t0 + TimeSpan.FromMinutes(1)));
+        Assert.Equal(2, source.Inner.CurrentFeatures.Count);
+
+        var changes = new List<DynamicFeaturesChanged>();
+        source.Inner.Changed += (_, e) => changes.Add(e);
+        source.Inner.Sweep(t0 + TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(30));
+
+        // MMSI 1 (age 2:30) is past retain (2 min); MMSI 2 (age 1:30) is not.
+        var feature = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("ais:2", feature.Id);
+        var change = Assert.Single(changes);
+        Assert.Equal(DynamicSourceChangeKind.Removed, change.Kind);
+        Assert.Contains("ais:1", change.ChangedIds);
+    }
+
+    [Fact]
+    public void Default_retention_window_is_six_minutes()
+        => Assert.Equal(TimeSpan.FromMinutes(6), AisDynamicFeatureSource.DefaultRetainWindow);
+
+    [Fact]
+    public void Target_lost_event_removes_feature_and_static_cache()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+        fake.Subscriptions[0].EmitStatic(Static(5, AisShipType.Cargo,
+            new AisDimensions { LengthMetres = 1, BeamMetres = 1, BowOffsetMetres = 0, PortOffsetMetres = 0 }));
+        fake.Subscriptions[0].EmitPosition(Pos(5, 0, 0));
+        Assert.Single(source.Inner.CurrentFeatures);
+
+        fake.Subscriptions[0].EmitTargetLost(new AisTargetLost
+        {
+            Mmsi = 5,
+            Timestamp = DateTimeOffset.UnixEpoch,
+        });
+
+        Assert.Empty(source.Inner.CurrentFeatures);
+
+        // After loss, a fresh position with no static yet should map to unknown class.
+        fake.Subscriptions[0].EmitPosition(Pos(5, 1, 1));
+        var feature = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("vessel.ais.unknown", feature.Kind);
+    }
+
+    [Fact]
+    public void UpdateArea_delegates_to_subscription()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+
+        var bbox = new BoundingBox(40, -120, 50, -110);
+        Assert.True(source.Inner.UpdateArea(bbox));
+        var update = Assert.Single(fake.Subscriptions[0].AreaUpdates);
+        Assert.Same(bbox, update);
+    }
+
+    [Fact]
+    public void UpdateArea_propagates_driver_inability()
+    {
+        var fake = new FakeAisMessageSource();
+        using var source = new AisDynamicFeatureSource("ais", fake).AsSyncDisposable();
+        fake.Subscriptions[0].SupportsAreaUpdate = false;
+
+        Assert.False(source.Inner.UpdateArea(new BoundingBox(1, 2, 3, 4)));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_disposes_subscription_and_blocks_further_use()
+    {
+        var fake = new FakeAisMessageSource();
+        var source = new AisDynamicFeatureSource("ais", fake);
+        await source.DisposeAsync();
+
+        Assert.True(fake.Subscriptions[0].Disposed);
+        Assert.Throws<ObjectDisposedException>(() => source.UpdateArea(null));
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_or_empty_id()
+    {
+        var fake = new FakeAisMessageSource();
+        Assert.Throws<ArgumentNullException>(() => new AisDynamicFeatureSource(null!, fake));
+        Assert.Throws<ArgumentException>(() => new AisDynamicFeatureSource("", fake));
+    }
+
+    [Fact]
+    public void FeatureIdForMmsi_is_stable()
+        => Assert.Equal("ais:123456789", AisDynamicFeatureSource.FeatureIdForMmsi(123456789));
+}
+
+internal static class AsyncDisposableExtensions
+{
+    /// <summary>
+    /// Wraps an <see cref="IAsyncDisposable"/> so that test
+    /// <c>using</c> blocks dispose synchronously without polluting
+    /// every test signature with <c>async</c>.
+    /// </summary>
+    public static SyncWrapper<T> AsSyncDisposable<T>(this T inner) where T : IAsyncDisposable
+        => new(inner);
+}
+
+internal readonly struct SyncWrapper<T>(T inner) : IDisposable where T : IAsyncDisposable
+{
+    public T Inner { get; } = inner;
+
+    public void Dispose() => Inner.DisposeAsync().AsTask().GetAwaiter().GetResult();
+}

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Tests/AisDynamicFeatureSourceTests.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Tests/AisDynamicFeatureSourceTests.cs
@@ -253,6 +253,51 @@ public class AisDynamicFeatureSourceTests
     [Fact]
     public void FeatureIdForMmsi_is_stable()
         => Assert.Equal("ais:123456789", AisDynamicFeatureSource.FeatureIdForMmsi(123456789));
+
+    [Fact]
+    public void ShipTypes_filter_admits_known_class_and_drops_disallowed_class()
+    {
+        var fake = new FakeAisMessageSource();
+        var request = new AisSubscriptionRequest
+        {
+            ShipTypes = new[] { AisShipTypeClass.Tanker },
+        };
+        using var source = new AisDynamicFeatureSource("ais", fake, request).AsSyncDisposable();
+
+        // Pre-classify both vessels via static data.
+        fake.Subscriptions[0].EmitStatic(Static(1, AisShipType.Tanker));
+        fake.Subscriptions[0].EmitStatic(Static(2, AisShipType.Cargo));
+
+        fake.Subscriptions[0].EmitPosition(Pos(1, 10, 10));
+        fake.Subscriptions[0].EmitPosition(Pos(2, 11, 11));
+
+        var feature = Assert.Single(source.Inner.CurrentFeatures);
+        Assert.Equal("ais:1", feature.Id);
+    }
+
+    [Fact]
+    public void ShipTypes_filter_evicts_when_static_data_reveals_disallowed_class()
+    {
+        var fake = new FakeAisMessageSource();
+        var request = new AisSubscriptionRequest
+        {
+            ShipTypes = new[] { AisShipTypeClass.Tanker },
+        };
+        using var source = new AisDynamicFeatureSource("ais", fake, request).AsSyncDisposable();
+        var changes = new List<DynamicFeaturesChanged>();
+        source.Inner.Changed += (_, e) => changes.Add(e);
+
+        // No static yet → admitted optimistically.
+        fake.Subscriptions[0].EmitPosition(Pos(7, 20, 20));
+        Assert.Single(source.Inner.CurrentFeatures);
+
+        // Static reveals Cargo (not in allow-list) → feature evicted.
+        fake.Subscriptions[0].EmitStatic(Static(7, AisShipType.Cargo));
+
+        Assert.Empty(source.Inner.CurrentFeatures);
+        Assert.Equal(DynamicSourceChangeKind.Removed, changes[^1].Kind);
+        Assert.Contains("ais:7", changes[^1].ChangedIds);
+    }
 }
 
 internal static class AsyncDisposableExtensions

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Tests/AisShipTypeClassTests.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Tests/AisShipTypeClassTests.cs
@@ -1,0 +1,42 @@
+using EncDotNet.S100.DynamicSources.Ais;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Tests;
+
+public class AisShipTypeClassTests
+{
+    [Theory]
+    [InlineData(0, AisShipTypeClass.Unknown)]
+    [InlineData(15, AisShipTypeClass.Other)]
+    [InlineData(20, AisShipTypeClass.HighSpeedCraft)]
+    [InlineData(29, AisShipTypeClass.HighSpeedCraft)]
+    [InlineData(30, AisShipTypeClass.Fishing)]
+    [InlineData(31, AisShipTypeClass.Tug)]
+    [InlineData(32, AisShipTypeClass.Tug)]
+    [InlineData(35, AisShipTypeClass.Military)]
+    [InlineData(36, AisShipTypeClass.Sailing)]
+    [InlineData(37, AisShipTypeClass.Pleasure)]
+    [InlineData(40, AisShipTypeClass.HighSpeedCraft)]
+    [InlineData(49, AisShipTypeClass.HighSpeedCraft)]
+    [InlineData(50, AisShipTypeClass.PilotVessel)]
+    [InlineData(51, AisShipTypeClass.SearchAndRescue)]
+    [InlineData(52, AisShipTypeClass.Tug)]
+    [InlineData(55, AisShipTypeClass.LawEnforcement)]
+    [InlineData(60, AisShipTypeClass.Passenger)]
+    [InlineData(69, AisShipTypeClass.Passenger)]
+    [InlineData(70, AisShipTypeClass.Cargo)]
+    [InlineData(79, AisShipTypeClass.Cargo)]
+    [InlineData(80, AisShipTypeClass.Tanker)]
+    [InlineData(89, AisShipTypeClass.Tanker)]
+    [InlineData(90, AisShipTypeClass.Other)]
+    [InlineData(255, AisShipTypeClass.Other)]
+    public void ToClass_BucketsPerItuTable53(int code, AisShipTypeClass expected)
+        => Assert.Equal(expected, AisShipTypeClassExtensions.ToClass(code));
+
+    [Theory]
+    [InlineData(AisShipTypeClass.Cargo, "cargo")]
+    [InlineData(AisShipTypeClass.Tanker, "tanker")]
+    [InlineData(AisShipTypeClass.SearchAndRescue, "sar")]
+    [InlineData(AisShipTypeClass.Unknown, "unknown")]
+    public void ToKindToken_IsLowerCaseAndStable(AisShipTypeClass cls, string expected)
+        => Assert.Equal(expected, cls.ToKindToken());
+}

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Tests/EncDotNet.S100.DynamicSources.Ais.Tests.csproj
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Tests/EncDotNet.S100.DynamicSources.Ais.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.DynamicSources.Ais\EncDotNet.S100.DynamicSources.Ais.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.DynamicSources.Ais.Tests/FakeAisMessageSource.cs
+++ b/tests/EncDotNet.S100.DynamicSources.Ais.Tests/FakeAisMessageSource.cs
@@ -1,0 +1,72 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.DynamicSources.Ais;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.DynamicSources.Ais.Tests;
+
+/// <summary>
+/// In-memory <see cref="IAisMessageSource"/> for tests — drives the
+/// dynamic source through scripted scenarios without any wire format.
+/// </summary>
+internal sealed class FakeAisMessageSource : IAisMessageSource
+{
+    public AisSourceMetadata Metadata { get; } = new()
+    {
+        DisplayName = "Fake AIS source",
+        Description = "Test fake.",
+    };
+
+    public List<FakeAisSubscription> Subscriptions { get; } = new();
+
+    public IAisSubscription Subscribe(AisSubscriptionRequest request)
+    {
+        var sub = new FakeAisSubscription(request);
+        Subscriptions.Add(sub);
+        return sub;
+    }
+}
+
+internal sealed class FakeAisSubscription : IAisSubscription
+{
+    private AisSubscriptionRequest _active;
+
+    public FakeAisSubscription(AisSubscriptionRequest request)
+    {
+        _active = request;
+    }
+
+    public AisSubscriptionRequest ActiveRequest => _active;
+
+    public bool Disposed { get; private set; }
+
+    public bool SupportsAreaUpdate { get; set; } = true;
+
+    public List<BoundingBox?> AreaUpdates { get; } = new();
+
+    public event EventHandler<AisPositionReport>? PositionReportReceived;
+    public event EventHandler<AisStaticVoyageData>? StaticVoyageDataReceived;
+    public event EventHandler<AisTargetLost>? TargetLost;
+
+    public bool TryUpdateArea(BoundingBox? area)
+    {
+        if (!SupportsAreaUpdate) return false;
+        AreaUpdates.Add(area);
+        _active = _active with { Area = area };
+        return true;
+    }
+
+    public void EmitPosition(AisPositionReport report)
+        => PositionReportReceived?.Invoke(this, report);
+
+    public void EmitStatic(AisStaticVoyageData data)
+        => StaticVoyageDataReceived?.Invoke(this, data);
+
+    public void EmitTargetLost(AisTargetLost lost)
+        => TargetLost?.Invoke(this, lost);
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/DynamicSources/AisVesselRendererTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DynamicSources/AisVesselRendererTests.cs
@@ -1,0 +1,147 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Mapsui.DynamicSources;
+using Mapsui.Nts;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+
+namespace EncDotNet.S100.Pipelines.Tests.DynamicSources;
+
+public class AisVesselRendererTests
+{
+    private static DynamicFeature MakeFeature(
+        string kind = "vessel.ais.cargo",
+        double lat = 50.8, double lon = -1.3,
+        double? headingDeg = 0.0, double sogKn = 10.0,
+        DynamicVesselGeometry? geometry = null) => new()
+    {
+        Id = "ais:123456789",
+        Kind = kind,
+        GeometryType = GeometryType.Point,
+        Coordinates = new[] { (lat, lon) },
+        Motion = headingDeg is null && sogKn == 0
+            ? null
+            : new DynamicMotion { HeadingDeg = headingDeg, SpeedOverGroundKn = sogKn },
+        VesselGeometry = geometry,
+        LastUpdated = DateTimeOffset.UtcNow,
+    };
+
+    private static DynamicVesselGeometry DefaultGeom() => new()
+    {
+        LengthMetres = 50,
+        BeamMetres = 10,
+        BowOffsetMetres = 25,
+        PortOffsetMetres = 5,
+    };
+
+    [Fact]
+    public void CanRender_RequiresPointAndAisKindPrefix()
+    {
+        var r = new AisVesselRenderer();
+
+        Assert.True(r.CanRender(MakeFeature()));
+        Assert.False(r.CanRender(MakeFeature(kind: "ownship")));
+        Assert.False(r.CanRender(new DynamicFeature
+        {
+            Id = "ais:1", Kind = "vessel.ais.cargo",
+            GeometryType = GeometryType.Curve,
+            Coordinates = new[] { (0.0, 0.0), (1.0, 1.0) },
+            LastUpdated = DateTimeOffset.UtcNow,
+        }));
+    }
+
+    [Fact]
+    public void NoGeometry_EmitsHeadingLine_Arrow_AndDiscOnly()
+    {
+        var features = new AisVesselRenderer().Render(MakeFeature()).ToArray();
+
+        Assert.Equal(3, features.Length);
+        Assert.IsType<LineString>(((GeometryFeature)features[0]).Geometry);
+        Assert.IsType<Point>(((GeometryFeature)features[1]).Geometry);
+        Assert.IsType<Point>(((GeometryFeature)features[2]).Geometry);
+    }
+
+    [Fact]
+    public void Stationary_NoGeometry_EmitsOnlyDisc()
+    {
+        var features = new AisVesselRenderer()
+            .Render(MakeFeature(headingDeg: null, sogKn: 0.0))
+            .ToArray();
+
+        Assert.Single(features);
+        Assert.IsType<Point>(((GeometryFeature)features[0]).Geometry);
+    }
+
+    [Fact]
+    public void WithGeometry_EmitsHullAndCcrpCrossAndPictogram()
+    {
+        var features = new AisVesselRenderer()
+            .Render(MakeFeature(geometry: DefaultGeom()))
+            .ToArray();
+
+        // heading line + arrow + hull + cross + disc = 5
+        Assert.Equal(5, features.Length);
+        Assert.IsType<Polygon>(((GeometryFeature)features[2]).Geometry);
+        Assert.IsType<Point>(((GeometryFeature)features[3]).Geometry);
+        // CCRP cross has an ImageStyle
+        Assert.Contains(((GeometryFeature)features[3]).Styles, s => s is ImageStyle);
+    }
+
+    [Fact]
+    public void TankerKind_UsesRedishPalette()
+    {
+        var features = new AisVesselRenderer()
+            .Render(MakeFeature(kind: "vessel.ais.tanker", geometry: DefaultGeom()))
+            .ToArray();
+
+        var hull = (GeometryFeature)features[2];
+        var style = (VectorStyle)hull.Styles.First(s => s is VectorStyle);
+        Assert.NotNull(style.Outline);
+        // Tanker stroke is (0xCC, 0x33, 0x33).
+        Assert.Equal(0xCC, style.Outline!.Color!.R);
+        Assert.Equal(0x33, style.Outline.Color.G);
+        Assert.Equal(0x33, style.Outline.Color.B);
+    }
+
+    [Fact]
+    public void CargoKind_UsesGreenDefaultPalette()
+    {
+        var features = new AisVesselRenderer()
+            .Render(MakeFeature(kind: "vessel.ais.cargo", geometry: DefaultGeom()))
+            .ToArray();
+
+        var hull = (GeometryFeature)features[2];
+        var style = (VectorStyle)hull.Styles.First(s => s is VectorStyle);
+        // Default stroke is (0x00, 0xA0, 0x40).
+        Assert.Equal(0x00, style.Outline!.Color!.R);
+        Assert.Equal(0xA0, style.Outline.Color.G);
+        Assert.Equal(0x40, style.Outline.Color.B);
+    }
+
+    [Fact]
+    public void UnknownClassToken_FallsBackToGreyPalette()
+    {
+        var features = new AisVesselRenderer()
+            .Render(MakeFeature(kind: "vessel.ais.somethingelse", geometry: DefaultGeom()))
+            .ToArray();
+
+        var hull = (GeometryFeature)features[2];
+        var style = (VectorStyle)hull.Styles.First(s => s is VectorStyle);
+        Assert.Equal(0x66, style.Outline!.Color!.R);
+        Assert.Equal(0x66, style.Outline.Color.G);
+        Assert.Equal(0x66, style.Outline.Color.B);
+    }
+
+    [Fact]
+    public void EmptyCoordinates_EmitsNothing()
+    {
+        var feature = new DynamicFeature
+        {
+            Id = "ais:1", Kind = "vessel.ais.cargo",
+            GeometryType = GeometryType.Point,
+            Coordinates = Array.Empty<(double, double)>(),
+            LastUpdated = DateTimeOffset.UtcNow,
+        };
+        Assert.Empty(new AisVesselRenderer().Render(feature));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/AisOverlayFactoryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/AisOverlayFactoryTests.cs
@@ -1,0 +1,60 @@
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services.DynamicSources.Ais;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources;
+
+public class AisOverlayFactoryTests
+{
+    [Fact]
+    public void Returns_disabled_when_settings_null()
+    {
+        var src = AisOverlayServiceCollectionExtensions.BuildSource(null, loggerFactory: null);
+        Assert.IsType<DisabledAisFeatureSource>(src);
+    }
+
+    [Fact]
+    public void Returns_disabled_when_overlay_disabled()
+    {
+        var src = AisOverlayServiceCollectionExtensions.BuildSource(
+            new AisOverlaySettings { Enabled = false },
+            loggerFactory: null);
+        Assert.IsType<DisabledAisFeatureSource>(src);
+    }
+
+    [Fact]
+    public void Returns_disabled_when_env_var_unset()
+    {
+        var envVarName = "AIS_OVERLAY_TEST_KEY_THAT_DOES_NOT_EXIST_" + Guid.NewGuid().ToString("N");
+        var src = AisOverlayServiceCollectionExtensions.BuildSource(
+            new AisOverlaySettings { Enabled = true, ApiKeyEnvironmentVariable = envVarName },
+            loggerFactory: null);
+        Assert.IsType<DisabledAisFeatureSource>(src);
+    }
+
+    [Fact]
+    public void Returns_disabled_when_env_var_blank()
+    {
+        var envVarName = "AIS_OVERLAY_TEST_KEY_BLANK_" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(envVarName, "   ");
+        try
+        {
+            var src = AisOverlayServiceCollectionExtensions.BuildSource(
+                new AisOverlaySettings { Enabled = true, ApiKeyEnvironmentVariable = envVarName },
+                loggerFactory: null);
+            Assert.IsType<DisabledAisFeatureSource>(src);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+
+    [Fact]
+    public async Task DisabledSource_emits_no_features_and_disposes_cleanly()
+    {
+        var src = new DisabledAisFeatureSource();
+        Assert.Empty(src.CurrentFeatures);
+        Assert.Equal("vessel.ais", src.Metadata.RendererKey);
+        await src.DisposeAsync();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/AisOverlayFactoryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/AisOverlayFactoryTests.cs
@@ -57,4 +57,76 @@ public class AisOverlayFactoryTests
         Assert.Equal("vessel.ais", src.Metadata.RendererKey);
         await src.DisposeAsync();
     }
+
+    [Fact]
+    public async Task Returns_real_source_when_settings_apikey_present_and_env_unset()
+    {
+        var envVarName = "AIS_OVERLAY_TEST_KEY_FALLBACK_" + Guid.NewGuid().ToString("N");
+        var src = AisOverlayServiceCollectionExtensions.BuildSource(
+            new AisOverlaySettings
+            {
+                Enabled = true,
+                ApiKeyEnvironmentVariable = envVarName,
+                ApiKey = "settings-key-not-leaked-anywhere",
+            },
+            loggerFactory: null);
+        try
+        {
+            Assert.IsNotType<DisabledAisFeatureSource>(src);
+            Assert.Equal("ais", src.Id);
+        }
+        finally
+        {
+            if (src is IAsyncDisposable d) await d.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task EnvVar_takes_precedence_over_settings_apikey()
+    {
+        var envVarName = "AIS_OVERLAY_TEST_KEY_PRECEDENCE_" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(envVarName, "env-key");
+        try
+        {
+            // Both present — env-var path is exercised. We can't peek
+            // the chosen key without hitting the network, but the
+            // factory should still produce a real source (i.e. not
+            // fall through to Disabled because both inputs resolve).
+            var src = AisOverlayServiceCollectionExtensions.BuildSource(
+                new AisOverlaySettings
+                {
+                    Enabled = true,
+                    ApiKeyEnvironmentVariable = envVarName,
+                    ApiKey = "settings-key",
+                },
+                loggerFactory: null);
+            try
+            {
+                Assert.IsNotType<DisabledAisFeatureSource>(src);
+            }
+            finally
+            {
+                if (src is IAsyncDisposable d) await d.DisposeAsync();
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+
+    [Fact]
+    public void Returns_disabled_when_apikey_blank_and_env_unset()
+    {
+        var envVarName = "AIS_OVERLAY_TEST_KEY_BOTH_BLANK_" + Guid.NewGuid().ToString("N");
+        var src = AisOverlayServiceCollectionExtensions.BuildSource(
+            new AisOverlaySettings
+            {
+                Enabled = true,
+                ApiKeyEnvironmentVariable = envVarName,
+                ApiKey = "   ",
+            },
+            loggerFactory: null);
+        Assert.IsType<DisabledAisFeatureSource>(src);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostRegistryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostRegistryTests.cs
@@ -18,7 +18,7 @@ public class DynamicSourceOverlayHostRegistryTests
     public void Sources_ReturnsRegisteredInOrder_AndFiresEventOnRegister()
     {
         var host = new FakeMapHost();
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         IDynamicFeatureSourceRegistry registry = sut;
         int events = 0;
         registry.SourcesChanged += () => events++;
@@ -35,7 +35,7 @@ public class DynamicSourceOverlayHostRegistryTests
     public void DisposeRegistration_RemovesFromSources_AndFiresEvent()
     {
         var host = new FakeMapHost();
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         var reg = sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
         IDynamicFeatureSourceRegistry registry = sut;
         int events = 0;
@@ -51,7 +51,7 @@ public class DynamicSourceOverlayHostRegistryTests
     public void SetVisible_TogglesMemoryLayerEnabled_AndFiresEvent()
     {
         var host = new FakeMapHost();
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
         IDynamicFeatureSourceRegistry registry = sut;
         var layer = (MemoryLayer)host.OverlayLayers[0];
@@ -70,7 +70,7 @@ public class DynamicSourceOverlayHostRegistryTests
     public void SetVisible_BeforeRegister_SeedsInitialEnabledState()
     {
         var host = new FakeMapHost();
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         IDynamicFeatureSourceRegistry registry = sut;
 
         registry.SetVisible("a", false);
@@ -85,7 +85,7 @@ public class DynamicSourceOverlayHostRegistryTests
     public void GetVisible_UnknownId_DefaultsToTrue()
     {
         var host = new FakeMapHost();
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
 
         Assert.True(((IDynamicFeatureSourceRegistry)sut).GetVisible("missing"));
     }

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostTests.cs
@@ -165,12 +165,22 @@ public class DynamicSourceOverlayHostTests
         var source = new FakeDynamicFeatureSource("ais", new DynamicSourceMetadata { DisplayName = "AIS" });
         source.SetFeatures(new[] { Point("seed") });
 
+        var burstRaised = 0;
+        var rebuildApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Action<Action> marshal = action =>
+        {
+            action();
+            if (Volatile.Read(ref burstRaised) != 0 &&
+                host.OverlayLayers.Count > 0 &&
+                ((MemoryLayer)host.OverlayLayers[0]).Features.Count() == 2)
+            {
+                rebuildApplied.TrySetResult();
+            }
+        };
+
         var window = TimeSpan.FromMilliseconds(80);
-        using var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal, coalesceWindow: window);
+        using var sut = new DynamicSourceOverlayHost(host, sp, marshal, coalesceWindow: window);
         sut.Register(source);
-        var initialRebuilds = host.OverlayLayers.Count == 0
-            ? 0
-            : ((MemoryLayer)host.OverlayLayers[0]).Features.Count();
 
         // Fire 50 events back-to-back inside a single window.
         for (int i = 0; i < 50; i++)
@@ -182,9 +192,9 @@ public class DynamicSourceOverlayHostTests
                 ChangedIds = new[] { "v" + i },
             });
         }
+        Volatile.Write(ref burstRaised, 1);
 
-        // Wait long enough for the trailing rebuild to fire.
-        await Task.Delay(window + window);
+        await rebuildApplied.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         var layer = (MemoryLayer)host.OverlayLayers[0];
         // Trailing rebuild should reflect the final feature set

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceOverlayHostTests.cs
@@ -30,7 +30,7 @@ public class DynamicSourceOverlayHostTests
         });
         source.SetFeatures(new[] { Point("ownship") });
 
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         var registration = sut.Register(source);
 
         Assert.Single(host.OverlayLayers);
@@ -50,7 +50,7 @@ public class DynamicSourceOverlayHostTests
             DisplayName = "Own Ship",
         });
 
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(source);
         var layer = (MemoryLayer)host.OverlayLayers[0];
         var initial = layer.Features.Count();
@@ -77,7 +77,7 @@ public class DynamicSourceOverlayHostTests
         });
         source.SetFeatures(new[] { Point("a") });
 
-        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, new ServiceCollection().BuildServiceProvider(), SyncMarshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(source);
 
         Assert.Single(host.OverlayLayers);
@@ -101,7 +101,7 @@ public class DynamicSourceOverlayHostTests
         source.SetFeatures(new[] { Point("a") });
 
         CountingRenderer.RenderCalls = 0;
-        using var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(source);
 
         Assert.Single(host.OverlayLayers);
@@ -113,7 +113,7 @@ public class DynamicSourceOverlayHostTests
     {
         var host = new FakeMapHost();
         var sp = new ServiceCollection().BuildServiceProvider();
-        using var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal);
+        using var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(new FakeDynamicFeatureSource("dup", new DynamicSourceMetadata { DisplayName = "A" }));
 
         Assert.Throws<InvalidOperationException>(() =>
@@ -125,7 +125,7 @@ public class DynamicSourceOverlayHostTests
     {
         var host = new FakeMapHost();
         var sp = new ServiceCollection().BuildServiceProvider();
-        var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal);
+        var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" }));
         sut.Register(new FakeDynamicFeatureSource("b", new DynamicSourceMetadata { DisplayName = "B" }));
 
@@ -143,7 +143,7 @@ public class DynamicSourceOverlayHostTests
         Action<Action> marshal = a => { marshalCalls++; a(); };
 
         var source = new FakeDynamicFeatureSource("a", new DynamicSourceMetadata { DisplayName = "A" });
-        using var sut = new DynamicSourceOverlayHost(host, sp, marshal);
+        using var sut = new DynamicSourceOverlayHost(host, sp, marshal, coalesceWindow: TimeSpan.Zero);
         sut.Register(source);
         var afterRegister = marshalCalls;
 
@@ -153,6 +153,45 @@ public class DynamicSourceOverlayHostTests
     }
 
     private static void SyncMarshal(Action a) => a();
+
+    [Fact]
+    public async Task RebuildCoalesce_collapses_burst_into_at_most_two_rebuilds()
+    {
+        // Leading-edge rebuild + at most one trailing rebuild for any
+        // burst inside one window. AIS at world scale would otherwise
+        // pin the UI thread.
+        var host = new FakeMapHost();
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var source = new FakeDynamicFeatureSource("ais", new DynamicSourceMetadata { DisplayName = "AIS" });
+        source.SetFeatures(new[] { Point("seed") });
+
+        var window = TimeSpan.FromMilliseconds(80);
+        using var sut = new DynamicSourceOverlayHost(host, sp, SyncMarshal, coalesceWindow: window);
+        sut.Register(source);
+        var initialRebuilds = host.OverlayLayers.Count == 0
+            ? 0
+            : ((MemoryLayer)host.OverlayLayers[0]).Features.Count();
+
+        // Fire 50 events back-to-back inside a single window.
+        for (int i = 0; i < 50; i++)
+        {
+            source.SetFeatures(new[] { Point("seed"), Point("v" + i) });
+            source.RaiseChanged(new DynamicFeaturesChanged
+            {
+                Kind = DynamicSourceChangeKind.Updated,
+                ChangedIds = new[] { "v" + i },
+            });
+        }
+
+        // Wait long enough for the trailing rebuild to fire.
+        await Task.Delay(window + window);
+
+        var layer = (MemoryLayer)host.OverlayLayers[0];
+        // Trailing rebuild should reflect the final feature set
+        // (seed + last update). The intermediate 49 events were
+        // collapsed into the same trailing rebuild.
+        Assert.Equal(2, layer.Features.Count());
+    }
 
     private sealed class CountingRenderer : IDynamicFeatureRenderer
     {

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/FakeDynamicFeatureSource.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/FakeDynamicFeatureSource.cs
@@ -18,10 +18,10 @@ internal sealed class FakeDynamicFeatureSource : IDynamicFeatureSource
 
     public string Id { get; }
     public DynamicSourceMetadata Metadata { get; }
-    public IReadOnlyList<DynamicFeature> CurrentFeatures => _features;
+    public IReadOnlyList<DynamicFeature> CurrentFeatures => Volatile.Read(ref _features);
     public event EventHandler<DynamicFeaturesChanged>? Changed;
 
-    public void SetFeatures(IReadOnlyList<DynamicFeature> features) => _features = features;
+    public void SetFeatures(IReadOnlyList<DynamicFeature> features) => Volatile.Write(ref _features, features);
 
     public void RaiseChanged(DynamicFeaturesChanged payload)
         => Changed?.Invoke(this, payload);


### PR DESCRIPTION
Closes the dynamic-feature-source thread end-to-end by shipping the second concrete `IDynamicFeatureSource` — AIS targets — and exercising the `DynamicVesselGeometry` sidecar (whose A/B/C/D-shaped fields were always intended for AIS Type 5).

Design doc: [`docs/design/ais-source.md`](../tree/philliphoff/philliphoff-pr-d3-ais-sample/docs/design/ais-source.md).

## Architecture

Three-layer split so wire-format knowledge stays isolated and the source itself is decoder-agnostic:

```
[aisstream.io WebSocket]
     │   JSON
     ▼
EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo   ← BCL only
     │   IAisMessageSource
     ▼
EncDotNet.S100.DynamicSources.Ais   ← per-MMSI cache, aging, projection
     │   IDynamicFeatureSource
     ▼
viewer overlay host → AisVesselRenderer → Mapsui
```

Future drivers (local antenna, recorded-JSON replay, other aggregators) plug in at the `IAisMessageSource` boundary without touching the source or renderer.

## Q1–Q8 resolutions (full rationale in design doc)

| # | Resolution |
|---|---|
| Q1 | **Both** — sample app `samples/EncDotNet.S100.Samples.Ais` (first occupant of new `/samples/` solution folder) and viewer flag, sharing the source library. |
| Q2 | **New `EncDotNet.S100.DynamicSources.Ais` library** — clean class library; viewer references it. |
| Q3 | **No third-party AIS dep.** aisstream.io ships already-decoded JSON, so the driver is BCL-only (`ClientWebSocket` + `System.Text.Json`). No `Ais.Net` / `NmeaParser`. |
| Q4 | **Captured aisstream.io JSON-lines** synthetic fixtures replayed through an `IAisStreamIoTransport` fake. No live service hits in CI. |
| Q5 | `Id = "ais:" + MMSI`, `Kind = "vessel.ais.{class}"`, `Motion` from COG/HDG/SOG with sentinels collapsed to null at the driver boundary, `VesselGeometry` populated from cached `ShipStaticData` dimensions. |
| Q6 | Refactored hull/arrowhead/CCRP-cross/heading-vector logic out of `OwnShipRenderer` into an internal `VesselSymbology` helper. Both `OwnShipRenderer` and the new `AisVesselRenderer` are thin wrappers that pass a colour palette. |
| Q7 | **Same `S98DisplayPlane.DynamicArrows`** as own-ship — per-source visibility already works via PR-D2.1. |
| Q8 | **Live wall-clock**, no replay knob. Recorded-JSON playback is a future PR. |

## Renderer refactor

`OwnShipRenderer` is now a ~58-line thin wrapper that delegates to `VesselSymbology.Render` with the own-ship blue palette. The 9 existing `OwnShipRendererTests` pass unmodified — byte-equivalent output (own-ship CCRP-cross stroke colour `#007ACC` matches the previous hardcoded SVG). The new `AisVesselRenderer` dispatches palette by `Kind` suffix (cargo/tanker/passenger/highspeedcraft/etc.) and parallels the own-ship suite with 8 tests.

## Viewer wiring

* `AisOverlaySettings` POCO on `ViewerSettings.AisOverlay` (Enabled flag, ApiKeyEnvironmentVariable name, optional InitialArea bbox).
* **API key never persisted** in `settings.json` — must come from the named env var (default `ENCDOTNET_AIS_STREAM_KEY`).
* `AddAisOverlay()` DI helper conditionally registers either the real source or a `DisabledAisFeatureSource` sentinel based on settings + env var presence.

## Sample

`samples/EncDotNet.S100.Samples.Ais` — minimal console app. Reads `ENCDOTNET_AIS_STREAM_KEY`, optional bbox CLI arg, prints `+`/`-`/`  ` markers per `DynamicSourceChangeKind` event. Demonstrates the source library without spinning up the viewer.

## Out of scope (future PRs)

* Local antenna / NMEA-0183 / AIVDM bytes
* Replay-from-recorded-JSON driver (needed for offline sample mode)
* AIS message types beyond `PositionReport` (1/2/3/18/19) and `ShipStaticData` (5/24)
* S-52 sleeping / lost / dangerous-target pictogram variants
* CPA/TCPA computations
* MCP-server exposure of AIS overlay
* Any change to `DynamicFeature` / `DynamicMotion` / `DynamicVesselGeometry`

## Rubber-duck-driven follow-ups (last commit)

* `ClientWebSocketTransport.DisposeAsync` close handshake bounded with a 2 s CTS so a wedged peer can't hang the host process.
* `AisSubscriptionRequest.ShipTypes` was documented as a filter but silently ignored (aisstream.io only takes MMSI filters upstream). Now enforced client-side in `AisDynamicFeatureSource` with optimistic admit + post-classification eviction; covered by two new tests.

## Verification

* `dotnet build EncDotNet.S100.slnx -c Release` — 0 errors (warnings are pre-existing in `SplitterPersistence.cs` / test analyzers).
* `dotnet test EncDotNet.S100.slnx -c Release` — all green (~1500 tests across the solution; 44 in the new AIS source suite, 19 in the driver suite, 8 in the AIS renderer suite, 5 in the viewer overlay-factory suite).

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;