### PR TITLE
Add open_dataset and close_dataset viewer MCP tools

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -123,6 +123,8 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `set_time_step` *(viewer only, **mutating**)* | Drives the viewer's global time clock to a specific sample for time-aware datasets (S-104 / S-111 / S-411). Supply EITHER `index` (0-based integer into `list_time_steps`) OR `timestamp` (ISO-8601, snapped to the nearest sample). Returns the resolved index and snapped timestamp. Counterpart to the `--time-step` CLI flag, but applicable mid-session. |
 | `await_render_idle` *(viewer only, read-only)* | Blocks until the live map settles — no completed paint, graphics-refresh request, or busy layer for a continuous quiet period — or until a timeout elapses (`quietPeriodMs` default 250, clamped `[0, 10000]`; `timeoutMs` default 5000, clamped `[50, 120000]`). Call it between `set_viewport` and `render_to_image` so the screenshot reflects a settled view instead of racing the render pass. Always waits at least the quiet period and measures the on-screen `InstrumentedMapControl` paint loop, not the offscreen `render_to_image` clone. Returns `wentIdle`, `timedOut`, `waitedMs`, and `paintsObserved`. |
 | `get_render_stats` *(viewer only, read-only)* | Reports the cost of the most recently completed on-screen map paint: wall-clock `frameDurationMs`, `intervalMs` since the previous paint, `totalDrawCalls`, and a per-style breakdown (`style`, `calls`, `durationMs`, ordered by descending duration). Use it to measure rendering performance across pan / zoom, palette, or time-step changes. Describes the live map paint, not the offscreen `render_to_image` clone; returns `hasData = false` when no paint has occurred yet. Pair with `await_render_idle` so the reported paint reflects a settled view. |
+| `open_dataset` *(viewer only, **mutating**)* | Loads a dataset into the live viewer using its existing open code path, so agents can measure the load hot path. `path` is a single file (S-101 `.000`, HDF5 `.h5`, GML, etc.) OR an exchange set (a folder containing `CATALOG.XML`, or a `.zip` of one); the kind is auto-detected. `spec` optionally forces a product-spec hint (e.g. `S-102`) for single-file loads. Returns the resulting catalog id(s), `spec`, bounding box (`southLatitude`/`westLongitude`/`northLatitude`/`eastLongitude`), `count`, `loadDurationMs`, and `timedOut` (exchange-set quiescence). |
+| `close_dataset` *(viewer only, **mutating**)* | Unloads a currently-loaded dataset from the live viewer by its catalog `id` (as returned by `list_datasets` / `open_dataset`), using the viewer's existing close code path so agents can measure the unload hot path. An unknown / already-removed id resolves gracefully as a non-error result with `removed = false`. Returns `removed`, `count`, and `removedDatasets` (`id` + `spec`). |
 
 ### Read-only vs mutating tools
 
@@ -137,7 +139,9 @@ Tools fall into two groups:
 * **Mutating** — modify the live viewer's state (navigator, palette,
   time step, loaded datasets, etc.). Use only when you intend to
   drive the viewer's UI from outside. Examples: `set_viewport`,
-  `set_palette`, `set_display_category`, `set_time_step`.
+  `set_palette`, `set_display_category`, `set_time_step`,
+  `open_dataset`, and `close_dataset` (which load / unload datasets
+  through the viewer's own open / close code path).
 
 Tool descriptions in the registered MCP catalogue identify each tool
 as one or the other; this table is the canonical reference.

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -341,6 +341,14 @@ public partial class App : Application
         services.AddSingleton<EncDotNet.S100.Viewer.Diagnostics.RenderActivityMonitor>();
         services.AddSingleton<IRenderActivityMonitor>(sp =>
             sp.GetRequiredService<EncDotNet.S100.Viewer.Diagnostics.RenderActivityMonitor>());
+        // Gateway over the existing GUI load/unload code path, used by the
+        // mutating open_dataset / close_dataset MCP tools so they reuse the
+        // same Add + LoadAsync / Remove + RemoveEntry flow as the file-open
+        // command rather than a parallel loader.
+        services.AddSingleton<IDatasetLoadGateway>(sp => new DatasetLoadGateway(
+            sp.GetRequiredService<DatasetsViewModel>(),
+            sp.GetRequiredService<IDatasetLoaderService>(),
+            sp.GetRequiredService<IExchangeSetService>()));
         services.AddSingleton<McpServerHost>(sp => new McpServerHost(
             sp.GetRequiredService<ViewerDatasetCatalog>(),
             sp.GetRequiredService<ViewerSettings>(),
@@ -348,7 +356,8 @@ public partial class App : Application
             sp.GetService<ILoggerFactory>(),
             sp.GetRequiredService<IRenderStateControllerAccessor>(),
             sp.GetRequiredService<GlobalTimeService>(),
-            sp.GetRequiredService<IRenderActivityMonitor>()));
+            sp.GetRequiredService<IRenderActivityMonitor>(),
+            sp.GetRequiredService<IDatasetLoadGateway>()));
 
         // View models
         services.AddSingleton<FeatureCataloguesViewModel>();

