### PR TITLE
PR-D4: pick support for dynamic feature sources

### DIFF
--- a/docs/design/dynamic-source-pick.md
+++ b/docs/design/dynamic-source-pick.md
@@ -1,0 +1,162 @@
+# Dynamic Source Pick — Design Note (PR-D4)
+
+> Status: **In progress** — describes the click-to-identify support
+> for dynamic feature sources shipped by PR-D4. See
+> [Dynamic feature sources](dynamic-feature-source.md) for the
+> underlying push-driven abstraction (PR-D1) and
+> [AIS dynamic feature source](ais-source.md) for the motivating
+> AIS overlay (PR-D3).
+
+## 0. Problem
+
+PR-D3 wired AIS targets and own-ship onto the map via
+`DynamicSourceOverlayHost`. The overlay layers are pure rendering —
+they carry no Mapsui feature attributes and are *not* enumerated by
+the existing `IPickService.HandlePick(MapInfo)` path, which only
+walks dataset-owned layers. Clicking an AIS target therefore does
+nothing.
+
+PR-D4 closes the gap: a click anywhere on the map collects both
+dataset hits (existing path) and dynamic-source hits (new path) and
+displays them side-by-side in the Pick Report panel.
+
+## 1. Decisions
+
+### Q1. Pick-hit shape — **sibling type**
+
+`DynamicPickHit` is a new internal record next to `PickHit`.
+
+```
+internal sealed record DynamicPickHit(
+    string SourceId,
+    string SourceDisplayName,
+    string FeatureId,
+    string? Kind,
+    string DisplayLabel,
+    DateTimeOffset LastUpdated,
+    double Latitude,
+    double Longitude,
+    DynamicMotion? Motion,
+    DynamicVesselGeometry? VesselGeometry,
+    IReadOnlyList<DynamicPickAttributeRow> Attributes);
+```
+
+Rationale: `PickHit` is dataset-centric (FC-decoded feature type,
+xlink references, dataset file name, station chart VM). Dynamic
+features have a fundamentally different identity model — opaque
+string id (MMSI for AIS, `"ownship"`), no FC, mutable position, free-
+form `Attributes` dictionary. Mixing them invites optional-field
+bloat. The pick report panel renders both with a small dispatch.
+
+### Q2. Hit-test geometry & tolerance — **12 device-pixel radius, point-distance only for v1**
+
+Hit testing happens in projected map units (Spherical Mercator). The
+click delivers `(MPoint mapPoint, double resolution)`; tolerance is
+`12 * resolution` (12 device pixels at the current zoom). Dynamic
+features are converted with `SphericalMercator.FromLonLat`.
+
+For v1 the tester treats every dynamic feature as a point regardless
+of its `GeometryType` — only `Point` features ship today
+(own-ship + AIS). When line/polygon dynamic features land they will
+get their own paths via `Geometry.Distance`; this is noted in the
+contract docs but unimplemented.
+
+Per-renderer custom tolerance (e.g. "anywhere inside the hull
+polygon") is **out of scope for v1** — see §3.
+
+### Q3. Where pick is wired — **separate `IDynamicSourcePickService`**
+
+A new service runs alongside `IPickService`. The click handler
+(`MapInteractionController`) computes the world position from the
+`MapInfo`, asks the dynamic-source service for hits, and forwards
+both result lists to `IPickService.HandlePick(MapInfo, IReadOnlyList<DynamicPickHit>)`.
+The pick service publishes both into `PickReportViewModel`.
+
+Reasons:
+- Different storage (registry of `IDynamicFeatureSource` vs loader
+  of `IDatasetProcessor`).
+- Easier to test (no `MapInfo` mocking; pure pixel math).
+- Keeps `PickService` from becoming a god service.
+
+### Q4. Pick report panel UI — **sectioned single list**
+
+The panel grows a third section between the dataset hit-list and
+the identity / attributes block:
+
+```
+┌─ FEATURES (3)              ─┐  ← existing dataset hit list (>1)
+│  • Cargo vessel — MV ALPHA   │
+│  • DepthArea — 12345         │
+└──────────────────────────────┘
+┌─ DYNAMIC FEATURES (1)      ─┐  ← new: shown when DynamicHits ≠ ∅
+│  AIS — vessel.ais.cargo      │
+│    MV ALPHA · 4s ago         │
+│    47.602°N 122.330°W        │
+│    COG 270° · SOG 12.4 kn    │
+│    MMSI: 367123456            │
+│    …                          │
+└──────────────────────────────┘
+[identity / references / attributes block — dataset only]
+```
+
+Both sections are visible at once when both have hits. Dataset
+section is hidden when `Hits.Count == 0`; dynamic section is hidden
+when `DynamicHits.Count == 0`. `HasPick` is now true if **either**
+list is non-empty.
+
+### Q5. Localisation — **all new strings via Strings.resx**
+
+Keys added: `PickReport_DynamicSection`, `PickReport_LastUpdatedRelative`,
+`PickReport_Mmsi`, `PickReport_VesselName`, `PickReport_CallSign`,
+`PickReport_Heading`, `PickReport_Cog`, `PickReport_Sog`,
+`PickReport_Dimensions`, `PickReport_Position`, `Tooltip_DynamicHit`.
+Tooltips on every new control.
+
+### Q6. Selection / highlight — **deferred**
+
+A future PR will add an S-52-style square selection ring drawn
+around the picked dynamic feature. Out of scope for PR-D4.
+
+## 2. Threading & lifetime
+
+- `DynamicSourcePickService` is constructed against the existing
+  `DynamicFeatureSourceRegistryAccessor` (late-bound; the host
+  attaches the registry when MainWindow finishes wiring). When the
+  registry is unattached, `Pick(...)` returns an empty list — the
+  click is a dataset-only pick, not an error.
+- `IDynamicFeatureSource.CurrentFeatures` is documented as safe from
+  any thread; the pick service is called on the UI thread (click
+  handler) and reads the immutable snapshot.
+- The hit-tester is pure and stateless; tests drive it directly.
+
+## 3. Out of scope
+
+- Selection ring / highlight on the map.
+- ARPA-style multi-target track viewer.
+- AIS aids-to-navigation, base stations, SAR aircraft.
+- CPA / TCPA computations.
+- Picking on time-step coverage products (S-102 / S-104 / S-111) —
+  goes through dataset pick.
+- Server-side / MCP exposure of dynamic picks.
+- Per-source custom hit-test geometry (e.g. polygon hull regions).
+  Easy follow-up: the `IDynamicSourceHitTester` becomes pluggable
+  per `RendererKey`.
+
+## 4. Test surfaces
+
+- `DynamicSourceHitTesterTests` — point-in-tolerance hits, miss,
+  visibility filter, ordering by distance, multiple sources.
+- `DynamicSourcePickServiceTests` — integration with a fake
+  registry; hits flow through the registry accessor.
+- `PickReportViewModelTests` — `SetDynamicPicks` populates the
+  `DynamicHits` collection and flips `HasPick` true; clears revert.
+- `PickServiceTests` — calling `HandlePick(null, dynamicHits)`
+  publishes the dynamic hits even with no `MapInfo`.
+
+## 5. References
+
+- S-52 / IEC 62388 — vessel symbology and pick ergonomics.
+- IEC 61174 §8 — ECDIS interrogation requirements (aspirational;
+  the standard does not normatively define dynamic-target
+  interrogation, but the "show all object info under the cursor"
+  pattern is the governing convention).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -14,5 +14,7 @@
       href: design/own-ship-symbology.md
     - name: AIS dynamic feature source
       href: design/ais-source.md
+    - name: Dynamic source pick
+      href: design/dynamic-source-pick.md
     - name: S-98 interoperability
       href: design/s98-interoperability.md

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -235,6 +235,9 @@ public partial class App : Application
         services.AddSingleton<IToastService, ToastService>();
         services.AddSingleton<IDatasetLoaderService, DatasetLoaderService>();
         services.AddSingleton<IPickService, PickService>();
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.IDynamicSourcePickService>(sp =>
+            new EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourcePickService(
+                sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.DynamicFeatureSourceRegistryAccessor>()));
         services.AddSingleton<IFeatureSearchService, FeatureSearchService>();
         services.AddSingleton<IFileDialogService, FileDialogService>();
         services.AddSingleton<IExchangeSetService, ExchangeSetService>();

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -279,7 +279,11 @@ public partial class MainWindow : ShadUI.Window
         // Enable trackpad pan/pinch/rotate gestures, single/double-tap pick,
         // long-press pick, mouse lat/lon readout, scale-bar/compass viewport
         // sync, and the zoom in/out overlay buttons.
-        var interactionController = new MapInteractionController(_viewModel, _pickService, _loader);
+        var interactionController = new MapInteractionController(
+            _viewModel,
+            _pickService,
+            _loader,
+            App.Services.GetService<EncDotNet.S100.Viewer.Services.DynamicSources.IDynamicSourcePickService>());
         interactionController.Attach(MapControl, ZoomInButton, ZoomOutButton, ZoomToExtentButton, ScaleBar, CompassRose);
 
         // Wire the map-tool controller to the map: tools are registered with

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -236,6 +236,20 @@ Own-ship visibility is controlled by its row in the **Dynamic
 Arrows** plane of the Layer Stack panel and is persisted between
 sessions.
 
+### Picking dynamic features
+
+Click (or long-press, on touch) on any dynamic-source target
+— own-ship, an AIS vessel pictogram — to identify it. The
+**Pick Report** panel renders a *Dynamic sources* section above
+the dataset hits showing the source display name, feature kind,
+last-updated relative time, position, course / heading / speed
+when available, and the full attribute snapshot (MMSI, vessel
+name, call sign, etc. for AIS). Dataset and dynamic hits stack in
+one panel so a single click reveals everything under the
+crosshair. The hit-test radius is 12 device pixels (matches the
+AIS pictogram outer disc). See
+[`docs/design/dynamic-source-pick.md`](../../docs/design/dynamic-source-pick.md).
+
 ## Optional MCP server
 
 The viewer can optionally host a Model Context Protocol server

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -416,4 +416,25 @@ internal static class Strings
     public static string Settings_AisApiKeyTooltip => Get(nameof(Settings_AisApiKeyTooltip));
     public static string Settings_AisApiKey_EnvVarHint => Get(nameof(Settings_AisApiKey_EnvVarHint));
     public static string Settings_AisApiKey_EnvVarPresent => Get(nameof(Settings_AisApiKey_EnvVarPresent));
+
+    // PR-D4: Dynamic-source pick report.
+    public static string PickReport_DynamicSection => Get(nameof(PickReport_DynamicSection));
+    public static string PickReport_LastUpdatedRelative => Get(nameof(PickReport_LastUpdatedRelative));
+    public static string PickReport_LastUpdatedSecondsAgo => Get(nameof(PickReport_LastUpdatedSecondsAgo));
+    public static string PickReport_LastUpdatedMinutesAgo => Get(nameof(PickReport_LastUpdatedMinutesAgo));
+    public static string PickReport_LastUpdatedHoursAgo => Get(nameof(PickReport_LastUpdatedHoursAgo));
+    public static string PickReport_LastUpdatedJustNow => Get(nameof(PickReport_LastUpdatedJustNow));
+    public static string PickReport_Position => Get(nameof(PickReport_Position));
+    public static string PickReport_PositionFormat => Get(nameof(PickReport_PositionFormat));
+    public static string PickReport_Cog => Get(nameof(PickReport_Cog));
+    public static string PickReport_Heading => Get(nameof(PickReport_Heading));
+    public static string PickReport_Sog => Get(nameof(PickReport_Sog));
+    public static string PickReport_DegreesFormat => Get(nameof(PickReport_DegreesFormat));
+    public static string PickReport_KnotsFormat => Get(nameof(PickReport_KnotsFormat));
+    public static string PickReport_Dimensions => Get(nameof(PickReport_Dimensions));
+    public static string PickReport_DimensionsFormat => Get(nameof(PickReport_DimensionsFormat));
+    public static string PickReport_Mmsi => Get(nameof(PickReport_Mmsi));
+    public static string PickReport_VesselName => Get(nameof(PickReport_VesselName));
+    public static string PickReport_CallSign => Get(nameof(PickReport_CallSign));
+    public static string Tooltip_DynamicHit => Get(nameof(Tooltip_DynamicHit));
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1103,4 +1103,70 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
     <value>Environment variable {0} is set; it will be used.</value>
     <comment>{0} = environment variable name.</comment>
   </data>
+
+  <!-- PR-D4: Dynamic-source pick report -->
+  <data name="PickReport_DynamicSection" xml:space="preserve">
+    <value>DYNAMIC FEATURES ({0})</value>
+    <comment>{0} = count of dynamic hits.</comment>
+  </data>
+  <data name="PickReport_LastUpdatedRelative" xml:space="preserve">
+    <value>Updated {0}</value>
+    <comment>{0} = formatted relative time string (e.g. "3s ago").</comment>
+  </data>
+  <data name="PickReport_LastUpdatedSecondsAgo" xml:space="preserve">
+    <value>{0}s ago</value>
+    <comment>{0} = whole seconds since the feature was updated.</comment>
+  </data>
+  <data name="PickReport_LastUpdatedMinutesAgo" xml:space="preserve">
+    <value>{0}m ago</value>
+    <comment>{0} = whole minutes since the feature was updated.</comment>
+  </data>
+  <data name="PickReport_LastUpdatedHoursAgo" xml:space="preserve">
+    <value>{0}h ago</value>
+    <comment>{0} = whole hours since the feature was updated.</comment>
+  </data>
+  <data name="PickReport_LastUpdatedJustNow" xml:space="preserve">
+    <value>just now</value>
+  </data>
+  <data name="PickReport_Position" xml:space="preserve">
+    <value>Position</value>
+  </data>
+  <data name="PickReport_PositionFormat" xml:space="preserve">
+    <value>{0:F4}°, {1:F4}°</value>
+    <comment>{0} = latitude, {1} = longitude. Use invariant culture.</comment>
+  </data>
+  <data name="PickReport_Cog" xml:space="preserve">
+    <value>COG</value>
+  </data>
+  <data name="PickReport_Heading" xml:space="preserve">
+    <value>Heading</value>
+  </data>
+  <data name="PickReport_Sog" xml:space="preserve">
+    <value>SOG</value>
+  </data>
+  <data name="PickReport_DegreesFormat" xml:space="preserve">
+    <value>{0:F1}°</value>
+  </data>
+  <data name="PickReport_KnotsFormat" xml:space="preserve">
+    <value>{0:F1} kn</value>
+  </data>
+  <data name="PickReport_Dimensions" xml:space="preserve">
+    <value>Dimensions</value>
+  </data>
+  <data name="PickReport_DimensionsFormat" xml:space="preserve">
+    <value>{0:F0} m × {1:F0} m</value>
+    <comment>{0} = length, {1} = beam, in metres.</comment>
+  </data>
+  <data name="PickReport_Mmsi" xml:space="preserve">
+    <value>MMSI</value>
+  </data>
+  <data name="PickReport_VesselName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="PickReport_CallSign" xml:space="preserve">
+    <value>Call sign</value>
+  </data>
+  <data name="Tooltip_DynamicHit" xml:space="preserve">
+    <value>Dynamic-source feature picked from the live overlay.</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicFeatureSourceRegistryAccessor.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicFeatureSourceRegistryAccessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using EncDotNet.S100.DynamicSources;
 
 namespace EncDotNet.S100.Viewer.Services.DynamicSources;
 
@@ -57,6 +58,9 @@ internal sealed class DynamicFeatureSourceRegistryAccessor : IDynamicFeatureSour
         _current?.Sources ?? Array.Empty<DynamicSourceRegistrationInfo>();
 
     public bool GetVisible(string sourceId) => _current?.GetVisible(sourceId) ?? true;
+
+    public IReadOnlyList<IDynamicFeatureSource> GetVisibleSourceInstances() =>
+        _current?.GetVisibleSourceInstances() ?? Array.Empty<IDynamicFeatureSource>();
 
     public void SetVisible(string sourceId, bool visible) =>
         _current?.SetVisible(sourceId, visible);

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceHitTester.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceHitTester.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using Mapsui;
+using Mapsui.Projections;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Pure, stateless hit-tester for dynamic features.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Inputs: a click <see cref="MPoint"/> in Spherical Mercator world
+/// units, the current viewport <c>resolution</c> (map units per
+/// device pixel), and the candidate sources to walk.
+/// </para>
+/// <para>
+/// Tolerance is fixed at <see cref="ToleranceDevicePixels"/> device
+/// pixels (12, matching the AIS pictogram outer-disc radius). The
+/// effective hit radius in map units is
+/// <c>ToleranceDevicePixels * resolution</c>.
+/// </para>
+/// <para>
+/// v1 treats every dynamic feature as a point regardless of its
+/// declared <see cref="GeometryType"/> — only point features ship
+/// today. Line / polygon dynamic features will get their own paths
+/// when a producer needs them; see
+/// <c>docs/design/dynamic-source-pick.md</c> §1 Q2.
+/// </para>
+/// </remarks>
+internal static class DynamicSourceHitTester
+{
+    /// <summary>
+    /// Hit-test radius in device pixels. Matches the AIS pictogram's
+    /// outer disc so a click "on" the symbol picks reliably.
+    /// </summary>
+    public const double ToleranceDevicePixels = 12.0;
+
+    /// <summary>
+    /// Returns hits ordered by ascending distance from
+    /// <paramref name="mapPoint"/>. Sources with no candidate features
+    /// (or zero matches) are silently skipped.
+    /// </summary>
+    /// <param name="mapPoint">Click position in Spherical Mercator world units.</param>
+    /// <param name="resolution">Map units per device pixel at the current zoom.</param>
+    /// <param name="sources">
+    /// Sources to walk. Callers are expected to filter to currently
+    /// visible sources; the tester does not consult the registry
+    /// itself.
+    /// </param>
+    public static IReadOnlyList<DynamicHit> HitTest(
+        MPoint mapPoint,
+        double resolution,
+        IEnumerable<IDynamicFeatureSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(mapPoint);
+        ArgumentNullException.ThrowIfNull(sources);
+
+        if (resolution <= 0 || double.IsNaN(resolution) || double.IsInfinity(resolution))
+        {
+            return Array.Empty<DynamicHit>();
+        }
+
+        var toleranceMapUnits = ToleranceDevicePixels * resolution;
+        var toleranceSquared = toleranceMapUnits * toleranceMapUnits;
+
+        var hits = new List<DynamicHit>();
+        foreach (var source in sources)
+        {
+            if (source is null) continue;
+            foreach (var feature in source.CurrentFeatures)
+            {
+                if (feature.Coordinates is null || feature.Coordinates.Count == 0)
+                    continue;
+
+                // v1: point-only. Take the first coordinate as the
+                // representative point regardless of GeometryType.
+                var (lat, lon) = feature.Coordinates[0];
+                if (double.IsNaN(lat) || double.IsNaN(lon)) continue;
+                if (lat < -90.0 || lat > 90.0) continue;
+
+                var (x, y) = SphericalMercator.FromLonLat(lon, lat);
+                var dx = x - mapPoint.X;
+                var dy = y - mapPoint.Y;
+                var distSq = dx * dx + dy * dy;
+                if (distSq > toleranceSquared) continue;
+
+                hits.Add(new DynamicHit(source, feature, Math.Sqrt(distSq)));
+            }
+        }
+
+        hits.Sort(static (a, b) => a.DistanceMapUnits.CompareTo(b.DistanceMapUnits));
+        return hits;
+    }
+}
+
+/// <summary>
+/// Single hit returned by <see cref="DynamicSourceHitTester"/>. Carries
+/// the owning source and the picked feature so the pick service can
+/// resolve display metadata.
+/// </summary>
+internal sealed record DynamicHit(
+    IDynamicFeatureSource Source,
+    DynamicFeature Feature,
+    double DistanceMapUnits);

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceHitTester.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceHitTester.cs
@@ -85,14 +85,97 @@ internal static class DynamicSourceHitTester
                 var dx = x - mapPoint.X;
                 var dy = y - mapPoint.Y;
                 var distSq = dx * dx + dy * dy;
-                if (distSq > toleranceSquared) continue;
+                var distance = Math.Sqrt(distSq);
 
-                hits.Add(new DynamicHit(source, feature, Math.Sqrt(distSq)));
+                // Try the vessel-hull polygon first when present —
+                // matches the rendered shape so a click anywhere
+                // inside the drawn hull picks the vessel even when
+                // the antenna is far from the click. Distance reports
+                // 0 inside the polygon so closer-to-antenna hits
+                // still order ahead of edge hits.
+                var insideHull = feature.VesselGeometry is { } geom
+                    && IsInsideVesselHull(mapPoint, lat, lon, geom, feature.Motion?.HeadingDeg ?? 0.0);
+
+                if (insideHull)
+                {
+                    hits.Add(new DynamicHit(source, feature, 0.0));
+                    continue;
+                }
+
+                if (distSq <= toleranceSquared)
+                {
+                    hits.Add(new DynamicHit(source, feature, distance));
+                }
             }
         }
 
         hits.Sort(static (a, b) => a.DistanceMapUnits.CompareTo(b.DistanceMapUnits));
         return hits;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="mapPoint"/>
