### PR TITLE
Add Mapsui rendering performance instrumentation

### DIFF
--- a/docs/design/mapsui-performance.md
+++ b/docs/design/mapsui-performance.md
@@ -1,0 +1,190 @@
+# Mapsui rendering performance
+
+This page records the May/June 2026 performance review of the
+Mapsui-based viewer pipeline (Avalonia frontend, SkiaSharp backend),
+the data captured, and the optimization plan that follows from it.
+
+Branch: `philliphoff/mapsui-performance-review`
+
+## Context
+
+Real-world S-101 datasets (especially when several are loaded at once)
+felt visibly laggy when panning in the viewer. Headline question:
+**are we getting as much performance out of Mapsui as we can?**
+
+The investigation was structured as a series of measurement passes,
+each adding instrumentation that narrowed where the cost lives.
+
+## TL;DR
+
+Mapsui is using the GPU and is not throttled — it is
+**vertex-bound**. ~93% of every paint is spent inside Mapsui's
+`VectorStyleRenderer`, and per-call cost scales linearly with geometry
+vertex count at ~1 µs/point. The single highest-leverage optimization
+is **resolution-aware geometry simplification at display-list build
+time**, projected to bring mean paint from ~100 ms (8 fps) to
+~30–40 ms (25–30 fps) on real-world multi-S-101 datasets.
+
+## What was measured
+
+### 1. GPU acceleration is on
+
+`GpuAccelerationProbe` (1×1 invisible Avalonia `Control`) reads
+`ISkiaSharpApiLease.GrContext` once on first paint. Reported on the
+investigator's Apple Silicon machine:
+
+```
+gpuAccelerated=True backend=OpenGL
+```
+
+Avalonia 11 on macOS prefers Metal first, then OpenGL, then software.
+The probe found OpenGL — meaning rendering goes through Apple's
+deprecated OpenGL→Metal translation layer. Forcing Metal is a possible
+incremental gain but unmeasured.
+
+### 2. Mapsui's pipeline is not throttled — it's saturated
+
+`InstrumentedMapControl` brackets `base.Render(DrawingContext)` with
+two `ICustomDrawOperation` markers that record the actual Skia paint
+duration on the compositor render thread. Heavy real-world S-101
+panning shows paint/interval ratio ≥ 0.9, i.e. the renderer is busy
+most of every cycle and has no slack to recover frame rate.
+
+### 3. Per-style apportionment
+
+`MapPaintInstrumentation` reflects into
+`Mapsui.Rendering.Skia.MapRenderer._styleRenderers` (a private static
+`Dictionary<Type, IStyleRenderer>`) and replaces each registered
+`IStyleRenderer` with a `CountingStyleRenderer` wrapper that times each
+`Draw` call. The wrapper's start/end is bracketed inside the per-paint
+markers, so per-paint accumulators reset cleanly each frame.
+
+Wrapper coverage = ~92% of paint wall-time. Across all measured
+configurations, **`VectorStyle` accounts for 90–94% of paint**.
+`RasterStyle`, `ImageStyle`, `SymbolStyle`, and `LabelStyle` are each
+< 5%.
+
+### 4. Per-call cost is purely a function of vertex count
+
+The decisive measurement: per-call cost tagged by both `layer` and
+`points` (vertex-count bucket). On a real multi-S-101 session
+(rasterizer off, mean paint 98 ms, 8 fps):
+
+| points | calls | total ms | µs/call | % of paint |
+|---|---:|---:|---:|---:|
+| 1–9 | 45,198 | 328 | 7 | 0.7% |
+| 10–99 | 109,620 | 3,421 | 31 | 6.8% |
+| **100–999** | **59,091** | **23,568** | **399** | **47.1%** |
+| **1k–10k** | **10,481** | **22,726** | **2,168** | **45.4%** |
+
+Per-vertex cost is ~1 µs across all buckets — meaning per-call cost is
+fully explained by vertex count alone. Layers with cheap geometries
+remain cheap regardless of how many other layers are loaded. There is
+no measurable structural overhead from layering itself.
+
+#### Top offending (layer × bucket) combinations
+
+| layer | bucket | total ms | calls | µs/call |
+|---|---|---:|---:|---:|
+| 101GB00GB302045 (lines) | 1k-10k | 11,476 | 4,032 | 2,846 |
+| 101GB00GB302045 (lines) | 100-999 | 9,631 | 13,344 | 722 |
+| 101GB00502038 (lines) | 100-999 | 8,338 | 18,326 | 455 |
+| 101GB0040242C (lines) | 1k-10k | 4,033 | 1,509 | 2,673 |
+
+A 3,000-vertex polyline (typical coastline / depth contour) costs
+~2.8 ms per draw. Drawing 4,000 such polylines per paint = 11 seconds
+of paint wall-time over a ~60 s measurement window.
+
+### 5. RasterizingTileLayer prototype: workload-dependent
+
+`S100RasterizingTileLayer` (gated by the `EnableVectorRasterization`
+viewer setting) wraps a `MemoryLayer` in Mapsui's tile-cached vector
+layer. Picking is preserved by delegating `GetFeatures` to the
+underlying source layer.
+
+| | OFF | ON | Δ |
+|---|---:|---:|---:|
+| Mean paint (moderate single dataset) | 30.3 ms | 36.1 ms | +19% |
+| Max paint (moderate single dataset) | 136 ms | 114 ms | −16% |
+
+Tail latency improves under heavy load when the cache warms; mean
+regresses on lighter loads. Right call to keep as an opt-in
+experimental setting, not safe to default-on.
+
+## What this rules out
+
+- **❌ Mapsui pipeline overhead.** Per-vertex cost is ~1 µs, which is
+  about as fast as Skia can tessellate a stroke. Patching
+  `VectorStyleRenderer` would not help.
+- **❌ State thrashing across layers.** Per-call cost depends only on
+  geometry, not on layer count or layer ordering.
+- **❌ Style class complexity.** The dominant cost is plain
+  `VectorStyle`; symbol / label / pattern-fill styles are negligible.
+- **❌ SKPaint allocations.** Even if every per-call paint were free,
+  max savings ≤ a few µs × N calls, swamped by the per-vertex cost.
+
+## High-leverage optimizations
+
+### 1. Resolution-aware geometry simplification (PRIMARY)
+
+Apply Douglas-Peucker (or equivalent) at display-list build time, with
+tolerance ≈ 1 screen pixel at the current zoom. Polylines with
+thousands of vertices typically reduce 10–100× without visible quality
+loss.
+
+Projected impact based on the measured cost model:
+- 1k-10k bucket → 100-999 bucket: ~5× cheaper draws (saves ~18 s of
+  paint over the measurement window).
+- 100-999 bucket → 10-99 bucket: similar magnitude (saves ~20 s).
+- Combined: mean paint drops from ~98 ms → ~30–40 ms on the heaviest
+  workload measured.
+
+Open design questions:
+- Where in the pipeline does simplification live? Almost certainly
+  inside `MapsuiDisplayListRenderer` when geometry is materialized
+  from `IDisplayList.GetGeometry`, gated by a resolution bucket.
+- Cache shape: keyed by `(feature-ref, zoom-bucket)`; values are
+  pre-simplified NTS geometries (or pre-built `SKPath`s).
+- Eviction policy: on zoom-band change, not per-paint.
+
+### 2. Verify SCAMIN / scale-visibility filtering is effective
+
+Some of the worst offenders may be features that should have been
+culled at the current zoom but weren't. The
+`s100.layer.get_features.*` metrics already track filter ratio;
+cross-check against the offending layer/feature combinations.
+
+### 3. Investigate per-feature-class cost distribution
+
+`101GB00GB302045` was responsible for ~67% of paint cost on its own.
+Worth identifying which S-101 feature class
+(`DepthContour`? `CoastlineLine`?) contributes most, so the
+simplification work in (1) can target the highest-impact features
+first. Requires extending `MapPaintInstrumentation` to tag by feature
+class via the `FeatureRefKey` round-trip.
+
+### 4. Batch polylines into shared SKPath objects
+
+Skia amortizes setup across multiple sub-paths in a single
+`canvas.DrawPath`. Lower priority than (1); explore after
+simplification lands.
+
+## What is NOT worth doing
+
+- **Forcing Metal backend on macOS.** Bottleneck is vertex-bound,
+  not blit-bound; backend swap unlikely to move the needle.
+- **Patching `VectorStyleRenderer` per-call optimisations.** Per-call
+  cost is already ~1 µs/point; nothing left to squeeze.
+- **SKPaint pooling.** Same reasoning.
+
+## Instrumentation reference
+
+See [`src/EncDotNet.S100.Renderers.Mapsui/README.md`](../../src/EncDotNet.S100.Renderers.Mapsui/README.md#performance-instrumentation)
+for the OTel instrument table and how to capture a measurement session.
+
+Files added on this branch:
+- `src/EncDotNet.S100.Viewer/Diagnostics/InstrumentedMapControl.cs`
+- `src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs`
+- `src/EncDotNet.S100.Viewer/Diagnostics/GpuAccelerationProbe.cs`
+- `src/EncDotNet.S100.Renderers.Mapsui/InstrumentedMemoryLayer.cs`
+- `src/EncDotNet.S100.Renderers.Mapsui/S100RasterizingTileLayer.cs`

--- a/src/EncDotNet.S100.Renderers.Mapsui/AnchoredPatternFillRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/AnchoredPatternFillRenderer.cs
@@ -41,6 +41,22 @@ public sealed class AnchoredPatternFillRenderer : ISkiaStyleRenderer
             return false;
         }
 
