### PR TITLE
Make portrayal pipeline async and cancellable

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
@@ -18,10 +18,12 @@ public class CoveragePipeline
     public Task<StyledCoverageLayer> ProcessAsync(
         ICoverageSource source,
         ICoveragePortrayalCatalogue catalogue,
-        MarinerSettings? mariner = null)
+        MarinerSettings? mariner = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(catalogue);
+        cancellationToken.ThrowIfCancellationRequested();
 
         using var activity = Telemetry.ActivitySource.StartActivity("s100.pipeline.coverage.process");
         activity?.SetTag(TelemetryTags.PipelineStage, "portray");
@@ -55,7 +57,7 @@ public class CoveragePipeline
             using (Telemetry.ActivitySource.StartActivity("s100.pipeline.coverage.stage.read"))
             {
                 var stageStart = Stopwatch.GetTimestamp();
-                sampled = source.Sample(GridRegion.Full);
+                sampled = source.Sample(GridRegion.Full, cancellationToken);
                 RecordCoverageStageDuration(stageStart, "read");
             }
 
@@ -112,7 +114,16 @@ public interface ICoverageSource
     void SelectTime(DateTime time);
     
     // The actual data access
-    SampledCoverage Sample(GridRegion region);
+    /// <summary>
+    /// Copies the requested grid region into a <see cref="SampledCoverage"/>.
+    /// The underlying grid is already resident in memory (the HDF5 read
+    /// happens at construction time), so this is a CPU-bound copy rather than
+    /// an I/O operation; <paramref name="cancellationToken"/> lets a large
+    /// copy be abandoned cooperatively. The method remains synchronous.
+    /// </summary>
+    /// <param name="region">The grid subset and stride to sample.</param>
+    /// <param name="cancellationToken">Signals that the render has been cancelled.</param>
+    SampledCoverage Sample(GridRegion region, CancellationToken cancellationToken = default);
 }
 
 public class CoverageMetadata

--- a/src/EncDotNet.S100.Core/Pipelines/PortrayalPipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/PortrayalPipeline.cs
@@ -35,11 +35,12 @@ public sealed class PortrayalPipeline
         IFeatureXmlSource source,
         IVectorPortrayalCatalogue catalogue,
         Viewport? viewport = null,
