### PR TITLE
Add scripted-measurement MCP tools and fix render_to_image PNG leak (perf-report follow-ups)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -118,6 +118,8 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `sample_coverage_along` | Samples a coverage along a polyline / great-circle path. |
 | `render_to_image` *(viewer only, read-only)* | Captures the viewer's current map view as a PNG image, returned as an MCP `ImageContentBlock`. Lets an agent see exactly what the user sees for diagnosis of rendering issues (palette banding, NoData voids, augmented-geometry artefacts, missing features, etc.). |
 | `set_viewport` *(viewer only, **mutating**)* | Drives the live viewer's map navigator to a specified WGS-84 viewport — either a bbox (`south`/`west`/`north`/`east`) or a centre + web-mercator zoom (`centerLat`/`centerLon`/`zoom`). Mixing the two forms is rejected. Antimeridian-crossing bboxes are not supported in v1. The companion of `render_to_image`: drive the navigator with `set_viewport`, then capture with `render_to_image` for scripted measurement runs. |
+| `set_palette` *(viewer only, **mutating**)* | Sets the live viewer's active map palette to `Day`, `Dusk`, or `Night` (case-insensitive). Idempotent — no-op when already at the requested palette. Returns the applied and previous palette so callers can detect no-ops. Lets scripted measurement runs drive palette-change scenarios from outside the GUI. |
+| `set_display_category` *(viewer only, **mutating**)* | Sets the live viewer's active ECDIS display category to `DisplayBase`, `Standard`, `OtherInformation`, or `All` (case-insensitive). Idempotent. Counterpart to the `--display-category` CLI flag, but applicable mid-session. |
 
 ### Read-only vs mutating tools
 
@@ -129,7 +131,8 @@ Tools fall into two groups:
   snapshots from a clone of the live `Map`).
 * **Mutating** — modify the live viewer's state (navigator, palette,
   time step, loaded datasets, etc.). Use only when you intend to
-  drive the viewer's UI from outside. Examples: `set_viewport`.
+  drive the viewer's UI from outside. Examples: `set_viewport`,
+  `set_palette`, `set_display_category`.
 
 Tool descriptions in the registered MCP catalogue identify each tool
 as one or the other; this table is the canonical reference.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -116,7 +116,23 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `query_features` | Returns features from loaded GML vector datasets whose geometry intersects a spatial query. |
 | `sample_coverage` | Samples a depth / water-level / current value at a lat/lon from an S-102 / S-104 / S-111 dataset. |
 | `sample_coverage_along` | Samples a coverage along a polyline / great-circle path. |
-| `render_to_image` *(viewer only)* | Captures the viewer's current map view as a PNG image, returned as an MCP `ImageContentBlock`. Lets an agent see exactly what the user sees for diagnosis of rendering issues (palette banding, NoData voids, augmented-geometry artefacts, missing features, etc.). |
+| `render_to_image` *(viewer only, read-only)* | Captures the viewer's current map view as a PNG image, returned as an MCP `ImageContentBlock`. Lets an agent see exactly what the user sees for diagnosis of rendering issues (palette banding, NoData voids, augmented-geometry artefacts, missing features, etc.). |
+| `set_viewport` *(viewer only, **mutating**)* | Drives the live viewer's map navigator to a specified WGS-84 viewport — either a bbox (`south`/`west`/`north`/`east`) or a centre + web-mercator zoom (`centerLat`/`centerLon`/`zoom`). Mixing the two forms is rejected. Antimeridian-crossing bboxes are not supported in v1. The companion of `render_to_image`: drive the navigator with `set_viewport`, then capture with `render_to_image` for scripted measurement runs. |
+
+### Read-only vs mutating tools
+
+Tools fall into two groups:
+
+* **Read-only** — never mutate viewer state. Safe to call from any
+  agent at any time. Examples: `list_datasets`, `find_at`,
+  `query_features`, `sample_coverage`, `render_to_image` (which
+  snapshots from a clone of the live `Map`).
+* **Mutating** — modify the live viewer's state (navigator, palette,
+  time step, loaded datasets, etc.). Use only when you intend to
+  drive the viewer's UI from outside. Examples: `set_viewport`.
+
+Tool descriptions in the registered MCP catalogue identify each tool
+as one or the other; this table is the canonical reference.
 
 ### Image content blocks (`render_to_image`)
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -120,6 +120,7 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `set_viewport` *(viewer only, **mutating**)* | Drives the live viewer's map navigator to a specified WGS-84 viewport — either a bbox (`south`/`west`/`north`/`east`) or a centre + web-mercator zoom (`centerLat`/`centerLon`/`zoom`). Mixing the two forms is rejected. Antimeridian-crossing bboxes are not supported in v1. The companion of `render_to_image`: drive the navigator with `set_viewport`, then capture with `render_to_image` for scripted measurement runs. |
 | `set_palette` *(viewer only, **mutating**)* | Sets the live viewer's active map palette to `Day`, `Dusk`, or `Night` (case-insensitive). Idempotent — no-op when already at the requested palette. Returns the applied and previous palette so callers can detect no-ops. Lets scripted measurement runs drive palette-change scenarios from outside the GUI. |
 | `set_display_category` *(viewer only, **mutating**)* | Sets the live viewer's active ECDIS display category to `DisplayBase`, `Standard`, `OtherInformation`, or `All` (case-insensitive). Idempotent. Counterpart to the `--display-category` CLI flag, but applicable mid-session. |
+| `set_time_step` *(viewer only, **mutating**)* | Drives the viewer's global time clock to a specific sample for time-aware datasets (S-104 / S-111 / S-411). Supply EITHER `index` (0-based integer into `list_time_steps`) OR `timestamp` (ISO-8601, snapped to the nearest sample). Returns the resolved index and snapped timestamp. Counterpart to the `--time-step` CLI flag, but applicable mid-session. |
 
 ### Read-only vs mutating tools
 
@@ -132,7 +133,7 @@ Tools fall into two groups:
 * **Mutating** — modify the live viewer's state (navigator, palette,
   time step, loaded datasets, etc.). Use only when you intend to
   drive the viewer's UI from outside. Examples: `set_viewport`,
-  `set_palette`, `set_display_category`.
+  `set_palette`, `set_display_category`, `set_time_step`.
 
 Tool descriptions in the registered MCP catalogue identify each tool
 as one or the other; this table is the canonical reference.

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -341,7 +341,8 @@ public partial class App : Application
             sp.GetRequiredService<ViewerSettings>(),
             sp.GetRequiredService<IMapHostAccessor>(),
             sp.GetService<ILoggerFactory>(),
-            sp.GetRequiredService<IRenderStateControllerAccessor>()));
+            sp.GetRequiredService<IRenderStateControllerAccessor>(),
+            sp.GetRequiredService<GlobalTimeService>()));
 
         // View models
         services.AddSingleton<FeatureCataloguesViewModel>();

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -335,11 +335,13 @@ public partial class App : Application
         // for read-only MCP queries; the host owns server lifecycle.
         services.AddSingleton<ViewerDatasetCatalog>();
         services.AddSingleton<IMapHostAccessor, MapHostAccessor>();
+        services.AddSingleton<IRenderStateControllerAccessor, RenderStateControllerAccessor>();
         services.AddSingleton<McpServerHost>(sp => new McpServerHost(
             sp.GetRequiredService<ViewerDatasetCatalog>(),
             sp.GetRequiredService<ViewerSettings>(),
             sp.GetRequiredService<IMapHostAccessor>(),
-            sp.GetService<ILoggerFactory>()));
+            sp.GetService<ILoggerFactory>(),
+            sp.GetRequiredService<IRenderStateControllerAccessor>()));
 
         // View models
         services.AddSingleton<FeatureCataloguesViewModel>();

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -125,6 +125,13 @@ public partial class MainWindow : ShadUI.Window
         // loader subscribes to its own settings dependencies internally.
         var mapHost = new MapsuiMapHost(MapControl);
         App.Services.GetRequiredService<IMapHostAccessor>().Current = mapHost;
+        // Render-state controller bridges MCP / scripted callers to the
+        // viewer's palette and ECDIS display category without exposing
+        // SettingsViewModel / EcdisDisplayState directly.
+        App.Services.GetRequiredService<IRenderStateControllerAccessor>().Current =
+            new ViewerRenderStateController(
+                App.Services.GetRequiredService<ViewModels.SettingsViewModel>(),
+                App.Services.GetRequiredService<EcdisDisplayState>());
         _loader.Initialize(mapHost, options);
         // Wire validation finding click-to-zoom: each finding view-model
         // routes its <c>ZoomToFindingCommand</c> through this dispatcher.

