### PR TITLE
Enrich FC/PC panel rows with product name and metadata

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -190,7 +190,8 @@ public partial class MainWindow : ShadUI.Window
         // Show built-in specification entries in the catalogue views
         foreach (var spec in Specifications.Specification.AvailableSpecs)
         {
-            _viewModel.FeatureCatalogues.AddBuiltIn(spec, Strings.Catalogue_BuiltInLabel, CatalogueSpecDetection.ReadBuiltInFeatureCatalogueVersion(spec));
+            var (fcVersion, fcVersionDate) = CatalogueSpecDetection.ReadBuiltInFeatureCatalogueInfo(spec);
+            _viewModel.FeatureCatalogues.AddBuiltIn(spec, Strings.Catalogue_BuiltInLabel, fcVersion, fcVersionDate);
 
             if (Specifications.Specification.HasPortrayalCatalogue(spec))
             {

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -28,6 +28,17 @@ internal static class Strings
     private static string Get(string name) =>
         ResourceManager.GetString(name, Culture) ?? name;
 
+    /// <summary>
+    /// Returns the curated human-readable product title for a spec code
+    /// (e.g. <c>"S-101"</c> → "Electronic Navigational Chart"), or
+    /// <c>null</c> when the spec is not in the curated map. Lookup keys drop
+    /// the hyphen from the spec code (<c>"S-101"</c> → <c>SpecName_S101</c>).
+    /// </summary>
+    public static string? SpecDisplayName(string spec) =>
+        string.IsNullOrEmpty(spec)
+            ? null
+            : ResourceManager.GetString("SpecName_" + spec.Replace("-", string.Empty), Culture);
+
     // Window
     public static string Window_Title => Get(nameof(Window_Title));
 

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -401,6 +401,52 @@
     <value>(built-in)</value>
   </data>
 
+  <!-- Curated product-specification titles (spec code -> human-readable name).
+       Shared by the Feature- and Portrayal-catalogue panels. Keys drop the
+       hyphen from the spec code (e.g. "S-101" -> SpecName_S101). -->
+  <data name="SpecName_S101" xml:space="preserve">
+    <value>Electronic Navigational Chart</value>
+  </data>
+  <data name="SpecName_S102" xml:space="preserve">
+    <value>Bathymetric Surface</value>
+  </data>
+  <data name="SpecName_S104" xml:space="preserve">
+    <value>Water Level Information for Surface Navigation</value>
+  </data>
+  <data name="SpecName_S111" xml:space="preserve">
+    <value>Surface Currents</value>
+  </data>
+  <data name="SpecName_S122" xml:space="preserve">
+    <value>Marine Protected Areas</value>
+  </data>
+  <data name="SpecName_S124" xml:space="preserve">
+    <value>Navigational Warnings</value>
+  </data>
+  <data name="SpecName_S125" xml:space="preserve">
+    <value>Marine Aids to Navigation</value>
+  </data>
+  <data name="SpecName_S127" xml:space="preserve">
+    <value>Marine Resources and Services</value>
+  </data>
+  <data name="SpecName_S128" xml:space="preserve">
+    <value>Catalogue of Nautical Products</value>
+  </data>
+  <data name="SpecName_S129" xml:space="preserve">
+    <value>Under Keel Clearance Management</value>
+  </data>
+  <data name="SpecName_S131" xml:space="preserve">
+    <value>Marine Harbour Infrastructure</value>
+  </data>
+  <data name="SpecName_S201" xml:space="preserve">
+    <value>Aids to Navigation Information</value>
+  </data>
+  <data name="SpecName_S411" xml:space="preserve">
+    <value>Sea Ice Information</value>
+  </data>
+  <data name="SpecName_S421" xml:space="preserve">
+    <value>Route Plan</value>
+  </data>
+
   <!-- Catalog (S-128) panel -->
   <data name="Catalog_EmptyMessage" xml:space="preserve">
     <value>No catalogues found.

--- a/src/EncDotNet.S100.Viewer/Services/CatalogueSpecDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/CatalogueSpecDetection.cs
@@ -60,17 +60,27 @@ internal static class CatalogueSpecDetection
     /// <paramref name="spec"/>, or null if not bundled / unreadable.
     /// </summary>
     public static string? ReadBuiltInFeatureCatalogueVersion(string spec)
+        => ReadBuiltInFeatureCatalogueInfo(spec).Version;
+
+    /// <summary>
+    /// Returns the version number and version date of the bundled feature
+    /// catalogue for <paramref name="spec"/>. Either component is null when
+    /// the catalogue is not bundled, unreadable, or omits the field.
+    /// </summary>
+    public static (string? Version, string? VersionDate) ReadBuiltInFeatureCatalogueInfo(string spec)
     {
         try
         {
             using var stream = Specifications.Specification.TryOpenFeatureCatalogue(spec);
-            if (stream is null) return null;
+            if (stream is null) return (null, null);
             var catalogue = FeatureCatalogueReader.Read(stream);
-            return string.IsNullOrEmpty(catalogue.VersionNumber) ? null : catalogue.VersionNumber;
+            return (
+                string.IsNullOrEmpty(catalogue.VersionNumber) ? null : catalogue.VersionNumber,
+                string.IsNullOrEmpty(catalogue.VersionDate) ? null : catalogue.VersionDate);
         }
         catch
         {
-            return null;
+            return (null, null);
         }
     }
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/CatalogueViewModels.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/CatalogueViewModels.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,7 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Viewer.Resources;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
 
@@ -31,7 +33,7 @@ internal sealed class FeatureCataloguesViewModel : ViewModelBase
         Entries.Clear();
         foreach (var (spec, path) in _settings.FeatureCataloguePaths.OrderBy(kv => kv.Key))
         {
-            Entries.Add(new CatalogueEntry(spec, path, version: ReadFeatureCatalogueVersion(path)));
+            Entries.Add(CreateEntry(spec, path, isBuiltIn: false));
         }
     }
 
@@ -47,32 +49,55 @@ internal sealed class FeatureCataloguesViewModel : ViewModelBase
     /// </summary>
     public void AddTransient(string spec, string path)
     {
-        Entries.Add(new CatalogueEntry(spec, path, version: ReadFeatureCatalogueVersion(path)));
+        Entries.Add(CreateEntry(spec, path, isBuiltIn: false));
     }
 
     /// <summary>
     /// Adds a built-in catalogue entry that cannot be removed by the user.
     /// Skipped if a user-provided entry already exists for the spec.
     /// </summary>
-    public void AddBuiltIn(string spec, string displayPath, string? version = null)
+    public void AddBuiltIn(string spec, string displayPath, string? version = null, string? versionDate = null)
     {
         if (!Entries.Any(e => e.ProductSpec.Equals(spec, StringComparison.OrdinalIgnoreCase)))
         {
-            Entries.Add(new CatalogueEntry(spec, displayPath, isBuiltIn: true, version: version));
+            // Built-in specs are always covered by the curated title map, so the
+            // parsed-name fallback never fires here.
+            var title = ComposeTitle(spec, Strings.SpecDisplayName(spec));
+            Entries.Add(new CatalogueEntry(spec, title, displayPath, isBuiltIn: true, version: version, versionDate: versionDate));
         }
     }
 
-    private static string? ReadFeatureCatalogueVersion(string path)
+    private static CatalogueEntry CreateEntry(string spec, string path, bool isBuiltIn)
+    {
+        var (name, version, date) = ReadFeatureCatalogueInfo(path);
+        // Curated name first; fall back to the catalogue's own declared name
+        // (for custom specs outside the bundled set).
+        var name2 = Strings.SpecDisplayName(spec) ?? (string.IsNullOrWhiteSpace(name) ? null : name);
+        return new CatalogueEntry(spec, ComposeTitle(spec, name2), path, isBuiltIn: isBuiltIn, version: version, versionDate: date);
+    }
+
+    /// <summary>
+    /// Composes the primary list line: the spec code followed by the
+    /// product name (e.g. "S-101 Electronic Navigational Chart"), or just
+    /// the spec code when no name is available.
+    /// </summary>
+    internal static string ComposeTitle(string spec, string? name) =>
+        string.IsNullOrWhiteSpace(name) ? spec : $"{spec} {name}";
+
+    private static (string? Name, string? Version, string? VersionDate) ReadFeatureCatalogueInfo(string path)
     {
         try
         {
             using var stream = File.OpenRead(path);
             var catalogue = FeatureCatalogueReader.Read(stream);
-            return string.IsNullOrEmpty(catalogue.VersionNumber) ? null : catalogue.VersionNumber;
+            return (
+                string.IsNullOrEmpty(catalogue.Name) ? null : catalogue.Name,
+                string.IsNullOrEmpty(catalogue.VersionNumber) ? null : catalogue.VersionNumber,
+                string.IsNullOrEmpty(catalogue.VersionDate) ? null : catalogue.VersionDate);
         }
         catch
         {
-            return null;
+            return (null, null, null);
         }
     }
 
@@ -109,7 +134,7 @@ internal sealed class PortrayalCataloguesViewModel : ViewModelBase
         Entries.Clear();
         foreach (var (spec, path) in _settings.CataloguePaths.OrderBy(kv => kv.Key))
         {
-            Entries.Add(new CatalogueEntry(spec, path, version: ReadPortrayalCatalogueVersion(path)));
+            Entries.Add(CreateEntry(spec, path, isBuiltIn: false));
         }
     }
 