-        MarinerSettings? mariner = null)
+        MarinerSettings? mariner = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(catalogue);
-        return await _vectorPipeline.ProcessAsync(source, catalogue, viewport, mariner)
+        return await _vectorPipeline.ProcessAsync(source, catalogue, viewport, mariner, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -51,11 +52,12 @@ public sealed class PortrayalPipeline
     public async Task<IPortrayalLayer> ProcessAsync(
         ICoverageSource source,
         ICoveragePortrayalCatalogue catalogue,
-        MarinerSettings? mariner = null)
+        MarinerSettings? mariner = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(catalogue);
-        return await _coveragePipeline.ProcessAsync(source, catalogue, mariner)
+        return await _coveragePipeline.ProcessAsync(source, catalogue, mariner, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/GmlFeatureXmlSource.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/GmlFeatureXmlSource.cs
@@ -60,7 +60,11 @@ public class GmlFeatureXmlSource<TFeature> : IFeatureXmlSource
     }
 
     /// <inheritdoc/>
-    public XmlReader GetFeatureXml() => BuildFeatureXml().CreateReader();
+    public XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return BuildFeatureXml().CreateReader();
+    }
 
     private XDocument BuildFeatureXml()
     {

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IFeatureXmlSource.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IFeatureXmlSource.cs
@@ -19,5 +19,11 @@ public interface IFeatureXmlSource
     /// Returns an <see cref="XmlReader"/> positioned at the start of the
     /// S-100 FeatureXML document. The caller owns the reader and will dispose it.
     /// </summary>
-    XmlReader GetFeatureXml();
+    /// <param name="cancellationToken">
+    /// Signals that the render has been cancelled. Implementations project
+    /// FeatureXML from already-in-memory dataset state, so the work is
+    /// CPU-bound rather than I/O-bound; the token lets a long projection be
+    /// abandoned cooperatively (the method remains synchronous).
+    /// </param>
+    XmlReader GetFeatureXml(CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/ILuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/ILuaRuleExecutor.cs
@@ -21,5 +21,11 @@ public interface ILuaRuleExecutor
     /// ready for the renderer.
     /// </summary>
     /// <param name="mariner">Mariner-configurable display preferences (S-100 Part 9 §4.2).</param>
-    IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner);
+    /// <param name="cancellationToken">
+    /// Signals that the render has been cancelled. The Lua interpreter step
+    /// itself is not interruptible mid-script, so implementations honour the
+    /// token at coarse boundaries (e.g. before invoking <c>PortrayalMain()</c>
+    /// and while parsing emit strings); the method remains synchronous.
+    /// </param>
+    IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner, CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
@@ -29,7 +29,8 @@ public class VectorPipeline
         IFeatureXmlSource source,
         IVectorPortrayalCatalogue catalogue,
         Viewport? viewport = null,
-        MarinerSettings? mariner = null)
+        MarinerSettings? mariner = null,
+        CancellationToken cancellationToken = default)
     {
         using var activity = Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.process");
         activity?.SetTag(TelemetryTags.PipelineStage, "portray");
@@ -44,12 +45,14 @@ public class VectorPipeline
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Stage 1 — load FeatureXML into a navigable document
             XDocument featureDoc;
             using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.feature_xml"))
             {
                 var stageStart = Stopwatch.GetTimestamp();
-                using (var reader = source.GetFeatureXml())
+                using (var reader = source.GetFeatureXml(cancellationToken))
                 {
                     featureDoc = XDocument.Load(reader);
                 }
@@ -60,6 +63,7 @@ public class VectorPipeline
             IReadOnlyList<PortrayalRule> applicableRules;
             using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.rule_select"))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var stageStart = Stopwatch.GetTimestamp();
                 var featureTypes = source.FeatureTypesPresent;
                 PipelineMetrics.FeaturesIn.Record(featureTypes.Count, stageTag);
@@ -74,7 +78,7 @@ public class VectorPipeline
             using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.xslt"))
             {
                 var stageStart = Stopwatch.GetTimestamp();
-                drawingInstructionsDoc = RunXsltRules(featureDoc, applicableRules, catalogue, viewport);
+                drawingInstructionsDoc = RunXsltRules(featureDoc, applicableRules, catalogue, viewport, cancellationToken);
                 RecordStageDuration(stageStart, "xslt");
             }
 
@@ -83,6 +87,7 @@ public class VectorPipeline
             List<DrawingInstruction> instructions;
             using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.assemble"))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var stageStart = Stopwatch.GetTimestamp();
                 instructions = Part9DisplayListReader.Read(drawingInstructionsDoc).ToList();
                 RecordStageDuration(stageStart, "assemble");
@@ -99,7 +104,7 @@ public class VectorPipeline
                 using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.lua"))
                 {
                     var stageStart = Stopwatch.GetTimestamp();
-                    instructions.AddRange(_luaExecutor.Execute(mariner ?? new MarinerSettings()));
+                    instructions.AddRange(_luaExecutor.Execute(mariner ?? new MarinerSettings(), cancellationToken));
                     RecordStageDuration(stageStart, "lua");
                     PipelineMetrics.StageInstructionsCount.Record(
                         instructions.Count,
@@ -111,6 +116,7 @@ public class VectorPipeline
             IReadOnlyList<DrawingInstruction> sorted;
             using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.viewing_groups"))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var stageStart = Stopwatch.GetTimestamp();
                 var filtered = ApplyViewingGroups(instructions, catalogue.ViewingGroups);
                 var planeFiltered = ApplyDisplayPlanes(filtered, catalogue.DisplayPlanes);
@@ -184,13 +190,19 @@ public class VectorPipeline
         XDocument featureDoc,
         IReadOnlyList<PortrayalRule> rules,
         IVectorPortrayalCatalogue catalogue,
-        Viewport? viewport)
+        Viewport? viewport,
+        CancellationToken cancellationToken)
     {
         var drawingInstructions = new XDocument(
             new XElement("DrawingInstructions"));
 
         foreach (var rule in rules.Where(r => r.Type == PortrayalRuleType.Xslt))
         {
+            // Cancellation is honoured between rules. A single
+            // XslCompiledTransform.Transform call is not interruptible, so a
+            // very large/slow individual rule cannot be abandoned mid-flight.
+            cancellationToken.ThrowIfCancellationRequested();
+
             var args = new XsltArgumentList();
 
             // Pass colour palette tokens as XSLT parameters

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -415,7 +415,13 @@ public sealed class DatasetPipelineFactory
     /// <summary>
     /// Convenience method: creates a processor and renders with default context.
     /// </summary>
-    public DatasetResult Process(string path) => CreateProcessor(path).Render();
+    /// <remarks>
+    /// This synchronous facade blocks on the async render path; it is intended
+    /// for batch / CLI callers that have no synchronization context. UI callers
+    /// should await <see cref="IDatasetProcessor.RenderAsync"/> directly.
+    /// </remarks>
+    public DatasetResult Process(string path) =>
+        CreateProcessor(path).RenderAsync().GetAwaiter().GetResult();
 
     /// <summary>
     /// Creates a processor for a dataset stored inside <paramref name="source"/>

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Diagnostics;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
@@ -131,8 +133,10 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
     protected string FileName => _fileName;
 
     /// <inheritdoc/>
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var preResult = CheckPreRender(context);
         if (preResult is not null) return preResult;
 
@@ -142,7 +146,8 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
 
         var featureSource = CreateFeatureXmlSource();
         var pipeline = new PortrayalPipeline();
-        var portrayalLayer = pipeline.ProcessAsync(featureSource, catalogue).GetAwaiter().GetResult();
+        var portrayalLayer = await pipeline.ProcessAsync(featureSource, catalogue, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         var instructions = PostProcessInstructions(((IVectorLayer)portrayalLayer).Instructions);
 
         Console.WriteLine($"[{Spec.Name.Replace("-", "")}] {_fileName}: {Features.Count} features, "

--- a/src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/IDatasetProcessor.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Validation;
 
@@ -7,7 +9,7 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 
 /// <summary>
 /// Processes a dataset file and renders it into Mapsui layers.
-/// Constructed once per file; <see cref="Render"/> may be called
+/// Constructed once per file; <see cref="RenderAsync"/> may be called
 /// multiple times with different spec-specific contexts.
 /// </summary>
 public interface IDatasetProcessor
@@ -22,7 +24,25 @@ public interface IDatasetProcessor
     /// </summary>
     SpecRef Spec { get; }
 
-    DatasetResult Render(RenderContext? context = null);
+    /// <summary>
+    /// Renders the dataset into portrayal layers. The render path is
+    /// CPU-bound on already-parsed, in-memory data; the returned task
+    /// typically completes synchronously. The supplied
+    /// <paramref name="cancellationToken"/> is honoured cooperatively at
+    /// pipeline-stage and per-row boundaries so a render in flight can be
+    /// abandoned (e.g. when the viewer's selected time step changes).
+    /// </summary>
+    /// <param name="context">
+    /// Optional spec-specific render context (palette, opacity, selected
+    /// time step, viewport). When <c>null</c> the processor renders with
+    /// its defaults.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Token observed cooperatively during rendering; cancellation surfaces
+    /// as an <see cref="OperationCanceledException"/>.
+    /// </param>
+    /// <returns>The rendered dataset result.</returns>
+    Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns information about a feature identified by its reference string

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -86,8 +86,10 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
     }
 
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var mariner = context?.Mariner ?? MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")
@@ -111,9 +113,10 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         var executor = new S101LuaRuleExecutor(_luaEngine, _dataset, s101Cat, fc);
         var featureSource = new S101FeatureXmlSource(_dataset);
         var pipeline = new PortrayalPipeline(executor);
-        var portrayalLayer = pipeline.ProcessAsync(featureSource, s101Cat, mariner: mariner)
-            .GetAwaiter().GetResult();
+        var portrayalLayer = await pipeline.ProcessAsync(featureSource, s101Cat, mariner: mariner, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         var prepared = ((IVectorLayer)portrayalLayer).Instructions;
+        Console.WriteLine($"[S101] Pipeline produced {prepared.Count} drawing instructions");
         Console.WriteLine($"[S101] Pipeline produced {prepared.Count} drawing instructions");
 
         // S-98 R-101-102-A (Annex A §A-6.9.1): S-102 must render between

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -115,8 +115,10 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
         // fields can be cleaned up here without further plumbing.
     }
 
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
         var metadata = _source.Metadata;
 
@@ -132,8 +134,8 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
         };
 
         var pipeline = _pipeline;
-        var layer = pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default)
-            .GetAwaiter().GetResult();
+        var layer = await pipeline.ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
+            .ConfigureAwait(false);
         var styledLayer = (StyledCoverageLayer)layer;
 
         var renderer = _renderer;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -129,16 +129,18 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         }
     }
 
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (_stationSeries is not null)
         {
             return RenderStationSeries(_stationSeries, context);
         }
-        return RenderGridded(context);
+        return await RenderGriddedAsync(context, cancellationToken).ConfigureAwait(false);
     }
 
