### PR TITLE
Fix S-101 legacy feature names falling back to DEFAULT symbology

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -33,6 +33,37 @@ bundled catalogue. Current patches:
 
 If upstream fixes a defect, the corresponding patch is dropped.
 
+## Legacy feature-name compatibility
+
+The bundled Portrayal Catalogue is **S-101 Edition 2.0.0**, whose Lua
+rule modules use the 2.0.0 (word-reversed) feature class names —
+`LateralBuoy.lua` defining `function LateralBuoy`, dispatched by
+`main.lua` via `require(feature.Code)` then `_G[feature.Code](...)`.
+Datasets authored against an earlier edition of the S-101 Feature
+Catalogue report the **pre-2.0.0** names (`BuoyLateral`,
+`BeaconCardinal`, `MooringWarpingFacility`, …). Those names match no
+2.0.0 rule module, so the dispatcher's `require` fails and the feature
+falls back to **DEFAULT** (`QUESMRK1`) symbology.
+
+`S101LegacyFeatureNames.Normalize` maps the legacy class names to their
+2.0.0 equivalents so the correct rule runs. Because simple attribute
+names are stable across these editions, only the feature **class** name
+needs remapping. The shim is applied **only** at the portrayal boundary
+(`S101LuaDataProvider.HostFeatureGetCode`); feature names are left
+as-authored everywhere else (document reader, vector source,
+validation, info panels).
+
+`MooringWarpingFacility` was structurally removed in 2.0.0, so it is
+mapped conditionally on `categoryOfMooringWarpingFacility`
+(dolphin → `Dolphin`, bollard → `Bollard`, post/pile → `Pile`,
+mooring buoy → `MooringBuoy`); categories without a clean 2.0.0
+equivalent are left unchanged and stay on DEFAULT. These conditional
+targets are approximations — only the class name is aliased, not the
+attributes the 2.0.0 rule reads — so symbology may be generic, and a
+target rule that rejects the feature's geometric primitive simply
+errors inside the dispatcher's `pcall` and falls back to DEFAULT
+(no regression versus today).
+
 ## Validation
 
 A bundled rule pack