@@ -127,7 +152,7 @@ internal sealed class PortrayalCataloguesViewModel : ViewModelBase
     public void AddTransient(string spec, string path)
     {
         _catalogueManager.SetPath(spec, path);
-        Entries.Add(new CatalogueEntry(spec, path, version: ReadPortrayalCatalogueVersion(path)));
+        Entries.Add(CreateEntry(spec, path, isBuiltIn: false));
     }
 
     /// <summary>
@@ -138,8 +163,17 @@ internal sealed class PortrayalCataloguesViewModel : ViewModelBase
     {
         if (!Entries.Any(e => e.ProductSpec.Equals(spec, StringComparison.OrdinalIgnoreCase)))
         {
-            Entries.Add(new CatalogueEntry(spec, displayPath, isBuiltIn: true, version: version));
+            var title = FeatureCataloguesViewModel.ComposeTitle(spec, Strings.SpecDisplayName(spec));
+            Entries.Add(new CatalogueEntry(spec, title, displayPath, isBuiltIn: true, version: version));
         }
+    }
+
+    private static CatalogueEntry CreateEntry(string spec, string path, bool isBuiltIn)
+    {
+        // Portrayal catalogues carry no human-readable name, so the curated map
+        // is the only name source; the title degrades to the spec code alone.
+        var title = FeatureCataloguesViewModel.ComposeTitle(spec, Strings.SpecDisplayName(spec));
+        return new CatalogueEntry(spec, title, path, isBuiltIn: isBuiltIn, version: ReadPortrayalCatalogueVersion(path));
     }
 
     private static string? ReadPortrayalCatalogueVersion(string folderPath)
