### PR TITLE
PR-N1: chart theming follows chrome Light/Dark theme + S-104/S-111 SwitchPalette toolbar

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -516,6 +516,40 @@
                             </Flyout>
                         </Button.Flyout>
                     </Button>
+                    <!--
+                      S-100 map palette pill (PR-N1) — Day/Dusk/Night
+                      switch for the chart S-100 colour profile. Bound to
+                      SettingsViewModel.SelectedPalette which already
+                      triggers a re-render through DatasetLoaderService;
+                      this is purely a more-accessible UI surface for an
+                      existing setting.
+                    -->
+                    <Button Classes="MapOverlay"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_SwitchPalette}"
+                            Padding="8,4"
+                            FontSize="11"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Content="{x:Static loc:Strings.Toolbar_Palette}">
+                        <Button.Flyout>
+                            <Flyout Placement="BottomEdgeAlignedRight">
+                                <StackPanel Spacing="4" MinWidth="160">
+                                    <RadioButton Content="{x:Static loc:Strings.Palette_Day}"
+                                                 GroupName="MapPaletteFlyout"
+                                                 IsChecked="{Binding Settings.IsPaletteDay, Mode=OneWay}"
+                                                 Command="{Binding Settings.SetPaletteDayCommand}" />
+                                    <RadioButton Content="{x:Static loc:Strings.Palette_Dusk}"
+                                                 GroupName="MapPaletteFlyout"
+                                                 IsChecked="{Binding Settings.IsPaletteDusk, Mode=OneWay}"
+                                                 Command="{Binding Settings.SetPaletteDuskCommand}" />
+                                    <RadioButton Content="{x:Static loc:Strings.Palette_Night}"
+                                                 GroupName="MapPaletteFlyout"
+                                                 IsChecked="{Binding Settings.IsPaletteNight, Mode=OneWay}"
+                                                 Command="{Binding Settings.SetPaletteNightCommand}" />
+                                </StackPanel>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
 
                     <!--
                       StackPanel with vertical margin gives the cluster its

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -355,6 +355,10 @@ internal static class Strings
     public static string TextGroup_Other => Get(nameof(TextGroup_Other));
     public static string TextGroup_All => Get(nameof(TextGroup_All));
 
+    // Map palette toolbar pill (PR-N1)
+    public static string Toolbar_Palette => Get(nameof(Toolbar_Palette));
+    public static string Tooltip_SwitchPalette => Get(nameof(Tooltip_SwitchPalette));
+
     // Toast notification titles
     public static string Toast_Error => Get(nameof(Toast_Error));
     public static string Toast_Warning => Get(nameof(Toast_Warning));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -931,6 +931,14 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
     <value>All other chart text</value>
   </data>
 
+  <!-- Map palette toolbar pill (PR-N1) -->
+  <data name="Toolbar_Palette" xml:space="preserve">
+    <value>Palette ▾</value>
+  </data>
+  <data name="Tooltip_SwitchPalette" xml:space="preserve">
+    <value>Switch S-100 map palette (Day / Dusk / Night)</value>
+  </data>
+
   <!-- Toast notification titles -->
   <data name="Toast_Error" xml:space="preserve">
     <value>Error</value>

--- a/src/EncDotNet.S100.Viewer/Services/IThemeService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IThemeService.cs
@@ -1,13 +1,30 @@
+using System;
+
 namespace EncDotNet.S100.Viewer.Services;
 
 /// <summary>
 /// Abstracts theme variant access so view-models do not need to reference
 /// Avalonia.Application or Avalonia.Styling.ThemeVariant directly.
 /// </summary>
+/// <remarks>
+/// "Theme" here refers exclusively to the chrome <see cref="Avalonia.Styling.ThemeVariant"/>
+/// (Light vs Dark) — it is unrelated to the S-100 map palette
+/// (Day / Dusk / Night) which is exposed by
+/// <see cref="ViewModels.SettingsViewModel.SelectedPalette"/>.
+/// </remarks>
 internal interface IThemeService
 {
     /// <summary>True when the application is currently using the dark theme.</summary>
     bool IsDarkTheme { get; }
+
+    /// <summary>
+    /// Raised when the chrome theme variant changes — including external
+    /// changes (e.g. system theme follow) as well as an explicit
+    /// <see cref="ToggleTheme"/> call. Subscribers should refresh any
+    /// theme-derived visuals (chart paints, custom-rendered overlays) in
+    /// response.
+    /// </summary>
+    event EventHandler? ThemeChanged;
 
     /// <summary>Toggles between light and dark theme. Returns the resulting state.</summary>
     bool ToggleTheme();

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -36,12 +36,13 @@ internal sealed class PickService : IPickService
     private readonly IStatusPresenter _status;
     private readonly GlobalTimeService? _globalTime;
     private readonly ITimeFormatProvider? _timeFormat;
+    private readonly IThemeService? _themeService;
 
     public PickService(
         IDatasetLoaderService loader,
         PickReportViewModel pickReport,
         IStatusPresenter status)
-        : this(loader, pickReport, status, globalTime: null, timeFormat: null)
+        : this(loader, pickReport, status, globalTime: null, timeFormat: null, themeService: null)
     {
     }
 
@@ -50,7 +51,7 @@ internal sealed class PickService : IPickService
         PickReportViewModel pickReport,
         IStatusPresenter status,
         GlobalTimeService? globalTime)
-        : this(loader, pickReport, status, globalTime, timeFormat: null)
+        : this(loader, pickReport, status, globalTime, timeFormat: null, themeService: null)
     {
     }
 
@@ -60,6 +61,17 @@ internal sealed class PickService : IPickService
         IStatusPresenter status,
         GlobalTimeService? globalTime,
         ITimeFormatProvider? timeFormat)
