### PR TITLE
Persist S-101 pattern-fill clip geometry to disk (step 2)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -70,6 +70,7 @@ public sealed class DatasetPipelineFactory
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly FeatureCatalogueManager _featureCatalogueManager;
     private readonly Interoperability.IInteroperabilityAuthorityProvider _authorityProvider;
+    private readonly IPatternClipCache? _sharedPatternClipCache;
 
     /// <summary>
     /// Creates a new factory. The supplied
@@ -81,12 +82,26 @@ public sealed class DatasetPipelineFactory
     /// cross-dataset paint-order authority through the host's DI
     /// container rather than a static singleton.
     /// </summary>
+    /// <param name="catalogueManager">Portrayal catalogue manager shared by every processor.</param>
+    /// <param name="luaEngine">Lua engine for Part 9A portrayal.</param>
+    /// <param name="crsTransformFactory">CRS transform factory for coverage products.</param>
+    /// <param name="featureCatalogueManager">Feature catalogue manager (shared FC parse cache).</param>
+    /// <param name="authorityProvider">Cross-dataset paint-order authority provider.</param>
+    /// <param name="sharedPatternClipCache">
+    /// Optional process-wide pattern-clip cache (e.g. a
+    /// <see cref="DiskPatternClipCache"/>) shared by every S-101 processor this
+    /// factory produces, so the cold first open of a previously-seen cell skips
+    /// the multi-second NetTopologySuite clip. When <see langword="null"/> each
+    /// S-101 processor falls back to its own in-memory single-slot cache — the
+    /// behaviour used by tools and tests.
+    /// </param>
     public DatasetPipelineFactory(
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         ICrsTransformFactory crsTransformFactory,
         FeatureCatalogueManager featureCatalogueManager,
-        Interoperability.IInteroperabilityAuthorityProvider authorityProvider)
+        Interoperability.IInteroperabilityAuthorityProvider authorityProvider,
+        IPatternClipCache? sharedPatternClipCache = null)
     {
         ArgumentNullException.ThrowIfNull(catalogueManager);
         ArgumentNullException.ThrowIfNull(luaEngine);
@@ -99,6 +114,7 @@ public sealed class DatasetPipelineFactory
         _crsTransformFactory = crsTransformFactory;
         _featureCatalogueManager = featureCatalogueManager;
         _authorityProvider = authorityProvider;
+        _sharedPatternClipCache = sharedPatternClipCache;
     }
 
     /// <summary>
@@ -394,7 +410,7 @@ public sealed class DatasetPipelineFactory
         return spec switch
         {
             "S-102" => new S102DatasetProcessor(path, _catalogueManager, _luaEngine, _crsTransformFactory),
-            "S-101" => new S101DatasetProcessor(path, _catalogueManager, _luaEngine, _featureCatalogueManager),
+            "S-101" => new S101DatasetProcessor(path, _catalogueManager, _luaEngine, _featureCatalogueManager, _sharedPatternClipCache),
             "S-57" => new S57DatasetProcessor(path, _catalogueManager, _luaEngine, _featureCatalogueManager),
             "S-104" => new S104DatasetProcessor(path, _crsTransformFactory),
             "S-111" => new S111DatasetProcessor(path, _catalogueManager, _crsTransformFactory),
@@ -453,7 +469,7 @@ public sealed class DatasetPipelineFactory
         return spec switch
         {
             "S-102" => new S102DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _crsTransformFactory),
-            "S-101" => new S101DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager),
+            "S-101" => new S101DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager, _sharedPatternClipCache),
             "S-57" => new S57DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager),
             "S-104" => new S104DatasetProcessor(source, relativePath, _crsTransformFactory),
             "S-111" => new S111DatasetProcessor(source, relativePath, _catalogueManager, _crsTransformFactory),

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -30,13 +30,25 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
     private readonly string _fileName;
     private readonly MapsuiRenderAssetCache _renderAssetCache = new();
 
-    // Single-slot cache of the pattern-fill priority clip geometry, keyed by
-    // the same portrayal cache key (mariner + ECDIS display state) as
-    // _cachedPortrayalInstructions. The clip result is palette-independent, so
-    // this lets a Day/Dusk/Night palette switch reuse the previously computed
-    // clip instead of re-paying the multi-second NetTopologySuite overlay.
-    // Per-processor (per-dataset) lifetime. Guarded by _renderGate.
-    private readonly InMemoryPatternClipCache _patternClipCache = new();
+    // Cache of the pattern-fill priority clip geometry. The clip result is
+    // palette-independent, so caching lets a Day/Dusk/Night palette switch
+    // reuse the previously computed clip instead of re-paying the multi-second
+    // NetTopologySuite overlay.
+    //
+    // Defaults to a per-processor single-slot in-memory cache (step 1), which
+    // only helps re-renders of this already-open dataset. When the host injects
+    // a shared DiskPatternClipCache (step 2) it is used instead, persisting the
+    // clip to disk so the cold first open of a previously-seen cell is fast even
+    // after a restart. The disk cache is process-global, so the clip key is
+    // fully qualified with _patternClipScope (see BuildDatasetScopeKey) to avoid
+    // cross-cell collisions. Guarded by _renderGate.
+    private readonly IPatternClipCache _patternClipCache;
+
+    // Deterministic per-dataset scope prepended to the portrayal cache key when
+    // forming the disk clip-cache key. Encodes dataset content + clip params +
+    // CRS + FormatVersion so the disk key is globally unique and self-
+    // invalidating. Constant for the lifetime of this processor.
+    private readonly string _patternClipScope;
     private Dictionary<long, EncDotNet.S100.Pipelines.Vector.Feature>? _featureIndex;
     private FeatureCatalogueDecoder? _decoder;
     private bool _decoderLoaded;
@@ -72,8 +84,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
 
     /// <summary>
     /// Number of area renders whose pattern-fill priority clip was served from
-    /// the in-memory <see cref="InMemoryPatternClipCache"/> (the multi-second
-    /// NetTopologySuite overlay was skipped — e.g. on a palette switch).
+    /// the pattern-clip cache (the multi-second NetTopologySuite overlay was
+    /// skipped — e.g. on a palette switch, or a warm disk-cache cold open).
     /// Exposed for tests.
     /// </summary>
     internal long PatternClipCacheHits => _patternClipCache.Hits;
@@ -93,8 +105,9 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         string path,
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
-        FeatureCatalogueManager featureCatalogueManager)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueManager)
+        FeatureCatalogueManager featureCatalogueManager,
+        IPatternClipCache? sharedPatternClipCache = null)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueManager, sharedPatternClipCache)
     {
     }
 
