### PR TITLE
Add await_render_idle and get_render_stats MCP tools

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -121,6 +121,8 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `set_palette` *(viewer only, **mutating**)* | Sets the live viewer's active map palette to `Day`, `Dusk`, or `Night` (case-insensitive). Idempotent — no-op when already at the requested palette. Returns the applied and previous palette so callers can detect no-ops. Lets scripted measurement runs drive palette-change scenarios from outside the GUI. |
 | `set_display_category` *(viewer only, **mutating**)* | Sets the live viewer's active ECDIS display category to `DisplayBase`, `Standard`, `OtherInformation`, or `All` (case-insensitive). Idempotent. Counterpart to the `--display-category` CLI flag, but applicable mid-session. |
 | `set_time_step` *(viewer only, **mutating**)* | Drives the viewer's global time clock to a specific sample for time-aware datasets (S-104 / S-111 / S-411). Supply EITHER `index` (0-based integer into `list_time_steps`) OR `timestamp` (ISO-8601, snapped to the nearest sample). Returns the resolved index and snapped timestamp. Counterpart to the `--time-step` CLI flag, but applicable mid-session. |
+| `await_render_idle` *(viewer only, read-only)* | Blocks until the live map settles — no completed paint, graphics-refresh request, or busy layer for a continuous quiet period — or until a timeout elapses (`quietPeriodMs` default 250, clamped `[0, 10000]`; `timeoutMs` default 5000, clamped `[50, 120000]`). Call it between `set_viewport` and `render_to_image` so the screenshot reflects a settled view instead of racing the render pass. Always waits at least the quiet period and measures the on-screen `InstrumentedMapControl` paint loop, not the offscreen `render_to_image` clone. Returns `wentIdle`, `timedOut`, `waitedMs`, and `paintsObserved`. |
+| `get_render_stats` *(viewer only, read-only)* | Reports the cost of the most recently completed on-screen map paint: wall-clock `frameDurationMs`, `intervalMs` since the previous paint, `totalDrawCalls`, and a per-style breakdown (`style`, `calls`, `durationMs`, ordered by descending duration). Use it to measure rendering performance across pan / zoom, palette, or time-step changes. Describes the live map paint, not the offscreen `render_to_image` clone; returns `hasData = false` when no paint has occurred yet. Pair with `await_render_idle` so the reported paint reflects a settled view. |
 
 ### Read-only vs mutating tools
 
@@ -129,7 +131,9 @@ Tools fall into two groups:
 * **Read-only** — never mutate viewer state. Safe to call from any
   agent at any time. Examples: `list_datasets`, `find_at`,
   `query_features`, `sample_coverage`, `render_to_image` (which
-  snapshots from a clone of the live `Map`).
+  snapshots from a clone of the live `Map`), `await_render_idle`, and
+  `get_render_stats` (which observe the live render loop without
+  changing it).
 * **Mutating** — modify the live viewer's state (navigator, palette,
   time step, loaded datasets, etc.). Use only when you intend to
   drive the viewer's UI from outside. Examples: `set_viewport`,

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -338,13 +338,17 @@ public partial class App : Application
         services.AddSingleton<ViewerDatasetCatalog>();
         services.AddSingleton<IMapHostAccessor, MapHostAccessor>();
         services.AddSingleton<IRenderStateControllerAccessor, RenderStateControllerAccessor>();
+        services.AddSingleton<EncDotNet.S100.Viewer.Diagnostics.RenderActivityMonitor>();
+        services.AddSingleton<IRenderActivityMonitor>(sp =>
+            sp.GetRequiredService<EncDotNet.S100.Viewer.Diagnostics.RenderActivityMonitor>());
         services.AddSingleton<McpServerHost>(sp => new McpServerHost(
             sp.GetRequiredService<ViewerDatasetCatalog>(),
             sp.GetRequiredService<ViewerSettings>(),
             sp.GetRequiredService<IMapHostAccessor>(),
             sp.GetService<ILoggerFactory>(),
             sp.GetRequiredService<IRenderStateControllerAccessor>(),
-            sp.GetRequiredService<GlobalTimeService>()));
+            sp.GetRequiredService<GlobalTimeService>(),
+            sp.GetRequiredService<IRenderActivityMonitor>()));
 
         // View models
         services.AddSingleton<FeatureCataloguesViewModel>();

--- a/src/EncDotNet.S100.Viewer/Diagnostics/InstrumentedMapControl.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/InstrumentedMapControl.cs
@@ -64,6 +64,17 @@ internal sealed class InstrumentedMapControl : MapControl
                 Telemetry.MapPaintInterval.Record(intervalMs);
             }
         }
+
+        // Feed the render-activity monitor so off-thread MCP callers can
+        // wait for idle and read the last paint's cost. Only collect the
+        // per-style snapshot when a sink is actually attached, so runs
+        // without an MCP consumer pay no per-paint allocation.
+        var sink = RenderActivityHub.Sink;
+        if (sink is not null)
+        {
+            var styles = MapPaintInstrumentation.CollectStyleSnapshot();
+            sink.NotifyPaint(durationMs, styles);
+        }
     }
     private sealed class PaintMarker
     {

--- a/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
@@ -142,6 +142,38 @@ internal static class MapPaintInstrumentation
     }
 
     /// <summary>
+    /// Builds an immutable, by-style aggregated snapshot of the paint
+    /// that just completed, ordered by descending duration. Returns a
+    /// fresh array of copied values so callers can retain it safely
+    /// while the next paint mutates / resets the in-place accumulators.
+    /// </summary>
+    /// <remarks>
+    /// Valid to call after <see cref="EndPaintAndEmit"/> and before the
+    /// next <see cref="BeginPaint"/> (accumulators are reset on the next
+    /// paint's start marker, not here). Runs on the render thread; the
+    /// caller should only invoke it when a sink is attached so idle /
+    /// stats-free runs pay no allocation.
+    /// </remarks>
+    public static IReadOnlyList<EncDotNet.S100.Viewer.Services.RenderStyleStat> CollectStyleSnapshot()
+    {
+        var byStyle = new Dictionary<string, (long Calls, double DurationMs)>();
+        foreach (var (key, stats) in s_perPaint)
+        {
+            if (stats.Calls == 0) continue;
+            byStyle.TryGetValue(key.Style, out var acc);
+            byStyle[key.Style] = (acc.Calls + stats.Calls, acc.DurationMs + stats.DurationMs);
+        }
+
+        var result = new List<EncDotNet.S100.Viewer.Services.RenderStyleStat>(byStyle.Count);
+        foreach (var (style, acc) in byStyle)
+        {
+            result.Add(new EncDotNet.S100.Viewer.Services.RenderStyleStat(style, acc.Calls, acc.DurationMs));
+        }
+        result.Sort(static (a, b) => b.DurationMs.CompareTo(a.DurationMs));
+        return result;
+    }
+
+    /// <summary>
     /// Bucket vertex count into a small, ordered set of labels so OTel
     /// histogram cardinality stays bounded. Buckets are powers of 10.
     /// </summary>

