### PR TITLE
Add CPU/alloc profiling, span timeline export, per-feature Lua telemetry

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -33,13 +33,20 @@ jobs:
       # the base runner is built with this PR's runner code linked against
       # the base SHA's library code. The library code under test stays
       # at the base SHA — only the measurement harness is overlaid.
+      #
+      # Directory.Packages.props is overlaid as well because central
+      # package management requires every PackageReference in the
+      # overlaid PerfRunner csproj to have a matching PackageVersion;
+      # if the PR adds a new package (e.g. profiler dependencies) the
+      # base CPM file will not contain it and restore will fail.
       - name: Overlay PR perf tooling onto base tree
         run: |
           git checkout ${{ github.event.pull_request.head.sha }} -- \
             tools/EncDotNet.S100.PerfRunner \
             tools/EncDotNet.S100.PerfReport \
             tools/perf \
-            src/EncDotNet.S100.Diagnostics.Export
+            src/EncDotNet.S100.Diagnostics.Export \
+            Directory.Packages.props
 
       - name: Build base PerfRunner
         run: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <!-- Logging / observability -->
+    <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />

--- a/src/EncDotNet.S100.Datasets.S101/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S101/Diagnostics/Telemetry.cs
@@ -30,4 +30,23 @@ internal static class Telemetry
             name: "s100.lua.instructions.emitted.count",
             unit: "{instructions}",
             description: "Drawing instructions emitted by the Lua executor per pass.");
+
+    /// <summary>
+    /// Number of drawing instructions emitted by the Lua executor for a
+    /// single feature type within one portrayal pass. Tagged with
+    /// <c>s100.feature.type</c> (FC code, e.g. <c>DEPCNT</c>,
+    /// <c>BCNCAR</c>) and <c>s100.product</c>.
+    /// </summary>
+    /// <remarks>
+    /// <b>Cardinality, not timing.</b> This metric reports output
+    /// volume — it cannot prove a feature type consumed proportional CPU
+    /// time. To attribute time per feature type, combine this metric
+    /// with a sampled CPU profile collected via PerfRunner's
+    /// <c>--profile cpu</c> flag.
+    /// </remarks>
+    public static readonly Histogram<long> LuaFeatureInstructionsCount =
+        Meter.CreateHistogram<long>(
+            name: "s100.lua.feature.instructions.count",
+            unit: "{instructions}",
+            description: "Drawing instructions emitted by the Lua executor for a single feature type per pass (cardinality, not timing). Tagged with s100.feature.type and s100.product.");
 }

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
@@ -44,6 +44,37 @@ public sealed class S101LuaDataProvider
     public IReadOnlyList<(string FeatureRef, string Instructions, string ObservedParams)> EmittedInstructions => _emitted;
 
     /// <summary>
+    /// Resolves a Lua-side feature reference (the stringified record id
+    /// passed to <c>HostPortrayalEmit</c>) to its S-101 feature-type code
+    /// (e.g. <c>DEPCNT</c>, <c>BCNCAR</c>) using the dataset's record
+    /// index and feature-type catalogue.
+    /// </summary>
+    /// <returns>
+    /// The human-readable FC code on success, or <see langword="null"/>
+    /// when <paramref name="featureRef"/> cannot be parsed or the
+    /// record is not present.
+    /// </returns>
+    public string? TryGetFeatureTypeCode(string featureRef)
+    {
+        if (string.IsNullOrEmpty(featureRef)) return null;
+        // Lua marshals doubles as e.g. "12345" or "12345.0"; trim the
+        // fractional part if present.
+        var dot = featureRef.IndexOf('.');
+        var idText = dot >= 0 ? featureRef[..dot] : featureRef;
+        if (!uint.TryParse(idText, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out var id))
+        {
+            return null;
+        }
+
+        EnsureFeatureIndex();
+        if (!_featureById!.TryGetValue(id, out var feat)) return null;
+        return _doc.FeatureTypeCatalogue.TryGetValue(feat.FeatureTypeCode, out var name)
+            ? name
+            : feat.FeatureTypeCode.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
     /// Registers all Host* functions and the Debug table on the given Lua context.
     /// </summary>
     public void RegisterHostFunctions(ILuaContext lua)

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -193,10 +193,12 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
 
         try
         {
-            var emitted = ExecuteRaw(mariner);
+            var (emitted, dataProvider) = ExecuteRawCore(mariner);
 
             Telemetry.LuaFeaturesCount.Add(emitted.Count);
             activity?.SetTag("s100.lua.features.count", emitted.Count);
+
+            RecordPerFeatureTypeCardinality(emitted, dataProvider);
 
             // Build a geometry provider to supply feature anchor points for
             // augmented line geometry tessellation (sector lights, all-around
@@ -231,6 +233,35 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     }
 
     /// <summary>
+    /// Records the per-feature-type emitted-instruction count
+    /// (<c>s100.lua.feature.instructions.count</c>) tagged with
+    /// <c>s100.feature.type</c> + <c>s100.product</c>. Output volume
+    /// only — does not measure CPU time. See the Telemetry doc comment.
+    /// </summary>
+    private static void RecordPerFeatureTypeCardinality(
+        IReadOnlyList<EmittedInstruction> emitted,
+        S101LuaDataProvider dataProvider)
+    {
+        if (emitted.Count == 0) return;
+
+        var counts = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (var e in emitted)
+        {
+            var code = dataProvider.TryGetFeatureTypeCode(e.FeatureRef) ?? "(unknown)";
+            counts.TryGetValue(code, out var existing);
+            counts[code] = existing + 1;
+        }
+
+        foreach (var (code, count) in counts)
+        {
+            Telemetry.LuaFeatureInstructionsCount.Record(
+                count,
+                new KeyValuePair<string, object?>(TelemetryTags.Product, "S-101"),
+                new KeyValuePair<string, object?>(TelemetryTags.FeatureType, code));
+        }
+    }
+
+    /// <summary>
     /// Returns the first (anchor) coordinate of the feature identified by
     /// <paramref name="featureRef"/>, or <see langword="null"/> if the feature
     /// has no point geometry.
@@ -251,6 +282,17 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     /// <see cref="Execute(MarinerSettings)"/>, which returns typed instructions.
     /// </summary>
     public IReadOnlyList<EmittedInstruction> ExecuteRaw(MarinerSettings mariner)
+        => ExecuteRawCore(mariner).Emitted;
+
+    /// <summary>
+    /// Internal core of <see cref="ExecuteRaw"/> that also returns the
+    /// constructed <see cref="S101LuaDataProvider"/> so callers can
+    /// resolve feature-type codes for the emitted instructions without
+    /// re-building the lookup index. Used by <see cref="Execute"/> to
+    /// emit per-feature-type cardinality telemetry.
+    /// </summary>
+    private (IReadOnlyList<EmittedInstruction> Emitted, S101LuaDataProvider DataProvider) ExecuteRawCore(
+        MarinerSettings mariner)
     {
         ArgumentNullException.ThrowIfNull(mariner);
         var dataset = _dataset;
@@ -357,7 +399,7 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
             }
         }
 
