### PR TITLE
perf(coverage): cache projection layout across coverage re-renders

### DIFF
--- a/.github/instructions/viewer.instructions.md
+++ b/.github/instructions/viewer.instructions.md
@@ -71,3 +71,91 @@ When modifying viewer code:
   selector `Button#PickModeButton.pickActive ic|FluentIcon` to push
   `Foreground=White` down to the icon (FluentIcon does not inherit
   Foreground automatically).
+
+## E2E performance testing via the MCP server
+
+The viewer hosts an MCP server that lets an agent drive it headlessly
+for **automated load/render performance testing**. Use this whenever
+profiling dataset load or render hot paths, or validating that a
+rendering optimization actually moves a real-world scenario. The full
+tool catalogue lives in `docs/mcp-server.md`; the workflow below is the
+performance-testing recipe.
+
+### 1. Launch an ephemeral instance with a dynamic MCP port
+
+Run the built binary (not `dotnet run`, so the PID you trace is the app
+itself) and let it pick a free port, writing the bound URL to a file:
+
+```
+src/EncDotNet.S100.Viewer/bin/Release/net10.0/<rid>/EncDotNet.S100.Viewer \
+  --ephemeral --mcp --mcp-port-file /tmp/perfrun/mcp.url
+```
+
+- `--ephemeral` keeps no persisted state between runs (clean baseline).
+- `--mcp` enables the server; `--mcp-port 0` (the default) picks an
+  ephemeral port. `--mcp-port-file` writes the endpoint URL once the
+  server is listening — poll that file for readiness.
+- Launch detached (`nohup … & disown`) so it survives the shell; the
+  app is a GUI process and ignores SIGTERM, so stop it with
+  `kill -9 <pid>`.
+- Real-world datasets for manual runs live under
+  `~/Downloads/Complete S10X datasets` (S-101/S-102/S-104/S-111 trial
+  cells). Never commit these.
+
+### 2. Connect an MCP Streamable-HTTP client
+
+The server speaks MCP over Streamable HTTP. A minimal Python client
+(initialize handshake → `tools/call`, parsing both SSE framing and
+`structuredContent`) is sufficient. Quirks that bite:
+
+- A dataset id comes back as `{"value": "<id>"}`. `list_time_steps`,
+  `describe_feature`, etc. want `{"datasetId": {"value": "<id>"}}`,
+  but `close_dataset` wants the bare string id.
+- `open_dataset` on an S-101 exchange-set folder may report world
+  bounds and not portray; point it at the concrete `.000` cell file
+  and supply your own viewport.
+
+### 3. Drive a scenario
+
+Key automation tools (all under the viewer's MCP server):
+
+| Tool | Use |
+|---|---|
+| `open_dataset` `{path, spec?}` | Load a cell/tile. Returns `loadDurationMs` (load hot-path wall time). |
+| `close_dataset` `{id}` | Unload (bare string id). |
+| `list_datasets` | Enumerate loaded datasets + ids. |
+| `set_viewport` `{south,west,north,east}` | Frame the data. |
+| `set_palette` `{palette}` | Day/Dusk/Night — triggers a full re-render of every dataset. |
+| `set_display_category` / `set_time_step` | Drive ECDIS display mode / coverage time-step. |
+| `await_render_idle` `{quietPeriodMs,timeoutMs}` | Block until rendering settles (the harness clock). |
+| `get_render_stats` | Returns `frameDurationMs` (last Mapsui paint). |
+| `render_to_image` | Capture the framebuffer for visual diffing. |
+
+Typical loop: `open_dataset` → `set_viewport` → `await_render_idle`
+(cold) → `await_render_idle` again (warm) → toggle `set_palette` N
+times, timing each `set_palette` + `await_render_idle` round-trip.
+
+### 4. Read server-side timing and profile
+
+- `open_dataset.loadDurationMs` and `get_render_stats.frameDurationMs`
+  are the cheap structured signals; capture cold vs warm.
+- Palette/display/time-step **wall time is dominated by fixed
+  settle/framework latency**, largely independent of per-dataset
+  render CPU. To attribute CPU, profile rather than trusting wall time.
+- Profile with `dotnet-trace collect -p <viewer-pid>` (omit
+  `--profile`; the default works — `cpu-sampling` is rejected by
+  `collect`). The PID to attach is the
+  `…/<rid>/EncDotNet.S100.Viewer` process, not a `dotnet` host.
+  Export with `dotnet-trace convert --format speedscope`; the export
+  is *evented* (open/close), so compute inclusive time by walking
+  stacks.
+- For one-off per-stage attribution inside a renderer, add a
+  temporary env-gated `Stopwatch` block (e.g. `S100_*_TIMING=1`) and
+  **remove it before committing** — do not leave diagnostic env
+  switches in shipped code.
+
+### 5. Reusable harness
+
+A throwaway Python harness (`mcp_client.py` + scenario drivers) is kept
+in the session-state `files/` dir, not the repo. Reuse it as a starting
+point; do not commit dataset paths or generated traces.

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -59,6 +59,13 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
     private readonly ICrsTransformFactory _crsTransformFactory;
     private readonly S104DatasetData _data;
     private readonly string _fileName;
+
+    /// <summary>
+    /// Long-lived coverage renderer reused across renders so its palette-/
+    /// value-independent projection layout cache survives palette switches
+    /// and time-step changes.
+    /// </summary>
+    private MapsuiCoverageRenderer? _colorRenderer;
     private ValidationReport? _validationReport;
     private bool _validationCached;
 
@@ -176,7 +183,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
             .ConfigureAwait(false);
         var styledLayer = (StyledCoverageLayer)layer;
 
-        var colorRenderer = new MapsuiCoverageRenderer(_crsTransformFactory)
+        var colorRenderer = _colorRenderer ??= new MapsuiCoverageRenderer(_crsTransformFactory)
         {
             LayerName = $"S-104: {_fileName}",
         };

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageArrowRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageArrowRenderer.cs
@@ -10,6 +10,7 @@ using Mapsui.Styles;
 using PipelineViewport = EncDotNet.S100.Pipelines.Viewport;
 
 [assembly: InternalsVisibleTo("EncDotNet.S100.Datasets.S111.Tests")]
+[assembly: InternalsVisibleTo("EncDotNet.S100.Pipelines.Tests")]
 
 namespace EncDotNet.S100.Renderers.Mapsui;
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiCoverageRenderer.cs
@@ -7,6 +7,7 @@ using Mapsui.Projections;
 using Mapsui.Styles;
 using SkiaSharp;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using PipelineViewport = EncDotNet.S100.Pipelines.Viewport;
 
@@ -23,6 +24,23 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
     private const int MaxDim = 4096;
 
     private readonly ICrsTransformFactory _transformFactory;
+
+    /// <summary>
+    /// Cached palette- and value-independent projection layout. The grid-node
+    /// reprojection (native CRS → Web Mercator) and the resulting node→pixel
+    /// mapping depend only on the grid geometry, so they can be reused across
+    /// renders that change only the colour palette, ECDIS display mode, or
+    /// coverage time-step. Published atomically via <see cref="Volatile"/>.
+    /// </summary>
+    private LayoutCacheEntry? _layoutCache;
+
+    /// <summary>Number of times the projection layout was reused from cache.</summary>
+    internal long LayoutCacheHits { get; private set; }
+
+    /// <summary>Number of times the projection layout was (re)built.</summary>
+    internal long LayoutCacheMisses { get; private set; }
+
+    private readonly object _cacheLock = new();
 
     /// <summary>Name assigned to the generated Mapsui layer.</summary>
     public string LayerName { get; set; } = "S-102 Coverage";
@@ -80,6 +98,118 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
             noDataIsFilled = noDataPacked != 0;
         }
 