@@ -171,16 +205,67 @@ internal sealed class PortrayalCataloguesViewModel : ViewModelBase
 internal sealed class CatalogueEntry
 {
     public string ProductSpec { get; }
+
+    /// <summary>
+    /// Human-readable product title shown as the primary line in the list
+    /// (e.g. "Electronic Navigational Chart"). Resolved from the curated
+    /// spec-name map, the catalogue's declared name, or the spec code.
+    /// </summary>
+    public string DisplayTitle { get; }
+
     public string Path { get; }
     public bool IsBuiltIn { get; }
     public string? Version { get; }
-    public string DisplayName => $"{ProductSpec} — {System.IO.Path.GetFileName(Path.TrimEnd(System.IO.Path.DirectorySeparatorChar))}";
+    public string? VersionDate { get; }
 
-    public CatalogueEntry(string productSpec, string path, bool isBuiltIn = false, string? version = null)
+    /// <summary>
+    /// Secondary identity line: version number, version date, and a
+    /// "built-in" marker for bundled catalogues. The spec code is omitted
+    /// here because it already leads <see cref="DisplayTitle"/>.
+    /// </summary>
+    public string Subtitle
+    {
+        get
+        {
+            var parts = new List<string>(3);
+            if (!string.IsNullOrEmpty(Version))
+            {
+                parts.Add($"v{Version}");
+            }
+            if (!string.IsNullOrEmpty(VersionDate))
+            {
+                parts.Add(VersionDate!);
+            }
+            if (IsBuiltIn)
+            {
+                parts.Add(Strings.Catalogue_BuiltInLabel);
+            }
+            return string.Join(" · ", parts);
+        }
+    }
+
+    /// <summary>True when <see cref="Subtitle"/> has content to display.</summary>
+    public bool HasSubtitle => Subtitle.Length > 0;
+
+    /// <summary>
+    /// True when the file-system path should be shown. Built-in catalogues
+    /// carry no meaningful path (their provenance is shown in the subtitle).
+    /// </summary>
+    public bool ShowPath => !IsBuiltIn && !string.IsNullOrEmpty(Path);
+
+    public CatalogueEntry(
+        string productSpec,
+        string displayTitle,
+        string path,
+        bool isBuiltIn = false,
+        string? version = null,
+        string? versionDate = null)
     {
         ProductSpec = productSpec;
+        DisplayTitle = displayTitle;
         Path = path;
         IsBuiltIn = isBuiltIn;
         Version = version;
+        VersionDate = versionDate;
     }
 }