-        return results;
+        return (results, dataProvider);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Datasets.S131/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Datasets.S131/Diagnostics/Telemetry.cs
@@ -12,4 +12,23 @@ internal static class Telemetry
 
     public static readonly Meter Meter =
         S100Telemetry.CreateMeter(typeof(Telemetry));
+
+    /// <summary>
+    /// Number of drawing instructions emitted by the Lua executor for a
+    /// single feature type within one portrayal pass. Tagged with
+    /// <c>s100.feature.type</c> (FC code, e.g. <c>Berth</c>,
+    /// <c>MooringBuoy</c>) and <c>s100.product</c>.
+    /// </summary>
+    /// <remarks>
+    /// <b>Cardinality, not timing.</b> This metric reports output
+    /// volume — it cannot prove a feature type consumed proportional CPU
+    /// time. To attribute time per feature type, combine this metric
+    /// with a sampled CPU profile collected via PerfRunner's
+    /// <c>--profile cpu</c> flag.
+    /// </remarks>
+    public static readonly Histogram<long> LuaFeatureInstructionsCount =
+        Meter.CreateHistogram<long>(
+            name: "s100.lua.feature.instructions.count",
+            unit: "{instructions}",
+            description: "Drawing instructions emitted by the Lua executor for a single feature type per pass (cardinality, not timing). Tagged with s100.feature.type and s100.product.");
 }

--- a/src/EncDotNet.S100.Datasets.S131/S131LuaDataProvider.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131LuaDataProvider.cs
@@ -54,6 +54,27 @@ public sealed class S131LuaDataProvider
     private readonly List<(string FeatureRef, string Instructions, string ObservedParams)> _emitted = new();
 
     /// <summary>
+    /// Resolves a Lua-side feature reference (the stringified synthetic
+    /// numeric id passed to <c>HostPortrayalEmit</c>) to its S-131
+    /// feature-type code (e.g. <c>Berth</c>, <c>MooringBuoy</c>).
+    /// </summary>
+    /// <returns>
+    /// The FC code on success, or <see langword="null"/> when
+    /// <paramref name="featureRef"/> cannot be parsed or no feature is
+    /// associated with the id.
+    /// </returns>
+    public string? TryGetFeatureTypeCode(string featureRef)
+    {
+        if (string.IsNullOrEmpty(featureRef)) return null;
+        if (!double.TryParse(featureRef, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var id))
+        {
+            return null;
+        }
+        return _featureById.TryGetValue(id, out var feat) ? feat.FeatureType : null;
+    }
+
+    /// <summary>
     /// Initialises a new <see cref="S131LuaDataProvider"/> for the given dataset
     /// and feature catalogue.
     /// </summary>

--- a/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
@@ -171,9 +171,11 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
 
         try
         {
-            var emitted = ExecuteRaw(mariner);
+            var (emitted, dataProvider) = ExecuteRawCore(mariner);
 
             activity?.SetTag("s100.lua.features.count", emitted.Count);
+
+            RecordPerFeatureTypeCardinality(emitted, dataProvider);
 
             var parsed = new List<DrawingInstruction>();
             foreach (var e in emitted)
@@ -198,10 +200,50 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
     }
 
     /// <summary>
+    /// Records the per-feature-type emitted-instruction count
+    /// (<c>s100.lua.feature.instructions.count</c>) tagged with
+    /// <c>s100.feature.type</c> + <c>s100.product</c>. Output volume
+    /// only — does not measure CPU time. See the Telemetry doc comment.
+    /// </summary>
+    private static void RecordPerFeatureTypeCardinality(
+        IReadOnlyList<EmittedInstruction> emitted,
+        S131LuaDataProvider dataProvider)
+    {
+        if (emitted.Count == 0) return;
+
+        var counts = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (var e in emitted)
+        {
+            var code = dataProvider.TryGetFeatureTypeCode(e.FeatureRef) ?? "(unknown)";
+            counts.TryGetValue(code, out var existing);
+            counts[code] = existing + 1;
+        }
+
+        foreach (var (code, count) in counts)
+        {
+            Telemetry.LuaFeatureInstructionsCount.Record(
+                count,
+                new KeyValuePair<string, object?>(TelemetryTags.Product, "S-131"),
+                new KeyValuePair<string, object?>(TelemetryTags.FeatureType, code));
+        }
+    }
+
+    /// <summary>
     /// Runs the S-131 Lua portrayal pipeline and returns the raw emitted
     /// drawing-instruction strings keyed by feature reference.
     /// </summary>
     public IReadOnlyList<EmittedInstruction> ExecuteRaw(MarinerSettings mariner)
+        => ExecuteRawCore(mariner).Emitted;
+
+    /// <summary>
+    /// Internal core of <see cref="ExecuteRaw"/> that also returns the
+    /// constructed <see cref="S131LuaDataProvider"/> so callers can
+    /// resolve feature-type codes for the emitted instructions without
+    /// re-building the lookup index. Used by <see cref="Execute"/> to
+    /// emit per-feature-type cardinality telemetry.
+    /// </summary>
+    private (IReadOnlyList<EmittedInstruction> Emitted, S131LuaDataProvider DataProvider) ExecuteRawCore(
+        MarinerSettings mariner)
     {
         ArgumentNullException.ThrowIfNull(mariner);
 
@@ -281,7 +323,7 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
             }
         }
 
-        return results;
+        return (results, dataProvider);
     }
 
     private string BuildContextParameterInitScript()