+        // Resolve the palette- and value-independent projection layout. The
+        // node→pixel mapping is reused when the grid geometry is unchanged
+        // (e.g. across palette switches or coverage time-step changes),
+        // skipping the per-node CRS transform + Mercator projection pass.
+        var layout = GetOrBuildLayout(georeferencer, srcRows, srcCols);
+
+        int outCols = layout.OutCols;
+        int outRows = layout.OutRows;
+        int[] nodeToPixel = layout.NodeToPixel;
+
+        // Render: for each grid node, place its color at the precomputed
+        // Mercator pixel. Fill a uint[] (RGBA8888) buffer directly to avoid
+        // the per-pixel managed→native round-trip that SKBitmap.SetPixel
+        // performs.
+        int pixelCount = outCols * outRows;
+        var pixels = new uint[pixelCount];
+
+        // Pre-resolve band colors to packed RGBA8888 (matches SKColorType.Rgba8888).
+        var bandPacked = new uint[bands.Length];
+        for (int i = 0; i < bands.Length; i++)
+            bandPacked[i] = PackRgba(bands[i].Color);
+
+        for (int r = 0; r < srcRows; r++)
+        for (int c = 0; c < srcCols; c++)
+        {
+            float value = fieldData[r, c];
+            bool isNoData = noDataIsNaN ? float.IsNaN(value) : value == noDataValue;
+
+            uint packed;
+            if (isNoData)
+            {
+                if (!noDataIsFilled) continue;
+                packed = noDataPacked;
+            }
+            else
+            {
+                packed = 0;
+                for (int b = 0; b < bands.Length; b++)
+                {
+                    if (value >= bands[b].Min && value < bands[b].Max)
+                    {
+                        packed = bandPacked[b];
+                        break;
+                    }
+                }
+                if (packed == 0) continue;
+            }
+
+            int target = nodeToPixel[r * srcCols + c];
+            if (target >= 0)
+                pixels[target] = packed;
+        }
+
+        using var bmp = new SKBitmap(new SKImageInfo(outCols, outRows, SKColorType.Rgba8888, SKAlphaType.Premul));
+        // Bulk-copy the pixel buffer into the bitmap's native backing store.
+        var pixelSpan = MemoryMarshal.AsBytes(pixels.AsSpan());
+        pixelSpan.CopyTo(new Span<byte>((void*)bmp.GetPixels(), pixelCount * 4));
+
+        // Encode to PNG
+        using var image = SKImage.FromBitmap(bmp);
+        using var data0 = image.Encode(SKEncodedImageFormat.Png, 100);
+        byte[] pngBytes = data0.ToArray();
+
+        var mercatorExtent = new MRect(layout.MercMinX, layout.MercMinY, layout.MercMaxX, layout.MercMaxY);
+
+        // Build the Mapsui layer
+        var rasterFeature = new RasterFeature(new MRaster(pngBytes, mercatorExtent))
+        {
+            Styles = { new RasterStyle() },
+        };
+
+        return new MemoryLayer
+        {
+            Name = LayerName,
+            Features = new List<RasterFeature> { rasterFeature },
+            Style = null,
+            Opacity = Opacity,
+        };
+    }
+
+    /// <summary>
+    /// Returns the cached projection layout when the grid geometry matches the
+    /// last render, otherwise (re)builds it. The cache key is value-based: it
+    /// compares the native CRS, grid dimensions, and the affine georeferencing
+    /// parameters (origin and spacing), all of which fully determine the
+    /// node→pixel mapping.
+    /// </summary>
+    private LayoutCacheEntry GetOrBuildLayout(GridGeoreferencer georeferencer, int srcRows, int srcCols)
+    {
+        var meta = georeferencer.Metadata;
+        var cached = Volatile.Read(ref _layoutCache);
+        if (cached is not null && cached.Matches(georeferencer.CRS, srcRows, srcCols, meta))
+        {
+            lock (_cacheLock) { LayoutCacheHits++; }
+            return cached;
+        }
+
+        var built = BuildLayout(georeferencer, srcRows, srcCols, meta);
+
+        // Build immutable entry locally, then publish atomically.
+        Volatile.Write(ref _layoutCache, built);
+        lock (_cacheLock) { LayoutCacheMisses++; }
+        return built;
+    }
+
+    /// <summary>
+    /// Projects every grid node to Web Mercator and computes the output raster
+    /// dimensions and the per-node destination pixel index. This is the
+    /// palette- and value-independent portion of a render.
+    /// </summary>
+    private LayoutCacheEntry BuildLayout(GridGeoreferencer georeferencer, int srcRows, int srcCols, GridMetadata meta)
+    {
         // Build CRS transform: native grid CRS → WGS84
         var nativeToWgs84 = _transformFactory.Create(georeferencer.CRS, "EPSG:4326");
 
@@ -137,77 +267,81 @@ public sealed class MapsuiCoverageRenderer : ICoverageRenderer<ILayer>
             cellSizeY = (mercMaxY - mercMinY) / outRows;
         }
 