--- a/src/EncDotNet.S100.Viewer/Diagnostics/RenderActivityMonitor.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/RenderActivityMonitor.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Default <see cref="IRenderActivityMonitor"/> / <see cref="IRenderActivitySink"/>
+/// implementation. Tracks paint completions and other render activity
+/// reported from the compositor render thread, and lets off-thread
+/// callers (MCP tool handlers) wait for the map to settle and read the
+/// last paint's cost.
+/// </summary>
+/// <remarks>
+/// <para>
+/// State shared across threads (<see cref="PaintCount"/>,
+/// <see cref="LatestStats"/>, the last-activity timestamp, and the
+/// wake-up pulse) is guarded by a single lock. The pulse is a
+/// <see cref="TaskCompletionSource"/> created with
+/// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> and
+/// completed outside the lock so waiter continuations never run inline
+/// on the render thread.
+/// </para>
+/// <para>
+/// Timing uses <see cref="Stopwatch.GetTimestamp"/> (monotonic). The
+/// idle decision is factored into the pure, side-effect-free
+/// <see cref="EvaluateIdle"/> so its boundary behaviour can be unit
+/// tested without timing dependence.
+/// </para>
+/// </remarks>
+internal sealed class RenderActivityMonitor : IRenderActivityMonitor, IRenderActivitySink
+{
+    private readonly object _gate = new();
+
+    private long _paintCount;
+    private long _lastActivityTimestamp = Stopwatch.GetTimestamp();
+    private RenderStatsSnapshot? _latestStats;
+    private TaskCompletionSource _pulse =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <inheritdoc />
+    public long PaintCount
+    {
+        get { lock (_gate) { return _paintCount; } }
+    }
+
+    /// <inheritdoc />
+    public RenderStatsSnapshot? LatestStats
+    {
+        get { lock (_gate) { return _latestStats; } }
+    }
+
+    /// <inheritdoc />
+    public Func<bool>? BusyProbe { get; set; }
+
+    /// <inheritdoc />
+    public void NotifyPaint(double frameDurationMs, IReadOnlyList<RenderStyleStat> styles)
+    {
+        ArgumentNullException.ThrowIfNull(styles);
+
+        long total = 0;
+        foreach (var s in styles) total += s.Calls;
+
+        TaskCompletionSource toSignal;
+        lock (_gate)
+        {
+            var now = Stopwatch.GetTimestamp();
+            double? intervalMs = _paintCount == 0
+                ? null
+                : Stopwatch.GetElapsedTime(_lastActivityTimestamp, now).TotalMilliseconds;
+
+            _paintCount++;
+            _lastActivityTimestamp = now;
+            _latestStats = new RenderStatsSnapshot(
+                FrameDurationMs: frameDurationMs,
+                IntervalMs: intervalMs,
+                TotalDrawCalls: total,
+                Styles: styles,
+                PaintSequence: _paintCount,
+                CapturedAtUtc: DateTimeOffset.UtcNow);
+
+            toSignal = _pulse;
+            _pulse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+        toSignal.TrySetResult();
+    }
+
+    /// <inheritdoc />
+    public void NotifyActivity()
+    {
+        TaskCompletionSource toSignal;
+        lock (_gate)
+        {
+            _lastActivityTimestamp = Stopwatch.GetTimestamp();
+            toSignal = _pulse;
+            _pulse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+        toSignal.TrySetResult();
+    }
+
+    /// <inheritdoc />
+    public async Task<RenderIdleResult> WaitForIdleAsync(
+        TimeSpan quietPeriod,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        if (quietPeriod < TimeSpan.Zero) quietPeriod = TimeSpan.Zero;
+        if (timeout < TimeSpan.Zero) timeout = TimeSpan.Zero;
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var quietTicks = ToStopwatchTicks(quietPeriod);
+        var timeoutTicks = ToStopwatchTicks(timeout);
+        var callStart = Stopwatch.GetTimestamp();
+        var startPaintCount = PaintCount;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            long lastActivity;
+            Task pulseTask;
+            lock (_gate)
+            {
+                lastActivity = _lastActivityTimestamp;
+                pulseTask = _pulse.Task;
+            }
+
+            var now = Stopwatch.GetTimestamp();
+            var busy = SafeBusy();
+            var decision = EvaluateIdle(now, callStart, lastActivity, quietTicks, timeoutTicks);
+
+            if (decision.Idle && !busy)
+            {
+                return Done(wentIdle: true, callStart, now, startPaintCount, lastActivity);
+            }
+
+            // The timeout always wins once the deadline passes — including
+            // the case where the quiet timer elapsed (decision.Idle) but a
+            // layer is still busy. Without this guard a map that stays busy
+            // forever (an async fetch that never produces a paint) would
+            // spin here past the requested timeout, because EvaluateIdle
+            // reports Idle as soon as the quiet period elapses whenever the
+            // quiet period is shorter than the timeout.
+            var deadlinePassed = (now - callStart) >= timeoutTicks;
+            if (decision.TimedOut || deadlinePassed)
+            {
+                return Done(wentIdle: false, callStart, now, startPaintCount, lastActivity);
+            }
+
+            // Wait either for the next activity pulse or until the next
+            // decision boundary (idle-at or deadline). When the map is
+            // busy we cannot trust the quiet timer, so poll on a short
+            // cap so the busy flag is re-checked promptly.
+            var waitTicks = decision.WaitTicks;
+            var waitMs = waitTicks <= 0 ? 0.0 : TicksToMilliseconds(waitTicks);
+            if (busy)
+            {
+                waitMs = waitMs <= 0 ? BusyPollMs : Math.Min(waitMs, BusyPollMs);
+
+                // Never poll past the deadline, so the timeout guard above
+                // fires promptly once the busy map exhausts its timeout.
+                var remainingToDeadlineMs = TicksToMilliseconds(callStart + timeoutTicks - now);
+                if (remainingToDeadlineMs > 0 && remainingToDeadlineMs < waitMs)
+                {
+                    waitMs = remainingToDeadlineMs;
+                }
+            }
+            if (waitMs <= 0) waitMs = 1;
+
+            var delayTask = Task.Delay(TimeSpan.FromMilliseconds(waitMs), cancellationToken);
+            var completed = await Task.WhenAny(delayTask, pulseTask).ConfigureAwait(false);
+            if (completed == delayTask)
+            {
+                // Observe cancellation surfaced through the delay.
+                await delayTask.ConfigureAwait(false);
+            }
+        }
+    }
+
+    private RenderIdleResult Done(
+        bool wentIdle, long callStart, long now, long startPaintCount, long lastActivity)
+    {
+        var waitedMs = Stopwatch.GetElapsedTime(callStart, now).TotalMilliseconds;
+        var quietForMs = Stopwatch.GetElapsedTime(lastActivity, now).TotalMilliseconds;
+        if (quietForMs < 0) quietForMs = 0;
+        var paintsObserved = PaintCount - startPaintCount;
+        if (paintsObserved < 0) paintsObserved = 0;
+        return new RenderIdleResult(
+            WentIdle: wentIdle,
+            TimedOut: !wentIdle,
+            WaitedMs: waitedMs,
+            PaintsObserved: paintsObserved,
+            QuietForMs: quietForMs);
+    }
+
+    private bool SafeBusy()
+    {
+        var probe = BusyProbe;
+        if (probe is null) return false;
+        try
+        {
+            return probe();
+        }
+        catch
+        {
+            // A probe that throws (e.g. the layer collection mutated
+            // mid-enumeration) must not abort the wait; treat as not busy.
+            return false;
+        }
+    }
+
+    /// <summary>Short re-check cadence (ms) used while a layer reports busy.</summary>
+    private const double BusyPollMs = 50.0;
+
+    /// <summary>
+    /// Pure idle decision. Given monotonic timestamps (in
+    /// <see cref="Stopwatch"/> ticks), decides whether the wait should
+    /// report idle, time out, or keep waiting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>idleAt = max(lastActivity, callStart) + quiet</c>. Flooring the
+    /// reference at <paramref name="callStartTicks"/> guarantees a minimum
+    /// wait of the quiet period from the call's start, which closes the
+    /// race where a viewport change scheduled a paint that has not begun
+    /// when the wait starts.
+    /// </para>
+    /// <para>
+    /// Timeout precedence is resolved against the idle threshold so a
+    /// late wake-up cannot report idle after the deadline — important
+    /// because the caller may request a quiet period longer than the
+    /// timeout.
+    /// </para>
+    /// </remarks>
+    internal static IdleDecision EvaluateIdle(
+        long nowTicks,
+        long callStartTicks,
+        long lastActivityTicks,
+        long quietTicks,
+        long timeoutTicks)
+    {
+        var reference = Math.Max(lastActivityTicks, callStartTicks);
+        var idleAt = reference + quietTicks;
+        var deadline = callStartTicks + timeoutTicks;
+
+        // If the deadline arrives strictly before the idle threshold, the
+        // timeout wins once reached. When the two coincide (e.g. a quiet
+        // period equal to the timeout with no activity), idle wins via the
+        // check below — a map that stayed quiet for the full period is a
+        // success, not a timeout.
+        if (deadline < idleAt && nowTicks >= deadline)
+        {
+            return new IdleDecision(false, true, 0);
+        }
+        if (nowTicks >= idleAt)
+        {
+            return new IdleDecision(true, false, 0);
+        }
+        if (nowTicks >= deadline)
+        {
+            return new IdleDecision(false, true, 0);
+        }
+
+        var nextBoundary = Math.Min(idleAt, deadline);
+        return new IdleDecision(false, false, nextBoundary - nowTicks);
+    }
+
+    private static long ToStopwatchTicks(TimeSpan span)
+    {
+        if (span <= TimeSpan.Zero) return 0;
+        return (long)(span.TotalSeconds * Stopwatch.Frequency);
+    }
+
+    private static double TicksToMilliseconds(long ticks)
+        => ticks * 1000.0 / Stopwatch.Frequency;
+
+    /// <summary>Result of <see cref="EvaluateIdle"/>.</summary>
+    /// <param name="Idle">The quiet period elapsed with no further activity.</param>
+    /// <param name="TimedOut">The overall timeout elapsed first.</param>
+    /// <param name="WaitTicks">Stopwatch ticks until the next decision boundary (only meaningful when neither flag is set).</param>
+    internal readonly record struct IdleDecision(bool Idle, bool TimedOut, long WaitTicks);
+}
+
+/// <summary>
+/// Static bridge that hands the render thread a reference to the live
+/// <see cref="IRenderActivitySink"/>. Needed because
+/// <see cref="InstrumentedMapControl"/> and the static
+/// <see cref="MapPaintInstrumentation"/> are not resolved from DI; the
+/// host assigns <see cref="Sink"/> from the DI singleton once it is
+/// available, mirroring the late-bound accessor pattern used elsewhere.
+/// </summary>
+internal static class RenderActivityHub
+{
+    /// <summary>
+    /// The live sink, or <see langword="null"/> before the host wires it
+    /// (or after teardown). Render-path code must null-check before use
+    /// and skip per-paint snapshot work when this is unset.
+    /// </summary>
+    public static volatile IRenderActivitySink? Sink;
+}

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -39,6 +39,9 @@ public partial class MainWindow : ShadUI.Window
     private readonly MainViewModel _viewModel;
     private readonly DatasetCatalogAggregator _catalogAggregator;
     private ValidationOverlayService? _validationOverlay;
+    private EncDotNet.S100.Viewer.Diagnostics.RenderActivityMonitor? _renderActivityMonitor;
+    private Map? _renderActivityMap;
+    private EventHandler? _renderActivityRefreshHandler;
     private EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost? _dynamicSourceOverlayHost;
     private readonly List<IDisposable> _dynamicSourceRegistrations = new();
     private string? _screenshotPath;
@@ -146,6 +149,20 @@ public partial class MainWindow : ShadUI.Window
         {
             _validationOverlay?.Dispose();
             _validationOverlay = null;
+            // Detach render-activity wiring so the static hub does not
+            // outlive the window and a torn-down map is not probed.
+            EncDotNet.S100.Viewer.Diagnostics.RenderActivityHub.Sink = null;
+            if (_renderActivityMonitor is not null)
+            {
+                _renderActivityMonitor.BusyProbe = null;
+                if (_renderActivityMap is not null && _renderActivityRefreshHandler is not null)
+                {
+                    _renderActivityMap.RefreshGraphicsRequest -= _renderActivityRefreshHandler;
+                }
+                _renderActivityMonitor = null;
+                _renderActivityMap = null;
+                _renderActivityRefreshHandler = null;
+            }
             // PR-M3: flush any pending debounced size writes so the last
             // splitter drag isn't lost on shutdown.
             _viewModel.OnShutdown();
@@ -218,6 +235,36 @@ public partial class MainWindow : ShadUI.Window
         if (MapControl.Map is { } mapForBackColor)
         {
             mapForBackColor.BackColor = new Mapsui.Styles.Color(170, 211, 223);
+        }
+
+        // Wire the render-activity monitor that backs the MCP
+        // 'await_render_idle' / 'get_render_stats' tools. The
+        // InstrumentedMapControl feeds paint stats through the static
+        // RenderActivityHub.Sink; here we additionally feed Mapsui's
+        // graphics-refresh signal as activity and expose a layer-busy
+        // probe so idle is not reported while an async fetch is pending.
+        if (MapControl.Map is { } activityMap)
+        {
+            var monitor = App.Services.GetRequiredService<
+                EncDotNet.S100.Viewer.Diagnostics.RenderActivityMonitor>();
+            _renderActivityMonitor = monitor;
+            _renderActivityMap = activityMap;
+            EncDotNet.S100.Viewer.Diagnostics.RenderActivityHub.Sink = monitor;
+
+            monitor.BusyProbe = () =>
+            {
+                // Snapshot the layer collection defensively: it may be
+                // mutated on the UI thread while this runs on a threadpool
+                // thread driving an MCP request.
+                foreach (var layer in activityMap.Layers.ToArray())
+                {
+                    if (layer.Busy) return true;
+                }
+                return false;
+            };
+
+            _renderActivityRefreshHandler = (_, _) => monitor.NotifyActivity();
+            activityMap.RefreshGraphicsRequest += _renderActivityRefreshHandler;
         }
 
         // Bind the map-viewport notifier as early as possible so the

--- a/src/EncDotNet.S100.Viewer/McpTools/AwaitRenderIdleMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/AwaitRenderIdleMcpAdapter.cs
@@ -1,0 +1,83 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="AwaitRenderIdleTool"/> as an MCP server tool.</summary>
+internal static class AwaitRenderIdleMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Blocks until the viewer's live map settles — no completed paint, graphics-refresh " +
+        "request, or busy layer for a continuous quiet period — or until a timeout elapses. " +
+        "Use it between 'set_viewport' and 'render_to_image' so the screenshot reflects a " +
+        "settled view instead of racing the render pass. Measures the on-screen map paint " +
+        "loop (not the offscreen render_to_image clone) and always waits at least the quiet " +
+        "period. Returns whether the map went idle, how long it waited, and how many paints " +
+        "completed while waiting.";
+
+    public static McpServerTool Create(AwaitRenderIdleTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [Description("Continuous inactivity (ms) that qualifies as idle; also the minimum time the call waits. Null defaults to 250. Clamped to [0, 10000].")] int? quietPeriodMs = null,
+            [Description("Maximum total time to wait (ms). Null defaults to 5000. Clamped to [50, 120000].")] int? timeoutMs = null,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new AwaitRenderIdleRequest(quietPeriodMs, timeoutMs), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = AwaitRenderIdleTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<AwaitRenderIdleResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return ToolErrorPayload.InternalError(ex, JsonOptions); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<AwaitRenderIdleResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var payload = new JsonObject
+            {
+                ["wentIdle"] = value!.WentIdle,
+                ["timedOut"] = value.TimedOut,
+                ["waitedMs"] = value.WaitedMs,
+                ["paintsObserved"] = value.PaintsObserved,
+                ["quietForMs"] = value.QuietForMs,
+                ["quietPeriodMs"] = value.QuietPeriodMs,
+                ["timeoutMs"] = value.TimeoutMs,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return ToolErrorPayload.AsCallToolResult(err!, JsonOptions);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/AwaitRenderIdleTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/AwaitRenderIdleTool.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Request payload for <see cref="AwaitRenderIdleTool"/>.</summary>
+internal sealed record AwaitRenderIdleRequest(int? QuietPeriodMs = null, int? TimeoutMs = null);
+
+/// <summary>Result payload for <see cref="AwaitRenderIdleTool"/>.</summary>
+internal sealed record AwaitRenderIdleResult(
+    bool WentIdle,
+    bool TimedOut,
+    double WaitedMs,
+    long PaintsObserved,
+    double QuietForMs,
+    int QuietPeriodMs,
+    int TimeoutMs);
+
+/// <summary>
+/// Blocks until the viewer's live map settles (no completed paint, no
+/// graphics-refresh request, and no busy layer for a continuous quiet
+/// period) or a timeout elapses. Lets scripted / agent callers make a
+/// subsequent <c>render_to_image</c> deterministic instead of racing
+/// the render pass.
+/// </summary>
+/// <remarks>
+/// Quiescence is measured against the on-screen
+/// <c>InstrumentedMapControl</c> paint loop and Mapsui's
+/// graphics-refresh / layer-busy signals — not against the offscreen
+/// PNG clone produced by <c>render_to_image</c>. The call always waits
+/// at least the quiet period so a paint just scheduled by a preceding
+/// <c>set_viewport</c> has time to begin.
+/// </remarks>
+internal sealed class AwaitRenderIdleTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "await_render_idle";
+
+    internal const int DefaultQuietPeriodMs = 250;
+    internal const int MinQuietPeriodMs = 0;
+    internal const int MaxQuietPeriodMs = 10_000;
+
+    internal const int DefaultTimeoutMs = 5_000;
+    internal const int MinTimeoutMs = 50;
+    internal const int MaxTimeoutMs = 120_000;
+
+    private readonly IRenderActivityMonitor _monitor;
+
+    /// <summary>Creates a new <see cref="AwaitRenderIdleTool"/>.</summary>
+    public AwaitRenderIdleTool(IRenderActivityMonitor monitor)
+    {
+        ArgumentNullException.ThrowIfNull(monitor);
+        _monitor = monitor;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public async Task<ToolResult<AwaitRenderIdleResult>> InvokeAsync(
+        AwaitRenderIdleRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var quiet = Clamp(request.QuietPeriodMs ?? DefaultQuietPeriodMs, MinQuietPeriodMs, MaxQuietPeriodMs);
+        var timeout = Clamp(request.TimeoutMs ?? DefaultTimeoutMs, MinTimeoutMs, MaxTimeoutMs);
+
+        var outcome = await _monitor.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(quiet),
+            TimeSpan.FromMilliseconds(timeout),
+            cancellationToken).ConfigureAwait(false);
+
+        return ToolResult<AwaitRenderIdleResult>.Ok(new AwaitRenderIdleResult(
+            WentIdle: outcome.WentIdle,
+            TimedOut: outcome.TimedOut,
+            WaitedMs: outcome.WaitedMs,
+            PaintsObserved: outcome.PaintsObserved,
+            QuietForMs: outcome.QuietForMs,
+            QuietPeriodMs: quiet,
+            TimeoutMs: timeout));
+    }
+
+    private static int Clamp(int value, int min, int max)
+        => value < min ? min : value > max ? max : value;
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/GetRenderStatsMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/GetRenderStatsMcpAdapter.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="GetRenderStatsTool"/> as an MCP server tool.</summary>
+internal static class GetRenderStatsMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Reports the cost of the viewer's most recently completed on-screen map paint: " +
+        "wall-clock frame duration (ms), interval since the previous paint, total style " +
+        "draw calls, and a per-style breakdown (calls + duration). Use it to measure " +
+        "rendering performance across pan/zoom, palette, or time-step changes. Pair with " +
+        "'await_render_idle' so the reported paint reflects a settled view. Describes the " +
+        "live map paint, not the offscreen render_to_image clone; returns hasData=false " +
+        "when no paint has occurred yet.";
+
+    public static McpServerTool Create(GetRenderStatsTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new GetRenderStatsRequest(), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = GetRenderStatsTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<GetRenderStatsResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return ToolErrorPayload.InternalError(ex, JsonOptions); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<GetRenderStatsResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var styles = new JsonArray();
+            foreach (var s in value!.Styles)
+            {
+                styles.Add(new JsonObject
+                {
+                    ["style"] = s.Style,
+                    ["calls"] = s.Calls,
+                    ["durationMs"] = s.DurationMs,
+                });
+            }
+
+            var payload = new JsonObject
+            {
+                ["hasData"] = value.HasData,
+                ["frameDurationMs"] = value.FrameDurationMs,
+                ["intervalMs"] = value.IntervalMs,
+                ["totalDrawCalls"] = value.TotalDrawCalls,
+                ["paintSequence"] = value.PaintSequence,
+                ["capturedAtUtc"] = value.CapturedAtUtc,
+                ["styles"] = styles,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return ToolErrorPayload.AsCallToolResult(err!, JsonOptions);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/GetRenderStatsTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/GetRenderStatsTool.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Request payload for <see cref="GetRenderStatsTool"/> (no parameters).</summary>
+internal sealed record GetRenderStatsRequest;
+
+/// <summary>Per-style entry in a <see cref="GetRenderStatsResult"/>.</summary>
+internal sealed record RenderStyleStatDto(string Style, long Calls, double DurationMs);
+
+/// <summary>Result payload for <see cref="GetRenderStatsTool"/>.</summary>
+internal sealed record GetRenderStatsResult(
+    bool HasData,
+    double? FrameDurationMs,
+    double? IntervalMs,
+    long? TotalDrawCalls,
+    long? PaintSequence,
+    string? CapturedAtUtc,
+    System.Collections.Generic.IReadOnlyList<RenderStyleStatDto> Styles);
+
+/// <summary>
+/// Reports the cost of the viewer's most recently completed map paint:
+/// wall-clock frame duration, interval since the previous paint, total
+/// style-renderer draw calls, and a per-style breakdown. Lets agents
+/// measure rendering performance (e.g. across pan/zoom or palette
+/// changes) without inferring it from external wall-clock timing.
+/// </summary>
+/// <remarks>
+/// The figures describe the on-screen <c>InstrumentedMapControl</c>
+/// paint, not the offscreen <c>render_to_image</c> clone. Pair with
+/// <c>await_render_idle</c> so the reported paint reflects a settled
+/// view. Returns <c>hasData == false</c> when no paint has occurred yet.
+/// </remarks>
+internal sealed class GetRenderStatsTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "get_render_stats";
+
+    private readonly IRenderActivityMonitor _monitor;
+
+    /// <summary>Creates a new <see cref="GetRenderStatsTool"/>.</summary>
+    public GetRenderStatsTool(IRenderActivityMonitor monitor)
+    {
+        ArgumentNullException.ThrowIfNull(monitor);
+        _monitor = monitor;
+    }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<GetRenderStatsResult>> InvokeAsync(
+        GetRenderStatsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var snapshot = _monitor.LatestStats;
+        if (snapshot is null)
+        {
+            return Task.FromResult(ToolResult<GetRenderStatsResult>.Ok(new GetRenderStatsResult(
+                HasData: false,
+                FrameDurationMs: null,
+                IntervalMs: null,
+                TotalDrawCalls: null,
+                PaintSequence: null,
+                CapturedAtUtc: null,
+                Styles: Array.Empty<RenderStyleStatDto>())));
+        }
+
+        var styles = new RenderStyleStatDto[snapshot.Styles.Count];
+        for (var i = 0; i < styles.Length; i++)
+        {
+            var s = snapshot.Styles[i];
+            styles[i] = new RenderStyleStatDto(s.Style, s.Calls, s.DurationMs);
+        }
+
+        return Task.FromResult(ToolResult<GetRenderStatsResult>.Ok(new GetRenderStatsResult(
+            HasData: true,
+            FrameDurationMs: snapshot.FrameDurationMs,
+            IntervalMs: snapshot.IntervalMs,
+            TotalDrawCalls: snapshot.TotalDrawCalls,
+            PaintSequence: snapshot.PaintSequence,
+            CapturedAtUtc: snapshot.CapturedAtUtc.ToString("O"),
+            Styles: styles)));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -305,14 +305,20 @@ sets the bind address (loopback recommended). Any MCP flag implies
 `--mcp-port-file <PATH>` writes the bound endpoint URI to a file once
 the server is listening (the endpoint is also echoed to stdout as
 `[MCP] listening on …`). A CLI-driven MCP run never persists the
-bound port back to the user's `settings.json`. Four viewer-only tools
+bound port back to the user's `settings.json`. Six viewer-only tools
 are injected when the server starts: `render_to_image` (read-only —
 captures a PNG snapshot from a clone of the live map),
 `set_viewport` (mutating — drives the live navigator to a bbox or
-centre+zoom), `set_palette` (mutating — Day / Dusk / Night), and
+centre+zoom), `set_palette` (mutating — Day / Dusk / Night),
 `set_display_category` (mutating — DisplayBase / Standard /
-OtherInformation / All). See `docs/mcp-server.md` for the full
-catalogue and the read-only / mutating split.
+OtherInformation / All), `await_render_idle` (read-only — blocks
+until the live map settles so a following `render_to_image` is
+deterministic instead of racing the render pass), and
+`get_render_stats` (read-only — reports the cost of the last
+on-screen paint: frame duration, interval, and per-style draw-call
+breakdown, for measuring rendering performance). See
+`docs/mcp-server.md` for the full catalogue and the read-only /
+mutating split.
 
 **Settings isolation.** `--settings <PATH>` points the run at an
 alternate settings file instead of the per-user default.

--- a/src/EncDotNet.S100.Viewer/Services/IRenderActivityMonitor.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IRenderActivityMonitor.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Per-style aggregate for a single completed map paint: how many
+/// style-renderer <c>Draw</c> calls of a given style type ran and how
+/// long they took in total. Aggregated across layers and geometry-size
+/// buckets so the list stays compact.
+/// </summary>
+/// <param name="Style">Style-renderer type name (e.g. <c>VectorStyle</c>, <c>SymbolStyle</c>, <c>LabelStyle</c>).</param>
+/// <param name="Calls">Number of <c>Draw</c> calls of this style in the paint.</param>
+/// <param name="DurationMs">Cumulative wall-clock duration of those calls, in milliseconds.</param>
+internal sealed record RenderStyleStat(string Style, long Calls, double DurationMs);
+
+/// <summary>
+/// Immutable snapshot of the most recently completed map paint on the
+/// live compositor render thread.
+/// </summary>
+/// <remarks>
+/// These figures describe the on-screen <c>InstrumentedMapControl</c>
+/// paint — <b>not</b> the offscreen PNG produced by
+/// <c>render_to_image</c>, which clones the map and renders on a
+/// separate path. Pair with <c>await_render_idle</c> to ensure the
+/// snapshot reflects a settled view.
+/// </remarks>
+/// <param name="FrameDurationMs">Wall-clock duration of the paint, in milliseconds.</param>
+/// <param name="IntervalMs">Interval since the previous paint completed, in milliseconds, or <see langword="null"/> for the first observed paint.</param>
+/// <param name="TotalDrawCalls">Total style-renderer <c>Draw</c> calls across all styles in the paint.</param>
+/// <param name="Styles">Per-style breakdown, ordered by descending duration.</param>
+/// <param name="PaintSequence">Monotonic 1-based index of this paint since the monitor started observing.</param>
+/// <param name="CapturedAtUtc">UTC wall-clock time the snapshot was published.</param>
+internal sealed record RenderStatsSnapshot(
+    double FrameDurationMs,
+    double? IntervalMs,
+    long TotalDrawCalls,
+    IReadOnlyList<RenderStyleStat> Styles,
+    long PaintSequence,
+    DateTimeOffset CapturedAtUtc);
+
+/// <summary>Outcome of <see cref="IRenderActivityMonitor.WaitForIdleAsync"/>.</summary>
+/// <param name="WentIdle">
+/// <see langword="true"/> when the map quiesced (no paint or refresh
+/// request for the requested quiet period, and no layer reporting busy)
+/// before the timeout elapsed.
+/// </param>
+/// <param name="TimedOut">
+/// <see langword="true"/> when the timeout elapsed before the map
+/// quiesced. Mutually exclusive with <see cref="WentIdle"/>.
+/// </param>
+/// <param name="WaitedMs">Total wall-clock time spent waiting, in milliseconds.</param>
+/// <param name="PaintsObserved">Number of paints that completed while the call was waiting.</param>
+/// <param name="QuietForMs">
+/// Milliseconds since the last observed render activity at the moment
+/// the call returned.
+/// </param>
+internal readonly record struct RenderIdleResult(
+    bool WentIdle,
+    bool TimedOut,
+    double WaitedMs,
+    long PaintsObserved,
+    double QuietForMs);
+
+/// <summary>
+/// Observes the viewer's live map render activity so scripted / agent
+/// callers can (a) block until the map settles before screenshotting
+/// and (b) read back the cost of the last paint. Registered as a DI
+/// singleton; fed from the render thread via <see cref="IRenderActivitySink"/>.
+/// </summary>
+/// <remarks>
+/// All members are safe to call from any thread. The monitor exists from
+/// app startup and simply reports "no activity" until the map control
+/// begins painting.
+/// </remarks>
+internal interface IRenderActivityMonitor
+{
+    /// <summary>
+    /// Total number of paints observed since startup. Monotonic.
+    /// </summary>
+    long PaintCount { get; }
+
+    /// <summary>
+    /// The most recently completed paint's statistics, or
+    /// <see langword="null"/> when no paint has been observed yet.
+    /// </summary>
+    RenderStatsSnapshot? LatestStats { get; }
+
+    /// <summary>
+    /// A predicate reporting whether the map currently has a render in
+    /// flight (e.g. a tile or feature fetch that has not yet produced a
+    /// paint). Set by the host once the map control exists; when
+    /// unset, the monitor assumes the map is never busy. Used to keep
+    /// <see cref="WaitForIdleAsync"/> from reporting idle while an
+    /// asynchronous fetch is still pending.
+    /// </summary>
+    Func<bool>? BusyProbe { get; set; }
+
+    /// <summary>
+    /// Waits until the live map has been quiet — no completed paint, no
+    /// graphics-refresh request, and no busy layer — for a continuous
+    /// <paramref name="quietPeriod"/>, or until <paramref name="timeout"/>
+    /// elapses, whichever comes first.
+    /// </summary>
+    /// <param name="quietPeriod">
+    /// Continuous span of inactivity that qualifies as idle. The call
+    /// always waits at least this long from invocation, which gives a
+    /// just-requested paint (e.g. from a preceding viewport change) time
+    /// to begin before idle can be declared.
+    /// </param>
+    /// <param name="timeout">Maximum total time to wait.</param>
+    /// <param name="cancellationToken">Cancels the wait.</param>
+    /// <returns>The wait outcome.</returns>
+    Task<RenderIdleResult> WaitForIdleAsync(
+        TimeSpan quietPeriod,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Render-thread-facing write surface of the render activity monitor.
+/// Implemented by the same singleton that implements
+/// <see cref="IRenderActivityMonitor"/>; kept separate so the
+/// instrumentation plumbing depends only on the narrow write contract.
+/// </summary>
+internal interface IRenderActivitySink
+{
+    /// <summary>
+    /// Records a completed paint. Called once per paint from the
+    /// compositor render thread.
+    /// </summary>
+    /// <param name="frameDurationMs">Wall-clock duration of the paint, in milliseconds.</param>
+    /// <param name="styles">
+    /// Immutable per-style breakdown for the paint. The caller must pass
+    /// a fresh list the monitor can retain; the monitor does not copy it.
+    /// </param>
+    void NotifyPaint(double frameDurationMs, IReadOnlyList<RenderStyleStat> styles);
+
+    /// <summary>
+    /// Records non-paint render activity (e.g. a graphics-refresh
+    /// request raised after an asynchronous data fetch). Resets the
+    /// quiet timer without producing a stats snapshot. Safe to call
+    /// from any thread.
+    /// </summary>
+    void NotifyActivity();
+}

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -30,6 +30,7 @@ internal sealed class McpServerHost : IAsyncDisposable
     private readonly IMapHostAccessor? _mapHostAccessor;
     private readonly IRenderStateControllerAccessor? _renderStateAccessor;
     private readonly GlobalTimeService? _globalTime;
+    private readonly IRenderActivityMonitor? _renderActivityMonitor;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -42,7 +43,8 @@ internal sealed class McpServerHost : IAsyncDisposable
         IMapHostAccessor? mapHostAccessor = null,
         ILoggerFactory? loggers = null,
         IRenderStateControllerAccessor? renderStateAccessor = null,
-        GlobalTimeService? globalTime = null)
+        GlobalTimeService? globalTime = null,
+        IRenderActivityMonitor? renderActivityMonitor = null)
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(settings);
@@ -51,6 +53,7 @@ internal sealed class McpServerHost : IAsyncDisposable
         _mapHostAccessor = mapHostAccessor;
         _renderStateAccessor = renderStateAccessor;
         _globalTime = globalTime;
+        _renderActivityMonitor = renderActivityMonitor;
         _loggers = loggers;
     }
 
@@ -273,6 +276,11 @@ internal sealed class McpServerHost : IAsyncDisposable
         if (_globalTime is not null)
         {
             tools.Add(SetTimeStepMcpAdapter.Create(new SetTimeStepTool(_globalTime)));
+        }
+        if (_renderActivityMonitor is not null)
+        {
+            tools.Add(AwaitRenderIdleMcpAdapter.Create(new AwaitRenderIdleTool(_renderActivityMonitor)));
+            tools.Add(GetRenderStatsMcpAdapter.Create(new GetRenderStatsTool(_renderActivityMonitor)));
         }
         return tools.Count == 0 ? null : tools;
     }

--- a/tests/EncDotNet.S100.Viewer.Tests/RenderActivityMonitorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RenderActivityMonitorTests.cs
@@ -146,17 +146,34 @@ public class RenderActivityMonitorTests
     [Fact]
     public async Task WaitForIdleAsync_observes_paint_during_wait()
     {
-        var m = new RenderActivityMonitor();
-        var waitTask = m.WaitForIdleAsync(
-            TimeSpan.FromMilliseconds(60), TimeSpan.FromSeconds(5));
+        // A paint that lands while the call is waiting must be counted in
+        // PaintsObserved, and the monitor must still settle afterwards.
+        //
+        // Driving the paint off a wall-clock delay races the quiet timer
+        // (under load the delayed paint can slip past the quiet window, so
+        // the monitor settles first and observes zero paints). Instead,
+        // inject the paint synchronously the first time the wait loop polls
+        // BusyProbe: that poll happens on the first iteration, before any
+        // idle can be declared, so the paint is deterministically observed
+        // exactly once while the probe stays "not busy".
+        RenderActivityMonitor m = null!;
+        var painted = false;
+        m = new RenderActivityMonitor
+        {
+            BusyProbe = () =>
+            {
+                if (!painted)
+                {
+                    painted = true;
+                    m.NotifyPaint(5.0, Styles(("VectorStyle", 1, 2.0)));
+                }
+                return false;
+            },
+        };
 
-        // Let the wait start, then report a paint. The 60ms quiet window
-        // means the paint lands well within the wait, so it is observed
-        // and the monitor still settles afterwards.
-        await Task.Delay(10);
-        m.NotifyPaint(5.0, Styles(("VectorStyle", 1, 2.0)));
+        var result = await m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(40), TimeSpan.FromSeconds(5));
 
-        var result = await waitTask;
         Assert.True(result.WentIdle);
         Assert.Equal(1, result.PaintsObserved);
     }

--- a/tests/EncDotNet.S100.Viewer.Tests/RenderActivityMonitorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RenderActivityMonitorTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.Diagnostics;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="RenderActivityMonitor"/>: the pure idle
+/// decision boundaries, stats capture, and the async wait loop.
+/// </summary>
+public class RenderActivityMonitorTests
+{
+    private static IReadOnlyList<RenderStyleStat> Styles(params (string name, long calls, double ms)[] s)
+    {
+        var list = new List<RenderStyleStat>();
+        foreach (var (name, calls, ms) in s) list.Add(new RenderStyleStat(name, calls, ms));
+        return list;
+    }
+
+    // ---- EvaluateIdle (pure) -------------------------------------------
+
+    [Fact]
+    public void EvaluateIdle_reports_idle_once_quiet_period_elapsed()
+    {
+        // callStart=0, no later activity, quiet=100, timeout=1000.
+        var d = RenderActivityMonitor.EvaluateIdle(
+            nowTicks: 100, callStartTicks: 0, lastActivityTicks: 0,
+            quietTicks: 100, timeoutTicks: 1000);
+        Assert.True(d.Idle);
+        Assert.False(d.TimedOut);
+    }
+
+    [Fact]
+    public void EvaluateIdle_keeps_waiting_before_quiet_period()
+    {
+        var d = RenderActivityMonitor.EvaluateIdle(
+            nowTicks: 40, callStartTicks: 0, lastActivityTicks: 0,
+            quietTicks: 100, timeoutTicks: 1000);
+        Assert.False(d.Idle);
+        Assert.False(d.TimedOut);
+        Assert.Equal(60, d.WaitTicks); // idleAt(100) - now(40)
+    }
+
+    [Fact]
+    public void EvaluateIdle_minimum_wait_floored_at_call_start()
+    {
+        // lastActivity is far in the past, but the call just started:
+        // idle must not be reported until quiet elapses from callStart.
+        var d = RenderActivityMonitor.EvaluateIdle(
+            nowTicks: 1000, callStartTicks: 1000, lastActivityTicks: 0,
+            quietTicks: 100, timeoutTicks: 5000);
+        Assert.False(d.Idle);
+        Assert.False(d.TimedOut);
+        Assert.Equal(100, d.WaitTicks);
+    }
+
+    [Fact]
+    public void EvaluateIdle_recent_activity_extends_wait()
+    {
+        // Activity at tick 500 pushes idleAt to 600.
+        var d = RenderActivityMonitor.EvaluateIdle(
+            nowTicks: 550, callStartTicks: 0, lastActivityTicks: 500,
+            quietTicks: 100, timeoutTicks: 5000);
+        Assert.False(d.Idle);
+        Assert.Equal(50, d.WaitTicks);
+    }
+
+    [Fact]
+    public void EvaluateIdle_times_out_when_deadline_precedes_idle()
+    {
+        // quietPeriod (1000) longer than timeout (200): the deadline at
+        // 200 must win and never falsely report idle afterwards.
+        var d = RenderActivityMonitor.EvaluateIdle(
+            nowTicks: 250, callStartTicks: 0, lastActivityTicks: 0,
+            quietTicks: 1000, timeoutTicks: 200);
+        Assert.False(d.Idle);
+        Assert.True(d.TimedOut);
+    }
+
+    [Fact]
+    public void EvaluateIdle_idle_wins_when_thresholds_coincide()
+    {
+        // idleAt == deadline == 100: success boundary wins.
+        var d = RenderActivityMonitor.EvaluateIdle(
+            nowTicks: 100, callStartTicks: 0, lastActivityTicks: 0,
+            quietTicks: 100, timeoutTicks: 100);
+        Assert.True(d.Idle);
+        Assert.False(d.TimedOut);
+    }
+
+    // ---- Stats capture -------------------------------------------------
+
+    [Fact]
+    public void NotifyPaint_captures_latest_stats_and_counts()
+    {
+        var m = new RenderActivityMonitor();
+        Assert.Null(m.LatestStats);
+        Assert.Equal(0, m.PaintCount);
+
+        m.NotifyPaint(12.5, Styles(("VectorStyle", 3, 8.0), ("LabelStyle", 2, 4.0)));
+
+        Assert.Equal(1, m.PaintCount);
+        var s = m.LatestStats;
+        Assert.NotNull(s);
+        Assert.Equal(12.5, s!.FrameDurationMs);
+        Assert.Null(s.IntervalMs); // first paint has no interval
+        Assert.Equal(5, s.TotalDrawCalls);
+        Assert.Equal(1, s.PaintSequence);
+        Assert.Equal(2, s.Styles.Count);
+    }
+
+    [Fact]
+    public void NotifyPaint_second_paint_has_interval_and_sequence()
+    {
+        var m = new RenderActivityMonitor();
+        m.NotifyPaint(10.0, Styles(("VectorStyle", 1, 1.0)));
+        m.NotifyPaint(11.0, Styles(("VectorStyle", 1, 1.0)));
+
+        Assert.Equal(2, m.PaintCount);
+        var s = m.LatestStats!;
+        Assert.Equal(2, s.PaintSequence);
+        Assert.NotNull(s.IntervalMs);
+        Assert.True(s.IntervalMs >= 0);
+    }
+
+    // ---- WaitForIdleAsync ----------------------------------------------
+
+    [Fact]
+    public async Task WaitForIdleAsync_returns_idle_when_quiet()
+    {
+        var m = new RenderActivityMonitor();
+        var result = await m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(20), TimeSpan.FromSeconds(2));
+
+        Assert.True(result.WentIdle);
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.PaintsObserved);
+        Assert.True(result.WaitedMs >= 0);
+    }
+
+    [Fact]
+    public async Task WaitForIdleAsync_observes_paint_during_wait()
+    {
+        var m = new RenderActivityMonitor();
+        var waitTask = m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(60), TimeSpan.FromSeconds(5));
+
+        // Let the wait start, then report a paint. The 60ms quiet window
+        // means the paint lands well within the wait, so it is observed
+        // and the monitor still settles afterwards.
+        await Task.Delay(10);
+        m.NotifyPaint(5.0, Styles(("VectorStyle", 1, 2.0)));
+
+        var result = await waitTask;
+        Assert.True(result.WentIdle);
+        Assert.Equal(1, result.PaintsObserved);
+    }
+
+    [Fact]
+    public async Task WaitForIdleAsync_times_out_while_busy()
+    {
+        var m = new RenderActivityMonitor { BusyProbe = () => true };
+        var result = await m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(150));
+
+        Assert.False(result.WentIdle);
+        Assert.True(result.TimedOut);
+    }
+
+    [Fact]
+    public async Task WaitForIdleAsync_recovers_when_busy_clears()
+    {
+        var busy = true;
+        // ReSharper disable once AccessToModifiedClosure
+        var m = new RenderActivityMonitor { BusyProbe = () => Volatile.Read(ref busy) };
+        var waitTask = m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(20), TimeSpan.FromSeconds(5));
+
+        await Task.Delay(60);
+        Volatile.Write(ref busy, false);
+        m.NotifyActivity(); // wake the waiter promptly
+
+        var result = await waitTask;
+        Assert.True(result.WentIdle);
+    }
+
+    [Fact]
+    public async Task WaitForIdleAsync_honours_cancellation()
+    {
+        var m = new RenderActivityMonitor { BusyProbe = () => true };
+        using var cts = new CancellationTokenSource();
+        var waitTask = m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(50), TimeSpan.FromSeconds(30), cts.Token);
+
+        await Task.Delay(20);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitTask);
+    }
+
+    [Fact]
+    public async Task WaitForIdleAsync_busy_probe_exception_is_swallowed()
+    {
+        var m = new RenderActivityMonitor { BusyProbe = () => throw new InvalidOperationException() };
+        var result = await m.WaitForIdleAsync(
+            TimeSpan.FromMilliseconds(20), TimeSpan.FromSeconds(2));
+        Assert.True(result.WentIdle);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RenderObservabilityToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RenderObservabilityToolTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests the two render-observability MCP tools and their adapters end
+/// to end against a fake <see cref="IRenderActivityMonitor"/>.
+/// </summary>
+public class RenderObservabilityToolTests
+{
+    private sealed class FakeMonitor : IRenderActivityMonitor
+    {
+        public long PaintCount { get; set; }
+        public RenderStatsSnapshot? LatestStats { get; set; }
+        public Func<bool>? BusyProbe { get; set; }
+        public RenderIdleResult NextResult { get; set; }
+        public TimeSpan SeenQuiet { get; private set; }
+        public TimeSpan SeenTimeout { get; private set; }
+
+        public Task<RenderIdleResult> WaitForIdleAsync(
+            TimeSpan quietPeriod, TimeSpan timeout, System.Threading.CancellationToken ct = default)
+        {
+            SeenQuiet = quietPeriod;
+            SeenTimeout = timeout;
+            return Task.FromResult(NextResult);
+        }
+    }
+
+    private static JsonObject Parse(CallToolResult result)
+    {
+        var text = Assert.IsType<TextContentBlock>(result.Content[0]).Text;
+        return (JsonObject)JsonNode.Parse(text)!;
+    }
+
+    // ---- await_render_idle ---------------------------------------------
+
+    [Fact]
+    public async Task AwaitRenderIdle_applies_defaults_and_echoes_outcome()
+    {
+        var monitor = new FakeMonitor
+        {
+            NextResult = new RenderIdleResult(true, false, 42.0, 3, 250.0),
+        };
+        var tool = new AwaitRenderIdleTool(monitor);
+
+        var result = await tool.InvokeAsync(new AwaitRenderIdleRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(AwaitRenderIdleTool.DefaultQuietPeriodMs, value!.QuietPeriodMs);
+        Assert.Equal(AwaitRenderIdleTool.DefaultTimeoutMs, value.TimeoutMs);
+        Assert.True(value.WentIdle);
+        Assert.Equal(3, value.PaintsObserved);
+        Assert.Equal(TimeSpan.FromMilliseconds(AwaitRenderIdleTool.DefaultQuietPeriodMs), monitor.SeenQuiet);
+    }
+
+    [Fact]
+    public async Task AwaitRenderIdle_clamps_out_of_range_arguments()
+    {
+        var monitor = new FakeMonitor { NextResult = new RenderIdleResult(false, true, 1, 0, 1) };
+        var tool = new AwaitRenderIdleTool(monitor);
+
+        var result = await tool.InvokeAsync(new AwaitRenderIdleRequest(QuietPeriodMs: 999_999, TimeoutMs: 1));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal(AwaitRenderIdleTool.MaxQuietPeriodMs, value!.QuietPeriodMs);
+        Assert.Equal(AwaitRenderIdleTool.MinTimeoutMs, value.TimeoutMs);
+    }
+
+    [Fact]
+    public void AwaitRenderIdle_adapter_serialises_success()
+    {
+        var ok = ToolResult<AwaitRenderIdleResult>.Ok(
+            new AwaitRenderIdleResult(true, false, 12.0, 2, 250.0, 250, 5000));
+        var call = AwaitRenderIdleMcpAdapter.TranslateResult(ok);
+
+        Assert.False(call.IsError);
+        var json = Parse(call);
+        Assert.True((bool)json["wentIdle"]!);
+        Assert.Equal(2, (long)json["paintsObserved"]!);
+        Assert.Equal(250, (int)json["quietPeriodMs"]!);
+    }
+
+    // ---- get_render_stats ----------------------------------------------
+
+    [Fact]
+    public async Task GetRenderStats_reports_no_data_when_no_paint()
+    {
+        var tool = new GetRenderStatsTool(new FakeMonitor { LatestStats = null });
+        var result = await tool.InvokeAsync(new GetRenderStatsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.False(value!.HasData);
+        Assert.Null(value.FrameDurationMs);
+        Assert.Empty(value.Styles);
+    }
+
+    [Fact]
+    public async Task GetRenderStats_projects_latest_snapshot()
+    {
+        var snapshot = new RenderStatsSnapshot(
+            FrameDurationMs: 14.0,
+            IntervalMs: 33.0,
+            TotalDrawCalls: 7,
+            Styles: new List<RenderStyleStat>
+            {
+                new("VectorStyle", 5, 9.0),
+                new("LabelStyle", 2, 3.0),
+            },
+            PaintSequence: 42,
+            CapturedAtUtc: DateTimeOffset.UnixEpoch);
+        var tool = new GetRenderStatsTool(new FakeMonitor { LatestStats = snapshot });
+
+        var result = await tool.InvokeAsync(new GetRenderStatsRequest());
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.True(value!.HasData);
+        Assert.Equal(14.0, value.FrameDurationMs);
+        Assert.Equal(7, value.TotalDrawCalls);
+        Assert.Equal(2, value.Styles.Count);
+        Assert.Equal("VectorStyle", value.Styles[0].Style);
+    }
+
+    [Fact]
+    public void GetRenderStats_adapter_serialises_styles_array()
+    {
+        var ok = ToolResult<GetRenderStatsResult>.Ok(new GetRenderStatsResult(
+            HasData: true,
+            FrameDurationMs: 14.0,
+            IntervalMs: 33.0,
+            TotalDrawCalls: 7,
+            PaintSequence: 42,
+            CapturedAtUtc: DateTimeOffset.UnixEpoch.ToString("O"),
+            Styles: new[] { new RenderStyleStatDto("VectorStyle", 5, 9.0) }));
+        var call = GetRenderStatsMcpAdapter.TranslateResult(ok);
+
+        Assert.False(call.IsError);
+        var json = Parse(call);
+        Assert.True((bool)json["hasData"]!);
+        var styles = (JsonArray)json["styles"]!;
+        Assert.Single(styles);
+        Assert.Equal("VectorStyle", (string)styles[0]!["style"]!);
+    }
+
+    [Fact]
+    public void GetRenderStats_adapter_serialises_no_data()
+    {
+        var ok = ToolResult<GetRenderStatsResult>.Ok(new GetRenderStatsResult(
+            HasData: false, null, null, null, null, null, Array.Empty<RenderStyleStatDto>()));
+        var call = GetRenderStatsMcpAdapter.TranslateResult(ok);
+
+        Assert.False(call.IsError);
+        var json = Parse(call);
+        Assert.False((bool)json["hasData"]!);
+        Assert.Empty((JsonArray)json["styles"]!);
+    }
+}


### PR DESCRIPTION
## Summary

Expands the viewer's embedded MCP server with two **render-observability** tools so automation agents can drive deterministic screenshots and measure rendering cost — the first slice of the broader "let agents drive a running viewer" effort.

| Tool | Kind | What it does |
|---|---|---|
| `await_render_idle` | viewer-only, read-only | Blocks until the live map settles (no completed paint, graphics-refresh request, or busy layer for a continuous quiet period) or a timeout elapses. Use it between `set_viewport` and `render_to_image` so a capture reflects a settled view instead of racing the render pass. `quietPeriodMs` default 250 (clamp `[0, 10000]`); `timeoutMs` default 5000 (clamp `[50, 120000]`). |
| `get_render_stats` | viewer-only, read-only | Reports the most recently completed on-screen paint's wall-clock frame duration, interval since the previous paint, total style draw calls, and a per-style breakdown (calls + duration), for measuring rendering performance across pan/zoom, palette, or time-step changes. |

Both describe the live `InstrumentedMapControl` paint loop — **not** the offscreen `render_to_image` clone — and that contract is documented in the tool descriptions.

## Implementation

- **`RenderActivityMonitor`** — thread-safe DI singleton implementing `IRenderActivityMonitor` (read/wait surface) and `IRenderActivitySink` (render-thread write surface). All shared state is guarded by a single lock; waiter wake-ups use a refreshable `TaskCompletionSource(RunContinuationsAsynchronously)` signalled outside the lock.
- **Pure `EvaluateIdle`** — the idle/timeout decision is a side-effect-free static method over monotonic `Stopwatch` ticks, so its boundary behaviour is deterministically unit-testable without timing flakiness.
- **Robust quiescence** — idle requires both a quiet period *and* no busy layer (`ILayer.Busy`), and treats `Map.RefreshGraphicsRequest` as activity. This prevents an async tile/feature fetch that hasn't painted yet from reading as idle. A minimum wait of the quiet period closes the `set_viewport` → scheduled-paint race.
- **Static `RenderActivityHub` bridge** — `InstrumentedMapControl` and the static `MapPaintInstrumentation` aren't DI-resolved, so the host assigns `Hub.Sink` from the DI singleton at startup (mirroring the existing late-bound accessor pattern). Per-paint snapshot allocation only happens when a sink is attached.
- Two tools + MCP adapters follow the established viewer adapter pattern (`ToolResult<T>` → `CallToolResult` with a single JSON `TextContentBlock`, `TranslateResult` test seam). `McpServerHost` gains an optional monitor parameter and registers the tools when present; existing ctor call sites are unaffected.

## Bug fixed (latent, not just a test artefact)

`WaitForIdleAsync` could **loop forever** when a layer stayed `Busy` and `quietPeriod < timeout`: once the quiet timer elapsed, `EvaluateIdle` reported `Idle`, the caller suppressed the return because the map was busy, and it **never re-checked the deadline** — so `await_render_idle` could hang well past its own timeout on a stuck-busy map. Fixed by adding a `deadlinePassed` guard in the wait loop (returns timed-out once the timeout elapses even when the timer says idle-but-busy) and capping the busy poll so it never waits past the deadline. `EvaluateIdle`'s first branch was tightened to strict `deadline < idleAt` so idle still wins exact ties. Covered by `WaitForIdleAsync_times_out_while_busy`.

## Tests

- `RenderActivityMonitorTests` (14) — pure `EvaluateIdle` boundary cases, stats/interval/sequence capture, and async `WaitForIdleAsync` behaviour (already-idle, paint-observed-mid-wait, busy timeout, busy-then-recovers, cancellation, probe-exception-swallowed).
- `RenderObservabilityToolTests` (7) — tool defaulting/clamping against a fake monitor and adapter JSON serialization (success, no-data, styles array).

**Verification:** `EncDotNet.S100.Viewer.Tests` 600/600 and `EncDotNet.S100.Mcp.Tests` 24/24 pass; build clean (only pre-existing warnings).

## Docs

- `src/EncDotNet.S100.Viewer/README.md` — now lists "Six viewer-only tools".
- `docs/mcp-server.md` — tool table rows for both tools and the read-only/mutating classification updated.