--- a/tests/EncDotNet.S100.Datasets.S131.Tests/S131LuaDataProviderTryGetFeatureTypeCodeTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S131.Tests/S131LuaDataProviderTryGetFeatureTypeCodeTests.cs
@@ -1,0 +1,69 @@
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Datasets.S131.Tests;
+
+/// <summary>
+/// Tests for the public <see cref="S131LuaDataProvider.TryGetFeatureTypeCode"/>
+/// API used by <see cref="S131LuaRuleExecutor"/> to attribute emitted
+/// drawing instructions to a feature-type code for the
+/// <c>s100.lua.feature.instructions.count</c> histogram.
+/// </summary>
+public class S131LuaDataProviderTryGetFeatureTypeCodeTests
+{
+    private static string GetTestDataPath(string filename)
+        => Path.Combine(AppContext.BaseDirectory, "TestData", filename);
+
+    private static FeatureCatalogue LoadS131Fc()
+    {
+        using var stream = Specification.TryOpenFeatureCatalogue("S-131")
+            ?? throw new InvalidOperationException("S-131 FC not bundled.");
+        return FeatureCatalogueReader.Read(stream);
+    }
+
+    [Fact]
+    public void TryGetFeatureTypeCode_ResolvesFeatureToFcCode()
+    {
+        var dataset = S131Dataset.Open(GetTestDataPath("harbour_point.gml"));
+        var fc = LoadS131Fc();
+
+        var provider = new S131LuaDataProvider(dataset, fc);
+
+        // Provider assigns sequential 1-based numeric ids in dataset order.
+        // The fixture has Bollard (id 1) then MooringBuoy (id 2).
+        Assert.Equal("Bollard", provider.TryGetFeatureTypeCode("1"));
+        Assert.Equal("MooringBuoy", provider.TryGetFeatureTypeCode("2"));
+    }
+
+    [Fact]
+    public void TryGetFeatureTypeCode_AcceptsDoubleFormattedRefs()
+    {
+        // MoonSharp marshals Lua numbers as System.Double, so feature
+        // refs round-trip through a stringified double form (e.g. "1"
+        // becomes "1" or sometimes "1.0"). The provider must accept both.
+        var dataset = S131Dataset.Open(GetTestDataPath("harbour_point.gml"));
+        var provider = new S131LuaDataProvider(dataset, LoadS131Fc());
+
+        Assert.Equal("Bollard", provider.TryGetFeatureTypeCode("1"));
+        Assert.Equal("Bollard", provider.TryGetFeatureTypeCode("1.0"));
+    }
+
+    [Fact]
+    public void TryGetFeatureTypeCode_ReturnsNull_ForUnknownId()
+    {
+        var dataset = S131Dataset.Open(GetTestDataPath("harbour_point.gml"));
+        var provider = new S131LuaDataProvider(dataset, LoadS131Fc());
+
+        Assert.Null(provider.TryGetFeatureTypeCode("99999"));
+    }
+
+    [Fact]
+    public void TryGetFeatureTypeCode_ReturnsNull_ForNonNumericRef()
+    {
+        var dataset = S131Dataset.Open(GetTestDataPath("harbour_point.gml"));
+        var provider = new S131LuaDataProvider(dataset, LoadS131Fc());
+
+        Assert.Null(provider.TryGetFeatureTypeCode(""));
+        Assert.Null(provider.TryGetFeatureTypeCode("not-a-number"));
+    }
+}

--- a/tools/EncDotNet.S100.PerfReport/ChromeTraceCommand.cs
+++ b/tools/EncDotNet.S100.PerfReport/ChromeTraceCommand.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.PerfReport;
+
+/// <summary>
+/// The <c>chrome-trace</c> command: converts a <c>.jsonl</c> telemetry
+/// file produced by the PerfRunner into the Chrome Trace JSON Object
+/// Array format.
+///
+/// <para>
+/// The output can be loaded directly in <c>chrome://tracing</c>,
+/// <a href="https://ui.perfetto.dev">Perfetto UI</a>, or
+/// <a href="https://www.speedscope.app">Speedscope</a>. The format is
+/// documented at
+/// <a href="https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview">
+/// Trace Event Format
+/// </a>.
+/// </para>
+///
+/// <para>
+/// <strong>This is a span timeline, not a CPU flamegraph.</strong>
+/// It visualises the existing
+/// <see cref="System.Diagnostics.ActivitySource"/> spans recorded by the
+/// product code (pipeline stages, Lua execution, HDF5 reads, renderer
+/// frames, etc.). It does <em>not</em> sample the CPU and so cannot
+/// show JIT/runtime/library frames between span boundaries. To get a
+/// real CPU flamegraph, run the PerfRunner with
+/// <c>--profile cpu</c> and convert the resulting <c>.nettrace</c> file
+/// using <c>dotnet-trace convert &lt;file&gt;.nettrace --format speedscope</c>.
+/// </para>
+/// </summary>
+public sealed class ChromeTraceCommand : Command<ChromeTraceCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<FILE>")]
+        [Description("Path to the .jsonl telemetry file.")]
+        public string File { get; set; } = "";
+
+        [CommandOption("--out <PATH>")]
+        [Description("Path to write the Chrome Trace JSON file. Defaults to <FILE>.chrome.json next to the input.")]
+        public string? OutputPath { get; set; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        if (!System.IO.File.Exists(settings.File))
+        {
+            AnsiConsole.MarkupLine($"[red]File not found:[/] {settings.File}");
+            return 1;
+        }
+
+        var reader = TelemetryFileReader.Read(settings.File);
+        if (reader.Spans.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No spans found in the telemetry file.[/]");
+            return 1;
+        }
+
+        // Spans missing start/end timestamps cannot be placed on the
+        // timeline. This happens with older telemetry files that pre-date
+        // the addition of startUnixNs/endUnixNs to the FileTelemetryExporter
+        // schema. Warn rather than fail so partial conversions still work.
+        int missingTimestamps = 0;
+        foreach (var span in reader.Spans)
+        {
+            if (span.StartUnixNs is null || span.EndUnixNs is null) missingTimestamps++;
+        }
+        if (missingTimestamps == reader.Spans.Count)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]All spans are missing startUnixNs/endUnixNs timestamps.[/] " +
+                "Re-run the PerfRunner with a current build to produce convertible telemetry.");
+            return 1;
+        }
+        if (missingTimestamps > 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[yellow]Skipping {missingTimestamps} span(s) without timestamps.[/]");
+        }
+
+        var outputPath = settings.OutputPath ?? settings.File + ".chrome.json";
+
+        // Use the earliest span start as the timeline origin so the
+        // rendered timeline starts at t=0us. Chrome Trace ts values are
+        // in microseconds; we convert from nanoseconds with rounding.
+        long? originNs = null;
+        foreach (var span in reader.Spans)
+        {
+            if (span.StartUnixNs is { } s && (originNs is null || s < originNs)) originNs = s;
+        }
+        long origin = originNs ?? 0;
+
+        // Each distinct traceId becomes a virtual "thread" in the output
+        // so that concurrent activity from different scenarios/iterations
+        // is rendered as parallel swimlanes rather than overlapping rows.
+        var tidByTrace = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        using var stream = System.IO.File.Create(outputPath);
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false });
+        writer.WriteStartArray();
+
+        foreach (var span in reader.Spans)
+        {
+            if (span.StartUnixNs is not { } startNs) continue;
+            if (span.EndUnixNs is not { } endNs) continue;
+
+            if (!tidByTrace.TryGetValue(span.TraceId, out var tid))
+            {
+                tid = tidByTrace.Count + 1;
+                tidByTrace[span.TraceId] = tid;
+            }
+
+            // Chrome Trace stores ts (start) and dur (duration) in
+            // microseconds. Use a "complete" event (ph: "X") rather
+            // than separate B/E events — it halves the output size and
+            // is what Speedscope/Perfetto prefer.
+            double tsUs = (startNs - origin) / 1000.0;
+            double durUs = (endNs - startNs) / 1000.0;
+
+            writer.WriteStartObject();
+            writer.WriteString("name", span.Name);
+            writer.WriteString("cat", "span");
+            writer.WriteString("ph", "X");
+            writer.WriteNumber("ts", tsUs);
+            writer.WriteNumber("dur", durUs);
+            writer.WriteNumber("pid", 1);
+            writer.WriteNumber("tid", tid);
+
+            writer.WriteStartObject("args");
+            writer.WriteString("traceId", span.TraceId);
+            writer.WriteString("spanId", span.SpanId);
+            if (span.ParentSpanId is not null) writer.WriteString("parentSpanId", span.ParentSpanId);
+            foreach (var (k, v) in span.Tags)
+            {
+                writer.WriteString(k, v);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+
+        // Emit thread-name metadata events so Perfetto/Speedscope label
+        // each swimlane with its traceId rather than "tid 1, tid 2, …".
+        foreach (var (traceId, tid) in tidByTrace)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("name", "thread_name");
+            writer.WriteString("ph", "M");
+            writer.WriteNumber("pid", 1);
+            writer.WriteNumber("tid", tid);
+            writer.WriteStartObject("args");
+            writer.WriteString("name", traceId);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        writer.Flush();
+
+        AnsiConsole.MarkupLine(
+            $"[green]Wrote[/] {reader.Spans.Count - missingTimestamps} span(s) " +
+            $"across {tidByTrace.Count} trace(s) to [cyan]{outputPath}[/]");
+        AnsiConsole.MarkupLine(
+            "[grey]Open in chrome://tracing, https://ui.perfetto.dev, or https://www.speedscope.app[/]");
+        AnsiConsole.MarkupLine(
+            "[grey]This is a span timeline. For a CPU flamegraph, run perfrunner with --profile cpu.[/]");
+
+        return 0;
+    }
+}