--- a/src/EncDotNet.S100.Viewer/Views/FeatureCataloguesView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeatureCataloguesView.axaml
@@ -26,19 +26,19 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="vm:CatalogueEntry">
                     <Grid ColumnDefinitions="*,Auto">
-                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <TextBlock Text="{Binding ProductSpec}"
-                                           FontWeight="SemiBold" />
-                                <TextBlock Text="{Binding Version}"
-                                           FontSize="11"
-                                           Opacity="0.6"
-                                           VerticalAlignment="Center"
-                                           IsVisible="{Binding Version, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                            </StackPanel>
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="1">
+                            <TextBlock Text="{Binding DisplayTitle}"
+                                       FontWeight="SemiBold"
+                                       TextTrimming="CharacterEllipsis" />
+                            <TextBlock Text="{Binding Subtitle}"
+                                       FontSize="11"
+                                       Opacity="0.6"
+                                       Margin="0,3,0,0"
+                                       IsVisible="{Binding HasSubtitle}" />
                             <TextBlock Text="{Binding Path}"
                                        FontSize="11"
                                        Opacity="0.6"
+                                       IsVisible="{Binding ShowPath}"
                                        TextTrimming="CharacterEllipsis" />
                         </StackPanel>
                         <Button Grid.Column="1"

--- a/src/EncDotNet.S100.Viewer/Views/PortrayalCataloguesView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PortrayalCataloguesView.axaml
@@ -26,19 +26,19 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="vm:CatalogueEntry">
                     <Grid ColumnDefinitions="*,Auto">
-                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <TextBlock Text="{Binding ProductSpec}"
-                                           FontWeight="SemiBold" />
-                                <TextBlock Text="{Binding Version}"
-                                           FontSize="11"
-                                           Opacity="0.6"
-                                           VerticalAlignment="Center"
-                                           IsVisible="{Binding Version, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                            </StackPanel>
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="1">
+                            <TextBlock Text="{Binding DisplayTitle}"
+                                       FontWeight="SemiBold"
+                                       TextTrimming="CharacterEllipsis" />
+                            <TextBlock Text="{Binding Subtitle}"
+                                       FontSize="11"
+                                       Opacity="0.6"
+                                       Margin="0,3,0,0"
+                                       IsVisible="{Binding HasSubtitle}" />
                             <TextBlock Text="{Binding Path}"
                                        FontSize="11"
                                        Opacity="0.6"
+                                       IsVisible="{Binding ShowPath}"
                                        TextTrimming="CharacterEllipsis" />
                         </StackPanel>
                         <Button Grid.Column="1"