--- a/src/EncDotNet.S100.Viewer/McpTools/CloseDatasetMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/CloseDatasetMcpAdapter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="CloseDatasetTool"/> as an MCP server tool.</summary>
+internal static class CloseDatasetMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Unloads a currently-loaded dataset from the live viewer by its catalog id (as returned by " +
+        "list_datasets or open_dataset), using the viewer's existing close code path so agents can " +
+        "measure the unload hot path. An unknown or already-removed id resolves gracefully as a " +
+        "non-error result with removed:false. Returns what was removed. MUTATING.";
+
+    public static McpServerTool Create(CloseDatasetTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [Description("Catalog id of the dataset to unload (from list_datasets or open_dataset).")] string id,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new CloseDatasetRequest(id), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = CloseDatasetTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<CloseDatasetResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return ToolErrorPayload.InternalError(ex, JsonOptions); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<CloseDatasetResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var removed = new JsonArray();
+            foreach (var d in value!.RemovedDatasets)
+            {
+                removed.Add(new JsonObject
+                {
+                    ["id"] = d.Id,
+                    ["spec"] = d.Spec,
+                });
+            }
+            var payload = new JsonObject
+            {
+                ["id"] = value.Id,
+                ["removed"] = value.Removed,
+                ["count"] = value.Count,
+                ["removedDatasets"] = removed,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return ToolErrorPayload.AsCallToolResult(err!, JsonOptions);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/CloseDatasetTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/CloseDatasetTool.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Request payload for <see cref="CloseDatasetTool"/>.</summary>
+/// <param name="Id">Catalog id of the dataset to unload.</param>
+internal sealed record CloseDatasetRequest(string? Id = null);
+
+/// <summary>Metadata for a single dataset removed by a close operation.</summary>
+/// <param name="Id">Catalog id that was removed.</param>
+/// <param name="Spec">Canonical product specification name (e.g. <c>"S-101"</c>).</param>
+internal sealed record RemovedDataset(string Id, string Spec);
+
+/// <summary>Result payload for <see cref="CloseDatasetTool"/>.</summary>
+/// <param name="Id">The id that was requested.</param>
+/// <param name="Removed"><see langword="true"/> when at least one dataset was removed.</param>
+/// <param name="Count">Number of catalog datasets removed (0 for an unknown id).</param>
+/// <param name="RemovedDatasets">Metadata for the datasets that were removed.</param>
+internal sealed record CloseDatasetResult(
+    string Id,
+    bool Removed,
+    int Count,
+    IReadOnlyList<RemovedDataset> RemovedDatasets);
+
+/// <summary>
+/// MCP tool that unloads a currently-loaded dataset by its catalog id
+/// using the viewer's existing GUI unload code path, so automation agents
+/// can measure the unload hot path. Unknown / already-removed ids resolve
+/// gracefully as a non-error <c>removed:false</c> result.
+/// </summary>
+internal sealed class CloseDatasetTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "close_dataset";
+
+    private readonly IDatasetCatalog _catalog;
+    private readonly IDatasetLoadGateway _gateway;
+
+    /// <summary>Creates the tool.</summary>
+    /// <param name="catalog">The dataset catalog to diff before / after the unload.</param>
+    /// <param name="gateway">The UI-thread load gateway.</param>
+    public CloseDatasetTool(IDatasetCatalog catalog, IDatasetLoadGateway gateway)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(gateway);
+        _catalog = catalog;
+        _gateway = gateway;
+    }
+
+    /// <summary>Unloads the dataset(s) matching the requested id.</summary>
+    public async Task<ToolResult<CloseDatasetResult>> InvokeAsync(
+        CloseDatasetRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var id = request.Id;
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return ToolResult<CloseDatasetResult>.Err(new InvalidArgument(
+                "id", "a non-empty dataset id is required"));
+        }
+        id = id.Trim();
+
+        if (!_gateway.IsReady)
+        {
+            return ToolResult<CloseDatasetResult>.Err(new MapNotReady(
+                "the dataset loader has not been initialised yet"));
+        }
+
+        using var _ = await _gateway.LockAsync(ct).ConfigureAwait(false);
+
+        var before = _catalog.Datasets;
+        var matched = before
+            .Where(d => string.Equals(d.Id.Value, id, StringComparison.Ordinal))
+            .Select(d => new RemovedDataset(d.Id.Value, d.Spec.Name))
+            .ToList();
+
+        await _gateway.RemoveAsync(id, ct).ConfigureAwait(false);
+
+        // Diff the catalog so the reported count reflects what actually left
+        // the catalog (an unknown id removes nothing → graceful success).
+        var afterIds = _catalog.Datasets.Select(d => d.Id.Value).ToHashSet(StringComparer.Ordinal);
+        var removedDatasets = matched.Where(m => !afterIds.Contains(m.Id)).ToList();
+
+        return ToolResult<CloseDatasetResult>.Ok(new CloseDatasetResult(
+            Id: id,
+            Removed: removedDatasets.Count > 0,
+            Count: removedDatasets.Count,
+            RemovedDatasets: removedDatasets));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/DatasetLoadFailed.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/DatasetLoadFailed.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using EncDotNet.S100.Mcp.Tools;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// A dataset open request was dispatched and reported success, yet no new
+/// dataset appeared in the viewer's catalog. Returned by
+/// <see cref="OpenDatasetTool"/> when the load path completed but produced
+/// no portrayable dataset (e.g. an exchange set whose products are all
+/// unsupported, or a file the pipeline accepted but could not surface).
+/// Distinguished from <see cref="InvalidArgument"/> in that the caller's
+/// request was well-formed; the load simply yielded nothing.
+/// </summary>
+/// <param name="Reason">Single-sentence description of why no dataset was produced.</param>
+[Description("Raised when a dataset load completed without surfacing any new dataset in the viewer's catalog.")]
+internal sealed record DatasetLoadFailed(
+    [property: Description("Single-sentence description of why no dataset was produced.")] string Reason)
+    : ToolError("dataset_load_failed", $"The dataset load produced no result: {Reason}.");

--- a/src/EncDotNet.S100.Viewer/McpTools/OpenDatasetMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/OpenDatasetMcpAdapter.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Wraps <see cref="OpenDatasetTool"/> as an MCP server tool.</summary>
+internal static class OpenDatasetMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string Description =
+        "Loads a dataset into the live viewer using its existing open code path, so agents can " +
+        "measure the load hot path. 'path' is a local file (S-101 .000, HDF5 .h5, GML, etc.) OR an " +
+        "exchange set (a folder containing CATALOG.XML, or a .zip of one); the kind is auto-detected. " +
+        "'spec' optionally forces a product-spec hint (e.g. \"S-102\") for single-file loads. Returns the " +
+        "resulting catalog id(s), spec, bounding box, and the measured load duration. MUTATING.";
+
+    public static McpServerTool Create(OpenDatasetTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [Description("Local filesystem path to a dataset file or an exchange set (folder containing CATALOG.XML, or a .zip of one).")] string path,
+            [Description("Optional explicit product-spec hint (e.g. \"S-102\") for single-file loads; ignored for exchange sets.")] string? spec = null,
+            CancellationToken ct = default) =>
+            DispatchAsync(() => inner.InvokeAsync(new OpenDatasetRequest(path, spec), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = OpenDatasetTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    private static async Task<CallToolResult> DispatchAsync(
+        Func<Task<ToolResult<OpenDatasetResult>>> factory)
+    {
+        try
+        {
+            var result = await factory().ConfigureAwait(false);
+            return TranslateResult(result);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return ToolErrorPayload.InternalError(ex, JsonOptions); }
+    }
+
+    internal static CallToolResult TranslateResult(ToolResult<OpenDatasetResult> result)
+    {
+        if (result.TryGetValue(out var value))
+        {
+            var datasets = new JsonArray();
+            foreach (var d in value!.Datasets)
+            {
+                datasets.Add(new JsonObject
+                {
+                    ["id"] = d.Id,
+                    ["spec"] = d.Spec,
+                    ["southLatitude"] = d.SouthLatitude,
+                    ["westLongitude"] = d.WestLongitude,
+                    ["northLatitude"] = d.NorthLatitude,
+                    ["eastLongitude"] = d.EastLongitude,
+                });
+            }
+            var payload = new JsonObject
+            {
+                ["path"] = value.Path,
+                ["kind"] = value.Kind,
+                ["count"] = value.Count,
+                ["loadDurationMs"] = value.LoadDurationMs,
+                ["timedOut"] = value.TimedOut,
+                ["datasets"] = datasets,
+            };
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = payload.ToJsonString(JsonOptions) }],
+                IsError = false,
+            };
+        }
+        result.TryGetError(out var err);
+        return ToolErrorPayload.AsCallToolResult(err!, JsonOptions);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/OpenDatasetTool.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/OpenDatasetTool.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>Request payload for <see cref="OpenDatasetTool"/>.</summary>
+/// <param name="Path">Local filesystem path to a dataset file or an exchange set (folder / ZIP).</param>
+/// <param name="Spec">Optional explicit product-spec hint (e.g. <c>"S-102"</c>) for single-file loads.</param>
+internal sealed record OpenDatasetRequest(string? Path = null, string? Spec = null);
+
+/// <summary>Metadata for a single dataset surfaced by an open operation.</summary>
+/// <param name="Id">Catalog id (stable for the host session).</param>
+/// <param name="Spec">Canonical product specification name (e.g. <c>"S-101"</c>).</param>
+/// <param name="SouthLatitude">South edge of the bounds (decimal degrees, WGS-84).</param>
+/// <param name="WestLongitude">West edge of the bounds (decimal degrees, WGS-84).</param>
+/// <param name="NorthLatitude">North edge of the bounds (decimal degrees, WGS-84).</param>
+/// <param name="EastLongitude">East edge of the bounds (decimal degrees, WGS-84).</param>
+internal sealed record OpenedDataset(
+    string Id,
+    string Spec,
+    double SouthLatitude,
+    double WestLongitude,
+    double NorthLatitude,
+    double EastLongitude);
+
+/// <summary>Result payload for <see cref="OpenDatasetTool"/>.</summary>
+/// <param name="Path">The path that was opened.</param>
+/// <param name="Kind">How the path was loaded — <c>"file"</c> or <c>"exchangeSet"</c>.</param>
+/// <param name="Count">Number of datasets newly added to the catalog.</param>
+/// <param name="LoadDurationMs">Wall-clock duration of the load hot path, in milliseconds.</param>
+/// <param name="TimedOut"><see langword="true"/> when an exchange-set load did not quiesce before the max wait.</param>
+/// <param name="Datasets">The datasets observed added to the catalog during the operation.</param>
+internal sealed record OpenDatasetResult(
+    string Path,
+    string Kind,
+    int Count,
+    double LoadDurationMs,
+    bool TimedOut,
+    IReadOnlyList<OpenedDataset> Datasets);
+
+/// <summary>
+/// MCP tool that loads a dataset file or exchange set into the live
+/// viewer using its existing GUI load code path, so automation agents can
+/// measure the load hot path. Returns the resulting catalog id(s) plus
+/// basic metadata (spec, bbox) and the measured load duration.
+/// </summary>
+internal sealed class OpenDatasetTool
+{
+    /// <summary>The MCP tool name as exposed to clients.</summary>
+    public const string Name = "open_dataset";
+
+    private readonly IDatasetCatalog _catalog;
+    private readonly IDatasetLoadGateway _gateway;
+    private readonly int _quietMs;
+    private readonly int _maxWaitMs;
+
+    /// <summary>Creates the tool with production quiescence timings.</summary>
+    public OpenDatasetTool(IDatasetCatalog catalog, IDatasetLoadGateway gateway)
+        : this(catalog, gateway, quietMs: 600, maxWaitMs: 30_000)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: allows tests to shorten the exchange-set quiescence
+    /// debounce so timing paths are exercised quickly.
+    /// </summary>
+    /// <param name="catalog">The dataset catalog to diff before / after the load.</param>
+    /// <param name="gateway">The UI-thread load gateway.</param>
+    /// <param name="quietMs">Quiet window (no new datasets) that signals quiescence.</param>
+    /// <param name="maxWaitMs">Hard ceiling on the exchange-set quiescence wait.</param>
+    internal OpenDatasetTool(IDatasetCatalog catalog, IDatasetLoadGateway gateway, int quietMs, int maxWaitMs)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(gateway);
+        _catalog = catalog;
+        _gateway = gateway;
+        _quietMs = quietMs;
+        _maxWaitMs = maxWaitMs;
+    }
+
+    /// <summary>Loads the requested dataset and returns the resulting catalog entries.</summary>
+    public async Task<ToolResult<OpenDatasetResult>> InvokeAsync(
+        OpenDatasetRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var path = request.Path;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return ToolResult<OpenDatasetResult>.Err(new InvalidArgument(
+                "path", "a non-empty filesystem path is required"));
+        }
+        path = path.Trim();
+
+        if (!File.Exists(path) && !Directory.Exists(path))
+        {
+            return ToolResult<OpenDatasetResult>.Err(new InvalidArgument(
+                "path", $"no file or directory exists at '{path}'"));
+        }
+
+        if (!_gateway.IsReady)
+        {
+            return ToolResult<OpenDatasetResult>.Err(new MapNotReady(
+                "the dataset loader has not been initialised yet"));
+        }
+
+        using var _ = await _gateway.LockAsync(ct).ConfigureAwait(false);
+
+        var kind = _gateway.Classify(path);
+        var before = _catalog.Datasets.Select(d => d.Id.Value).ToHashSet(StringComparer.Ordinal);
+
+        // Subscribe BEFORE triggering so synchronous adds (single-file load)
+        // and the first asynchronous add (exchange set) are both observed.
+        var activity = new SemaphoreSlim(0);
+        void OnChanged(object? sender, DatasetCatalogChangedEventArgs e)
+        {
+            if (e.Kind is DatasetCatalogChangeKind.Added or DatasetCatalogChangeKind.Batch)
+            {
+                activity.Release();
+            }
+        }
+        _catalog.Changed += OnChanged;
+
+        var stopwatch = Stopwatch.StartNew();
+        var timedOut = false;
+        try
+        {
+            if (kind == DatasetPathKind.File)
+            {
+                var recognised = await _gateway.LoadFileAsync(path, request.Spec, ct).ConfigureAwait(false);
+                if (!recognised)
+                {
+                    return ToolResult<OpenDatasetResult>.Err(new InvalidArgument(
+                        "path", $"the file type of '{path}' is not a recognised S-100 product"));
+                }
+                // Single-file load updates the catalog synchronously during
+                // the awaited LoadAsync, so no quiescence wait is needed.
+            }
+            else
+            {
+                var dispatched = await _gateway.TriggerExchangeSetAsync(path, ct).ConfigureAwait(false);
+                if (dispatched == 0)
+                {
+                    // The exchange set contained no datasets this viewer can
+                    // read — fail fast rather than waiting out the quiet window.
+                    return ToolResult<OpenDatasetResult>.Err(new DatasetLoadFailed(
+                        "the exchange set contained no datasets this viewer can portray"));
+                }
+                timedOut = await WaitForQuiescenceAsync(
+                    activity, dispatched, () => CountAdded(before), ct).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            stopwatch.Stop();
+            _catalog.Changed -= OnChanged;
+            // The SemaphoreSlim is intentionally NOT disposed: a catalog
+            // event could still be racing toward OnChanged after the
+            // unsubscribe above, and Release on a disposed semaphore throws.
+            // It uses no wait handle (only WaitAsync), so it needs no
+            // deterministic disposal.
+        }
+
+        var added = _catalog.Datasets
+            .Where(d => !before.Contains(d.Id.Value))
+            .Select(d => new OpenedDataset(
+                d.Id.Value,
+                d.Spec.Name,
+                d.Bounds.SouthLatitude,
+                d.Bounds.WestLongitude,
+                d.Bounds.NorthLatitude,
+                d.Bounds.EastLongitude))
+            .ToList();
+
+        if (added.Count == 0)
+        {
+            return ToolResult<OpenDatasetResult>.Err(new DatasetLoadFailed(
+                kind == DatasetPathKind.File
+                    ? "the file loaded but produced no portrayable dataset"
+                    : "the exchange set contained no datasets this viewer can portray"));
+        }
+
+        return ToolResult<OpenDatasetResult>.Ok(new OpenDatasetResult(
+            Path: path,
+            Kind: kind == DatasetPathKind.File ? "file" : "exchangeSet",
+            Count: added.Count,
+            LoadDurationMs: stopwatch.Elapsed.TotalMilliseconds,
+            TimedOut: timedOut,
+            Datasets: added));
+    }
+
+    private int CountAdded(System.Collections.Generic.HashSet<string> before)
+        => _catalog.Datasets.Count(d => !before.Contains(d.Id.Value));
+
+    /// <summary>
+    /// Waits for an exchange-set load (which dispatched
+    /// <paramref name="expectedCount"/> datasets fire-and-forget) to settle:
+    /// returns once every dispatched dataset has been added, or a full quiet
+    /// window has elapsed after at least one add (some dispatched loads may
+    /// have failed). Returns <see langword="true"/> when the
+    /// <see cref="_maxWaitMs"/> ceiling is hit first (timed out).
+    /// </summary>
+    /// <remarks>
+    /// Crucially, a quiet window with <em>zero</em> adds does NOT resolve as
+    /// quiescent: because datasets were dispatched, "no events yet" means the
+    /// first load is still in flight (a slow first load must not be reported
+    /// as a failure). Only the max-wait ceiling ends that case.
+    /// </remarks>
+    private async Task<bool> WaitForQuiescenceAsync(
+        SemaphoreSlim activity, int expectedCount, Func<int> addedCount, CancellationToken ct)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (true)
+        {
+            if (addedCount() >= expectedCount)
+            {
+                // Every dispatched dataset arrived.
+                return false;
+            }
+
+            var remaining = _maxWaitMs - (int)deadline.ElapsedMilliseconds;
+            if (remaining <= 0)
+            {
+                return true;
+            }
+
+            var wait = Math.Min(_quietMs, remaining);
+            var signalled = await activity.WaitAsync(wait, ct).ConfigureAwait(false);
+            if (!signalled)
+            {
+                if (wait < _quietMs)
+                {
+                    // The wait was truncated by the max-wait deadline, not a
+                    // genuine quiet window — report a timeout.
+                    return true;
+                }
+                if (addedCount() >= 1)
+                {
+                    // A full quiet window elapsed after at least one add; the
+                    // remaining dispatched loads must have failed. Settled.
+                    return false;
+                }
+                // No adds yet though datasets were dispatched: the first load
+                // is still in flight. Keep waiting up to the max.
+                continue;
+            }
+
+            // Drain any adds that piled up so the next wait measures a fresh
+            // quiet window rather than immediately returning.
+            while (activity.Wait(0))
+            {
+            }
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -305,18 +305,24 @@ sets the bind address (loopback recommended). Any MCP flag implies
 `--mcp-port-file <PATH>` writes the bound endpoint URI to a file once
 the server is listening (the endpoint is also echoed to stdout as
 `[MCP] listening on …`). A CLI-driven MCP run never persists the
-bound port back to the user's `settings.json`. Six viewer-only tools
+bound port back to the user's `settings.json`. Nine viewer-only tools
 are injected when the server starts: `render_to_image` (read-only —
 captures a PNG snapshot from a clone of the live map),
 `set_viewport` (mutating — drives the live navigator to a bbox or
 centre+zoom), `set_palette` (mutating — Day / Dusk / Night),
 `set_display_category` (mutating — DisplayBase / Standard /
-OtherInformation / All), `await_render_idle` (read-only — blocks
+OtherInformation / All), `set_time_step` (mutating — drives the
+global time clock to a sample by index or timestamp),
+`await_render_idle` (read-only — blocks
 until the live map settles so a following `render_to_image` is
-deterministic instead of racing the render pass), and
+deterministic instead of racing the render pass),
 `get_render_stats` (read-only — reports the cost of the last
 on-screen paint: frame duration, interval, and per-style draw-call
-breakdown, for measuring rendering performance). See
+breakdown, for measuring rendering performance), `open_dataset`
+(mutating — loads a file or exchange set through the viewer's own
+open code path and reports the resulting catalog id(s), bbox, and
+load duration), and `close_dataset` (mutating — unloads a dataset by
+catalog id, tolerating unknown ids gracefully). See
 `docs/mcp-server.md` for the full catalogue and the read-only /
 mutating split.
 

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoadGateway.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoadGateway.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Production <see cref="IDatasetLoadGateway"/> that drives the viewer's
+/// existing load / unload code paths on the UI thread.
+/// </summary>
+internal sealed class DatasetLoadGateway : IDatasetLoadGateway
+{
+    private readonly DatasetsViewModel _datasets;
+    private readonly IDatasetLoaderService _loader;
+    private readonly IExchangeSetService _exchangeSet;
+    private readonly Func<Func<Task>, Task> _dispatcher;
+    private readonly SemaphoreSlim _operationGate = new(1, 1);
+
+    public DatasetLoadGateway(
+        DatasetsViewModel datasets,
+        IDatasetLoaderService loader,
+        IExchangeSetService exchangeSet)
+        : this(datasets, loader, exchangeSet, dispatcher: null)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: allows tests to provide a synchronous dispatcher so the
+    /// production path through <see cref="Dispatcher.UIThread"/> can be
+    /// exercised without a running Avalonia application.
+    /// </summary>
+    internal DatasetLoadGateway(
+        DatasetsViewModel datasets,
+        IDatasetLoaderService loader,
+        IExchangeSetService exchangeSet,
+        Func<Func<Task>, Task>? dispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(datasets);
+        ArgumentNullException.ThrowIfNull(loader);
+        ArgumentNullException.ThrowIfNull(exchangeSet);
+        _datasets = datasets;
+        _loader = loader;
+        _exchangeSet = exchangeSet;
+        _dispatcher = dispatcher ?? DefaultDispatchAsync;
+    }
+
+    /// <inheritdoc />
+    public bool IsReady => _loader.IsInitialized;
+
+    /// <inheritdoc />
+    public DatasetPathKind Classify(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        if (System.IO.Directory.Exists(path))
+        {
+            return ExchangeSetDetection.LooksLikeExchangeSetFolder(path)
+                ? DatasetPathKind.ExchangeSet
+                : DatasetPathKind.File;
+        }
+
+        if (ExchangeSetDetection.IsZipPath(path)
+            && ExchangeSetDetection.LooksLikeExchangeSetZip(path))
+        {
+            return DatasetPathKind.ExchangeSet;
+        }
+
+        return DatasetPathKind.File;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> LoadFileAsync(
+        string path, string? specHint, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        var loaded = false;
+        await _dispatcher(async () =>
+        {
+            var spec = string.IsNullOrWhiteSpace(specHint)
+                ? DatasetPipelineFactory.DetectProductSpec(path)
+                : specHint.Trim();
+            if (spec is null)
+            {
+                loaded = false;
+                return;
+            }
+
+            var entry = _datasets.Add(path, spec);
+            try
+            {
+                await _loader.LoadAsync(entry, cancellationToken).ConfigureAwait(true);
+            }
+            catch
+            {
+                // Do not leave a half-loaded entry in the panel / catalog
+                // when the load throws; remove it before surfacing the error.
+                _datasets.Entries.Remove(entry);
+                throw;
+            }
+            loaded = true;
+        }).ConfigureAwait(false);
+        return loaded;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> TriggerExchangeSetAsync(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        var dispatched = 0;
+        await _dispatcher(async () =>
+        {
+            var result = await _exchangeSet.OpenAsync(path, progress: null, cancellationToken).ConfigureAwait(true);
+            dispatched = result.Loaded;
+        }).ConfigureAwait(false);
+        return dispatched;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> RemoveAsync(string datasetId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(datasetId);
+
+        var removed = 0;
+        await _dispatcher(() =>
+        {
+            var matches = _datasets.Entries
+                .Where(e => string.Equals(e.DisplayName, datasetId, StringComparison.Ordinal))
+                .ToList();
+            foreach (var entry in matches)
+            {
+                // Remove from the panel collection AND drop the loader's
+                // layers/processor directly. RemoveEntry is idempotent, so
+                // the overlap with MainWindow's CollectionChanged handler is
+                // a harmless no-op — this keeps the gateway self-sufficient
+                // and independent of that window wiring.
+                _datasets.Entries.Remove(entry);
+                _loader.RemoveEntry(entry);
+                removed++;
+            }
+            return Task.CompletedTask;
+        }).ConfigureAwait(false);
+        return removed;
+    }
+
+    /// <inheritdoc />
+    public async Task<IDisposable> LockAsync(CancellationToken cancellationToken = default)
+    {
+        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(_operationGate);
+    }
+
+    private static async Task DefaultDispatchAsync(Func<Task> work)
+    {
+        await Dispatcher.UIThread.InvokeAsync(work).ConfigureAwait(false);
+    }
+
+    private sealed class Releaser : IDisposable
+    {
+        private SemaphoreSlim? _gate;
+        public Releaser(SemaphoreSlim gate) => _gate = gate;
+        public void Dispose() => Interlocked.Exchange(ref _gate, null)?.Release();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -105,6 +105,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     private IMapHost? _mapHost;
 
+    /// <inheritdoc />
+    public bool IsInitialized => _mapHost is not null;
+
     // Coalesce slider scrubs into a single render pass after the user has
     // paused for ~100 ms. Each new SetCurrentTime cancels the in-flight
     // debounce + render so we never queue dozens of stale renders behind

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoadGateway.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoadGateway.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// How a path supplied to <see cref="IDatasetLoadGateway"/> should be
+/// loaded into the viewer.
+/// </summary>
+internal enum DatasetPathKind
+{
+    /// <summary>A single dataset file (S-101 <c>.000</c>, HDF5 <c>.h5</c>,
+    /// GML, etc.).</summary>
+    File,
+
+    /// <summary>An exchange set — a folder containing a
+    /// <c>CATALOG.XML</c> or a <c>.zip</c> archive containing one.</summary>
+    ExchangeSet,
+}
+
+/// <summary>
+/// Thin, UI-thread-bound seam over the viewer's existing dataset
+/// load / unload code paths (<see cref="ViewModels.DatasetsViewModel"/>,
+/// <see cref="IDatasetLoaderService"/>, and
+/// <see cref="IExchangeSetService"/>). The MCP <c>open_dataset</c> /
+/// <c>close_dataset</c> tools depend on this seam so their orchestration
+/// logic (validation, catalog diffing, quiescence waiting, result
+/// shaping) stays testable with a fake while the actual collection /
+/// Mapsui-layer mutation is marshalled to the dispatcher here.
+/// </summary>
+/// <remarks>
+/// The gateway deliberately reuses the same <c>Add</c> + <c>LoadAsync</c>
+/// and <c>Entries.Remove</c> + <c>RemoveEntry</c> calls the GUI's
+/// file-open command and Datasets panel use, rather than introducing a
+/// parallel loader. All members are safe to call from any thread; the
+/// implementation marshals to the UI thread as needed.
+/// </remarks>
+internal interface IDatasetLoadGateway
+{
+    /// <summary>
+    /// <see langword="true"/> once the underlying
+    /// <see cref="IDatasetLoaderService"/> has been initialised by the
+    /// window. Tools gate on this to return a clean "map not ready"
+    /// error instead of throwing when invoked before the viewer is up.
+    /// </summary>
+    bool IsReady { get; }
+
+    /// <summary>
+    /// Classifies <paramref name="path"/> as a single dataset file or an
+    /// exchange set (folder with <c>CATALOG.XML</c> or exchange-set ZIP),
+    /// mirroring the viewer's drag-and-drop routing.
+    /// </summary>
+    DatasetPathKind Classify(string path);
+
+    /// <summary>
+    /// Loads a single dataset file on the UI thread via the canonical
+    /// <c>Add</c> + <see cref="IDatasetLoaderService.LoadAsync"/> path and
+    /// awaits its completion (so the dataset catalog is updated before
+    /// this method returns).
+    /// </summary>
+    /// <param name="path">Local filesystem path to the dataset file.</param>
+    /// <param name="specHint">Optional explicit product-spec name (e.g.
+    /// <c>"S-102"</c>) to use instead of extension-based detection.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when a product spec was resolved and
+    /// the load was dispatched; <see langword="false"/> when the file type
+    /// could not be recognised.</returns>
+    Task<bool> LoadFileAsync(string path, string? specHint, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Triggers an exchange-set open on the UI thread via
+    /// <see cref="IExchangeSetService.OpenAsync"/>. The underlying loads
+    /// are dispatched fire-and-forget, so this method returns before they
+    /// complete — callers must wait for the dataset catalog to quiesce.
+    /// </summary>
+    /// <returns>The number of datasets dispatched for loading (0 when the
+    /// exchange set contained no datasets this viewer can read), so callers
+    /// can distinguish "nothing to load" from "loads still in flight".</returns>
+    Task<int> TriggerExchangeSetAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes every loaded dataset whose catalog id (the entry's display
+    /// name) equals <paramref name="datasetId"/>, on the UI thread.
+    /// </summary>
+    /// <returns>The number of entries removed (0 when the id is unknown).</returns>
+    Task<int> RemoveAsync(string datasetId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acquires the gateway's single-operation lock. Open / close tools
+    /// hold it for the duration of a snapshot → trigger → quiesce → diff
+    /// sequence so concurrent MCP operations do not interleave and
+    /// misattribute catalog changes to one another. Dispose the returned
+    /// handle to release.
+    /// </summary>
+    Task<IDisposable> LockAsync(CancellationToken cancellationToken = default);
+}

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -25,6 +25,22 @@ internal interface IDatasetLoaderService
     void Initialize(IMapHost host, ViewerCommandSettings? options);
 
     /// <summary>
+    /// <see langword="true"/> once <see cref="Initialize"/> has wired the
+    /// loader to a map host, after which <see cref="LoadAsync"/> /
+    /// <see cref="RemoveEntry"/> are safe to call. Consumers that may run
+    /// before the window has constructed the map host (e.g. the MCP
+    /// open/close dataset tools) gate on this to return a clean
+    /// "map not ready" error instead of throwing.
+    /// </summary>
+    /// <remarks>
+    /// Provided as a default interface member (returns <see langword="true"/>)
+    /// so the many test doubles that implement this interface need not all
+    /// override it; the production <c>DatasetLoaderService</c> backs it with
+    /// real state.
+    /// </remarks>
+    bool IsInitialized => true;
+
+    /// <summary>
     /// When <see langword="true"/>, per-dataset loads skip their
     /// automatic zoom-to-extent. Set by the window when an explicit
     /// startup viewport (<c>--center</c>/<c>--zoom</c> or <c>--bbox</c>)

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -31,6 +31,7 @@ internal sealed class McpServerHost : IAsyncDisposable
     private readonly IRenderStateControllerAccessor? _renderStateAccessor;
     private readonly GlobalTimeService? _globalTime;
     private readonly IRenderActivityMonitor? _renderActivityMonitor;
+    private readonly IDatasetLoadGateway? _loadGateway;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -44,7 +45,8 @@ internal sealed class McpServerHost : IAsyncDisposable
         ILoggerFactory? loggers = null,
         IRenderStateControllerAccessor? renderStateAccessor = null,
         GlobalTimeService? globalTime = null,
-        IRenderActivityMonitor? renderActivityMonitor = null)
+        IRenderActivityMonitor? renderActivityMonitor = null,
+        IDatasetLoadGateway? loadGateway = null)
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(settings);
@@ -54,6 +56,7 @@ internal sealed class McpServerHost : IAsyncDisposable
         _renderStateAccessor = renderStateAccessor;
         _globalTime = globalTime;
         _renderActivityMonitor = renderActivityMonitor;
+        _loadGateway = loadGateway;
         _loggers = loggers;
     }
 
@@ -281,6 +284,11 @@ internal sealed class McpServerHost : IAsyncDisposable
         {
             tools.Add(AwaitRenderIdleMcpAdapter.Create(new AwaitRenderIdleTool(_renderActivityMonitor)));
             tools.Add(GetRenderStatsMcpAdapter.Create(new GetRenderStatsTool(_renderActivityMonitor)));
+        }
+        if (_loadGateway is not null)
+        {
+            tools.Add(OpenDatasetMcpAdapter.Create(new OpenDatasetTool(_catalog, _loadGateway)));
+            tools.Add(CloseDatasetMcpAdapter.Create(new CloseDatasetTool(_catalog, _loadGateway)));
         }
         return tools.Count == 0 ? null : tools;
     }

--- a/tests/EncDotNet.S100.Viewer.Tests/CloseDatasetToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/CloseDatasetToolTests.cs
@@ -1,0 +1,88 @@
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class CloseDatasetToolTests
+{
+    [Fact]
+    public async Task Close_existing_dataset_reports_removed_metadata()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add("a.000", "S-101");
+        catalog.Add("b.000", "S-102");
+        var gateway = new FakeDatasetLoadGateway
+        {
+            OnRemove = id => Task.FromResult(catalog.Remove(id)),
+        };
+        var tool = new CloseDatasetTool(catalog, gateway);
+
+        var result = await tool.InvokeAsync(new CloseDatasetRequest("a.000"));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.True(ok!.Removed);
+        Assert.Equal(1, ok.Count);
+        var removed = Assert.Single(ok.RemovedDatasets);
+        Assert.Equal("a.000", removed.Id);
+        Assert.Equal("S-101", removed.Spec);
+    }
+
+    [Fact]
+    public async Task Unknown_id_resolves_gracefully_as_not_removed()
+    {
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add("a.000", "S-101");
+        var gateway = new FakeDatasetLoadGateway
+        {
+            OnRemove = id => Task.FromResult(catalog.Remove(id)),
+        };
+        var tool = new CloseDatasetTool(catalog, gateway);
+
+        var result = await tool.InvokeAsync(new CloseDatasetRequest("nope.000"));
+
+        Assert.True(result.TryGetValue(out var ok));
+        Assert.False(ok!.Removed);
+        Assert.Equal(0, ok.Count);
+        Assert.Empty(ok.RemovedDatasets);
+    }
+
+    [Fact]
+    public async Task Empty_id_returns_invalid_argument()
+    {
+        var tool = new CloseDatasetTool(new FakeDatasetCatalog(), new FakeDatasetLoadGateway());
+
+        var result = await tool.InvokeAsync(new CloseDatasetRequest("  "));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Not_ready_returns_map_not_ready()
+    {
+        var gateway = new FakeDatasetLoadGateway { IsReady = false };
+        var tool = new CloseDatasetTool(new FakeDatasetCatalog(), gateway);
+
+        var result = await tool.InvokeAsync(new CloseDatasetRequest("a.000"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<MapNotReady>(err);
+    }
+
+    [Fact]
+    public void Adapter_translates_success_payload()
+    {
+        var ok = ToolResult<CloseDatasetResult>.Ok(new CloseDatasetResult(
+            "a.000", true, 1, new[] { new RemovedDataset("a.000", "S-101") }));
+
+        var call = CloseDatasetMcpAdapter.TranslateResult(ok);
+
+        Assert.False(call.IsError);
+        var text = Assert.IsType<ModelContextProtocol.Protocol.TextContentBlock>(call.Content[0]).Text;
+        Assert.Contains("\"removed\":true", text);
+        Assert.Contains("a.000", text);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetLoadGatewayTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetLoadGatewayTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class DatasetLoadGatewayTests
+{
+    /// <summary>Stub exchange-set service; gateway logic tests never open one.</summary>
+    private sealed class StubExchangeSetService : IExchangeSetService
+    {
+        public Task<ExchangeSetOpenResult> OpenAsync(
+            string folderOrZipPath, IProgress<ExchangeSetProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ExchangeSetOpenResult { SourcePath = folderOrZipPath });
+    }
+
+    // Synchronous dispatcher so the production gateway runs without an
+    // Avalonia UI thread.
+    private static readonly Func<Func<Task>, Task> Inline = work => work();
+
+    private static DatasetLoadGateway Make(out DatasetsViewModel datasets, out FakeDatasetLoaderService loader)
+    {
+        loader = new FakeDatasetLoaderService();
+        datasets = new DatasetsViewModel(loader);
+        return new DatasetLoadGateway(datasets, loader, new StubExchangeSetService(), Inline);
+    }
+
+    [Fact]
+    public void Classify_returns_file_for_plain_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"gw-{Guid.NewGuid():N}.000");
+        File.WriteAllText(path, "x");
+        try
+        {
+            var gateway = Make(out _, out _);
+            Assert.Equal(DatasetPathKind.File, gateway.Classify(path));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Classify_returns_exchange_set_for_folder_with_catalogue()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"gw-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "CATALOG.XML"), "<x/>");
+        try
+        {
+            var gateway = Make(out _, out _);
+            Assert.Equal(DatasetPathKind.ExchangeSet, gateway.Classify(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void IsReady_reflects_loader_initialisation()
+    {
+        var gateway = Make(out _, out var loader);
+        loader.IsInitializedValue = false;
+        Assert.False(gateway.IsReady);
+        loader.IsInitializedValue = true;
+        Assert.True(gateway.IsReady);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_removes_entry_and_calls_loader_directly()
+    {
+        var gateway = Make(out var datasets, out var loader);
+        var entry = datasets.Add("/tmp/chart.000", "S-101");
+        Assert.Contains(entry, datasets.Entries);
+
+        var removed = await gateway.RemoveAsync(entry.DisplayName);
+
+        Assert.Equal(1, removed);
+        Assert.DoesNotContain(entry, datasets.Entries);
+        // Self-sufficient: drops the loader's layers without relying on the
+        // window's CollectionChanged → RemoveEntry wiring.
+        Assert.Contains(entry, loader.RemovedEntries);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_unknown_id_removes_nothing()
+    {
+        var gateway = Make(out var datasets, out _);
+        datasets.Add("/tmp/chart.000", "S-101");
+
+        var removed = await gateway.RemoveAsync("not-loaded.000");
+
+        Assert.Equal(0, removed);
+        Assert.Single(datasets.Entries);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_removes_all_entries_sharing_a_display_name()
+    {
+        var gateway = Make(out var datasets, out _);
+        // Two distinct paths whose file name (and thus DisplayName / catalog
+        // id) collide — the documented duplicate-DisplayName case.
+        datasets.Add("/a/chart.000", "S-101");
+        datasets.Add("/b/chart.000", "S-101");
+
+        var removed = await gateway.RemoveAsync("chart.000");
+
+        Assert.Equal(2, removed);
+        Assert.Empty(datasets.Entries);
+    }
+
+    [Fact]
+    public async Task LoadFileAsync_removes_entry_when_load_throws()
+    {
+        var gateway = Make(out var datasets, out var loader);
+        loader.LoadHook = (_, _) => throw new InvalidOperationException("boom");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => gateway.LoadFileAsync("/tmp/chart.000", specHint: "S-101"));
+
+        // No stale half-loaded entry left behind.
+        Assert.Empty(datasets.Entries);
+    }
+
+    [Fact]
+    public async Task LoadFileAsync_with_spec_hint_adds_and_loads_entry()
+    {
+        var gateway = Make(out var datasets, out var loader);
+        DatasetEntry? loaded = null;
+        loader.LoadHook = (e, _) => { loaded = e; return Task.CompletedTask; };
+
+        var ok = await gateway.LoadFileAsync("/tmp/chart.000", specHint: "S-101");
+
+        Assert.True(ok);
+        Assert.NotNull(loaded);
+        Assert.Equal("S-101", loaded!.ProductSpec);
+        Assert.Contains(loaded, datasets.Entries);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetLoadToolFakes.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetLoadToolFakes.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Test-only <see cref="LoadedDatasetData"/> payload so tests can build
+/// <see cref="LoadedDataset"/> snapshots without real dataset bytes. The
+/// open / close tools only read <c>Id</c>, <c>Spec</c>, and <c>Bounds</c>,
+/// never the payload.
+/// </summary>
+internal sealed record FakeLoadedData : LoadedDatasetData;
+
+/// <summary>
+/// Mutable in-memory <see cref="IDatasetCatalog"/> for tool tests. Adds /
+/// removes publish a fresh immutable snapshot and raise
+/// <see cref="Changed"/>, mirroring the production catalog contract.
+/// </summary>
+internal sealed class FakeDatasetCatalog : IDatasetCatalog
+{
+    private readonly object _gate = new();
+    private ImmutableArray<LoadedDataset> _datasets = ImmutableArray<LoadedDataset>.Empty;
+
+    public ImmutableArray<LoadedDataset> Datasets
+    {
+        get { lock (_gate) { return _datasets; } }
+    }
+
+    public event EventHandler<DatasetCatalogChangedEventArgs>? Changed;
+
+    public LoadedDataset Add(string id, string spec = "S-101", BoundingBox? bounds = null)
+    {
+        var dataset = new LoadedDataset(
+            new DatasetId(id),
+            new SpecRef(spec, new SpecVersion(1, 0, 0)),
+            bounds ?? new BoundingBox(50.0, -1.5, 50.5, -1.0),
+            TimeRange: null,
+            new FakeLoadedData());
+        lock (_gate) { _datasets = _datasets.Add(dataset); }
+        Changed?.Invoke(this, new DatasetCatalogChangedEventArgs
+        {
+            Kind = DatasetCatalogChangeKind.Added,
+            DatasetId = dataset.Id,
+        });
+        return dataset;
+    }
+
+    public int Remove(string id)
+    {
+        var removed = 0;
+        lock (_gate)
+        {
+            var next = ImmutableArray.CreateBuilder<LoadedDataset>();
+            foreach (var d in _datasets)
+            {
+                if (string.Equals(d.Id.Value, id, StringComparison.Ordinal))
+                {
+                    removed++;
+                }
+                else
+                {
+                    next.Add(d);
+                }
+            }
+            _datasets = next.ToImmutable();
+        }
+        if (removed > 0)
+        {
+            Changed?.Invoke(this, new DatasetCatalogChangedEventArgs
+            {
+                Kind = DatasetCatalogChangeKind.Removed,
+                DatasetId = new DatasetId(id),
+            });
+        }
+        return removed;
+    }
+}
+
+/// <summary>
+/// Scriptable <see cref="IDatasetLoadGateway"/> so tool-logic tests can
+/// drive load / unload outcomes deterministically without the UI thread.
+/// </summary>
+internal sealed class FakeDatasetLoadGateway : IDatasetLoadGateway
+{
+    public bool IsReady { get; set; } = true;
+    public DatasetPathKind Kind { get; set; } = DatasetPathKind.File;
+    public Func<string, string?, Task<bool>>? OnLoadFile { get; set; }
+    public Func<string, Task<int>>? OnTriggerExchangeSet { get; set; }
+    public Func<string, Task<int>>? OnRemove { get; set; }
+
+    public DatasetPathKind Classify(string path) => Kind;
+
+    public Task<bool> LoadFileAsync(string path, string? specHint, CancellationToken cancellationToken = default)
+        => OnLoadFile?.Invoke(path, specHint) ?? Task.FromResult(false);
+
+    public Task<int> TriggerExchangeSetAsync(string path, CancellationToken cancellationToken = default)
+        => OnTriggerExchangeSet?.Invoke(path) ?? Task.FromResult(0);
+
+    public Task<int> RemoveAsync(string datasetId, CancellationToken cancellationToken = default)
+        => OnRemove?.Invoke(datasetId) ?? Task.FromResult(0);
+
+    public Task<IDisposable> LockAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IDisposable>(new NoopScope());
+
+    private sealed class NoopScope : IDisposable
+    {
+        public void Dispose() { }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
@@ -23,11 +23,26 @@ internal sealed class FakeDatasetLoaderService : IDatasetLoaderService
 
     public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
 
+    /// <summary>Backs <see cref="IsInitialized"/>; settable by tests.</summary>
+    public bool IsInitializedValue { get; set; } = true;
+    public bool IsInitialized => IsInitializedValue;
+
+    /// <summary>Optional override so tests can make <see cref="LoadAsync"/> throw or stall.</summary>
+    public Func<DatasetEntry, CancellationToken, Task>? LoadHook { get; set; }
+
+    /// <summary>Entries passed to <see cref="RemoveEntry"/>, in call order.</summary>
+    public List<DatasetEntry> RemovedEntries { get; } = new();
+
     public bool SuppressAutoZoom { get; set; }
-    public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default)
+        => LoadHook?.Invoke(entry, cancellationToken) ?? Task.CompletedTask;
     public Task ReRenderAtTimeAsync(DateTime t, CancellationToken cancellationToken) => Task.CompletedTask;
     public Task ReRenderAllAsync() => Task.CompletedTask;
-    public void RemoveEntry(DatasetEntry entry) => DatasetRemoved?.Invoke(entry);
+    public void RemoveEntry(DatasetEntry entry)
+    {
+        RemovedEntries.Add(entry);
+        DatasetRemoved?.Invoke(entry);
+    }
     public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries) { }
 
     public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; } =

--- a/tests/EncDotNet.S100.Viewer.Tests/OpenDatasetToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/OpenDatasetToolTests.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class OpenDatasetToolTests
+{
+    private static string NewTempFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"encdotnet-open-{Guid.NewGuid():N}.000");
+        File.WriteAllText(path, "x");
+        return path;
+    }
+
+    private static string NewTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"encdotnet-open-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    [Fact]
+    public async Task File_load_happy_path_returns_id_spec_and_bounds()
+    {
+        var path = NewTempFile();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.File,
+                OnLoadFile = (p, _) => { catalog.Add(Path.GetFileName(p), "S-102"); return Task.FromResult(true); },
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 50, maxWaitMs: 1000);
+
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(path));
+
+            Assert.True(result.TryGetValue(out var ok));
+            Assert.Equal("file", ok!.Kind);
+            Assert.Equal(1, ok.Count);
+            Assert.False(ok.TimedOut);
+            Assert.True(ok.LoadDurationMs >= 0);
+            var ds = Assert.Single(ok.Datasets);
+            Assert.Equal(Path.GetFileName(path), ds.Id);
+            Assert.Equal("S-102", ds.Spec);
+            Assert.Equal(50.0, ds.SouthLatitude);
+            Assert.Equal(-1.0, ds.EastLongitude);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Unrecognised_file_type_returns_invalid_argument()
+    {
+        var path = NewTempFile();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.File,
+                OnLoadFile = (_, _) => Task.FromResult(false),
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 50, maxWaitMs: 1000);
+
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(path));
+
+            Assert.True(result.TryGetError(out var err));
+            Assert.IsType<InvalidArgument>(err);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Missing_path_returns_invalid_argument()
+    {
+        var tool = new OpenDatasetTool(new FakeDatasetCatalog(), new FakeDatasetLoadGateway());
+        var result = await tool.InvokeAsync(new OpenDatasetRequest("/no/such/path-xyz.000"));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Empty_path_returns_invalid_argument()
+    {
+        var tool = new OpenDatasetTool(new FakeDatasetCatalog(), new FakeDatasetLoadGateway());
+        var result = await tool.InvokeAsync(new OpenDatasetRequest("   "));
+
+        Assert.True(result.TryGetError(out var err));
+        Assert.IsType<InvalidArgument>(err);
+    }
+
+    [Fact]
+    public async Task Not_ready_returns_map_not_ready()
+    {
+        var path = NewTempFile();
+        try
+        {
+            var gateway = new FakeDatasetLoadGateway { IsReady = false };
+            var tool = new OpenDatasetTool(new FakeDatasetCatalog(), gateway);
+
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(path));
+
+            Assert.True(result.TryGetError(out var err));
+            Assert.IsType<MapNotReady>(err);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task Load_succeeds_but_adds_nothing_returns_dataset_load_failed()
+    {
+        var path = NewTempFile();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.File,
+                OnLoadFile = (_, _) => Task.FromResult(true), // reports success but adds nothing
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 50, maxWaitMs: 1000);
+
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(path));
+
+            Assert.True(result.TryGetError(out var err));
+            Assert.IsType<DatasetLoadFailed>(err);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task ExchangeSet_collects_delayed_adds()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.ExchangeSet,
+                OnTriggerExchangeSet = path =>
+                {
+                    // Fire-and-forget adds after the trigger returns, like
+                    // the real exchange-set service; 2 datasets dispatched.
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(20);
+                        catalog.Add("a.000", "S-101");
+                        await Task.Delay(20);
+                        catalog.Add("b.000", "S-102");
+                    });
+                    return Task.FromResult(2);
+                },
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 150, maxWaitMs: 5000);
+
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(dir));
+
+            Assert.True(result.TryGetValue(out var ok));
+            Assert.Equal("exchangeSet", ok!.Kind);
+            Assert.Equal(2, ok.Count);
+            Assert.False(ok.TimedOut);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExchangeSet_partial_failure_settles_via_quiet_window()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.ExchangeSet,
+                OnTriggerExchangeSet = path =>
+                {
+                    // 2 datasets dispatched, but only 1 ever loads (the other
+                    // failed). Must settle via the quiet window after the add.
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(20);
+                        catalog.Add("only.000", "S-101");
+                    });
+                    return Task.FromResult(2);
+                },
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 120, maxWaitMs: 5000);
+
+            var sw = Stopwatch.StartNew();
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(dir));
+            sw.Stop();
+
+            // Resolves shortly after the single add + quiet window, well below
+            // the 5s ceiling — not a timeout.
+            Assert.True(sw.ElapsedMilliseconds < 2000, $"took {sw.ElapsedMilliseconds}ms");
+            Assert.True(result.TryGetValue(out var ok));
+            Assert.Equal(1, ok!.Count);
+            Assert.False(ok.TimedOut);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExchangeSet_with_no_supported_datasets_fails_fast()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.ExchangeSet,
+                OnTriggerExchangeSet = _ => Task.FromResult(0), // nothing dispatched
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 100, maxWaitMs: 5000);
+
+            var sw = Stopwatch.StartNew();
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(dir));
+            sw.Stop();
+
+            // Zero dispatched datasets must fail fast, not wait out any window.
+            Assert.True(sw.ElapsedMilliseconds < 2000, $"took {sw.ElapsedMilliseconds}ms");
+            Assert.True(result.TryGetError(out var err));
+            Assert.IsType<DatasetLoadFailed>(err);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExchangeSet_event_before_trigger_returns_is_counted()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var catalog = new FakeDatasetCatalog();
+            var gateway = new FakeDatasetLoadGateway
+            {
+                Kind = DatasetPathKind.ExchangeSet,
+                OnTriggerExchangeSet = _ =>
+                {
+                    // Synchronous add before the trigger returns.
+                    catalog.Add("sync.000", "S-104");
+                    return Task.FromResult(1);
+                },
+            };
+            var tool = new OpenDatasetTool(catalog, gateway, quietMs: 100, maxWaitMs: 5000);
+
+            var result = await tool.InvokeAsync(new OpenDatasetRequest(dir));
+
+            Assert.True(result.TryGetValue(out var ok));
+            Assert.Equal(1, ok!.Count);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Adapter_translates_success_payload()
+    {
+        var ok = ToolResult<OpenDatasetResult>.Ok(new OpenDatasetResult(
+            "/tmp/x.000", "file", 1, 12.5, false,
+            new[] { new OpenedDataset("x.000", "S-102", 1, 2, 3, 4) }));
+
+        var call = OpenDatasetMcpAdapter.TranslateResult(ok);
+
+        Assert.False(call.IsError);
+        var text = Assert.IsType<ModelContextProtocol.Protocol.TextContentBlock>(call.Content[0]).Text;
+        Assert.Contains("\"kind\":\"file\"", text);
+        Assert.Contains("\"southLatitude\":1", text);
+    }
+
+    [Fact]
+    public void Adapter_translates_error_payload()
+    {
+        var err = ToolResult<OpenDatasetResult>.Err(new DatasetLoadFailed("nothing"));
+
+        var call = OpenDatasetMcpAdapter.TranslateResult(err);
+
+        Assert.True(call.IsError);
+        var text = Assert.IsType<ModelContextProtocol.Protocol.TextContentBlock>(call.Content[0]).Text;
+        Assert.Contains("dataset_load_failed", text);
+    }
+}


### PR DESCRIPTION
## Summary

Adds two **mutating** viewer-only MCP tools so automation agents can drive a running viewer and profile dataset load/unload hot paths:

- **`open_dataset`** — loads a dataset into the live viewer using its existing open code path. `path` is a single file (S-101 `.000`, HDF5 `.h5`, GML, etc.) **or** an exchange set (a folder containing `CATALOG.XML`, or a `.zip` of one); the kind is auto-detected. `spec` optionally forces a product-spec hint (e.g. `S-102`) for single-file loads. Returns the resulting catalog id(s), `spec`, bounding box, `count`, `loadDurationMs`, and `timedOut` (exchange-set quiescence).
- **`close_dataset`** — unloads a loaded dataset by its catalog `id` using the viewer's existing close path. Unknown / already-removed ids resolve gracefully as a non-error result with `removed = false`. Returns `removed`, `count`, and `removedDatasets`.

This is the next step in the broader "let agents drive a running viewer" effort, following the render-observability tools (`await_render_idle`, `get_render_stats`).

## Approach

Follows the existing viewer MCP conventions end to end:

- Both tools reuse the viewer's **existing GUI load/unload code** via a thin UI-thread-bound `IDatasetLoadGateway` seam (no parallel loader). Single-file loads go through `DatasetsViewModel.Add` → `loader.LoadAsync`; exchange sets go through `IExchangeSetService.OpenAsync`. UI-thread work is marshalled via the dispatcher pattern used by the other tools.
- Each tool mirrors the `*McpAdapter` pattern: `ToolResult<T>` → `CallToolResult` with a single JSON `TextContentBlock`, `ToolErrorPayload.AsCallToolResult/InternalError`, and an internal `TranslateResult` test seam.
- Registered/classified as **mutating** in `McpServerHost.BuildAdditionalTools()` and wired through `App.axaml.cs` DI.
- MCP handlers run off the UI thread; the gateway serialises snapshot→trigger→quiesce→diff under a per-gateway lock.

Exchange-set loads are dispatched fire-and-forget by `OpenAsync`, so `open_dataset` waits for the dataset catalog to quiesce. The wait uses the dispatched-count returned by the gateway: it fails fast on zero datasets, settles once all dispatched datasets arrive (or after a quiet window with ≥1 add for partial failures), and correctly reports `timedOut` when the max-wait ceiling truncates the window — so a slow first load is never misreported as a failure.

## Tests

- New deterministic xunit tests using fake `IDatasetCatalog` / `IDatasetLoadGateway` (no live data): `OpenDatasetToolTests`, `CloseDatasetToolTests`, `DatasetLoadGatewayTests`, plus shared `DatasetLoadToolFakes`. Covers single-file + exchange-set success, fail-fast on zero datasets, partial-failure quiet-window settle, graceful unknown-id close, and adapter JSON translation.
- `EncDotNet.S100.Viewer.Tests`: 625 passing. `EncDotNet.S100.Mcp.Tests`: 24 passing (generic additional-tools advertisement). Viewer builds clean.

## Docs

Updated `docs/mcp-server.md` (tool table + read-only / mutating split) and `src/EncDotNet.S100.Viewer/README.md` (viewer-only tool count + descriptions).

## Notes

This branch was originally stacked on #173 (render-observability tools). #173 has since squash-merged into `main`, so this branch has been rebased onto the latest `origin/main` and **targets `main`** — it contains only the dataset open/close work (the duplicated render-observability commit was dropped during the rebase).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>