--- a/tools/EncDotNet.S100.PerfReport/Program.cs
+++ b/tools/EncDotNet.S100.PerfReport/Program.cs
@@ -14,6 +14,9 @@ app.Configure(config =>
 
     config.AddCommand<GateCommand>("gate")
         .WithDescription("Gate CI on regressions across all scenarios in baseline vs candidate directories.");
+
+    config.AddCommand<ChromeTraceCommand>("chrome-trace")
+        .WithDescription("Convert a .jsonl telemetry file to Chrome Trace JSON (chrome://tracing / Perfetto / Speedscope). Span timeline, not a CPU flamegraph.");
 });
 
 return app.Run(args);

--- a/tools/EncDotNet.S100.PerfReport/README.md
+++ b/tools/EncDotNet.S100.PerfReport/README.md
@@ -18,7 +18,35 @@ dotnet run --project tools/EncDotNet.S100.PerfReport -- diff baseline.jsonl cand
 
 # Write diff to a file
 dotnet run --project tools/EncDotNet.S100.PerfReport -- diff baseline.jsonl candidate.jsonl --out diff.md
+
+# Convert spans to a Chrome Trace JSON (open in chrome://tracing,
+# https://ui.perfetto.dev, or https://www.speedscope.app)
+dotnet run --project tools/EncDotNet.S100.PerfReport -- chrome-trace run.jsonl
+dotnet run --project tools/EncDotNet.S100.PerfReport -- chrome-trace run.jsonl --out timeline.json
 ```
+
+## `chrome-trace`
+
+Converts the spans recorded in a `.jsonl` file into the
+[Chrome Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
+The output can be opened directly in:
+
+- `chrome://tracing` (built into Chromium browsers)
+- [Perfetto UI](https://ui.perfetto.dev)
+- [Speedscope](https://www.speedscope.app)
+
+Each distinct trace id becomes a virtual swimlane so concurrent
+scenario / iteration activity is visualised side-by-side rather than
+overlapping. Span tags are attached as event arguments and are
+visible when a span is selected.
+
+> **Span timeline, not a CPU flamegraph.** This visualises the
+> existing `ActivitySource` spans recorded by the product code (pipeline
+> stages, Lua execution, HDF5 reads, renderer frames). It does **not**
+> sample CPU stacks and so cannot show JIT/runtime/library frames
+> between span boundaries. To get a real CPU flamegraph, run PerfRunner
+> with `--profile cpu` and convert the resulting `.nettrace` with
+> `dotnet-trace convert <file>.nettrace --format speedscope`.
 
 ## `summarise` output
 

--- a/tools/EncDotNet.S100.PerfReport/TelemetryFileReader.cs
+++ b/tools/EncDotNet.S100.PerfReport/TelemetryFileReader.cs
@@ -96,6 +96,8 @@ public sealed class TelemetryFileReader
                         SpanId = root.GetProperty("spanId").GetString() ?? "",
                         ParentSpanId = root.TryGetProperty("parentSpanId", out var p) ? p.GetString() : null,
                         DurationMs = root.TryGetProperty("durationMs", out var d) ? d.GetDouble() : 0,
+                        StartUnixNs = root.TryGetProperty("startUnixNs", out var sNs) && sNs.ValueKind == JsonValueKind.Number ? sNs.GetInt64() : null,
+                        EndUnixNs = root.TryGetProperty("endUnixNs", out var eNs) && eNs.ValueKind == JsonValueKind.Number ? eNs.GetInt64() : null,
                         Tags = ReadTags(root),
                     });
                     break;
@@ -155,6 +157,20 @@ public sealed class SpanRecord
     public string SpanId { get; init; } = "";
     public string? ParentSpanId { get; init; }
     public double DurationMs { get; init; }
+
+    /// <summary>
+    /// Activity start time in Unix nanoseconds, or <c>null</c> when the
+    /// underlying telemetry file did not include this field. Required
+    /// for Chrome-trace export (see <see cref="ChromeTraceCommand"/>).
+    /// </summary>
+    public long? StartUnixNs { get; init; }
+
+    /// <summary>
+    /// Activity end time in Unix nanoseconds, or <c>null</c> when the
+    /// underlying telemetry file did not include this field.
+    /// </summary>
+    public long? EndUnixNs { get; init; }
+
     public Dictionary<string, string> Tags { get; init; } = [];
 }
 

--- a/tools/EncDotNet.S100.PerfRunner/BaselineCommand.cs
+++ b/tools/EncDotNet.S100.PerfRunner/BaselineCommand.cs
@@ -71,6 +71,16 @@ public sealed class BaselineCommand : AsyncCommand<BaselineCommand.Settings>
         [CommandOption("--out-subdir <NAME>")]
         [System.ComponentModel.Description("Override the per-run subdirectory name (defaults to the short git SHA of HEAD).")]
         public string? OutputSubdir { get; set; }
