### PR TITLE
Hide S-101 detail when zoomed out past the cell's scale band

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -223,6 +223,24 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         TagMapsuiFeaturesWithFeatureType(areaLayer);
         TagMapsuiFeaturesWithFeatureType(lineLayer);
 
+        // Out-of-scale-band declutter: when the viewport is zoomed out past
+        // the cell's intended display scale band (S-101 DataCoverage /
+        // minimumDisplayScale, FC §3.1.1), the point/line/text display
+        // collapses into an unreadable mass of overlapping symbology. Cap
+        // those detail features' maximum visible resolution so they drop out
+        // when zoomed too far out, while leaving the area fills uncapped so
+        // the cell's land / depth-area silhouette stays visible as a
+        // coverage footprint. Honour the mariner's IgnoreScaleMinimum
+        // override (S-101 PC context parameter) so "show everything
+        // regardless of scale" disables the cap, consistent with SCAMIN.
+        if (!mariner.IgnoreScaleMinimum)
+        {
+            _featureIndex ??= BuildFeatureIndex();
+            var bandMaxResolution = ResolveOutOfBandMaxResolution(_featureIndex.Values);
+            if (bandMaxResolution is double cap && lineLayer is MemoryLayer lineMemoryLayer)
+                ApplyOutOfScaleBandCap(lineMemoryLayer.Features, cap);
+        }
+
         // Union the two layer extents (each is in EPSG:3857). Mapsui
         // returns a zero-extent rect when a layer has no features, so
         // skip such layers in the union.
@@ -325,6 +343,77 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
             sb.Append(plane).Append(',');
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Resolves the cell's out-of-scale-band cutoff as a Mapsui maximum
+    /// visible resolution (m/px in EPSG:3857) from the
+    /// <c>DataCoverage</c> feature's <c>minimumDisplayScale</c> attribute
+    /// (S-101 FC §3.1.1 — the smallest scale, i.e. largest denominator, at
+    /// which the cell is intended to be displayed). Detail features become
+    /// invisible once the viewport resolution exceeds this value (i.e. the
+    /// chart is zoomed out beyond its compilation scale band).
+    /// </summary>
+    /// <param name="features">The dataset's vector features.</param>
+    /// <returns>
+    /// The cutoff resolution (<c>minimumDisplayScale × DenomToResolutionMetres</c>),
+    /// or <see langword="null"/> when no <c>DataCoverage</c> feature carries a
+    /// usable <c>minimumDisplayScale</c>. When several <c>DataCoverage</c>
+    /// features declare different bands, the most permissive (largest
+    /// denominator) is used so detail stays visible wherever any coverage
+    /// region still permits it.
+    /// </returns>
+    internal static double? ResolveOutOfBandMaxResolution(
+        IEnumerable<EncDotNet.S100.Pipelines.Vector.Feature> features)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+
+        int? minDisplayScale = null;
+        foreach (var feature in features)
+        {
+            if (!string.Equals(feature.FeatureType, "DataCoverage", StringComparison.Ordinal))
+                continue;
+            if (!feature.Attributes.TryGetValue("minimumDisplayScale", out var raw) || raw is null)
+                continue;
+            if (!int.TryParse(raw.ToString(), System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var denom) || denom <= 0)
+                continue;
+
+            minDisplayScale = minDisplayScale is null ? denom : Math.Max(minDisplayScale.Value, denom);
+        }
+
+        return minDisplayScale is null
+            ? null
+            : minDisplayScale.Value * MapsuiDisplayListRenderer.DenomToResolutionMetres;
+    }
+
+    /// <summary>
+    /// Clamps the maximum visible resolution (zoomed-out limit) of every
+    /// style on <paramref name="features"/> to <paramref name="maxResolution"/>,
+    /// suppressing point/line/text detail when the viewport is zoomed out
+    /// past the cell's intended scale band. The clamp only ever
+    /// <em>reduces</em> visibility: a tighter SCAMIN-derived limit already
+    /// applied by the renderer is preserved, and any style with a
+    /// non-positive (sentinel) limit is left untouched.
+    /// </summary>
+    /// <param name="features">The Mapsui features to cap (point/line/text).</param>
+    /// <param name="maxResolution">The band cutoff resolution (m/px).</param>
+    internal static void ApplyOutOfScaleBandCap(IEnumerable<IFeature> features, double maxResolution)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+
+        foreach (var mapFeature in features)
+        {
+            foreach (var style in mapFeature.Styles)
+            {
+                if (style is null) continue;
+                // Only tighten: default MaxVisible (double.MaxValue) and any
+                // looser SCAMIN limit collapse to the band cap; a tighter
+                // SCAMIN limit wins; non-positive sentinels are preserved.
+                if (style.MaxVisible > 0)
+                    style.MaxVisible = Math.Min(style.MaxVisible, maxResolution);
+            }
+        }
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -314,7 +314,7 @@ public sealed class MapsuiDisplayListRenderer
     /// at 96 DPI: 1 px = 0.28 mm = 0.00028 m on the nominal display surface,
     /// so resolution ≈ scaleDenominator × 0.00028.
     /// </summary>