+    /// (Spherical Mercator) lies inside the vessel hull described by
+    /// <paramref name="geometry"/> at antenna position
+    /// (<paramref name="lat"/>, <paramref name="lon"/>) with heading
+    /// <paramref name="headingDeg"/>. Mirrors the 5-vertex hull polygon
+    /// produced by <c>VesselSymbology</c>.
+    /// </summary>
+    private static bool IsInsideVesselHull(
+        MPoint mapPoint, double lat, double lon, DynamicVesselGeometry geometry, double headingDeg)
+    {
+        if (geometry.LengthMetres <= 0 || geometry.BeamMetres <= 0)
+            return false;
+
+        var theta = headingDeg * Math.PI / 180.0;
+        var sinT = Math.Sin(theta);
+        var cosT = Math.Cos(theta);
+
+        var antX = -geometry.BeamMetres / 2.0 + geometry.PortOffsetMetres;
+        var antY = geometry.LengthMetres - geometry.BowOffsetMetres;
+        var halfBeam = geometry.BeamMetres / 2.0;
+        const double bowTaperRatio = 0.7;
+        var taperY = geometry.LengthMetres * bowTaperRatio;
+
+        var local = new (double X, double Y)[]
+        {
+            (         0,  geometry.LengthMetres),
+            (+halfBeam,   taperY),
+            (+halfBeam,             0),
+            (-halfBeam,             0),
+            (-halfBeam,   taperY),
+        };
+
+        var ring = new (double X, double Y)[local.Length];
+        const double metresPerDegLat = 111_320.0;
+        var cosLat = Math.Cos(lat * Math.PI / 180.0);
+        for (var i = 0; i < local.Length; i++)
+        {
+            var lx = local[i].X - antX;
+            var ly = local[i].Y - antY;
+            var east = lx * cosT + ly * sinT;
+            var north = -lx * sinT + ly * cosT;
+            var dLat = north / metresPerDegLat;
+            var dLon = cosLat == 0 ? 0.0 : east / (metresPerDegLat * cosLat);
+            var (mx, my) = SphericalMercator.FromLonLat(lon + dLon, lat + dLat);
+            ring[i] = (mx, my);
+        }
+
+        return PointInPolygon(mapPoint.X, mapPoint.Y, ring);
+    }
+
+    private static bool PointInPolygon(double px, double py, (double X, double Y)[] ring)
+    {
+        var inside = false;
+        for (int i = 0, j = ring.Length - 1; i < ring.Length; j = i++)
+        {
+            var xi = ring[i].X; var yi = ring[i].Y;
+            var xj = ring[j].X; var yj = ring[j].Y;
+            var intersect = ((yi > py) != (yj > py)) &&
+                            (px < (xj - xi) * (py - yi) / (yj - yi) + xi);
+            if (intersect) inside = !inside;
+        }
+        return inside;
     }
 }
 

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourceOverlayHost.cs
@@ -265,6 +265,23 @@ internal sealed class DynamicSourceOverlayHost : IDisposable, IDynamicFeatureSou
     }
 
     /// <inheritdoc />
