### PR TITLE
Fix viewer MCP server startup crash (missing TypeInfoResolver on tool adapters)

### DIFF
--- a/src/EncDotNet.S100.Viewer/McpTools/AwaitRenderIdleMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/AwaitRenderIdleMcpAdapter.cs
@@ -17,6 +17,7 @@ internal static class AwaitRenderIdleMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/CloseDatasetMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/CloseDatasetMcpAdapter.cs
@@ -17,6 +17,7 @@ internal static class CloseDatasetMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/GetRenderStatsMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/GetRenderStatsMcpAdapter.cs
@@ -16,6 +16,7 @@ internal static class GetRenderStatsMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/OpenDatasetMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/OpenDatasetMcpAdapter.cs
@@ -17,6 +17,7 @@ internal static class OpenDatasetMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/SetDisplayCategoryMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetDisplayCategoryMcpAdapter.cs
@@ -17,6 +17,7 @@ internal static class SetDisplayCategoryMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/SetPaletteMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetPaletteMcpAdapter.cs
@@ -17,6 +17,7 @@ internal static class SetPaletteMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/src/EncDotNet.S100.Viewer/McpTools/SetTimeStepMcpAdapter.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/SetTimeStepMcpAdapter.cs
@@ -17,6 +17,7 @@ internal static class SetTimeStepMcpAdapter
     {
         WriteIndented = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
     };
 
     private const string Description =

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewerMcpAdapterJsonOptionsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewerMcpAdapterJsonOptionsTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.McpTools;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Regression guard for the viewer MCP server startup crash: every
+/// <c>*McpAdapter</c> builds its tool via <see cref="McpServerTool.Create(Delegate, McpServerToolCreateOptions)"/>
+/// passing a private static <c>JsonOptions</c> field as the
+/// <see cref="McpServerToolCreateOptions.SerializerOptions"/>. The MCP SDK
+/// calls <see cref="JsonSerializerOptions.MakeReadOnly()"/> on those options,
+/// which throws when no <see cref="JsonSerializerOptions.TypeInfoResolver"/>
+/// has been configured (reflection-based serialization is disabled in the
+/// published viewer). Several adapters originally omitted the resolver, so
+/// <c>McpServerHost.BuildAdditionalTools()</c> threw on the first such tool
+/// and the entire MCP server failed to start. These tests assert every
+/// adapter's options can be made read-only.
+/// </summary>
+public class ViewerMcpAdapterJsonOptionsTests
+{
+    private static JsonSerializerOptions OptionsFor(string adapterName)
+    {
+        var adapter = typeof(OpenDatasetMcpAdapter).Assembly.GetTypes()
+            .Single(t => t.Name == adapterName);
+        var field = adapter.GetField("JsonOptions", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"{adapterName} has no private static JsonOptions field.");
+        return (JsonSerializerOptions)field.GetValue(null)!;
+    }
+
+    private static List<string> AdapterNames() =>
+        typeof(OpenDatasetMcpAdapter).Assembly.GetTypes()
+            .Where(t => t.Name.EndsWith("McpAdapter", StringComparison.Ordinal))
+            .Where(t => t.GetField("JsonOptions", BindingFlags.NonPublic | BindingFlags.Static) is not null)
+            .Select(t => t.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+    public static IEnumerable<object[]> Adapters() =>
+        AdapterNames().Select(n => new object[] { n });
+
+    [Fact]
+    public void Every_viewer_adapter_is_discovered()
+    {
+        var names = AdapterNames();
+
+        // Sanity: all the known viewer-only tool adapters are discovered. If
+        // this drops, the reflection probe stopped finding adapters and the
+        // per-adapter theories below would vacuously pass.
+        Assert.True(names.Count >= 9, $"Expected >= 9 *McpAdapter types, found {names.Count}: {string.Join(", ", names)}");
+    }
+
+    [Theory]
+    [MemberData(nameof(Adapters))]
+    public void Adapter_options_have_a_type_info_resolver(string adapterName)
+    {
+        var options = OptionsFor(adapterName);
+
+        Assert.NotNull(options);
+        Assert.True(
+            options.TypeInfoResolver is not null,
+            $"{adapterName}.JsonOptions must set TypeInfoResolver, otherwise McpServerTool.Create throws at server startup.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Adapters))]
+    public void Adapter_options_can_build_an_mcp_tool(string adapterName)
+    {
+        var options = OptionsFor(adapterName);
+
+        // Reproduces the exact failing call: McpServerTool.Create marks the
+        // supplied SerializerOptions read-only. With a missing resolver this
+        // threw InvalidOperationException and aborted server startup.
+        var del = (string value, CancellationToken ct = default) => Task.FromResult(value);
+
+        var exception = Record.Exception(() => McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = $"probe_{adapterName}",
+            Description = "regression probe",
+            SerializerOptions = options,
+        }));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## What

Seven of the nine viewer-only MCP tool adapters built their static `JsonSerializerOptions` **without** a `TypeInfoResolver`. When `McpServerHost.BuildAdditionalTools()` registers each tool, the MCP SDK (`ModelContextProtocol` 1.3.0) calls `JsonSerializerOptions.MakeReadOnly()`, which throws `InvalidOperationException` when no resolver is set **and** reflection-based serialization is disabled — which is the case in the published viewer (`JsonSerializer.IsReflectionEnabledByDefault == false`).

Because `set_palette` registers before the two adapters that already had a resolver, the MCP server aborted during startup and never wrote its `--mcp-port-file`. **The MCP server could not start at all.**

This was discovered while exercising the newly-merged `open_dataset`/`close_dataset` tools (#174) end-to-end against real S-101 datasets.

## Fix

Set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` on the seven affected adapters, matching the pattern already used by `S100McpServerToolFactory`, `RenderToImageMcpAdapter`, and `SetViewportMcpAdapter`:

- `AwaitRenderIdleMcpAdapter`
- `CloseDatasetMcpAdapter`
- `GetRenderStatsMcpAdapter`
- `OpenDatasetMcpAdapter`
- `SetDisplayCategoryMcpAdapter`
- `SetPaletteMcpAdapter`
- `SetTimeStepMcpAdapter`

## Test

Adds `ViewerMcpAdapterJsonOptionsTests`, which reflects over **every** `*McpAdapter` in the viewer assembly and asserts `McpServerTool.Create` succeeds with its `JsonOptions` (reproducing the exact failing call). Verified the test **fails** when the resolver is removed from any adapter and **passes** with the fix — so a future adapter missing the resolver is caught before runtime.

## Validation

- `dotnet build tests/EncDotNet.S100.Viewer.Tests` — succeeds
- `EncDotNet.S100.Viewer.Tests`: **644 passed** (625 prior + 19 new)
- `EncDotNet.S100.Mcp.Tests`: **24 passed**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>