--- a/src/EncDotNet.S100.Viewer/McpTools/SetDisplayCategoryMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetDisplayCategoryMcpAdapter.cs
@@ -1,0 +1,79 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="SetDisplayCategoryTool"/> as an MCP server tool.</summary>
+internal static class SetDisplayCategoryMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Mutates the live viewer's ECDIS display category. Allowed values: 'DisplayBase', " +
+        "'Standard', 'OtherInformation', 'All' (case-insensitive). Idempotent — setting the " +
+        "current category is a no-op. Returns the applied and previous category. " +
+        "See docs/mcp-server.md for the read-only / mutating split.";
+
+    public static McpServerTool Create(SetDisplayCategoryTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [Description("Category: 'DisplayBase', 'Standard', 'OtherInformation', or 'All' (case-insensitive).")] string displayCategory,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new SetDisplayCategoryRequest(displayCategory), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SetDisplayCategoryTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(Func<Task<ToolResult<SetDisplayCategoryResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return InternalError(ex); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<SetDisplayCategoryResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var payload = new JsonObject
+            {
+                ["displayCategory"] = value!.DisplayCategory,
+                ["previous"] = value.Previous,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return Failure(err!);
+    }
+
+    private static CallToolResult Failure(ToolError error) =>
+        ToolErrorPayload.AsCallToolResult(error, JsonOptions);
+
+    private static CallToolResult InternalError(Exception ex) =>
+        ToolErrorPayload.InternalError(ex, JsonOptions);
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetDisplayCategoryTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetDisplayCategoryTool.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Request payload for <see cref="SetDisplayCategoryTool"/>.</summary>
+internal sealed record SetDisplayCategoryRequest(string DisplayCategory);
+
+/// <summary>Result payload for <see cref="SetDisplayCategoryTool"/>.</summary>
+internal sealed record SetDisplayCategoryResult(string DisplayCategory, string Previous);
+
+/// <summary>
+/// MCP tool that mutates the live viewer's active ECDIS display
+/// category (DisplayBase / Standard / OtherInformation / All).
+/// </summary>
+internal sealed class SetDisplayCategoryTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "set_display_category";
+
+    private readonly IRenderStateControllerAccessor _accessor;
+
+    public SetDisplayCategoryTool(IRenderStateControllerAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        _accessor = accessor;
+    }
+
+    /// <summary>
+    /// Sets the live ECDIS display category to the requested value.
+    /// Idempotent. Returns the previous category for caller bookkeeping.
+    /// </summary>
+    public async Task<ToolResult<SetDisplayCategoryResult>> InvokeAsync(
+        SetDisplayCategoryRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.DisplayCategory))
+        {
+            return ToolResult<SetDisplayCategoryResult>.Err(new InvalidArgument(
+                "displayCategory",
+                "value is required; allowed values are 'DisplayBase', 'Standard', 'OtherInformation', 'All'"));
+        }
+
+        // Reject pure-numeric input — see SetPaletteTool for rationale.
+        var trimmed = request.DisplayCategory.Trim();
+        if (long.TryParse(trimmed, out _)
+            || !Enum.TryParse<EcdisDisplayCategory>(trimmed, ignoreCase: true, out var category)
+            || !Enum.IsDefined(category))
+        {
+            return ToolResult<SetDisplayCategoryResult>.Err(new InvalidArgument(
+                "displayCategory",
+                $"value '{request.DisplayCategory}' is not one of: DisplayBase, Standard, OtherInformation, All"));
+        }
+
+        var controller = _accessor.Current;
+        if (controller is null)
+        {
+            return ToolResult<SetDisplayCategoryResult>.Err(new MapNotReady(
+                "the viewer's render-state controller has not been initialised yet"));
+        }
+
+        var previous = controller.CurrentDisplayCategory;
+        await controller.SetDisplayCategoryAsync(category, ct).ConfigureAwait(false);
+        return ToolResult<SetDisplayCategoryResult>.Ok(
+            new SetDisplayCategoryResult(category.ToString(), previous.ToString()));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetPaletteMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetPaletteMcpAdapter.cs
@@ -1,0 +1,79 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="SetPaletteTool"/> as an MCP server tool.</summary>
+internal static class SetPaletteMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Mutates the live viewer's active map palette. Allowed values: 'Day', 'Dusk', 'Night' " +
+        "(case-insensitive). Idempotent — setting the current palette is a no-op. Returns the " +
+        "applied and previous palette so callers can detect no-op invocations. Distinguished " +
+        "from read-only tools (e.g. render_to_image) — see docs/mcp-server.md.";
+
+    public static McpServerTool Create(SetPaletteTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [Description("Palette name: 'Day', 'Dusk', or 'Night' (case-insensitive).")] string palette,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new SetPaletteRequest(palette), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SetPaletteTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(Func<Task<ToolResult<SetPaletteResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return InternalError(ex); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<SetPaletteResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var payload = new JsonObject
+            {
+                ["palette"] = value!.Palette,
+                ["previous"] = value.Previous,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return Failure(err!);
+    }
+
+    private static CallToolResult Failure(ToolError error) =>
+        ToolErrorPayload.AsCallToolResult(error, JsonOptions);
+
+    private static CallToolResult InternalError(Exception ex) =>
+        ToolErrorPayload.InternalError(ex, JsonOptions);
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetPaletteTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetPaletteTool.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Request payload for <see cref="SetPaletteTool"/>.</summary>
+internal sealed record SetPaletteRequest(string Palette);
+
+/// <summary>Result payload for <see cref="SetPaletteTool"/>.</summary>
+internal sealed record SetPaletteResult(string Palette, string Previous);
+
+/// <summary>
+/// MCP tool that mutates the live viewer's active map palette
+/// (Day / Dusk / Night). The companion to <c>set_viewport</c> for
+/// scripted measurement runs that need to drive palette changes
+/// from outside the GUI.
+/// </summary>
+internal sealed class SetPaletteTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "set_palette";
+
+    private readonly IRenderStateControllerAccessor _accessor;
+
+    public SetPaletteTool(IRenderStateControllerAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        _accessor = accessor;
+    }
+
+    /// <summary>
+    /// Sets the live map palette to the requested value. Idempotent.
+    /// Returns the previous palette so callers can detect no-op
+    /// invocations and stitch repeated runs cleanly.
+    /// </summary>
+    public async Task<ToolResult<SetPaletteResult>> InvokeAsync(
+        SetPaletteRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.Palette))
+        {
+            return ToolResult<SetPaletteResult>.Err(new InvalidArgument(
+                "palette",
+                "value is required; allowed values are 'Day', 'Dusk', 'Night'"));
+        }
+
+        // Reject pure-numeric input. Enum.TryParse accepts the underlying
+        // integer (e.g. "0" → Day), but the public contract here is the
+        // string name only; numeric coupling would be brittle.
+        var trimmed = request.Palette.Trim();
+        if (long.TryParse(trimmed, out _)
+            || !Enum.TryParse<PaletteType>(trimmed, ignoreCase: true, out var palette)
+            || !Enum.IsDefined(palette))
+        {
+            return ToolResult<SetPaletteResult>.Err(new InvalidArgument(
+                "palette",
+                $"value '{request.Palette}' is not one of: Day, Dusk, Night"));
+        }
+
+        var controller = _accessor.Current;
+        if (controller is null)
+        {
+            return ToolResult<SetPaletteResult>.Err(new MapNotReady(
+                "the viewer's render-state controller has not been initialised yet"));
+        }
+
+        var previous = controller.CurrentPalette;
+        await controller.SetPaletteAsync(palette, ct).ConfigureAwait(false);
+        return ToolResult<SetPaletteResult>.Ok(new SetPaletteResult(palette.ToString(), previous.ToString()));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetTimeStepMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetTimeStepMcpAdapter.cs
@@ -1,0 +1,79 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="SetTimeStepTool"/> as an MCP server tool.</summary>
+internal static class SetTimeStepMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Mutates the live viewer's global time clock to a specific sample. Supply EITHER " +
+        "'index' (a 0-based integer into list_time_steps) OR 'timestamp' (ISO-8601, snapped " +
+        "to the nearest sample). Mixing the two is rejected. Returns the resolved index and " +
+        "snapped timestamp so callers can stitch repeated runs without recomputing the " +
+        "timeline. Counterpart to the --time-step CLI flag, but applicable mid-session.";
+
+    public static McpServerTool Create(SetTimeStepTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [Description("0-based index into the aggregated time samples (see list_time_steps). Mutually exclusive with timestamp.")] int? index = null,
+            [Description("ISO-8601 timestamp; snapped to the nearest available sample. Mutually exclusive with index.")] string? timestamp = null,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new SetTimeStepRequest(index, timestamp), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SetTimeStepTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<SetTimeStepResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return ToolErrorPayload.InternalError(ex, JsonOptions); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<SetTimeStepResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var payload = new JsonObject
+            {
+                ["mode"] = value!.Mode,
+                ["index"] = value.Index,
+                ["timestamp"] = value.Timestamp,
+                ["sampleCount"] = value.SampleCount,
+                ["previous"] = value.Previous,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return ToolErrorPayload.AsCallToolResult(err!, JsonOptions);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetTimeStepTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetTimeStepTool.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Request payload for <see cref="SetTimeStepTool"/>. Exactly one of
+/// <see cref="Index"/> or <see cref="Timestamp"/> must be supplied.
+/// </summary>
+internal sealed record SetTimeStepRequest(int? Index = null, string? Timestamp = null);
+
+/// <summary>Result payload for <see cref="SetTimeStepTool"/>.</summary>
+internal sealed record SetTimeStepResult(
+    string Mode,
+    int Index,
+    string Timestamp,
+    int SampleCount,
+    string? Previous);
+
+/// <summary>
+/// MCP tool that drives the viewer's <see cref="GlobalTimeService"/>
+/// to a specific time sample, mirroring the <c>--time-step</c> CLI
+/// flag but applicable mid-session. Accepts either a 0-based index
+/// into the aggregated samples or an ISO-8601 timestamp (snapped to
+/// the nearest sample).
+/// </summary>
+internal sealed class SetTimeStepTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "set_time_step";
+
+    private readonly GlobalTimeService _globalTime;
+    private readonly Func<Action, Task> _dispatcher;
+
+    public SetTimeStepTool(GlobalTimeService globalTime)
+        : this(globalTime, dispatcher: null)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: allows tests to provide a synchronous dispatcher so
+    /// the production code path through <see cref="Dispatcher.UIThread"/>
+    /// can be exercised without a running Avalonia application.
+    /// </summary>
+    internal SetTimeStepTool(GlobalTimeService globalTime, Func<Action, Task>? dispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(globalTime);
+        _globalTime = globalTime;
+        _dispatcher = dispatcher ?? (a =>
+        {
+            var op = Dispatcher.UIThread.InvokeAsync(a);
+            return op.GetTask();
+        });
+    }
+
+    /// <summary>
+    /// Sets the global clock. Returns the snapped-to sample plus the
+    /// (now resolved) index so callers can stitch repeated runs without
+    /// recomputing the timeline.
+    /// </summary>
+    public async Task<ToolResult<SetTimeStepResult>> InvokeAsync(
+        SetTimeStepRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var hasIndex = request.Index is not null;
+        var hasTimestamp = !string.IsNullOrWhiteSpace(request.Timestamp);
+
+        if (hasIndex && hasTimestamp)
+        {
+            return ToolResult<SetTimeStepResult>.Err(new InvalidArgument(
+                "request",
+                "supply either 'index' or 'timestamp', not both"));
+        }
+        if (!hasIndex && !hasTimestamp)
+        {
+            return ToolResult<SetTimeStepResult>.Err(new InvalidArgument(
+                "request",
+                "one of 'index' (0-based integer) or 'timestamp' (ISO-8601) is required"));
+        }
+
+        if (!_globalTime.IsActive)
+        {
+            return ToolResult<SetTimeStepResult>.Err(new MapNotReady(
+                "no time-aware dataset is currently loaded"));
+        }
+
+        var samples = _globalTime.AllSamples;
+        if (samples.Count == 0)
+        {
+            return ToolResult<SetTimeStepResult>.Err(new MapNotReady(
+                "global time range is not yet available"));
+        }
+
+        DateTime target;
+        string mode;
+        if (hasIndex)
+        {
+            var index = request.Index!.Value;
+            if (index < 0 || index >= samples.Count)
+            {
+                return ToolResult<SetTimeStepResult>.Err(new InvalidArgument(
+                    "index",
+                    $"value {index} is outside the available range [0, {samples.Count - 1}] (sampleCount={samples.Count})"));
+            }
+            target = samples[index];
+            mode = "index";
+        }
+        else
+        {
+            var raw = request.Timestamp!.Trim();
+            if (!DateTime.TryParse(raw,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal,
+                    out var parsed))
+            {
+                return ToolResult<SetTimeStepResult>.Err(new InvalidArgument(
+                    "timestamp",
+                    $"value '{raw}' is not a parseable ISO-8601 timestamp"));
+            }
+            target = samples.OrderBy(s => Math.Abs((s - parsed).Ticks)).First();
+            mode = "timestamp";
+        }
+
+        var previous = _globalTime.CurrentTime;
+        await _dispatcher(() => _globalTime.SetCurrentTime(target));
+
+        var resolvedIndex = -1;
+        for (var i = 0; i < samples.Count; i++)
+        {
+            if (samples[i] == target) { resolvedIndex = i; break; }
+        }
+        return ToolResult<SetTimeStepResult>.Ok(new SetTimeStepResult(
+            Mode: mode,
+            Index: resolvedIndex,
+            Timestamp: target.ToString("o", CultureInfo.InvariantCulture),
+            SampleCount: samples.Count,
+            Previous: previous?.ToString("o", CultureInfo.InvariantCulture)));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetViewportMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetViewportMcpAdapter.cs
@@ -1,0 +1,163 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Wraps a <see cref="SetViewportTool"/> as an <see cref="McpServerTool"/>
+/// so the viewer's <c>McpServerHost</c> can inject it into the hosted
+/// <c>EncDotNet.S100.Mcp.S100McpServer</c>. The tool mutates the live
+/// viewer's navigator and so is explicitly NOT side-effect-free —
+/// callers should treat it as the counterpart to the read-only
+/// <c>render_to_image</c> tool when scripting measurement runs.
+/// </summary>
+internal static class SetViewportMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
+    };
+
+    private const string Description =
+        "Mutates the live viewer's map navigator to a specific WGS-84 viewport. Supply EITHER a " +
+        "bbox (south/west/north/east) OR centre+zoom (centerLat/centerLon/zoom); mixing the two " +
+        "is rejected. Coordinates are decimal degrees. Zoom is the standard web-mercator level " +
+        "(0–24). Antimeridian-crossing bboxes are not supported in v1. Companion to render_to_image: " +
+        "this tool drives the navigator, render_to_image then captures the resulting frame. " +
+        "Viewer-injected tool — not available from a headless MCP host until that host supplies its own equivalent.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(SetViewportTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+
+        var del = (
+            [Description("Bounding-box south edge in decimal degrees (WGS-84). Must be paired with west/north/east; mutually exclusive with centre+zoom.")] double? south = null,
+            [Description("Bounding-box west edge in decimal degrees (WGS-84). Must be paired with south/north/east; mutually exclusive with centre+zoom.")] double? west = null,
+            [Description("Bounding-box north edge in decimal degrees (WGS-84). Must be paired with south/west/east; mutually exclusive with centre+zoom.")] double? north = null,
+            [Description("Bounding-box east edge in decimal degrees (WGS-84). Must be paired with south/west/north; mutually exclusive with centre+zoom.")] double? east = null,
+            [Description("Centre latitude in decimal degrees (WGS-84). Must be paired with centerLon and zoom; mutually exclusive with the bbox form.")] double? centerLat = null,
+            [Description("Centre longitude in decimal degrees (WGS-84). Must be paired with centerLat and zoom; mutually exclusive with the bbox form.")] double? centerLon = null,
+            [Description("Web-mercator zoom level in [0, 24]. Must be paired with centerLat/centerLon; mutually exclusive with the bbox form.")] double? zoom = null,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(
+                new SetViewportRequest(south, west, north, east, centerLat, centerLon, zoom),
+                ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SetViewportTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<SetViewportResult>>> resultFactory)
+    {
+        try
+        {
+            var result = await resultFactory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return InternalError(ex);
+        }
+    }
+
+    /// <summary>
+    /// Test seam: translates an already-completed <see cref="ToolResult{T}"/>
+    /// into a <see cref="CallToolResult"/> using the same shape this
+    /// adapter produces in production.
+    /// </summary>
+    internal static CallToolResult TranslateResult(ToolResult<SetViewportResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            return Success(value);
+        }
+        result.TryGetError(out var err);
+        return Failure(err!);
+    }
+
+    private static CallToolResult Success(SetViewportResult value)
+    {
+        var payload = new JsonObject
+        {
+            ["mode"] = value.Mode,
+            ["south"] = value.South,
+            ["west"] = value.West,
+            ["north"] = value.North,
+            ["east"] = value.East,
+        };
+
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = payload.ToJsonString(JsonOptions) },
+            ],
+            IsError = false,
+        };
+    }
+
+    private static CallToolResult Failure(ToolError error)
+    {
+        var details = JsonSerializer.SerializeToNode(error, error.GetType(), JsonOptions) as JsonObject
+            ?? new JsonObject();
+        details.Remove("code");
+        details.Remove("message");
+        details.Remove("Code");
+        details.Remove("Message");
+
+        var payload = new JsonObject
+        {
+            ["code"] = error.Code,
+            ["message"] = error.Message,
+            ["details"] = details,
+        };
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = payload.ToJsonString(JsonOptions) },
+            ],
+            IsError = true,
+        };
+    }
+
+    private static CallToolResult InternalError(Exception ex)
+    {
+        var payload = new JsonObject
+        {
+            ["code"] = "internal_error",
+            ["message"] = ex.Message,
+            ["details"] = new JsonObject
+            {
+                ["exceptionType"] = ex.GetType().FullName,
+            },
+        };
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = payload.ToJsonString(JsonOptions) },
+            ],
+            IsError = true,
+        };
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/SetViewportTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetViewportTool.cs
@@ -1,0 +1,246 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+using Mapsui;
+using Mapsui.Projections;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Request payload for <see cref="SetViewportTool"/>.
+/// </summary>
+/// <remarks>
+/// Two mutually-exclusive forms are accepted: a WGS-84 bounding box
+/// (<paramref name="South"/>/<paramref name="West"/>/<paramref name="North"/>/<paramref name="East"/>),
+/// or a centre/zoom pair (<paramref name="CenterLat"/>/<paramref name="CenterLon"/>/<paramref name="Zoom"/>).
+/// All bbox edges or all three centre/zoom values must be supplied
+/// together; mixing the two forms is rejected with
+/// <see cref="InvalidArgument"/>. Antimeridian-crossing bboxes are not
+/// supported in v1 (would need <c>west &gt; east</c>).
+/// </remarks>
+[Description("Request for set_viewport: supply EITHER a WGS-84 bbox (south/west/north/east) OR centre+zoom (centerLat/centerLon/zoom). Coordinates are decimal degrees. Zoom is the standard web-mercator level (0–24).")]
+internal sealed record SetViewportRequest(
+    [property: Description("Bounding-box south edge in decimal degrees (WGS-84). Must be paired with west/north/east; mutually exclusive with centre+zoom.")] double? South = null,
+    [property: Description("Bounding-box west edge in decimal degrees (WGS-84). Must be paired with south/north/east; mutually exclusive with centre+zoom.")] double? West = null,
+    [property: Description("Bounding-box north edge in decimal degrees (WGS-84). Must be paired with south/west/east; mutually exclusive with centre+zoom.")] double? North = null,
+    [property: Description("Bounding-box east edge in decimal degrees (WGS-84). Must be paired with south/west/north; mutually exclusive with centre+zoom.")] double? East = null,
+    [property: Description("Centre latitude in decimal degrees (WGS-84). Must be paired with centerLon and zoom; mutually exclusive with the bbox form.")] double? CenterLat = null,
+    [property: Description("Centre longitude in decimal degrees (WGS-84). Must be paired with centerLat and zoom; mutually exclusive with the bbox form.")] double? CenterLon = null,
+    [property: Description("Web-mercator zoom level in [0, 24]. Must be paired with centerLat/centerLon; mutually exclusive with the bbox form.")] double? Zoom = null);
+
+/// <summary>Result of <see cref="SetViewportTool"/>.</summary>
+[Description("Result of set_viewport: the request mode that was applied (bbox or center) plus an echo of the resolved WGS-84 viewport. The echo is the precise frame the navigator was set to and is suitable for verification in scripted runs.")]
+internal sealed record SetViewportResult(
+    [property: Description("\"bbox\" when the call resolved through the south/west/north/east form; \"center\" when it resolved through the centerLat/centerLon/zoom form.")] string Mode,
+    [property: Description("Echoed south edge of the resolved viewport in decimal degrees, WGS-84.")] double South,
+    [property: Description("Echoed west edge of the resolved viewport in decimal degrees, WGS-84.")] double West,
+    [property: Description("Echoed north edge of the resolved viewport in decimal degrees, WGS-84.")] double North,
+    [property: Description("Echoed east edge of the resolved viewport in decimal degrees, WGS-84.")] double East);
+
+/// <summary>
+/// Mutates the live viewer's navigator to a specific WGS-84 viewport
+/// so that scripted / agent-driven measurement runs can drive pan,
+/// zoom, and viewport-change scenarios from outside the GUI.
+/// Distinguished from <see cref="RenderToImageTool"/>, which is
+/// deliberately read-only and clones the Map: this tool intentionally
+/// mutates the live <see cref="IMapHost"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Closes part of the tooling gap identified in the perf-report: MCP
+/// could not previously drive viewport changes from outside, so warm
+/// "pan/zoom" measurements were impossible without the GUI in the
+/// loop.
+/// </para>
+/// <para>
+/// Validation:
+/// <list type="bullet">
+/// <item><description>Latitudes must be in [-90, 90]; longitudes in [-180, 180].</description></item>
+/// <item><description>Bbox: <c>south &lt; north</c> and <c>west &lt; east</c> (no antimeridian wrap).</description></item>
+/// <item><description>Zoom: in [0, 24] and finite.</description></item>
+/// <item><description>Exactly one of {bbox, center+zoom} must be fully supplied; partial / mixed forms are rejected.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+internal sealed class SetViewportTool
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "set_viewport";
+
+    internal const double MinLat = -90.0;
+    internal const double MaxLat = 90.0;
+    internal const double MinLon = -180.0;
+    internal const double MaxLon = 180.0;
+    internal const double MinZoom = 0.0;
+    internal const double MaxZoom = 24.0;
+
+    // Standard web-mercator resolution (metres / pixel) at zoom 0 with a
+    // 256-pixel tile, used to convert a zoom level to the resolution the
+    // Mapsui Navigator wants. 156543.0339... = 2 * pi * 6378137 / 256.
+    internal const double ResolutionAtZoomZero = 156543.03392804097;
+
+    private readonly IMapHostAccessor _accessor;
+
+    /// <summary>Creates a new <see cref="SetViewportTool"/>.</summary>
+    public SetViewportTool(IMapHostAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        _accessor = accessor;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<SetViewportResult>> InvokeAsync(
+        SetViewportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var hasBboxAny = request.South.HasValue || request.West.HasValue
+            || request.North.HasValue || request.East.HasValue;
+        var hasCenterAny = request.CenterLat.HasValue || request.CenterLon.HasValue
+            || request.Zoom.HasValue;
+
+        if (hasBboxAny && hasCenterAny)
+        {
+            return Err(new InvalidArgument(
+                "request",
+                "supply EITHER a bbox (south/west/north/east) OR centre+zoom (centerLat/centerLon/zoom), not both"));
+        }
+        if (!hasBboxAny && !hasCenterAny)
+        {
+            return Err(new InvalidArgument(
+                "request",
+                "must supply either a bbox (south/west/north/east) or centre+zoom (centerLat/centerLon/zoom)"));
+        }
+
+        var host = _accessor.Current;
+        if (host is null)
+        {
+            return Err(new MapNotReady("the viewer's map control has not been initialised yet"));
+        }
+
+        return hasBboxAny
+            ? ApplyBbox(request, host)
+            : ApplyCenterZoom(request, host);
+    }
+
+    private static Task<ToolResult<SetViewportResult>> ApplyBbox(
+        SetViewportRequest request,
+        IMapHost host)
+    {
+        if (request.South is not { } south
+            || request.West is not { } west
+            || request.North is not { } north
+            || request.East is not { } east)
+        {
+            return Err(new InvalidArgument(
+                "request",
+                "bbox form requires all four of south, west, north, east"));
+        }
+
+        if (Validate(south, "south", MinLat, MaxLat) is { } e1) return Err(e1);
+        if (Validate(west, "west", MinLon, MaxLon) is { } e2) return Err(e2);
+        if (Validate(north, "north", MinLat, MaxLat) is { } e3) return Err(e3);
+        if (Validate(east, "east", MinLon, MaxLon) is { } e4) return Err(e4);
+
+        if (south >= north)
+        {
+            return Err(new GeometryInvalid(
+                "request",
+                $"south ({south}) must be less than north ({north})"));
+        }
+        if (west >= east)
+        {
+            return Err(new GeometryInvalid(
+                "request",
+                $"west ({west}) must be less than east ({east}); antimeridian crossing is not supported in v1"));
+        }
+
+        var (minX, minY) = SphericalMercator.FromLonLat(west, south);
+        var (maxX, maxY) = SphericalMercator.FromLonLat(east, north);
+        host.SetViewportToExtent(new MRect(minX, minY, maxX, maxY));
+
+        return Ok(new SetViewportResult("bbox", south, west, north, east));
+    }
+
+    private static Task<ToolResult<SetViewportResult>> ApplyCenterZoom(
+        SetViewportRequest request,
+        IMapHost host)
+    {
+        if (request.CenterLat is not { } lat
+            || request.CenterLon is not { } lon
+            || request.Zoom is not { } zoom)
+        {
+            return Err(new InvalidArgument(
+                "request",
+                "centre+zoom form requires all three of centerLat, centerLon, zoom"));
+        }
+
+        if (Validate(lat, "centerLat", MinLat, MaxLat) is { } e1) return Err(e1);
+        if (Validate(lon, "centerLon", MinLon, MaxLon) is { } e2) return Err(e2);
+        if (double.IsNaN(zoom) || double.IsInfinity(zoom))
+        {
+            return Err(new InvalidArgument("zoom", $"value {zoom} is not a finite number"));
+        }
+        if (zoom < MinZoom || zoom > MaxZoom)
+        {
+            return Err(new InvalidArgument(
+                "zoom",
+                $"value {zoom} is outside the supported range [{MinZoom}, {MaxZoom}]"));
+        }
+
+        var (cx, cy) = SphericalMercator.FromLonLat(lon, lat);
+        var resolution = ResolutionAtZoomZero / Math.Pow(2, zoom);
+        host.SetViewportToCenterAndResolution(new MPoint(cx, cy), resolution);
+
+        // Echo the WGS-84 frame implied by the centre+zoom so callers
+        // can verify what was applied. The half-extent is computed in
+        // Mercator and back-projected, which keeps the verification
+        // identical to whatever the navigator will surface to the
+        // render pass.
+        var (south, west, north, east) = ResolveCenterFrame(cx, cy, resolution);
+        return Ok(new SetViewportResult("center", south, west, north, east));
+    }
+
+    /// <summary>
+    /// Approximates the WGS-84 frame produced by the centre+zoom form
+    /// using a default 1024×768 reference viewport so the echoed bbox
+    /// is reproducible regardless of the live control's current size.
+    /// The reference matches the default render_to_image dimensions so
+    /// scripted runs that pair set_viewport + render_to_image see a
+    /// coherent frame.
+    /// </summary>
+    private static (double South, double West, double North, double East) ResolveCenterFrame(
+        double centerMx, double centerMy, double resolution)
+    {
+        const int refWidthPx = 1024;
+        const int refHeightPx = 768;
+        var halfWMeters = refWidthPx * resolution * 0.5;
+        var halfHMeters = refHeightPx * resolution * 0.5;
+        var (west, south) = SphericalMercator.ToLonLat(centerMx - halfWMeters, centerMy - halfHMeters);
+        var (east, north) = SphericalMercator.ToLonLat(centerMx + halfWMeters, centerMy + halfHMeters);
+        // Clamp to valid WGS-84 ranges in case the centre+zoom strays
+        // close to the poles where the Mercator projection diverges.
+        return (Math.Clamp(south, MinLat, MaxLat), Math.Clamp(west, MinLon, MaxLon),
+                Math.Clamp(north, MinLat, MaxLat), Math.Clamp(east, MinLon, MaxLon));
+    }
+
+    private static ToolError? Validate(double value, string name, double min, double max)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            return new InvalidArgument(name, $"value {value} is not a finite number");
+        if (value < min || value > max)
+            return new InvalidArgument(name, $"value {value} is outside the WGS-84 range [{min}, {max}]");
+        return null;
+    }
+
+    private static Task<ToolResult<SetViewportResult>> Ok(SetViewportResult value)
+        => Task.FromResult(ToolResult<SetViewportResult>.Ok(value));
+
+    private static Task<ToolResult<SetViewportResult>> Err(ToolError error)
+        => Task.FromResult(ToolResult<SetViewportResult>.Err(error));
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/ToolErrorPayload.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/ToolErrorPayload.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Shared <see cref="ToolError"/> → <see cref="CallToolResult"/> translation
+/// used by every viewer-side MCP adapter that emits a single text content
+/// block on failure. Keeps the failure shape consistent across tools.
+/// </summary>
+internal static class ToolErrorPayload
+{
+    public static CallToolResult AsCallToolResult(ToolError error, JsonSerializerOptions json)
+    {
+        var details = JsonSerializer.SerializeToNode(error, error.GetType(), json) as JsonObject
+            ?? new JsonObject();
+        details.Remove("code");
+        details.Remove("message");
+        details.Remove("Code");
+        details.Remove("Message");
+
+        var payload = new JsonObject
+        {
+            ["code"] = error.Code,
+            ["message"] = error.Message,
+            ["details"] = details,
+        };
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = payload.ToJsonString(json) }],
+            IsError = true,
+        };
+    }
+
+    public static CallToolResult InternalError(Exception ex, JsonSerializerOptions json)
+    {
+        var payload = new JsonObject
+        {
+            ["code"] = "internal_error",
+            ["message"] = ex.Message,
+            ["details"] = new JsonObject
+            {
+                ["exceptionType"] = ex.GetType().FullName,
+            },
+        };
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = payload.ToJsonString(json) }],
+            IsError = true,
+        };
+    }
+}

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -305,7 +305,12 @@ sets the bind address (loopback recommended). Any MCP flag implies
 `--mcp-port-file <PATH>` writes the bound endpoint URI to a file once
 the server is listening (the endpoint is also echoed to stdout as
 `[MCP] listening on …`). A CLI-driven MCP run never persists the