-    private DatasetResult RenderGridded(RenderContext? context)
+    private async Task<DatasetResult> RenderGriddedAsync(RenderContext? context, CancellationToken cancellationToken)
     {
         var source = _source!;
         var catalogue = _catalogue!;
@@ -170,8 +172,8 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default)
-            .GetAwaiter().GetResult();
+        var layer = await pipeline.ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
+            .ConfigureAwait(false);
         var styledLayer = (StyledCoverageLayer)layer;
 
         var colorRenderer = new MapsuiCoverageRenderer(_crsTransformFactory)

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -163,16 +163,18 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         }
     }
 
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (_stationSeries is not null)
         {
             return RenderStationSeries(_stationSeries, context);
         }
-        return RenderGridded(context);
+        return await RenderGriddedAsync(context, cancellationToken).ConfigureAwait(false);
     }
 
-    private DatasetResult RenderGridded(RenderContext? context)
+    private async Task<DatasetResult> RenderGriddedAsync(RenderContext? context, CancellationToken cancellationToken)
     {
         var source = _source!;
         var catalogue = _catalogue!;
@@ -205,8 +207,8 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
         };
 
         var pipeline = new PortrayalPipeline();
-        var layer = pipeline.ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default)
-            .GetAwaiter().GetResult();
+        var layer = await pipeline.ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
+            .ConfigureAwait(false);
         var styledLayer = (StyledCoverageLayer)layer;
 
         // The bundled S-111 portrayal catalogue

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -114,8 +114,10 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
     }
 
     /// <inheritdoc/>
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var mariner = context?.Mariner ?? MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-131")
@@ -137,9 +139,9 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
         var executor = new S131LuaRuleExecutor(_luaEngine, _dataset, _catalogue, fc);
         var featureSource = new EmptyFeatureXmlSource();
         var pipeline = new PortrayalPipeline(executor);
-        var portrayalLayer = pipeline.ProcessAsync(
-                featureSource, _catalogue, mariner: mariner)
-            .GetAwaiter().GetResult();
+        var portrayalLayer = await pipeline.ProcessAsync(
+                featureSource, _catalogue, mariner: mariner, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         var prepared = ((IVectorLayer)portrayalLayer).Instructions;
 
         // Render to Mapsui layer
@@ -334,8 +336,9 @@ internal sealed class EmptyFeatureXmlSource : IFeatureXmlSource
     public IReadOnlyList<string> FeatureTypesPresent => [];
 
     /// <inheritdoc/>
-    public XmlReader GetFeatureXml()
+    public XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         // Return a minimal well-formed XML document so XDocument.Load succeeds.
         return XmlReader.Create(new StringReader("<Features/>"));
     }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -104,8 +104,10 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         Diagnostics.CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", default), _catalogue.CatalogueRef, "portrayal");
     }
 
-    public DatasetResult Render(RenderContext? context = null)
+    public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var mariner = MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")
@@ -122,8 +124,8 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
         var executor = new S101LuaRuleExecutor(_luaEngine, _translatedDataset, s101Cat, fc);
         var featureSource = new S101FeatureXmlSource(_translatedDataset);
         var pipeline = new PortrayalPipeline(executor);
-        var portrayalLayer = pipeline.ProcessAsync(featureSource, s101Cat, mariner: mariner)
-            .GetAwaiter().GetResult();
+        var portrayalLayer = await pipeline.ProcessAsync(featureSource, s101Cat, mariner: mariner, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         var prepared = ((IVectorLayer)portrayalLayer).Instructions;
         Console.WriteLine($"[S57] Pipeline produced {prepared.Count} drawing instructions");
 

--- a/src/EncDotNet.S100.Datasets.S101/S101FeatureXmlSource.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101FeatureXmlSource.cs
@@ -51,8 +51,9 @@ public sealed class S101FeatureXmlSource : IFeatureXmlSource
         }
     }
 
-    public XmlReader GetFeatureXml()
+    public XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var xmlDoc = BuildFeatureXml();
         return xmlDoc.CreateReader();
     }

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -183,8 +183,12 @@ public sealed class S101LuaRuleExecutor : ILuaRuleExecutor
     /// <see cref="DrawingInstructionParser.Parse"/> and
     /// <see cref="S101SafconLabelMerger.Merge"/>.
     /// </summary>