-        // Render: for each grid node, place its color at the correct Mercator pixel.
-        // Fill a uint[] (RGBA8888) buffer directly to avoid the per-pixel
-        // managed→native round-trip that SKBitmap.SetPixel performs. On a
-        // 2000×2000 grid this saves ~4M P/Invoke crossings per render.
-        int pixelCount = outCols * outRows;
-        var pixels = new uint[pixelCount];
-
-        // Pre-resolve band colors to packed RGBA8888 (matches SKColorType.Rgba8888).
-        var bandPacked = new uint[bands.Length];
-        for (int i = 0; i < bands.Length; i++)
-            bandPacked[i] = PackRgba(bands[i].Color);
-
+        // Compute the destination pixel for each grid node using the final
+        // (post-MaxDim) cell sizes. Out-of-bounds nodes map to -1.
+        var nodeToPixel = new int[srcRows * srcCols];
         for (int r = 0; r < srcRows; r++)
         for (int c = 0; c < srcCols; c++)
         {
-            float value = fieldData[r, c];
-            bool isNoData = noDataIsNaN ? float.IsNaN(value) : value == noDataValue;
-
-            uint packed;
-            if (isNoData)
-            {
-                if (!noDataIsFilled) continue;
-                packed = noDataPacked;
-            }
-            else
-            {
-                packed = 0;
-                for (int b = 0; b < bands.Length; b++)
-                {
-                    if (value >= bands[b].Min && value < bands[b].Max)
-                    {
-                        packed = bandPacked[b];
-                        break;
-                    }
-                }
-                if (packed == 0) continue;
-            }
-
             var (mx, my) = nodePositions[r, c];
             int px = (int)((mx - mercMinX) / cellSizeX);
             int py = outRows - 1 - (int)((my - mercMinY) / cellSizeY);
-
-            if (px >= 0 && px < outCols && py >= 0 && py < outRows)
-                pixels[py * outCols + px] = packed;
+            nodeToPixel[r * srcCols + c] =
+                (px >= 0 && px < outCols && py >= 0 && py < outRows)
+                    ? py * outCols + px
+                    : -1;
         }
 