-    private const double DenomToResolutionMetres = 0.00028;
+    public const double DenomToResolutionMetres = 0.00028;
 
     /// <summary>
     /// Maps the S-100 Part 9 §11.1 <see cref="DrawingInstruction.ScaleMinimum"/> /

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101OutOfScaleBandTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101OutOfScaleBandTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Styles;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies the out-of-scale-band declutter helpers on
+/// <see cref="S101DatasetProcessor"/>: the band cutoff is derived from the
+/// <c>DataCoverage</c> feature's <c>minimumDisplayScale</c> attribute
+/// (S-101 FC §3.1.1), and the per-feature cap only ever reduces visibility.
+/// </summary>
+public class S101OutOfScaleBandTests
+{
+    private static EncDotNet.S100.Pipelines.Vector.Feature Feature(
+        string featureType, long id, params (string Key, object? Value)[] attributes)
+    {
+        var attrs = new Dictionary<string, object?>();
+        foreach (var (key, value) in attributes)
+            attrs[key] = value;
+
+        return new EncDotNet.S100.Pipelines.Vector.Feature
+        {
+            FeatureType = featureType,
+            Id = id,
+            GeometryType = GeometryType.Surface,
+            Coordinates = new (double, double)[] { (0, 0) },
+            Attributes = attrs,
+        };
+    }
+
+    [Fact]
+    public void Resolve_SingleDataCoverage_ReturnsDenomTimesResolutionFactor()
+    {
+        var features = new[]
+        {
+            Feature("DepthArea", 1),
+            Feature("DataCoverage", 2, ("minimumDisplayScale", "90000")),
+        };
+
+        var result = S101DatasetProcessor.ResolveOutOfBandMaxResolution(features);
+
+        Assert.NotNull(result);
+        Assert.Equal(90000 * MapsuiDisplayListRenderer.DenomToResolutionMetres, result!.Value, 6);
+    }
+
+    [Fact]
+    public void Resolve_NoDataCoverage_ReturnsNull()
+    {
+        var features = new[] { Feature("DepthArea", 1), Feature("Sounding", 2) };
+
+        Assert.Null(S101DatasetProcessor.ResolveOutOfBandMaxResolution(features));
+    }
+
+    [Fact]
+    public void Resolve_DataCoverageWithoutAttribute_ReturnsNull()
+    {
+        var features = new[] { Feature("DataCoverage", 1) };
+
+        Assert.Null(S101DatasetProcessor.ResolveOutOfBandMaxResolution(features));
+    }
+
+    [Fact]
+    public void Resolve_MalformedValue_ReturnsNull()
+    {
+        var features = new[] { Feature("DataCoverage", 1, ("minimumDisplayScale", "not-a-number")) };
+
+        Assert.Null(S101DatasetProcessor.ResolveOutOfBandMaxResolution(features));
+    }
+
+    [Fact]
+    public void Resolve_NonPositiveValue_ReturnsNull()
+    {
+        var features = new[] { Feature("DataCoverage", 1, ("minimumDisplayScale", "0")) };
+
+        Assert.Null(S101DatasetProcessor.ResolveOutOfBandMaxResolution(features));
+    }
+
+    [Fact]
+    public void Resolve_MultipleDataCoverage_UsesMostPermissiveLargestDenominator()
+    {
+        var features = new[]
+        {
+            Feature("DataCoverage", 1, ("minimumDisplayScale", "45000")),
+            Feature("DataCoverage", 2, ("minimumDisplayScale", "180000")),
+            Feature("DataCoverage", 3, ("minimumDisplayScale", "90000")),
+        };
+
+        var result = S101DatasetProcessor.ResolveOutOfBandMaxResolution(features);
+
+        Assert.NotNull(result);
+        Assert.Equal(180000 * MapsuiDisplayListRenderer.DenomToResolutionMetres, result!.Value, 6);
+    }
+
+    [Fact]
+    public void Resolve_MinimumDisplayScaleOnNonDataCoverage_IsIgnored()
+    {
+        var features = new[] { Feature("DepthArea", 1, ("minimumDisplayScale", "90000")) };
+
+        Assert.Null(S101DatasetProcessor.ResolveOutOfBandMaxResolution(features));
+    }
+
+    private static IFeature PointWithMaxVisible(double maxVisible)
+    {
+        var feature = new PointFeature(0, 0);
+        feature.Styles.Add(new SymbolStyle { MaxVisible = maxVisible });
+        return feature;
+    }
+
+    [Fact]
+    public void Cap_DefaultUnboundedVisibility_IsCappedToBand()
+    {
+        var feature = PointWithMaxVisible(double.MaxValue);
+
+        S101DatasetProcessor.ApplyOutOfScaleBandCap(new[] { feature }, 25.2);
+
+        Assert.Equal(25.2, GetMaxVisible(feature), 6);
+    }
+
+    [Fact]
+    public void Cap_TighterScaminLimit_IsPreserved()
+    {
+        var feature = PointWithMaxVisible(10.0);
+
+        S101DatasetProcessor.ApplyOutOfScaleBandCap(new[] { feature }, 25.2);
+
+        Assert.Equal(10.0, GetMaxVisible(feature), 6);
+    }
+
+    [Fact]
+    public void Cap_LooserScaminLimit_IsReducedToBand()
+    {
+        var feature = PointWithMaxVisible(100.0);
+
+        S101DatasetProcessor.ApplyOutOfScaleBandCap(new[] { feature }, 25.2);
+
+        Assert.Equal(25.2, GetMaxVisible(feature), 6);
+    }
+
+    [Fact]
+    public void Cap_NonPositiveSentinel_IsLeftUntouched()
+    {
+        var feature = PointWithMaxVisible(0.0);
+
+        S101DatasetProcessor.ApplyOutOfScaleBandCap(new[] { feature }, 25.2);
+
+        Assert.Equal(0.0, GetMaxVisible(feature), 6);
+    }
+
+    private static double GetMaxVisible(IFeature feature)
+    {
+        foreach (var style in feature.Styles)
+            return style.MaxVisible;
+        return double.NaN;
+    }
+}