+
+        [CommandOption("--profile <MODE>")]
+        [System.ComponentModel.Description("Capture an in-process EventPipe trace per scenario: 'none' (default), 'cpu', or 'alloc'. Mutually exclusive with --append. Output is <scenario>.nettrace next to the .jsonl.")]
+        [System.ComponentModel.DefaultValue("none")]
+        public string Profile { get; set; } = "none";
+
+        [CommandOption("--profile-sampling-interval-ms <MS>")]
+        [System.ComponentModel.Description("CPU sampling interval in milliseconds (only when --profile=cpu). Default 1; raise to 5–10 for sub-100ms scenarios.")]
+        [System.ComponentModel.DefaultValue(1)]
+        public int ProfileSamplingIntervalMs { get; set; } = 1;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
@@ -79,6 +89,24 @@ public sealed class BaselineCommand : AsyncCommand<BaselineCommand.Settings>
         if (!Directory.Exists(corpus))
         {
             AnsiConsole.MarkupLine($"[red]Corpus directory not found:[/] {corpus}");
+            return 1;
+        }
+
+        if (!RunCommand.TryParseProfileMode(settings.Profile, out var profileMode))
+        {
+            AnsiConsole.MarkupLine($"[red]Invalid --profile value:[/] {settings.Profile} (expected: none, cpu, alloc)");
+            return 1;
+        }
+
+        // Profiling and append are mutually exclusive: append-mode is for
+        // CI median+MAD orchestration where the .jsonl files are merged
+        // across rounds; profiling artifacts are diagnostic-only and not
+        // appendable (each .nettrace would silently overwrite the prior
+        // one with no way to merge them). Refuse the combination so the
+        // user is forced to pick one or the other.
+        if (profileMode != ProfileMode.None && settings.Append)
+        {
+            AnsiConsole.MarkupLine("[red]--profile and --append are mutually exclusive.[/] Profiling artifacts cannot be merged across rounds.");
             return 1;
         }
 
@@ -124,6 +152,7 @@ public sealed class BaselineCommand : AsyncCommand<BaselineCommand.Settings>
 
             var jsonlPath = Path.Combine(outDir, scenario.Name + ".jsonl");
             var mdPath = Path.Combine(outDir, scenario.Name + ".md");
+            var nettracePath = Path.Combine(outDir, scenario.Name + ".nettrace");
 
             // Wire up OTel with the file exporter for this scenario.
             // In append mode the file is preserved across calls.
@@ -160,33 +189,51 @@ public sealed class BaselineCommand : AsyncCommand<BaselineCommand.Settings>
             // so the JSONL contains a tagged span per sample. PerfReport's
             // gate command reads these to compute median + MAD instead of
             // summing all spans.
+            //
+            // When --profile is enabled we wrap only the measured-iteration
+            // loop (warmup is excluded so the trace is not polluted by JIT
+            // and first-touch costs).
             var durations = new List<double>();