-bound port back to the user's `settings.json`.
+bound port back to the user's `settings.json`. Two viewer-only tools
+are injected when the server starts: `render_to_image` (read-only —
+captures a PNG snapshot from a clone of the live map) and
+`set_viewport` (mutating — drives the live navigator to a bbox or
+centre+zoom). See `docs/mcp-server.md` for the full catalogue and
+the read-only / mutating split.
 
 **Settings isolation.** `--settings <PATH>` points the run at an
 alternate settings file instead of the per-user default.

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -305,12 +305,14 @@ sets the bind address (loopback recommended). Any MCP flag implies
 `--mcp-port-file <PATH>` writes the bound endpoint URI to a file once
 the server is listening (the endpoint is also echoed to stdout as
 `[MCP] listening on …`). A CLI-driven MCP run never persists the
-bound port back to the user's `settings.json`. Two viewer-only tools
+bound port back to the user's `settings.json`. Four viewer-only tools
 are injected when the server starts: `render_to_image` (read-only —
-captures a PNG snapshot from a clone of the live map) and
+captures a PNG snapshot from a clone of the live map),
 `set_viewport` (mutating — drives the live navigator to a bbox or
-centre+zoom). See `docs/mcp-server.md` for the full catalogue and
-the read-only / mutating split.
+centre+zoom), `set_palette` (mutating — Day / Dusk / Night), and
+`set_display_category` (mutating — DisplayBase / Standard /
+OtherInformation / All). See `docs/mcp-server.md` for the full
+catalogue and the read-only / mutating split.
 
 **Settings isolation.** `--settings <PATH>` points the run at an
 alternate settings file instead of the per-user default.