@@ -108,13 +121,15 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         string relativePath,
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
-        FeatureCatalogueManager featureCatalogueManager)
+        FeatureCatalogueManager featureCatalogueManager,
+        IPatternClipCache? sharedPatternClipCache = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
             luaEngine,
-            featureCatalogueManager)
+            featureCatalogueManager,
+            sharedPatternClipCache)
     {
     }
 
@@ -123,20 +138,98 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         string fileName,
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
-        FeatureCatalogueManager featureCatalogueManager)
+        FeatureCatalogueManager featureCatalogueManager,
+        IPatternClipCache? sharedPatternClipCache)
     {
         ArgumentNullException.ThrowIfNull(datasetStream);
         _fileName = fileName;
         _luaEngine = luaEngine;
         _provider = catalogueManager.GetProvider("S-101");
         _catalogue = new S101PortrayalCatalogue(_provider, _luaEngine);
+
+        // Buffer the raw dataset bytes once so we can (a) parse the document and
+        // (b) compute a content hash for the disk clip-cache scope key. S-101
+        // cells are small enough (a few MB) that buffering is cheap, and the
+        // content hash makes the persisted clip auto-invalidate when the cell's
+        // bytes change.
+        byte[] datasetBytes;
         using (datasetStream)
         {
-            _dataset = S101Dataset.Open(datasetStream);
+            datasetBytes = ReadAllBytes(datasetStream);
         }
+        _dataset = S101Dataset.Open(new MemoryStream(datasetBytes, writable: false));
+
+        // When a shared disk cache is injected use it (persistent, cross-cell,
+        // process-global); otherwise fall back to a per-processor in-memory slot.
+        _patternClipCache = sharedPatternClipCache ?? new InMemoryPatternClipCache();
+        _patternClipScope = BuildDatasetScopeKey(datasetBytes, _dataset);
+
         _featureCatalogueManager = featureCatalogueManager;
 
         Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
+    }
+
+    /// <summary>
+    /// Reads <paramref name="stream"/> to its end into a byte array. Used to
+    /// snapshot the dataset bytes for parsing and content hashing.
+    /// </summary>
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        if (stream is MemoryStream existing)
+            return existing.ToArray();
+
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Builds the deterministic per-dataset scope that, prefixed to the
+    /// portrayal cache key, fully qualifies the disk pattern-clip cache key so
+    /// it is globally unique and self-invalidating.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The pattern-fill priority clip geometry is a pure function of the dataset
+    /// geometry and the clip parameters (it is palette-independent — the palette
+    /// only recolours tiles applied after clipping). The scope therefore
+    /// encodes:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>the SHA-256 of the raw dataset bytes (content identity);</item>
+    /// <item>the S-101 product-specification edition and dataset name from the
+    /// DSID record (belt-and-suspenders alongside the content hash);</item>
+    /// <item>the clip parameters that affect the output geometry —
+    /// <see cref="MapsuiDisplayListRenderer.PatternClipSimplifyToleranceMetres"/>
+    /// and <see cref="MapsuiDisplayListRenderer.MinPointsToSimplifyForClip"/>;</item>
+    /// <item>the rendering CRS (EPSG:3857, the renderer's fixed projection);</item>
+    /// <item>the <see cref="DiskPatternClipCache.FormatVersion"/> stamp.</item>
+    /// </list>
+    /// <para>
+    /// Any change to dataset content, clip parameters, the CRS, or the cache /
+    /// serialization format yields a different scope and therefore a cache miss
+    /// (recompute), so persisted geometry can never be reused incorrectly.
+    /// </para>
+    /// </remarks>
+    internal static string BuildDatasetScopeKey(byte[] datasetBytes, S101Dataset dataset)
+    {
+        ArgumentNullException.ThrowIfNull(datasetBytes);
+        ArgumentNullException.ThrowIfNull(dataset);
+
+        var c = System.Globalization.CultureInfo.InvariantCulture;
+        var contentHash = Convert.ToHexStringLower(
+            System.Security.Cryptography.SHA256.HashData(datasetBytes));
+
+        var id = dataset.Document.Identification;
+        var sb = new StringBuilder();
+        sb.Append("ds:").Append(contentHash);
+        sb.Append("|name:").Append(id.DatasetName);
+        sb.Append("|ed:").Append(id.ProductSpecificationEdition);
+        sb.Append("|tol:").Append(MapsuiDisplayListRenderer.PatternClipSimplifyToleranceMetres.ToString("R", c));
+        sb.Append("|gate:").Append(MapsuiDisplayListRenderer.MinPointsToSimplifyForClip.ToString(c));
+        sb.Append("|crs:EPSG:3857");
+        sb.Append("|fmt:").Append(DiskPatternClipCache.FormatVersion.ToString(c));
+        return sb.ToString();
     }
 
     public async Task<DatasetResult> RenderAsync(RenderContext? context = null, CancellationToken cancellationToken = default)
@@ -227,7 +320,12 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
 
         var geometryProvider = new S101FeatureGeometryProvider(_dataset);
 
-        var areaLayer = CreateRenderer(s101Cat, palette, context, suffix: "areas", patternClipCacheKey: cacheKey)
+        // Fully qualify the clip-cache key with the per-dataset scope so a
+        // process-global disk cache cannot collide across cells. The in-memory
+        // fallback is unaffected (its scope is constant within this processor).
+        var patternClipKey = $"{_patternClipScope}|{cacheKey}";
+
+        var areaLayer = CreateRenderer(s101Cat, palette, context, suffix: "areas", patternClipCacheKey: patternClipKey)
             .Render(areaInstructions, geometryProvider);
         var lineLayer = CreateRenderer(s101Cat, palette, context, suffix: "lines", patternClipCacheKey: null)
             .Render(otherInstructions, geometryProvider);

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -217,8 +217,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor
         ArgumentNullException.ThrowIfNull(dataset);
 
         var c = System.Globalization.CultureInfo.InvariantCulture;
-        var contentHash = Convert.ToHexStringLower(
-            System.Security.Cryptography.SHA256.HashData(datasetBytes));
+        var contentHash = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(datasetBytes)).ToLowerInvariant();
 
         var id = dataset.Document.Identification;
         var sb = new StringBuilder();