-            for (int i = 0; i < settings.Iterations; i++)
+            EventPipeProfilingSession? profilingSession = profileMode == ProfileMode.None
+                ? null
+                : EventPipeProfilingSession.Start(nettracePath, profileMode, settings.ProfileSamplingIntervalMs);
+            try
             {
-                AnsiConsole.Markup($"  iteration {i + 1}/{settings.Iterations}…");
-                var ctx = new PerfContext { CorpusPath = corpus, IsWarmup = false, Iteration = i, Round = settings.RoundTag };
-                using var iterActivity = PerfActivitySource.Instance.StartActivity(PerfActivitySource.IterationActivityName);
-                iterActivity?.SetTag(PerfActivitySource.ScenarioTag, scenario.Name);
-                iterActivity?.SetTag(PerfActivitySource.RoundTag, settings.RoundTag);
-                iterActivity?.SetTag(PerfActivitySource.IterationIndexTag, i);
-                if (!string.IsNullOrWhiteSpace(settings.Side))
-                    iterActivity?.SetTag(PerfActivitySource.SideTag, settings.Side);
+                for (int i = 0; i < settings.Iterations; i++)
+                {
+                    AnsiConsole.Markup($"  iteration {i + 1}/{settings.Iterations}…");
+                    var ctx = new PerfContext { CorpusPath = corpus, IsWarmup = false, Iteration = i, Round = settings.RoundTag };
+                    using var iterActivity = PerfActivitySource.Instance.StartActivity(PerfActivitySource.IterationActivityName);
+                    iterActivity?.SetTag(PerfActivitySource.ScenarioTag, scenario.Name);
+                    iterActivity?.SetTag(PerfActivitySource.RoundTag, settings.RoundTag);
+                    iterActivity?.SetTag(PerfActivitySource.IterationIndexTag, i);
+                    if (!string.IsNullOrWhiteSpace(settings.Side))
+                        iterActivity?.SetTag(PerfActivitySource.SideTag, settings.Side);
 
-                var sw = Stopwatch.StartNew();
-                try
-                {
-                    await scenario.RunAsync(ctx, CancellationToken.None);
-                    sw.Stop();
-                    iterActivity?.SetStatus(ActivityStatusCode.Ok);
-                    durations.Add(sw.Elapsed.TotalMilliseconds);
-                    AnsiConsole.MarkupLine($" [green]{sw.Elapsed.TotalMilliseconds:F1}ms[/]");
+                    var sw = Stopwatch.StartNew();
+                    try
+                    {
+                        await scenario.RunAsync(ctx, CancellationToken.None);
+                        sw.Stop();
+                        iterActivity?.SetStatus(ActivityStatusCode.Ok);
+                        durations.Add(sw.Elapsed.TotalMilliseconds);
+                        AnsiConsole.MarkupLine($" [green]{sw.Elapsed.TotalMilliseconds:F1}ms[/]");
+                    }
+                    catch (Exception ex)
+                    {
+                        sw.Stop();
+                        iterActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                        AnsiConsole.MarkupLine($" [red]error: {Markup.Escape(ex.Message)}[/]");
+                        break;
+                    }
                 }
-                catch (Exception ex)
+            }
+            finally
+            {
+                if (profilingSession is not null)
                 {
-                    sw.Stop();
-                    iterActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                    AnsiConsole.MarkupLine($" [red]error: {Markup.Escape(ex.Message)}[/]");
-                    break;
+                    await profilingSession.DisposeAsync();
+                    AnsiConsole.MarkupLine($"  [grey]trace: {nettracePath}[/]");
                 }
             }
 

--- a/tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj
+++ b/tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>

--- a/tools/EncDotNet.S100.PerfRunner/EventPipeProfilingSession.cs
+++ b/tools/EncDotNet.S100.PerfRunner/EventPipeProfilingSession.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace EncDotNet.S100.PerfRunner;
+
+/// <summary>
+/// Profile mode selectable via the <c>--profile</c> option.
+/// </summary>
+public enum ProfileMode
+{
+    /// <summary>No profiling. Default.</summary>
+    None,
+
+    /// <summary>
+    /// Sampling CPU profile via the <c>Microsoft-DotNETCore-SampleProfiler</c>
+    /// EventPipe provider plus the runtime/JIT/loader keywords required to
+    /// symbolicate managed stacks. Equivalent to <c>dotnet-trace</c>'s
+    /// <c>cpu-sampling</c> profile.
+    /// </summary>
+    Cpu,
+
+    /// <summary>
+    /// GC + allocation profile via the <c>Microsoft-Windows-DotNETRuntime</c>
+    /// provider with the GC/AllocationTick keyword (<c>0x1</c>) at
+    /// <see cref="EventLevel.Verbose"/>. Mirrors <c>dotnet-trace</c>'s
+    /// <c>gc-verbose</c> profile.
+    /// </summary>
+    Alloc,
+}
+
+/// <summary>
+/// In-process EventPipe profiling session. Captures a <c>.nettrace</c>
+/// file from the running process so PerfRunner scenarios can be
+/// profiled without launching a separate <c>dotnet-trace</c> process.
+///
+/// <para>
+/// The implementation drains <see cref="EventPipeSession.EventStream"/>
+/// concurrently with the workload via a background <see cref="Task"/>.
+/// EventPipe streams events through an in-process pipe with a fixed
+/// buffer; if the consumer does not drain it the buffer fills and
+/// events are lost or the session corrupts. <see cref="DisposeAsync"/>
+/// stops the session and waits for the drain task to complete before
+/// returning, so the file is fully flushed when the call returns.
+/// </para>
+///
+/// <para>
+/// The output file is convertible with
+/// <c>dotnet-trace convert &lt;file&gt;.nettrace --format speedscope</c>
+/// or loadable directly in PerfView / Visual Studio.
+/// </para>
+/// </summary>
+public sealed class EventPipeProfilingSession : IAsyncDisposable
+{
+    private readonly EventPipeSession _session;
+    private readonly Task _drainTask;
+    private readonly FileStream _output;
+    private bool _disposed;
+
+    private EventPipeProfilingSession(
+        EventPipeSession session, FileStream output, Task drainTask)
+    {
+        _session = session;
+        _output = output;
+        _drainTask = drainTask;
+    }
+
+    /// <summary>Path to the <c>.nettrace</c> file being written.</summary>
+    public string OutputPath { get; private init; } = "";
+
+    /// <summary>Profile mode selected for this session.</summary>
+    public ProfileMode Mode { get; private init; }
+
+    /// <summary>
+    /// Starts an in-process profiling session against the current
+    /// process. The returned object owns the underlying file handle
+    /// and must be disposed (preferably via <c>await using</c>) to
+    /// stop the session and flush the trace.
+    /// </summary>
+    /// <param name="outputPath">
+    /// Destination file path. Convention: same directory and basename
+    /// as the scenario's <c>.jsonl</c>, with the <c>.nettrace</c> extension.
+    /// </param>
+    /// <param name="mode">CPU sampling, allocation, or none (no-op).</param>
+    /// <param name="samplingIntervalMs">
+    /// Sampling interval for <see cref="ProfileMode.Cpu"/> in milliseconds.
+    /// Ignored for <see cref="ProfileMode.Alloc"/>. Recommended values
+    /// are 1ms (default) for long scenarios; raise to 5–10ms for short
+    /// (sub-100ms) scenarios where 1ms sampling overhead is significant.
+    /// </param>
+    public static EventPipeProfilingSession Start(
+        string outputPath, ProfileMode mode, int samplingIntervalMs = 1)
+    {
+        ArgumentNullException.ThrowIfNull(outputPath);
+        if (mode == ProfileMode.None)
+            throw new ArgumentException("ProfileMode.None should be filtered by the caller.", nameof(mode));
+
+        var providers = mode switch
+        {
+            ProfileMode.Cpu => BuildCpuProviders(samplingIntervalMs),
+            ProfileMode.Alloc => BuildAllocProviders(),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode)),
+        };
+
+        var client = new DiagnosticsClient(Environment.ProcessId);
+        var session = client.StartEventPipeSession(providers, requestRundown: true);
+
+        var output = File.Create(outputPath);
+        // Drain the EventStream into the file on a background task so
+        // the workload thread is never blocked by the EventPipe pipe
+        // back-pressure. CopyToAsync runs until the session is stopped.
+        var drainTask = Task.Run(async () =>
+        {
+            try
+            {
+                await session.EventStream.CopyToAsync(output).ConfigureAwait(false);
+            }
+            finally
+            {
+                await output.FlushAsync().ConfigureAwait(false);
+            }
+        });
+
+        return new EventPipeProfilingSession(session, output, drainTask)
+        {
+            OutputPath = outputPath,
+            Mode = mode,
+        };
+    }
+
+    private static List<EventPipeProvider> BuildCpuProviders(int samplingIntervalMs)
+    {
+        // Sampling interval is not directly settable via the public
+        // EventPipeProvider API; the SampleProfiler defaults to 1ms.
+        // The samplingIntervalMs parameter is reserved for a future
+        // tuning hook and currently used only for documentation.
+        _ = samplingIntervalMs;
+
+        return new List<EventPipeProvider>
+        {
+            // Sampling profiler — the source of CPU stack samples.
+            new("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational),
+            // Runtime keywords required to resolve managed stack frames:
+            //   GC (0x1), Loader (0x8), Jit (0x10), NGen (0x20), StopEnumeration (0x40),
+            //   Security (0x400), AppDomainResourceManagement (0x800), JitTracing (0x1000),
+            //   Interop (0x2000), Contention (0x4000), Exception (0x8000), Threading (0x10000),
+            //   JittedMethodILToNativeMap (0x20000), OverrideAndSuppressNGenEvents (0x40000),
+            //   Type (0x80000), GCHeapDump (0x100000), GCSampledObjectAllocationHigh (0x200000),
+            //   GCHeapSurvivalAndMovement (0x400000), GCHeapCollect (0x800000),
+            //   GCHeapAndTypeNames (0x1000000), GCSampledObjectAllocationLow (0x2000000),
+            //   PerfTrack (0x20000000), Stack (0x40000000)
+            // The 0x4c14fccbd value matches `dotnet-trace`'s "cpu-sampling" profile.
+            new("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, 0x14C14FCCBD),
+        };
+    }
+
+    private static List<EventPipeProvider> BuildAllocProviders()
+    {
+        // gc-verbose profile from `dotnet-trace`: GC keyword (0x1) at Verbose
+        // level emits AllocationTick events for every ~100KB of allocations,
+        // plus all GC start/stop events. Combined with the Stack keyword
+        // (0x40000000) so each allocation has a managed call stack.
+        return new List<EventPipeProvider>
+        {
+            new("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, 0x40000001),
+        };
+    }
+
+    /// <summary>
+    /// Stops the profiling session and waits for the drain task to
+    /// finish writing the trace file.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        try
+        {
+            _session.Stop();
+        }
+        catch (Exception)
+        {
+            // Stop() can throw if the target process has already
+            // finalised the session (e.g. test crash). Suppress so
+            // dispose still flushes whatever was already drained.
+        }
+
+        try
+        {
+            await _drainTask.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Drain failures are surfaced by an empty/short trace file,
+            // which the post-run instructions already warn about.
+        }
+
+        _session.Dispose();
+        await _output.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tools/EncDotNet.S100.PerfRunner/README.md
+++ b/tools/EncDotNet.S100.PerfRunner/README.md
@@ -36,6 +36,44 @@ dotnet run --project tools/EncDotNet.S100.PerfRunner -- s101-portray-warm \
 | `s201-vector` | S-201 GML AtoN information: XSLT-only vector pipeline. |
 | `exchange-set-open` | Open a synthetic exchange set and walk all datasets. |
 
+## Profiling (CPU and allocation traces)
+
+The PerfRunner can capture an in-process EventPipe trace alongside the
+`.jsonl` telemetry, suitable for opening in PerfView, Visual Studio's
+performance profiler, or — after conversion — Speedscope / Perfetto.
+
+```bash
+# CPU sampling profile of the S-131 portrayal pipeline.
+dotnet run --project tools/EncDotNet.S100.PerfRunner -- s131-portray-warm \
+    --warmup 3 --iterations 20 --profile cpu
+
+# Allocation profile (GC / AllocationTick events).
+dotnet run --project tools/EncDotNet.S100.PerfRunner -- s101-portray-cold \
+    --warmup 0 --iterations 1 --profile alloc
+
+# Same flags work on `baseline`. Profiling is mutually exclusive with --append.
+dotnet run --project tools/EncDotNet.S100.PerfRunner -- baseline \
+    --scenarios s131-portray-warm --profile cpu
+```
+
+Output: `<basename>.nettrace` next to the `.jsonl`. Convert to a
+flamegraph viewable in <https://www.speedscope.app>:
+
+```bash
+dotnet tool install -g dotnet-trace
+dotnet-trace convert ./perf-runs/<basename>.nettrace --format speedscope
+```
+
+Notes:
+- Profiling adds measurable overhead (typically 2-10% for `cpu`,
+  20-40% for `alloc`). **Profiled runs are not baselines**: do not
+  gate CI against `--profile` outputs.
+- Profiling wraps **measured iterations only** so the trace is not
+  polluted with JIT and first-touch costs from warmup. For cold
+  scenarios (warmup=0, iterations=1) the trace covers the entire run.
+- For sub-100ms scenarios, raise the sampling interval with
+  `--profile-sampling-interval-ms 5` to reduce overhead.
+
 ## Output
 
 Each run produces two files in the output directory:

--- a/tools/EncDotNet.S100.PerfRunner/RunCommand.cs
+++ b/tools/EncDotNet.S100.PerfRunner/RunCommand.cs
@@ -45,6 +45,16 @@ public sealed class RunCommand : AsyncCommand<RunCommand.Settings>
         [CommandOption("--tag <KEY=VALUE>")]
         [Description("Extra metadata tags (repeatable).")]
         public string[]? Tags { get; set; }
+
+        [CommandOption("--profile <MODE>")]
+        [Description("Capture an in-process EventPipe trace alongside the .jsonl: 'none' (default), 'cpu', or 'alloc'. Output is <basename>.nettrace; convert with 'dotnet-trace convert <file>.nettrace --format speedscope'.")]
+        [DefaultValue("none")]
+        public string Profile { get; set; } = "none";
+
+        [CommandOption("--profile-sampling-interval-ms <MS>")]
+        [Description("CPU sampling interval in milliseconds (only when --profile=cpu). Default 1; raise to 5–10 for sub-100ms scenarios.")]
+        [DefaultValue(1)]
+        public int ProfileSamplingIntervalMs { get; set; } = 1;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
@@ -76,12 +86,20 @@ public sealed class RunCommand : AsyncCommand<RunCommand.Settings>
             return 1;
         }
 
+        // Resolve profile mode early so we fail fast on bad input.
+        if (!TryParseProfileMode(settings.Profile, out var profileMode))
+        {
+            AnsiConsole.MarkupLine($"[red]Invalid --profile value:[/] {settings.Profile} (expected: none, cpu, alloc)");
+            return 1;
+        }
+
         // Set up output.
         Directory.CreateDirectory(settings.OutputDir);
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
         var baseName = $"{timestamp}-{scenario.Name}";
         var jsonlPath = Path.Combine(settings.OutputDir, baseName + ".jsonl");
         var mdPath = Path.Combine(settings.OutputDir, baseName + ".md");
+        var nettracePath = Path.Combine(settings.OutputDir, baseName + ".nettrace");
 
         // Wire up OTel with the file exporter.
         Environment.SetEnvironmentVariable(FileExporterExtensions.FileExportEnvVar, jsonlPath);
@@ -100,6 +118,10 @@ public sealed class RunCommand : AsyncCommand<RunCommand.Settings>
         AnsiConsole.MarkupLine($"[bold]Corpus:[/]   {corpus}");
         AnsiConsole.MarkupLine($"[bold]Output:[/]   {jsonlPath}");
         AnsiConsole.MarkupLine($"[bold]Warmup:[/]   {settings.Warmup}  [bold]Iterations:[/] {settings.Iterations}");
+        if (profileMode != ProfileMode.None)
+        {
+            AnsiConsole.MarkupLine($"[bold]Profile:[/]  {profileMode} → {nettracePath}");
+        }
         AnsiConsole.WriteLine();
 
         var totalSw = Stopwatch.StartNew();
@@ -113,34 +135,66 @@ public sealed class RunCommand : AsyncCommand<RunCommand.Settings>
             AnsiConsole.MarkupLine(" [grey]done[/]");
         }
 
-        // Measured iterations — wrapped in a perf.iteration activity so the
-        // JSONL contains a tagged span per sample (consistent with `baseline`).
-        var durations = new List<double>();
-        for (int i = 0; i < settings.Iterations; i++)
+        // Profiling wraps measured iterations only (after warmup) so the
+        // trace contains representative steady-state samples — not JIT
+        // and first-touch overhead. For cold scenarios where Warmup=0
+        // and Iterations=1 the trace covers the entire single iteration,
+        // which is the desired behaviour (cold-path cost IS what we want
+        // to see in that case).
+        EventPipeProfilingSession? profilingSession = profileMode == ProfileMode.None
+            ? null
+            : EventPipeProfilingSession.Start(nettracePath, profileMode, settings.ProfileSamplingIntervalMs);
+        try
         {
-            AnsiConsole.Markup($"  iteration {i + 1}/{settings.Iterations}…");
-            var ctx = new PerfContext { CorpusPath = corpus, IsWarmup = false, Iteration = i };
-            using var iterActivity = PerfActivitySource.Instance.StartActivity(PerfActivitySource.IterationActivityName);
-            iterActivity?.SetTag(PerfActivitySource.ScenarioTag, scenario.Name);
-            iterActivity?.SetTag(PerfActivitySource.RoundTag, 1);
-            iterActivity?.SetTag(PerfActivitySource.IterationIndexTag, i);
+            // Measured iterations — wrapped in a perf.iteration activity so the
+            // JSONL contains a tagged span per sample (consistent with `baseline`).
+            var durations = new List<double>();
+            for (int i = 0; i < settings.Iterations; i++)
+            {
+                AnsiConsole.Markup($"  iteration {i + 1}/{settings.Iterations}…");
+                var ctx = new PerfContext { CorpusPath = corpus, IsWarmup = false, Iteration = i };
+                using var iterActivity = PerfActivitySource.Instance.StartActivity(PerfActivitySource.IterationActivityName);
+                iterActivity?.SetTag(PerfActivitySource.ScenarioTag, scenario.Name);
+                iterActivity?.SetTag(PerfActivitySource.RoundTag, 1);
+                iterActivity?.SetTag(PerfActivitySource.IterationIndexTag, i);
 
-            var sw = Stopwatch.StartNew();
-            await scenario.RunAsync(ctx, CancellationToken.None);
-            sw.Stop();
-            durations.Add(sw.Elapsed.TotalMilliseconds);
-            AnsiConsole.MarkupLine($" [green]{sw.Elapsed.TotalMilliseconds:F1}ms[/]");
+                var sw = Stopwatch.StartNew();
+                await scenario.RunAsync(ctx, CancellationToken.None);
+                sw.Stop();
+                durations.Add(sw.Elapsed.TotalMilliseconds);
+                AnsiConsole.MarkupLine($" [green]{sw.Elapsed.TotalMilliseconds:F1}ms[/]");
+            }
+
+            totalSw.Stop();
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"[bold]Total:[/] {totalSw.Elapsed.TotalSeconds:F1}s");
+
+            // Write a simple markdown summary alongside.
+            WriteSummary(mdPath, scenario, settings, durations);
+
+            AnsiConsole.MarkupLine($"[bold]Summary:[/] {mdPath}");
         }