--- a/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IMapHost.cs
@@ -68,6 +68,24 @@ internal interface IMapHost
     void ZoomToExtent(MRect extent);
 
     /// <summary>
+    /// Sets the navigator's viewport to exactly the supplied Mercator
+    /// extent. Unlike <see cref="ZoomToExtent"/> (which adds 10 % padding
+    /// for the load-time auto-fit use case), this method applies no
+    /// padding — it is intended for programmatic / scripted viewport
+    /// overrides where the caller wants the precise box they asked for.
+    /// No-op when the map's navigator is unavailable.
+    /// </summary>
+    void SetViewportToExtent(MRect mercatorExtent);
+
+    /// <summary>
+    /// Sets the navigator to centre on the supplied Mercator point at
+    /// the supplied resolution (metres per pixel). Used by scripted
+    /// viewport overrides that specify a centre + zoom pair instead of
+    /// a bounding box. No-op when the map's navigator is unavailable.
+    /// </summary>
+    void SetViewportToCenterAndResolution(MPoint mercatorCenter, double resolution);
+
+    /// <summary>
     /// Captures the current map view as a PNG byte array.
     /// </summary>
     /// <param name="widthPx">Output image width in pixels (caller-clamped).</param>

--- a/src/EncDotNet.S100.Viewer/Services/IRenderStateController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IRenderStateController.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Late-bound controller for the viewer's render-state knobs (palette,
+/// ECDIS display category) — the analogue of <see cref="IMapHostAccessor"/>
+/// for state that lives in view-models and singletons rather than in the
+/// Mapsui control. Lets MCP tools mutate the live render state from
+/// off-UI threads without coupling them directly to <c>SettingsViewModel</c>
+/// or <c>EcdisDisplayState</c>.
+/// </summary>
+internal interface IRenderStateController
+{
+    /// <summary>The currently active map palette.</summary>
+    PaletteType CurrentPalette { get; }
+
+    /// <summary>The currently active ECDIS display category.</summary>
+    EcdisDisplayCategory CurrentDisplayCategory { get; }
+
+    /// <summary>
+    /// Sets the active map palette. Marshals to the UI thread when
+    /// the underlying setter has thread affinity (e.g. INotifyPropertyChanged
+    /// observers bound to the UI). Idempotent: setting the current value
+    /// is a no-op.
+    /// </summary>
+    Task SetPaletteAsync(PaletteType palette, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets the active ECDIS display category. Marshals to the UI
+    /// thread for parity with <see cref="SetPaletteAsync"/> — the
+    /// underlying state is itself thread-safe but downstream
+    /// <c>Changed</c> subscribers may touch UI state.
+    /// </summary>
+    Task SetDisplayCategoryAsync(EcdisDisplayCategory category, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Late-bound accessor for <see cref="IRenderStateController"/>, mirroring
+/// <see cref="IMapHostAccessor"/>. Allows <see cref="McpServerHost"/> to
+/// resolve the controller before the viewer's main window finishes
+/// constructing it.
+/// </summary>
+internal interface IRenderStateControllerAccessor
+{
+    /// <summary>The current render-state controller, or null when not yet attached.</summary>
+    IRenderStateController? Current { get; set; }
+}
+
+/// <summary>Default in-memory implementation of <see cref="IRenderStateControllerAccessor"/>.</summary>
+internal sealed class RenderStateControllerAccessor : IRenderStateControllerAccessor
+{
+    public IRenderStateController? Current { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
@@ -126,6 +126,26 @@ internal sealed class MapsuiMapHost : IMapHost
         }
     }
 
+    public void SetViewportToExtent(MRect mercatorExtent)
+    {
+        ArgumentNullException.ThrowIfNull(mercatorExtent);
+        if (_mapControl.Map?.Navigator is { } nav)
+        {
+            // duration: 0 for an instantaneous, scripted viewport set —
+            // animations would prevent reproducible measurement runs.
+            nav.ZoomToBox(mercatorExtent, duration: 0);
+        }
+    }
+
+    public void SetViewportToCenterAndResolution(MPoint mercatorCenter, double resolution)
+    {
+        ArgumentNullException.ThrowIfNull(mercatorCenter);
+        if (_mapControl.Map?.Navigator is { } nav)
+        {
+            nav.CenterOnAndZoomTo(mercatorCenter, resolution, duration: 0);
+        }
+    }
+
     public void AddOverlayLayer(ILayer layer)
     {
         ArgumentNullException.ThrowIfNull(layer);

--- a/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapsuiMapHost.cs
@@ -195,33 +195,67 @@ internal sealed class MapsuiMapHost : IMapHost
             // exactly) but owns its own Navigator. The live map is
             // therefore untouched: setting size / zoom on the clone
             // does not trigger a redraw on screen.
+            //
+            // PERF: the snapshot Map is IDisposable. Prior to this
+            // change it was let go to the GC, which left subscriptions
+            // from its layer-collection / property-changed plumbing
+            // rooting it indefinitely; over the course of many
+            // render_to_image calls the per-call PNG buffer plus
+            // associated native bitmaps could not be reclaimed
+            // (RSS grew ~9× over 150 renders in the perf report's
+            // Track-B measurements). We now detach the live layers
+            // from the snapshot before disposing it so the snapshot's
+            // dispose path only touches its own owned resources, not
+            // the live layers we don't own.
             var snapshot = new Map { CRS = liveMap.CRS, BackColor = liveMap.BackColor };
-            foreach (var layer in liveMap.Layers)
+            try
             {
-                snapshot.Layers.Add(layer);
+                foreach (var layer in liveMap.Layers)
+                {
+                    snapshot.Layers.Add(layer);
+                }
+
+                snapshot.Navigator.SetSize(widthPx, heightPx);
+
+                // Match the world-extent the user currently sees. With
+                // MBoxFit.Fit, aspect-ratio mismatches show slightly more
+                // area rather than cropping — acceptable for diagnostic
+                // snapshots; the requested pixel dimensions are exact.
+                var extent = liveViewport.ToExtent();
+                if (extent is not null && extent.Width > 0 && extent.Height > 0)
+                {
+                    snapshot.Navigator.ZoomToBox(extent, MBoxFit.Fit);
+                }
+
+                using var stream = new MapRenderer().RenderToBitmapStream(
+                    snapshot,
+                    pixelDensity: (float)pixelDensity,
+                    renderFormat: RenderFormat.Png,
+                    quality: 100);
+                stream.Position = 0;
+                using var ms = new MemoryStream();
+                stream.CopyTo(ms);
+                return ms.ToArray();
             }
-
-            snapshot.Navigator.SetSize(widthPx, heightPx);
-
-            // Match the world-extent the user currently sees. With
-            // MBoxFit.Fit, aspect-ratio mismatches show slightly more
-            // area rather than cropping — acceptable for diagnostic
-            // snapshots; the requested pixel dimensions are exact.
-            var extent = liveViewport.ToExtent();
-            if (extent is not null && extent.Width > 0 && extent.Height > 0)
+            finally
             {
-                snapshot.Navigator.ZoomToBox(extent, MBoxFit.Fit);
+                // Detach the live layers from the snapshot before the
+                // snapshot is disposed, so the snapshot's dispose path
+                // (and any teardown subscriptions Mapsui has registered
+                // on layer collection mutations) cannot release / dispose
+                // layer instances the live Map still owns. Best-effort:
+                // we never want a teardown failure to mask a render
+                // failure or otherwise crash the dispatcher.
+                try
+                {
+                    snapshot.Layers.ClearAllGroups();
+                }
+                catch
+                {
+                    // ignore — see comment above
+                }
+                snapshot.Dispose();
             }
-
-            using var stream = new MapRenderer().RenderToBitmapStream(
-                snapshot,
-                pixelDensity: (float)pixelDensity,
-                renderFormat: RenderFormat.Png,
-                quality: 100);
-            stream.Position = 0;
-            using var ms = new MemoryStream();
-            stream.CopyTo(ms);
-            return ms.ToArray();
         }).GetTask().ConfigureAwait(false);
     }
 

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -255,7 +255,12 @@ internal sealed class McpServerHost : IAsyncDisposable
     {
         if (_mapHostAccessor is null) return null;
         var renderTool = new RenderToImageTool(_mapHostAccessor);
-        return new[] { RenderToImageMcpAdapter.Create(renderTool) };
+        var setViewportTool = new SetViewportTool(_mapHostAccessor);
+        return new[]
+        {
+            RenderToImageMcpAdapter.Create(renderTool),
+            SetViewportMcpAdapter.Create(setViewportTool),
+        };
     }
 
     private static bool IsPortInUse(Exception ex)

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -28,6 +28,7 @@ internal sealed class McpServerHost : IAsyncDisposable
     private readonly EncDotNet.S100.Mcp.Tools.Catalog.IDatasetCatalog _catalog;
     private readonly ViewerSettings _settings;
     private readonly IMapHostAccessor? _mapHostAccessor;
+    private readonly IRenderStateControllerAccessor? _renderStateAccessor;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -38,13 +39,15 @@ internal sealed class McpServerHost : IAsyncDisposable
         EncDotNet.S100.Mcp.Tools.Catalog.IDatasetCatalog catalog,
         ViewerSettings settings,
         IMapHostAccessor? mapHostAccessor = null,
-        ILoggerFactory? loggers = null)
+        ILoggerFactory? loggers = null,
+        IRenderStateControllerAccessor? renderStateAccessor = null)
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(settings);
         _catalog = catalog;
         _settings = settings;
         _mapHostAccessor = mapHostAccessor;