--- a/src/EncDotNet.S100.Renderers.Mapsui/DiskPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/DiskPatternClipCache.cs
@@ -155,7 +155,7 @@ public sealed class DiskPatternClipCache : IPatternClipCache
     private string GetEntryPath(string key)
     {
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
-        return Path.Combine(_cacheDirectory, Convert.ToHexStringLower(hash) + FileExtension);
+        return Path.Combine(_cacheDirectory, Convert.ToHexString(hash).ToLowerInvariant() + FileExtension);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/DiskPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/DiskPatternClipCache.cs
@@ -1,0 +1,393 @@
+using System.Security.Cryptography;
+using System.Text;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// Disk-backed <see cref="IPatternClipCache"/>: persists each computed S-101
+/// pattern-fill priority clip result (see <see cref="MapsuiDisplayListRenderer"/>'s
+/// <c>ClipPatternsByPriority</c>) as a WKB sidecar file so that the
+/// <em>cold</em> first open of a previously-seen cell — including after a
+/// process restart — skips the multi-second NetTopologySuite overlay.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The in-memory <see cref="InMemoryPatternClipCache"/> (step 1) only eliminates
+/// re-clip cost for re-renders of the <em>same already-open</em> dataset (e.g.
+/// Day/Dusk/Night palette switches). It cannot help the very first open of a
+/// cell — nothing is cached yet — and its state is lost on close/restart. This
+/// implementation closes that gap by persisting the clip geometry to disk.
+/// </para>
+/// <para>
+/// The clip geometry is <em>palette-independent</em> (the palette only recolours
+/// the raster tiles applied <em>after</em> clipping), so it is safe to persist
+/// and reuse across palette/display re-renders. To make the on-disk key globally
+/// unique — the <see cref="GetOrCompute"/> contract's <c>key</c> is only unique
+/// within one processor's single in-memory slot — the S-101 processor composes a
+/// fully-qualified key <c>{datasetScope}|{portrayalKey}</c> whose
+/// <c>datasetScope</c> deterministically encodes the dataset content hash, the
+/// clip parameters, the CRS, and the cache <see cref="FormatVersion"/>. Any
+/// change to dataset content, clip parameters, or the serialization format
+/// therefore yields a different filename and recomputes (auto-invalidation).
+/// </para>
+/// <para>
+/// Robustness: any IO error, truncated/corrupt file, or
+/// <see cref="FormatVersion"/> mismatch is treated as a miss (the factory runs
+/// and overwrites the entry); failures never propagate to the caller. Writes are
+/// atomic (temp file + move) so a crash mid-write cannot leave a half-written
+/// entry that later deserializes incorrectly.
+/// </para>
+/// <para>
+/// The cache is bounded by a total-bytes cap enforced with a least-recently-used
+/// eviction policy. The cache directory is shared across every S-101 processor,
+/// so all instance methods are thread-safe (guarded by a single lock).
+/// </para>
+/// </remarks>
+public sealed class DiskPatternClipCache : IPatternClipCache
+{
+    /// <summary>
+    /// Version stamp for the on-disk serialization frame. It is written into
+    /// every cache file and verified on read; a mismatch is treated as a miss.
+    /// The S-101 processor also folds this value into the <c>datasetScope</c>
+    /// component of the cache key, so bumping it both renames future files and
+    /// rejects stale ones. Increment whenever the serialization frame or the
+    /// clip algorithm changes in a way that invalidates persisted geometry.
+    /// </summary>
+    public const int FormatVersion = 1;
+
+    /// <summary>File extension for persisted clip sidecar files.</summary>
+    private const string FileExtension = ".clip";
+
+    private readonly string _cacheDirectory;
+    private readonly long _maxBytes;
+    private readonly object _gate = new();
+    private readonly WKBWriter _wkbWriter = new();
+    private readonly WKBReader _wkbReader = new();
+
+    private long _hits;
+    private long _misses;
+
+    /// <summary>
+    /// Creates a disk-backed pattern-clip cache rooted at
+    /// <paramref name="cacheDirectory"/>.
+    /// </summary>
+    /// <param name="cacheDirectory">
+    /// Directory under which clip sidecar files are stored. Created on first
+    /// write if it does not exist. The directory is assumed to be private to
+    /// this cache (the LRU sweep enumerates every <c>*.clip</c> file in it).
+    /// </param>
+    /// <param name="maxBytes">
+    /// Soft upper bound, in bytes, on the total size of all persisted clip
+    /// files. After each write the least-recently-accessed files are evicted
+    /// until the total is at or below this cap. Must be positive.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="cacheDirectory"/> is null or empty.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="maxBytes"/> is not positive.
+    /// </exception>
+    public DiskPatternClipCache(string cacheDirectory, long maxBytes)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(cacheDirectory);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxBytes);
+
+        _cacheDirectory = cacheDirectory;
+        _maxBytes = maxBytes;
+    }
+
+    /// <inheritdoc />
+    public long Hits
+    {
+        get { lock (_gate) { return _hits; } }
+    }
+
+    /// <inheritdoc />
+    public long Misses
+    {
+        get { lock (_gate) { return _misses; } }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<(string PatternRef, int Priority, Geometry Geometry)> GetOrCompute(
+        string key,
+        Func<IReadOnlyList<(string PatternRef, int Priority, Geometry Geometry)>> factory)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var path = GetEntryPath(key);
+
+        lock (_gate)
+        {
+            var cached = TryRead(path);
+            if (cached is not null)
+            {
+                _hits++;
+                TouchAccessTime(path);
+                return cached;
+            }
+
+            _misses++;
+        }
+
+        // Run the expensive clip OUTSIDE the lock so a single ~multi-second miss
+        // does not stall hits / unrelated computes on other processors sharing
+        // this cache. Concurrent misses on the same key merely duplicate work
+        // (rare) and the last writer wins; the result is identical either way.
+        var produced = factory();
+
+        lock (_gate)
+        {
+            TryWrite(path, produced);
+        }
+
+        return produced;
+    }
+
+    /// <summary>
+    /// Maps a cache key to its sidecar file path. The filename is the lowercase
+    /// hex SHA-256 of the UTF-8 key, so arbitrary key content (including path
+    /// separators) maps to a single safe filename.
+    /// </summary>
+    private string GetEntryPath(string key)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        return Path.Combine(_cacheDirectory, Convert.ToHexStringLower(hash) + FileExtension);
+    }
+
+    /// <summary>
+    /// Attempts to read and deserialize a persisted clip entry. Returns
+    /// <see langword="null"/> (a miss) when the file is absent, unreadable, has a
+    /// mismatched <see cref="FormatVersion"/>, or is otherwise corrupt/truncated.
+    /// </summary>
+    private IReadOnlyList<(string PatternRef, int Priority, Geometry Geometry)>? TryRead(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+
+            var bytes = File.ReadAllBytes(path);
+            return Deserialize(bytes);
+        }
+        catch
+        {
+            // Any IO/parse failure is a miss: recompute and overwrite.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Serializes and atomically writes a clip entry, then enforces the LRU size
+    /// cap. All failures are swallowed: an unwritable cache must never break a
+    /// render (the freshly computed value is still returned to the caller).
+    /// </summary>
+    private void TryWrite(
+        string path,
+        IReadOnlyList<(string PatternRef, int Priority, Geometry Geometry)> entries)
+    {
+        var temp = Path.Combine(
+            _cacheDirectory,
+            Path.GetRandomFileName() + ".tmp");
+        try
+        {
+            Directory.CreateDirectory(_cacheDirectory);
+            var bytes = Serialize(entries);
+
+            // Temp file in the same directory so File.Move is an atomic rename.
+            File.WriteAllBytes(temp, bytes);
+            File.Move(temp, path, overwrite: true);
+            TouchAccessTime(path);
+
+            EnforceSizeCap(path);
+        }
+        catch
+        {
+            // Best-effort persistence only.
+        }
+        finally
+        {
+            // A crash/throw before File.Move can orphan the temp file; remove it.
+            TryDelete(temp);
+        }
+    }
+
+    /// <summary>Deletes a file if present, swallowing any IO error.</summary>
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Non-fatal.
+        }
+    }
+
+    /// <summary>
+    /// Stamps a cache file's last-access time to "now" so the LRU sweep treats a
+    /// just-written or just-read entry as most-recently-used. Explicitly setting
+    /// the timestamp avoids relying on filesystem access-time tracking, which may
+    /// be disabled (e.g. <c>noatime</c> mounts).
+    /// </summary>
+    private static void TouchAccessTime(string path)
+    {
+        try
+        {
+            File.SetLastAccessTimeUtc(path, DateTime.UtcNow);
+        }
+        catch
+        {
+            // Non-fatal: a missed touch only affects eviction ordering.
+        }
+    }
+
+    /// <summary>
+    /// Evicts least-recently-accessed sidecar files until the total size of all
+    /// persisted entries is at or below <see cref="_maxBytes"/>. The
+    /// just-written <paramref name="freshPath"/> is evicted only as a last
+    /// resort (when it alone still exceeds the cap), so a normal write is never
+    /// immediately discarded due to coarse access-time resolution. Also sweeps
+    /// orphaned <c>*.tmp</c> files left by interrupted writes.
+    /// </summary>
+    private void EnforceSizeCap(string freshPath)
+    {
+        FileInfo[] files;
+        try
+        {
+            var dir = new DirectoryInfo(_cacheDirectory);
+
+            // Remove orphaned temp files from interrupted writes; they are not
+            // counted toward the cap but would otherwise accumulate unbounded.
+            foreach (var tmp in dir.GetFiles("*.tmp", SearchOption.TopDirectoryOnly))
+                TryDelete(tmp.FullName);
+
+            files = dir.GetFiles("*" + FileExtension, SearchOption.TopDirectoryOnly);
+        }
+        catch
+        {
+            return;
+        }
+
+        long total = 0;
+        foreach (var f in files)
+            total += f.Length;
+
+        if (total <= _maxBytes)
+            return;
+
+        // Oldest access time first (least-recently-used); the just-written entry
+        // is sorted last so it survives unless it is the only thing left.
+        Array.Sort(files, (a, b) =>
+        {
+            var aFresh = string.Equals(a.FullName, freshPath, StringComparison.Ordinal);
+            var bFresh = string.Equals(b.FullName, freshPath, StringComparison.Ordinal);
+            if (aFresh != bFresh)
+                return aFresh ? 1 : -1;
+            return a.LastAccessTimeUtc.CompareTo(b.LastAccessTimeUtc);
+        });
+
+        foreach (var f in files)
+        {
+            if (total <= _maxBytes)
+                break;
+
+            var len = f.Length;
+            try
+            {
+                f.Delete();
+                total -= len;
+            }
+            catch
+            {
+                // Skip files we cannot delete (e.g. transient lock).
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serializes clip entries into the on-disk frame:
+    /// <c>[FormatVersion:int][count:int]</c> then, per entry,
+    /// <c>[patternRefUtf8Len:int][patternRefUtf8 bytes][priority:int][wkbLen:int][wkb bytes]</c>.
+    /// All integers are written little-endian via <see cref="BinaryWriter"/>.
+    /// </summary>
+    private byte[] Serialize(
+        IReadOnlyList<(string PatternRef, int Priority, Geometry Geometry)> entries)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(FormatVersion);
+            writer.Write(entries.Count);
+
+            foreach (var (patternRef, priority, geometry) in entries)
+            {
+                var refBytes = Encoding.UTF8.GetBytes(patternRef);
+                writer.Write(refBytes.Length);
+                writer.Write(refBytes);
+                writer.Write(priority);
+
+                var wkb = _wkbWriter.Write(geometry);
+                writer.Write(wkb.Length);
+                writer.Write(wkb);
+            }
+        }
+
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Deserializes the frame produced by <see cref="Serialize"/>. Returns
+    /// <see langword="null"/> when the leading version does not match
+    /// <see cref="FormatVersion"/>. Throws on truncation/corruption, which the
+    /// caller treats as a miss.
+    /// </summary>
+    private IReadOnlyList<(string PatternRef, int Priority, Geometry Geometry)>? Deserialize(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes, writable: false);
+        using var reader = new BinaryReader(ms, Encoding.UTF8, leaveOpen: true);
+
+        var version = reader.ReadInt32();
+        if (version != FormatVersion)
+            return null;
+
+        var count = reader.ReadInt32();
+        // Guard against corrupt/hostile lengths driving huge allocations: each
+        // entry needs at least three ints (refLen, priority, wkbLen) = 12 bytes,
+        // so a valid count cannot exceed the remaining byte budget.
+        var remaining = ms.Length - ms.Position;
+        if (count < 0 || count > remaining / 12)
+            return null;
+
+        var result = new List<(string PatternRef, int Priority, Geometry Geometry)>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var refLen = reader.ReadInt32();
+            if (refLen < 0 || refLen > ms.Length - ms.Position)
+                return null;
+            var refBytes = reader.ReadBytes(refLen);
+            if (refBytes.Length != refLen)
+                return null;
+            var patternRef = Encoding.UTF8.GetString(refBytes);
+
+            var priority = reader.ReadInt32();
+
+            var wkbLen = reader.ReadInt32();
+            if (wkbLen < 0 || wkbLen > ms.Length - ms.Position)
+                return null;
+            var wkb = reader.ReadBytes(wkbLen);
+            if (wkb.Length != wkbLen)
+                return null;
+            var geometry = _wkbReader.Read(wkb);
+
+            result.Add((patternRef, priority, geometry));
+        }
+
+        return result;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/IPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/IPatternClipCache.cs
@@ -30,11 +30,11 @@ namespace EncDotNet.S100.Renderers.Mapsui;
 /// switch reuse the previously computed geometry verbatim.
 /// </para>
 /// <para>
-/// The abstraction is intentionally minimal so that the current in-memory
-/// implementation (<see cref="InMemoryPatternClipCache"/>) and a future
-/// disk-backed (WKB sidecar) implementation — which could also eliminate the
-/// cold first-load cost of previously-seen cells — both fit behind the same
-/// contract.
+/// The abstraction is intentionally minimal so that the single-slot in-memory
+/// implementation (<see cref="InMemoryPatternClipCache"/>) and the disk-backed
+/// (WKB sidecar) implementation (<see cref="DiskPatternClipCache"/>) — which
+/// also eliminates the cold first-load cost of previously-seen cells — both fit
+/// behind the same contract.
 /// </para>
 /// </remarks>
 public interface IPatternClipCache

--- a/src/EncDotNet.S100.Renderers.Mapsui/InMemoryPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/InMemoryPatternClipCache.cs
@@ -15,8 +15,8 @@ namespace EncDotNet.S100.Renderers.Mapsui;
 /// <c>_cachedPortrayalInstructions</c> cache, which is keyed the same way.
 /// </para>
 /// <para>
-/// A future disk-backed (WKB sidecar) implementation can retain multiple cells
-/// and survive process restarts behind the same <see cref="IPatternClipCache"/>
+/// The disk-backed <see cref="DiskPatternClipCache"/> retains multiple cells
+/// and survives process restarts behind the same <see cref="IPatternClipCache"/>
 /// contract; this implementation deliberately keeps the in-process footprint to
 /// a single cell.
 /// </para>

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -1214,7 +1214,7 @@ public sealed class MapsuiDisplayListRenderer
     /// ground metres) away from the equator. The clipped boundary only bounds a
     /// tiled raster pattern fill, so this generalization is not visually significant.
     /// </summary>
-    private const double PatternClipSimplifyToleranceMetres = 1.0;
+    public const double PatternClipSimplifyToleranceMetres = 1.0;
 
     /// <summary>
     /// Minimum vertex count at which <see cref="SimplifyForClip"/> generalizes a
@@ -1228,7 +1228,7 @@ public sealed class MapsuiDisplayListRenderer
     /// leaves the common case (small/moderate areas) byte-identical to no
     /// generalization at all.
     /// </summary>
-    private const int MinPointsToSimplifyForClip = 2000;
+    public const int MinPointsToSimplifyForClip = 2000;
 
     /// <summary>
     /// Generalizes a polygonal geometry for use as a clip subject/mask, preserving

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -244,10 +244,44 @@ with the same key is a cache hit that skips the overlay entirely
 (measured on the dense trial cell: a cold Day render ~6 s, the subsequent
 Night palette switch ~0.2 s). When either is unset the clip is computed
 inline, preserving behaviour for S-57/S-131/GML products and the line
-renderer (which has no pattern fills). The interface is deliberately
-minimal so a future disk-backed (WKB sidecar) implementation — which could
-also eliminate the cold first-load cost of previously-seen cells — can drop
-in behind the same contract.
+renderer (which has no pattern fills).
+
+Two implementations ship behind this contract:
+
+- **`InMemoryPatternClipCache`** — a single-slot, per-processor cache that
+  bounds memory to one cell. It only eliminates re-clip cost for re-renders
+  of the *same already-open* dataset (palette/display switches) and is lost
+  on close/restart.
+- **`DiskPatternClipCache`** — a process-wide, disk-backed cache
+  (`ctor(string cacheDirectory, long maxBytes)`). It persists each clip
+  result as a WKB sidecar (filename = `SHA256(key)` hex + `.clip`) so the
+  **cold first open of a previously-seen cell** skips the overlay, even
+  after a restart. Writes are atomic (temp file + move) and a total-bytes
+  LRU cap evicts least-recently-accessed entries; any IO/deserialization
+  error or `FormatVersion` mismatch is treated as a miss (recompute) and
+  never throws to the caller. Because the disk cache is process-global, the
+  key must be **fully qualified** by the caller — the S-101 processor
+  composes `{datasetScope}|{portrayalKey}`, where `datasetScope` encodes the
+  dataset content hash, clip parameters
+  (`PatternClipSimplifyToleranceMetres`, `MinPointsToSimplifyForClip`), CRS,
+  and the `DiskPatternClipCache.FormatVersion` stamp, so persisted geometry
+  auto-invalidates when content, parameters, or the serialization format
+  change.
+
+```csharp
+// Per-processor in-memory (step 1):
+private readonly InMemoryPatternClipCache _patternClipCache = new();
+
+// Or one shared disk cache for the whole process (step 2):
+var sharedClipCache = new DiskPatternClipCache(cacheDir, maxBytes: 256L * 1024 * 1024);
+
+var renderer = new MapsuiDisplayListRenderer
+{
+    // … palette, providers, asset cache …
+    PatternClipCache = sharedClipCache,
+    PatternClipCacheKey = $"{datasetScope}|{portrayalCacheKey}",
+};
+```
 
 ## Installation
 

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -187,13 +187,28 @@ public partial class App : Application
         services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider>(sp =>
             new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
                 new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority()));