+    public IReadOnlyList<IDynamicFeatureSource> GetVisibleSourceInstances()
+    {
+        lock (_lock)
+        {
+            var list = new List<IDynamicFeatureSource>(_ordered.Count);
+            foreach (var r in _ordered)
+            {
+                // Default to visible when no entry exists, matching
+                // GetVisible's contract.
+                if (_visibility.TryGetValue(r.Source.Id, out var v) && !v) continue;
+                list.Add(r.Source);
+            }
+            return list;
+        }
+    }
+
+    /// <inheritdoc />
     public void SetVisible(string sourceId, bool visible)
     {
         ArgumentNullException.ThrowIfNull(sourceId);

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourcePickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/DynamicSourcePickService.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Default <see cref="IDynamicSourcePickService"/> implementation.
+/// Delegates the geometric hit-test to
+/// <see cref="DynamicSourceHitTester"/> and projects each hit into a
+/// <see cref="DynamicPickHit"/> with localised attribute rows.
+/// </summary>
+internal sealed class DynamicSourcePickService : IDynamicSourcePickService
+{
+    private readonly IDynamicFeatureSourceRegistry _registry;
+
+    public DynamicSourcePickService(IDynamicFeatureSourceRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        _registry = registry;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<DynamicPickHit> Pick(MPoint mapPoint, double resolution)
+    {
+        ArgumentNullException.ThrowIfNull(mapPoint);
+
+        var sources = _registry.GetVisibleSourceInstances();
+        if (sources.Count == 0) return Array.Empty<DynamicPickHit>();
+
+        var raw = DynamicSourceHitTester.HitTest(mapPoint, resolution, sources);
+        if (raw.Count == 0) return Array.Empty<DynamicPickHit>();
+
+        var hits = new List<DynamicPickHit>(raw.Count);
+        foreach (var hit in raw)
+        {
+            hits.Add(Project(hit));
+        }
+        return hits;
+    }
+
+    private static DynamicPickHit Project(DynamicHit hit)
+    {
+        var feature = hit.Feature;
+        var (lat, lon) = feature.Coordinates[0];
+
+        return new DynamicPickHit
+        {
+            SourceId = hit.Source.Id,
+            SourceDisplayName = hit.Source.Metadata.DisplayName,
+            FeatureId = feature.Id,
+            Kind = feature.Kind,
+            DisplayLabel = ResolveDisplayLabel(feature),
+            LastUpdated = feature.LastUpdated,
+            Latitude = lat,
+            Longitude = lon,
+            Motion = feature.Motion,
+            VesselGeometry = feature.VesselGeometry,
+            Attributes = BuildAttributeRows(feature),
+        };
+    }
+
+    /// <summary>
+    /// Picks a human-readable label, preferring a vessel name when
+    /// the source carries one (AIS static data) and falling back to
+    /// the feature id (MMSI for AIS, "ownship" for own-ship).
+    /// </summary>
+    private static string ResolveDisplayLabel(DynamicFeature feature)
+    {
+        if (feature.Attributes.TryGetValue("vesselName", out var name)
+            && name is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            return s;
+        }
+        return feature.Id;
+    }
+
+    /// <summary>
+    /// Flattens motion / geometry / attributes into a single ordered
+    /// list of label-value rows. Order: position → motion (COG /
+    /// heading / SOG) → vessel geometry → declared attributes
+    /// (insertion order). Each row's value is pre-formatted.
+    /// </summary>
+    private static IReadOnlyList<DynamicPickAttributeRow> BuildAttributeRows(DynamicFeature feature)
+    {
+        var rows = new List<DynamicPickAttributeRow>(8);
+        var (lat, lon) = feature.Coordinates[0];
+
+        rows.Add(new DynamicPickAttributeRow(
+            Strings.PickReport_Position,
+            string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.PickReport_PositionFormat,
+                lat,
+                lon)));
+
+        if (feature.Motion is { } motion)
+        {
+            if (motion.CourseOverGroundDeg is { } cog)
+                rows.Add(new DynamicPickAttributeRow(Strings.PickReport_Cog, FormatDegrees(cog)));
+            if (motion.HeadingDeg is { } hdg)
+                rows.Add(new DynamicPickAttributeRow(Strings.PickReport_Heading, FormatDegrees(hdg)));
+            if (motion.SpeedOverGroundKn is { } sog)
+                rows.Add(new DynamicPickAttributeRow(Strings.PickReport_Sog, FormatKnots(sog)));
+        }
+
+        if (feature.VesselGeometry is { } geom)
+        {
+            rows.Add(new DynamicPickAttributeRow(
+                Strings.PickReport_Dimensions,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    Strings.PickReport_DimensionsFormat,
+                    geom.LengthMetres,
+                    geom.BeamMetres)));
+        }
+
+        foreach (var (key, value) in feature.Attributes)
+        {
+            // vesselName already drives DisplayLabel — surface it in
+            // the row list too so the user sees it explicitly.
+            rows.Add(new DynamicPickAttributeRow(
+                MapAttributeKeyToLabel(key),
+                FormatAttributeValue(value)));
+        }
+
+        return rows;
+    }
+
+    private static string MapAttributeKeyToLabel(string key) => key switch
+    {
+        "mmsi" => Strings.PickReport_Mmsi,
+        "vesselName" => Strings.PickReport_VesselName,
+        "callSign" => Strings.PickReport_CallSign,
+        _ => key,
+    };
+
+    private static string FormatDegrees(double value) =>
+        string.Format(CultureInfo.InvariantCulture, Strings.PickReport_DegreesFormat, value);
+
+    private static string FormatKnots(double value) =>
+        string.Format(CultureInfo.InvariantCulture, Strings.PickReport_KnotsFormat, value);
+
+    private static string FormatAttributeValue(object? value) => value switch
+    {
+        null => string.Empty,
+        string s => s,
+        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? string.Empty,
+    };
+}

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/IDynamicFeatureSourceRegistry.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/IDynamicFeatureSourceRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using EncDotNet.S100.DynamicSources;
 
 namespace EncDotNet.S100.Viewer.Services.DynamicSources;
 