### PR DESCRIPTION
## Problem

When the viewer is zoomed out well past an S-101 cell's intended display scale, the chart collapses into an unreadable mass of overlapping point symbols, labels, and line work — a "blob of black" with no useful information.

The cell already declares its intended scale band via the `DataCoverage` feature's `minimumDisplayScale` attribute (S-101 FC §3.1.1 — the smallest scale / largest denominator at which the cell is meant to be displayed), but nothing honoured it at the layer level:

- `DataCoverage` portrays as a `NullInstruction` (draws nothing), so there was no footprint.
- ~23% of features carry no SCAMIN (plus some with `infinite` / `1:50M` sentinels), so they were always drawn regardless of zoom.

## Change

Cap the **maximum visible resolution** of point/line/text detail to `minimumDisplayScale × DenomToResolutionMetres`, so that detail drops out once the chart is zoomed out past its compilation scale. **Area fills are left uncapped**, so the cell's land / depth-area silhouette remains visible as a natural coverage footprint instead of going blank.

Details:
- The clamp only ever **reduces** visibility — a tighter per-feature SCAMIN limit already applied by the renderer wins; non-positive sentinel limits are left untouched.
- When several `DataCoverage` features declare different bands, the **most permissive** (largest denominator) is used so detail stays visible wherever any coverage region still permits it.
- The mariner's `IgnoreScaleMinimum` override disables the cap entirely, consistent with how SCAMIN is overridden.
- Applied **post-render** in `S101DatasetProcessor` (which already splits area vs. line/point/text layers and maintains a feature index), so the cached drawing-instruction list and all **in-band rendering are byte-identical** — only the out-of-band zoom behaviour changes.

## Validation

- New unit tests (`S101OutOfScaleBandTests`, 11 cases) cover band extraction (single / none / missing attribute / malformed / non-positive / multiple / non-DataCoverage) and the clamp logic (default unbounded, tighter-preserved, looser-reduced, non-positive untouched).
- Full Pipelines suite: **452 passed** (441 existing + 11 new), confirming in-band rendering is unchanged.
- Visual check on trial cell `101GB00GB302045.000`:
  - Continental zoom: black blob gone → tiny area-fill silhouette marks the cell location.
  - Just out of band: clean land/water footprint, clutter removed.
  - In band: full detail intact.

## Notes

- This is independent of #169 (OverlayNG pattern-clip swap); the only renderer change here is making `DenomToResolutionMetres` `public` so the processor can reuse the scale→resolution factor.
- The global (per-layer) band reconciliation is intentionally conservative for v1; per-`DataCoverage`-region spatial capping could be a future refinement.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>