-        using var bmp = new SKBitmap(new SKImageInfo(outCols, outRows, SKColorType.Rgba8888, SKAlphaType.Premul));
-        // Bulk-copy the pixel buffer into the bitmap's native backing store.
-        var pixelSpan = MemoryMarshal.AsBytes(pixels.AsSpan());
-        pixelSpan.CopyTo(new Span<byte>((void*)bmp.GetPixels(), pixelCount * 4));
+        return new LayoutCacheEntry(
+            georeferencer.CRS, srcRows, srcCols,
+            meta.OriginLongitude, meta.OriginLatitude,
+            meta.SpacingLongitudinal, meta.SpacingLatitudinal,
+            outCols, outRows, nodeToPixel,
+            mercMinX, mercMinY, mercMaxX, mercMaxY);
+    }
 
-        // Encode to PNG
-        using var image = SKImage.FromBitmap(bmp);
-        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
-        var pngBytes = data.ToArray();
-
-        var mercatorExtent = new MRect(mercMinX, mercMinY, mercMaxX, mercMaxY);
-
-        // Build the Mapsui layer
-        var rasterFeature = new RasterFeature(new MRaster(pngBytes, mercatorExtent))
+    /// <summary>
+    /// Immutable, palette-independent projection layout for one grid geometry.
+    /// </summary>
+    private sealed class LayoutCacheEntry
+    {
+        public LayoutCacheEntry(
+            string crs, int srcRows, int srcCols,
+            double originLon, double originLat,
+            double spacingLon, double spacingLat,
+            int outCols, int outRows, int[] nodeToPixel,
+            double mercMinX, double mercMinY, double mercMaxX, double mercMaxY)
         {
-            Styles = { new RasterStyle() },
-        };
+            _crs = crs;
+            _srcRows = srcRows;
+            _srcCols = srcCols;
+            _originLon = originLon;
+            _originLat = originLat;
+            _spacingLon = spacingLon;
+            _spacingLat = spacingLat;
+            OutCols = outCols;
+            OutRows = outRows;
+            NodeToPixel = nodeToPixel;
+            MercMinX = mercMinX;
+            MercMinY = mercMinY;
+            MercMaxX = mercMaxX;
+            MercMaxY = mercMaxY;
+        }
 