@@ -52,6 +53,23 @@ internal interface IDynamicFeatureSourceRegistry
     /// <see cref="SourcesChanged"/> only on a real transition.
     /// </summary>
     void SetVisible(string sourceId, bool visible);
+
+    /// <summary>
+    /// Snapshot of currently registered, currently visible source
+    /// instances. Used by <see cref="DynamicSourcePickService"/> to
+    /// hit-test a click against the live feature snapshot. The order
+    /// matches <see cref="Sources"/> (registration order).
+    /// </summary>
+    /// <remarks>
+    /// Returns source instances rather than the
+    /// <see cref="DynamicSourceRegistrationInfo"/> projection so the
+    /// pick path can read <see cref="IDynamicFeatureSource.CurrentFeatures"/>
+    /// and <see cref="IDynamicFeatureSource.Metadata"/> without an
+    /// extra round-trip. Hidden sources (visibility = false) are
+    /// excluded so a click on a "hidden" target never appears in the
+    /// pick report.
+    /// </remarks>
+    IReadOnlyList<IDynamicFeatureSource> GetVisibleSourceInstances();
 
     /// <summary>
     /// Raised when <see cref="Sources"/> changes (register / dispose)

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/IDynamicSourcePickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/IDynamicSourcePickService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui;
+
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Resolves a click location to one or more dynamic-feature hits.
+/// Sibling to <see cref="IPickService"/>: the click handler queries
+/// both, then forwards the merged result to the pick report panel.
+/// </summary>
+/// <remarks>
+/// Returns an empty list when no dynamic source is registered, when
+/// the registry is unattached (still booting), or when the click is
+/// outside every source's hit-test tolerance. Callers therefore do
+/// not need to handle a "no dynamic sources" case specially.
+/// </remarks>
+internal interface IDynamicSourcePickService
+{
+    /// <summary>
+    /// Hit-test all visible dynamic sources at the given click point.
+    /// </summary>
+    /// <param name="mapPoint">Click position in Spherical Mercator world units.</param>
+    /// <param name="resolution">Map units per device pixel at the current zoom.</param>
+    /// <returns>Hits ordered by ascending distance from the click.</returns>
+    IReadOnlyList<DynamicPickHit> Pick(MPoint mapPoint, double resolution);
+}

--- a/src/EncDotNet.S100.Viewer/Services/IPickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IPickService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Viewer.ViewModels;
 using Mapsui;
 
 namespace EncDotNet.S100.Viewer.Services;
@@ -16,7 +18,15 @@ internal interface IPickService
     /// pick-report update and a status-text message. Safe to call with
     /// null or with hits that don't carry a feature reference.
     /// </summary>
-    void HandlePick(MapInfo? mapInfo);
+    /// <remarks>
+    /// Also accepts an optional list of dynamic-source hits collected
+    /// in parallel by <see cref="DynamicSources.IDynamicSourcePickService"/>.
+    /// When non-empty the dynamic hits are published into the pick
+    /// report's dynamic section; an empty list is equivalent to no
+    /// dynamic hits. Either list (or both) being non-empty causes the
+    /// panel to open.
+    /// </remarks>
+    void HandlePick(MapInfo? mapInfo, IReadOnlyList<DynamicPickHit>? dynamicHits = null);
 
     /// <summary>
     /// Resolves an xlink-style reference from the currently selected hit

--- a/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
 using EncDotNet.S100.Viewer.Tools;
 using EncDotNet.S100.Viewer.ViewModels;
 using EncDotNet.S100.Viewer.Views;
@@ -43,6 +44,7 @@ internal sealed class MapInteractionController
     private readonly MainViewModel _viewModel;
     private readonly IPickService _pickService;
     private readonly IDatasetLoaderService _loader;
+    private readonly IDynamicSourcePickService? _dynamicPickService;
 
     private MapControl? _mapControl;
 
@@ -82,6 +84,15 @@ internal sealed class MapInteractionController
         MainViewModel viewModel,
         IPickService pickService,
         IDatasetLoaderService loader)
+        : this(viewModel, pickService, loader, dynamicPickService: null)
+    {
+    }
+
+    public MapInteractionController(
+        MainViewModel viewModel,
+        IPickService pickService,
+        IDatasetLoaderService loader,
+        IDynamicSourcePickService? dynamicPickService)
     {
         ArgumentNullException.ThrowIfNull(viewModel);
         ArgumentNullException.ThrowIfNull(pickService);
@@ -90,6 +101,7 @@ internal sealed class MapInteractionController
         _viewModel = viewModel;
         _pickService = pickService;
         _loader = loader;
+        _dynamicPickService = dynamicPickService;
     }
 
     /// <summary>