-    public IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner)
+    public IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner, CancellationToken cancellationToken = default)
     {
+        // The MoonSharp interpreter is not interruptible mid-script, so the
+        // token is honoured at the coarse boundary before invocation.
+        cancellationToken.ThrowIfCancellationRequested();
+
         // TODO: Per-Lua-rule timing is deferred to PR P2 — requires a small
         // executor refactor to inject timing hooks around individual rule calls.
         using var activity = Telemetry.ActivitySource.StartActivity("s100.lua.execute");

--- a/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102CoverageSource.cs
@@ -67,7 +67,7 @@ public class S102CoverageSource : ICoverageSource
     public IReadOnlyList<DateTime> AvailableTimes => [];
     public void SelectTime(DateTime time) { }  // no-op
     
-    public virtual SampledCoverage Sample(GridRegion region)
+    public virtual SampledCoverage Sample(GridRegion region, CancellationToken cancellationToken = default)
     {
         var values = _coverage.Values;
         int gridRows = _coverage.NumPointsLatitudinal;
@@ -88,6 +88,9 @@ public class S102CoverageSource : ICoverageSource
 
         for (int r = 0; r < rows; r++)
         {
+            // Per-row (not per-cell) cancellation check keeps the inner copy
+            // loop branch-free while still bounding cancellation latency.
+            cancellationToken.ThrowIfCancellationRequested();
             int dstRowBase = r * cols;
             int srcRowBase = (rowStart + r * region.RowStride) * gridCols + colStart;
             for (int c = 0; c < cols; c++)

--- a/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104CoverageSource.cs
@@ -109,7 +109,7 @@ public class S104CoverageSource : ICoverageSource
     }
 
     /// <inheritdoc/>
-    public SampledCoverage Sample(GridRegion region)
+    public SampledCoverage Sample(GridRegion region, CancellationToken cancellationToken = default)
     {
         var coverage = _dataset.Coverages[_selectedTimeIndex];
         var values = coverage.Values;
@@ -128,6 +128,7 @@ public class S104CoverageSource : ICoverageSource
 
         for (int r = 0; r < rows; r++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             int dstRowBase = r * cols;
             int srcRowBase = (rowStart + r * region.RowStride) * gridCols + colStart;
             for (int c = 0; c < cols; c++)

--- a/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111CoverageSource.cs
@@ -97,7 +97,7 @@ public class S111CoverageSource : ICoverageSource
         _selectedTimeIndex = closest;
     }
 
-    public SampledCoverage Sample(GridRegion region)
+    public SampledCoverage Sample(GridRegion region, CancellationToken cancellationToken = default)
     {
         var coverage = _dataset.Coverages[_selectedTimeIndex];
         var values = coverage.Values;
@@ -116,6 +116,7 @@ public class S111CoverageSource : ICoverageSource
 
         for (int r = 0; r < rows; r++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             int dstRowBase = r * cols;
             int srcRowBase = (rowStart + r * region.RowStride) * gridCols + colStart;
             for (int c = 0; c < cols; c++)

--- a/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
@@ -163,8 +163,12 @@ public sealed class S131LuaRuleExecutor : ILuaRuleExecutor
     /// Runs the S-131 Lua portrayal stage and returns typed drawing instructions
     /// ready for the renderer.
     /// </summary>
-    public IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner)
+    public IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner, CancellationToken cancellationToken = default)
     {
+        // The MoonSharp interpreter is not interruptible mid-script, so the
+        // token is honoured at the coarse boundary before invocation.
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var activity = Telemetry.ActivitySource.StartActivity("s100.lua.execute");
         activity?.SetTag(TelemetryTags.Product, "S-131");
         var start = Stopwatch.GetTimestamp();

--- a/src/EncDotNet.S100.Datasets.S411/S411FeatureXmlSource.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411FeatureXmlSource.cs
@@ -41,5 +41,9 @@ public sealed class S411FeatureXmlSource : IFeatureXmlSource
     }
 
     /// <inheritdoc/>
-    public System.Xml.XmlReader GetFeatureXml() => _dataset.SourceDocument.CreateReader();
+    public System.Xml.XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _dataset.SourceDocument.CreateReader();
+    }
 }

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -320,8 +320,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 initialTime = adapter.SnapTo(globalNow);
 
             var initialContext = CreateRenderContext(processor, initialTime);
-            var result = await Task.Run(() => processor.Render(initialContext), token);
+            var result = await Task.Run(() => processor.RenderAsync(initialContext, token), token).ConfigureAwait(true);
 
+            token.ThrowIfCancellationRequested();
             ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
             // Exchange-set entries opt out of the per-dataset auto-zoom so
             // the union-extent zoom from `IExchangeSetService` (or the
@@ -469,8 +470,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             try
             {
                 var context = CreateRenderContext(proc, snapped);
-                var result = await Task.Run(() => proc.Render(context), token).ConfigureAwait(true);
+                var result = await Task.Run(() => proc.RenderAsync(context, token), token).ConfigureAwait(true);
 
+                token.ThrowIfCancellationRequested();
                 ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
                 entry.Info = result.Info;
                 entry.CurrentTime = snapped;
@@ -498,7 +500,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             {
                 var context = CreateRenderContext(proc, entry.CurrentTime);
 
-                var result = await Task.Run(() => proc.Render(context));
+                var result = await Task.Run(() => proc.RenderAsync(context, CancellationToken.None));
 
                 ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
                 entry.Info = result.Info;

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S102Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S102Synth.cs
@@ -47,10 +47,10 @@ internal sealed class DisposableS102CoverageSource(S102Dataset dataset) : S102Co
 {
     private bool _disposed;
 
-    public override EncDotNet.S100.Pipelines.Coverage.SampledCoverage Sample(EncDotNet.S100.Pipelines.Coverage.GridRegion region)
+    public override EncDotNet.S100.Pipelines.Coverage.SampledCoverage Sample(EncDotNet.S100.Pipelines.Coverage.GridRegion region, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        return base.Sample(region);
+        return base.Sample(region, cancellationToken);
     }
 
     public void Dispose() => _disposed = true;

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePickHelperTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePickHelperTests.cs
@@ -114,7 +114,7 @@ public class CoveragePickHelperTests
         public CoverageMetadata Metadata { get; }
         public IReadOnlyList<DateTime> AvailableTimes => Array.Empty<DateTime>();
         public void SelectTime(DateTime time) { }
-        public SampledCoverage Sample(GridRegion region)
+        public SampledCoverage Sample(GridRegion region, CancellationToken cancellationToken = default)
         {
             var rs = region.RowStart ?? 0;
             var re = region.RowEnd ?? Metadata.GridMetadata.NumRows;

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
@@ -141,6 +141,27 @@ public class CoveragePipelineTests
         Assert.Equal(noData, layer.NoDataValue);
     }
 
+    [Fact]
+    public async Task ProcessAsync_PreCancelledToken_ThrowsWithoutSampling()
+    {
+        var source = new FakeCoverageSource(
+            noDataValue: float.NaN,
+            fields: new Dictionary<string, float[,]>
+            {
+                ["depth"] = new float[,] { { 5f } }
+            });
+        var catalogue = new FakeCoveragePortrayalCatalogue(DepthColorScheme);
+        var pipeline = new CoveragePipeline();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => pipeline.ProcessAsync(source, catalogue, cancellationToken: cts.Token));
+
+        Assert.False(source.WasSampled);
+    }
+
     #region Fakes
 
     private sealed class FakeCoverageSource : ICoverageSource
@@ -156,6 +177,8 @@ public class CoveragePipelineTests
         private readonly string _productSpec;
         private readonly string _horizontalCRS;
         private readonly string _verticalDatum;
+
+        public bool WasSampled { get; private set; }
 
         public FakeCoverageSource(
             float noDataValue,
@@ -230,8 +253,9 @@ public class CoveragePipelineTests
         public IReadOnlyList<DateTime> AvailableTimes => [];
         public void SelectTime(DateTime time) { }
 
-        public SampledCoverage Sample(GridRegion region)
+        public SampledCoverage Sample(GridRegion region, CancellationToken cancellationToken = default)
         {
+            WasSampled = true;
             var (rows, cols) = GridSize;
             return new SampledCoverage
             {

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
@@ -244,7 +244,7 @@ public class S101PipelineTests
 
         public IReadOnlyList<string> FeatureTypesPresent { get; }
 
-        public XmlReader GetFeatureXml() =>
+        public XmlReader GetFeatureXml(CancellationToken cancellationToken = default) =>
             XmlReader.Create(new StringReader(_featureXml));
     }
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/S104Dcf8ProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S104Dcf8ProcessorTests.cs
@@ -72,7 +72,7 @@ public class S104Dcf8ProcessorTests
             using var processor = (System.IDisposable?)null; // placeholder so analyzers don't complain about disposable processors
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
 
-            var result = p.Render();
+            var result = p.RenderAsync().GetAwaiter().GetResult();
 
             Assert.Single(result.Layers);
             var memoryLayer = Assert.IsType<MemoryLayer>(result.Layers[0]);
@@ -105,7 +105,7 @@ public class S104Dcf8ProcessorTests
             // Render at the second time-step; GetFeatureInfo should report
             // the value at the same step (height = 1.5, trend = 2 for Alpha).
             var secondStep = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
-            _ = p.Render(new S104RenderContext { TimeStep = secondStep });
+            _ = p.RenderAsync(new S104RenderContext { TimeStep = secondStep }).GetAwaiter().GetResult();
 
             var info = p.GetFeatureInfo("station:Alpha");
 
@@ -135,7 +135,7 @@ public class S104Dcf8ProcessorTests
         try
         {
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
-            _ = p.Render();
+            _ = p.RenderAsync().GetAwaiter().GetResult();
 
             Assert.Null(p.GetFeatureInfo("station:Missing"));
             Assert.Null(p.GetFeatureInfo("not-a-station-ref"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111Dcf8ProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111Dcf8ProcessorTests.cs
@@ -75,7 +75,7 @@ public class S111Dcf8ProcessorTests
             using var catalogues = new PortrayalCatalogueManager();
             var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
 
-            var result = p.Render();
+            var result = p.RenderAsync().GetAwaiter().GetResult();
 
             Assert.Single(result.Layers);
             var memoryLayer = Assert.IsType<MemoryLayer>(result.Layers[0]);
@@ -108,7 +108,7 @@ public class S111Dcf8ProcessorTests
 
             // Render at the second time-step; expected S1 speed = 0.6, dir = 50.
             var secondStep = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
-            _ = p.Render(new S111RenderContext { TimeStep = secondStep });
+            _ = p.RenderAsync(new S111RenderContext { TimeStep = secondStep }).GetAwaiter().GetResult();
 
             var info = p.GetFeatureInfo("station:S1");
 
@@ -139,7 +139,7 @@ public class S111Dcf8ProcessorTests
         {
             using var catalogues = new PortrayalCatalogueManager();
             var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
-            _ = p.Render();
+            _ = p.RenderAsync().GetAwaiter().GetResult();
 
             Assert.Null(p.GetFeatureInfo("station:Nope"));
             Assert.Null(p.GetFeatureInfo("plain-ref"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/StationTimeSeriesSnapshotTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/StationTimeSeriesSnapshotTests.cs
@@ -78,7 +78,7 @@ public class StationTimeSeriesSnapshotTests
         try
         {
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
-            _ = p.Render();
+            _ = p.RenderAsync().GetAwaiter().GetResult();
             var info = p.GetFeatureInfo("station:ST01");
 
             Assert.NotNull(info);
@@ -100,7 +100,7 @@ public class StationTimeSeriesSnapshotTests
         try
         {
             var p = new S111DatasetProcessor(path, new PortrayalCatalogueManager(), IdentityFactory.Instance);
-            _ = p.Render();
+            _ = p.RenderAsync().GetAwaiter().GetResult();
             var info = p.GetFeatureInfo("station:S1");
 
             Assert.NotNull(info);
@@ -123,7 +123,7 @@ public class StationTimeSeriesSnapshotTests
         try
         {
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
-            _ = p.Render();
+            _ = p.RenderAsync().GetAwaiter().GetResult();
             // unknown ref returns null FeatureInfo entirely
             Assert.Null(p.GetFeatureInfo("station:Missing"));
             Assert.Null(p.GetFeatureInfo("not-a-station"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
@@ -197,7 +197,7 @@ public sealed class TelemetrySmokeTests
 
         public IReadOnlyList<string> FeatureTypesPresent { get; }
 
-        public XmlReader GetFeatureXml() =>
+        public XmlReader GetFeatureXml(CancellationToken cancellationToken = default) =>
             XmlReader.Create(new System.IO.StringReader(_featureXml));
     }
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
@@ -566,6 +566,39 @@ public class VectorPipelineTests
 
     #endregion
 
+    #region Cancellation
+
+    [Fact]
+    public async Task ProcessAsync_PreCancelledToken_ThrowsWithoutTouchingSource()
+    {
+        var source = new ThrowingFeatureXmlSource();
+        var catalogue = new FakeVectorPortrayalCatalogue([]);
+        var pipeline = new VectorPipeline();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => pipeline.ProcessAsync(source, catalogue, cancellationToken: cts.Token));
+
+        Assert.False(source.WasQueried);
+    }
+
+    private sealed class ThrowingFeatureXmlSource : IFeatureXmlSource
+    {
+        public bool WasQueried { get; private set; }
+
+        public IReadOnlyList<string> FeatureTypesPresent { get; } = [];
+
+        public XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
+        {
+            WasQueried = true;
+            return XmlReader.Create(new StringReader("<Dataset/>"));
+        }
+    }
+
+    #endregion
+
     #region Fakes
 
     private sealed class FakeFeatureXmlSource : IFeatureXmlSource
@@ -580,7 +613,7 @@ public class VectorPipelineTests
 
         public IReadOnlyList<string> FeatureTypesPresent { get; }
 
-        public XmlReader GetFeatureXml() =>
+        public XmlReader GetFeatureXml(CancellationToken cancellationToken = default) =>
             XmlReader.Create(new StringReader(_featureXml));
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
@@ -26,7 +26,7 @@ public class FeatureSearchServiceTests
         }
         public string ProductSpec { get; }
         public SpecRef Spec { get; }
-        public DatasetResult Render(RenderContext? context = null) => throw new NotSupportedException();
+        public Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public FeatureInfo? GetFeatureInfo(string featureRef) => null;
         public IEnumerable<FeatureSummary> EnumerateFeatures() => _features;
     }

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -145,7 +145,7 @@ public class PickServiceTests
 
         public string ProductSpec { get; }
         public SpecRef Spec { get; }
-        public DatasetResult Render(RenderContext? context = null)
+        public Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
         public FeatureInfo? GetFeatureInfo(string featureRef)
             => _features.TryGetValue(featureRef, out var info) ? info : null;

--- a/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
+++ b/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
@@ -34,7 +34,7 @@ namespace EncDotNet.S100.VisualRegression;
 /// <list type="number">
 ///   <item>The harness picks the right <see cref="IDatasetProcessor"/> via
 ///         <see cref="DatasetPipelineFactory"/> (same code path as the viewer).</item>
-///   <item>It invokes <see cref="IDatasetProcessor.Render"/> with a spec-specific
+///   <item>It invokes <see cref="IDatasetProcessor.RenderAsync"/> with a spec-specific
 ///         <see cref="RenderContext"/> derived from <see cref="HarnessOptions"/>.</item>
 ///   <item>The resulting Mapsui <see cref="ILayer"/>s are dropped into a
 ///         <see cref="Map"/>, the viewport is zoomed to the dataset extent, and
@@ -100,7 +100,7 @@ public sealed class RenderHarness : IDisposable
 
         var processor = _factory.CreateProcessor(path);
         var context = BuildContext(processor, options);
-        var result = processor.Render(context);
+        var result = processor.RenderAsync(context).GetAwaiter().GetResult();
 
         return Rasterize(result, options);
     }
@@ -118,7 +118,7 @@ public sealed class RenderHarness : IDisposable
 
         var processor = _factory.CreateProcessor(path);
         var context = BuildContext(processor, options);
-        var result = processor.Render(context);
+        var result = processor.RenderAsync(context).GetAwaiter().GetResult();
 
         return (Rasterize(result, options), result);
     }

--- a/tools/EncDotNet.S100.PerfRunner/ProcessorRenderBridge.cs
+++ b/tools/EncDotNet.S100.PerfRunner/ProcessorRenderBridge.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.PerfRunner;
+
+/// <summary>
+/// Bridges the dataset-processor render entry point across the base /
+/// candidate library boundary that the performance gate spans.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The perf gate (<c>.github/workflows/perf.yml</c>) deliberately overlays
+/// <em>this</em> (head) perf harness onto the <em>base</em> SHA's library
+/// source so the base runner is "this PR's runner code linked against the
+/// base SHA's library code". A render call compiled here therefore has to
+/// bind on both library surfaces:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     Base: <c>DatasetResult Render(RenderContext?)</c> (synchronous).
+///   </description></item>
+///   <item><description>
+///     Candidate: <c>Task&lt;DatasetResult&gt; RenderAsync(RenderContext?,
+///     CancellationToken)</c> (the async entry point this PR introduces).
+///   </description></item>
+/// </list>
+/// <para>
+/// Reflection keeps the scenario call sites source-compatible with either
+/// shape without re-introducing a synchronous render API on the production
+/// <see cref="IDatasetProcessor"/> interface — the version-bridging concern
+/// belongs in the harness the gate overlays, not in the library under test.
+/// The method handle is resolved once into a strongly typed delegate so the
+/// measured render region pays only an ordinary delegate invocation (no
+/// per-iteration reflection cost), keeping the base/candidate comparison
+/// meaningful.
+/// </para>
+/// </remarks>
+internal static class ProcessorRenderBridge
+{
+    private static readonly Func<IDatasetProcessor, RenderContext?, CancellationToken, DatasetResult> s_render = Create();
+
+    /// <summary>
+    /// Renders the dataset synchronously, dispatching to whichever render
+    /// entry point the linked library exposes.
+    /// </summary>
+    public static DatasetResult Render(
+        IDatasetProcessor processor,
+        RenderContext? context = null,
+        CancellationToken cancellationToken = default)
+        => s_render(processor, context, cancellationToken);
+
+    private static Func<IDatasetProcessor, RenderContext?, CancellationToken, DatasetResult> Create()
+    {
+        var type = typeof(IDatasetProcessor);
+
+        var asyncMethod = type.GetMethod(
+            "RenderAsync",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: [typeof(RenderContext), typeof(CancellationToken)],
+            modifiers: null);
+
+        if (asyncMethod is not null && asyncMethod.ReturnType == typeof(Task<DatasetResult>))
+        {
+            var invoke = asyncMethod.CreateDelegate<
+                Func<IDatasetProcessor, RenderContext?, CancellationToken, Task<DatasetResult>>>();
+
+            return (processor, context, cancellationToken) =>
+                invoke(processor, context, cancellationToken).GetAwaiter().GetResult();
+        }
+
+        var syncMethod = type.GetMethod(
+            "Render",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: [typeof(RenderContext)],
+            modifiers: null);
+
+        if (syncMethod is not null && syncMethod.ReturnType == typeof(DatasetResult))
+        {
+            var invoke = syncMethod.CreateDelegate<
+                Func<IDatasetProcessor, RenderContext?, DatasetResult>>();
+
+            return (processor, context, _) => invoke(processor, context);
+        }
+
+        throw new InvalidOperationException(
+            "IDatasetProcessor exposes neither RenderAsync(RenderContext?, CancellationToken) " +
+            "nor Render(RenderContext?); the perf harness cannot bind a render entry point.");
+    }
+}

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/ExchangeSetOpenScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/ExchangeSetOpenScenario.cs
@@ -32,7 +32,7 @@ internal sealed class ExchangeSetOpenScenario : IPerfScenario
                 // Drive the pipeline for each dataset.
                 try
                 {
-                    result.Processor.RenderAsync().GetAwaiter().GetResult();
+                    ProcessorRenderBridge.Render(result.Processor);
                 }
                 catch
                 {

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/ExchangeSetOpenScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/ExchangeSetOpenScenario.cs
@@ -32,7 +32,7 @@ internal sealed class ExchangeSetOpenScenario : IPerfScenario
                 // Drive the pipeline for each dataset.
                 try
                 {
-                    result.Processor.Render();
+                    result.Processor.RenderAsync().GetAwaiter().GetResult();
                 }
                 catch
                 {

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayColdScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayColdScenario.cs
@@ -18,7 +18,7 @@ internal sealed class S101PortrayColdScenario : IPerfScenario
 
         var factory = SharedInfrastructure.CreatePipelineFactory();
         var processor = factory.CreateProcessor(files[0]);
-        processor.RenderAsync().GetAwaiter().GetResult();
+        ProcessorRenderBridge.Render(processor);
 
         return Task.CompletedTask;
     }

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayColdScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayColdScenario.cs
@@ -18,7 +18,7 @@ internal sealed class S101PortrayColdScenario : IPerfScenario
 
         var factory = SharedInfrastructure.CreatePipelineFactory();
         var processor = factory.CreateProcessor(files[0]);
-        processor.Render();
+        processor.RenderAsync().GetAwaiter().GetResult();
 
         return Task.CompletedTask;
     }

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayWarmScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayWarmScenario.cs
@@ -23,7 +23,7 @@ internal sealed class S101PortrayWarmScenario : IPerfScenario
             _processor = factory.CreateProcessor(files[0]);
         }
 
-        _processor.Render();
+        _processor.RenderAsync().GetAwaiter().GetResult();
         return Task.CompletedTask;
     }
 }

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayWarmScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S101PortrayWarmScenario.cs
@@ -23,7 +23,7 @@ internal sealed class S101PortrayWarmScenario : IPerfScenario
             _processor = factory.CreateProcessor(files[0]);
         }
 
-        _processor.RenderAsync().GetAwaiter().GetResult();
+        ProcessorRenderBridge.Render(_processor);
         return Task.CompletedTask;
     }
 }

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S101RenderWarmScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S101RenderWarmScenario.cs
@@ -27,7 +27,7 @@ internal sealed class S101RenderWarmScenario : IPerfScenario
         // Render() invokes the full pipeline including the Mapsui
         // display-list renderer — the returned layers are in-memory
         // Mapsui MemoryLayers, no UI thread required.
-        var result = _processor.Render();
+        var result = _processor.RenderAsync().GetAwaiter().GetResult();
 
         // Touch the layer list to prevent dead-code elimination.
         if (result.Layers.Count == 0)

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S101RenderWarmScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S101RenderWarmScenario.cs
@@ -27,7 +27,7 @@ internal sealed class S101RenderWarmScenario : IPerfScenario
         // Render() invokes the full pipeline including the Mapsui
         // display-list renderer — the returned layers are in-memory
         // Mapsui MemoryLayers, no UI thread required.
-        var result = _processor.RenderAsync().GetAwaiter().GetResult();
+        var result = ProcessorRenderBridge.Render(_processor);
 
         // Touch the layer list to prevent dead-code elimination.
         if (result.Layers.Count == 0)

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageRenderLargeScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageRenderLargeScenario.cs
@@ -32,7 +32,7 @@ internal sealed class S102CoverageRenderLargeScenario : IPerfScenario
             _processor = factory.CreateProcessor(_fixturePath);
         }
 
-        var result = _processor.Render();
+        var result = _processor.RenderAsync().GetAwaiter().GetResult();
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-102 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageRenderLargeScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageRenderLargeScenario.cs
@@ -32,7 +32,7 @@ internal sealed class S102CoverageRenderLargeScenario : IPerfScenario
             _processor = factory.CreateProcessor(_fixturePath);
         }
 
-        var result = _processor.RenderAsync().GetAwaiter().GetResult();
+        var result = ProcessorRenderBridge.Render(_processor);
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-102 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageScenario.cs
@@ -23,7 +23,7 @@ internal sealed class S102CoverageScenario : IPerfScenario
             _processor = factory.CreateProcessor(h5Path);
         }
 
-        var result = _processor.RenderAsync().GetAwaiter().GetResult();
+        var result = ProcessorRenderBridge.Render(_processor);
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-102 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S102CoverageScenario.cs
@@ -23,7 +23,7 @@ internal sealed class S102CoverageScenario : IPerfScenario
             _processor = factory.CreateProcessor(h5Path);
         }
 