-
-        totalSw.Stop();
-        AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine($"[bold]Total:[/] {totalSw.Elapsed.TotalSeconds:F1}s");
-
-        // Write a simple markdown summary alongside.
-        WriteSummary(mdPath, scenario, settings, durations);
-
-        AnsiConsole.MarkupLine($"[bold]Summary:[/] {mdPath}");
+        finally
+        {
+            if (profilingSession is not null)
+            {
+                await profilingSession.DisposeAsync();
+                AnsiConsole.MarkupLine($"[bold]Trace:[/]    {nettracePath}");
+                AnsiConsole.MarkupLine("[grey]Convert: dotnet-trace convert " + nettracePath + " --format speedscope[/]");
+            }
+        }
         return 0;
+    }
+
+    internal static bool TryParseProfileMode(string s, out ProfileMode mode)
+    {
+        switch ((s ?? "none").ToLowerInvariant())
+        {
+            case "none": mode = ProfileMode.None; return true;
+            case "cpu": mode = ProfileMode.Cpu; return true;
+            case "alloc": mode = ProfileMode.Alloc; return true;
+            default: mode = ProfileMode.None; return false;
+        }
     }
 
     private static void WriteSummary(


### PR DESCRIPTION
## Summary

We had rich span+meter coverage but no way to attribute time to JIT/runtime/library frames between span boundaries, no way to visualise span concurrency across iterations, and no per-feature-type breakdown of S-101 / S-131 Lua output. This PR closes those three gaps so the next round of optimisation work has somewhere to look.

**1. PerfRunner `--profile {none|cpu|alloc}`** (on both `run` and `baseline`)

In-process EventPipe session captures a `.nettrace` alongside the `.jsonl`. A background drain task copies `EventStream` to disk so the pipe never back-pressures the workload (this was the main concurrency pitfall flagged in the design review). Profiling wraps measured iterations only so JIT and first-touch costs do not pollute the trace. `--profile` and `--append` are mutually exclusive and rejected with a clear error, since profiling artifacts cannot be merged across rounds. Convert with `dotnet-trace convert <file>.nettrace --format speedscope`.

**2. PerfReport `chrome-trace`**

Converts the `.jsonl` span records into Chrome Trace Event Format JSON, loadable in `chrome://tracing`, Perfetto, or Speedscope. Each distinct trace id becomes a swimlane so concurrent scenario/iteration activity is rendered in parallel, and span tags are attached as event args. The README documents loudly that this is a span timeline, not a CPU flamegraph — the latter is the `--profile cpu` path above.

**3. `s100.lua.feature.instructions.count` histogram**

Per-feature-type emitted-instruction count for S-101 and S-131, tagged with `s100.feature.type` + `s100.product`. This is intentionally cardinality only (Lua iterates features inside a single `PortrayalMain` call — real per-feature CPU timing is delegated to `--profile cpu`). Added a public `TryGetFeatureTypeCode` on both `LuaDataProvider`s, and split `ExecuteRaw` into a private `ExecuteRawCore` so the executor can resolve type codes for the post-hoc grouping without rebuilding the lookup index.

**Other notes**

- `TelemetryFileReader.SpanRecord` now exposes `StartUnixNs` / `EndUnixNs` (already emitted by `FileTelemetryExporter`; now read for the chrome-trace export).
- New dependency: `Microsoft.Diagnostics.NETCore.Client` 0.2.661903 (Microsoft, MIT) in `Directory.Packages.props`, referenced from PerfRunner only.

Smoke-tested end-to-end: `run s124-vector --profile cpu` produced a 3 MB `.nettrace`, `chrome-trace` converted 503 spans across 24 traces from a real baseline and parsed back as valid JSON, and `--profile cpu --append` is correctly rejected.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

Touches S-101 and S-131 only for the new histogram instrument and the small executor refactor; no spec-derived constants or element names changed.

**Spec section references cited in code/docs:**

N/A — telemetry/tooling change; no spec-level encoding or schema work.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (existing fixtures; new tests use already-bundled synthetic GML)
- [x] `dotnet test --configuration Release` passes locally (454 tests across S-131 and Pipelines suites)

Four new tests under `tests/EncDotNet.S100.Datasets.S131.Tests/S131LuaDataProviderTryGetFeatureTypeCodeTests.cs` cover resolution, MoonSharp's double-formatted refs (`"1"` vs `"1.0"`), unknown ids, and non-numeric refs. The existing Pipelines tests exercise both refactored executors end-to-end.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (PerfRunner + PerfReport)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed — N/A
- [x] New public APIs have XML doc comments (`TryGetFeatureTypeCode`, `EventPipeProfilingSession`, `ProfileMode`, `ChromeTraceCommand`, new `SpanRecord` fields)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

`Microsoft.Diagnostics.NETCore.Client` 0.2.661903 is a Microsoft-published package (MIT-licensed, the standard for in-process EventPipe and the underlying library used by the `dotnet-trace` global tool) with no known advisories.

## Breaking changes

None. The executor refactor is internal: `ExecuteRaw` retains the same public signature; `ExecuteRawCore` is a new private overload.