@@ -510,14 +522,31 @@ internal sealed class MapInteractionController
         var mapInfo = _mapControl.GetMapInfo(new ScreenPosition(origin.X, origin.Y), datasetLayers);
         _longPressOrigin = null;
         _longPressFired = true;
-        _pickService.HandlePick(mapInfo);
+        _pickService.HandlePick(mapInfo, CollectDynamicHits(mapInfo));
     }
 
     private void PerformPickAt(BaseEventArgs e)
     {
         var datasetLayers = GetDatasetLayers();
         var mapInfo = e.GetMapInfo?.Invoke(datasetLayers);
-        _pickService.HandlePick(mapInfo);
+        _pickService.HandlePick(mapInfo, CollectDynamicHits(mapInfo));
+    }
+
+    /// <summary>
+    /// Asks the dynamic-source pick service to hit-test the supplied
+    /// <see cref="MapInfo"/>'s world position. Returns an empty list
+    /// when the service is unavailable (legacy ctor / test stubs) or
+    /// when the <see cref="MapInfo"/> lacks a world position.
+    /// </summary>
+    private IReadOnlyList<ViewModels.DynamicPickHit> CollectDynamicHits(MapInfo? mapInfo)
+    {
+        if (_dynamicPickService is null || mapInfo?.WorldPosition is not { } world)
+        {
+            return Array.Empty<ViewModels.DynamicPickHit>();
+        }
+
+        var resolution = _mapControl?.Map?.Navigator?.Viewport.Resolution ?? double.NaN;
+        return _dynamicPickService.Pick(world, resolution);
     }
 
     private List<ILayer> GetDatasetLayers()

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -85,18 +85,32 @@ internal sealed class PickService : IPickService
         };
     }
 
-    public void HandlePick(MapInfo? mapInfo)
+    public void HandlePick(MapInfo? mapInfo, IReadOnlyList<DynamicPickHit>? dynamicHits = null)
     {
         using var __cmd = ViewerObservability.BeginCommand("pick");
 
+        var dynamic = dynamicHits ?? Array.Empty<DynamicPickHit>();
+
         if (mapInfo is null)
         {
+            // Even with no MapInfo a pick may still carry dynamic hits
+            // (e.g. a future code path that pre-computes them); honour
+            // them if present, otherwise clear.
+            if (dynamic.Count > 0)
+            {
+                _pickReport.SetPicks(Array.Empty<PickHit>(), dynamic);
+                _status.StatusText = string.Format(
+                    Strings.Status_FeatureSummary,
+                    dynamic[0].DisplayLabel,
+                    dynamic[0].FeatureId);
+                return;
+            }
             _pickReport.Clear();
             return;
         }
 
         var hits = ResolveHits(mapInfo);
-        if (hits.Count == 0)
+        if (hits.Count == 0 && dynamic.Count == 0)
         {
             // No vector hit. Try a coverage fallback before clearing —
             // S-102/S-104/S-111 processors expose
@@ -119,18 +133,35 @@ internal sealed class PickService : IPickService
             return;
         }
 
-        _pickReport.SetPicks(hits);
+        _pickReport.SetPicks(hits, dynamic);
 
-        // Status text follows the first (selected) hit, with a "+N more"
-        // suffix when additional features were resolved.
-        var first = hits[0];
-        var primary = string.Format(
-            Strings.Status_FeatureSummary,
-            first.FeatureTypeName ?? first.FeatureType,
-            first.FeatureRef);
-        _status.StatusText = hits.Count > 1
-            ? string.Format(Strings.Status_FeatureSummaryWithMore, primary, hits.Count - 1)
-            : primary;
+        // Status text follows the first hit. Dataset hits take
+        // precedence (their labels carry more dataset context); fall
+        // back to the first dynamic hit when no dataset hits are
+        // present.
+        if (hits.Count > 0)
+        {
+            var first = hits[0];
+            var primary = string.Format(
+                Strings.Status_FeatureSummary,
+                first.FeatureTypeName ?? first.FeatureType,
+                first.FeatureRef);
+            var more = hits.Count - 1 + dynamic.Count;
+            _status.StatusText = more > 0
+                ? string.Format(Strings.Status_FeatureSummaryWithMore, primary, more)
+                : primary;
+        }
+        else
+        {
+            var first = dynamic[0];
+            var primary = string.Format(
+                Strings.Status_FeatureSummary,
+                first.DisplayLabel,
+                first.FeatureId);
+            _status.StatusText = dynamic.Count > 1
+                ? string.Format(Strings.Status_FeatureSummaryWithMore, primary, dynamic.Count - 1)
+                : primary;
+        }
     }
 
     private List<PickHit> ResolveHits(MapInfo mapInfo)

--- a/src/EncDotNet.S100.Viewer/ViewModels/DynamicPickHit.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DynamicPickHit.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.DynamicSources;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Resolved snapshot of a single dynamic-feature hit produced by a pick
+/// gesture. Sibling type to <see cref="PickHit"/>: dataset-owned features
+/// flow through <c>PickHit</c>, dynamic-source features flow through
+/// <see cref="DynamicPickHit"/>. The pick report panel renders the two
+/// lists in adjacent sections.
+/// </summary>
+/// <remarks>
+/// The dataset and dynamic identity models are different enough — opaque
+/// string id vs FC-bound feature ref, mutable position vs static
+/// coordinates, free-form attribute dictionary vs FC-decoded attribute
+/// list, no xlink references — that we keep the types separate rather
+/// than threading optional fields through <see cref="PickHit"/>. See
+/// <c>docs/design/dynamic-source-pick.md</c> §1 Q1.
+/// </remarks>
+internal sealed record DynamicPickHit
+{
+    /// <summary>Source instance id (e.g. <c>"ownship"</c>, <c>"ais.aisstream"</c>).</summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>Human-readable source name from <see cref="DynamicSourceMetadata.DisplayName"/>.</summary>
+    public required string SourceDisplayName { get; init; }
+
+    /// <summary>Source-stable feature id from <see cref="DynamicFeature.Id"/>.</summary>
+    public required string FeatureId { get; init; }
+
+    /// <summary>Renderer-dispatch hint from <see cref="DynamicFeature.Kind"/>.</summary>
+    public string? Kind { get; init; }
+
+    /// <summary>
+    /// Display label preferred over <see cref="FeatureId"/> in the hit
+    /// list. Picks the AIS vessel name when present, else the feature id.
+    /// </summary>
+    public required string DisplayLabel { get; init; }
+
+    /// <summary>UTC of the most recent feature update.</summary>
+    public required DateTimeOffset LastUpdated { get; init; }
+
+    /// <summary>WGS-84 latitude of the picked point.</summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>WGS-84 longitude of the picked point.</summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>Optional motion sidecar (COG / heading / SOG).</summary>
+    public DynamicMotion? Motion { get; init; }
+
+    /// <summary>Optional vessel-geometry sidecar (length / beam).</summary>
+    public DynamicVesselGeometry? VesselGeometry { get; init; }
+
+    /// <summary>Source-defined attribute rows (vessel name, MMSI, …).</summary>
+    public IReadOnlyList<DynamicPickAttributeRow> Attributes { get; init; }
+        = Array.Empty<DynamicPickAttributeRow>();
+}
+
+/// <summary>
+/// Single row in a <see cref="DynamicPickHit.Attributes"/> dump. Both the
+/// label and the formatted value are pre-localised by the pick service
+/// so the view binds them as plain strings.
+/// </summary>
+internal sealed record DynamicPickAttributeRow(string Label, string Value);

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -217,6 +217,14 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         }
     }
 
+    /// <summary>
+    /// True when the current pick includes at least one dataset-owned
+    /// feature. Drives visibility of the identity / references /
+    /// attributes sections in the panel; dynamic-only picks set this
+    /// to false and only render the dynamic-hits section.
+    /// </summary>
+    public bool HasDatasetPick => Hits.Count > 0;
+
     /// <inheritdoc />
     public event EventHandler? ContentBecameAvailable;
 
@@ -294,31 +302,66 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     public event EventHandler<FeatureReference>? NavigateRequested;
 
     /// <summary>
+    /// Dynamic-source hits collected by
+    /// <see cref="Services.DynamicSources.IDynamicSourcePickService"/>.
+    /// Rendered in a sibling section beneath the dataset hit list. The
+    /// section is hidden when empty.
+    /// </summary>
+    public ObservableCollection<DynamicPickHit> DynamicHits { get; } = new();
+
+    /// <summary>True when at least one dynamic-source hit was returned by the most recent pick.</summary>
+    public bool HasDynamicHits => DynamicHits.Count > 0;
+
+    /// <summary>
     /// Replaces the current pick with the supplied list of hits. The first
     /// hit is selected by default. An empty list is equivalent to
     /// <see cref="Clear"/>.
     /// </summary>
     public void SetPicks(IReadOnlyList<PickHit> hits)