+        _renderStateAccessor = renderStateAccessor;
         _loggers = loggers;
     }
 
@@ -253,14 +256,18 @@ internal sealed class McpServerHost : IAsyncDisposable
     /// </summary>
     private System.Collections.Generic.IReadOnlyList<McpServerTool>? BuildAdditionalTools()
     {
-        if (_mapHostAccessor is null) return null;
-        var renderTool = new RenderToImageTool(_mapHostAccessor);
-        var setViewportTool = new SetViewportTool(_mapHostAccessor);
-        return new[]
+        var tools = new System.Collections.Generic.List<McpServerTool>();
+        if (_mapHostAccessor is not null)
         {
-            RenderToImageMcpAdapter.Create(renderTool),
-            SetViewportMcpAdapter.Create(setViewportTool),
-        };
+            tools.Add(RenderToImageMcpAdapter.Create(new RenderToImageTool(_mapHostAccessor)));
+            tools.Add(SetViewportMcpAdapter.Create(new SetViewportTool(_mapHostAccessor)));
+        }
+        if (_renderStateAccessor is not null)
+        {
+            tools.Add(SetPaletteMcpAdapter.Create(new SetPaletteTool(_renderStateAccessor)));
+            tools.Add(SetDisplayCategoryMcpAdapter.Create(new SetDisplayCategoryTool(_renderStateAccessor)));
+        }
+        return tools.Count == 0 ? null : tools;
     }
 
     private static bool IsPortInUse(Exception ex)

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -29,6 +29,7 @@ internal sealed class McpServerHost : IAsyncDisposable
     private readonly ViewerSettings _settings;
     private readonly IMapHostAccessor? _mapHostAccessor;
     private readonly IRenderStateControllerAccessor? _renderStateAccessor;