+        services.AddSingleton<EncDotNet.S100.Renderers.Mapsui.IPatternClipCache>(sp =>
+        {
+            // One process-wide disk cache shared by every S-101 processor so the
+            // cold first open of a previously-seen cell skips the multi-second
+            // NetTopologySuite pattern-fill clip, even across restarts. The clip
+            // geometry is palette-independent and the cache key is content-hash +
+            // FormatVersion stamped, so persisted entries auto-invalidate.
+            var cacheDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "EncDotNet.S100",
+                "PatternClipCache");
+            const long maxBytes = 256L * 1024 * 1024;
+            return new EncDotNet.S100.Renderers.Mapsui.DiskPatternClipCache(cacheDir, maxBytes);
+        });
         services.AddSingleton<EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory>(sp =>
             new EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory(
                 sp.GetRequiredService<PortrayalCatalogueManager>(),
                 new EncDotNet.S100.Scripting.MoonSharp.MoonSharpLuaEngine(),
                 new EncDotNet.S100.Renderers.Mapsui.ProjNetCrsTransformFactory(),
                 sp.GetRequiredService<EncDotNet.S100.Features.FeatureCatalogueManager>(),
-                sp.GetRequiredService<EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider>()));
+                sp.GetRequiredService<EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider>(),
+                sp.GetRequiredService<EncDotNet.S100.Renderers.Mapsui.IPatternClipCache>()));
 
         // Leaf services extracted in phase 2
         services.AddSingleton<IThemeService, ThemeService>();