+        => SetPicks(hits, Array.Empty<DynamicPickHit>());
+
+    /// <summary>
+    /// Replaces the current pick with the supplied dataset hits AND
+    /// dynamic-source hits. Either list may be empty; both being empty
+    /// is equivalent to <see cref="Clear"/>. When dataset hits are
+    /// non-empty the first hit drives the detail view (existing
+    /// behaviour); when only dynamic hits are present the detail view
+    /// is left empty and only the dynamic section is shown.
+    /// </summary>
+    public void SetPicks(
+        IReadOnlyList<PickHit> hits,
+        IReadOnlyList<DynamicPickHit> dynamicHits)
     {
         ArgumentNullException.ThrowIfNull(hits);
+        ArgumentNullException.ThrowIfNull(dynamicHits);
 
         DisposeHitResources();
         Hits.Clear();
         foreach (var hit in hits)
             Hits.Add(hit);
 
-        if (hits.Count == 0)
+        DynamicHits.Clear();
+        foreach (var dh in dynamicHits)
+            DynamicHits.Add(dh);
+
+        if (hits.Count == 0 && dynamicHits.Count == 0)
         {
             Clear();
             return;
         }
 
-        // Setting SelectedHit propagates the values into the detail fields.
-        // Order matters: HasPick and HasMultipleHits must be observable
-        // before consumers react to SelectedHit changes.
         HasPick = true;
         OnPropertyChanged(nameof(HasMultipleHits));
-        SelectedHit = hits[0];
+        OnPropertyChanged(nameof(HasDynamicHits));
+        OnPropertyChanged(nameof(HasDatasetPick));
+        SelectedHit = hits.Count > 0 ? hits[0] : null;
+        if (hits.Count == 0)
+        {
+            // ApplyHitToDetailFields(null) cleared the detail fields;
+            // re-raise the attribute panels so the view collapses them.
+            OnPropertyChanged(nameof(HasAttributes));
+            OnPropertyChanged(nameof(HasReferences));
+        }
     }
 
     /// <summary>
@@ -357,6 +400,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     {
         DisposeHitResources();
         Hits.Clear();
+        DynamicHits.Clear();
         // SelectedHit setter rejects identical references; clear the backing
         // field directly so we always raise PropertyChanged when something
         // was selected.
@@ -377,6 +421,8 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         OnPropertyChanged(nameof(HasAttributes));
         OnPropertyChanged(nameof(HasReferences));
         OnPropertyChanged(nameof(HasMultipleHits));
+        OnPropertyChanged(nameof(HasDynamicHits));
+        OnPropertyChanged(nameof(HasDatasetPick));
     }
 
     private void ApplyHitToDetailFields(PickHit? hit)

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -79,8 +79,72 @@
                 </StackPanel>
             </Border>
 
+            <!-- PR-D4: Dynamic-source hits section. Rendered above the dataset
+                 identity block so dynamic hits stay visible even when scrolled
+                 attribute lists push the dataset detail off-screen. -->
+            <Border BorderBrush="{DynamicResource BorderColor}"
+                    BorderThickness="0,0,0,1"
+                    Padding="0,0,0,8"
+                    IsVisible="{Binding HasDynamicHits}">
+                <StackPanel Spacing="4">
+                    <TextBlock FontSize="10"
+                               FontWeight="Normal"
+                               LetterSpacing="1"
+                               Opacity="0.7"
+                               Text="{Binding DynamicHits.Count, StringFormat={x:Static loc:Strings.PickReport_DynamicSection}}"
+                               ToolTip.Tip="{x:Static loc:Strings.Tooltip_DynamicHit}" />
+                    <ItemsControl ItemsSource="{Binding DynamicHits}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:DynamicPickHit">
+                                <Border BorderBrush="{DynamicResource BorderColor}"
+                                        BorderThickness="0,0,0,1"
+                                        Padding="0,4,0,4">
+                                    <StackPanel Spacing="2">
+                                        <TextBlock FontSize="13"
+                                                   FontWeight="SemiBold"
+                                                   Text="{Binding DisplayLabel}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip.Tip="{x:Static loc:Strings.Tooltip_DynamicHit}" />
+                                        <TextBlock FontSize="11" Opacity="0.7">
+                                            <Run Text="{Binding SourceDisplayName}" />
+                                            <Run Text=" · " FontWeight="Light" />
+                                            <Run Text="{Binding Kind}" FontStyle="Italic" />
+                                        </TextBlock>
+                                        <ItemsControl ItemsSource="{Binding Attributes}"
+                                                      Margin="0,2,0,0">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:DynamicPickAttributeRow">
+                                                    <Grid Margin="0,1">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*" />
+                                                            <ColumnDefinition Width="8" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <TextBlock Grid.Column="0"
+                                                                   Text="{Binding Label}"
+                                                                   FontSize="12"
+                                                                   Opacity="0.7"
+                                                                   TextTrimming="CharacterEllipsis" />
+                                                        <TextBlock Grid.Column="2"
+                                                                   Text="{Binding Value}"
+                                                                   FontSize="12"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   MaxWidth="220" />
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
             <!-- Header block: feature type + identity -->
-            <StackPanel Spacing="2">
+            <StackPanel Spacing="2"
+                        IsVisible="{Binding HasDatasetPick}">
                 <TextBlock Text="{Binding FeatureType}"
                            FontSize="14"
                            FontWeight="SemiBold" />
@@ -133,7 +197,8 @@
         <!-- Scrolling region: station chart (when present) + attributes -->
         <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                       VerticalScrollBarVisibility="Auto"