+        var drawStartTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+        try
+        {
+            return DrawCore(canvas, viewport, layer, gf, patternStyle);
+        }
+        finally
+        {
+            var elapsedMs = System.Diagnostics.Stopwatch
+                .GetElapsedTime(drawStartTimestamp).TotalMilliseconds;
+            Diagnostics.Telemetry.PatternFillDrawDuration.Record(elapsedMs);
+        }
+    }
+
+    private bool DrawCore(SKCanvas canvas, Viewport viewport, ILayer layer,
+                          GeometryFeature gf, AnchoredPatternFillStyle patternStyle)
+    {
         IEnumerable<Polygon> polygons = gf.Geometry switch
         {
             Polygon p => [p],
@@ -48,7 +64,7 @@ public sealed class AnchoredPatternFillRenderer : ISkiaStyleRenderer
             _ => []
         };
 
-        float opacity = (float)(layer.Opacity * style.Opacity);
+        float opacity = (float)(layer.Opacity * patternStyle.Opacity);
         var clipRect = viewport.ToSkiaRect();
 
         // Build a combined path from all polygons so the pattern is drawn

--- a/src/EncDotNet.S100.Renderers.Mapsui/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Diagnostics/Telemetry.cs
@@ -1,5 +1,8 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Threading;
 using EncDotNet.S100.Diagnostics;
 
 namespace EncDotNet.S100.Renderers.Mapsui.Diagnostics;
@@ -12,6 +15,38 @@ internal static class Telemetry
 
     public static readonly Meter Meter =
         S100Telemetry.CreateMeter(typeof(Telemetry));
+
+    /// <summary>
+    /// Per-product (or untagged) call-rate state used to derive
+    /// <c>s100.layer.getfeatures.fps</c> as an <see cref="ObservableGauge{T}"/>.
+    /// Each <see cref="InstrumentedMemoryLayer.GetFeatures"/> invocation
+    /// calls <see cref="RecordGetFeaturesCall"/>, which atomically bumps
+    /// <see cref="CallStats.Count"/> for the matching product key. The
+    /// gauge callback (registered below) computes <c>delta-count /
+    /// delta-time</c> across export intervals to emit a true rate.
+    /// </summary>
+    private sealed class CallStats
+    {
+        public long Count;
+        public long LastReadCount;
+        public long LastReadTimestamp = Stopwatch.GetTimestamp();
+    }
+
+    private static readonly ConcurrentDictionary<string, CallStats> s_callStats =
+        new ConcurrentDictionary<string, CallStats>();
+
+    /// <summary>
+    /// Records a single <c>GetFeatures</c> invocation for fps accounting.
+    /// Pass <see langword="null"/> when no product is configured; the
+    /// stats are aggregated under an empty key (emitted as an untagged
+    /// gauge measurement).
+    /// </summary>
+    internal static void RecordGetFeaturesCall(string? product)
+    {
+        var key = product ?? string.Empty;
+        var stats = s_callStats.GetOrAdd(key, static _ => new CallStats());
+        Interlocked.Increment(ref stats.Count);
+    }
 
     public static readonly Histogram<double> FrameDuration =
         Meter.CreateHistogram<double>(
@@ -67,4 +102,136 @@ internal static class Telemetry
             name: "s100.pattern.cache.miss.count",
             unit: "{misses}",
             description: "Pattern-tile cache misses during area-fill resolution (tile rasterisation triggered). Tagged with s100.product when the renderer is configured by a dataset processor.");
+
+    /// <summary>
+    /// Wall-clock duration of a single Mapsui <c>GetFeatures(rect,resolution)</c>
+    /// call on an <see cref="InstrumentedMemoryLayer"/>. Mapsui invokes this
+    /// once per visible layer per rendered frame, so the histogram reflects
+    /// the per-frame extent-filter cost. Tagged with <c>s100.product</c>
+    /// when the renderer is configured by a dataset processor.
+    /// </summary>
+    public static readonly Histogram<double> LayerGetFeaturesDuration =
+        Meter.CreateHistogram<double>(
+            name: "s100.layer.getfeatures.duration",
+            unit: "ms",
+            description: "Wall-clock duration of MemoryLayer.GetFeatures (per-frame extent filter cost).");
+
+    /// <summary>
+    /// Number of features returned by a single <c>GetFeatures</c> call —
+    /// i.e. the count of features whose extent intersects the visible
+    /// viewport (K). Combined with <see cref="LayerGetFeaturesTotalCount"/>
+    /// this gives the K/N selectivity that determines how much a spatial
+    /// index would help: low K/N at a given zoom = big win.
+    /// </summary>
+    public static readonly Histogram<long> LayerGetFeaturesVisibleCount =
+        Meter.CreateHistogram<long>(
+            name: "s100.layer.getfeatures.visible.count",
+            unit: "{features}",
+            description: "Features returned by MemoryLayer.GetFeatures (visible/in-extent count K per frame).");
+
+    /// <summary>
+    /// Total feature count scanned by a <c>GetFeatures</c> call (N).
+    /// This is the size of the layer's feature list, identical for every
+    /// frame until the layer is re-rendered. Recorded per call so the
+    /// histogram reports it alongside the visible count without the
+    /// caller needing to correlate metrics.
+    /// </summary>
+    public static readonly Histogram<long> LayerGetFeaturesTotalCount =
+        Meter.CreateHistogram<long>(
+            name: "s100.layer.getfeatures.total.count",
+            unit: "{features}",
+            description: "Total feature count scanned by MemoryLayer.GetFeatures (N per frame).");
+
+    /// <summary>
+    /// Cumulative count of <c>GetFeatures</c> calls per product. Most
+    /// observability backends derive a per-second rate from a counter
+    /// automatically; the dedicated <c>s100.layer.getfeatures.fps</c>
+    /// gauge below provides the same value pre-computed for the
+    /// console exporter, where counters are reported as totals over the
+    /// export interval.
+    /// </summary>
+    public static readonly Counter<long> LayerGetFeaturesCalls =
+        Meter.CreateCounter<long>(
+            name: "s100.layer.getfeatures.calls.count",
+            unit: "{calls}",
+            description: "GetFeatures call count per product (each call ~= one rendered frame for that product).");
+
+    /// <summary>
+    /// Per-product frame rate (calls/second of <c>GetFeatures</c>),
+    /// computed from the rolling call counter on each meter export.
+    /// For a single visible layer per product this matches the map
+    /// control's effective fps; if N visible layers of the same product
+    /// are stacked, divide by N for the actual frame rate.
+    /// </summary>
+    /// <remarks>
+    /// Implemented as a multi-measurement <see cref="ObservableGauge{T}"/>
+    /// so a single instrument emits one sample per active product on
+    /// every collection cycle. Untagged measurements (empty product
+    /// key) are emitted with no <c>s100.product</c> tag, preserving
+    /// legacy behaviour for ad-hoc callers.
+    /// </remarks>
+    public static readonly ObservableGauge<double> LayerGetFeaturesFps =
+        Meter.CreateObservableGauge<double>(
+            name: "s100.layer.getfeatures.fps",
+            observeValues: ObserveLayerGetFeaturesFps,
+            unit: "{frames}/s",
+            description: "Average GetFeatures call rate per product (~fps for single-layer maps).");
+
+    /// <summary>
+    /// Inter-frame interval recorded on each <c>GetFeatures</c> entry
+    /// (gap since the previous call returned), in milliseconds.
+    /// Subtracting the matching
+    /// <see cref="LayerGetFeaturesDuration"/> sample yields the
+    /// render-plus-paint slice of frame time — i.e. everything Mapsui
+    /// and Skia did between two consecutive feature pulls. Idle gaps
+    /// (longer than ~500 ms) are not recorded so the histogram
+    /// reflects active rendering only.
+    /// </summary>
+    public static readonly Histogram<double> LayerFrameInterval =
+        Meter.CreateHistogram<double>(
+            name: "s100.layer.frame.interval",
+            unit: "ms",
+            description: "Inter-frame interval (gap between consecutive GetFeatures calls). Subtract LayerGetFeaturesDuration to estimate render+paint cost.");
+
+    /// <summary>
+    /// Per-call duration of <c>AnchoredPatternFillRenderer.Draw</c>, in
+    /// milliseconds. Pattern fills are the most expensive S-101 style
+    /// we render ourselves; this histogram quantifies their share of
+    /// post-filter frame time. Combined with
+    /// <see cref="LayerFrameInterval"/> minus
+    /// <see cref="LayerGetFeaturesDuration"/>, the residue is time
+    /// Mapsui's stock style renderers (vector / label / symbol) spent
+    /// on the layer.
+    /// </summary>
+    public static readonly Histogram<double> PatternFillDrawDuration =
+        Meter.CreateHistogram<double>(
+            name: "s100.style.pattern_fill.draw.duration",
+            unit: "ms",
+            description: "Per-call duration of AnchoredPatternFillRenderer.Draw (one call per pattern-fill feature per frame).");
+
+    private static IEnumerable<Measurement<double>> ObserveLayerGetFeaturesFps()
+    {
+        var measurements = new List<Measurement<double>>(s_callStats.Count);
+        foreach (var pair in s_callStats)
+        {
+            var stats = pair.Value;
+            var nowTimestamp = Stopwatch.GetTimestamp();
+            var currentCount = Interlocked.Read(ref stats.Count);
+            var deltaSeconds = Stopwatch.GetElapsedTime(stats.LastReadTimestamp).TotalSeconds;
+            var deltaCalls = currentCount - stats.LastReadCount;
+
+            // Mutated only from the meter's collection thread, so no
+            // lock is needed; the call-side increments only touch
+            // Count, never these fields.
+            stats.LastReadCount = currentCount;
+            stats.LastReadTimestamp = nowTimestamp;
+
+            var fps = deltaSeconds > 0 ? deltaCalls / deltaSeconds : 0.0;
+            measurements.Add(string.IsNullOrEmpty(pair.Key)
+                ? new Measurement<double>(fps)
+                : new Measurement<double>(fps,
+                    new KeyValuePair<string, object?>("s100.product", pair.Key)));
+        }
+        return measurements;
+    }
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/InstrumentedMemoryLayer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/InstrumentedMemoryLayer.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Styles;
+using S100Diag = EncDotNet.S100.Renderers.Mapsui.Diagnostics;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// <see cref="MemoryLayer"/> subclass that records per-frame timing and
+/// selectivity metrics each time Mapsui asks for the layer's visible
+/// features.  Used by <see cref="MapsuiDisplayListRenderer"/> so we can
+/// quantify how much of a render frame is spent in the layer's
+/// extent-filter loop versus downstream Skia drawing — i.e. whether a
+/// spatial index (e.g. an STRtree-backed provider) would actually help
+/// real-world S-100 datasets.
+/// </summary>
+/// <remarks>
+/// Mapsui's base <see cref="MemoryLayer"/> implements <c>GetFeatures</c>
+/// as an O(N) linear extent test on every render frame.  This subclass
+/// re-implements the same filter while wrapping it in a
+/// <see cref="Stopwatch"/> measurement and emitting:
+/// <list type="bullet">
+///   <item><description><c>s100.layer.getfeatures.duration</c> (ms)</description></item>
+///   <item><description><c>s100.layer.getfeatures.visible.count</c> (K)</description></item>
+///   <item><description><c>s100.layer.getfeatures.total.count</c> (N)</description></item>
+/// </list>
+/// Each metric is tagged with <c>s100.product</c> when the renderer is
+/// configured by a dataset processor, so per-product percentiles can be
+/// read directly from the OTLP / console exporter.
+/// </remarks>
+public sealed class InstrumentedMemoryLayer : MemoryLayer
+{
+    /// <summary>
+    /// Inter-frame gaps longer than this are treated as idle (no
+    /// rendering happening) and excluded from the
+    /// <c>s100.layer.frame.interval</c> /
+    /// <c>s100.layer.frame.render_plus_paint</c> histograms. Without
+    /// this, a single idle pause would dominate the percentile.
+    /// </summary>
+    private const double IdleGapThresholdMs = 500.0;
+
+    private readonly KeyValuePair<string, object?>[] _tags;
+    private readonly string? _product;
+    private long _lastExitTimestamp;
+
+    /// <summary>
+    /// Creates a new instrumented layer.  <paramref name="product"/> is
+    /// attached as the <c>s100.product</c> dimension on each emitted
+    /// metric; pass <see langword="null"/> for ad-hoc / one-shot use.
+    /// </summary>
+    public InstrumentedMemoryLayer(string? product = null)
+    {
+        _product = product;
+        _tags = product is null
+            ? System.Array.Empty<KeyValuePair<string, object?>>()
+            : new[] { new KeyValuePair<string, object?>("s100.product", product) };
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Replicates <see cref="MemoryLayer.GetFeatures"/>'s extent-filter
+    /// behaviour (Mapsui grows the query rect by
+    /// <c>SymbolStyle.DefaultWidth * 2 * resolution</c> to keep large
+    /// symbols on edge features visible).  Returns a materialised list
+    /// rather than yielding lazily so the recorded duration reflects
+    /// the filter pass alone, not downstream consumer work.
+    /// </remarks>
+    public override IEnumerable<IFeature> GetFeatures(MRect? rect, double resolution)
+    {
+        if (rect is null)
+            return System.Array.Empty<IFeature>();
+
+        // Inter-frame gap: time since the previous GetFeatures returned.
+        // Captured before doing any filter work, so it reflects the gap
+        // between two consecutive frame-emissions on this layer. Mapsui
+        // calls GetFeatures once per visible layer per render pass, so
+        // for a single-layer map this is the frame interval; the
+        // render+paint slice is the gap minus the previous frame's
+        // filter duration. Skipped when the gap exceeds the idle
+        // threshold (no active rendering between samples).
+        var entryTimestamp = Stopwatch.GetTimestamp();
+        if (_lastExitTimestamp != 0)
+        {
+            var gapMs = Stopwatch.GetElapsedTime(_lastExitTimestamp, entryTimestamp).TotalMilliseconds;
+            if (gapMs > 0 && gapMs <= IdleGapThresholdMs)
+            {
+                S100Diag.Telemetry.LayerFrameInterval.Record(gapMs, _tags);
+            }
+        }
+
+        var startTimestamp = entryTimestamp;
+        var grow = SymbolStyle.DefaultWidth * 2.0 * resolution;
+        var biggerRect = rect.Grow(grow, grow);
+
+        var visible = new List<IFeature>();
+        long total = 0;
+        foreach (var feature in Features)
+        {
+            total++;
+            if (feature is not null && feature.Extent?.Intersects(biggerRect) == true)
+                visible.Add(feature);
+        }
+
+        var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+        S100Diag.Telemetry.LayerGetFeaturesDuration.Record(elapsedMs, _tags);
+        S100Diag.Telemetry.LayerGetFeaturesVisibleCount.Record(visible.Count, _tags);
+        S100Diag.Telemetry.LayerGetFeaturesTotalCount.Record(total, _tags);
+        S100Diag.Telemetry.LayerGetFeaturesCalls.Add(1, _tags);
+        S100Diag.Telemetry.RecordGetFeaturesCall(_product);
+
+        _lastExitTimestamp = Stopwatch.GetTimestamp();
+        return visible;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -274,7 +274,7 @@ public sealed class MapsuiDisplayListRenderer
         S100Diag.Telemetry.FrameDuration.Record(
             (Stopwatch.GetTimestamp() - renderStart) * 1000.0 / Stopwatch.Frequency);
 
-        return new MemoryLayer
+        return new InstrumentedMemoryLayer(Product)
         {
             Name = LayerName,
             Features = mapFeatures,

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -60,6 +60,46 @@ The cache segments entries per palette (`Day` / `Dusk` / `Night`) so flipping ba
 
   The viewer's overlay host resolves the renderer at registration time via `IServiceProvider.GetKeyedService<IDynamicFeatureRenderer>(source.Metadata.RendererKey)`.
 
+## Performance instrumentation
+
+The renderer ships with optional OpenTelemetry instrumentation that
+attributes paint cost down to the style-renderer, layer, and geometry
+vertex count. All instruments are sub-millisecond per paint when no
+OTel listener is attached, so they are safe to leave in production
+builds.
+
+| Instrument | Unit | Tags | Purpose |
+|---|---|---|---|
+| `s100.map.paint.duration` | ms | — | Compositor-thread paint wall-time per frame |
+| `s100.map.paint.interval` | ms | — | Time between paints (idle gaps > 500 ms dropped) |
+| `s100.map.paint.style.calls` | count | `style`, `layer`, `points` | Style-renderer `Draw` calls per paint |
+| `s100.map.paint.style.duration` | ms | `style`, `layer`, `points` | Cumulative `Draw` duration per paint |
+| `s100.layer.get_features.duration` | ms | `layer` | Layer-level filter cost per `GetFeatures` call |
+| `s100.layer.get_features.visible` / `total` | count | `layer` | Visible / total feature counts per call |
+| `s100.layer.get_features.fps` | gauge | `layer` | Effective `GetFeatures` rate per layer |
+| `s100.pattern_fill.draw.duration` | ms | — | `AnchoredPatternFillRenderer` per-call cost |
+
+The `points` tag is bucketed (`1-9`, `10-99`, `100-999`, `1k-10k`,
+`10k-100k`, `100k+`) to keep histogram cardinality bounded while
+still revealing whether a layer's cost is driven by many cheap draws
+or a few expensive ones.
+
+To capture a measurement session, run the viewer with the OTel console
+exporter enabled:
+
+```sh
+ENC_DOTNET_OTEL_CONSOLE=1 OTEL_METRIC_EXPORT_INTERVAL=2000 \
+  dotnet run -c Release --project src/EncDotNet.S100.Viewer
+```
+
+Histograms are emitted every 2 s with cumulative counts and per-bucket
+distributions. Aggregate by `(layer, points)` to identify which
+geometries are dominating paint time — empirically, ~93% of paint cost
+on real-world S-101 datasets is spent on geometries with ≥100 vertices,
+with per-vertex cost ~1 µs. See
+[`docs/design/mapsui-performance.md`](../../docs/design/mapsui-performance.md)
+for the full investigation and optimization plan.
+
 ## Installation
 
 ```sh

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100RasterizingTileLayer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100RasterizingTileLayer.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Tiling.Layers;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// Experimental wrapper around <see cref="RasterizingTileLayer"/> that
+/// keeps picking working when the source vector layer is rasterised to
+/// a tile cache. The base class draws cached PNG tiles for performance,
+/// but stops returning the underlying vector features from
+/// <see cref="MemoryLayer.GetFeatures"/>; Mapsui's <c>MapInfo</c> hit
+/// detection therefore can't find the features the user clicks on.
+/// This subclass forwards <c>GetFeatures</c> to <see cref="SourceLayer"/>
+/// so picks resolve to the original <c>IFeature</c> instances (carrying
+/// the <c>FeatureRefKey</c> tag the viewer's <c>PickService</c> uses).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per-frame rendering is unaffected — Mapsui's tile-render path uses
+/// <c>RasterizingTileSource</c>, not <c>GetFeatures</c>. Only hit
+/// detection (one-shot per click) calls into the source's full
+/// extent-filter loop.
+/// </para>
+/// <para>
+/// This is a prototype gated by <c>ViewerSettings.EnableVectorRasterization</c>
+/// so we can A/B compare frame rate, visual quality, and pick latency
+/// against the un-wrapped path.
+/// </para>
+/// </remarks>
+public sealed class S100RasterizingTileLayer : RasterizingTileLayer
+{
+    /// <summary>
+    /// Wraps <paramref name="sourceLayer"/> in a tile-cached rasteriser.
+    /// All other <see cref="RasterizingTileLayer"/> defaults are
+    /// preserved so the prototype isolates the rasterisation effect.
+    /// </summary>
+    public S100RasterizingTileLayer(ILayer sourceLayer)
+        : base(sourceLayer)
+    {
+    }
+
+    /// <inheritdoc />
+    public override IEnumerable<IFeature> GetFeatures(MRect? rect, double resolution)
+        => rect is null
+            ? System.Array.Empty<IFeature>()
+            : SourceLayer.GetFeatures(rect, resolution);
+}

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -59,6 +59,8 @@ public partial class App : Application
 
         s_services = ConfigureServices();
 
+        EncDotNet.S100.Viewer.Diagnostics.MapPaintInstrumentation.Install();
+
         // The viewer uses a plain ServiceCollection (no generic IHost),
         // so the IHostedService registered by AddOpenTelemetry() never
         // runs — meaning the TracerProvider / MeterProvider would

--- a/src/EncDotNet.S100.Viewer/Diagnostics/GpuAccelerationProbe.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/GpuAccelerationProbe.cs
@@ -1,0 +1,132 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Skia;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// One-shot diagnostic that asks Avalonia for a Skia API lease the
+/// same way Mapsui's <c>MapControl</c> does (via
+/// <see cref="ISkiaSharpApiLease"/>) and reports whether the lease
+/// exposes a non-null <c>GrContext</c>. A non-null context means the
+/// canvas Mapsui is drawing into is GPU-backed; null means the
+/// Avalonia compositor handed Skia a software bitmap and every paint
+/// is rasterised on the CPU.
+/// </summary>
+/// <remarks>
+/// The control is invisible (transparent, hit-test disabled, 1×1)
+/// and removes itself after the first successful probe so it costs
+/// nothing in steady state. Result is written to <see cref="LastResult"/>
+/// and to <c>stderr</c> for log scraping.
+/// </remarks>
+public sealed class GpuAccelerationProbe : Control
+{
+    /// <summary>Latest probe result; null until first paint.</summary>
+    public static GpuProbeResult? LastResult { get; private set; }
+
+    /// <summary>Raised on the UI thread when a probe completes.</summary>
+    public static event Action<GpuProbeResult>? Probed;
+
+    private bool _reported;
+
+    public GpuAccelerationProbe()
+    {
+        Width = 1;
+        Height = 1;
+        IsHitTestVisible = false;
+        // Note: do NOT set Opacity = 0; Avalonia's compositor skips
+        // Render() on zero-opacity visuals, so the probe op would
+        // never run.
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        // Force at least one paint so the custom draw op gets a
+        // chance to lease the Skia API.
+        InvalidateVisual();
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        if (_reported) return;
+        context.Custom(new ProbeOp(new Rect(0, 0, 1, 1), this));
+    }
+
+    private void Report(GpuProbeResult result)
+    {
+        if (_reported) return;
+        _reported = true;
+        LastResult = result;
+        Console.Error.WriteLine(
+            $"[GPU-PROBE] gpuAccelerated={result.GpuAccelerated} " +
+            $"backend={result.BackendName} " +
+            $"surfaceWidth={result.SurfaceWidth} " +
+            $"surfaceHeight={result.SurfaceHeight}");
+        try { Probed?.Invoke(result); } catch { }
+    }
+
+    private sealed class ProbeOp : ICustomDrawOperation
+    {
+        private readonly GpuAccelerationProbe _owner;
+
+        public ProbeOp(Rect bounds, GpuAccelerationProbe owner)
+        {
+            Bounds = bounds;
+            _owner = owner;
+        }
+
+        public Rect Bounds { get; }
+
+        public void Dispose() { }
+
+        public bool HitTest(Point p) => false;
+
+        public bool Equals(ICustomDrawOperation? other) => false;
+
+        public void Render(ImmediateDrawingContext context)
+        {
+            var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+            if (leaseFeature is null)
+            {
+                _owner.Report(new GpuProbeResult(false, "no-skia-lease-feature", 0, 0));
+                return;
+            }
+
+            using var lease = leaseFeature.Lease();
+            var gr = lease.GrContext;
+            var surface = lease.SkSurface;
+            int w = 0, h = 0;
+            try
+            {
+                if (surface is not null)
+                {
+                    w = surface.Canvas.LocalClipBounds is { } b
+                        ? (int)b.Width
+                        : 0;
+                    h = surface.Canvas.LocalClipBounds is { } b2
+                        ? (int)b2.Height
+                        : 0;
+                }
+            }
+            catch { }
+
+            string backend = gr is null
+                ? "software"
+                : gr.Backend.ToString();
+            _owner.Report(new GpuProbeResult(gr is not null, backend, w, h));
+        }
+    }
+}
+
+/// <summary>Result of a single <see cref="GpuAccelerationProbe"/> paint.</summary>
+public sealed record GpuProbeResult(
+    bool GpuAccelerated,
+    string BackendName,
+    int SurfaceWidth,
+    int SurfaceHeight);

--- a/src/EncDotNet.S100.Viewer/Diagnostics/InstrumentedMapControl.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/InstrumentedMapControl.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Rendering.SceneGraph;
+using Mapsui.UI.Avalonia;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// <see cref="MapControl"/> subclass that wall-clock-times the
+/// Mapsui custom draw operation on the compositor render thread.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mapsui's <c>MapsuiCustomDrawOperation.Render(ImmediateDrawingContext)</c>
+/// is sealed inside the Mapsui.UI.Avalonia DLL, so we can't subclass
+/// it directly. Instead we sandwich it between two
+/// <see cref="ICustomDrawOperation"/>s of our own. Avalonia replays
+/// custom draw ops in registration order on the render thread, so
+/// the elapsed time between the start and end markers is the actual
+/// Skia paint duration — independent of UI-thread / dispatch /
+/// invalidation cadence.
+/// </para>
+/// <para>
+/// The approach is non-invasive: Mapsui's draw op is unchanged, the
+/// markers do nothing visual, and the rest of <see cref="MapControl"/>
+/// behaves identically. Frame interval is computed from end-marker
+/// timestamps, with a 500 ms idle-gap filter so a single pause
+/// doesn't dominate percentiles.
+/// </para>
+/// </remarks>
+internal sealed class InstrumentedMapControl : MapControl
+{
+    /// <summary>Idle-gap threshold above which an interval sample is dropped.</summary>
+    private const double IdleGapThresholdMs = 500.0;
+
+    private long _lastEndTimestamp;
+
+    public override void Render(DrawingContext context)
+    {
+        // Shared between the two markers so the END marker can
+        // compute duration relative to START's timestamp without
+        // touching shared state on the render thread.
+        var marker = new PaintMarker();
+
+        context.Custom(new StartMarkerOp(marker));
+        base.Render(context);
+        context.Custom(new EndMarkerOp(marker, this));
+    }
+
+    private void RecordPaint(long startTimestamp, long endTimestamp)
+    {
+        var durationMs = Stopwatch.GetElapsedTime(startTimestamp, endTimestamp).TotalMilliseconds;
+        Telemetry.MapPaintDuration.Record(durationMs);
+
+        var prevEnd = _lastEndTimestamp;
+        _lastEndTimestamp = endTimestamp;
+        if (prevEnd != 0)
+        {
+            var intervalMs = Stopwatch.GetElapsedTime(prevEnd, endTimestamp).TotalMilliseconds;
+            if (intervalMs <= IdleGapThresholdMs)
+            {
+                Telemetry.MapPaintInterval.Record(intervalMs);
+            }
+        }
+    }
+    private sealed class PaintMarker
+    {
+        public long StartTimestamp;
+    }
+
+    private sealed class StartMarkerOp : ICustomDrawOperation
+    {
+        private readonly PaintMarker _marker;
+        public StartMarkerOp(PaintMarker marker) => _marker = marker;
+        public Rect Bounds => default;
+        public void Dispose() { }
+        public bool HitTest(Point p) => false;
+        public bool Equals(ICustomDrawOperation? other) => false;
+        public void Render(ImmediateDrawingContext context)
+        {
+            _marker.StartTimestamp = Stopwatch.GetTimestamp();
+            MapPaintInstrumentation.BeginPaint();
+        }
+    }
+
+    private sealed class EndMarkerOp : ICustomDrawOperation
+    {
+        private readonly PaintMarker _marker;
+        private readonly InstrumentedMapControl _owner;
+
+        public EndMarkerOp(PaintMarker marker, InstrumentedMapControl owner)
+        {
+            _marker = marker;
+            _owner = owner;
+        }
+
+        public Rect Bounds => default;
+        public void Dispose() { }
+        public bool HitTest(Point p) => false;
+        public bool Equals(ICustomDrawOperation? other) => false;
+
+        public void Render(ImmediateDrawingContext context)
+        {
+            var end = Stopwatch.GetTimestamp();
+            // Defensive: if the start marker somehow didn't run
+            // (e.g. compositor culled it on a clipped frame), the
+            // delta would be wildly negative — skip the sample.
+            if (_marker.StartTimestamp == 0) return;
+            _owner.RecordPaint(_marker.StartTimestamp, end);
+            MapPaintInstrumentation.EndPaintAndEmit();
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using EncDotNet.S100.Diagnostics;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Rendering;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.SkiaStyles;
+using Mapsui.Styles;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Wraps Mapsui's per-style <see cref="IStyleRenderer"/> registrations
+/// so that every style draw is timed and counted, and the
+/// per-paint totals are emitted to OpenTelemetry tagged by style
+/// type. Combined with <see cref="InstrumentedMapControl"/>'s
+/// per-paint markers, this apportions the wall-clock paint
+/// duration across <c>VectorStyle</c>, <c>LabelStyle</c>,
+/// <c>SymbolStyle</c>, etc., so we can see which style class
+/// dominates a paint.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mapsui's <c>MapRenderer</c> stores its style renderers in a
+/// private static dictionary keyed by style type. The runtime
+/// public surface (<c>MapRenderer.RegisterStyleRenderer</c>) lets
+/// callers add new renderers but does not expose the existing
+/// registrations, so we use reflection to read out the defaults
+/// and re-register each as a wrapped <see cref="CountingStyleRenderer"/>.
+/// All style draws run on the compositor render thread between
+/// the start and end paint markers, so the accumulator is single-
+/// threaded and lock-free.
+/// </para>
+/// <para>
+/// The wrapping is one-shot: <see cref="Install"/> is idempotent
+/// and a no-op after the first call.
+/// </para>
+/// </remarks>
+internal static class MapPaintInstrumentation
+{
+    private static readonly object Sync = new();
+    private static bool s_installed;
+
+    private static readonly Meter Meter =
+        S100Telemetry.CreateMeter(typeof(MapPaintInstrumentation));
+
+    private static readonly Histogram<long> StyleCallsPerPaint =
+        Meter.CreateHistogram<long>(
+            name: "s100.map.paint.style.calls",
+            unit: "{calls}",
+            description: "Number of style-renderer Draw calls per paint, tagged by style type.");
+
+    private static readonly Histogram<double> StyleDurationPerPaint =
+        Meter.CreateHistogram<double>(
+            name: "s100.map.paint.style.duration",
+            unit: "ms",
+            description: "Cumulative duration of style-renderer Draw calls per paint, tagged by style type.");
+
+    /// <summary>
+    /// Per (style-type, layer) accumulator for the in-flight paint.
+    /// Mutated only on the compositor render thread (between
+    /// <see cref="BeginPaint"/> and <see cref="EndPaintAndEmit"/>),
+    /// so no locking is required.
+    /// </summary>
+    private static readonly Dictionary<(string Style, string Layer, string PointBucket), StyleStats> s_perPaint = new();
+
+    private sealed class StyleStats
+    {
+        public long Calls;
+        public double DurationMs;
+    }
+
+    public static void Install()
+    {
+        lock (Sync)
+        {
+            if (s_installed) return;
+            s_installed = true;
+
+            // Make sure our pattern-fill renderer is in the dict
+            // before we wrap. Subsequent registrations of the same
+            // style type overwrite, so this is safe even if Render()
+            // hasn't run yet.
+            EncDotNet.S100.Renderers.Mapsui.AnchoredPatternFillRenderer.Register();
+
+            var dictField = typeof(MapRenderer).GetField(
+                "_styleRenderers",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (dictField is null)
+            {
+                Console.Error.WriteLine(
+                    "[MapPaintInstrumentation] could not find MapRenderer._styleRenderers; instrumentation disabled.");
+                return;
+            }
+
+            if (dictField.GetValue(null) is not IDictionary<Type, IStyleRenderer> dict)
+            {
+                Console.Error.WriteLine(
+                    "[MapPaintInstrumentation] _styleRenderers had unexpected type; instrumentation disabled.");
+                return;
+            }
+
+            // Snapshot first because we'll mutate the dict.
+            var snapshot = new List<KeyValuePair<Type, IStyleRenderer>>(dict);
+            foreach (var pair in snapshot)
+            {
+                if (pair.Value is CountingStyleRenderer) continue;
+                dict[pair.Key] = new CountingStyleRenderer(pair.Key, pair.Value);
+            }
+        }
+    }
+
+    /// <summary>Called from <see cref="InstrumentedMapControl"/>'s start marker.</summary>
+    public static void BeginPaint()
+    {
+        // Reset accumulators in place to avoid GC churn.
+        foreach (var stats in s_perPaint.Values)
+        {
+            stats.Calls = 0;
+            stats.DurationMs = 0;
+        }
+    }
+
+    /// <summary>Called from <see cref="InstrumentedMapControl"/>'s end marker.</summary>
+    public static void EndPaintAndEmit()
+    {
+        foreach (var (key, stats) in s_perPaint)
+        {
+            if (stats.Calls == 0) continue;
+            var styleTag = new KeyValuePair<string, object?>("style", key.Style);
+            var layerTag = new KeyValuePair<string, object?>("layer", key.Layer);
+            var bucketTag = new KeyValuePair<string, object?>("points", key.PointBucket);
+            StyleCallsPerPaint.Record(stats.Calls, styleTag, layerTag, bucketTag);
+            StyleDurationPerPaint.Record(stats.DurationMs, styleTag, layerTag, bucketTag);
+        }
+    }
+
+    /// <summary>
+    /// Bucket vertex count into a small, ordered set of labels so OTel
+    /// histogram cardinality stays bounded. Buckets are powers of 10.
+    /// </summary>
+    private static string BucketPoints(int n) => n switch
+    {
+        < 0 => "n/a",
+        0 => "0",
+        < 10 => "1-9",
+        < 100 => "10-99",
+        < 1_000 => "100-999",
+        < 10_000 => "1k-10k",
+        < 100_000 => "10k-100k",
+        _ => "100k+",
+    };
+
+    private static StyleStats GetStats(string styleName, string layerName, string pointBucket)
+    {
+        var key = (styleName, layerName, pointBucket);
+        if (!s_perPaint.TryGetValue(key, out var stats))
+        {
+            stats = new StyleStats();
+            s_perPaint[key] = stats;
+        }
+        return stats;
+    }
+
+    /// <summary>
+    /// Wraps an inner <see cref="IStyleRenderer"/>, timing each
+    /// <c>Draw</c> call and accumulating into the per-paint
+    /// dictionary keyed by the wrapped style type's name.
+    /// </summary>
+    private sealed class CountingStyleRenderer : ISkiaStyleRenderer
+    {
+        private readonly string _styleName;
+        private readonly IStyleRenderer _inner;
+        private readonly ISkiaStyleRenderer? _innerSkia;
+
+        public CountingStyleRenderer(Type styleType, IStyleRenderer inner)
+        {
+            _styleName = styleType.Name;
+            _inner = inner;
+            _innerSkia = inner as ISkiaStyleRenderer;
+        }
+
+        public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer,
+            IFeature feature, IStyle style, RenderService renderService, long iteration)
+        {
+            // Mapsui dispatches via the ISkiaStyleRenderer interface
+            // when targeting Skia; non-Skia renderers cannot be timed
+            // through this path, so fall back to the base interface
+            // (no-op for our purposes since the Skia pipeline is
+            // exclusive on this control).
+            if (_innerSkia is null) return false;
+
+            var pointCount = (feature is GeometryFeature gf && gf.Geometry is not null)
+                ? gf.Geometry.NumPoints
+                : -1;
+            var stats = GetStats(_styleName, layer?.Name ?? "(unnamed)", BucketPoints(pointCount));
+            var startTimestamp = Stopwatch.GetTimestamp();
+            try
+            {
+                return _innerSkia.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
+            }
+            finally
+            {
+                stats.Calls++;
+                stats.DurationMs += Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+            }
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/Telemetry.cs
@@ -34,4 +34,29 @@ internal static class Telemetry
         Meter.CreateCounter<long>(
             "s100.viewer.displayplane.toggled",
             description: "Number of times a user toggled a display-plane override.");
+
+    /// <summary>
+    /// Wall-clock duration of one Mapsui paint on the compositor
+    /// render thread, captured by bracketing the
+    /// <c>MapsuiCustomDrawOperation</c> with marker custom draw
+    /// operations. Compare against <see cref="MapPaintInterval"/>:
+    /// if duration ≪ interval, paints are throttled by Avalonia's
+    /// invalidation/dispatch cadence rather than by Skia rendering.
+    /// </summary>
+    public static readonly Histogram<double> MapPaintDuration =
+        Meter.CreateHistogram<double>(
+            name: "s100.map.paint.duration",
+            unit: "ms",
+            description: "Wall-clock duration of one Mapsui paint on the compositor render thread.");
+
+    /// <summary>
+    /// Wall-clock interval between successive paint completions on
+    /// the compositor render thread. Idle gaps over 500 ms are
+    /// excluded so a single pause doesn't dominate percentiles.
+    /// </summary>
+    public static readonly Histogram<double> MapPaintInterval =
+        Meter.CreateHistogram<double>(
+            name: "s100.map.paint.interval",
+            unit: "ms",
+            description: "Wall-clock interval between successive Mapsui paints on the compositor render thread.");
 }

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -8,6 +8,7 @@
         xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
         xmlns:views="using:EncDotNet.S100.Viewer.Views"
         xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+        xmlns:diag="using:EncDotNet.S100.Viewer.Diagnostics"
         xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"
         xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -346,7 +347,8 @@
                                    bh:CollapsibleRow.SavedHeight="{Binding BottomDockSavedHeight, Mode=TwoWay}" />
                 </Grid.RowDefinitions>
                 <Grid Grid.Row="0" DragDrop.AllowDrop="True">
-                <mapsui:MapControl x:Name="MapControl" />
+                <diag:InstrumentedMapControl x:Name="MapControl" />
+                <diag:GpuAccelerationProbe />
                 <views:ScaleBarView x:Name="ScaleBar"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Top"

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -264,6 +264,8 @@ internal static class Strings
     public static string Tooltip_RadarOverlay => Get(nameof(Tooltip_RadarOverlay));
     public static string Settings_IgnoreScaleMinimum => Get(nameof(Settings_IgnoreScaleMinimum));
     public static string Tooltip_IgnoreScaleMinimum => Get(nameof(Tooltip_IgnoreScaleMinimum));
+    public static string Settings_EnableVectorRasterization => Get(nameof(Settings_EnableVectorRasterization));
+    public static string Tooltip_EnableVectorRasterization => Get(nameof(Tooltip_EnableVectorRasterization));
     public static string Settings_NationalLanguage => Get(nameof(Settings_NationalLanguage));
     public static string Tooltip_NationalLanguage => Get(nameof(Tooltip_NationalLanguage));
     public static string Settings_NationalLanguage_Default => Get(nameof(Settings_NationalLanguage_Default));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -685,6 +685,12 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Tooltip_IgnoreScaleMinimum" xml:space="preserve">
     <value>Always portray features regardless of cell scale-minimum attribute (S-101 PC IgnoreScaleMinimum).</value>
   </data>
+  <data name="Settings_EnableVectorRasterization" xml:space="preserve">
+    <value>Rasterize vector layers (experimental)</value>
+  </data>
+  <data name="Tooltip_EnableVectorRasterization" xml:space="preserve">
+    <value>Cache S-100 vector layers as raster tiles for higher pan/zoom frame rate. Trades vector crispness during gestures for performance on large datasets.</value>
+  </data>
   <data name="Settings_NationalLanguage" xml:space="preserve">
     <value>National Language</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -748,6 +748,49 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     {
         bool isFirstLoad = !_entryOrder.Contains(entry);
 
+        // Experimental: wrap S-100 vector (MemoryLayer) outputs in a
+        // rasterising tile cache so each visible region is rendered
+        // once and re-used during subsequent pan/zoom frames.
+        // Coverage / image layers (S-102/S-104/S-111) are already
+        // raster, so we leave them alone. Wrapping happens AFTER the
+        // processor's AnnotateFeatures step (which type-checks the
+        // raw MemoryLayer), so feature tagging is preserved.
+        if (_settingsVm.EnableVectorRasterization && layers.Count > 0)
+        {
+            var wrapMap = new Dictionary<ILayer, ILayer>(ReferenceEqualityComparer.Instance);
+            var wrapped = new List<ILayer>(layers.Count);
+            foreach (var layer in layers)
+            {
+                if (layer is MemoryLayer memoryLayer)
+                {
+                    var wrapper = new S100RasterizingTileLayer(memoryLayer)
+                    {
+                        Name = memoryLayer.Name,
+                    };
+                    wrapped.Add(wrapper);
+                    wrapMap[memoryLayer] = wrapper;
+                }
+                else
+                {
+                    wrapped.Add(layer);
+                }
+            }
+            if (wrapMap.Count > 0)
+            {
+                layers = wrapped;
+                if (stackEntries is not null && stackEntries.Count > 0)
+                {
+                    var remapped = new List<LayerStackEntry>(stackEntries.Count);
+                    foreach (var se in stackEntries)
+                    {
+                        var l = wrapMap.TryGetValue(se.Layer, out var w) ? w : se.Layer;
+                        remapped.Add(se with { Layer = l });
+                    }
+                    stackEntries = remapped;
+                }
+            }
+        }
+
         RemoveEntryLayers(entry);
         _entryLayers[entry] = layers;
         _entryLayerKeys[entry] = layerKeys;

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -439,6 +439,19 @@ internal sealed class SettingsViewModel : ViewModelBase
         set { if (SetProperty(ref _ignoreScaleMinimum, value)) { _settings.IgnoreScaleMinimum = value; RaiseMarinerChanged(); } }
     }
 
+    private bool _enableVectorRasterization;
+    /// <summary>
+    /// Experimental: when true, S-100 vector layers are wrapped in a
+    /// rasterising tile cache for higher pan/zoom frame rate at the
+    /// cost of vector crispness during gestures. Toggling triggers a
+    /// full re-render via <c>MarinerChanged</c>.
+    /// </summary>
+    public bool EnableVectorRasterization
+    {
+        get => _enableVectorRasterization;
+        set { if (SetProperty(ref _enableVectorRasterization, value)) { _settings.EnableVectorRasterization = value; RaiseMarinerChanged(); } }
+    }
+
     private string _nationalLanguage = "";
     public string NationalLanguage
     {
@@ -522,6 +535,7 @@ internal sealed class SettingsViewModel : ViewModelBase
         _fullLightLines = settings.FullLightLines ?? def.FullLightLines;
         _radarOverlay = settings.RadarOverlay ?? def.RadarOverlay;
         _ignoreScaleMinimum = settings.IgnoreScaleMinimum ?? def.IgnoreScaleMinimum;
+        _enableVectorRasterization = settings.EnableVectorRasterization ?? false;
         _nationalLanguage = settings.NationalLanguage ?? def.NationalLanguage;
 
         _mcpEnabled = settings.McpEnabled;

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -130,6 +130,15 @@ internal sealed class ViewerSettings
     public bool? RadarOverlay { get; set; }
     public bool? IgnoreScaleMinimum { get; set; }
 
+    /// <summary>
+    /// Experimental: when true, S-100 vector layers are wrapped in a
+    /// Mapsui <c>RasterizingTileLayer</c> so each visible region is
+    /// rasterised once into a tile cache and re-used during pan/zoom.
+    /// Trades vector crispness during gestures for higher frame rate
+    /// on large datasets. Defaults to false (un-cached vector path).
+    /// </summary>
+    public bool? EnableVectorRasterization { get; set; }
+
     /// <summary>3-letter ISO 639-2/B language code; empty = catalogue default.</summary>
     public string? NationalLanguage { get; set; }
 

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -260,6 +260,9 @@
             <CheckBox Content="{x:Static loc:Strings.Settings_IgnoreScaleMinimum}"
                       IsChecked="{Binding IgnoreScaleMinimum}"
                       ToolTip.Tip="{x:Static loc:Strings.Tooltip_IgnoreScaleMinimum}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_EnableVectorRasterization}"
+                      IsChecked="{Binding EnableVectorRasterization}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_EnableVectorRasterization}" />
 
             <!-- National Language -->
             <StackPanel Spacing="6">

--- a/tests/EncDotNet.S100.Datasets.S421.Tests/S421RendererIntegrationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S421.Tests/S421RendererIntegrationTests.cs
@@ -86,9 +86,7 @@ public class S421RendererIntegrationTests
         var instructions = Part9DisplayListReader.Read(displayList);
         var geometryProvider = new GmlFeatureGeometryProvider<S421Feature>(dataset.Features);
         var layer = renderer.Render(instructions, geometryProvider);
-        Assert.IsType<MemoryLayer>(layer);
-
-        var memLayer = (MemoryLayer)layer;
+        var memLayer = Assert.IsAssignableFrom<MemoryLayer>(layer);
         var features = memLayer.Features.ToList();
         Assert.Equal(2, features.Count); // both waypoints
 


### PR DESCRIPTION
Adds OpenTelemetry-backed instrumentation that attributes Mapsui paint
cost down to the style-renderer, layer, and geometry vertex count,
plus a one-shot GPU acceleration probe and an experimental
tile-cached vector layer for A/B comparison.

This is the result of an end-to-end performance review of the viewer's
Mapsui pipeline; the full investigation, data, and optimization
roadmap lives in [`docs/design/mapsui-performance.md`](docs/design/mapsui-performance.md).

## TL;DR of the findings

Mapsui is using the GPU and is not throttled — it is **vertex-bound**.
~93% of every paint is spent inside `VectorStyleRenderer`, and per-call
cost scales linearly with geometry vertex count at ~1 µs/point. The
single highest-leverage optimization is **resolution-aware geometry
simplification at display-list build time**, projected to bring mean
paint from ~100 ms (8 fps) to ~30–40 ms (25–30 fps) on real-world
multi-S-101 datasets. That work is tracked separately in #164.

| points | calls | total ms | µs/call | % of paint |
|---|---:|---:|---:|---:|
| 1–9 | 45,198 | 328 | 7 | 0.7% |
| 10–99 | 109,620 | 3,421 | 31 | 6.8% |
| **100–999** | **59,091** | **23,568** | **399** | **47.1%** |
| **1k–10k** | **10,481** | **22,726** | **2,168** | **45.4%** |

## What's added

### Instrumentation (sub-ms cost when no OTel listener attached)

- **`InstrumentedMapControl`** (Viewer) — subclass of Mapsui's
  `MapControl` that brackets `base.Render(DrawingContext)` with two
  `ICustomDrawOperation` markers to measure actual Skia paint duration
  on the compositor render thread. Records `s100.map.paint.duration`
  and `s100.map.paint.interval` (idle gaps > 500 ms dropped).

- **`MapPaintInstrumentation`** (Viewer) — reflects into
  `Mapsui.Rendering.Skia.MapRenderer._styleRenderers` and replaces
  each registered `IStyleRenderer` with a `CountingStyleRenderer`
  wrapper that times every `Draw` call. Per-paint accumulators are
  reset/emit-ted by the start/end markers above. Tags:
  `style` / `layer` / `points` (vertex-count bucket).

- **`GpuAccelerationProbe`** (Viewer) — 1×1 invisible Avalonia control
  that reads `ISkiaSharpApiLease.GrContext` once on first paint to
  verify the renderer is GPU-accelerated and report the backend
  (OpenGL / Metal / Vulkan / software).

- **`InstrumentedMemoryLayer`** (Renderers.Mapsui) — `MemoryLayer`
  subclass that records `s100.layer.get_features.{duration, visible,
  total, fps}` per layer per call.

- **Telemetry additions** in `EncDotNet.S100.Renderers.Mapsui` and
  `EncDotNet.S100.Viewer` define the histograms above.

- **`AnchoredPatternFillRenderer`** now wraps its `Draw` body in a
  Stopwatch via an extracted `DrawCore`, recording
  `s100.pattern_fill.draw.duration`.

### Experimental rasterizer (opt-in)

- **`S100RasterizingTileLayer`** — wraps a `MemoryLayer` in Mapsui's
  tile-cached vector layer; picking is preserved by delegating
  `GetFeatures` to the underlying source layer. Workload-dependent
  benefit (helps tail latency on heavy loads, slight mean regression
  on lighter loads), so it's gated by a new viewer setting:
  `Settings → Rasterize vector layers (experimental)`.

### Documentation

- New `docs/design/mapsui-performance.md` — full investigation,
  measurement data, and optimization plan.
- New "Performance instrumentation" section in
  `src/EncDotNet.S100.Renderers.Mapsui/README.md` with the OTel
  instrument table and capture instructions.

## How to capture a measurement session

```sh
ENC_DOTNET_OTEL_CONSOLE=1 OTEL_METRIC_EXPORT_INTERVAL=2000 \
  dotnet run -c Release --project src/EncDotNet.S100.Viewer
```

Histograms are emitted every 2 s with cumulative counts and per-bucket
distributions.

## Tests

All 461 viewer + 405 pipeline + 195 mcp.tools + 24 mcp + 26
visual-regression tests pass.

## Follow-ups

- #164 — Resolution-aware geometry simplification (the projected
  8 fps → 25–30 fps win).
- #165 — Investigate per-feature-class cost distribution within
  S-101 line layers (informs which classes #164 should target first).