--- a/src/EncDotNet.S100.Datasets.S101/S101LegacyFeatureNames.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LegacyFeatureNames.cs
@@ -1,0 +1,135 @@
+using System.Collections.Frozen;
+
+namespace EncDotNet.S100.Datasets.S101;
+
+/// <summary>
+/// Maps legacy (pre-2.0.0) S-101 feature class names to their S-101 Edition
+/// 2.0.0 equivalents so that datasets authored against an earlier edition of
+/// the S-101 Feature Catalogue can be portrayed with the bundled Edition 2.0.0
+/// Portrayal Catalogue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Between S-101 1.x and 2.0.0 several compound feature class names were
+/// re-ordered (for example <c>BuoyLateral</c> became <c>LateralBuoy</c> and
+/// <c>BeaconCardinal</c> became <c>CardinalBeacon</c>). Because the S-100
+/// Part 9A Lua portrayal dispatcher (<c>main.lua</c>) loads and invokes a rule
+/// module whose file name and global function name both equal the feature's
+/// class code (<c>require(feature.Code)</c> then <c>_G[feature.Code](...)</c>),
+/// a dataset that reports a legacy class code finds no matching 2.0.0 rule
+/// module and falls back to DEFAULT symbology.
+/// </para>
+/// <para>
+/// Simple attribute names are stable across these editions, so re-mapping only
+/// the feature <em>class</em> name restores correct symbology. The mapping is
+/// applied at the portrayal boundary only (see
+/// <see cref="S101LuaDataProvider"/>); feature names are left as-authored
+/// everywhere else.
+/// </para>
+/// <para>
+/// <c>MooringWarpingFacility</c> was structurally removed in S-101 2.0.0 and
+/// split into several distinct feature classes, so it is mapped conditionally
+/// on the legacy <c>categoryOfMooringWarpingFacility</c> enumerant. Categories
+/// without a clean 2.0.0 equivalent are left unchanged (and therefore portrayed
+/// with DEFAULT symbology). The conditional targets are approximations: only
+/// the class name is aliased, not the attributes the 2.0.0 rule reads (for
+/// example <c>Dolphin.lua</c> inspects <c>categoryOfDolphin</c>), so the
+/// resulting symbology may be generic. A target rule that rejects the legacy
+/// feature's geometric primitive simply errors inside the dispatcher's
+/// <c>pcall</c> and falls back to DEFAULT — i.e. no worse than today.
+/// </para>
+/// <para>References: S-101 Feature Catalogue (Edition 1.x and 2.0.0); S-100
+/// Part 9A (Portrayal — Lua rules engine).</para>
+/// </remarks>
+public static class S101LegacyFeatureNames
+{
+    /// <summary>The legacy attribute used to discriminate the removed
+    /// <c>MooringWarpingFacility</c> feature class.</summary>
+    private const string MooringWarpingFacility = "MooringWarpingFacility";
+    private const string MooringWarpingCategoryAttribute = "categoryOfMooringWarpingFacility";
+
+    /// <summary>
+    /// Legacy S-101 1.x feature class name → S-101 2.0.0 feature class name.
+    /// Keys are matched case-insensitively. Only names that do not exist in
+    /// 2.0.0 are present, so genuine 2.0.0 datasets are never altered.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> SimpleRenames =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Buoys (S-101 2.0.0 reverses the compound order).
+            ["BuoyCardinal"] = "CardinalBuoy",
+            ["BuoyInstallation"] = "InstallationBuoy",
+            ["BuoyIsolatedDanger"] = "IsolatedDangerBuoy",
+            ["BuoyLateral"] = "LateralBuoy",
+            ["BuoySafeWater"] = "SafeWaterBuoy",
+            ["BuoySpecialPurposeGeneral"] = "SpecialPurposeGeneralBuoy",
+            // The "new danger marking" buoy was renamed "emergency wreck marking".
+            ["BuoyNewDangerMarking"] = "EmergencyWreckMarkingBuoy",
+
+            // Beacons (S-101 2.0.0 reverses the compound order).
+            ["BeaconCardinal"] = "CardinalBeacon",
+            ["BeaconIsolatedDanger"] = "IsolatedDangerBeacon",
+            ["BeaconLateral"] = "LateralBeacon",
+            ["BeaconSafeWater"] = "SafeWaterBeacon",
+            ["BeaconSpecialPurposeGeneral"] = "SpecialPurposeGeneralBeacon",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Legacy <c>categoryOfMooringWarpingFacility</c> enumerant (stringified
+    /// integer code) → S-101 2.0.0 feature class name. Categories without a
+    /// clean 2.0.0 equivalent (tie-up wall = 4, chain/wire/cable = 6) are
+    /// intentionally absent so the feature is left on DEFAULT symbology.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> MooringWarpingByCategory =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["1"] = "Dolphin",     // dolphin
+            ["2"] = "Dolphin",     // deviation dolphin (approximated as a dolphin)
+            ["3"] = "Bollard",     // bollard
+            ["5"] = "Pile",        // post or pile
+            ["7"] = "MooringBuoy", // mooring buoy
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns the S-101 2.0.0 feature class name equivalent to
+    /// <paramref name="featureCode"/>, or <paramref name="featureCode"/>
+    /// unchanged when it is already a 2.0.0 name or has no clean mapping.
+    /// </summary>
+    /// <param name="featureCode">
+    /// The feature class code reported by the dataset (from its embedded
+    /// feature-type-name catalogue).
+    /// </param>
+    /// <param name="categoryLookup">
+    /// Optional callback that resolves the first value of a simple attribute on
+    /// the feature being normalized, used to disambiguate the removed
+    /// <c>MooringWarpingFacility</c> class via
+    /// <c>categoryOfMooringWarpingFacility</c>. When <see langword="null"/>,
+    /// <c>MooringWarpingFacility</c> is left unchanged.
+    /// </param>
+    /// <returns>The normalized feature class name.</returns>
+    public static string Normalize(string featureCode, Func<string, string?>? categoryLookup = null)
+    {
+        if (string.IsNullOrEmpty(featureCode))
+        {
+            return featureCode;
+        }
+
+        if (SimpleRenames.TryGetValue(featureCode, out var renamed))
+        {
+            return renamed;
+        }
+
+        if (categoryLookup is not null &&
+            string.Equals(featureCode, MooringWarpingFacility, StringComparison.OrdinalIgnoreCase))
+        {
+            var category = categoryLookup(MooringWarpingCategoryAttribute);
+            if (category is not null &&
+                MooringWarpingByCategory.TryGetValue(category.Trim(), out var mapped))
+            {
+                return mapped;
+            }
+        }
+
+        return featureCode;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
@@ -161,8 +161,18 @@ public sealed class S101LuaDataProvider
     private string HostFeatureGetCode(double featureId)
     {
         var feat = GetFeature((uint)featureId);
-        return _doc.FeatureTypeCatalogue.TryGetValue(feat.FeatureTypeCode, out var name)
+        var raw = _doc.FeatureTypeCatalogue.TryGetValue(feat.FeatureTypeCode, out var name)
             ? name : feat.FeatureTypeCode.ToString();
+
+        // Normalize legacy (pre-2.0.0) S-101 feature class names to their
+        // Edition 2.0.0 equivalents so the bundled 2.0.0 Portrayal Catalogue's
+        // Lua rule modules can be dispatched (S-100 Part 9A). Applied only here,
+        // at the portrayal boundary; names are left as-authored elsewhere.
+        return S101LegacyFeatureNames.Normalize(
+            raw,
+            attributeCode => GetSimpleAttributeValues(feat.Attributes, attributeCode)
+                .OfType<string>()
+                .FirstOrDefault());
     }
 
     private List<object> HostFeatureGetSimpleAttribute(double featureId, string attributePath, string attributeCode)

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101LegacyFeatureNamesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101LegacyFeatureNamesTests.cs
@@ -1,0 +1,116 @@
+using EncDotNet.S100.Datasets.S101;
+
+namespace EncDotNet.S100.Datasets.S101.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S101LegacyFeatureNames"/>, the legacy (pre-2.0.0)
+/// → S-101 Edition 2.0.0 feature class name normalization used to dispatch the
+/// bundled 2.0.0 Portrayal Catalogue Lua rules (S-100 Part 9A).
+/// </summary>
+public class S101LegacyFeatureNamesTests
+{
+    [Theory]
+    [InlineData("BuoyCardinal", "CardinalBuoy")]
+    [InlineData("BuoyInstallation", "InstallationBuoy")]
+    [InlineData("BuoyIsolatedDanger", "IsolatedDangerBuoy")]
+    [InlineData("BuoyLateral", "LateralBuoy")]
+    [InlineData("BuoySafeWater", "SafeWaterBuoy")]
+    [InlineData("BuoySpecialPurposeGeneral", "SpecialPurposeGeneralBuoy")]
+    [InlineData("BuoyNewDangerMarking", "EmergencyWreckMarkingBuoy")]
+    [InlineData("BeaconCardinal", "CardinalBeacon")]
+    [InlineData("BeaconIsolatedDanger", "IsolatedDangerBeacon")]
+    [InlineData("BeaconLateral", "LateralBeacon")]
+    [InlineData("BeaconSafeWater", "SafeWaterBeacon")]
+    [InlineData("BeaconSpecialPurposeGeneral", "SpecialPurposeGeneralBeacon")]
+    public void Normalize_LegacyBuoyOrBeacon_ReturnsRenamed(string legacy, string expected)
+    {
+        Assert.Equal(expected, S101LegacyFeatureNames.Normalize(legacy));
+    }
+
+    [Theory]
+    [InlineData("buoylateral", "LateralBuoy")]
+    [InlineData("BUOYLATERAL", "LateralBuoy")]
+    [InlineData("BeaconCARDINAL", "CardinalBeacon")]
+    public void Normalize_IsCaseInsensitive(string legacy, string expected)
+    {
+        Assert.Equal(expected, S101LegacyFeatureNames.Normalize(legacy));
+    }
+
+    [Theory]
+    [InlineData("LateralBuoy")]
+    [InlineData("CardinalBeacon")]
+    [InlineData("LightFloat")]
+    [InlineData("RadarTransponderBeacon")]
+    [InlineData("DepthArea")]
+    [InlineData("SomeUnrelatedFeature")]
+    public void Normalize_NonLegacyName_ReturnsUnchanged(string name)
+    {
+        Assert.Equal(name, S101LegacyFeatureNames.Normalize(name));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Normalize_NullOrEmpty_ReturnsInput(string? input)
+    {
+        Assert.Equal(input, S101LegacyFeatureNames.Normalize(input!));
+    }
+
+    [Theory]
+    [InlineData("1", "Dolphin")]
+    [InlineData("2", "Dolphin")]
+    [InlineData("3", "Bollard")]
+    [InlineData("5", "Pile")]
+    [InlineData("7", "MooringBuoy")]
+    public void Normalize_MooringWarpingFacility_MappedCategory_ReturnsTarget(string category, string expected)
+    {
+        var result = S101LegacyFeatureNames.Normalize(
+            "MooringWarpingFacility",
+            code => code == "categoryOfMooringWarpingFacility" ? category : null);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("4")]   // tie-up wall — no clean 2.0.0 equivalent
+    [InlineData("6")]   // chain/wire/cable — no clean 2.0.0 equivalent
+    [InlineData("99")]  // unknown enumerant
+    [InlineData("")]    // present but empty
+    public void Normalize_MooringWarpingFacility_UnmappedCategory_ReturnsUnchanged(string category)
+    {
+        var result = S101LegacyFeatureNames.Normalize(
+            "MooringWarpingFacility",
+            code => category);
+
+        Assert.Equal("MooringWarpingFacility", result);
+    }
+
+    [Fact]
+    public void Normalize_MooringWarpingFacility_NullLookupResult_ReturnsUnchanged()
+    {
+        var result = S101LegacyFeatureNames.Normalize(
+            "MooringWarpingFacility",
+            code => null);
+
+        Assert.Equal("MooringWarpingFacility", result);
+    }
+
+    [Fact]
+    public void Normalize_MooringWarpingFacility_NoLookup_ReturnsUnchanged()
+    {
+        Assert.Equal(
+            "MooringWarpingFacility",
+            S101LegacyFeatureNames.Normalize("MooringWarpingFacility"));
+    }
+
+    [Fact]
+    public void Normalize_MooringWarpingFacility_LookupRequestsCategoryAttribute()
+    {
+        string? requested = null;
+        S101LegacyFeatureNames.Normalize(
+            "MooringWarpingFacility",
+            code => { requested = code; return "3"; });
+
+        Assert.Equal("categoryOfMooringWarpingFacility", requested);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101LegacyFeatureNameDispatchTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101LegacyFeatureNameDispatchTests.cs
@@ -1,0 +1,131 @@
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Regression tests for the S-101 legacy feature-name compatibility shim
+/// (<see cref="S101LegacyFeatureNames"/>). Datasets authored against a pre-2.0.0
+/// edition of the S-101 Feature Catalogue report legacy feature class names
+/// (e.g. <c>BuoyLateral</c>) that do not match the word-reversed rule modules in
+/// the bundled 2.0.0 Portrayal Catalogue (e.g. <c>LateralBuoy.lua</c>). Without
+/// normalization the Lua dispatcher (<c>main.lua</c>) fails its
+/// <c>require(feature.Code)</c> and falls back to DEFAULT symbology
+/// (the <c>QUESMRK1</c> "question mark" symbol).
+/// </summary>
+public class S101LegacyFeatureNameDispatchTests
+{
+    /// <summary>
+    /// Fixture containing legacy-named buoy and beacon features
+    /// (<c>BuoyLateral</c>, <c>BuoyCardinal</c>, <c>BuoySpecialPurposeGeneral</c>,
+    /// <c>BeaconCardinal</c>).
+    /// </summary>
+    private const string BuoyBeaconFixture = "101AA00DS0020.000";
+
+    /// <summary>The DEFAULT (rule-not-found) fallback symbol from Default.lua.</summary>
+    private const string DefaultSymbol = "QUESMRK1";
+
+    private static readonly string[] LegacyBuoyBeaconCodes =
+    [
+        "BuoyLateral",
+        "BuoyCardinal",
+        "BuoySpecialPurposeGeneral",
+        "BeaconCardinal",
+    ];
+
+    [SkippableFact]
+    public void LegacyNamedBuoyAndBeaconFeatures_DoNotFallBackToDefaultSymbology()
+    {
+        var fixturePath = ResolveFixturePath(BuoyBeaconFixture);
+        Skip.IfNot(File.Exists(fixturePath),
+            $"S-101 fixture not found at expected path: {fixturePath}");
+
+        var dataset = S101Dataset.Open(fixturePath);
+        var doc = dataset.Document;
+
+        // Map record ID -> legacy feature class code for the features of interest.
+        var legacyFeatures = new Dictionary<uint, string>();
+        foreach (var feat in doc.Features)
+        {
+            if (!doc.FeatureTypeCatalogue.TryGetValue(feat.FeatureTypeCode, out var code))
+                continue;
+            if (LegacyBuoyBeaconCodes.Contains(code, StringComparer.OrdinalIgnoreCase))
+                legacyFeatures[feat.RecordId] = code;
+        }
+
+        Skip.If(legacyFeatures.Count == 0,
+            "Fixture contains no legacy-named buoy or beacon features.");
+
+        var emitted = RunExecutor(dataset);
+
+        // Group emitted instructions by feature.
+        var byFeature = emitted
+            .Where(e => uint.TryParse(e.FeatureRef, out _))
+            .GroupBy(e => uint.Parse(e.FeatureRef))
+            .ToDictionary(g => g.Key, g => g.Select(e => e.InstructionString).ToList());
+
+        var defaultedFeatures = new List<string>();
+        var properlyPortrayed = 0;
+        foreach (var (recordId, code) in legacyFeatures)
+        {
+            if (!byFeature.TryGetValue(recordId, out var instructions) || instructions.Count == 0)
+            {
+                // No instructions at all is itself a failure to portray.
+                defaultedFeatures.Add($"{code} (ID={recordId}): no instructions");
+                continue;
+            }
+
+            // A feature left on DEFAULT symbology emits only QUESMRK1 references.
+            var hasNonDefault = instructions.Any(
+                s => !s.Contains(DefaultSymbol, StringComparison.Ordinal));
+            if (hasNonDefault)
+                properlyPortrayed++;
+            else
+                defaultedFeatures.Add($"{code} (ID={recordId})");
+        }
+
+        Assert.True(
+            defaultedFeatures.Count == 0,
+            $"Expected all {legacyFeatures.Count} legacy-named buoy/beacon features to be " +
+            $"portrayed with their proper 2.0.0 symbology, but {defaultedFeatures.Count} fell " +
+            $"back to DEFAULT ({DefaultSymbol}): {string.Join(", ", defaultedFeatures)}.");
+
+        Assert.True(properlyPortrayed > 0, "Expected at least one legacy feature to be portrayed.");
+    }
+
+    private static IReadOnlyList<EmittedInstruction> RunExecutor(S101Dataset dataset)
+    {
+        using var fcStream = Specification.TryOpenFeatureCatalogue("S-101")
+            ?? throw new InvalidOperationException("S-101 feature catalogue not bundled.");
+        var fc = FeatureCatalogueReader.Read(fcStream);
+
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var pcProvider = PortrayalCatalogueProvider.OpenAsync(pcSource).GetAwaiter().GetResult();
+        var luaEngine = new MoonSharpLuaEngine();
+        var catalogue = new S101PortrayalCatalogue(pcProvider, luaEngine);
+        catalogue.SwitchPalette(PaletteType.Day);
+
+        var executor = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
+        return executor.ExecuteRaw(MarinerSettings.Default);
+    }
+
+    /// <summary>
+    /// Resolves the bundled S-101 test dataset by walking up from the test
+    /// assembly's base directory until the <c>tests/datasets/S101</c>
+    /// folder is found.
+    /// </summary>
+    private static string ResolveFixturePath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "tests", "datasets", "S101", "S-101", "DATASET_FILES", fileName);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return Path.Combine("tests", "datasets", "S101", "S-101", "DATASET_FILES", fileName);
+    }
+}


### PR DESCRIPTION
## Problem

When loading an S-101 ENC in the viewer, the MoonSharp Lua portrayal engine logs a batch of errors and many features fall back to DEFAULT symbology:

```
[Lua] Error: libfunc_require:(12,1-44): module 'BuoyLateral' not found.  Default symbology for BuoyLateral ID=2450 returned.
[Lua] Error: libfunc_require:(12,1-44): module 'BuoyCardinal' not found.  Default symbology for BuoyCardinal ID=2459 returned.
...
```

## Root cause

Edition skew. The bundled Portrayal Catalogue is **S-101 Edition 2.0.0**, whose Lua rule modules use the 2.0.0 (word-reversed) feature class names — `LateralBuoy.lua` defining `function LateralBuoy`, dispatched by `main.lua` via `require(feature.Code)` then `_G[feature.Code](...)`. Datasets authored against an earlier edition of the S-101 Feature Catalogue report the **pre-2.0.0** names (`BuoyLateral`, `BeaconCardinal`, `MooringWarpingFacility`, …). Those names match no 2.0.0 rule module, so the dispatcher's `require` fails and the feature falls back to **DEFAULT** (`QUESMRK1`) symbology.

## Fix

Targeted alias at the portrayal/Lua boundary only:

- **New `S101LegacyFeatureNames.Normalize`** — case-insensitive legacy → 2.0.0 rename map for buoys/beacons (all targets have rule files), plus conditional `MooringWarpingFacility` mapping on `categoryOfMooringWarpingFacility` (dolphin → `Dolphin`, bollard → `Bollard`, post/pile → `Pile`, mooring buoy → `MooringBuoy`; ambiguous categories left on DEFAULT).
- **Applied only in `S101LuaDataProvider.HostFeatureGetCode`** — the single dispatch chokepoint. `TryGetFeatureTypeCode`, the document reader, vector source, and validation are untouched (names stay as-authored). Bundled FC/PC remain byte-identical to upstream.

Because simple attribute names are stable across these editions, aliasing only the class name yields **correct** symbology, not just a non-default symbol.

## Tests

- 35 new unit tests (`S101LegacyFeatureNamesTests`) — every rename, all mooring categories incl. unknown/missing/null lookup, passthrough of 2.0.0 + unrelated names, case-insensitivity.
- New executor-level integration test (`S101LegacyFeatureNameDispatchTests`) drives the real `S101LuaRuleExecutor` against bundled fixture `101AA00DS0020.000` and asserts all legacy buoy/beacon features now portray without the `QUESMRK1` DEFAULT fallback.
- Full suites green: **64** S101 + **406** pipeline tests, no regressions.

## Docs

- `EncDotNet.S100.Datasets.S101/README.md` gains a "Legacy feature-name compatibility" section.