### PR TITLE
Add env-var-driven PerfRunner scenarios for real UKHO S-101/S-102/S-111 datasets

### DIFF
--- a/tools/EncDotNet.S100.PerfRunner/ScenarioRegistry.cs
+++ b/tools/EncDotNet.S100.PerfRunner/ScenarioRegistry.cs
@@ -18,6 +18,10 @@ public static class ScenarioRegistry
         Register(() => new Scenarios.S124VectorScenario());
         Register(() => new Scenarios.S201VectorScenario());
         Register(() => new Scenarios.ExchangeSetOpenScenario());
+        Register(() => new Scenarios.S101RealColdScenario());
+        Register(() => new Scenarios.S101RealWarmScenario());
+        Register(() => new Scenarios.S102RealWarmScenario());
+        Register(() => new Scenarios.S111RealWarmScenario());
     }
 
     /// <summary>Registers a scenario factory keyed by its <see cref="IPerfScenario.Name"/>.</summary>

--- a/tools/EncDotNet.S100.PerfRunner/Scenarios/RealCorpusScenarios.cs
+++ b/tools/EncDotNet.S100.PerfRunner/Scenarios/RealCorpusScenarios.cs
@@ -1,0 +1,145 @@
+namespace EncDotNet.S100.PerfRunner.Scenarios;
+
+/// <summary>
+/// Helpers for env-var-driven real-world dataset scenarios. The actual
+/// trial-cell data (UKHO S-100 / S-102 / S-111) is licensed and lives
+/// outside the repo; the scenarios below read its location from
+/// environment variables so paths are never committed.
+/// </summary>
+internal static class RealCorpusEnv
+{
+    public const string S101Var = "ENC_DOTNET_PERF_REAL_S101";
+    public const string S102Var = "ENC_DOTNET_PERF_REAL_S102";
+    public const string S111Var = "ENC_DOTNET_PERF_REAL_S111";
+
+    public static string Require(string envVar)
+    {
+        var path = Environment.GetEnvironmentVariable(envVar);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException(
+                $"Real-corpus scenario requires environment variable {envVar} " +
+                "to point at a dataset file. This scenario is not used in CI " +
+                "and intentionally has no checked-in fixture.");
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"Dataset referenced by {envVar} does not exist: {path}", path);
+        }
+
+        return path;
+    }
+}
+
+/// <summary>
+/// Cold-start S-101 portrayal against a real UKHO trial cell. Path
+/// supplied via the <c>ENC_DOTNET_PERF_REAL_S101</c> environment variable
+/// (a single <c>.000</c> file).
+/// </summary>
+internal sealed class S101RealColdScenario : IPerfScenario
+{
+    public string Name => "s101-real-cold";
+    public string Description => "S-101 cold-start: real UKHO .000 cell from $ENC_DOTNET_PERF_REAL_S101.";
+
+    public Task RunAsync(PerfContext ctx, CancellationToken ct)
+    {
+        var path = RealCorpusEnv.Require(RealCorpusEnv.S101Var);
+
+        var factory = SharedInfrastructure.CreatePipelineFactory();
+        var processor = factory.CreateProcessor(path);
+        var result = ProcessorRenderBridge.Render(processor);
+
+        if (result.Layers.Count == 0)
+            throw new InvalidOperationException("Expected at least one layer from S-101 render.");
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Warm S-101 render against a real UKHO trial cell, sharing the
+/// processor across iterations.
+/// </summary>
+internal sealed class S101RealWarmScenario : IPerfScenario
+{
+    public string Name => "s101-real-warm";
+    public string Description => "S-101 warm pipeline+render on a real UKHO .000 cell from $ENC_DOTNET_PERF_REAL_S101.";
+
+    private Datasets.Pipelines.IDatasetProcessor? _processor;
+
+    public Task RunAsync(PerfContext ctx, CancellationToken ct)
+    {
+        if (_processor is null)
+        {
+            var path = RealCorpusEnv.Require(RealCorpusEnv.S101Var);
+            var factory = SharedInfrastructure.CreatePipelineFactory();
+            _processor = factory.CreateProcessor(path);
+        }
+
+        var result = ProcessorRenderBridge.Render(_processor);
+        if (result.Layers.Count == 0)
+            throw new InvalidOperationException("Expected at least one layer from S-101 render.");
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Warm S-102 coverage render against a real UKHO bathymetric tile.
+/// Path supplied via the <c>ENC_DOTNET_PERF_REAL_S102</c> environment
+/// variable (a single <c>.h5</c> file).
+/// </summary>
+internal sealed class S102RealWarmScenario : IPerfScenario
+{
+    public string Name => "s102-real-warm";
+    public string Description => "S-102 warm coverage render on a real UKHO .h5 tile from $ENC_DOTNET_PERF_REAL_S102.";
+
+    private Datasets.Pipelines.IDatasetProcessor? _processor;
+
+    public Task RunAsync(PerfContext ctx, CancellationToken ct)
+    {
+        if (_processor is null)
+        {
+            var path = RealCorpusEnv.Require(RealCorpusEnv.S102Var);
+            var factory = SharedInfrastructure.CreatePipelineFactory();
+            _processor = factory.CreateProcessor(path);
+        }
+
+        var result = ProcessorRenderBridge.Render(_processor);
+        if (result.Layers.Count == 0)
+            throw new InvalidOperationException("Expected at least one layer from S-102 render.");
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Warm S-111 surface-currents render against a real UKHO trial file
+/// (typically a single Solent regularly-gridded time-series cell). Path
+/// supplied via the <c>ENC_DOTNET_PERF_REAL_S111</c> environment variable.
+/// </summary>
+internal sealed class S111RealWarmScenario : IPerfScenario
+{
+    public string Name => "s111-real-warm";
+    public string Description => "S-111 warm surface-currents render on a real UKHO .h5 file from $ENC_DOTNET_PERF_REAL_S111.";
+
+    private Datasets.Pipelines.IDatasetProcessor? _processor;
+
+    public Task RunAsync(PerfContext ctx, CancellationToken ct)
+    {
+        if (_processor is null)
+        {
+            var path = RealCorpusEnv.Require(RealCorpusEnv.S111Var);
+            var factory = SharedInfrastructure.CreatePipelineFactory();
+            _processor = factory.CreateProcessor(path);
+        }
+
+        var result = ProcessorRenderBridge.Render(_processor);
+        if (result.Layers.Count == 0)
+            throw new InvalidOperationException("Expected at least one layer from S-111 render.");
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Adds four env-var-driven `PerfRunner` scenarios so portrayal/render measurements against real-world UKHO trial-cell datasets are reproducible. Output of a measurement-only profiling pass — **no product-code optimisations** in this PR; those are tracked as separate follow-up issues.

The trial-cell datasets are licensed (Data Exploration Licence), live outside the repo, and must not be committed. Each scenario reads its dataset path from an environment variable; if the variable is unset or the file is missing, the scenario fails fast with a clear message and is skipped on CI.

## Scenarios added

| Name | Dataset (via env var) | What it exercises |
|---|---|---|
| `s101-real-cold` | `ENC_DOTNET_PERF_REAL_S101` (a `.000` cell) | One open + portray, single iter |
| `s101-real-warm` | same | Warm re-portray-on-render loop (worst-case re-portrayal cost) |
| `s102-real-warm` | `ENC_DOTNET_PERF_REAL_S102` (an `.h5` tile) | Warm bathymetry coverage render |
| `s111-real-warm` | `ENC_DOTNET_PERF_REAL_S111` (an `.h5` file) | Warm surface-current render at fixed time-step |

## Why "warm" is worst-case here

`s101-real-warm` re-portrays from raw features every iteration; the live viewer does not. Read PerfRunner warm numbers as the worst-case re-portrayal cost. The live-viewer warm-rasterise cost (~430 ms steady-state on the same dataset/viewport) lives in the viewer, not in PerfRunner — that gap is tracked in #160.

## Profile findings (follow-up issues)

The profile run that motivated these scenarios produced the following follow-up issues (full report is in the originating session workspace, not committed):

**Optimisation candidates** (with confidence labels):

- #151 — Stop leaking PNG buffers across `render_to_image` MCP calls (High, Large impact)
- #152 — Cache PureHDF metadata at dataset open (High, Large)
- #153 — Cache `S111DatasetReader.ReadValues` for active time-step + viewport (Medium)
- #154 — Replace XLinq round-trip in `S101FeatureXmlSource.MakePointElement` (High source / Medium impact)
- #155 — Memoise `ClipPatternsByPriority` and reduce NTS exception-driven snap-retry (High memoisation / Medium NTS)
- #156 — Eliminate `MetricStreamIdentity` per-record allocation (Medium)
- #157 — Skip PNG encode in S-102 warm render path (Low — needs spike)

**Tooling gaps**:

- #158 — Add MCP commands to mutate viewer state (palette, display-category, time-step, viewport)
- #159 — Add close-dataset CLI flag and MCP command (for retention testing)
- #160 — PerfRunner doesn't drive Avalonia + Skia GPU render path

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

## Tests

- [x] No new tests (perf-tooling change; scenarios are skipped without env vars)
- [x] `dotnet build --configuration Release` passes locally

## Documentation

- [x] Reproduction recipe lives in the profile report and follow-up issues
- [x] New public APIs have XML doc comments (the scenario classes + `RealCorpusEnv`)

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None.