### PR TITLE
Add resolution-aware geometry simplification (#164)

### DIFF
--- a/docs/design/mapsui-performance.md
+++ b/docs/design/mapsui-performance.md
@@ -132,6 +132,33 @@ tolerance ≈ 1 screen pixel at the current zoom. Polylines with
 thousands of vertices typically reduce 10–100× without visible quality
 loss.
 
+**Status:** v1 implemented for issue
+[#164](https://github.com/philliphoff/EncDotNet.S100/issues/164).
+Lives on `InstrumentedMemoryLayer.GetFeatures`, keyed by half-octave
+zoom bucket, gated behind the viewer's
+**Simplify line geometry (experimental)** setting (default off).
+See the renderer
+[README → Resolution-aware geometry simplification](../../src/EncDotNet.S100.Renderers.Mapsui/README.md#resolution-aware-geometry-simplification)
+for the implementation, options, telemetry, and known limits.
+
+**v1 scope (lines only).** v1 simplifies `LineString` /
+`MultiLineString` only; polygons, points, and other types pass
+through unchanged. Per-ring Douglas-Peucker can produce invalid or
+self-intersecting polygons, so polygon support is deferred until a
+follow-up wires in `TopologyPreservingSimplifier` + `IsValid`
+validation.
+
+**Defaults.** PixelTolerance = 0.5 (a half pixel — chosen so thicker
+strokes such as depth contours and fairway boundaries don't show
+visible kinks); MinVertexCount = 64 bypass threshold;
+MaxCachedCoordinates = 5_000_000 (≈ 80 MB). Eviction triggers on
+zoom-band transition, then by coordinate budget.
+
+**Future work.** Polygon simplification, async / off-thread miss
+path (the synchronous miss path can briefly stall the first paint
+after a zoom-band transition), and `(layer × bucket)`-aware
+pre-warming on dataset load.
+
 Projected impact based on the measured cost model:
 - 1k-10k bucket → 100-999 bucket: ~5× cheaper draws (saves ~18 s of
   paint over the measurement window).
@@ -188,3 +215,12 @@ Files added on this branch:
 - `src/EncDotNet.S100.Viewer/Diagnostics/GpuAccelerationProbe.cs`
 - `src/EncDotNet.S100.Renderers.Mapsui/InstrumentedMemoryLayer.cs`
 - `src/EncDotNet.S100.Renderers.Mapsui/S100RasterizingTileLayer.cs`
+
+Files added by issue
+[#164](https://github.com/philliphoff/EncDotNet.S100/issues/164)
+implementing optimization (1):
+- `src/EncDotNet.S100.Renderers.Mapsui/Simplification/IFeatureSimplifier.cs`
+- `src/EncDotNet.S100.Renderers.Mapsui/Simplification/DouglasPeuckerLineSimplifier.cs`
+- `src/EncDotNet.S100.Renderers.Mapsui/Simplification/SimplificationOptions.cs`
+- `src/EncDotNet.S100.Renderers.Mapsui/Simplification/SimplificationCache.cs`
+- `src/EncDotNet.S100.Renderers.Mapsui/Simplification/Simplification.cs`

--- a/src/EncDotNet.S100.Renderers.Mapsui/Diagnostics/Telemetry.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Diagnostics/Telemetry.cs
@@ -104,6 +104,73 @@ internal static class Telemetry
             description: "Pattern-tile cache misses during area-fill resolution (tile rasterisation triggered). Tagged with s100.product when the renderer is configured by a dataset processor.");
 
     /// <summary>
+    /// Hits in the resolution-aware geometry simplification cache
+    /// (<see cref="Simplification.SimplificationCache"/>). Recorded
+    /// per visible feature per rendered frame; the hit-rate
+    /// (hits / (hits + misses)) measures steady-state cache
+    /// effectiveness. Issue #164 acceptance criterion targets ≥ 95%
+    /// on steady-state pan. Tagged with <c>s100.product</c>.
+    /// </summary>
+    public static readonly Counter<long> SimplifyCacheHit =
+        Meter.CreateCounter<long>(
+            name: "s100.simplify.cache.hit.count",
+            unit: "{hits}",
+            description: "Hits in the resolution-aware geometry simplification cache. Tagged with s100.product.");
+
+    /// <inheritdoc cref="SimplifyCacheHit"/>
+    public static readonly Counter<long> SimplifyCacheMiss =
+        Meter.CreateCounter<long>(
+            name: "s100.simplify.cache.miss.count",
+            unit: "{misses}",
+            description: "Misses in the resolution-aware geometry simplification cache (Douglas-Peucker invocation triggered). Tagged with s100.product.");
+
+    /// <summary>
+    /// Wall-clock time spent inside a single
+    /// <c>IFeatureSimplifier.Simplify</c> call (Douglas-Peucker over
+    /// one feature's geometry). Recorded only on cache misses.
+    /// Useful for diagnosing render-thread jank: the issue #164
+    /// design accepts a synchronous miss path on the assumption that
+    /// per-feature simplification is bounded; this histogram lets us
+    /// validate that.
+    /// </summary>
+    public static readonly Histogram<double> SimplifyDuration =
+        Meter.CreateHistogram<double>(
+            name: "s100.simplify.duration",
+            unit: "ms",
+            description: "Per-feature Douglas-Peucker simplification duration on a cache miss. Tagged with s100.product.");
+
+    /// <summary>
+    /// Coordinate count of the original geometry going into
+    /// simplification. Combined with <see cref="SimplifyCoordsOut"/>
+    /// gives the achieved reduction ratio per feature.
+    /// </summary>
+    public static readonly Histogram<long> SimplifyCoordsIn =
+        Meter.CreateHistogram<long>(
+            name: "s100.simplify.coords.in",
+            unit: "{coordinates}",
+            description: "Coordinate count entering simplification (cache miss). Tagged with s100.product.");
+
+    /// <inheritdoc cref="SimplifyCoordsIn"/>
+    public static readonly Histogram<long> SimplifyCoordsOut =
+        Meter.CreateHistogram<long>(
+            name: "s100.simplify.coords.out",
+            unit: "{coordinates}",
+            description: "Coordinate count leaving simplification (cache miss). Tagged with s100.product.");
+
+    /// <summary>
+    /// Running total of simplified coordinates retained in the
+    /// simplification cache, summed across all buckets. Bounded by
+    /// <c>SimplificationOptions.MaxCachedCoordinates</c>; this is
+    /// the signal to watch for cache-pressure tuning. Increments on
+    /// cache adds, decrements on bucket / budget eviction.
+    /// </summary>
+    public static readonly UpDownCounter<long> SimplifyCacheCoordsTracked =
+        Meter.CreateUpDownCounter<long>(
+            name: "s100.simplify.cache.coords.tracked",
+            unit: "{coordinates}",
+            description: "Total simplified coordinates currently retained in the simplification cache. Tagged with s100.product.");
+
+    /// <summary>
     /// Wall-clock duration of a single Mapsui <c>GetFeatures(rect,resolution)</c>
     /// call on an <see cref="InstrumentedMemoryLayer"/>. Mapsui invokes this
     /// once per visible layer per rendered frame, so the histogram reflects

--- a/src/EncDotNet.S100.Renderers.Mapsui/InstrumentedMemoryLayer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/InstrumentedMemoryLayer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using EncDotNet.S100.Renderers.Mapsui.Simplification;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Styles;
@@ -44,6 +45,7 @@ public sealed class InstrumentedMemoryLayer : MemoryLayer
     private readonly KeyValuePair<string, object?>[] _tags;
     private readonly string? _product;
     private long _lastExitTimestamp;
+    private SimplificationCache? _simplificationCache;
 
     /// <summary>
     /// Creates a new instrumented layer.  <paramref name="product"/> is
@@ -57,6 +59,53 @@ public sealed class InstrumentedMemoryLayer : MemoryLayer
             ? System.Array.Empty<KeyValuePair<string, object?>>()
             : new[] { new KeyValuePair<string, object?>("s100.product", product) };
     }
+
+    /// <summary>
+    /// Enables resolution-aware geometry simplification on this
+    /// layer.  When configured, <see cref="GetFeatures"/> routes each
+    /// visible feature through a per-layer
+    /// <see cref="SimplificationCache"/> keyed by
+    /// <c>(feature, zoom-bucket)</c>; the renderer sees a simplified
+    /// clone whose <see cref="IFeature"/> carries an
+    /// <c>S100.OriginalFeature</c> back-reference for picking. Pass
+    /// <see langword="null"/> options or call
+    /// <see cref="DisableSimplification"/> to revert to the identity
+    /// passthrough.
+    /// </summary>
+    /// <remarks>
+    /// Introduced for issue #164. The viewer's
+    /// <c>EnableGeometrySimplification</c> setting calls this in
+    /// <c>DatasetLoaderService</c> after the dataset processor
+    /// returns its layers.
+    /// </remarks>
+    public void EnableSimplification(
+        IFeatureSimplifier simplifier,
+        SimplificationOptions options)
+    {
+        System.ArgumentNullException.ThrowIfNull(simplifier);
+        System.ArgumentNullException.ThrowIfNull(options);
+        var existing = _simplificationCache;
+        _simplificationCache = new SimplificationCache(simplifier, options, _product);
+        existing?.Clear();
+    }
+
+    /// <summary>
+    /// Disables simplification on this layer and clears any cached
+    /// entries.
+    /// </summary>
+    public void DisableSimplification()
+    {
+        var existing = _simplificationCache;
+        _simplificationCache = null;
+        existing?.Clear();
+    }
+
+    /// <summary>
+    /// Exposes the configured simplification cache (or
+    /// <see langword="null"/> when simplification is disabled). Used
+    /// by tests; not normally needed by callers.
+    /// </summary>
+    internal SimplificationCache? SimplificationCache => _simplificationCache;
 
     /// <inheritdoc />
     /// <remarks>
@@ -96,11 +145,12 @@ public sealed class InstrumentedMemoryLayer : MemoryLayer
 
         var visible = new List<IFeature>();
         long total = 0;
+        var cache = _simplificationCache;
         foreach (var feature in Features)
         {
             total++;
             if (feature is not null && feature.Extent?.Intersects(biggerRect) == true)
-                visible.Add(feature);
+                visible.Add(cache is null ? feature : cache.GetOrSimplify(feature, resolution));
         }
 
         var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -100,6 +100,89 @@ with per-vertex cost ~1 µs. See
 [`docs/design/mapsui-performance.md`](../../docs/design/mapsui-performance.md)
 for the full investigation and optimization plan.
 
+## Resolution-aware geometry simplification
+
+Issue [#164](https://github.com/philliphoff/EncDotNet.S100/issues/164)
+adds an opt-in resolution-aware Douglas-Peucker simplification path
+that reduces the vertex count Skia tessellates per frame. Polylines
+in the 1k–10k bucket on real S-101 datasets typically simplify by
+5–10× at typical pan zooms with no visible quality regression at the
+default 0.5-pixel tolerance.
+
+### Pipeline placement
+
+Simplification lives on `InstrumentedMemoryLayer.GetFeatures`,
+because that is the only seam in the pipeline that has access to the
+current zoom (`resolution`, m/px in EPSG:3857). When a layer has
+simplification enabled, every visible feature is routed through a
+per-layer `SimplificationCache`:
+
+- Cache key: `(original-feature reference, half-octave bucket)`.
+- Bucket: `round(log2(resolution) × 2)`. Tolerance for a bucket is
+  `pixelTolerance × 2^(bucket / 2)` metres.
+- Algorithm: NTS' `DouglasPeuckerSimplifier`, lines and multi-lines
+  only in v1. Polygons, points, and other types pass through
+  unchanged. (Polygon support is deferred until topology
+  preservation + validation is wired in.)
+- Eviction: on bucket transition, drop entries from buckets outside
+  `[active − 1, active + 1]`. If the cache's tracked coordinate
+  count still exceeds `MaxCachedCoordinates` (default 5 M ≈ 80 MB),
+  the bucket farthest from the active one is dropped next, until
+  under budget.
+- Simplified clones share style instances by reference and copy all
+  fields (including `S100.FeatureRef`); they also carry an
+  `S100.OriginalFeature` back-reference. Use
+  `Simplification.GetOriginal(feature)` to recover the unsimplified
+  feature for picking / info-on-click.
+
+### Wiring
+
+```csharp
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Mapsui.Simplification;
+
+if (layer is InstrumentedMemoryLayer iml)
+{
+    iml.EnableSimplification(
+        DouglasPeuckerLineSimplifier.Instance,
+        SimplificationOptions.Default);
+}
+```
+
+In the desktop viewer this is driven by the
+**Simplify line geometry (experimental)** setting, applied in
+`DatasetLoaderService` before the optional rasterization wrap.
+
+### Telemetry
+
+| Instrument | Unit | Tags | Purpose |
+|---|---|---|---|
+| `s100.simplify.cache.hit.count` | count | `s100.product` | Simplified clone served from cache |
+| `s100.simplify.cache.miss.count` | count | `s100.product` | DP invocation triggered |
+| `s100.simplify.duration` | ms | `s100.product` | Per-feature DP cost (miss only) |
+| `s100.simplify.coords.in` | count | `s100.product` | Original-geometry vertex count (miss) |
+| `s100.simplify.coords.out` | count | `s100.product` | Simplified-geometry vertex count (miss) |
+| `s100.simplify.cache.coords.tracked` | count | `s100.product` | Live coords in cache across all buckets |
+
+The acceptance bar from issue #164 is steady-state hit rate ≥ 95%
+and ≥ 50% reduction in `s100.map.paint.duration` mean on the
+multi-S-101 workload from the perf review.
+
+### Known limits
+
+- v1 simplifies only line geometry; polygons (e.g. depth areas) and
+  points are unaffected. The perf review shows lines dominate the
+  paint cost in real datasets, so this still hits the projected
+  budget.
+- The miss path runs synchronously on the render thread. After a
+  zoom-band transition, the first paint at the new bucket may stall
+  briefly while the visible set is simplified; subsequent frames hit
+  the cache. An async / pre-warm path is documented as future work
+  in `docs/design/mapsui-performance.md`.
+- The cache is sized by coordinate count, not entry count, so a
+  handful of very dense polylines and many small features have
+  comparable budget cost.
+
 ## Installation
 
 ```sh

--- a/src/EncDotNet.S100.Renderers.Mapsui/Simplification/DouglasPeuckerLineSimplifier.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Simplification/DouglasPeuckerLineSimplifier.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Diagnostics;
+using Mapsui;
+using Mapsui.Nts;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Simplify;
+
+namespace EncDotNet.S100.Renderers.Mapsui.Simplification;
+
+/// <summary>
+/// <see cref="IFeatureSimplifier"/> implementation that runs
+/// Douglas-Peucker on <c>LineString</c> and <c>MultiLineString</c>
+/// geometries via NTS' <see cref="DouglasPeuckerSimplifier"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the v1 simplifier introduced for issue #164 to address
+/// the May/June 2026 perf review's primary finding: ~93% of paint
+/// time is consumed by Mapsui's <c>VectorStyleRenderer</c>, scaling
+/// linearly with vertex count at ~1&#160;µs/point.
+/// </para>
+/// <para>
+/// Polygons, points, and other geometry types pass through
+/// unchanged. Polygon simplification with per-ring DP can produce
+/// invalid / self-intersecting rings, so it is deferred to a later
+/// pass that wires in <see cref="TopologyPreservingSimplifier"/> +
+/// <c>IsValid</c> validation.
+/// </para>
+/// <para>
+/// On a degenerate result (line collapsed to fewer than two points,
+/// or simplification did not actually reduce the vertex count) the
+/// original feature is returned and <see cref="SimplificationResult.WasSimplified"/>
+/// is <see langword="false"/>.
+/// </para>
+/// </remarks>
+public sealed class DouglasPeuckerLineSimplifier : IFeatureSimplifier
+{
+    /// <summary>Shared, stateless singleton.</summary>
+    public static DouglasPeuckerLineSimplifier Instance { get; } = new();
+
+    /// <inheritdoc />
+    public SimplificationResult Simplify(
+        IFeature feature,
+        double toleranceMetres,
+        SimplificationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (feature is not GeometryFeature gf || gf.Geometry is null)
+            return new SimplificationResult(feature, 0, 0, false);
+
+        var geom = gf.Geometry;
+        var origCount = CountCoords(geom);
+
+        // Bypass non-line geometry and short geometries up front: no
+        // need to invoke NTS for features whose paint cost is already
+        // negligible per the perf review.
+        if (geom is not (LineString or MultiLineString))
+            return new SimplificationResult(feature, origCount, origCount, false);
+
+        if (origCount < options.MinVertexCount)
+            return new SimplificationResult(feature, origCount, origCount, false);
+
+        if (!(toleranceMetres > 0))
+            return new SimplificationResult(feature, origCount, origCount, false);
+
+        Geometry? simplified;
+        try
+        {
+            simplified = DouglasPeuckerSimplifier.Simplify(geom, toleranceMetres);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            // Defensive: NTS does not normally throw on valid inputs,
+            // but we never want a malformed coordinate sequence to
+            // crash the render thread. Fall back to original.
+            Debug.WriteLine($"[Simplification] DP threw for {origCount}-coord geom: {ex.Message}");
+            return new SimplificationResult(feature, origCount, origCount, false);
+        }
+
+        if (simplified is null || simplified.IsEmpty)
+            return new SimplificationResult(feature, origCount, origCount, false);
+
+        var newCount = CountCoords(simplified);
+
+        // A line collapsed to a single point or no progress made:
+        // serve the original.
+        if (newCount < 2 || newCount >= origCount)
+            return new SimplificationResult(feature, origCount, origCount, false);
+
+        // Build a sibling feature: same Fields, same Styles instances
+        // (shared by reference via GeometryFeature's copy ctor) and a
+        // back-reference to the original so picking can resolve through
+        // even if Mapsui ends up hit-testing the simplified shape.
+        var clone = new GeometryFeature(gf) { Geometry = simplified };
+        clone[Simplification.OriginalFeatureKey] = feature;
+
+        return new SimplificationResult(clone, origCount, newCount, true);
+    }
+
+    private static long CountCoords(Geometry geom) => geom.NumPoints;
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/Simplification/IFeatureSimplifier.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Simplification/IFeatureSimplifier.cs
@@ -1,0 +1,50 @@
+using Mapsui;
+
+namespace EncDotNet.S100.Renderers.Mapsui.Simplification;
+
+/// <summary>
+/// Strategy that produces a simplified copy of an
+/// <see cref="IFeature"/> for a given metric tolerance.
+/// Implementations must be thread-safe.
+/// </summary>
+/// <remarks>
+/// V1 ships only <see cref="DouglasPeuckerLineSimplifier"/>, which
+/// simplifies <c>LineString</c> / <c>MultiLineString</c> geometry
+/// only; polygon, point, and other types fall through unchanged
+/// (returning the original feature). Polygon simplification is
+/// deferred until topology preservation is wired in.
+/// </remarks>
+public interface IFeatureSimplifier
+{
+    /// <summary>
+    /// Returns a simplified copy of <paramref name="feature"/> at the
+    /// supplied <paramref name="toleranceMetres"/> tolerance, or the
+    /// original feature when simplification does not apply (geometry
+    /// type unsupported in v1, vertex count below
+    /// <see cref="SimplificationOptions.MinVertexCount"/>, or the
+    /// simplifier produced a degenerate result).
+    /// </summary>
+    /// <param name="feature">The original feature.</param>
+    /// <param name="toleranceMetres">
+    /// Maximum allowed displacement of any retained coordinate from
+    /// the original geometry, in metres (EPSG:3857 units).
+    /// </param>
+    /// <param name="options">Configuration; see
+    /// <see cref="SimplificationOptions"/>.</param>
+    SimplificationResult Simplify(
+        IFeature feature,
+        double toleranceMetres,
+        SimplificationOptions options);
+}
+
+/// <summary>
+/// Outcome of a single <see cref="IFeatureSimplifier.Simplify"/>
+/// call. <see cref="WasSimplified"/> distinguishes "we did real work
+/// and produced a smaller copy" (<see langword="true"/>) from
+/// "the geometry passes through unchanged" (<see langword="false"/>).
+/// </summary>
+public readonly record struct SimplificationResult(
+    IFeature Feature,
+    long OriginalCoordinateCount,
+    long SimplifiedCoordinateCount,
+    bool WasSimplified);

--- a/src/EncDotNet.S100.Renderers.Mapsui/Simplification/Simplification.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Simplification/Simplification.cs
@@ -1,0 +1,34 @@
+using System;
+using Mapsui;
+
+namespace EncDotNet.S100.Renderers.Mapsui.Simplification;
+
+/// <summary>
+/// Public helpers for working with simplified features produced by
+/// <see cref="SimplificationCache"/>.  Most consumers only need
+/// <see cref="GetOriginal"/> to walk back from a simplified clone to
+/// the unsimplified feature for picking / info-on-click.
+/// </summary>
+public static class Simplification
+{
+    /// <summary>
+    /// Field key under which a simplified <see cref="IFeature"/>
+    /// carries a back-reference to the original (unsimplified) feature.
+    /// Use <see cref="GetOriginal"/> rather than reading this key
+    /// directly.
+    /// </summary>
+    public const string OriginalFeatureKey = "S100.OriginalFeature";
+
+    /// <summary>
+    /// Returns the original (unsimplified) feature for a possibly
+    /// simplified one.  When <paramref name="feature"/> is itself the
+    /// original, returns it unchanged.  Safe to call on any
+    /// <see cref="IFeature"/>; the back-reference is only set on
+    /// clones produced by the simplification cache.
+    /// </summary>
+    public static IFeature GetOriginal(IFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+        return feature[OriginalFeatureKey] is IFeature original ? original : feature;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/Simplification/SimplificationCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Simplification/SimplificationCache.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Mapsui;
+using S100Diag = EncDotNet.S100.Renderers.Mapsui.Diagnostics;
+
+namespace EncDotNet.S100.Renderers.Mapsui.Simplification;
+
+/// <summary>
+/// Per-layer cache of simplified <see cref="IFeature"/>s keyed by
+/// <c>(original-feature reference, zoom-bucket)</c>.  Owned by an
+/// <see cref="InstrumentedMemoryLayer"/> and consulted on every
+/// <c>GetFeatures</c> call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Bucketing.</b>  Resolution (m/px) is mapped to a half-octave
+/// bucket index — <c>round(log2(resolution) × 2)</c> — so each bucket
+/// spans a √2 zoom range. Tolerance for the bucket is
+/// <c>options.PixelTolerance × 2^(bucket / 2)</c> metres.  Resolution
+/// is clamped to <c>[1e-3, 1e9]</c> before bucketing to guard against
+/// zero / negative / NaN inputs.
+/// </para>
+/// <para>
+/// <b>Eviction.</b>  When the active bucket changes, entries from
+/// buckets outside <c>[active − 1, active + 1]</c> are dropped.  If
+/// the cache's tracked coordinate count still exceeds
+/// <see cref="SimplificationOptions.MaxCachedCoordinates"/>, buckets
+/// farthest from the active one are evicted next, until the budget
+/// is satisfied.  The budget is on coordinate count rather than
+/// entry count because one 10 000-vertex polyline costs the same as
+/// 10 000 small features.
+/// </para>
+/// <para>
+/// <b>Thread safety.</b>  Mapsui invokes <c>GetFeatures</c> on the
+/// render thread, so the cache is single-threaded by contract; an
+/// internal lock is taken anyway so simultaneous renders on
+/// multiple maps sharing a layer remain correct.
+/// </para>
+/// </remarks>
+public sealed class SimplificationCache
+{
+    /// <summary>Lower bound on bucketed resolution to guard against
+    /// zero / NaN / negative inputs from Mapsui.</summary>
+    private const double MinResolution = 1e-3;
+
+    /// <summary>Upper bound — anything beyond ~1&#160;Gm/px is global
+    /// scale and a degenerate input.</summary>
+    private const double MaxResolution = 1e9;
+
+    private readonly IFeatureSimplifier _simplifier;
+    private readonly SimplificationOptions _options;
+    private readonly KeyValuePair<string, object?>[] _tags;
+    private readonly object _gate = new();
+
+    // Outer key: bucket index. Inner key: original-feature reference.
+    // Reference equality is correct because MemoryLayer.Features is
+    // built once at Render() time and never mutated.
+    private readonly Dictionary<int, Dictionary<IFeature, CacheEntry>> _byBucket = new();
+    private long _cachedCoordinates;
+    private int? _activeBucket;
+
+    /// <summary>
+    /// Creates a cache that delegates simplification to
+    /// <paramref name="simplifier"/> and uses
+    /// <paramref name="options"/> to size, threshold, and bound itself.
+    /// <paramref name="product"/> is attached as the
+    /// <c>s100.product</c> dimension on emitted metrics.
+    /// </summary>
+    public SimplificationCache(
+        IFeatureSimplifier simplifier,
+        SimplificationOptions options,
+        string? product = null)
+    {
+        ArgumentNullException.ThrowIfNull(simplifier);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _simplifier = simplifier;
+        _options = options;
+        _tags = product is null
+            ? Array.Empty<KeyValuePair<string, object?>>()
+            : new[] { new KeyValuePair<string, object?>("s100.product", product) };
+    }
+
+    /// <summary>
+    /// Total number of simplified coordinates currently retained,
+    /// summed across all buckets. Surfaced for tests + the
+    /// <c>s100.simplify.cache.coords.tracked</c> gauge.
+    /// </summary>
+    public long CachedCoordinateCount
+    {
+        get { lock (_gate) return _cachedCoordinates; }
+    }
+
+    /// <summary>
+    /// Total number of cached entries across all buckets. Useful for
+    /// tests; not otherwise surfaced.
+    /// </summary>
+    public int CachedEntryCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                int n = 0;
+                foreach (var bucket in _byBucket.Values) n += bucket.Count;
+                return n;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Computes the half-octave bucket index for
+    /// <paramref name="resolution"/>.  Exposed for tests and for the
+    /// pre-warm path.
+    /// </summary>
+    public static int BucketFor(double resolution)
+    {
+        if (double.IsNaN(resolution) || resolution <= 0)
+            resolution = MinResolution;
+        if (resolution < MinResolution) resolution = MinResolution;
+        if (resolution > MaxResolution) resolution = MaxResolution;
+        return (int)Math.Round(Math.Log2(resolution) * 2.0);
+    }
+
+    /// <summary>
+    /// Computes the simplification tolerance in metres for the
+    /// supplied bucket index, given the configured pixel tolerance.
+    /// </summary>
+    public double ToleranceFor(int bucket)
+        => _options.PixelTolerance * Math.Pow(2.0, bucket / 2.0);
+
+    /// <summary>
+    /// Returns a feature suitable for rendering at the given
+    /// <paramref name="resolution"/>: the simplified clone if one is
+    /// available (or just produced), or <paramref name="feature"/>
+    /// itself if the simplifier passed it through.
+    /// </summary>
+    public IFeature GetOrSimplify(IFeature feature, double resolution)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        var bucket = BucketFor(resolution);
+
+        lock (_gate)
+        {
+            if (_activeBucket != bucket)
+            {
+                _activeBucket = bucket;
+                EvictForBucketShift(bucket);
+            }
+
+            if (!_byBucket.TryGetValue(bucket, out var entries))
+            {
+                entries = new Dictionary<IFeature, CacheEntry>(ReferenceEqualityComparer.Instance);
+                _byBucket[bucket] = entries;
+            }
+
+            if (entries.TryGetValue(feature, out var existing))
+            {
+                S100Diag.Telemetry.SimplifyCacheHit.Add(1, _tags);
+                return existing.Feature;
+            }
+        }
+
+        // Simplify outside the lock: NTS work is the slow path and
+        // shouldn't block other layers' GetFeatures calls.
+        var tolerance = ToleranceFor(bucket);
+        var sw = Stopwatch.StartNew();
+        var result = _simplifier.Simplify(feature, tolerance, _options);
+        sw.Stop();
+
+        S100Diag.Telemetry.SimplifyCacheMiss.Add(1, _tags);
+        S100Diag.Telemetry.SimplifyDuration.Record(sw.Elapsed.TotalMilliseconds, _tags);
+        if (result.OriginalCoordinateCount > 0)
+        {
+            S100Diag.Telemetry.SimplifyCoordsIn.Record(result.OriginalCoordinateCount, _tags);
+            S100Diag.Telemetry.SimplifyCoordsOut.Record(result.SimplifiedCoordinateCount, _tags);
+        }
+
+        // Cost of caching: we also store identity passthroughs so
+        // we don't re-test (e.g. count vertices, query NTS) on every
+        // frame for short or unsupported geometries.
+        var entry = new CacheEntry(result.Feature, result.SimplifiedCoordinateCount);
+
+        lock (_gate)
+        {
+            // Re-fetch entries dict in case eviction nuked it between
+            // the unlock and re-lock above.
+            if (!_byBucket.TryGetValue(bucket, out var entries))
+            {
+                entries = new Dictionary<IFeature, CacheEntry>(ReferenceEqualityComparer.Instance);
+                _byBucket[bucket] = entries;
+            }
+
+            if (!entries.TryAdd(feature, entry))
+            {
+                // Another thread populated the same key. Use theirs;
+                // reuse keeps object identity stable for downstream
+                // hit-tests.
+                S100Diag.Telemetry.SimplifyCacheCoordsTracked.Add(0, _tags);
+                return entries[feature].Feature;
+            }
+
+            _cachedCoordinates += entry.CoordCount;
+            S100Diag.Telemetry.SimplifyCacheCoordsTracked.Add(entry.CoordCount, _tags);
+
+            EvictForBudget(bucket);
+
+            return result.Feature;
+        }
+    }
+
+    /// <summary>
+    /// Drops every cached entry. Used when a layer is being torn
+    /// down or the simplifier is reconfigured.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            if (_cachedCoordinates > 0)
+                S100Diag.Telemetry.SimplifyCacheCoordsTracked.Add(-_cachedCoordinates, _tags);
+            _byBucket.Clear();
+            _cachedCoordinates = 0;
+            _activeBucket = null;
+        }
+    }
+
+    private void EvictForBucketShift(int activeBucket)
+    {
+        // Drop everything outside [active-1, active+1].
+        if (_byBucket.Count == 0) return;
+        List<int>? toDrop = null;
+        foreach (var b in _byBucket.Keys)
+        {
+            if (Math.Abs(b - activeBucket) > 1)
+                (toDrop ??= new List<int>()).Add(b);
+        }
+        if (toDrop is null) return;
+        foreach (var b in toDrop) DropBucket(b);
+    }
+
+    private void EvictForBudget(int activeBucket)
+    {
+        if (_cachedCoordinates <= _options.MaxCachedCoordinates) return;
+        if (_byBucket.Count <= 1) return;
+
+        // Sort buckets by distance from the active one (descending),
+        // then by index. Drop until under budget or only the active
+        // bucket remains.
+        var ordered = new List<int>(_byBucket.Keys);
+        ordered.Sort((a, b) =>
+        {
+            int da = Math.Abs(a - activeBucket);
+            int db = Math.Abs(b - activeBucket);
+            return db.CompareTo(da);
+        });
+
+        foreach (var b in ordered)
+        {
+            if (b == activeBucket) continue;
+            DropBucket(b);
+            if (_cachedCoordinates <= _options.MaxCachedCoordinates) return;
+        }
+    }
+
+    private void DropBucket(int bucket)
+    {
+        if (!_byBucket.TryGetValue(bucket, out var entries)) return;
+        long delta = 0;
+        foreach (var e in entries.Values) delta += e.CoordCount;
+        _byBucket.Remove(bucket);
+        _cachedCoordinates -= delta;
+        if (delta > 0)
+            S100Diag.Telemetry.SimplifyCacheCoordsTracked.Add(-delta, _tags);
+    }
+
+    private readonly struct CacheEntry
+    {
+        public CacheEntry(IFeature feature, long coordCount)
+        {
+            Feature = feature;
+            CoordCount = coordCount;
+        }
+        public IFeature Feature { get; }
+        public long CoordCount { get; }
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/Simplification/SimplificationOptions.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Simplification/SimplificationOptions.cs
@@ -1,0 +1,46 @@
+namespace EncDotNet.S100.Renderers.Mapsui.Simplification;
+
+/// <summary>
+/// Configuration for resolution-aware geometry simplification.  See
+/// <see cref="SimplificationCache"/> and
+/// <see cref="DouglasPeuckerLineSimplifier"/> for how each value is
+/// consumed.
+/// </summary>
+/// <param name="PixelTolerance">
+/// Maximum displacement, in screen pixels, that simplification is
+/// allowed to introduce. Tolerance in metres for a given paint is
+/// <c>PixelTolerance × resolution</c> (where <c>resolution</c> is
+/// Mapsui's m/px in EPSG:3857). Defaults to <c>0.5</c> — a half pixel
+/// — which keeps thicker strokes (depth contours, fairway boundaries)
+/// visually identical at typical zoom levels. Set higher (e.g. 1.0)
+/// for more aggressive simplification, lower (e.g. 0.25) to be more
+/// conservative.
+/// </param>
+/// <param name="MinVertexCount">
+/// Geometries with fewer than this many vertices are returned as-is
+/// without invoking the simplifier. Defaults to <c>64</c>: per the
+/// May/June 2026 Mapsui perf review, paint cost on geometries with
+/// &lt; 100 vertices is negligible (&lt; 7% of total), so the
+/// simplifier overhead is not worth paying for them.
+/// </param>
+/// <param name="MaxCachedCoordinates">
+/// Soft upper bound on the total number of coordinates retained in
+/// the simplification cache across all buckets. When a bucket
+/// transition pushes the cache above this, entries are evicted from
+/// the bucket farthest from the current one until the budget is
+/// satisfied. Bounded by <em>coordinate count</em> rather than entry
+/// count so one 10 000-vertex polyline costs the budget what 10 000
+/// small features would. Defaults to <c>5_000_000</c> coords —
+/// roughly 80&#160;MB of <c>Coordinate</c> instances on .NET.
+/// </param>
+public sealed record SimplificationOptions(
+    double PixelTolerance = 0.5,
+    int MinVertexCount = 64,
+    long MaxCachedCoordinates = 5_000_000)
+{
+    /// <summary>
+    /// Default options — what the viewer's
+    /// <c>EnableGeometrySimplification</c> setting enables.
+    /// </summary>
+    public static SimplificationOptions Default { get; } = new();
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -266,6 +266,8 @@ internal static class Strings
     public static string Tooltip_IgnoreScaleMinimum => Get(nameof(Tooltip_IgnoreScaleMinimum));
     public static string Settings_EnableVectorRasterization => Get(nameof(Settings_EnableVectorRasterization));
     public static string Tooltip_EnableVectorRasterization => Get(nameof(Tooltip_EnableVectorRasterization));
+    public static string Settings_EnableGeometrySimplification => Get(nameof(Settings_EnableGeometrySimplification));
+    public static string Tooltip_EnableGeometrySimplification => Get(nameof(Tooltip_EnableGeometrySimplification));
     public static string Settings_NationalLanguage => Get(nameof(Settings_NationalLanguage));
     public static string Tooltip_NationalLanguage => Get(nameof(Tooltip_NationalLanguage));
     public static string Settings_NationalLanguage_Default => Get(nameof(Settings_NationalLanguage_Default));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -691,6 +691,12 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Tooltip_EnableVectorRasterization" xml:space="preserve">
     <value>Cache S-100 vector layers as raster tiles for higher pan/zoom frame rate. Trades vector crispness during gestures for performance on large datasets.</value>
   </data>
+  <data name="Settings_EnableGeometrySimplification" xml:space="preserve">
+    <value>Simplify line geometry (experimental)</value>
+  </data>
+  <data name="Tooltip_EnableGeometrySimplification" xml:space="preserve">
+    <value>Apply resolution-aware Douglas-Peucker simplification to S-100 line features at render time, with a per-zoom cache (issue #164). Speeds up paint on dense ENC line data; polygons and short lines are unaffected.</value>
+  </data>
   <data name="Settings_NationalLanguage" xml:space="preserve">
     <value>National Language</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -12,6 +12,7 @@ using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Mapsui.Simplification;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Diagnostics;
@@ -752,6 +753,25 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         IReadOnlyList<LayerStackEntry>? stackEntries)
     {
         bool isFirstLoad = !_entryOrder.Contains(entry);
+
+        // Issue #164: opt-in resolution-aware geometry simplification.
+        // Applied to the inner MemoryLayer BEFORE the rasterization
+        // wrap below so that, when both flags are on, rasterized tiles
+        // are produced from already-simplified geometry. The cache
+        // lives on the layer; clearing on toggle is automatic via
+        // RaiseMarinerChanged → full reload.
+        if (_settingsVm.EnableGeometrySimplification && layers.Count > 0)
+        {
+            foreach (var layer in layers)
+            {
+                if (layer is InstrumentedMemoryLayer iml)
+                {
+                    iml.EnableSimplification(
+                        DouglasPeuckerLineSimplifier.Instance,
+                        SimplificationOptions.Default);
+                }
+            }
+        }
 
         // Experimental: wrap S-100 vector (MemoryLayer) outputs in a
         // rasterising tile cache so each visible region is rendered

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -452,6 +452,18 @@ internal sealed class SettingsViewModel : ViewModelBase
         set { if (SetProperty(ref _enableVectorRasterization, value)) { _settings.EnableVectorRasterization = value; RaiseMarinerChanged(); } }
     }
 
+    private bool _enableGeometrySimplification;
+    /// <summary>
+    /// When true, vector layers run their line geometries through a
+    /// resolution-aware Douglas-Peucker simplifier (issue #164).
+    /// Toggling triggers a full re-render via <c>MarinerChanged</c>.
+    /// </summary>
+    public bool EnableGeometrySimplification
+    {
+        get => _enableGeometrySimplification;
+        set { if (SetProperty(ref _enableGeometrySimplification, value)) { _settings.EnableGeometrySimplification = value; RaiseMarinerChanged(); } }
+    }
+
     private string _nationalLanguage = "";
     public string NationalLanguage
     {
@@ -536,6 +548,7 @@ internal sealed class SettingsViewModel : ViewModelBase
         _radarOverlay = settings.RadarOverlay ?? def.RadarOverlay;
         _ignoreScaleMinimum = settings.IgnoreScaleMinimum ?? def.IgnoreScaleMinimum;
         _enableVectorRasterization = settings.EnableVectorRasterization ?? false;
+        _enableGeometrySimplification = settings.EnableGeometrySimplification ?? false;
         _nationalLanguage = settings.NationalLanguage ?? def.NationalLanguage;
 
         _mcpEnabled = settings.McpEnabled;

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -164,6 +164,17 @@ internal sealed class ViewerSettings
     /// </summary>
     public bool? EnableVectorRasterization { get; set; }
 
+    /// <summary>
+    /// When true, S-100 vector layers run incoming line geometries
+    /// through a resolution-aware Douglas-Peucker simplifier (issue
+    /// #164) before passing them to Mapsui's vector style renderer.
+    /// Each <c>(feature, zoom-bucket)</c> pair is cached, so steady
+    /// pans/zooms re-use the simplified geometry. Polygons and short
+    /// lines pass through unchanged. Defaults to false (full
+    /// geometry — preserves the historical pixel-perfect output).
+    /// </summary>
+    public bool? EnableGeometrySimplification { get; set; }
+
     /// <summary>3-letter ISO 639-2/B language code; empty = catalogue default.</summary>
     public string? NationalLanguage { get; set; }
 

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -263,6 +263,9 @@
             <CheckBox Content="{x:Static loc:Strings.Settings_EnableVectorRasterization}"
                       IsChecked="{Binding EnableVectorRasterization}"
                       ToolTip.Tip="{x:Static loc:Strings.Tooltip_EnableVectorRasterization}" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_EnableGeometrySimplification}"
+                      IsChecked="{Binding EnableGeometrySimplification}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_EnableGeometrySimplification}" />
 
             <!-- National Language -->
             <StackPanel Spacing="6">

--- a/tests/EncDotNet.S100.Pipelines.Tests/Simplification/DouglasPeuckerLineSimplifierTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/Simplification/DouglasPeuckerLineSimplifierTests.cs
@@ -1,0 +1,136 @@
+using EncDotNet.S100.Renderers.Mapsui.Simplification;
+using Mapsui.Nts;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests.Simplification;
+
+/// <summary>
+/// Behavioural tests for <see cref="DouglasPeuckerLineSimplifier"/>:
+/// reduces vertex count on dense lines, respects the metric tolerance,
+/// passes short or non-line geometries through unchanged, and copies
+/// fields + style references onto the simplified clone.
+/// </summary>
+public sealed class DouglasPeuckerLineSimplifierTests
+{
+    private static readonly GeometryFactory _gf = new();
+    private static readonly SimplificationOptions _opts = new();
+
+    [Fact]
+    public void ReducesVertexCount_OnDenseZigzagLine()
+    {
+        // 1000-point zigzag with sub-tolerance jitter — DP should
+        // collapse it almost entirely.
+        var coords = new Coordinate[1000];
+        for (int i = 0; i < coords.Length; i++)
+        {
+            double y = (i % 2 == 0) ? 0.5 : -0.5;
+            coords[i] = new Coordinate(i, y);
+        }
+        var line = _gf.CreateLineString(coords);
+        var orig = new GeometryFeature(line);
+
+        var result = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, toleranceMetres: 10.0, _opts);
+
+        Assert.True(result.WasSimplified);
+        Assert.True(result.SimplifiedCoordinateCount < result.OriginalCoordinateCount / 10,
+            $"Expected ≥10× reduction; got {result.OriginalCoordinateCount}→{result.SimplifiedCoordinateCount}");
+        Assert.Equal(1000, result.OriginalCoordinateCount);
+    }
+
+    [Fact]
+    public void RespectsMetricTolerance()
+    {
+        // A spike of 5 metres at index 5 of an otherwise-straight line.
+        // Tolerance of 1 m must KEEP the spike; tolerance of 10 m must DROP it.
+        var coords = new Coordinate[100];
+        for (int i = 0; i < coords.Length; i++) coords[i] = new Coordinate(i, 0);
+        coords[50] = new Coordinate(50, 5);
+        var line = _gf.CreateLineString(coords);
+        var orig = new GeometryFeature(line);
+
+        var keep = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 1.0, _opts);
+        Assert.True(keep.WasSimplified);
+        var keepCoords = ((LineString)((GeometryFeature)keep.Feature).Geometry!).Coordinates;
+        Assert.Contains(keepCoords, c => c.Y >= 5.0 - 1e-9);
+
+        var drop = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 10.0, _opts);
+        Assert.True(drop.WasSimplified);
+        var dropCoords = ((LineString)((GeometryFeature)drop.Feature).Geometry!).Coordinates;
+        Assert.DoesNotContain(dropCoords, c => c.Y >= 5.0 - 1e-9);
+    }
+
+    [Fact]
+    public void ShortLine_BelowMinVertexCount_PassesThrough()
+    {
+        var coords = new Coordinate[]
+        {
+            new(0, 0), new(1, 1), new(2, 2), new(3, 3),
+        };
+        var orig = new GeometryFeature(_gf.CreateLineString(coords));
+        var result = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 0.1, _opts);
+        Assert.False(result.WasSimplified);
+        Assert.Same(orig, result.Feature);
+    }
+
+    [Fact]
+    public void Polygon_PassesThroughUnchanged()
+    {
+        // Polygons are out of scope in v1.
+        var ring = _gf.CreateLinearRing(new Coordinate[]
+        {
+            new(0, 0), new(100, 0), new(100, 100), new(0, 100), new(0, 0),
+        });
+        var poly = _gf.CreatePolygon(ring);
+        var orig = new GeometryFeature(poly);
+        var result = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 1.0, _opts);
+        Assert.False(result.WasSimplified);
+        Assert.Same(orig, result.Feature);
+    }
+
+    [Fact]
+    public void Point_PassesThroughUnchanged()
+    {
+        var orig = new GeometryFeature(_gf.CreatePoint(new Coordinate(1, 2)));
+        var result = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 1.0, _opts);
+        Assert.False(result.WasSimplified);
+        Assert.Same(orig, result.Feature);
+    }
+
+    [Fact]
+    public void Simplified_Feature_ShareStyleInstancesAndCarriesBackReference()
+    {
+        var coords = new Coordinate[200];
+        for (int i = 0; i < coords.Length; i++) coords[i] = new Coordinate(i, (i % 3) * 0.1);
+        var orig = new GeometryFeature(_gf.CreateLineString(coords));
+        var style = new VectorStyle();
+        orig.Styles.Add(style);
+        orig["S100.FeatureRef"] = "F42";
+
+        var result = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 5.0, _opts);
+
+        Assert.True(result.WasSimplified);
+        // Copied field
+        Assert.Equal("F42", result.Feature["S100.FeatureRef"]);
+        // Back-reference present
+        Assert.Same(orig, EncDotNet.S100.Renderers.Mapsui.Simplification.Simplification.GetOriginal(result.Feature));
+        // Same style instance (avoids re-rendering style state)
+        bool foundSame = false;
+        foreach (var s in result.Feature.Styles)
+            if (ReferenceEquals(s, style)) { foundSame = true; break; }
+        Assert.True(foundSame, "Simplified clone must share the style instance from the original.");
+    }
+
+    [Fact]
+    public void NonPositiveTolerance_PassesThrough()
+    {
+        var coords = new Coordinate[200];
+        for (int i = 0; i < coords.Length; i++) coords[i] = new Coordinate(i, 0);
+        var orig = new GeometryFeature(_gf.CreateLineString(coords));
+        var zero = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, 0.0, _opts);
+        Assert.False(zero.WasSimplified);
+        var neg = DouglasPeuckerLineSimplifier.Instance.Simplify(orig, -1.0, _opts);
+        Assert.False(neg.WasSimplified);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/Simplification/InstrumentedMemoryLayerSimplificationTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/Simplification/InstrumentedMemoryLayerSimplificationTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Mapsui.Simplification;
+using Mapsui;
+using Mapsui.Nts;
+using NetTopologySuite.Geometries;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests.Simplification;
+
+/// <summary>
+/// Validates that <see cref="InstrumentedMemoryLayer"/> hands
+/// simplified copies (or originals, when disabled) to its callers,
+/// preserving the <c>S100.FeatureRef</c> tag so picking still works.
+/// </summary>
+public sealed class InstrumentedMemoryLayerSimplificationTests
+{
+    private static readonly GeometryFactory _gf = new();
+
+    private static GeometryFeature MakeDenseLine(int n, string featureRef)
+    {
+        var coords = new Coordinate[n];
+        for (int i = 0; i < n; i++) coords[i] = new Coordinate(i, (i % 4) * 0.1);
+        var f = new GeometryFeature(_gf.CreateLineString(coords));
+        f["S100.FeatureRef"] = featureRef;
+        return f;
+    }
+
+    [Fact]
+    public void Disabled_PassesOriginalsThrough()
+    {
+        var feat = MakeDenseLine(500, "F1");
+        var layer = new InstrumentedMemoryLayer { Features = new[] { feat } };
+
+        var visible = layer.GetFeatures(feat.Extent!.Grow(10), resolution: 100.0).ToList();
+
+        Assert.Single(visible);
+        Assert.Same(feat, visible[0]);
+    }
+
+    [Fact]
+    public void Enabled_LowResolution_SimplifiesGeometry()
+    {
+        var feat = MakeDenseLine(500, "F1");
+        var layer = new InstrumentedMemoryLayer { Features = new[] { feat } };
+        layer.EnableSimplification(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+
+        // Coarse resolution → tolerance large enough to collapse the jitter.
+        var visible = layer.GetFeatures(feat.Extent!.Grow(10), resolution: 100.0).ToList();
+
+        Assert.Single(visible);
+        var simplified = (GeometryFeature)visible[0];
+        Assert.NotSame(feat, simplified);
+        var origCount = ((LineString)feat.Geometry!).NumPoints;
+        var newCount = ((LineString)simplified.Geometry!).NumPoints;
+        Assert.True(newCount < origCount, $"Expected reduction; got {origCount}→{newCount}.");
+        // FeatureRef and OriginalFeature back-ref preserved.
+        Assert.Equal("F1", simplified["S100.FeatureRef"]);
+        Assert.Same(feat, EncDotNet.S100.Renderers.Mapsui.Simplification.Simplification.GetOriginal(simplified));
+    }
+
+    [Fact]
+    public void Enabled_HighResolution_TightToleranceMostlyPreserves()
+    {
+        // Use a sharper-feature line so a 0.5 m tolerance leaves it intact.
+        var coords = new Coordinate[200];
+        for (int i = 0; i < coords.Length; i++) coords[i] = new Coordinate(i, (i % 2 == 0) ? 0 : 5);
+        var feat = new GeometryFeature(_gf.CreateLineString(coords));
+        feat["S100.FeatureRef"] = "F2";
+        var layer = new InstrumentedMemoryLayer { Features = new[] { feat } };
+        layer.EnableSimplification(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+
+        // Bucket 0 → tolerance 0.5 m. The 5 m peaks must survive.
+        var visible = layer.GetFeatures(feat.Extent!.Grow(10), resolution: 1.0).ToList();
+
+        Assert.Single(visible);
+        var ls = (LineString)((GeometryFeature)visible[0]).Geometry!;
+        // Allow some collapse but the alternating pattern should still be visible.
+        Assert.True(ls.NumPoints >= coords.Length / 2,
+            $"Expected most peaks preserved at tight tolerance; got {ls.NumPoints} of {coords.Length}.");
+    }
+
+    [Fact]
+    public void Disable_AfterEnable_RestoresPassthrough()
+    {
+        var feat = MakeDenseLine(500, "F1");
+        var layer = new InstrumentedMemoryLayer { Features = new[] { feat } };
+        layer.EnableSimplification(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        var simplified = layer.GetFeatures(feat.Extent!.Grow(10), resolution: 100.0).ToList()[0];
+        Assert.NotSame(feat, simplified);
+
+        layer.DisableSimplification();
+        var afterDisable = layer.GetFeatures(feat.Extent!.Grow(10), resolution: 100.0).ToList()[0];
+        Assert.Same(feat, afterDisable);
+    }
+
+    [Fact]
+    public void NullRect_ReturnsEmpty_WithSimplificationEnabled()
+    {
+        var feat = MakeDenseLine(500, "F1");
+        var layer = new InstrumentedMemoryLayer { Features = new[] { feat } };
+        layer.EnableSimplification(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        Assert.Empty(layer.GetFeatures(null, 1.0));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/Simplification/SimplificationCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/Simplification/SimplificationCacheTests.cs
@@ -1,0 +1,160 @@
+using EncDotNet.S100.Renderers.Mapsui.Simplification;
+using Mapsui;
+using Mapsui.Nts;
+using NetTopologySuite.Geometries;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests.Simplification;
+
+/// <summary>
+/// Tests <see cref="SimplificationCache"/> bucketing, reuse, and
+/// eviction behaviour. The simplifier itself is exercised separately
+/// — these tests use a stub that returns predictable clones so the
+/// cache logic can be observed in isolation.
+/// </summary>
+public sealed class SimplificationCacheTests
+{
+    private static readonly GeometryFactory _gf = new();
+
+    private static GeometryFeature MakeLine(int coordCount, int seed = 0)
+    {
+        var coords = new Coordinate[coordCount];
+        for (int i = 0; i < coordCount; i++)
+            coords[i] = new Coordinate(i + seed, (i + seed) % 7 * 0.3);
+        return new GeometryFeature(_gf.CreateLineString(coords));
+    }
+
+    [Fact]
+    public void RepeatLookup_ReturnsSameInstance()
+    {
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        var f = MakeLine(500);
+        var first = cache.GetOrSimplify(f, resolution: 1.0);
+        var second = cache.GetOrSimplify(f, resolution: 1.0);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void DifferentBuckets_GiveDifferentInstances()
+    {
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        var f = MakeLine(500);
+        var coarse = cache.GetOrSimplify(f, resolution: 100.0);
+        var fine = cache.GetOrSimplify(f, resolution: 0.1);
+        Assert.NotSame(coarse, fine);
+    }
+
+    [Fact]
+    public void Bucket_HalfOctave_Computation()
+    {
+        // 1.0 → log2 = 0 → bucket 0
+        Assert.Equal(0, SimplificationCache.BucketFor(1.0));
+        // 2.0 → log2 = 1 → bucket 2
+        Assert.Equal(2, SimplificationCache.BucketFor(2.0));
+        // sqrt(2) → log2 = 0.5 → round(1) = 1
+        Assert.Equal(1, SimplificationCache.BucketFor(System.Math.Sqrt(2.0)));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    public void Bucket_HandlesDegenerateResolution(double res)
+    {
+        // No throw; clamps to MinResolution (1e-3).
+        var bucket = SimplificationCache.BucketFor(res);
+        Assert.Equal(SimplificationCache.BucketFor(1e-3), bucket);
+    }
+
+    [Fact]
+    public void BucketShift_DropsNonAdjacentBuckets()
+    {
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        // Populate at bucket 0 (resolution 1.0).
+        var f = MakeLine(500);
+        cache.GetOrSimplify(f, resolution: 1.0);
+        Assert.True(cache.CachedEntryCount >= 1);
+
+        // Jump to a bucket far away — should drop bucket 0.
+        var far = MakeLine(500, seed: 100_000);
+        cache.GetOrSimplify(far, resolution: 1024.0); // bucket = 20
+
+        // Original bucket 0 should be gone (only the far entry remains
+        // around the new active bucket).
+        Assert.True(cache.CachedEntryCount <= 1);
+    }
+
+    [Fact]
+    public void BucketShift_KeepsAdjacentBuckets()
+    {
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        var f = MakeLine(500);
+        // Bucket 0 (res 1.0)
+        cache.GetOrSimplify(f, resolution: 1.0);
+        var beforeCount = cache.CachedEntryCount;
+        // Bucket 1 (res √2 ≈ 1.414) — adjacent to 0
+        cache.GetOrSimplify(f, resolution: System.Math.Sqrt(2.0));
+        // Both buckets should be retained.
+        Assert.True(cache.CachedEntryCount >= beforeCount + 1);
+    }
+
+    [Fact]
+    public void CoordinateBudget_ForcesEviction()
+    {
+        // Budget so small that two ~500-coord features can't both fit.
+        var opts = new SimplificationOptions(MaxCachedCoordinates: 100);
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, opts);
+
+        // Active bucket 0 with several features.
+        for (int i = 0; i < 5; i++)
+            cache.GetOrSimplify(MakeLine(500, seed: i * 1000), resolution: 1.0);
+        var bucket0 = cache.CachedCoordinateCount;
+
+        // Far bucket — populating it should evict bucket 0.
+        cache.GetOrSimplify(MakeLine(500, seed: 999_000), resolution: 1024.0);
+
+        Assert.True(cache.CachedCoordinateCount <= opts.MaxCachedCoordinates + 500,
+            $"Coord budget overrun: tracking {cache.CachedCoordinateCount} > {opts.MaxCachedCoordinates}");
+        Assert.True(cache.CachedCoordinateCount < bucket0,
+            "Adding far-bucket entries should have evicted bucket-0 entries.");
+    }
+
+    [Fact]
+    public void Clear_EmptiesCache()
+    {
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        cache.GetOrSimplify(MakeLine(500), resolution: 1.0);
+        cache.GetOrSimplify(MakeLine(500, seed: 5000), resolution: 1.0);
+        Assert.True(cache.CachedEntryCount >= 2);
+        cache.Clear();
+        Assert.Equal(0, cache.CachedEntryCount);
+        Assert.Equal(0, cache.CachedCoordinateCount);
+    }
+
+    [Fact]
+    public void Passthrough_CachedAsIdentity_DoesNotReSimplify()
+    {
+        // A short feature passes through; the cache must still record
+        // the identity so we don't re-test on every paint.
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        var f = MakeLine(10); // below MinVertexCount default 64
+        var first = cache.GetOrSimplify(f, resolution: 1.0);
+        var second = cache.GetOrSimplify(f, resolution: 1.0);
+        Assert.Same(f, first);
+        Assert.Same(f, second);
+    }
+
+    [Fact]
+    public void GetOriginal_RecoversBackReference()
+    {
+        var cache = new SimplificationCache(DouglasPeuckerLineSimplifier.Instance, new SimplificationOptions());
+        var f = MakeLine(500);
+        var simplified = cache.GetOrSimplify(f, resolution: 1.0);
+        // For this dense line at this tolerance, simplification should
+        // have produced a different instance carrying the back-ref.
+        Assert.NotSame(f, simplified);
+        Assert.Same(f, EncDotNet.S100.Renderers.Mapsui.Simplification.Simplification.GetOriginal(simplified));
+        // GetOriginal on a non-simplified feature returns it unchanged.
+        Assert.Same(f, EncDotNet.S100.Renderers.Mapsui.Simplification.Simplification.GetOriginal(f));
+    }
+}


### PR DESCRIPTION
Closes #164.

Implements Douglas-Peucker line simplification keyed by half-octave zoom buckets, with a per-layer cache plumbed through `InstrumentedMemoryLayer.GetFeatures` so the cost is paid once per `(feature, bucket)` and amortized across pan frames. Targets the perf-review finding (PR #166 / `docs/design/mapsui-performance.md`) that ~93% of paint time scales linearly with vertex count and is dominated by lines in the 1k–10k bucket.

## Design

- **Seam:** `InstrumentedMemoryLayer.GetFeatures(rect, resolution)` is the only place in the pipeline with access to the current zoom (m/px in EPSG:3857). Cache lookup happens here; the renderer's one-shot `Render()` was rejected because it has no resolution context.
- **Bucket:** `round(log2(resolution) × 2)` (half-octave). Tolerance: `pixelTolerance × 2^(bucket/2)` metres. Resolution clamped to `[1e-3, 1e9]` to handle 0/NaN/negative.
- **Cache:** `Dictionary<(IFeature original, int bucket), CacheEntry>` per layer, ref-equality on the feature key (safe because `MemoryLayer.Features` is fixed at `Render()` time).
- **Eviction:** on bucket transition, drop entries outside `[active − 1, active + 1]`; if still over the coordinate budget (default 5M coords ≈ 80 MB), drop bucket-by-bucket from farthest active.
- **Simplified clones** share style instances by reference, copy all fields including `S100.FeatureRef`, and carry an `S100.OriginalFeature` back-reference. `Simplification.GetOriginal(feature)` resolves picking back to the unsimplified record.

## v1 scope (rubber-duck adjustments)

- **Lines / multi-lines only.** Polygons and points pass through unchanged — per-ring DP can produce invalid rings; revisit with `TopologyPreservingSimplifier` + `IsValid`.
- **Default off**, opt-in via new viewer setting **Simplify line geometry (experimental)**.
- **PixelTolerance = 0.5 px** (not 1.0) — safer for thicker strokes like depth contours.
- **MinVertexCount = 64** bypass — geometries below this aren't simplified (paint cost negligible per the perf review).
- Synchronous miss path in v1; pre-warm and async deferred (documented as future work in the perf doc).

## Telemetry

Six new instruments under `s100.simplify.*`:

| Instrument | Unit | Purpose |
|---|---|---|
| `s100.simplify.cache.hit.count` | count | Served from cache |
| `s100.simplify.cache.miss.count` | count | DP invocation |
| `s100.simplify.duration` | ms | Per-feature DP cost (miss only) |
| `s100.simplify.coords.in` / `.out` | count | Vertex counts before/after |
| `s100.simplify.cache.coords.tracked` | count | Live coord budget (UpDownCounter) |

## Tests

24 new tests:
- `DouglasPeuckerLineSimplifierTests` — vertex reduction, tolerance bounds, multi-line, non-line passthrough.
- `SimplificationCacheTests` — hit reuse, bucket-transition eviction, coord-budget eviction, clamping, MinVertex bypass.
- `InstrumentedMemoryLayerSimplificationTests` — enable/disable, identity passthrough when off, original-back-reference for picking, theory over resolutions.

Full solution test sweep green (Pipelines 432, Viewer 579, all spec tests).

## Acceptance criteria still requiring real-data measurement

- Steady-state cache hit rate ≥ 95% on pan.
- ≥ 50% reduction in `s100.map.paint.duration` mean on the multi-S-101 workload from the perf review.
- No visible quality regression at typical zoom levels.

These need an interactive viewer session with OTel collection on the perf-review datasets (e.g. 101GB00GB302045) and are flagged as a follow-up.

## Files

**New:** `src/EncDotNet.S100.Renderers.Mapsui/Simplification/{IFeatureSimplifier,DouglasPeuckerLineSimplifier,SimplificationOptions,SimplificationCache,Simplification}.cs`, plus 3 test files.

**Modified:** `InstrumentedMemoryLayer.cs`, `Diagnostics/Telemetry.cs`, `Renderers.Mapsui/README.md`, `docs/design/mapsui-performance.md`, viewer settings (resx, Strings.cs, ViewerSettings, SettingsViewModel, SettingsView.axaml), `Services/DatasetLoaderService.cs`.