--- a/tests/EncDotNet.S100.Viewer.Tests/CatalogueEntryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/CatalogueEntryTests.cs
@@ -1,0 +1,86 @@
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Verifies the inline metadata projected by <see cref="CatalogueEntry"/> and
+/// the curated spec-title lookup in <see cref="Strings.SpecDisplayName"/> that
+/// the Feature- and Portrayal-catalogue panels display.
+/// </summary>
+public class CatalogueEntryTests
+{
+    [Theory]
+    [InlineData("S-101", "Electronic Navigational Chart")]
+    [InlineData("S-104", "Water Level Information for Surface Navigation")]
+    [InlineData("S-421", "Route Plan")]
+    public void SpecDisplayName_returns_curated_title_for_known_spec(string spec, string expected)
+    {
+        Assert.Equal(expected, Strings.SpecDisplayName(spec));
+    }
+
+    [Theory]
+    [InlineData("S-999")]
+    [InlineData("")]
+    public void SpecDisplayName_returns_null_for_unknown_or_empty_spec(string spec)
+    {
+        Assert.Null(Strings.SpecDisplayName(spec));
+    }
+
+    [Fact]
+    public void Subtitle_contains_only_version_and_date()
+    {
+        var entry = new CatalogueEntry(
+            "S-101",
+            "S-101 Electronic Navigational Chart",
+            "/tmp/fc.xml",
+            version: "1.0.0",
+            versionDate: "2023-01-01");
+
+        Assert.Equal("v1.0.0 · 2023-01-01", entry.Subtitle);
+        Assert.True(entry.HasSubtitle);
+        Assert.True(entry.ShowPath);
+    }
+
+    [Fact]
+    public void Subtitle_appends_built_in_marker_and_path_is_hidden_for_built_ins()
+    {
+        var entry = new CatalogueEntry(
+            "S-101",
+            "S-101 Electronic Navigational Chart",
+            Strings.Catalogue_BuiltInLabel,
+            isBuiltIn: true,
+            version: "1.0.0",
+            versionDate: "2023-01-01");
+
+        Assert.Equal($"v1.0.0 · 2023-01-01 · {Strings.Catalogue_BuiltInLabel}", entry.Subtitle);
+        Assert.False(entry.ShowPath);
+    }
+
+    [Fact]
+    public void ComposeTitle_prefixes_spec_code_before_name()
+    {
+        Assert.Equal(
+            "S-101 Electronic Navigational Chart",
+            FeatureCataloguesViewModel.ComposeTitle("S-101", "Electronic Navigational Chart"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ComposeTitle_falls_back_to_spec_code_when_name_missing(string? name)
+    {
+        Assert.Equal("S-999", FeatureCataloguesViewModel.ComposeTitle("S-999", name));
+    }
+
+    [Fact]
+    public void Subtitle_is_empty_when_no_secondary_metadata_is_available()
+    {
+        var entry = new CatalogueEntry("S-999", "S-999", "/tmp/fc.xml");
+
+        Assert.Equal(string.Empty, entry.Subtitle);
+        Assert.False(entry.HasSubtitle);
+    }
+}


### PR DESCRIPTION
## Summary

The Feature Catalogue and Portrayal Catalogue activity panels previously listed only the bare spec code, a version, and a path, which made entries hard to identify at a glance. This surfaces the actual product name inline and tidies the secondary metadata so each row is self-describing.

Each row now shows:

- **Primary line:** the spec code followed by the product name, e.g. `S-101 Electronic Navigational Chart`. The name is resolved from a curated, localizable spec-name map in `Strings.resx`, falling back to the catalogue's own declared `Name` for custom specs outside the bundled set, then to the spec code alone.
- **Secondary line:** version, version date (FC only), and a `(built-in)` marker for bundled catalogues, joined by middle dots (e.g. `v2.0.0 · 2024-10-16 · (built-in)`).
- **Path line:** shown only for user-loaded catalogues; hidden for built-ins since their path is not meaningful.

The curated map is the chosen source of truth because the parsed FC `Name` is inconsistent across specs (some return a friendly title like "Electronic Navigational Chart", others just "S-104" or "Route"), and Portrayal Catalogues carry no name at all. Both panels share the same map so PC titles stay consistent with their FC counterparts.

This is the inline-enrichment step; a details/properties subpane (producer, scope, content counts) remains a possible follow-up but is intentionally out of scope here.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a viewer UI presentation change only; it does not alter any spec encoding, attribute names, or portrayal semantics.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/` (`CatalogueEntryTests` covering title composition, subtitle content, the built-in marker, path visibility, and the curated name lookup)
- [x] Tests requiring real data files use `SkippableFact` (N/A — new tests use only in-memory fixtures)
- [x] `dotnet test --configuration Release` passes locally (viewer test project: 12 catalogue tests plus full suite green)

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (N/A — the viewer README does not document the panel row layout)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A)
- [x] New public APIs have XML doc comments (`Strings.SpecDisplayName`, enriched `CatalogueEntry` members)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependencies)

## Breaking changes

None. All changed types (`CatalogueEntry`, the catalogue view models) are `internal` to the viewer; new strings are additive.