-        return new MemoryLayer
-        {
-            Name = LayerName,
-            Features = new List<RasterFeature> { rasterFeature },
-            Style = null,
-            Opacity = Opacity,
-        };
+        private readonly string _crs;
+        private readonly int _srcRows;
+        private readonly int _srcCols;
+        private readonly double _originLon;
+        private readonly double _originLat;
+        private readonly double _spacingLon;
+        private readonly double _spacingLat;
+
+        public int OutCols { get; }
+        public int OutRows { get; }
+        public int[] NodeToPixel { get; }
+        public double MercMinX { get; }
+        public double MercMinY { get; }
+        public double MercMaxX { get; }
+        public double MercMaxY { get; }
+
+        public bool Matches(string crs, int srcRows, int srcCols, GridMetadata meta) =>
+            _srcRows == srcRows &&
+            _srcCols == srcCols &&
+            _crs == crs &&
+            _originLon == meta.OriginLongitude &&
+            _originLat == meta.OriginLatitude &&
+            _spacingLon == meta.SpacingLongitudinal &&
+            _spacingLat == meta.SpacingLatitudinal;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -39,6 +39,29 @@ var renderer = new MapsuiDisplayListRenderer
 
 The cache segments entries per palette (`Day` / `Dusk` / `Night`) so flipping back and forth keeps every palette warm. When `AssetCache` is unset, the renderer falls back to a per-instance cache, which preserves legacy behaviour for ad-hoc / one-shot callers.
 
+### Caching the coverage projection layout across re-renders
+
+`MapsuiCoverageRenderer` reprojects every grid node from the coverage's
+native CRS to Web Mercator and derives a node→pixel mapping. That work
+depends only on the grid geometry (native CRS, dimensions, and the
+affine origin/spacing), so it is **independent of the colour palette,
+ECDIS display mode, and the per-cell values**. The renderer caches the
+resulting `int[]` node→pixel index array (along with the output raster
+dimensions and Mercator extent) keyed on those geometry parameters, and
+reuses it whenever the next render presents the same geometry — e.g. a
+palette switch or a coverage time-step change. Only the value
+classification + pixel fill + PNG encode re-run; the projection pass is
+skipped.
+
+To benefit, keep the renderer instance alive across renders rather than
+constructing a fresh one each time (`S102DatasetProcessor` and
+`S104DatasetProcessor` hold the renderer in a field). The cache is a
+single-slot, value-keyed entry published atomically, so it stays
+correct if a renderer is ever reused for a different geometry (the key
+mismatch forces a rebuild). It caches only the compact index array, not
+the per-node Mercator coordinates, to bound memory (~4 MB per
+megapixel grid).
+
 ## Dynamic feature sources
 
 `EncDotNet.S100.Renderers.Mapsui.DynamicSources` hosts the Mapsui-bound side of the dynamic-feature-source abstraction defined in `EncDotNet.S100.Core` (see [`docs/design/dynamic-feature-source.md`](../../docs/design/dynamic-feature-source.md)). Renderers turn `DynamicFeature` snapshots into Mapsui `IFeature` + `IStyle` instances that the viewer's `DynamicSourceOverlayHost` attaches to a `MemoryLayer` on the overlay tier of `IMapHost`.