--- a/tests/EncDotNet.S100.Pipelines.Tests/DiskPatternClipCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DiskPatternClipCacheTests.cs
@@ -1,0 +1,292 @@
+using EncDotNet.S100.Renderers.Mapsui;
+using NetTopologySuite.Geometries;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies the disk-backed pattern-clip cache: WKB round-trip fidelity,
+/// cross-restart persistence (a second cache instance over the same directory
+/// returns a hit), self-invalidation on key/<see cref="DiskPatternClipCache.FormatVersion"/>
+/// change, miss-on-corruption resilience, and LRU size-cap eviction.
+/// </summary>
+public class DiskPatternClipCacheTests : IDisposable
+{
+    private readonly string _dir;
+
+    public DiskPatternClipCacheTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "encdotnet-clipcache-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private static readonly GeometryFactory Gf = new();
+
+    // A simple polygon plus an overlapping polygon-with-hole, mirroring typical
+    // NTS overlay output (Polygon / MultiPolygon with interior rings).
+    private static List<(string PatternRef, int Priority, Geometry Geometry)> SampleEntries()
+    {
+        var square = Gf.CreatePolygon(
+        [
+            new Coordinate(0, 0), new Coordinate(0, 4),
+            new Coordinate(4, 4), new Coordinate(4, 0), new Coordinate(0, 0),
+        ]);
+
+        var shell = Gf.CreateLinearRing(
+        [
+            new Coordinate(10, 10), new Coordinate(10, 20),
+            new Coordinate(20, 20), new Coordinate(20, 10), new Coordinate(10, 10),
+        ]);
+        var hole = Gf.CreateLinearRing(
+        [
+            new Coordinate(13, 13), new Coordinate(13, 17),
+            new Coordinate(17, 17), new Coordinate(17, 13), new Coordinate(13, 13),
+        ]);
+        var holed = Gf.CreatePolygon(shell, [hole]);
+
+        return
+        [
+            ("DQUAL", 5, square),
+            ("DIAMOND1", 9, holed),
+        ];
+    }
+
+    [Fact]
+    public void RoundTrip_IsGeometryExact_AndPreservesRefPriorityOrder()
+    {
+        var cache = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        var expected = SampleEntries();
+
+        // First call is a miss (writes); second call is a hit (reads back).
+        var first = cache.GetOrCompute("k", () => expected);
+        var second = cache.GetOrCompute("k", () => throw new InvalidOperationException("should not recompute"));
+
+        Assert.Equal(1, cache.Misses);
+        Assert.Equal(1, cache.Hits);
+
+        Assert.Equal(expected.Count, second.Count);
+        for (int i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].PatternRef, second[i].PatternRef);
+            Assert.Equal(expected[i].Priority, second[i].Priority);
+            Assert.True(
+                expected[i].Geometry.EqualsExact(second[i].Geometry),
+                $"Geometry {i} did not round-trip exactly.");
+        }
+
+        // The in-memory first result must equal the expected too.
+        Assert.Same(expected, first);
+    }
+
+    [Fact]
+    public void SecondInstance_SameDirectory_ReturnsHit_ProvingPersistence()
+    {
+        var expected = SampleEntries();
+
+        var writer = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        writer.GetOrCompute("k", () => expected);
+        Assert.Equal(1, writer.Misses);
+
+        // A brand-new instance over the same directory simulates a restart.
+        var reader = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        var hit = reader.GetOrCompute("k", () => throw new InvalidOperationException("should be served from disk"));
+
+        Assert.Equal(1, reader.Hits);
+        Assert.Equal(0, reader.Misses);
+        Assert.Equal(expected.Count, hit.Count);
+        Assert.True(expected[0].Geometry.EqualsExact(hit[0].Geometry));
+    }
+
+    [Fact]
+    public void DifferentKey_IsMiss()
+    {
+        var cache = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        cache.GetOrCompute("scope-A|portrayal", SampleEntries);
+
+        var recomputed = false;
+        cache.GetOrCompute("scope-B|portrayal", () => { recomputed = true; return SampleEntries(); });
+
+        Assert.True(recomputed);
+        Assert.Equal(2, cache.Misses);
+        Assert.Equal(0, cache.Hits);
+    }
+
+    [Fact]
+    public void FormatVersionMismatch_IsMiss()
+    {
+        var expected = SampleEntries();
+        var cache = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        cache.GetOrCompute("k", () => expected);
+
+        // Corrupt the leading FormatVersion int (first 4 bytes) of the only file.
+        var file = Directory.GetFiles(_dir, "*.clip").Single();
+        var bytes = File.ReadAllBytes(file);
+        BitConverter.GetBytes(DiskPatternClipCache.FormatVersion + 999).CopyTo(bytes, 0);
+        File.WriteAllBytes(file, bytes);
+
+        var recomputed = false;
+        var fresh = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        fresh.GetOrCompute("k", () => { recomputed = true; return expected; });
+
+        Assert.True(recomputed);
+        Assert.Equal(1, fresh.Misses);
+        Assert.Equal(0, fresh.Hits);
+    }
+
+    [Fact]
+    public void CorruptOrTruncatedFile_IsMiss_NoThrow()
+    {
+        var expected = SampleEntries();
+        var cache = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        cache.GetOrCompute("k", () => expected);
+
+        // Truncate the file to a few bytes so deserialization runs off the end.
+        var file = Directory.GetFiles(_dir, "*.clip").Single();
+        File.WriteAllBytes(file, [1, 2, 3]);
+
+        var recomputed = false;
+        var fresh = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        var result = fresh.GetOrCompute("k", () => { recomputed = true; return expected; });
+
+        Assert.True(recomputed);
+        Assert.Equal(1, fresh.Misses);
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public void GarbageLengthHeader_IsMiss_NoHugeAllocation()
+    {
+        var expected = SampleEntries();
+        var cache = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        cache.GetOrCompute("k", () => expected);
+
+        // Valid FormatVersion, then a hostile entry count of int.MaxValue.
+        var file = Directory.GetFiles(_dir, "*.clip").Single();
+        using (var fs = File.Create(file))
+        using (var w = new BinaryWriter(fs))
+        {
+            w.Write(DiskPatternClipCache.FormatVersion);
+            w.Write(int.MaxValue);
+        }
+
+        var fresh = new DiskPatternClipCache(_dir, maxBytes: 16 * 1024 * 1024);
+        var result = fresh.GetOrCompute("k", () => expected);
+
+        Assert.Equal(1, fresh.Misses);
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public void ExceedingMaxBytes_EvictsToHonourCap_AndProtectsFreshEntry()
+    {
+        // Deterministic circle polygon (many vertices, identical WKB size for
+        // every seed since it is only translated), so cache file sizes are equal
+        // and predictable.
+        static Geometry Circle(int seed)
+        {
+            var coords = new Coordinate[129];
+            for (int i = 0; i < 128; i++)
+            {
+                var a = 2 * Math.PI * i / 128;
+                coords[i] = new Coordinate(seed + Math.Cos(a), seed + Math.Sin(a));
+            }
+            coords[128] = coords[0];
+            return Gf.CreatePolygon(coords);
+        }
+
+        List<(string, int, Geometry)> Entry(int seed) => [($"P{seed}", seed, Circle(seed))];
+
+        // Measure one entry's on-disk size in an isolated probe directory.
+        var probeDir = Path.Combine(_dir, "probe");
+        var probe = new DiskPatternClipCache(probeDir, maxBytes: long.MaxValue);
+        probe.GetOrCompute("x", () => Entry(1));
+        var oneSize = new FileInfo(Directory.GetFiles(probeDir, "*.clip").Single()).Length;
+
+        // Cap holds at most ONE entry, so the second write must evict the first
+        // (the just-written entry is protected, so it is the older one that goes).
+        var capDir = Path.Combine(_dir, "cap1");
+        Directory.CreateDirectory(capDir);
+        var cache = new DiskPatternClipCache(capDir, maxBytes: oneSize + oneSize / 2);
+
+        cache.GetOrCompute("a", () => Entry(1));
+        cache.GetOrCompute("b", () => Entry(2));
+
+        // Only the most recent entry survives.
+        Assert.Single(Directory.GetFiles(capDir, "*.clip"));
+
+        var bRecomputed = false;
+        cache.GetOrCompute("b", () => { bRecomputed = true; return Entry(2); });
+        Assert.False(bRecomputed); // "b" is still cached (a hit).
+
+        var aRecomputed = false;
+        cache.GetOrCompute("a", () => { aRecomputed = true; return Entry(1); });
+        Assert.True(aRecomputed); // "a" was evicted (a miss).
+    }
+
+    [Fact]
+    public void Eviction_RemovesLeastRecentlyUsedEntry()
+    {
+        static Geometry Circle(int seed)
+        {
+            var coords = new Coordinate[129];
+            for (int i = 0; i < 128; i++)
+            {
+                var a = 2 * Math.PI * i / 128;
+                coords[i] = new Coordinate(seed + Math.Cos(a), seed + Math.Sin(a));
+            }
+            coords[128] = coords[0];
+            return Gf.CreatePolygon(coords);
+        }
+
+        List<(string, int, Geometry)> Entry(int seed) => [($"P{seed}", seed, Circle(seed))];
+
+        var probeDir = Path.Combine(_dir, "probe2");
+        var probe = new DiskPatternClipCache(probeDir, maxBytes: long.MaxValue);
+        probe.GetOrCompute("x", () => Entry(1));
+        var oneSize = new FileInfo(Directory.GetFiles(probeDir, "*.clip").Single()).Length;
+
+        var capDir = Path.Combine(_dir, "cap2");
+        Directory.CreateDirectory(capDir);
+        // Cap holds two entries; a third write evicts the least-recently-used.
+        var cache = new DiskPatternClipCache(capDir, maxBytes: oneSize * 2 + oneSize / 2);
+
+        // Sleep > 1s between access-time-affecting operations so the ordering is
+        // unambiguous even on filesystems with coarse (1s) timestamp resolution.
+        cache.GetOrCompute("a", () => Entry(1));
+        Thread.Sleep(1100);
+        cache.GetOrCompute("b", () => Entry(2));
+        Thread.Sleep(1100);
+        // Re-access "a" so "b" is now the least-recently-used.
+        cache.GetOrCompute("a", () => throw new InvalidOperationException("a should be a hit"));
+        Thread.Sleep(1100);
+        // Writing "c" exceeds the cap; the LRU entry "b" must be evicted.
+        cache.GetOrCompute("c", () => Entry(3));
+
+        Assert.Equal(2, Directory.GetFiles(capDir, "*.clip").Length);
+
+        var bRecomputed = false;
+        cache.GetOrCompute("b", () => { bRecomputed = true; return Entry(2); });
+        Assert.True(bRecomputed); // "b" (the LRU) was evicted.
+    }
+
+    [Fact]
+    public void GetOrCompute_NullArguments_Throw()
+    {
+        var cache = new DiskPatternClipCache(_dir, maxBytes: 1024);
+        Assert.Throws<ArgumentNullException>(() => cache.GetOrCompute(null!, () => []));
+        Assert.Throws<ArgumentNullException>(() => cache.GetOrCompute("k", null!));
+    }
+
+    [Fact]
+    public void Constructor_InvalidArguments_Throw()
+    {
+        Assert.Throws<ArgumentException>(() => new DiskPatternClipCache("", 1024));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DiskPatternClipCache(_dir, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DiskPatternClipCache(_dir, -1));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101DiskPatternClipCacheProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101DiskPatternClipCacheProcessorTests.cs
@@ -1,0 +1,82 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Processor-level coverage of the persisted (disk-backed) pattern-clip cache:
+/// with a warm <see cref="DiskPatternClipCache"/>, the <em>second</em> cold open
+/// of a cell serves its pattern-fill priority clip from disk (a clip-cache hit),
+/// while the first cold open recomputes it. Requires a real S-101 trial cell and
+/// is skipped when absent so CI stays green.
+/// </summary>
+public class S101DiskPatternClipCacheProcessorTests
+{
+    // The densest known real S-101 trial cell (~64k-vertex M_QUAL coverage),
+    // never committed (real ENC data is not checked in). Present only locally.
+    private static string DenseCellPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "Downloads", "Complete S10X datasets", "S-101 Trial Cells",
+        "101GB00GB302045.000");
+
+    private static PortrayalCatalogueManager CreateCatalogueManager()
+    {
+        var manager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                manager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+        return manager;
+    }
+
+    [SkippableFact]
+    public async Task WarmDiskCache_SecondColdOpen_IsClipCacheHit()
+    {
+        Skip.IfNot(File.Exists(DenseCellPath), $"Dense S-101 trial cell not present: {DenseCellPath}");
+
+        var cacheDir = Path.Combine(
+            Path.GetTempPath(), "encdotnet-clipcache-proc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(cacheDir);
+        try
+        {
+            var sharedCache = new DiskPatternClipCache(cacheDir, maxBytes: 256L * 1024 * 1024);
+
+            var catalogueManager = CreateCatalogueManager();
+            var fcManager = new FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue);
+            var factory = new DatasetPipelineFactory(
+                catalogueManager,
+                new MoonSharpLuaEngine(),
+                new ProjNetCrsTransformFactory(),
+                fcManager,
+                new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthorityProvider(
+                    new EncDotNet.S100.Datasets.Pipelines.Interoperability.InteroperabilityAuthority()),
+                sharedCache);
+
+            // First cold open: the disk cache is empty, so the clip is computed
+            // (a miss) and persisted. This processor sees no clip-cache hits.
+            var first = (S101DatasetProcessor)factory.CreateProcessor(DenseCellPath);
+            await first.RenderAsync();
+            Assert.Equal(0, first.PatternClipCacheHits);
+
+            // Second cold open (simulates reopening the cell, even after a
+            // restart): a brand-new processor over the same shared disk cache.
+            // Its area render must be served from disk — a clip-cache hit — so
+            // the multi-second NetTopologySuite overlay is skipped.
+            var second = (S101DatasetProcessor)factory.CreateProcessor(DenseCellPath);
+            await second.RenderAsync();
+            Assert.True(
+                second.PatternClipCacheHits >= 1,
+                "Second cold open should hit the warm disk pattern-clip cache.");
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Step 2 of the two-step pattern-clip caching effort. Step 1 (the in-memory `InMemoryPatternClipCache`) is already on `main` and only eliminates re-clip cost for re-renders of an *already-open* dataset (palette/display switches). It cannot help the **cold first open** of a cell, and its state is lost on close/restart.

This PR adds `DiskPatternClipCache`, a persistent disk-backed implementation behind the **same** `IPatternClipCache` interface, so the **2nd+ cold open of a previously-seen cell is fast** — even after a process restart. On the densest real trial cell (`101GB00GB302045`, a ~64k-vertex M_QUAL polygon) the priority clip costs ~6 s cold, dominated by an irreducible `Buffer(0)` validity repair; persisting the result removes that from every subsequent cold open.

## Why it's safe (palette-independent + content-hash/version busting)

The clip geometry is **palette-independent** — the palette only recolours the raster tiles applied *after* clipping — so it is safe to persist and reuse across palette/display re-renders.

The merged `GetOrCompute` key is the short per-dataset portrayal key (mariner + ECDIS), unique only *within* one processor's single in-memory slot. A process-global disk cache would collide across cells, so the S-101 processor now composes a **fully-qualified key** `{datasetScope}|{portrayalKey}` without changing the interface. `datasetScope` deterministically encodes:

- SHA-256 of the raw dataset bytes (+ product-spec edition / dataset name),
- the clip parameters that affect geometry (`PatternClipSimplifyToleranceMetres`, `MinPointsToSimplifyForClip`),
- the CRS (EPSG:3857),
- a `DiskPatternClipCache.FormatVersion` stamp.

Any change to dataset content, clip parameters, or the algorithm/serialization (via a `FormatVersion` bump) misses and recomputes. The in-memory per-processor cache is unaffected because its scope is constant within a processor.

## Implementation

- **`DiskPatternClipCache : IPatternClipCache`** (`EncDotNet.S100.Renderers.Mapsui`): `ctor(string cacheDirectory, long maxBytes)`, `public const int FormatVersion`. Filename = `SHA256(key)` hex + `.clip`. Hit → read + deserialize. Miss → run factory, serialize, write atomically (temp file + `File.Move`), enforce an **LRU total-bytes cap** (evicts least-recently-accessed files; the just-written entry is protected). Any IO/deserialization error, truncation, garbage length header, or `FormatVersion` mismatch is treated as a miss (recompute) and never throws. Thread-safe; `factory()` runs **outside** the lock so a single multi-second miss does not stall hits on other processors. Serialization via NTS `WKBWriter`/`WKBReader` with a length-prefixed frame; round-trips geometry exactly.
- **`S101DatasetProcessor`**: field is now `IPatternClipCache` (defaults to the step-1 in-memory slot) and accepts an optional injected shared cache; buffers dataset bytes once to compute the content hash; passes `PatternClipCacheKey = {datasetScope}|{portrayalKey}` to the AREA renderer.
- **`DatasetPipelineFactory`**: optional shared `IPatternClipCache` threaded to both S-101 call sites; tools/tests keep the in-memory fallback.
- **Viewer DI**: one shared `DiskPatternClipCache` under `LocalApplicationData` (256 MB cap) shared by every S-101 processor.
- Exposed `PatternClipSimplifyToleranceMetres` / `MinPointsToSimplifyForClip` as `public const` so the scope key can encode them.

## Tests

Pure unit tests (no ENC required): WKB round-trip exactness (incl. PatternRef/Priority/ordering), cross-restart persistence (a second instance over the same directory returns a hit), key-change and `FormatVersion`-change invalidation, corrupt/truncated/garbage-length-header resilience, and size-cap + LRU eviction. Plus a `SkippableFact` processor-level test asserting the 2nd cold open of the dense trial cell is a clip-cache hit (skips when the cell is absent). Full `EncDotNet.S100.Pipelines.Tests` (469 passed) and S-131 (57 passed) suites are green. Verified end-to-end locally against committed pattern-bearing cells: first open = miss, second open via a separate processor sharing the disk cache = hit.

Sits behind the same `IPatternClipCache` as step 1. PRs #175 and #176 are independent prior work and are untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>