-        var result = _processor.Render();
+        var result = _processor.RenderAsync().GetAwaiter().GetResult();
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-102 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S124VectorScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S124VectorScenario.cs
@@ -24,7 +24,7 @@ internal sealed class S124VectorScenario : IPerfScenario
             _processor = factory.CreateProcessor(files[0]);
         }
 
-        var result = _processor.RenderAsync().GetAwaiter().GetResult();
+        var result = ProcessorRenderBridge.Render(_processor);
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-124 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S124VectorScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S124VectorScenario.cs
@@ -24,7 +24,7 @@ internal sealed class S124VectorScenario : IPerfScenario
             _processor = factory.CreateProcessor(files[0]);
         }
 
-        var result = _processor.Render();
+        var result = _processor.RenderAsync().GetAwaiter().GetResult();
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-124 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S201VectorScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S201VectorScenario.cs
@@ -26,7 +26,7 @@ internal sealed class S201VectorScenario : IPerfScenario
             _processor = factory.CreateProcessor(files[0]);
         }
 
-        var result = _processor.RenderAsync().GetAwaiter().GetResult();
+        var result = ProcessorRenderBridge.Render(_processor);
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-201 render.");

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/S201VectorScenario.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/S201VectorScenario.cs
@@ -26,7 +26,7 @@ internal sealed class S201VectorScenario : IPerfScenario
             _processor = factory.CreateProcessor(files[0]);
         }
 