--- a/tests/EncDotNet.S100.Pipelines.Tests/MapsuiCoverageRendererCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/MapsuiCoverageRendererCacheTests.cs
@@ -1,0 +1,162 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Validates the palette- and value-independent projection layout cache in
+/// <see cref="MapsuiCoverageRenderer"/>: the cached node→pixel mapping must be
+/// reused across renders that change only the colour palette or coverage
+/// values, without altering the rendered output.
+/// </summary>
+public class MapsuiCoverageRendererCacheTests
+{
+    private static readonly Viewport DefaultViewport = new()
+    {
+        MinLatitude = 0, MaxLatitude = 1,
+        MinLongitude = 0, MaxLongitude = 1,
+        WidthPixels = 100, HeightPixels = 100,
+        ScaleDenominator = 50_000,
+    };
+
+    [Fact]
+    public void Render_RepeatedSameGeometry_ReusesLayout()
+    {
+        var renderer = new MapsuiCoverageRenderer(new ProjNetCrsTransformFactory());
+        var layer = MakeStyledLayer(SchemeA, new float[,] { { 5f, 25f }, { 1f, 50f } });
+
+        var first = GetPng(renderer.Render(layer, DefaultViewport));
+        var second = GetPng(renderer.Render(layer, DefaultViewport));
+
+        Assert.Equal(1, renderer.LayoutCacheMisses);
+        Assert.Equal(1, renderer.LayoutCacheHits);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Render_PaletteChange_ReusesLayout_ButChangesOutput()
+    {
+        var renderer = new MapsuiCoverageRenderer(new ProjNetCrsTransformFactory());
+        var depths = new float[,] { { 5f, 25f }, { 1f, 50f } };
+
+        var withA = GetPng(renderer.Render(MakeStyledLayer(SchemeA, depths), DefaultViewport));
+        var withB = GetPng(renderer.Render(MakeStyledLayer(SchemeB, depths), DefaultViewport));
+
+        // Geometry unchanged → one build, one reuse.
+        Assert.Equal(1, renderer.LayoutCacheMisses);
+        Assert.Equal(1, renderer.LayoutCacheHits);
+
+        // Different palette → different pixels → different PNG bytes.
+        Assert.NotEqual(withA, withB);
+
+        // A palette switch on the cached renderer must match a fresh renderer
+        // that never cached the first palette's geometry.
+        var fresh = new MapsuiCoverageRenderer(new ProjNetCrsTransformFactory());
+        var freshB = GetPng(fresh.Render(MakeStyledLayer(SchemeB, depths), DefaultViewport));
+        Assert.Equal(freshB, withB);
+    }
+
+    [Fact]
+    public void Render_DifferentGeometry_RebuildsLayout()
+    {
+        var renderer = new MapsuiCoverageRenderer(new ProjNetCrsTransformFactory());
+
+        renderer.Render(MakeStyledLayer(SchemeA, new float[,] { { 5f, 25f }, { 1f, 50f } }), DefaultViewport);
+        // Different origin → different geometry → cache miss.
+        renderer.Render(MakeStyledLayer(SchemeA, new float[,] { { 5f, 25f }, { 1f, 50f } }, originLat: 10.0), DefaultViewport);
+
+        Assert.Equal(2, renderer.LayoutCacheMisses);
+        Assert.Equal(0, renderer.LayoutCacheHits);
+    }
+
+    [Fact]
+    public void Render_ValueChangeSameGeometry_ReusesLayout()
+    {
+        var renderer = new MapsuiCoverageRenderer(new ProjNetCrsTransformFactory());
+
+        // Simulates a time-step change: identical grid geometry, new values.
+        var step1 = GetPng(renderer.Render(MakeStyledLayer(SchemeA, new float[,] { { 5f, 25f }, { 1f, 50f } }), DefaultViewport));
+        var step2 = GetPng(renderer.Render(MakeStyledLayer(SchemeA, new float[,] { { 50f, 1f }, { 25f, 5f } }), DefaultViewport));
+
+        Assert.Equal(1, renderer.LayoutCacheMisses);
+        Assert.Equal(1, renderer.LayoutCacheHits);
+        Assert.NotEqual(step1, step2);
+    }
+
+    #region Helpers
+
+    private static readonly CoverageColorScheme SchemeA = new()
+    {
+        FieldName = "depth",
+        Bands =
+        [
+            new ColorBand { MinValue = 0f, MaxValue = 3f, Color = "#ADE3FF" },
+            new ColorBand { MinValue = 3f, MaxValue = 10f, Color = "#6BC5FF" },
+            new ColorBand { MinValue = 10f, MaxValue = 30f, Color = "#2196F3" },
+            new ColorBand { MinValue = 30f, MaxValue = 100f, Color = "#0D47A1" },
+        ],
+    };
+
+    private static readonly CoverageColorScheme SchemeB = new()
+    {
+        FieldName = "depth",
+        Bands =
+        [
+            new ColorBand { MinValue = 0f, MaxValue = 3f, Color = "#FF0000" },
+            new ColorBand { MinValue = 3f, MaxValue = 10f, Color = "#00FF00" },
+            new ColorBand { MinValue = 10f, MaxValue = 30f, Color = "#0000FF" },
+            new ColorBand { MinValue = 30f, MaxValue = 100f, Color = "#FFFF00" },
+        ],
+    };
+
+    private static StyledCoverageLayer MakeStyledLayer(
+        CoverageColorScheme scheme,
+        float[,] depths,
+        double originLat = 0.0)
+    {
+        var gridMeta = new GridMetadata
+        {
+            NumRows = depths.GetLength(0),
+            NumColumns = depths.GetLength(1),
+            OriginLatitude = originLat,
+            OriginLongitude = 0,
+            SpacingLatitudinal = 0.01,
+            SpacingLongitudinal = 0.01,
+        };
+
+        return new()
+        {
+            Coverage = new SampledCoverage
+            {
+                Region = GridRegion.Full,
+                Metadata = gridMeta,
+                Values = new Dictionary<string, float[]> { ["depth"] = Flatten(depths) },
+            },
+            ColorScheme = scheme,
+            NoDataValue = float.NaN,
+            Georeferencer = new GridGeoreferencer(gridMeta, "EPSG:4326"),
+        };
+    }
+
+    private static float[] Flatten(float[,] src)
+    {
+        int rows = src.GetLength(0), cols = src.GetLength(1);
+        var flat = new float[rows * cols];
+        for (int r = 0; r < rows; r++)
+            for (int c = 0; c < cols; c++)
+                flat[r * cols + c] = src[r, c];
+        return flat;
+    }
+
+    private static byte[] GetPng(ILayer layer)
+    {
+        var memoryLayer = Assert.IsType<MemoryLayer>(layer);
+        var feature = memoryLayer.Features.OfType<RasterFeature>().First();
+        return feature.Raster!.Data;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Continuing the dataset load/render performance review using the viewer's MCP automation tools, this adds a **projection-layout cache** to the Mapsui coverage renderer (S-102 / S-104) and documents the end-to-end MCP performance-testing workflow.

### The optimization

`MapsuiCoverageRenderer` reprojects every grid node native-CRS → WGS84 → Web Mercator and derives a node→pixel mapping on **every** render. That work depends only on the grid geometry (native CRS, dimensions, affine origin/spacing) and is **independent of the colour palette, ECDIS display mode, and per-cell values** — yet it re-ran on every palette switch and time-step scrub.

Profiling the 12-tile S-102 trial set via MCP showed this projection pass costs **~8.5 ms per ~1 Mpx tile** (≈100 ms across 12 tiles per palette switch).

The pass1 projection, output-dimension derivation, and per-node destination-pixel computation are now factored into an immutable, value-keyed `LayoutCacheEntry`:
- Key: `srcRows`, `srcCols`, CRS string, and the affine `Origin{Lon,Lat}` / `Spacing{Lon,Lat}` — which fully determine the projection.
- Caches only the compact `int[]` node→pixel index array (+ output dims + Mercator extent), **not** per-node Mercator coordinates, to bound memory (~4 MB / Mpx).
- Single-slot field, published atomically (`Volatile`); a key mismatch forces a rebuild if a renderer is ever reused for a different geometry.

On a palette/time-step change only value classification + pixel fill + PNG encode re-run.

`S104DatasetProcessor`'s renderer is hoisted to a field so it benefits (S-102 already held one). S-111 uses the arrow renderer and is unaffected.

### Workflow documentation (per request)

`.github/instructions/viewer.instructions.md` now documents the repeatable E2E MCP performance-testing recipe: launch ephemerally with `--mcp --mcp-port-file`, connect a Streamable-HTTP client, drive `open_dataset` / `set_viewport` / `await_render_idle` / `get_render_stats` / `set_palette`, and attribute CPU with `dotnet-trace`. It captures the key finding that **palette-switch wall time is dominated by fixed settle/framework latency** (≈935 ms regardless of dataset count), so profiling — not wall time — is the right signal, and the next user-facing lever is the re-render orchestration rather than coverage CPU.

## Tests

New `MapsuiCoverageRendererCacheTests` (4 cases) validate:
- repeated same-geometry renders reuse the layout (1 miss, 1 hit);
- a palette change reuses the layout but produces different bytes, and a cache-hit render is **byte-identical** to a fresh renderer rendering the same palette;
- different geometry rebuilds (2 misses);
- a value/time-step change with identical geometry reuses the layout.

All green: Pipelines.Tests 473 passed (1 pre-existing skip), S104 49, S111 88.

## Notes

- No behavioural change to rendered output — only the projection work is memoized.
- Temporary profiling instrumentation used during the review was removed; no diagnostic env switches ship.