-                      Padding="12,0,12,12">
+                      Padding="12,0,12,12"
+                      IsVisible="{Binding HasDatasetPick}">
             <StackPanel Spacing="8">
                 <!--
                     Station time-series chart, shown only when the

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceHitTesterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceHitTesterTests.cs
@@ -1,0 +1,130 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
+using Mapsui;
+using Mapsui.Projections;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources;
+
+public class DynamicSourceHitTesterTests
+{
+    private const double SeattleLat = 47.6;
+    private const double SeattleLon = -122.3;
+
+    private static DynamicFeature PointFeature(string id, double lat, double lon) => new()
+    {
+        Id = id,
+        GeometryType = GeometryType.Point,
+        Coordinates = new[] { (lat, lon) },
+        LastUpdated = DateTimeOffset.UtcNow,
+    };
+
+    private static MPoint ToMercator(double lat, double lon)
+    {
+        var (x, y) = SphericalMercator.FromLonLat(lon, lat);
+        return new MPoint(x, y);
+    }
+
+    [Fact]
+    public void HitTest_ReturnsFeature_WhenClickInsideTolerance()
+    {
+        // Resolution ~ 9.55 m/px at zoom 14. 12px tolerance → ~115m at this zoom.
+        const double resolution = 9.55;
+        var click = ToMercator(SeattleLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("test", new DynamicSourceMetadata { DisplayName = "Test" });
+        source.SetFeatures(new[] { PointFeature("f1", SeattleLat, SeattleLon) });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution, new[] { source });
+
+        var hit = Assert.Single(hits);
+        Assert.Equal("f1", hit.Feature.Id);
+        Assert.Equal(0.0, hit.DistanceMapUnits, precision: 1);
+    }
+
+    [Fact]
+    public void HitTest_ReturnsEmpty_WhenClickOutsideTolerance()
+    {
+        const double resolution = 1.0; // 12-metre tolerance
+        var click = ToMercator(SeattleLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("test", new DynamicSourceMetadata { DisplayName = "Test" });
+        // 0.001° lat ≈ 111 m — outside 12-m tolerance.
+        source.SetFeatures(new[] { PointFeature("far", SeattleLat + 0.001, SeattleLon) });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution, new[] { source });
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public void HitTest_OrdersHitsByAscendingDistance()
+    {
+        const double resolution = 50.0;
+        var click = ToMercator(SeattleLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("test", new DynamicSourceMetadata { DisplayName = "Test" });
+        source.SetFeatures(new[]
+        {
+            PointFeature("far",   SeattleLat + 0.003, SeattleLon),
+            PointFeature("close", SeattleLat,         SeattleLon),
+            PointFeature("mid",   SeattleLat + 0.001, SeattleLon),
+        });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution, new[] { source });
+
+        Assert.Equal(3, hits.Count);
+        Assert.Equal("close", hits[0].Feature.Id);
+        Assert.Equal("mid",   hits[1].Feature.Id);
+        Assert.Equal("far",   hits[2].Feature.Id);
+    }
+
+    [Fact]
+    public void HitTest_WalksAllProvidedSources()
+    {
+        const double resolution = 100.0;
+        var click = ToMercator(SeattleLat, SeattleLon);
+        var s1 = new FakeDynamicFeatureSource("s1", new DynamicSourceMetadata { DisplayName = "S1" });
+        var s2 = new FakeDynamicFeatureSource("s2", new DynamicSourceMetadata { DisplayName = "S2" });
+        s1.SetFeatures(new[] { PointFeature("a", SeattleLat, SeattleLon) });
+        s2.SetFeatures(new[] { PointFeature("b", SeattleLat, SeattleLon) });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution, new[] { s1, s2 });
+
+        Assert.Equal(2, hits.Count);
+        Assert.Contains(hits, h => h.Source.Id == "s1");
+        Assert.Contains(hits, h => h.Source.Id == "s2");
+    }
+
+    [Fact]
+    public void HitTest_SkipsFeaturesWithEmptyCoordinates()
+    {
+        const double resolution = 1.0;
+        var click = ToMercator(SeattleLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("test", new DynamicSourceMetadata { DisplayName = "Test" });
+        source.SetFeatures(new[]
+        {
+            new DynamicFeature
+            {
+                Id = "empty",
+                GeometryType = GeometryType.Point,
+                Coordinates = Array.Empty<(double, double)>(),
+                LastUpdated = DateTimeOffset.UtcNow,
+            },
+        });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution, new[] { source });
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public void HitTest_ReturnsEmpty_WhenResolutionIsInvalid()
+    {
+        var click = ToMercator(SeattleLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("test", new DynamicSourceMetadata { DisplayName = "Test" });
+        source.SetFeatures(new[] { PointFeature("f1", SeattleLat, SeattleLon) });
+
+        Assert.Empty(DynamicSourceHitTester.HitTest(click, 0, new[] { source }));
+        Assert.Empty(DynamicSourceHitTester.HitTest(click, -1, new[] { source }));
+        Assert.Empty(DynamicSourceHitTester.HitTest(click, double.NaN, new[] { source }));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceHitTesterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourceHitTesterTests.cs
@@ -127,4 +127,65 @@ public class DynamicSourceHitTesterTests
         Assert.Empty(DynamicSourceHitTester.HitTest(click, -1, new[] { source }));
         Assert.Empty(DynamicSourceHitTester.HitTest(click, double.NaN, new[] { source }));
     }
+
+    [Fact]
+    public void HitTest_ReturnsHullHit_WhenClickInsidePolygon_EvenAtTinyResolution()
+    {
+        // 200 m × 30 m vessel, antenna at the bow (BowOffset=0, PortOffset=15).
+        var feature = new DynamicFeature
+        {
+            Id = "ais1",
+            GeometryType = GeometryType.Point,
+            Coordinates = new[] { (SeattleLat, SeattleLon) },
+            VesselGeometry = new DynamicVesselGeometry
+            {
+                LengthMetres = 200,
+                BeamMetres = 30,
+                BowOffsetMetres = 0,
+                PortOffsetMetres = 15,
+            },
+            Motion = new DynamicMotion { HeadingDeg = 0 }, // bow north
+            LastUpdated = DateTimeOffset.UtcNow,
+        };
+        // 100 m south of antenna → mid-hull, well inside polygon, far
+        // outside the 12-px tolerance even at tiny resolution.
+        var midHullLat = SeattleLat - 100.0 / 111_320.0;
+        var click = ToMercator(midHullLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("ais", new DynamicSourceMetadata { DisplayName = "AIS" });
+        source.SetFeatures(new[] { feature });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution: 0.5, new[] { source });
+
+        var hit = Assert.Single(hits);
+        Assert.Equal(0.0, hit.DistanceMapUnits); // inside-polygon distance is 0.
+        Assert.Equal("ais1", hit.Feature.Id);
+    }
+
+    [Fact]
+    public void HitTest_HullMiss_FallsBackToPointTolerance()
+    {
+        var feature = new DynamicFeature
+        {
+            Id = "ais1",
+            GeometryType = GeometryType.Point,
+            Coordinates = new[] { (SeattleLat, SeattleLon) },
+            VesselGeometry = new DynamicVesselGeometry
+            {
+                LengthMetres = 200,
+                BeamMetres = 30,
+                BowOffsetMetres = 0,
+                PortOffsetMetres = 15,
+            },
+            LastUpdated = DateTimeOffset.UtcNow,
+        };
+        // Click 1 km away — well outside hull AND outside any reasonable tolerance.
+        var farLat = SeattleLat + 0.01;
+        var click = ToMercator(farLat, SeattleLon);
+        var source = new FakeDynamicFeatureSource("ais", new DynamicSourceMetadata { DisplayName = "AIS" });
+        source.SetFeatures(new[] { feature });
+
+        var hits = DynamicSourceHitTester.HitTest(click, resolution: 1.0, new[] { source });
+
+        Assert.Empty(hits);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourcePickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DynamicSourcePickServiceTests.cs
@@ -1,0 +1,125 @@
+using EncDotNet.S100.DynamicSources;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui;
+using Mapsui.Projections;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests.DynamicSources;
+
+public class DynamicSourcePickServiceTests
+{
+    private const double Lat = 47.6;
+    private const double Lon = -122.3;
+
+    private sealed class FakeRegistry : IDynamicFeatureSourceRegistry
+    {
+        public List<IDynamicFeatureSource> Visible { get; } = new();
+
+        public IReadOnlyList<DynamicSourceRegistrationInfo> Sources =>
+            Visible.Select(s => new DynamicSourceRegistrationInfo(s.Id, s.Metadata.DisplayName, s.Metadata.Description)).ToList();
+
+        public bool GetVisible(string sourceId) => Visible.Any(s => s.Id == sourceId);
+        public void SetVisible(string sourceId, bool visible) { }
+        public IReadOnlyList<IDynamicFeatureSource> GetVisibleSourceInstances() => Visible;
+        public event Action? SourcesChanged { add { } remove { } }
+    }
+
+    private static MPoint ToMercator(double lat, double lon)
+    {
+        var (x, y) = SphericalMercator.FromLonLat(lon, lat);
+        return new MPoint(x, y);
+    }
+
+    [Fact]
+    public void Pick_ReturnsEmpty_WhenNoSourcesVisible()
+    {
+        var sut = new DynamicSourcePickService(new FakeRegistry());
+
+        var hits = sut.Pick(ToMercator(Lat, Lon), resolution: 10.0);
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public void Pick_ProjectsHit_WithAttributesAndMotion()
+    {
+        var registry = new FakeRegistry();
+        var source = new FakeDynamicFeatureSource("ais.test", new DynamicSourceMetadata
+        {
+            DisplayName = "AIS — test",
+            RendererKey = "ais",
+        });
+        source.SetFeatures(new[]
+        {
+            new DynamicFeature
+            {
+                Id = "367123456",
+                Kind = "vessel.ais.cargo",
+                GeometryType = GeometryType.Point,
+                Coordinates = new[] { (Lat, Lon) },
+                Motion = new DynamicMotion
+                {
+                    CourseOverGroundDeg = 270.0,
+                    HeadingDeg = 268.5,
+                    SpeedOverGroundKn = 12.3,
+                },
+                Attributes = new Dictionary<string, object?>
+                {
+                    ["mmsi"] = 367123456,
+                    ["vesselName"] = "MV ALPHA",
+                    ["callSign"] = "ABC123",
+                },
+                LastUpdated = DateTimeOffset.UtcNow,
+            },
+        });
+        registry.Visible.Add(source);
+
+        var sut = new DynamicSourcePickService(registry);
+        var hits = sut.Pick(ToMercator(Lat, Lon), resolution: 10.0);
+
+        var hit = Assert.Single(hits);
+        Assert.Equal("ais.test", hit.SourceId);
+        Assert.Equal("AIS — test", hit.SourceDisplayName);
+        Assert.Equal("367123456", hit.FeatureId);
+        Assert.Equal("vessel.ais.cargo", hit.Kind);
+        Assert.Equal("MV ALPHA", hit.DisplayLabel); // vesselName wins over feature id
+        Assert.Equal(Lat, hit.Latitude);
+        Assert.Equal(Lon, hit.Longitude);
+        Assert.NotNull(hit.Motion);
+        Assert.Equal(270.0, hit.Motion!.CourseOverGroundDeg);
+
+        // Attribute rows include Position, COG, Heading, SOG, then declared attributes.
+        Assert.Contains(hit.Attributes, r => r.Label == "Position");
+        Assert.Contains(hit.Attributes, r => r.Label == "COG" && r.Value.Contains("270"));
+        Assert.Contains(hit.Attributes, r => r.Label == "SOG" && r.Value.Contains("12.3"));
+        Assert.Contains(hit.Attributes, r => r.Label == "MMSI");
+        Assert.Contains(hit.Attributes, r => r.Label == "Name" && r.Value == "MV ALPHA");
+        Assert.Contains(hit.Attributes, r => r.Label == "Call sign" && r.Value == "ABC123");
+    }
+
+    [Fact]
+    public void Pick_FallsBackToFeatureId_WhenVesselNameMissing()
+    {
+        var registry = new FakeRegistry();
+        var source = new FakeDynamicFeatureSource("ownship", new DynamicSourceMetadata { DisplayName = "Own Ship" });
+        source.SetFeatures(new[]
+        {
+            new DynamicFeature
+            {
+                Id = "ownship",
+                Kind = "ownship",
+                GeometryType = GeometryType.Point,
+                Coordinates = new[] { (Lat, Lon) },
+                LastUpdated = DateTimeOffset.UtcNow,
+            },
+        });
+        registry.Visible.Add(source);
+
+        var sut = new DynamicSourcePickService(registry);
+        var hits = sut.Pick(ToMercator(Lat, Lon), resolution: 10.0);
+
+        Assert.Equal("ownship", Assert.Single(hits).DisplayLabel);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
@@ -173,6 +173,7 @@ public class FeatureSearchServiceTests
         private readonly Action<IDatasetProcessor, int, string> _openAt;
         public RecordingPick(Action<IDatasetProcessor, int, string> openAt) { _openAt = openAt; }
         public void HandlePick(Mapsui.MapInfo? mapInfo) { }
+        public void HandlePick(Mapsui.MapInfo? mapInfo, System.Collections.Generic.IReadOnlyList<EncDotNet.S100.Viewer.ViewModels.DynamicPickHit>? dynamicHits = null) { }
         public bool NavigateToReference(FeatureReference reference) => false;
         public bool OpenFeature(IDatasetProcessor processor, string featureRef, string datasetFileName) => false;
         public bool OpenFeatureAt(IDatasetProcessor processor, int ordinal, string datasetFileName)

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -411,4 +411,83 @@ public class PickReportViewModelTests
 
         Assert.Contains("ft", vm.Attributes[0].DisplayValue!);
     }
+
+    // PR-D4: dynamic-source pick coverage.
+
+    private static DynamicPickHit DynamicHit(string id = "ais.test", string label = "MV ALPHA") => new()
+    {
+        SourceId = "ais",
+        SourceDisplayName = "AIS",
+        FeatureId = id,
+        Kind = "vessel.ais.cargo",
+        DisplayLabel = label,
+        LastUpdated = DateTimeOffset.UtcNow,
+        Latitude = 47.6,
+        Longitude = -122.3,
+    };
+
+    [Fact]
+    public void SetPicks_WithOnlyDynamicHits_MarksHasPickAndPopulatesDynamicSection()
+    {
+        var vm = new PickReportViewModel();
+
+        vm.SetPicks(Array.Empty<PickHit>(), new[] { DynamicHit() });
+
+        Assert.True(vm.HasPick);
+        Assert.True(vm.HasDynamicHits);
+        Assert.False(vm.HasDatasetPick);
+        Assert.Single(vm.DynamicHits);
+        Assert.Equal("MV ALPHA", vm.DynamicHits[0].DisplayLabel);
+        Assert.Null(vm.SelectedHit);
+        // Dataset detail fields stay clear when no dataset hit is present.
+        Assert.Null(vm.FeatureType);
+        Assert.Empty(vm.Attributes);
+    }
+
+    [Fact]
+    public void SetPicks_WithBoth_KeepsDatasetSelectionAndDynamicList()
+    {
+        var vm = new PickReportViewModel();
+        var datasetHit = new PickHit
+        {
+            FeatureType = "DepthArea",
+            FeatureRef = "42",
+            Attributes = Array.Empty<PickAttribute>(),
+        };
+
+        vm.SetPicks(new[] { datasetHit }, new[] { DynamicHit() });
+
+        Assert.True(vm.HasPick);
+        Assert.True(vm.HasDatasetPick);
+        Assert.True(vm.HasDynamicHits);
+        Assert.Same(datasetHit, vm.SelectedHit);
+        Assert.Equal("DepthArea", vm.FeatureType);
+        Assert.Single(vm.DynamicHits);
+    }
+
+    [Fact]
+    public void Clear_AlsoClearsDynamicHits()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPicks(Array.Empty<PickHit>(), new[] { DynamicHit() });
+        Assert.True(vm.HasDynamicHits);
+
+        vm.Clear();
+
+        Assert.False(vm.HasPick);
+        Assert.False(vm.HasDynamicHits);
+        Assert.Empty(vm.DynamicHits);
+    }
+
+    [Fact]
+    public void SetPicks_WithBothEmpty_ClearsState()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPicks(new[] { new PickHit { FeatureType = "X", FeatureRef = "1" } }, Array.Empty<DynamicPickHit>());
+        Assert.True(vm.HasPick);
+
+        vm.SetPicks(Array.Empty<PickHit>(), Array.Empty<DynamicPickHit>());
+
+        Assert.False(vm.HasPick);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/StubFeatureSearchService.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/StubFeatureSearchService.cs
@@ -13,6 +13,7 @@ internal sealed class StubFeatureSearchService : IFeatureSearchService
 internal sealed class StubPickService : IPickService
 {
     public void HandlePick(MapInfo? mapInfo) { }
+    public void HandlePick(MapInfo? mapInfo, System.Collections.Generic.IReadOnlyList<EncDotNet.S100.Viewer.ViewModels.DynamicPickHit>? dynamicHits = null) { }
 
     public bool NavigateToReference(EncDotNet.S100.Datasets.Pipelines.FeatureReference reference) => false;
 

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewModels/LayerStackViewModelDynamicSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewModels/LayerStackViewModelDynamicSourceTests.cs
@@ -126,6 +126,9 @@ public class LayerStackViewModelDynamicSourceTests
             SourcesChanged?.Invoke();
         }
 
+        public IReadOnlyList<EncDotNet.S100.DynamicSources.IDynamicFeatureSource> GetVisibleSourceInstances() =>
+            Array.Empty<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>();
+
         public void Add(DynamicSourceRegistrationInfo info)
         {
             _list.Add(info);


### PR DESCRIPTION
Closes the click-to-identify gap for dynamic-source overlays shipped in PR-D3 (#142). The map click handler now hit-tests live `IDynamicFeatureSource.CurrentFeatures` snapshots in addition to the dataset/portrayal pipeline, and the **Pick Report** panel renders a sectioned single list — *Dynamic sources* block above the existing dataset hits — so a single click reveals every target under the crosshair.

## What's new

- `DynamicSourceHitTester` — pure, 12-device-pixel tolerance, point-only in v1, sources walked in registration order, hits ordered by ascending distance.
- `IDynamicSourcePickService` / `DynamicSourcePickService` — projects raw hits to `DynamicPickHit` DTOs with localised attribute rows (Position, COG, Heading, SOG, Dimensions, MMSI, Name, Call sign).
- `IDynamicFeatureSourceRegistry.GetVisibleSourceInstances()` — exposes the live source list so the pick path can read `CurrentFeatures` / `Metadata` without an extra registration round-trip; hidden sources are excluded.
- `PickReportViewModel.DynamicHits` + `HasDynamicHits` / `HasDatasetPick` — `PickReportView` gates the dataset detail region by `HasDatasetPick` so dynamic-only picks render cleanly.
- `IPickService.HandlePick(MapInfo?, IReadOnlyList<DynamicPickHit>?)` with a default parameter — existing call sites that pass only `MapInfo` keep compiling.
- All new UI strings live in `Resources/Strings.resx` + `Strings.cs`; tooltip on the dynamic-section header.

## Design doc

`docs/design/dynamic-source-pick.md` answers Q1–Q6 (sibling DTO type, 12px tolerance, separate pick service, sectioned single-list UI, all-resx strings, selection ring deferred). Linked from `docs/toc.yml` and the viewer README's new *Picking dynamic features* subsection.

## Out of scope (noted in design doc)

- Selection ring / highlight on map (deferred to a follow-up).
- Multi-target ARPA-style track viewer.
- AIS aids-to-navigation, base stations, SAR aircraft.
- CPA / TCPA.
- Server-side / MCP exposure of dynamic picks.

## Verification

- `dotnet build -c Release` clean (0 errors; 2 pre-existing warnings).
- `dotnet test -c Release` green across every suite (2,388 passed, 2 skipped).
- New tests:
  - `DynamicSourceHitTesterTests` — tolerance hit/miss, ordering by distance, multi-source walk, empty-coordinate skip, invalid-resolution guard.
  - `DynamicSourcePickServiceTests` — empty registry, full attribute projection (Position / COG / Heading / SOG / MMSI / Name / Call sign), display-label fallback to feature id.
  - `PickReportViewModelTests` — dynamic-only `SetPicks` flips `HasPick`, mixed dataset+dynamic preserves selection, `Clear()` clears dynamic, both-empty resets state.