-        var result = _processor.Render();
+        var result = _processor.RenderAsync().GetAwaiter().GetResult();
 
         if (result.Layers.Count == 0)
             throw new InvalidOperationException("Expected at least one layer from S-201 render.");


### PR DESCRIPTION
## Summary

Renders previously ran through "fake-async" pipelines (synchronous bodies returning `Task.FromResult`), processors did sync-over-async via `.GetAwaiter().GetResult()`, and no `CancellationToken` ever reached inside a render. This PR threads cancellation end-to-end and converts the processor render entry point to a genuine async signature, so a render can be cancelled mid-flight and a superseded render can never clobber the UI with stale layers.

A key finding worth calling out: the render path is **CPU-bound over already-in-memory data** — the genuine async I/O (HDF5 / asset reads) happens at *construction* time, not during render. So the primary win here is **cancellation responsiveness**, not I/O offload.

### Approach

- **Core pipelines:** `VectorPipeline` and `CoveragePipeline` gain `ProcessAsync(..., CancellationToken)` that call `ThrowIfCancellationRequested()` *before* touching the source, plus per-stage checks. `PortrayalPipeline` overloads forward the token. Source interfaces (`IFeatureXmlSource.GetFeatureXml`, `ILuaRuleExecutor.Execute`, `ICoverageSource.Sample`) take a **defaulted** `CancellationToken` to keep existing callers compiling.
- **Processors:** `IDatasetProcessor.Render` is renamed to `RenderAsync` (the one breaking change); processors `await pipeline.ProcessAsync(..., ct).ConfigureAwait(false)`.
- **Leaf sources kept synchronous-but-cancellable.** They do pure in-memory CPU work; making them `Task`-returning would be dishonest fake-async. `ICoverageSource.Sample` is the natural future seam if sampling ever streams from disk.
- **Viewer:** `DatasetLoaderService` awaits `RenderAsync` inside `Task.Run` (the render completes synchronously, so awaiting on the UI thread would freeze it) with a post-await `ThrowIfCancellationRequested` guard before each `ReplaceLayers` so a stale render can't overwrite newer layers.
- Updated PerfRunner scenarios, tools, and test fakes/harnesses to match.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a cross-cutting infrastructural change to the shared pipeline plumbing in `EncDotNet.S100.Core` and the per-spec processors; it does not alter any spec-derived encoding, attribute names, or portrayal semantics.

**Spec section references cited in code/docs:** N/A — no spec-derived constants added.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added pre-cancelled-token tests for both pipelines (`VectorPipelineTests`, `CoveragePipelineTests`) asserting the source is never queried/sampled when the token is already cancelled. Full suite: 27 projects, all passing, 0 failures. Also smoke-tested the viewer against a real S-101 ENC (5297 drawing instructions portrayed via the new `RenderAsync` path).

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

New/changed signatures carry XML doc comments (including the rationale for keeping leaf sources synchronous-but-cancellable). No user-facing behaviour changed, so conceptual docs were left as-is.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

`IDatasetProcessor.Render` is renamed to `IDatasetProcessor.RenderAsync` (returns `Task<DatasetResult>`). This is the only breaking change; all other signature additions use defaulted `CancellationToken` parameters. All in-repo callers (viewer, tools, tests) have been updated.