+        : this(loader, pickReport, status, globalTime, timeFormat, themeService: null)
+    {
+    }
+
+    public PickService(
+        IDatasetLoaderService loader,
+        PickReportViewModel pickReport,
+        IStatusPresenter status,
+        GlobalTimeService? globalTime,
+        ITimeFormatProvider? timeFormat,
+        IThemeService? themeService)
     {
         ArgumentNullException.ThrowIfNull(loader);
         ArgumentNullException.ThrowIfNull(pickReport);
@@ -69,6 +81,7 @@ internal sealed class PickService : IPickService
         _status = status;
         _globalTime = globalTime;
         _timeFormat = timeFormat;
+        _themeService = themeService;
 
         // The pick-report VM raises NavigateRequested when the user
         // clicks a row in the References list. Failures surface as a
@@ -223,8 +236,8 @@ internal sealed class PickService : IPickService
         // exposes a single height channel; S-111 exposes speed + direction.
         return processor.Spec.Name switch
         {
-            "S-104" => new S104StationTimeSeriesViewModel(snapshot, _globalTime, _timeFormat),
-            "S-111" => new S111StationTimeSeriesViewModel(snapshot, _globalTime, _timeFormat),
+            "S-104" => new S104StationTimeSeriesViewModel(snapshot, _globalTime, _timeFormat, _themeService),
+            "S-111" => new S111StationTimeSeriesViewModel(snapshot, _globalTime, _timeFormat, _themeService),
             _ => null,
         };
     }

--- a/src/EncDotNet.S100.Viewer/Services/ThemeService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ThemeService.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia;
 using Avalonia.Styling;
 
@@ -6,11 +7,23 @@ namespace EncDotNet.S100.Viewer.Services;
 /// <summary>
 /// Default <see cref="IThemeService"/> backed by
 /// <see cref="Application.Current"/>'s <see cref="ThemeVariant"/>.