+    private readonly GlobalTimeService? _globalTime;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -40,7 +41,8 @@ internal sealed class McpServerHost : IAsyncDisposable
         ViewerSettings settings,
         IMapHostAccessor? mapHostAccessor = null,
         ILoggerFactory? loggers = null,
-        IRenderStateControllerAccessor? renderStateAccessor = null)
+        IRenderStateControllerAccessor? renderStateAccessor = null,
+        GlobalTimeService? globalTime = null)
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(settings);
@@ -48,6 +50,7 @@ internal sealed class McpServerHost : IAsyncDisposable
         _settings = settings;
         _mapHostAccessor = mapHostAccessor;
         _renderStateAccessor = renderStateAccessor;
+        _globalTime = globalTime;
         _loggers = loggers;
     }
 
@@ -266,6 +269,10 @@ internal sealed class McpServerHost : IAsyncDisposable
         {
             tools.Add(SetPaletteMcpAdapter.Create(new SetPaletteTool(_renderStateAccessor)));
             tools.Add(SetDisplayCategoryMcpAdapter.Create(new SetDisplayCategoryTool(_renderStateAccessor)));
+        }
+        if (_globalTime is not null)
+        {
+            tools.Add(SetTimeStepMcpAdapter.Create(new SetTimeStepTool(_globalTime)));
         }
         return tools.Count == 0 ? null : tools;
     }

--- a/src/EncDotNet.S100.Viewer/Services/ViewerRenderStateController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerRenderStateController.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="IRenderStateController"/> implementation — drives
+/// <see cref="SettingsViewModel.SelectedPalette"/> and
+/// <see cref="EcdisDisplayState.SetCategory"/> through the Avalonia UI
+/// dispatcher.
+/// </summary>
+/// <remarks>
+/// Setting <see cref="SettingsViewModel.SelectedPalette"/> raises
+/// <c>PropertyChanged</c> and <c>PaletteChanged</c>; bound view-models
+/// expect those notifications on the UI thread. We therefore marshal
+/// every setter through <see cref="Dispatcher.UIThread"/> regardless
+/// of caller thread (a no-op when already on the UI thread).
+/// </remarks>
+internal sealed class ViewerRenderStateController : IRenderStateController
+{
+    private readonly SettingsViewModel _settings;
+    private readonly EcdisDisplayState _ecdis;
+
+    public ViewerRenderStateController(SettingsViewModel settings, EcdisDisplayState ecdis)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(ecdis);
+        _settings = settings;
+        _ecdis = ecdis;
+    }
+
+    public PaletteType CurrentPalette => _settings.SelectedPalette;
+
+    public EcdisDisplayCategory CurrentDisplayCategory => _ecdis.Category;
+
+    public async Task SetPaletteAsync(PaletteType palette, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (_settings.SelectedPalette == palette) return;
+        await Dispatcher.UIThread.InvokeAsync(() => _settings.SelectedPalette = palette);
+    }
+
+    public async Task SetDisplayCategoryAsync(EcdisDisplayCategory category, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (_ecdis.Category == category) return;
+        await Dispatcher.UIThread.InvokeAsync(() => _ecdis.SetCategory(category));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/FakeMapHost.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/FakeMapHost.cs
@@ -26,6 +26,8 @@ internal sealed class FakeMapHost : IMapHost
     public void RemoveOverlayLayer(ILayer layer) => OverlayLayers.Remove(layer);
 
     public void ZoomToExtent(MRect extent) { }
+    public void SetViewportToExtent(MRect mercatorExtent) { }
+    public void SetViewportToCenterAndResolution(MPoint mercatorCenter, double resolution) { }
 
     public Task<byte[]?> RenderCurrentViewToPngAsync(
         int widthPx, int heightPx, double pixelDensity, CancellationToken cancellationToken = default)

--- a/tests/EncDotNet.S100.Viewer.Tests/RenderToImageToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RenderToImageToolTests.cs
@@ -38,6 +38,8 @@ public class RenderToImageToolTests
         public void RemoveOverlayLayer(ILayer layer) { }
         public void ReorderDatasetLayers(System.Collections.Generic.IReadOnlyList<ILayer> orderedDatasetLayers) { }
         public void ZoomToExtent(MRect extent) { }
+        public void SetViewportToExtent(MRect mercatorExtent) { }
+        public void SetViewportToCenterAndResolution(MPoint mercatorCenter, double resolution) { }
 
         public Task<byte[]?> RenderCurrentViewToPngAsync(int widthPx, int heightPx, double pixelDensity, CancellationToken ct = default)
         {

--- a/tests/EncDotNet.S100.Viewer.Tests/SetPaletteToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/SetPaletteToolTests.cs
@@ -1,0 +1,177 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class SetPaletteToolTests
+{
+    private sealed class FakeController : IRenderStateController
+    {
+        public PaletteType CurrentPalette { get; set; } = PaletteType.Day;
+        public EcdisDisplayCategory CurrentDisplayCategory { get; set; } = EcdisDisplayCategory.Standard;
+        public int PaletteCalls { get; private set; }
+        public int CategoryCalls { get; private set; }
+
+        public Task SetPaletteAsync(PaletteType palette, CancellationToken ct = default)
+        {
+            PaletteCalls++;
+            CurrentPalette = palette;
+            return Task.CompletedTask;
+        }
+
+        public Task SetDisplayCategoryAsync(EcdisDisplayCategory category, CancellationToken ct = default)
+        {
+            CategoryCalls++;
+            CurrentDisplayCategory = category;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeAccessor : IRenderStateControllerAccessor
+    {
+        public IRenderStateController? Current { get; set; }
+    }
+
+    [Theory]
+    [InlineData("Day", PaletteType.Day)]
+    [InlineData("dusk", PaletteType.Dusk)]
+    [InlineData("NIGHT", PaletteType.Night)]
+    public async Task Sets_palette_case_insensitively(string input, PaletteType expected)
+    {
+        var ctrl = new FakeController { CurrentPalette = PaletteType.Day };
+        var tool = new SetPaletteTool(new FakeAccessor { Current = ctrl });
+
+        var result = await tool.InvokeAsync(new SetPaletteRequest(input));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal(expected.ToString(), ok!.Palette);
+        Assert.Equal("Day", ok.Previous);
+        Assert.Equal(expected, ctrl.CurrentPalette);
+        Assert.Equal(1, ctrl.PaletteCalls);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Sepia")]
+    [InlineData("0")]
+    public async Task Rejects_invalid_palette(string input)
+    {
+        var ctrl = new FakeController();
+        var tool = new SetPaletteTool(new FakeAccessor { Current = ctrl });
+        var result = await tool.InvokeAsync(new SetPaletteRequest(input));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+        Assert.Equal(0, ctrl.PaletteCalls);
+    }
+
+    [Fact]
+    public async Task Map_not_ready_when_accessor_returns_null()
+    {
+        var tool = new SetPaletteTool(new FakeAccessor { Current = null });
+        var result = await tool.InvokeAsync(new SetPaletteRequest("Day"));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public void Adapter_translates_success()
+    {
+        var ok = ToolResult<SetPaletteResult>.Ok(new SetPaletteResult("Night", "Day"));
+        var call = SetPaletteMcpAdapter.TranslateResult(ok);
+        Assert.False(call.IsError);
+        var single = Assert.Single(call.Content);
+        var text = Assert.IsType<ModelContextProtocol.Protocol.TextContentBlock>(single);
+        Assert.Contains("\"palette\":\"Night\"", text.Text);
+        Assert.Contains("\"previous\":\"Day\"", text.Text);
+    }
+
+    [Fact]
+    public void Adapter_translates_error()
+    {
+        var err = ToolResult<SetPaletteResult>.Err(new InvalidArgument("palette", "bad"));
+        var call = SetPaletteMcpAdapter.TranslateResult(err);
+        Assert.True(call.IsError);
+    }
+}
+
+public class SetDisplayCategoryToolTests
+{
+    private sealed class FakeController : IRenderStateController
+    {
+        public PaletteType CurrentPalette { get; set; } = PaletteType.Day;
+        public EcdisDisplayCategory CurrentDisplayCategory { get; set; } = EcdisDisplayCategory.Standard;
+        public int Calls { get; private set; }
+
+        public Task SetPaletteAsync(PaletteType palette, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetDisplayCategoryAsync(EcdisDisplayCategory category, CancellationToken ct = default)
+        {
+            Calls++;
+            CurrentDisplayCategory = category;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeAccessor : IRenderStateControllerAccessor
+    {
+        public IRenderStateController? Current { get; set; }
+    }
+
+    [Theory]
+    [InlineData("DisplayBase", EcdisDisplayCategory.DisplayBase)]
+    [InlineData("standard", EcdisDisplayCategory.Standard)]
+    [InlineData("OTHERINFORMATION", EcdisDisplayCategory.OtherInformation)]
+    [InlineData("All", EcdisDisplayCategory.All)]
+    public async Task Sets_category_case_insensitively(string input, EcdisDisplayCategory expected)
+    {
+        var ctrl = new FakeController { CurrentDisplayCategory = EcdisDisplayCategory.Standard };
+        var tool = new SetDisplayCategoryTool(new FakeAccessor { Current = ctrl });
+        var result = await tool.InvokeAsync(new SetDisplayCategoryRequest(input));
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal(expected.ToString(), ok!.DisplayCategory);
+        Assert.Equal("Standard", ok.Previous);
+        Assert.Equal(expected, ctrl.CurrentDisplayCategory);
+        Assert.Equal(1, ctrl.Calls);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("BadValue")]
+    [InlineData("  ")]
+    public async Task Rejects_invalid_category(string input)
+    {
+        var ctrl = new FakeController();
+        var tool = new SetDisplayCategoryTool(new FakeAccessor { Current = ctrl });
+        var result = await tool.InvokeAsync(new SetDisplayCategoryRequest(input));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+        Assert.Equal(0, ctrl.Calls);
+    }
+
+    [Fact]
+    public async Task Map_not_ready_when_accessor_returns_null()
+    {
+        var tool = new SetDisplayCategoryTool(new FakeAccessor { Current = null });
+        var result = await tool.InvokeAsync(new SetDisplayCategoryRequest("Standard"));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public void Adapter_translates_success()
+    {
+        var ok = ToolResult<SetDisplayCategoryResult>.Ok(
+            new SetDisplayCategoryResult("All", "Standard"));
+        var call = SetDisplayCategoryMcpAdapter.TranslateResult(ok);
+        Assert.False(call.IsError);
+        var single = Assert.Single(call.Content);
+        var text = Assert.IsType<ModelContextProtocol.Protocol.TextContentBlock>(single);
+        Assert.Contains("\"displayCategory\":\"All\"", text.Text);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/SetTimeStepToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/SetTimeStepToolTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class SetTimeStepToolTests
+{
+    private sealed class FakeTimeAware : ITimeAwareDataset
+    {
+        public IReadOnlyList<DateTime> AvailableTimes { get; }
+        public DateTime? CurrentTime => null;
+        public FakeTimeAware(params DateTime[] samples) => AvailableTimes = samples;
+        public DateTime? SnapTo(DateTime t) => null;
+    }
+
+    private static (SetTimeStepTool tool, GlobalTimeService time, List<DateTime> renders) Make(params DateTime[] samples)
+    {
+        var time = new GlobalTimeService();
+        var renders = new List<DateTime>();
+        time.CurrentTimeChanged += t => renders.Add(t);
+        var entry = new DatasetEntry("/tmp/x.h5", "S-111");
+        time.Register(entry, new FakeTimeAware(samples));
+        var tool = new SetTimeStepTool(time, dispatcher: a => { a(); return Task.CompletedTask; });
+        return (tool, time, renders);
+    }
+
+    [Fact]
+    public async Task Index_form_sets_to_sample()
+    {
+        var t0 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var samples = new[] { t0, t0.AddHours(1), t0.AddHours(2), t0.AddHours(3) };
+        var (tool, time, renders) = Make(samples);
+
+        var result = await tool.InvokeAsync(new SetTimeStepRequest(Index: 2));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal("index", ok!.Mode);
+        Assert.Equal(2, ok.Index);
+        Assert.Equal(4, ok.SampleCount);
+        Assert.Equal(samples[2], time.CurrentTime);
+        Assert.Single(renders);
+        Assert.Equal(samples[2], renders[0]);
+    }
+
+    [Fact]
+    public async Task Timestamp_form_snaps_to_nearest()
+    {
+        var t0 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var samples = new[] { t0, t0.AddHours(1), t0.AddHours(2), t0.AddHours(3) };
+        var (tool, time, _) = Make(samples);
+
+        // 1:20 is closer to t0+1h than to t0+2h.
+        var result = await tool.InvokeAsync(new SetTimeStepRequest(
+            Timestamp: t0.AddMinutes(80).ToString("o")));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal("timestamp", ok!.Mode);
+        Assert.Equal(1, ok.Index);
+        Assert.Equal(samples[1], time.CurrentTime);
+    }
+
+    [Fact]
+    public async Task Mixing_forms_is_rejected()
+    {
+        var t0 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var (tool, _, _) = Make(t0, t0.AddHours(1));
+        var result = await tool.InvokeAsync(new SetTimeStepRequest(Index: 0, Timestamp: t0.ToString("o")));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Empty_request_is_rejected()
+    {
+        var t0 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var (tool, _, _) = Make(t0);
+        var result = await tool.InvokeAsync(new SetTimeStepRequest());
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(99)]
+    public async Task Out_of_range_index_is_rejected(int index)
+    {
+        var t0 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var (tool, _, _) = Make(t0, t0.AddHours(1));
+        var result = await tool.InvokeAsync(new SetTimeStepRequest(Index: index));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Bad_timestamp_is_rejected()
+    {
+        var t0 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var (tool, _, _) = Make(t0);
+        var result = await tool.InvokeAsync(new SetTimeStepRequest(Timestamp: "not-a-timestamp"));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Map_not_ready_when_no_time_aware_dataset()
+    {
+        var time = new GlobalTimeService();
+        var tool = new SetTimeStepTool(time, dispatcher: a => { a(); return Task.CompletedTask; });
+        var result = await tool.InvokeAsync(new SetTimeStepRequest(Index: 0));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public void Adapter_translates_success()
+    {
+        var ok = ToolResult<SetTimeStepResult>.Ok(
+            new SetTimeStepResult("index", 3, "2024-01-01T03:00:00.0000000Z", 24, "2024-01-01T00:00:00.0000000Z"));
+        var call = SetTimeStepMcpAdapter.TranslateResult(ok);
+        Assert.False(call.IsError);
+        var single = Assert.Single(call.Content);
+        var text = Assert.IsType<ModelContextProtocol.Protocol.TextContentBlock>(single);
+        Assert.Contains("\"mode\":\"index\"", text.Text);
+        Assert.Contains("\"index\":3", text.Text);
+        Assert.Contains("\"sampleCount\":24", text.Text);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/SetViewportToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/SetViewportToolTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using Mapsui;
+using Mapsui.Layers;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class SetViewportToolTests
+{
+    private sealed record ExtentCall(double MinX, double MinY, double MaxX, double MaxY);
+    private sealed record CenterCall(double X, double Y, double Resolution);
+
+    private sealed class RecordingMapHost : IMapHost
+    {
+        public List<ExtentCall> ExtentCalls { get; } = new();
+        public List<CenterCall> CenterCalls { get; } = new();
+
+        public void AddLayer(ILayer layer) { }
+        public void RemoveLayer(ILayer layer) { }
+        public void AddOverlayLayer(ILayer layer) { }
+        public void RemoveOverlayLayer(ILayer layer) { }
+        public void ReorderDatasetLayers(IReadOnlyList<ILayer> orderedDatasetLayers) { }
+        public void ZoomToExtent(MRect extent) { }
+
+        public void SetViewportToExtent(MRect mercatorExtent)
+            => ExtentCalls.Add(new ExtentCall(
+                mercatorExtent.MinX, mercatorExtent.MinY,
+                mercatorExtent.MaxX, mercatorExtent.MaxY));
+
+        public void SetViewportToCenterAndResolution(MPoint mercatorCenter, double resolution)
+            => CenterCalls.Add(new CenterCall(mercatorCenter.X, mercatorCenter.Y, resolution));
+
+        public Task<byte[]?> RenderCurrentViewToPngAsync(int widthPx, int heightPx, double pixelDensity, CancellationToken ct = default)
+            => Task.FromResult<byte[]?>(null);
+    }
+
+    private sealed class FakeAccessor : IMapHostAccessor
+    {
+        public IMapHost? Current { get; set; }
+    }
+
+    private static (SetViewportTool tool, RecordingMapHost host) Make(IMapHost? hostOverride = null)
+    {
+        var host = (hostOverride as RecordingMapHost) ?? new RecordingMapHost();
+        var accessor = new FakeAccessor { Current = hostOverride is null ? host : hostOverride };
+        return (new SetViewportTool(accessor), host);
+    }
+
+    [Fact]
+    public async Task Bbox_form_projects_and_calls_extent()
+    {
+        var (tool, host) = Make();
+
+        var result = await tool.InvokeAsync(new SetViewportRequest(
+            South: 50.40, West: -3.66, North: 50.50, East: -3.50));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal("bbox", ok!.Mode);
+        Assert.Equal(50.40, ok.South, 6);
+        Assert.Equal(-3.66, ok.West, 6);
+        Assert.Equal(50.50, ok.North, 6);
+        Assert.Equal(-3.50, ok.East, 6);
+        Assert.Single(host.ExtentCalls);
+        Assert.Empty(host.CenterCalls);
+        var call = host.ExtentCalls[0];
+        // Coarse sanity: bbox roughly around south-west UK in Mercator.
+        Assert.True(call.MinX < call.MaxX);
+        Assert.True(call.MinY < call.MaxY);
+    }
+
+    [Fact]
+    public async Task Center_zoom_form_projects_and_calls_center()
+    {
+        var (tool, host) = Make();
+
+        var result = await tool.InvokeAsync(new SetViewportRequest(
+            CenterLat: 50.45, CenterLon: -3.58, Zoom: 12));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.Equal("center", ok!.Mode);
+        // Echoed bbox brackets the centre at z=12 (1024×768 reference frame ≈ 0.4° × 0.2° at this latitude).
+        Assert.InRange(ok.South, 50.0, 50.45);
+        Assert.InRange(ok.North, 50.45, 50.9);
+        Assert.InRange(ok.West, -4.5, -3.58);
+        Assert.InRange(ok.East, -3.58, -2.5);
+        Assert.Empty(host.ExtentCalls);
+        Assert.Single(host.CenterCalls);
+        // Resolution at zoom 12: 156543.0339... / 4096 ≈ 38.22 m/px.
+        Assert.Equal(SetViewportTool.ResolutionAtZoomZero / 4096.0, host.CenterCalls[0].Resolution, 6);
+    }
+
+    [Fact]
+    public async Task Empty_request_is_rejected()
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest());
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Mixing_bbox_and_center_is_rejected()
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest(
+            South: 50, West: -4, North: 51, East: -3,
+            CenterLat: 50.5, CenterLon: -3.5, Zoom: 12));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Partial_bbox_is_rejected()
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest(South: 50, West: -4));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Partial_center_zoom_is_rejected()
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest(CenterLat: 50, CenterLon: -3));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Theory]
+    [InlineData(-91.0, -3.66, 50.50, -3.50)] // south < -90
+    [InlineData(50.40, -181.0, 50.50, -3.50)] // west < -180
+    [InlineData(50.40, -3.66, 91.0, -3.50)] // north > 90
+    [InlineData(50.40, -3.66, 50.50, 181.0)] // east > 180
+    public async Task Out_of_range_bbox_edge_is_rejected(
+        double south, double west, double north, double east)
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest(south, west, north, east));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Theory]
+    [InlineData(50.50, -3.50, 50.40, -3.66)] // south >= north
+    [InlineData(50.40, -3.50, 50.50, -3.66)] // west >= east (no antimeridian)
+    public async Task Inverted_bbox_is_rejected_with_geometry_invalid(
+        double south, double west, double north, double east)
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest(south, west, north, east));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<GeometryInvalid>(err);
+    }
+
+    [Theory]
+    [InlineData(-0.5)]
+    [InlineData(24.5)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public async Task Out_of_range_zoom_is_rejected(double zoom)
+    {
+        var (tool, _) = Make();
+        var result = await tool.InvokeAsync(new SetViewportRequest(
+            CenterLat: 50, CenterLon: -3, Zoom: zoom));
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Map_not_ready_when_accessor_returns_null()
+    {
+        var accessor = new FakeAccessor { Current = null };
+        var tool = new SetViewportTool(accessor);
+
+        var result = await tool.InvokeAsync(new SetViewportRequest(
+            South: 50, West: -4, North: 51, East: -3));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public void Adapter_translates_success_to_text_block()
+    {
+        var ok = ToolResult<SetViewportResult>.Ok(new SetViewportResult("bbox", 50, -4, 51, -3));
+        var call = SetViewportMcpAdapter.TranslateResult(ok);
+        Assert.False(call.IsError);
+        var single = Assert.Single(call.Content);
+        var text = Assert.IsType<TextContentBlock>(single);
+        Assert.Contains("\"mode\":\"bbox\"", text.Text);
+        Assert.Contains("\"south\":50", text.Text);
+    }
+
+    [Fact]
+    public void Adapter_translates_error_to_error_payload()
+    {
+        var err = ToolResult<SetViewportResult>.Err(new InvalidArgument("zoom", "out of range"));
+        var call = SetViewportMcpAdapter.TranslateResult(err);
+        Assert.True(call.IsError);
+        var single = Assert.Single(call.Content);
+        var text = Assert.IsType<TextContentBlock>(single);
+        Assert.Contains("\"code\":\"invalid_argument\"", text.Text);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ValidationOverlayTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ValidationOverlayTests.cs
@@ -33,6 +33,8 @@ public class ValidationOverlayTests
         public void RemoveLayer(ILayer layer) { }
         public void ReorderDatasetLayers(IReadOnlyList<ILayer> orderedDatasetLayers) { }
         public void ZoomToExtent(MRect extent) => ZoomCalls.Add(extent);
+        public void SetViewportToExtent(MRect mercatorExtent) { }
+        public void SetViewportToCenterAndResolution(MPoint mercatorCenter, double resolution) { }
         public void AddOverlayLayer(ILayer layer) => Overlays.Add(layer);
         public void RemoveOverlayLayer(ILayer layer) => Overlays.Remove(layer);
         public System.Threading.Tasks.Task<byte[]?> RenderCurrentViewToPngAsync(int widthPx, int heightPx, double pixelDensity, System.Threading.CancellationToken cancellationToken = default)


### PR DESCRIPTION
Implements the highest-priority items from the perf-report optimisation plan: 3 new Viewer MCP tools that unblock scripted performance measurement, plus the P1 fix for the PNG-buffer / native-bitmap retention leak in `render_to_image`.

## Commits (split for per-commit review)

| Commit | Plan ID | Summary |
|---|---|---|
| `2c3dd08` | **PR-A1** | `set_viewport` MCP tool — bbox or center+resolution; extends `IMapHost` with `SetViewportToExtent` / `SetViewportToCenterAndResolution` |
| `5855e97` | **PR-A2** | `set_palette` + `set_display_category` MCP tools; introduces `IRenderStateController` UI-thread marshaling abstraction |
| `b283f18` | **PR-A3** | `set_time_step` MCP tool — accepts int index or ISO timestamp, snaps to nearest sample |
| `dbe48f3` | **P1** | Fix `render_to_image` snapshot-`Map` retention leak (responsible for 144 MB → 1.46 GB RSS growth over 150 renders in the perf report) |

## Why these four together

The 3 MCP tools (`set_viewport`, `set_palette`/`set_display_category`, `set_time_step`) are the scripted-measurement primitives the perf-report's Track-A and Track-B harnesses need to drive deterministic warm-render scenarios. The P1 fix is in `MapsuiMapHost.RenderCurrentViewToPngAsync` — the body of the existing `render_to_image` MCP tool, which is itself one of those measurement primitives. Without P1, every Track-B retention measurement is contaminated by ~10 MB of leaked PNG buffer and native-bitmap memory per render call. The plan called this out as **must land before any other Track-B retention work**.

## P1 root cause + fix

`Mapsui.Map` implements `IDisposable`, but the snapshot `Map` constructed per-call in `RenderCurrentViewToPngAsync` was let go to the GC un-disposed. Its `LayerCollection` and property-changed plumbing kept the snapshot rooted indefinitely, holding the per-call PNG buffer plus its associated SkiaSharp bitmaps.

Fix: detach live layers (`snapshot.Layers.ClearAllGroups()`) **before** disposing the snapshot, so the snapshot's dispose path only releases its own owned resources and never touches the live layer instances we share with the on-screen `Map`. Layer-collection teardown is wrapped in a best-effort `try/catch` so a teardown failure cannot mask a render failure.

## Verification

- All 579 viewer unit tests pass.
- New unit tests for the 3 MCP tools (full coverage of the validation paths and error shapes).
- P1 has no unit-test surface — `MapsuiMapHost` requires a real Avalonia `MapControl`. Validation for the leak fix belongs to the perf-report's Track-B path: rerun the 150-render `dotnet-gcdump` harness against this branch and expect the RSS ceiling to drop from ~1.46 GB to roughly 200 MB. Adding a headless Avalonia harness for `MapsuiMapHost` is a candidate follow-up tooling gap (it would also enable end-to-end testing of PR-A1's viewport setters).

## Docs

`docs/mcp-server.md` and `src/EncDotNet.S100.Viewer/README.md` updated to describe the 4 new tools and the read-only / mutating tool convention.

## Not in this PR

The remaining 12 items from the optimisation plan (PR-A4 `close_dataset`, PR-A5, the 4 PerfRunner harness improvements, and P2–P7) are deliberately deferred — they all benefit from re-running the perf harness against the post-P1 baseline, and shipping them blind would violate the plan's own sequencing rule.