+/// Subscribes to <see cref="Application.ActualThemeVariantChanged"/> and
+/// re-raises it as <see cref="IThemeService.ThemeChanged"/> so consumers
+/// can observe theme changes regardless of whether the trigger was the
+/// in-app toggle button or an external source (system theme follow).
 /// </summary>
 internal sealed class ThemeService : IThemeService
 {
+    public ThemeService()
+    {
+        if (Application.Current is { } app)
+            app.ActualThemeVariantChanged += OnApplicationThemeVariantChanged;
+    }
+
     public bool IsDarkTheme =>
         Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+
+    public event EventHandler? ThemeChanged;
 
     public bool ToggleTheme()
     {
@@ -23,4 +36,7 @@ internal sealed class ThemeService : IThemeService
         app.RequestedThemeVariant = next;
         return next == ThemeVariant.Dark;
     }
+
+    private void OnApplicationThemeVariantChanged(object? sender, EventArgs e)
+        => ThemeChanged?.Invoke(this, EventArgs.Empty);
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/ChartTheme.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ChartTheme.cs
@@ -1,0 +1,90 @@
+using SkiaSharp;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Palette of <see cref="SKColor"/> values used by the LiveCharts2
+/// station-time-series charts shown in the Object Information (pick)
+/// panel. A new instance is produced for each chrome theme variant via
+/// <see cref="Resolve(bool)"/>; chart view-models hold the current
+/// instance in <see cref="StationTimeSeriesViewModel.CurrentChartTheme"/>
+/// and copy its colours into their <c>SolidColorPaint</c> instances on
+/// theme change.
+/// </summary>
+/// <remarks>
+/// <para>
+/// "Theme" here refers exclusively to the Avalonia chrome
+/// <see cref="Avalonia.Styling.ThemeVariant"/> (Light vs Dark) — it is
+/// <b>independent of the S-100 map palette</b>
+/// (<see cref="EncDotNet.S100.Pipelines.PaletteType"/>: Day / Dusk /
+/// Night). The map S-100 palette colours map content (depth shading,
+/// chart symbols) and is consumed by the renderers; this chart palette
+/// colours UI chrome (axis labels, gridlines, series strokes) for the
+/// LiveCharts2 surfaces and never participates in S-100 rendering.
+/// </para>
+/// <para>
+/// Series stroke and now-marker stroke colours are picked explicitly per
+/// theme rather than resolved from ShadUI dynamic resources, because the
+/// chart's SkiaSharp surface paints in a vacuum (no Avalonia visual
+/// tree) and the stroke choices here have to read well against a chart
+/// canvas — not against a button or text-block background.
+/// </para>
+/// </remarks>
+internal sealed record ChartTheme(
+    SKColor SeriesPrimary,
+    SKColor SeriesSpeed,
+    SKColor SeriesDirection,
+    SKColor NowMarker,
+    SKColor AxisLabel,
+    SKColor AxisName,
+    SKColor Separator)
+{
+    // ── Light-theme colours ──────────────────────────────────────────
+    // Series colours follow the matplotlib Tab10-ish palette used since
+    // PR-J. They sit on a near-white chart canvas in the light theme
+    // (LiveCharts2 default) and have adequate contrast there.
+    //   SeriesPrimary  (#1F77B4) — S-104 water-level height (blue)
+    //   SeriesSpeed    (#2CA02C) — S-111 surface-current speed (green)
+    //   SeriesDirection(#FF7F0E) — S-111 surface-current direction (orange)
+    //   NowMarker      (#E6494B) — vertical "now" rule (red)
+    private static readonly ChartTheme Light = new(
+        SeriesPrimary:   new SKColor(0x1F, 0x77, 0xB4),
+        SeriesSpeed:     new SKColor(0x2C, 0xA0, 0x2C),
+        SeriesDirection: new SKColor(0xFF, 0x7F, 0x0E),
+        NowMarker:       new SKColor(0xE6, 0x49, 0x4B),
+        AxisLabel:       new SKColor(0x33, 0x33, 0x33),
+        AxisName:        new SKColor(0x1A, 0x1A, 0x1A),
+        Separator:       new SKColor(0xE0, 0xE0, 0xE0));
+
+    // ── Dark-theme colours ───────────────────────────────────────────
+    // Lifted / desaturated variants of the light series picks. Saturated
+    // primaries (especially red) bloom against a dark canvas, so the
+    // dark palette swaps:
+    //   SeriesPrimary  (#4FC3F7) — light cyan-blue (was deep blue)
+    //   SeriesSpeed    (#7FE07F) — soft green (was deep green)
+    //   SeriesDirection(#FFB74D) — amber (was deep orange)
+    //   NowMarker      (#FF8A80) — coral (was saturated red — the high
+    //                              chroma red bloomed visibly on dark)
+    // Axis label/name greys are pulled toward the light end so they
+    // remain legible against ShadUI dark-theme background colours.
+    private static readonly ChartTheme Dark = new(
+        SeriesPrimary:   new SKColor(0x4F, 0xC3, 0xF7),
+        SeriesSpeed:     new SKColor(0x7F, 0xE0, 0x7F),
+        SeriesDirection: new SKColor(0xFF, 0xB7, 0x4D),
+        NowMarker:       new SKColor(0xFF, 0x8A, 0x80),
+        AxisLabel:       new SKColor(0xCC, 0xCC, 0xCC),
+        AxisName:        new SKColor(0xE6, 0xE6, 0xE6),
+        Separator:       new SKColor(0x40, 0x40, 0x40));
+
+    /// <summary>
+    /// Returns the chart palette appropriate for the current chrome
+    /// theme. Pure function — no dependency on
+    /// <see cref="Avalonia.Application"/> — so unit tests can exercise
+    /// both branches without standing up an Avalonia application.
+    /// </summary>
+    /// <param name="isDark">
+    /// True when the chrome theme is <c>ThemeVariant.Dark</c>; false for
+    /// <c>ThemeVariant.Light</c> or <c>ThemeVariant.Default</c>.
+    /// </param>
+    public static ChartTheme Resolve(bool isDark) => isDark ? Dark : Light;
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/S104StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/S104StationTimeSeriesViewModel.cs
@@ -8,7 +8,6 @@ using LiveChartsCore.Defaults;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
-using SkiaSharp;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -18,14 +17,25 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// </summary>
 internal sealed class S104StationTimeSeriesViewModel : StationTimeSeriesViewModel
 {
+    private readonly SolidColorPaint _heightStrokePaint;
+    private readonly SolidColorPaint _heightAxisLabelsPaint;
+    private readonly SolidColorPaint _heightAxisNamePaint;
+    private readonly SolidColorPaint _heightAxisSeparatorsPaint;
+
     public S104StationTimeSeriesViewModel(
         StationTimeSeriesSnapshot snapshot,
         GlobalTimeService? globalTime,
-        ITimeFormatProvider? timeFormat = null)
-        : base(snapshot, globalTime, timeFormat)
+        ITimeFormatProvider? timeFormat = null,
+        IThemeService? themeService = null)
+        : base(snapshot, globalTime, timeFormat, themeService)
     {
         var channel = FindChannel(snapshot, "waterLevelHeight");
         var points = channel is null ? new List<DateTimePoint>() : ProjectChannel(snapshot.Times, channel);
+
+        _heightStrokePaint = new SolidColorPaint(CurrentChartTheme.SeriesPrimary, 2f);
+        _heightAxisLabelsPaint = new SolidColorPaint(CurrentChartTheme.AxisLabel);
+        _heightAxisNamePaint = new SolidColorPaint(CurrentChartTheme.AxisName);
+        _heightAxisSeparatorsPaint = new SolidColorPaint(CurrentChartTheme.Separator);
 
         HeightSeries = new ISeries[]
         {
@@ -33,7 +43,7 @@ internal sealed class S104StationTimeSeriesViewModel : StationTimeSeriesViewMode
             {
                 Name = Strings.Pick_Chart_Title_WaterLevel,
                 Values = points,
-                Stroke = new SolidColorPaint(new SKColor(0x1F, 0x77, 0xB4), 2f),
+                Stroke = _heightStrokePaint,
                 Fill = null,
                 GeometrySize = 0,
                 GeometryStroke = null,
@@ -50,6 +60,9 @@ internal sealed class S104StationTimeSeriesViewModel : StationTimeSeriesViewMode
         HeightAxis = new Axis
         {
             Name = Strings.Pick_Chart_Axis_HeightMetres,
+            LabelsPaint = _heightAxisLabelsPaint,
+            NamePaint = _heightAxisNamePaint,
+            SeparatorsPaint = _heightAxisSeparatorsPaint,
         };
         HeightAxisArray = new ICartesianAxis[] { HeightAxis };
     }
@@ -62,6 +75,21 @@ internal sealed class S104StationTimeSeriesViewModel : StationTimeSeriesViewMode
 
     /// <summary>Single-element wrapper around <see cref="HeightAxis"/>.</summary>
     public ICartesianAxis[] HeightAxisArray { get; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Mutates the height-series stroke and Y-axis paints in place so
+    /// LiveCharts2 redraws on the next paint cycle without rebuilding
+    /// the series.
+    /// </remarks>
+    protected override void OnChartThemeChanged(ChartTheme theme)
+    {
+        base.OnChartThemeChanged(theme);
+        _heightStrokePaint.Color = theme.SeriesPrimary;
+        _heightAxisLabelsPaint.Color = theme.AxisLabel;
+        _heightAxisNamePaint.Color = theme.AxisName;
+        _heightAxisSeparatorsPaint.Color = theme.Separator;
+    }
 
     /// <summary>Convenience accessor: title for the chart.</summary>
     public string Title => Strings.Pick_Chart_Title_WaterLevel;

--- a/src/EncDotNet.S100.Viewer/ViewModels/S111StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/S111StationTimeSeriesViewModel.cs
@@ -8,7 +8,6 @@ using LiveChartsCore.Defaults;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
-using SkiaSharp;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -20,11 +19,21 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 /// </summary>
 internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewModel
 {
+    private readonly SolidColorPaint _speedStrokePaint;
+    private readonly SolidColorPaint _directionStrokePaint;
+    private readonly SolidColorPaint _speedAxisLabelsPaint;
+    private readonly SolidColorPaint _speedAxisNamePaint;
+    private readonly SolidColorPaint _speedAxisSeparatorsPaint;
+    private readonly SolidColorPaint _directionAxisLabelsPaint;
+    private readonly SolidColorPaint _directionAxisNamePaint;
+    private readonly SolidColorPaint _directionAxisSeparatorsPaint;
+
     public S111StationTimeSeriesViewModel(
         StationTimeSeriesSnapshot snapshot,
         GlobalTimeService? globalTime,
-        ITimeFormatProvider? timeFormat = null)
-        : base(snapshot, globalTime, timeFormat)
+        ITimeFormatProvider? timeFormat = null,
+        IThemeService? themeService = null)
+        : base(snapshot, globalTime, timeFormat, themeService)
     {
         var speedChannel = FindChannel(snapshot, "surfaceCurrentSpeed");
         var directionChannel = FindChannel(snapshot, "surfaceCurrentDirection");
@@ -36,13 +45,22 @@ internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewMode
             ? new List<DateTimePoint>()
             : ProjectChannel(snapshot.Times, directionChannel);
 
+        _speedStrokePaint = new SolidColorPaint(CurrentChartTheme.SeriesSpeed, 2f);
+        _directionStrokePaint = new SolidColorPaint(CurrentChartTheme.SeriesDirection, 2f);
+        _speedAxisLabelsPaint = new SolidColorPaint(CurrentChartTheme.AxisLabel);
+        _speedAxisNamePaint = new SolidColorPaint(CurrentChartTheme.AxisName);
+        _speedAxisSeparatorsPaint = new SolidColorPaint(CurrentChartTheme.Separator);
+        _directionAxisLabelsPaint = new SolidColorPaint(CurrentChartTheme.AxisLabel);
+        _directionAxisNamePaint = new SolidColorPaint(CurrentChartTheme.AxisName);
+        _directionAxisSeparatorsPaint = new SolidColorPaint(CurrentChartTheme.Separator);
+
         SpeedSeries = new ISeries[]
         {
             new LineSeries<DateTimePoint>
             {
                 Name = Strings.Pick_Chart_Title_SurfaceCurrentSpeed,
                 Values = speedPoints,
-                Stroke = new SolidColorPaint(new SKColor(0x2C, 0xA0, 0x2C), 2f),
+                Stroke = _speedStrokePaint,
                 Fill = null,
                 GeometrySize = 0,
                 GeometryStroke = null,
@@ -59,7 +77,7 @@ internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewMode
             {
                 Name = Strings.Pick_Chart_Title_SurfaceCurrentDirection,
                 Values = directionPoints,
-                Stroke = new SolidColorPaint(new SKColor(0xFF, 0x7F, 0x0E), 2f),
+                Stroke = _directionStrokePaint,
                 Fill = null,
                 GeometrySize = 0,
                 GeometryStroke = null,
@@ -70,15 +88,42 @@ internal sealed class S111StationTimeSeriesViewModel : StationTimeSeriesViewMode
             },
         };
 
-        SpeedAxis = new Axis { Name = Strings.Pick_Chart_Axis_SpeedMetresPerSecond };
+        SpeedAxis = new Axis
+        {
+            Name = Strings.Pick_Chart_Axis_SpeedMetresPerSecond,
+            LabelsPaint = _speedAxisLabelsPaint,
+            NamePaint = _speedAxisNamePaint,
+            SeparatorsPaint = _speedAxisSeparatorsPaint,
+        };
         DirectionAxis = new Axis
         {
             Name = Strings.Pick_Chart_Axis_DirectionDegrees,
             MinLimit = 0,
             MaxLimit = 360,
+            LabelsPaint = _directionAxisLabelsPaint,
+            NamePaint = _directionAxisNamePaint,
+            SeparatorsPaint = _directionAxisSeparatorsPaint,
         };
         SpeedAxisArray = new ICartesianAxis[] { SpeedAxis };
         DirectionAxisArray = new ICartesianAxis[] { DirectionAxis };
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Mutates the speed/direction series strokes and the two Y-axis
+    /// paint sets in place; LiveCharts2 redraws on the next paint cycle.
+    /// </remarks>
+    protected override void OnChartThemeChanged(ChartTheme theme)
+    {
+        base.OnChartThemeChanged(theme);
+        _speedStrokePaint.Color = theme.SeriesSpeed;
+        _directionStrokePaint.Color = theme.SeriesDirection;
+        _speedAxisLabelsPaint.Color = theme.AxisLabel;
+        _speedAxisNamePaint.Color = theme.AxisName;
+        _speedAxisSeparatorsPaint.Color = theme.Separator;
+        _directionAxisLabelsPaint.Color = theme.AxisLabel;
+        _directionAxisNamePaint.Color = theme.AxisName;
+        _directionAxisSeparatorsPaint.Color = theme.Separator;
     }
 
     /// <summary>Top chart series: surface-current speed.</summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -43,9 +43,30 @@ internal sealed class SettingsViewModel : ViewModelBase
                 _settings.ColorProfile = value.ToString();
                 _settings.Save();
                 PaletteChanged?.Invoke(value);
+                OnPropertyChanged(nameof(IsPaletteDay));
+                OnPropertyChanged(nameof(IsPaletteDusk));
+                OnPropertyChanged(nameof(IsPaletteNight));
             }
         }
     }
+
+    /// <summary>True when the active S-100 map palette is Day. Drives the toolbar palette flyout's RadioButton state.</summary>
+    public bool IsPaletteDay => _selectedPalette == PaletteType.Day;
+
+    /// <summary>True when the active S-100 map palette is Dusk.</summary>
+    public bool IsPaletteDusk => _selectedPalette == PaletteType.Dusk;
+
+    /// <summary>True when the active S-100 map palette is Night.</summary>
+    public bool IsPaletteNight => _selectedPalette == PaletteType.Night;
+
+    /// <summary>Sets the S-100 map palette to Day. Bound from the toolbar palette flyout.</summary>
+    public ICommand SetPaletteDayCommand { get; }
+
+    /// <summary>Sets the S-100 map palette to Dusk. Bound from the toolbar palette flyout.</summary>
+    public ICommand SetPaletteDuskCommand { get; }
+
+    /// <summary>Sets the S-100 map palette to Night. Bound from the toolbar palette flyout.</summary>
+    public ICommand SetPaletteNightCommand { get; }
 
     public event Action<PaletteType>? PaletteChanged;
 
@@ -468,6 +489,10 @@ internal sealed class SettingsViewModel : ViewModelBase
         _ownShipBeam = own.BeamMetres;
         _ownShipBowOffset = own.BowOffsetMetres;
         _ownShipPortOffset = own.PortOffsetMetres;
+
+        SetPaletteDayCommand = new RelayCommand(() => SelectedPalette = PaletteType.Day);
+        SetPaletteDuskCommand = new RelayCommand(() => SelectedPalette = PaletteType.Dusk);
+        SetPaletteNightCommand = new RelayCommand(() => SelectedPalette = PaletteType.Night);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/StationTimeSeriesViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/StationTimeSeriesViewModel.cs
@@ -35,33 +35,51 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
 {
     private readonly GlobalTimeService? _globalTime;
     private readonly ITimeFormatProvider? _timeFormat;
+    private readonly IThemeService? _themeService;
     private readonly RectangularSection _nowSection;
+    private readonly SolidColorPaint _nowMarkerPaint;
+    private readonly SolidColorPaint _timeAxisLabelsPaint;
+    private readonly SolidColorPaint _timeAxisNamePaint;
+    private readonly SolidColorPaint _timeAxisSeparatorsPaint;
     private bool _disposed;
 
     /// <summary>
     /// Constructs a view model bound to <paramref name="snapshot"/>. The
     /// <paramref name="globalTime"/> service may be <c>null</c> in unit
     /// tests; when supplied, <see cref="GlobalTimeService.CurrentTimeChanged"/>
-    /// is observed for the lifetime of this view model.
+    /// is observed for the lifetime of this view model. Likewise
+    /// <paramref name="themeService"/> may be <c>null</c>; when supplied,
+    /// <see cref="IThemeService.ThemeChanged"/> drives in-place updates of
+    /// the chart's <see cref="SolidColorPaint"/> colours so the chart
+    /// follows the chrome <see cref="Avalonia.Styling.ThemeVariant"/>.
     /// </summary>
     protected StationTimeSeriesViewModel(
         StationTimeSeriesSnapshot snapshot,
         GlobalTimeService? globalTime,
-        ITimeFormatProvider? timeFormat = null)
+        ITimeFormatProvider? timeFormat = null,
+        IThemeService? themeService = null)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
         Snapshot = snapshot;
         _globalTime = globalTime;
         _timeFormat = timeFormat;
+        _themeService = themeService;
 
+        CurrentChartTheme = ChartTheme.Resolve(themeService?.IsDarkTheme ?? false);
+
+        _nowMarkerPaint = new SolidColorPaint(CurrentChartTheme.NowMarker, 1.5f);
         _nowSection = new RectangularSection
         {
             Xi = double.NaN,
             Xj = double.NaN,
             Fill = null,
-            Stroke = new SolidColorPaint(new SKColor(0xE6, 0x49, 0x4B), 1.5f),
+            Stroke = _nowMarkerPaint,
         };
         Sections = new[] { _nowSection };
+
+        _timeAxisLabelsPaint = new SolidColorPaint(CurrentChartTheme.AxisLabel);
+        _timeAxisNamePaint = new SolidColorPaint(CurrentChartTheme.AxisName);
+        _timeAxisSeparatorsPaint = new SolidColorPaint(CurrentChartTheme.Separator);
 
         TimeAxis = new Axis
         {
@@ -70,6 +88,9 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
             LabelsRotation = 0,
             UnitWidth = TimeSpan.FromMinutes(1).Ticks,
             MinStep = TimeSpan.FromMinutes(1).Ticks,
+            LabelsPaint = _timeAxisLabelsPaint,
+            NamePaint = _timeAxisNamePaint,
+            SeparatorsPaint = _timeAxisSeparatorsPaint,
         };
         TimeAxisArray = new ICartesianAxis[] { TimeAxis };
 
@@ -82,6 +103,9 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
 
         if (_timeFormat is not null)
             _timeFormat.TimeFormatChanged += OnTimeFormatChanged;
+
+        if (_themeService is not null)
+            _themeService.ThemeChanged += OnThemeChanged;
     }
 
     /// <summary>The raw snapshot that backs this view model.</summary>
@@ -138,6 +162,46 @@ internal abstract class StationTimeSeriesViewModel : ViewModelBase, IDisposable
             _globalTime.CurrentTimeChanged -= OnGlobalTimeChanged;
         if (_timeFormat is not null)
             _timeFormat.TimeFormatChanged -= OnTimeFormatChanged;
+        if (_themeService is not null)
+            _themeService.ThemeChanged -= OnThemeChanged;
+    }
+
+    /// <summary>
+    /// Current chart palette derived from the chrome
+    /// <see cref="Avalonia.Styling.ThemeVariant"/>. Refreshed in place
+    /// when <see cref="IThemeService.ThemeChanged"/> fires; subclasses
+    /// read this from <see cref="OnChartThemeChanged"/> to update their
+    /// per-product paints.
+    /// </summary>
+    /// <remarks>
+    /// This responds to <b>chrome theme</b> (Light vs Dark), not the
+    /// S-100 map palette (Day / Dusk / Night). The map palette is owned
+    /// by <see cref="SettingsViewModel.SelectedPalette"/> and is not
+    /// consumed by these charts.
+    /// </remarks>
+    protected internal ChartTheme CurrentChartTheme { get; private set; }
+
+    /// <summary>
+    /// Override to update product-specific <see cref="SolidColorPaint"/>
+    /// instances when <see cref="CurrentChartTheme"/> changes. Mutating
+    /// existing paints in place (via <see cref="SolidColorPaint.Color"/>)
+    /// avoids the cost of rebuilding series; LiveCharts2 redraws on the
+    /// next paint cycle. Base implementation updates the shared time
+    /// axis paints and the "now" marker stroke.
+    /// </summary>
+    /// <param name="theme">The new chart palette.</param>
+    protected virtual void OnChartThemeChanged(ChartTheme theme)
+    {
+        _nowMarkerPaint.Color = theme.NowMarker;
+        _timeAxisLabelsPaint.Color = theme.AxisLabel;
+        _timeAxisNamePaint.Color = theme.AxisName;
+        _timeAxisSeparatorsPaint.Color = theme.Separator;
+    }
+
+    private void OnThemeChanged(object? sender, EventArgs e)
+    {
+        CurrentChartTheme = ChartTheme.Resolve(_themeService?.IsDarkTheme ?? false);
+        OnChartThemeChanged(CurrentChartTheme);
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Viewer.Tests/ActivityTabRegistryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ActivityTabRegistryTests.cs
@@ -63,6 +63,7 @@ public sealed class ActivityTabRegistryTests : IDisposable
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme => false;
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() => false;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/ChartThemeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ChartThemeTests.cs
@@ -1,0 +1,215 @@
+using System;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests for <see cref="ChartTheme"/> and the chart view-models'
+/// chrome-theme subscription behaviour.
+/// </summary>
+public class ChartThemeTests
+{
+    private sealed class StubThemeService : IThemeService
+    {
+        public bool IsDarkTheme { get; private set; }
+        public event EventHandler? ThemeChanged;
+        public bool ToggleTheme()
+        {
+            IsDarkTheme = !IsDarkTheme;
+            ThemeChanged?.Invoke(this, EventArgs.Empty);
+            return IsDarkTheme;
+        }
+        public void RaiseChanged() => ThemeChanged?.Invoke(this, EventArgs.Empty);
+        public void Set(bool dark)
+        {
+            IsDarkTheme = dark;
+            ThemeChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private static StationTimeSeriesSnapshot WaterLevelSnapshot()
+    {
+        var start = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        return new StationTimeSeriesSnapshot
+        {
+            StationId = "ST01",
+            Latitude = 0,
+            Longitude = 0,
+            Times = new[] { start, start.AddMinutes(15) },
+            Channels = new[]
+            {
+                new StationTimeSeriesChannel
+                {
+                    Key = "waterLevelHeight",
+                    DisplayName = "Water Level Height",
+                    Unit = "m",
+                    Values = new[] { 1f, 2f },
+                    FillValue = -9999f,
+                },
+            },
+        };
+    }
+
+    private static StationTimeSeriesSnapshot CurrentsSnapshot()
+    {
+        var start = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        return new StationTimeSeriesSnapshot
+        {
+            StationId = "ST02",
+            Latitude = 0,
+            Longitude = 0,
+            Times = new[] { start, start.AddMinutes(15) },
+            Channels = new[]
+            {
+                new StationTimeSeriesChannel
+                {
+                    Key = "surfaceCurrentSpeed",
+                    DisplayName = "Speed",
+                    Unit = "m/s",
+                    Values = new[] { 0.1f, 0.2f },
+                    FillValue = -9999f,
+                },
+                new StationTimeSeriesChannel
+                {
+                    Key = "surfaceCurrentDirection",
+                    DisplayName = "Direction",
+                    Unit = "deg",
+                    Values = new[] { 90f, 180f },
+                    FillValue = -9999f,
+                },
+            },
+        };
+    }
+
+    private static SKColor GetStrokeColor(LiveChartsCore.ISeries series)
+    {
+        // Stroke lives on IStrokedAndFilled which the LineSeries
+        // implementations satisfy. Cast through that interface to avoid
+        // depending on the concrete generic type.
+        var strokable = (LiveChartsCore.Kernel.Sketches.IStrokedAndFilled)series;
+        var paint = (SolidColorPaint?)strokable.Stroke;
+        Assert.NotNull(paint);
+        return paint!.Color;
+    }
+
+    private static SolidColorPaint GetStrokePaint(LiveChartsCore.ISeries series)
+    {
+        var strokable = (LiveChartsCore.Kernel.Sketches.IStrokedAndFilled)series;
+        var paint = (SolidColorPaint?)strokable.Stroke;
+        Assert.NotNull(paint);
+        return paint!;
+    }
+
+    [Fact]
+    public void Resolve_LightAndDark_ProduceDistinctValuesForEveryColour()
+    {
+        var light = ChartTheme.Resolve(isDark: false);
+        var dark = ChartTheme.Resolve(isDark: true);
+
+        Assert.NotEqual(light.SeriesPrimary, dark.SeriesPrimary);
+        Assert.NotEqual(light.SeriesSpeed, dark.SeriesSpeed);
+        Assert.NotEqual(light.SeriesDirection, dark.SeriesDirection);
+        Assert.NotEqual(light.NowMarker, dark.NowMarker);
+        Assert.NotEqual(light.AxisLabel, dark.AxisLabel);
+        Assert.NotEqual(light.AxisName, dark.AxisName);
+        Assert.NotEqual(light.Separator, dark.Separator);
+    }
+
+    [Fact]
+    public void Resolve_NowMarker_HasFullAlphaOnBothThemes()
+    {
+        // Section strokes need to be opaque or LiveCharts2 antialiases
+        // them away on a busy chart canvas.
+        Assert.Equal((byte)0xFF, ChartTheme.Resolve(false).NowMarker.Alpha);
+        Assert.Equal((byte)0xFF, ChartTheme.Resolve(true).NowMarker.Alpha);
+    }
+
+    [Fact]
+    public void Resolve_NoApplicationDependency()
+    {
+        // Resolve must not require Avalonia.Application.Current — it's
+        // pure on its bool input. Verify by simply calling it; if it
+        // ever touches Application.Current under test, this throws.
+        var theme = ChartTheme.Resolve(isDark: false);
+        Assert.NotNull(theme);
+    }
+
+    [Fact]
+    public void StationTimeSeriesViewModel_DefaultsToLightWhenNoThemeService()
+    {
+        using var vm = new S104StationTimeSeriesViewModel(WaterLevelSnapshot(), globalTime: null);
+        Assert.Equal(ChartTheme.Resolve(false).SeriesPrimary, GetStrokeColor(vm.HeightSeries[0]));
+    }
+
+    [Fact]
+    public void StationTimeSeriesViewModel_AppliesInitialThemeFromService()
+    {
+        var theme = new StubThemeService();
+        theme.Set(dark: true);
+        using var vm = new S104StationTimeSeriesViewModel(WaterLevelSnapshot(), null, null, theme);
+        Assert.Equal(ChartTheme.Resolve(true).SeriesPrimary, GetStrokeColor(vm.HeightSeries[0]));
+    }
+
+    [Fact]
+    public void S104_HeightStroke_FollowsThemeChange()
+    {
+        var theme = new StubThemeService();
+        using var vm = new S104StationTimeSeriesViewModel(WaterLevelSnapshot(), null, null, theme);
+
+        Assert.Equal(ChartTheme.Resolve(false).SeriesPrimary, GetStrokeColor(vm.HeightSeries[0]));
+
+        theme.Set(dark: true);
+
+        Assert.Equal(ChartTheme.Resolve(true).SeriesPrimary, GetStrokeColor(vm.HeightSeries[0]));
+        Assert.Equal(ChartTheme.Resolve(true), vm.CurrentChartTheme);
+    }
+
+    [Fact]
+    public void S111_SpeedAndDirectionStrokes_FollowThemeChange()
+    {
+        var theme = new StubThemeService();
+        using var vm = new S111StationTimeSeriesViewModel(CurrentsSnapshot(), null, null, theme);
+
+        Assert.Equal(ChartTheme.Resolve(false).SeriesSpeed, GetStrokeColor(vm.SpeedSeries[0]));
+        Assert.Equal(ChartTheme.Resolve(false).SeriesDirection, GetStrokeColor(vm.DirectionSeries[0]));
+
+        theme.Set(dark: true);
+
+        Assert.Equal(ChartTheme.Resolve(true).SeriesSpeed, GetStrokeColor(vm.SpeedSeries[0]));
+        Assert.Equal(ChartTheme.Resolve(true).SeriesDirection, GetStrokeColor(vm.DirectionSeries[0]));
+    }
+
+    [Fact]
+    public void NowMarkerStroke_FollowsThemeChange()
+    {
+        var theme = new StubThemeService();
+        using var vm = new S104StationTimeSeriesViewModel(WaterLevelSnapshot(), null, null, theme);
+
+        var nowPaint = (SolidColorPaint)vm.Sections[0].Stroke!;
+        Assert.Equal(ChartTheme.Resolve(false).NowMarker, nowPaint.Color);
+
+        theme.Set(dark: true);
+
+        Assert.Equal(ChartTheme.Resolve(true).NowMarker, nowPaint.Color);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromThemeChanged()
+    {
+        var theme = new StubThemeService();
+        var vm = new S104StationTimeSeriesViewModel(WaterLevelSnapshot(), null, null, theme);
+        var stroke = GetStrokePaint(vm.HeightSeries[0]);
+        var initial = stroke.Color;
+
+        vm.Dispose();
+
+        // After Dispose the VM must no longer respond to theme changes.
+        theme.Set(dark: true);
+        Assert.Equal(initial, stroke.Color);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/LayoutPersistenceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LayoutPersistenceTests.cs
@@ -63,6 +63,7 @@ public sealed class LayoutPersistenceTests : IDisposable
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme => false;
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() => false;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -36,6 +36,7 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme => false;
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() => false;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -41,6 +41,7 @@ public class MainViewModelOpenRecentTests : IDisposable
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme => false;
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() => false;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickEmptyStateTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickEmptyStateTests.cs
@@ -56,6 +56,7 @@ public sealed class MainViewModelPickEmptyStateTests : IDisposable
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme => false;
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() => false;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -24,6 +24,7 @@ public class MainViewModelPickModeTests
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme { get; private set; }
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() { IsDarkTheme = !IsDarkTheme; return IsDarkTheme; }
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MultiDockActivityTabTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MultiDockActivityTabTests.cs
@@ -63,6 +63,7 @@ public sealed class MultiDockActivityTabTests : IDisposable
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme => false;
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() => false;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -40,6 +40,7 @@ public class PickServiceTests
     private sealed class StubThemeService : IThemeService
     {
         public bool IsDarkTheme { get; private set; }
+        public event System.EventHandler? ThemeChanged { add { } remove { } }
         public bool ToggleTheme() { IsDarkTheme = !IsDarkTheme; return IsDarkTheme; }
     }
 


### PR DESCRIPTION
## Summary

Closes the gap left by PR-J: the LiveCharts2 station time-series charts in the Pick Report panel (S-104 water level, S-111 surface currents) now follow the chrome theme toggle (Avalonia `ThemeVariant.Light` / `.Dark`) instead of using hardcoded colours that clash on dark backgrounds.

Also bundles a small carryover from PR-H/J: a Day/Dusk/Night flyout pill on the map toolbar wired to the existing `SettingsViewModel.SelectedPalette` (no new logic — purely a UI surface).

> **Scope clarification:** This PR is about **chrome theme** (`ThemeVariant.Light` / `.Dark`), NOT the **S-100 map palette** (Day / Dusk / Night). The two are intentionally separate axes. Charts only consume the chrome theme; the toolbar pill only drives the map palette. This split is documented inline in `ChartTheme.cs` for future maintainers.

## Part 1 — Chart theming

- **`IThemeService`** gets a `ThemeChanged` event; `ThemeService` forwards `Application.Current.ActualThemeVariantChanged`.
- **New `ChartTheme.cs`** — sealed record with `Resolve(bool isDark)` returning a complete palette: series strokes, now-marker stroke, axis label / name / separator colours. Light values match PR-J starting points (Tab10-ish blue/green/orange + red marker); dark values lift toward cyan/teal/amber/coral with desaturated reds to avoid bloom on dark canvas. Rationale documented inline next to each pair.
- **`StationTimeSeriesViewModel` base class** subscribes to `IThemeService.ThemeChanged`, applies palette to `_nowSection.Stroke` and the time-axis paints, exposes `protected virtual OnChartThemeChanged(ChartTheme)`, and unsubscribes in `Dispose`.
- **S-104 / S-111 view-models** override `OnChartThemeChanged` to mutate per-series `SolidColorPaint.Color` and Y-axis paint colours **in place** rather than rebuilding series — LiveCharts2 redraws on next paint cycle.
- **`PickService`** gains an optional `IThemeService` ctor parameter and propagates it through to chart VM construction. DI auto-resolves the widest constructor.

### ShadUI dynamic resources?

I evaluated and **opted out**. The Skia chart surface paints in a vacuum (no Avalonia visual tree), and ShadUI's keys are exposed as `IBrush` instances that would need imperative resource lookup + colour extraction at every theme change. The cost outweighs the benefit when there are only ~3 chrome colours involved (axis labels, axis names, separators). Hardcoded per-theme greys are documented inline and a reviewer can adjust them in one place. If a future PR wants to free-ride on ShadUI tweaks, the change is localised to `ChartTheme.Resolve`.

## Part 2 — Toolbar SwitchPalette pill

A flyout pill sits between the existing Display Category and Text pills. RadioButton items bound to new `IsPaletteDay/Dusk/Night` getters and `SetPaletteDay/Dusk/NightCommand` on `SettingsViewModel`. No new logic — the existing `SelectedPalette` setter already triggers `DatasetLoaderService.PaletteChanged` and re-renders. Tooltip required by `viewer.instructions.md`: new `Tooltip_SwitchPalette` and `Toolbar_Palette` resources.

**Decision: shipped, not deferred.** The pill mirrors the existing Display/Text pill pattern, fits in the toolbar with no chrome noise, and is materially more discoverable than nesting palette under Settings. No `TODO PR-N-future` markers.

## Tests

- **`ChartThemeTests`** (+9 tests, viewer test file): asserts `Resolve(false)` vs `Resolve(true)` differ on every colour token, marker alpha is opaque on each theme, helper has no `Application.Current` dependency, and the `StationTimeSeriesViewModel` base correctly:
  - Defaults to Light when no theme service is supplied
  - Applies the initial theme on construction
  - Updates S-104 height stroke, S-111 speed + direction strokes, and the now-marker stroke when `ThemeChanged` fires
  - Unsubscribes on `Dispose` (paint stays at initial after a post-Dispose theme-change event)
- 8 existing test files with `StubThemeService` patched to expose the new event (no-op `add { } remove { }` to avoid CS0067).
- No visual regression snapshots — interactive UI snapshots flake on CI; the contract is the colour resolution + paint mutation tested above.

**Test count delta:** Viewer suite goes from baseline (per the original spec, 368) to **426** (the suite has grown since that figure). New tests in this PR: **+9**. Full solution: **0 new warnings**, all suites green.

## LOC delta

`20 files changed, 584 insertions(+), 17 deletions(-)`

## Notable design decisions

1. **Mutate `SolidColorPaint.Color` in place** rather than rebuilding `ISeries` collections on theme change. LiveCharts2 picks up the change on the next paint cycle without churning the DataTemplate-backed `ChartView` binding.
2. **Stroke lives on `LiveChartsCore.Kernel.Sketches.IStrokedAndFilled`** (not `ISeries`). Tests cast through it.
3. **`PickService` constructor chain widens** rather than introducing a new options object — keeps the change reviewable and DI auto-resolves the widest available constructor.
4. **Branch name carries an extra `philliphoff/` prefix** because the `rename_branch` tool auto-prefixes the username; the second rename was rejected. The PR title is the source of truth.