### PR TITLE
Split S-100 vector renderer into a backend-agnostic core + headless Skia renderer

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -12,10 +12,12 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Skia.Scene;
 using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Projections;
+using SkiaSharp;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -213,6 +215,160 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
                     WithinPlanePriority: 0,
                     SourceDatasetId: _fileName),
             },
+        };
+    }
+
+    /// <summary>
+    /// Renders this dataset to a standalone <see cref="SKBitmap"/> through the
+    /// headless, backend-agnostic Skia vector core
+    /// (<see cref="VectorSceneBuilder"/> → <see cref="SkiaDisplayListRenderer"/>),
+    /// bypassing Mapsui entirely. This is the vector analogue of the direct-Skia
+    /// coverage renderer and the basis for a headless tile-serving API.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <param name="context">Optional render context (palette, symbol/text scale, ECDIS display settings).</param>
+    /// <param name="background">Optional background fill; defaults to opaque white.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    /// <remarks>
+    /// Pattern area-fills are not yet represented in the shared IR, so areas with
+    /// an area-fill reference are omitted here; all point, line, solid-colour
+    /// area, and text portrayal is rendered. Use <see cref="RenderAsync"/> (the
+    /// Mapsui path) for full pattern-fill fidelity. The viewport is auto-fitted
+    /// to the dataset extent and padded to the output aspect ratio.
+    /// </remarks>
+    public async Task<SKBitmap> RenderHeadlessAsync(
+        int widthPixels,
+        int heightPixels,
+        RenderContext? context = null,
+        RgbaColor? background = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var catalogue = _catalogue;
+        context?.EcdisDisplay?.ApplyTo(catalogue);
+        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+
+        var featureSource = CreateFeatureXmlSource();
+        var pipeline = new PortrayalPipeline();
+        var portrayalLayer = await pipeline.ProcessAsync(featureSource, catalogue, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        var instructions = PostProcessInstructions(((IVectorLayer)portrayalLayer).Instructions);
+
+        var palette = catalogue.ActivePalette;
+        var builder = new VectorSceneBuilder
+        {
+            ResolveColor = ColorResolver.Create(palette),
+            SymbolResolver = name =>
+            {
+                try { return VectorSceneBuilder.ResolveSymbolAsset(catalogue.GetSymbol(name).SvgContent, palette); }
+                catch { return null; }
+            },
+            LineStyleProvider = name =>
+            {
+                try { return catalogue.GetLineStyle(name); }
+                catch { return null; }
+            },
+            SymbolScale = context?.SymbolScale ?? 1.0,
+            TextScale = context?.TextScale ?? 1.0,
+        };
+
+        var geometryProvider = new GmlFeatureGeometryProvider<TFeature>(Features);
+        var scene = builder.Build(instructions, geometryProvider);
+
+        var viewport = BuildFittedViewport(widthPixels, heightPixels);
+        var renderer = new SkiaDisplayListRenderer
+        {
+            Background = background ?? new RgbaColor(255, 255, 255, 255),
+        };
+        return renderer.Render(scene, viewport);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="Viewport"/> fitted to the dataset's geographic extent,
+    /// padded so its EPSG:3857 aspect ratio matches the requested pixel rectangle
+    /// (so the headless renderer's independent X/Y scaling does not distort).
+    /// </summary>
+    private EncDotNet.S100.Pipelines.Viewport BuildFittedViewport(int widthPixels, int heightPixels)
+    {
+        double minLon = double.MaxValue, minLat = double.MaxValue;
+        double maxLon = double.MinValue, maxLat = double.MinValue;
+        bool any = false;
+
+        void Expand(double lat, double lon)
+        {
+            any = true;
+            if (lat < minLat) minLat = lat;
+            if (lat > maxLat) maxLat = lat;
+            if (lon < minLon) minLon = lon;
+            if (lon > maxLon) maxLon = lon;
+        }
+
+        foreach (var feature in Features)
+        {
+            foreach (var (lat, lon) in feature.Points) Expand(lat, lon);
+            foreach (var curve in feature.Curves)
+                foreach (var (lat, lon) in curve) Expand(lat, lon);
+            foreach (var (lat, lon) in feature.ExteriorRing) Expand(lat, lon);
+        }
+
+        if (!any)
+        {
+            minLon = -0.001; maxLon = 0.001;
+            minLat = -0.001; maxLat = 0.001;
+        }
+
+        var latPad = Math.Max(MinExtentPadding, (maxLat - minLat) * 0.1);
+        var lonPad = Math.Max(MinExtentPadding, (maxLon - minLon) * 0.1);
+        minLat -= latPad; maxLat += latPad;
+        minLon -= lonPad; maxLon += lonPad;
+
+        // Match the output aspect ratio in projected (EPSG:3857) space, then
+        // convert the expanded corners back to lon/lat for the Viewport.
+        var (x1, y1) = SphericalMercator.FromLonLat(minLon, minLat);
+        var (x2, y2) = SphericalMercator.FromLonLat(maxLon, maxLat);
+        double spanX = x2 - x1, spanY = y2 - y1;
+        double viewAspect = (double)widthPixels / heightPixels;
+
+        if (spanX > 0 && spanY > 0)
+        {
+            double dataAspect = spanX / spanY;
+            if (dataAspect > viewAspect)
+            {
+                double targetSpanY = spanX / viewAspect;
+                double grow = (targetSpanY - spanY) / 2.0;
+                y1 -= grow; y2 += grow;
+            }
+            else
+            {
+                double targetSpanX = spanY * viewAspect;
+                double grow = (targetSpanX - spanX) / 2.0;
+                x1 -= grow; x2 += grow;
+            }
+        }
+
+        var (fitMinLon, fitMinLat) = SphericalMercator.ToLonLat(x1, y1);
+        var (fitMaxLon, fitMaxLat) = SphericalMercator.ToLonLat(x2, y2);
+
+        // Approximate scale denominator for scale-visibility culling: ground
+        // metres per pixel ÷ the S-100 standard 0.00028 m/px screen pitch.
+        double midLatRad = (fitMinLat + fitMaxLat) * 0.5 * Math.PI / 180.0;
+        double groundMetresPerPixel = (x2 - x1) / widthPixels * Math.Cos(midLatRad);
+        double denom = groundMetresPerPixel / ScaleVisibility.DenomToResolutionMetres;
+
+        return new EncDotNet.S100.Pipelines.Viewport
+        {
+            MinLongitude = fitMinLon,
+            MaxLongitude = fitMaxLon,
+            MinLatitude = fitMinLat,
+            MaxLatitude = fitMaxLat,
+            WidthPixels = widthPixels,
+            HeightPixels = heightPixels,
+            ScaleDenominator = denom > 0 ? denom : 1.0,
         };
     }
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -6,6 +6,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Renderers.Skia;
+using Scene = EncDotNet.S100.Renderers.Skia.Scene;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -189,21 +190,35 @@ public sealed class MapsuiDisplayListRenderer
             .ThenBy(i => i.DrawingPriority)
             .ToList();
 
-        // 2. Build color resolver from palette
-        var resolveColor = BuildColorResolver(Palette);
+        // 2. Lower the non-pattern instructions into the shared, backend-agnostic
+        //    VectorScene. All S-100 Part 9 correctness (draw ordering, colour /
+        //    mm→px / symbol / line-style / text-anchor resolution, and the
+        //    lat/lon → EPSG:3857 projection half) now lives in VectorSceneBuilder;
+        //    the Mapsui-specific feature/style construction below merely consumes
+        //    that IR. Pattern fills are intentionally NOT represented in the IR for
+        //    this slice — they keep their dedicated collection / priority-clip /
+        //    insert phase below, so Mapsui pattern output is byte-for-byte
+        //    unchanged.
+        var builder = new Scene.VectorSceneBuilder
+        {
+            ResolveColor = Scene.ColorResolver.Create(Palette),
+            SymbolResolver = ResolveSymbolAsset,
+            LineStyleProvider = LineStyleProvider,
+            SymbolScale = SymbolScale,
+            TextScale = TextScale,
+        };
+        var scene = builder.Build(instructions, geometryProvider);
 
-        // 3. Convert each instruction to a Mapsui feature.
-        //    Pattern fills are collected and merged per unique pattern so that
-        //    overlapping polygons with the same globally-anchored pattern are
-        //    drawn exactly once, preventing alpha accumulation artifacts.
-        //    Merged patterns are inserted after all color fills to ensure no
-        //    solid fill can cover a previously-drawn pattern.
-        var mapFeatures = new List<IFeature>();
+        var mapFeatures = new List<IFeature>(scene.Ops.Count);
         var patternEntries = new List<(string PatternRef, int Priority, List<Polygon> Polygons)>();
         int lastColorFillIndex = -1;
 
-        // Track which features produce pattern fills, so we can identify
-        // "non-patterned" color fill areas (like land) that should occlude patterns.
+        // 3a. Pattern bookkeeping (unchanged): collect pattern polygons grouped
+        //     by (pattern, priority), plus the non-patterned colour fills (e.g.
+        //     land) that clip them. Pattern fills are merged per unique pattern so
+        //     overlapping polygons with the same globally-anchored pattern are
+        //     drawn exactly once. This mirrors the legacy single-pass collection
+        //     and is kept separate from the IR for this slice.
         var featuresWithPatterns = new HashSet<string>(StringComparer.Ordinal);
         foreach (var instruction in sorted)
         {
@@ -211,9 +226,6 @@ public sealed class MapsuiDisplayListRenderer
                 featuresWithPatterns.Add(pa.FeatureReference);
         }
 
-        // Collect opaque color fill polygons from features that do NOT also
-        // produce a pattern fill. These represent areas (such as land) where
-        // patterns from other features should not be visible.
         var nonPatternedColorFillPolygons = new List<Polygon>();
 
         foreach (var instruction in sorted)
@@ -271,16 +283,22 @@ public sealed class MapsuiDisplayListRenderer
                 if (polygon is not null)
                     nonPatternedColorFillPolygons.Add(polygon);
             }
+        }
 
-            var mapFeature = CreateMapFeature(instruction, geom, resolveColor, this);
-            if (mapFeature is not null)
-            {
-                mapFeatures.Add(mapFeature);
+        // 3b. Build Mapsui features from the IR, in Part 9 draw order. Solid-area
+        //     ops mark the colour-fill boundary so merged patterns are inserted
+        //     after them (preventing a solid fill from occluding a pattern). The
+        //     scene contains the same non-pattern ops, in the same order, as the
+        //     legacy single-pass loop produced.
+        foreach (var op in scene.Ops)
+        {
+            var mapFeature = CreateMapFeature(op);
+            if (mapFeature is null)
+                continue;
 
-                // Track where color fills end so we can insert patterns after them
-                if (instruction is AreaInstruction { FillColor: not null })
-                    lastColorFillIndex = mapFeatures.Count;
-            }
+            mapFeatures.Add(mapFeature);
+            if (op is Scene.AreaPaintOp)
+                lastColorFillIndex = mapFeatures.Count;
         }
 
         // Clip lower-priority pattern groups to exclude areas covered by
@@ -325,25 +343,51 @@ public sealed class MapsuiDisplayListRenderer
         };
     }
 
-    private static IFeature? CreateMapFeature(
-        DrawingInstruction instruction,
-        FeatureGeometry? geometry,
-        Func<string?, MapsuiColor> resolveColor,
-        MapsuiDisplayListRenderer renderer)
+    private static MapsuiColor ToMapsui(RgbaColor c) => new(c.R, c.G, c.B, c.A);
+
+    /// <summary>
+    /// Resolves a symbol name to a processed-SVG asset for the shared
+    /// <see cref="Scene.VectorSceneBuilder"/>, routing through the renderer's
+    /// cache-backed <see cref="GetSymbolEntry"/> so symbol processing is reused
+    /// across re-renders. The cached source carries the Mapsui
+    /// <c>svg-content://</c> prefix; the IR stores the raw processed SVG, so the
+    /// prefix is stripped here and re-applied by <see cref="CreatePointFeature"/>.
+    /// </summary>
+    private Scene.SymbolAsset? ResolveSymbolAsset(string symbolRef)
     {
-        var feature = instruction switch
+        var entry = GetSymbolEntry(symbolRef);
+        if (entry.Source is null)
+            return null;
+
+        const string prefix = "svg-content://";
+        var processed = entry.Source.StartsWith(prefix, StringComparison.Ordinal)
+            ? entry.Source[prefix.Length..]
+            : entry.Source;
+
+        return new Scene.SymbolAsset(processed, entry.RelativeOffsetX, entry.RelativeOffsetY);
+    }
+
+    /// <summary>
+    /// Converts a single backend-agnostic <see cref="Scene.PaintOp"/> into a
+    /// Mapsui <see cref="IFeature"/>, tagging it with the originating S-100
+    /// feature reference and applying scale-visibility limits. Geometry in the
+    /// op is already projected to EPSG:3857; sizes are already in display pixels.
+    /// </summary>
+    private IFeature? CreateMapFeature(Scene.PaintOp op)
+    {
+        IFeature? feature = op switch
         {
-            AreaInstruction area when geometry is not null => CreateAreaFeature(area, geometry, resolveColor, renderer),
-            LineInstruction line => CreateLineFeature(line, geometry, resolveColor, renderer),
-            PointInstruction point when geometry is not null => CreatePointFeature(point, geometry, resolveColor, renderer),
-            TextInstruction text when geometry is not null => CreateTextFeature(text, geometry, resolveColor, renderer),
+            Scene.AreaPaintOp area => CreateAreaFeature(area),
+            Scene.LinePaintOp line => CreateLineFeature(line),
+            Scene.PointPaintOp point => CreatePointFeature(point),
+            Scene.TextPaintOp text => CreateTextFeature(text),
             _ => null,
         };
 
         if (feature is not null)
         {
-            feature[FeatureRefKey] = instruction.FeatureReference;
-            ApplyScaleVisibility(feature, instruction);
+            feature[FeatureRefKey] = op.FeatureReference;
+            ApplyScaleVisibility(feature, op.ScaleMinimum, op.ScaleMaximum);
         }
 
         return feature;
@@ -357,24 +401,22 @@ public sealed class MapsuiDisplayListRenderer
     public const double DenomToResolutionMetres = 0.00028;
 
     /// <summary>
-    /// Maps the S-100 Part 9 §11.1 <see cref="DrawingInstruction.ScaleMinimum"/> /
-    /// <see cref="DrawingInstruction.ScaleMaximum"/> denominators on each
-    /// rendered style.  Per the field documentation in
-    /// <c>DrawingInstruction</c>, <c>ScaleMinimum</c> is the most zoomed-out
-    /// limit (largest allowed denominator) and maps to Mapsui's
-    /// <c>MaxVisible</c>; <c>ScaleMaximum</c> is the most zoomed-in limit
-    /// (smallest allowed denominator) and maps to <c>MinVisible</c>.
+    /// Maps the S-100 Part 9 §11.1 scale denominators carried on a
+    /// <see cref="Scene.PaintOp"/> onto each Mapsui style.  <c>ScaleMinimum</c>
+    /// is the most zoomed-out limit (largest allowed denominator) and maps to
+    /// Mapsui's <c>MaxVisible</c>; <c>ScaleMaximum</c> is the most zoomed-in
+    /// limit (smallest allowed denominator) and maps to <c>MinVisible</c>.
     /// </summary>
-    private static void ApplyScaleVisibility(IFeature feature, DrawingInstruction instruction)
+    private static void ApplyScaleVisibility(IFeature feature, double? scaleMinimum, double? scaleMaximum)
     {
-        if (!instruction.ScaleMinimum.HasValue && !instruction.ScaleMaximum.HasValue)
+        if (!scaleMinimum.HasValue && !scaleMaximum.HasValue)
             return;
 
-        double? maxRes = instruction.ScaleMinimum.HasValue
-            ? instruction.ScaleMinimum.Value * DenomToResolutionMetres
+        double? maxRes = scaleMinimum.HasValue
+            ? scaleMinimum.Value * DenomToResolutionMetres
             : (double?)null;
-        double? minRes = instruction.ScaleMaximum.HasValue
-            ? instruction.ScaleMaximum.Value * DenomToResolutionMetres
+        double? minRes = scaleMaximum.HasValue
+            ? scaleMaximum.Value * DenomToResolutionMetres
             : (double?)null;
 
         foreach (var style in feature.Styles)
@@ -385,118 +427,44 @@ public sealed class MapsuiDisplayListRenderer
         }
     }
 
-    private static IFeature? CreateAreaFeature(
-        AreaInstruction instruction,
-        FeatureGeometry geometry,
-        Func<string?, MapsuiColor> resolveColor,
-        MapsuiDisplayListRenderer renderer)
+    private static IFeature? CreateAreaFeature(Scene.AreaPaintOp op)
     {
-        var polygon = CreatePolygonFromGeometry(geometry);
+        var polygon = CreatePolygonFromWorld(op.WorldShell, op.WorldHoles);
         if (polygon is null)
             return null;
 
-        if (instruction.FillColor is not null)
+        var style = new VectorStyle
         {
-            // Solid color fill
-            var fillColor = resolveColor(instruction.FillColor);
-
-            if (instruction.Transparency.HasValue)
-            {
-                int alpha = (int)(255 * (1.0 - instruction.Transparency.Value));
-                fillColor = new MapsuiColor(fillColor.R, fillColor.G, fillColor.B, alpha);
-            }
-
-            var style = new VectorStyle
-            {
-                Fill = new Brush { Color = fillColor },
-                Outline = new Pen { Color = new MapsuiColor(0, 0, 0, 40), Width = 0.5 },
-            };
-
-            var feature = new GeometryFeature(polygon);
-            feature.Styles.Add(style);
-            return feature;
-        }
-
-        // Pattern fill via AreaFillReference, using a custom style so the
-        // pattern is anchored to the geometry and moves during panning.
-        var tilePng = renderer.GetPatternTilePng(instruction.AreaFillReference);
-        if (tilePng is null)
-            return null;
-
-        var patternStyle = new AnchoredPatternFillStyle
-        {
-            TilePng = tilePng,
+            Fill = new Brush { Color = ToMapsui(op.Fill) },
+            Outline = new Pen { Color = ToMapsui(op.OutlineColor), Width = op.OutlineWidthPx },
         };
 
-        var patternFeature = new GeometryFeature(polygon);
-        patternFeature.Styles.Add(patternStyle);
-        return patternFeature;
+        var feature = new GeometryFeature(polygon);
+        feature.Styles.Add(style);
+        return feature;
     }
 
-    private static IFeature? CreateLineFeature(
-        LineInstruction instruction,
-        FeatureGeometry? geometry,
-        Func<string?, MapsuiColor> resolveColor,
-        MapsuiDisplayListRenderer renderer)
+    private static IFeature? CreateLineFeature(Scene.LinePaintOp op)
     {
-        // Prefer augmented (synthetic) coordinates from AugmentedRay/ArcByRadius
-        // over the feature's natural geometry.
-        var coords = instruction.CoordinatesOverride ?? geometry?.Coordinates;
-        if (coords is null || coords.Count < 2)
+        if (op.World.Count < 2)
             return null;
 
-        var projected = ProjectCoordinates(coords);
-        var lineString = new LineString(projected.ToArray());
+        var coords = new Coordinate[op.World.Count];
+        for (int i = 0; i < op.World.Count; i++)
+            coords[i] = new Coordinate(op.World[i].X, op.World[i].Y);
+        var lineString = new LineString(coords);
 
-        // Resolve color, width, and dash pattern.  Inline lineStyle wins; if
-        // only a lineStyleReference is supplied, look up the external style
-        // through the LineStyleProvider (e.g. S-421 RTEACTLEGLINE).
-        string? colorToken = instruction.LineColor;
-        double width = instruction.LineWidth;
-        bool dashed = instruction.Dashes is { Count: > 0 };
-
-        if (colorToken is null && instruction.LineStyleReference is not null && renderer.LineStyleProvider is not null)
-        {
-            var externalStyle = renderer.LineStyleProvider(instruction.LineStyleReference);
-            if (externalStyle is not null)
-            {
-                colorToken = externalStyle.Color;
-                if (externalStyle.Width > 0)
-                    width = externalStyle.Width;
-                if (externalStyle.DashPattern is { Length: > 0 })
-                    dashed = true;
-            }
-        }
-
-        // S-100 Part 9 specifies pen widths in millimetres on the nominal
-        // display surface, where 1 portrayal pixel = 0.32 mm.  Mapsui Pen.Width
-        // is in screen pixels, so convert mm → px before assigning.
-        var widthPx = width > 0 ? (width / S100PixelSizeMm) : 0.0;
         var pen = new Pen
         {
-            Color = resolveColor(colorToken),
-            Width = Math.Max(widthPx, 1.0),
+            Color = ToMapsui(op.Color),
+            Width = op.WidthPx,
         };
-        if (dashed && instruction.Dashes is { Count: > 0 })
+        if (op.DashArrayPx is { Count: > 0 } dashes)
         {
-            // Build a SkiaSharp-compatible [on, off] dash array from the S-100
-            // dash specification.  The Dash command gives (offset, gapMm) pairs
-            // and the LineStyle second parameter gives the dash "on" length.
-            // NOTE: SkiaSharp applies the dash pattern in screen space, which
-            // causes a subtle "marquee" shift when the viewport pans.  This is
-            // an inherent limitation of the SkiaSharp/Mapsui rendering pipeline;
-            // a proper fix would require a custom Mapsui renderer that anchors
-            // the dash phase to the geometry's world coordinates.
-            var onMm = instruction.DashOnLengthMm > 0
-                ? instruction.DashOnLengthMm
-                : instruction.Dashes[0].Length;   // fallback: use gap length
-            var gapMm = instruction.Dashes[0].Length;
-            var onPx = (float)(onMm / S100PixelSizeMm);
-            var gapPx = (float)(gapMm / S100PixelSizeMm);
-            pen.DashArray = [Math.Max(onPx, 1f), Math.Max(gapPx, 1f)];
+            pen.DashArray = dashes.ToArray();
             pen.PenStyle = PenStyle.UserDefined;
         }
-        else if (dashed)
+        else if (op.DefaultDash)
         {
             pen.PenStyle = PenStyle.Dash;
         }
@@ -513,60 +481,24 @@ public sealed class MapsuiDisplayListRenderer
         return feature;
     }
 
-    private static IFeature? CreatePointFeature(
-        PointInstruction instruction,
-        FeatureGeometry geometry,
-        Func<string?, MapsuiColor> resolveColor,
-        MapsuiDisplayListRenderer renderer)
+    private static IFeature CreatePointFeature(Scene.PointPaintOp op)
     {
-        var coords = geometry.Coordinates;
+        var feature = new PointFeature(op.World.X, op.World.Y);
 
-        // S-100 Part 9 §11.5 AugmentedPoint (GeographicCRS) lets a rule
-        // override the per-instruction anchor — e.g. SOUNDG03 places each
-        // sounding of a MultiPoint feature at its own coordinate.
-        double lat, lon;
-        if (instruction.CoordinateOverride is { } anchor)
+        var hasSymbolOffset = op.OffsetXpx != 0 || op.OffsetYpx != 0;
+
+        if (op.Symbol is { } sym)
         {
-            (lat, lon) = (anchor.Latitude, anchor.Longitude);
-        }
-        else
-        {
-            if (coords.Count == 0)
-                return null;
-            (lat, lon) = coords[0];
-        }
-        var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
+            // The IR stores the raw processed SVG; Mapsui consumes it via the
+            // svg-content:// pseudo-scheme.
+            var svgSource = "svg-content://" + sym.ProcessedSvg;
+            var svgScale = sym.Scale;
 
-        var feature = new PointFeature(mx, my);
-
-        // Translate the S-100 §11.3 LocalOffset (millimetres on the nominal
-        // display surface) to screen pixels using the standard 1 px = 0.32 mm
-        // convention.  Both ImageStyle and SymbolStyle expose Offset via the
-        // shared VectorStyle base.
-        var symOffsetXpx = instruction.LocalOffsetX / S100PixelSizeMm;
-        var symOffsetYpx = instruction.LocalOffsetY / S100PixelSizeMm;
-        var hasSymbolOffset = symOffsetXpx != 0 || symOffsetYpx != 0;
-
-        // Try to render with an actual SVG symbol
-        var symbolRef = instruction.SymbolReference;
-        var entry = renderer.GetSymbolEntry(symbolRef);
-        var svgSource = entry.Source;
-        if (svgSource is not null)
-        {
-            var svgScale = 0.6 * instruction.SymbolScale * renderer.SymbolScale;
-
-            // Recover S-100 Part 9 §11.5 pivot placement.  Mapsui's ImageStyle
-            // centres the SVG bounding box on the anchor (pivot semantics are
-            // ignored), so composite symbols built from off-centre glyph
-            // tiles — most visibly multi-digit soundings — collapse on top of
-            // each other.  Mapsui's RelativeOffset is expressed as a fraction
-            // of the symbol size and matches the (vbCenter - pivot)/vbSize
-            // ratio computed from the SVG, so it stays correct regardless of
-            // SymbolScale or any mm→px convention used by the SVG rasteriser.
-            // Mapsui's RelativeOffset uses +Y = up (map frame); SVG/screen use
-            // +Y = down, so the Y component is negated here.
-            var pivotRelX = entry.RelativeOffsetX;
-            var pivotRelY = -entry.RelativeOffsetY;
+            // Mapsui's RelativeOffset uses +Y = up (map frame); the IR carries
+            // the pivot in screen-space (+Y = down), so the Y component is
+            // negated here.
+            var pivotRelX = sym.PivotRelativeX;
+            var pivotRelY = -sym.PivotRelativeY;
             var hasPivotRelative = pivotRelX != 0 || pivotRelY != 0;
 
             // Add a nearly-invisible rectangle as a hit-test area so that
@@ -581,10 +513,10 @@ public sealed class MapsuiDisplayListRenderer
                 Line = null,
                 Outline = null,
             };
-            if (instruction.Rotation.HasValue)
-                hitStyle.SymbolRotation = instruction.Rotation.Value;
+            if (op.Rotation.HasValue)
+                hitStyle.SymbolRotation = op.Rotation.Value;
             if (hasSymbolOffset)
-                hitStyle.Offset = new Offset(symOffsetXpx, symOffsetYpx);
+                hitStyle.Offset = new Offset(op.OffsetXpx, op.OffsetYpx);
             if (hasPivotRelative)
                 hitStyle.RelativeOffset = new RelativeOffset(pivotRelX, pivotRelY);
             feature.Styles.Add(hitStyle);
@@ -594,10 +526,10 @@ public sealed class MapsuiDisplayListRenderer
                 Image = new Image { Source = svgSource, RasterizeSvg = true },
             };
             style.SymbolScale = svgScale;
-            if (instruction.Rotation.HasValue)
-                style.SymbolRotation = instruction.Rotation.Value;
+            if (op.Rotation.HasValue)
+                style.SymbolRotation = op.Rotation.Value;
             if (hasSymbolOffset)
-                style.Offset = new Offset(symOffsetXpx, symOffsetYpx);
+                style.Offset = new Offset(op.OffsetXpx, op.OffsetYpx);
             if (hasPivotRelative)
                 style.RelativeOffset = new RelativeOffset(pivotRelX, pivotRelY);
             feature.Styles.Add(style);
@@ -605,113 +537,38 @@ public sealed class MapsuiDisplayListRenderer
         else
         {
             // Fallback: colored dot
-            var symbolColor = ResolveSymbolColor(symbolRef, resolveColor);
             var style = new SymbolStyle
             {
-                SymbolScale = 0.15 * instruction.SymbolScale * renderer.SymbolScale,
-                Fill = new Brush { Color = symbolColor },
+                SymbolScale = op.FallbackScale,
+                Fill = new Brush { Color = ToMapsui(op.FallbackColor) },
                 Line = null,
             };
-            if (instruction.Rotation.HasValue)
-                style.SymbolRotation = instruction.Rotation.Value;
+            if (op.Rotation.HasValue)
+                style.SymbolRotation = op.Rotation.Value;
             if (hasSymbolOffset)
-                style.Offset = new Offset(symOffsetXpx, symOffsetYpx);
+                style.Offset = new Offset(op.OffsetXpx, op.OffsetYpx);
             feature.Styles.Add(style);
         }
 
         return feature;
     }
 
-    private static IFeature? CreateTextFeature(
-        TextInstruction instruction,
-        FeatureGeometry geometry,
-        Func<string?, MapsuiColor> resolveColor,
-        MapsuiDisplayListRenderer renderer)
+    private static IFeature CreateTextFeature(Scene.TextPaintOp op)
     {
-        var coords = geometry.Coordinates;
-        if (string.IsNullOrEmpty(instruction.Text))
-            return null;
-
-        // S-100 Part 9 §11.5 AugmentedPoint (GeographicCRS) anchor override
-        // takes precedence over any feature-derived anchor.
-        double lat, lon;
-        if (instruction.CoordinateOverride is { } anchor)
-        {
-            (lat, lon) = (anchor.Latitude, anchor.Longitude);
-        }
-        else if (coords.Count == 0)
-        {
-            return null;
-        }
-        else if (instruction.LinePlacementPosition.HasValue && coords.Count >= 2
-            && geometry.Type == GeometryType.Curve)
-        {
-            (lat, lon) = InterpolateAlongPolyline(coords, instruction.LinePlacementPosition.Value);
-        }
-        else if (geometry.Type == GeometryType.Surface && coords.Count >= 3)
-        {
-            (lat, lon) = ComputeRingCentroid(coords);
-        }
-        else if (geometry.Type == GeometryType.Curve && coords.Count >= 2)
-        {
-            (lat, lon) = coords[coords.Count / 2];
-        }
-        else
-        {
-            (lat, lon) = coords[0];
-        }
-
-        var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
-
-        // Apply the optional S-100 §11.4 transparency attribute (0 = opaque,
-        // 1 = fully transparent) on top of the resolved palette colour.
-        var textColor = ApplyTransparency(resolveColor(instruction.FontColor), instruction.FontTransparency);
-
-        // Convert mm offsets (S-100 §11.4 nominal display surface) to screen
-        // pixels using the standard 1 px = 0.32 mm convention.
-        var offsetXpx = (instruction.OffsetXmm ?? 0) / S100PixelSizeMm;
-        var offsetYpx = (instruction.OffsetYmm ?? 0) / S100PixelSizeMm;
-
-        Brush? backBrush = null;
-        if (!string.IsNullOrEmpty(instruction.BackgroundColor))
-        {
-            var bgBase = resolveColor(instruction.BackgroundColor);
-            // Default background transparency: when the spec leaves it
-            // unspecified, fall back to the same translucency convention as
-            // legacy renderers (~50%).
-            var bgColor = ApplyTransparency(bgBase, instruction.BackgroundTransparency ?? 0.5);
-            backBrush = new Brush { Color = bgColor };
-        }
-
         var style = new LabelStyle
         {
-            Text = instruction.Text,
-            ForeColor = textColor,
-            Font = new Font { Size = instruction.FontSize * renderer.TextScale },
-            HorizontalAlignment = MapHAlign(instruction.HorizontalAlignment),
-            VerticalAlignment = MapVAlign(instruction.VerticalAlignment),
-            Offset = new Offset(offsetXpx, offsetYpx),
-            BackColor = backBrush,
+            Text = op.Text,
+            ForeColor = ToMapsui(op.ForeColor),
+            Font = new Font { Size = op.FontSizePx },
+            HorizontalAlignment = MapHAlign(op.HorizontalAlignment),
+            VerticalAlignment = MapVAlign(op.VerticalAlignment),
+            Offset = new Offset(op.OffsetXpx, op.OffsetYpx),
+            BackColor = op.BackColor is { } b ? new Brush { Color = ToMapsui(b) } : null,
         };
 
-        var feature = new PointFeature(mx, my);
+        var feature = new PointFeature(op.World.X, op.World.Y);
         feature.Styles.Add(style);
         return feature;
-    }
-
-    /// <summary>
-    /// Returns <paramref name="color"/> with its alpha attenuated by
-    /// <paramref name="transparency"/> (0 = unchanged opaque, 1 = fully
-    /// transparent).  When <paramref name="transparency"/> is null the input
-    /// colour is returned unchanged.
-    /// </summary>
-    private static MapsuiColor ApplyTransparency(MapsuiColor color, double? transparency)
-    {
-        if (!transparency.HasValue)
-            return color;
-        var t = Math.Clamp(transparency.Value, 0.0, 1.0);
-        var a = (int)Math.Round(color.A * (1.0 - t));
-        return new MapsuiColor(color.R, color.G, color.B, a);
     }
 
     private static LabelStyle.HorizontalAlignmentEnum MapHAlign(TextHorizontalAlignment a) => a switch
@@ -728,80 +585,10 @@ public sealed class MapsuiDisplayListRenderer
         _ => LabelStyle.VerticalAlignmentEnum.Center,
     };
 
-    /// <summary>
-    /// Centroid of a closed exterior ring (lat/lon, simple unweighted average
-    /// of the unique vertices).  Sufficient for label placement on the
-    /// near-equirectangular ring sizes typical of S-100 surface features.
-    /// </summary>
-    private static (double Lat, double Lon) ComputeRingCentroid(
-        IReadOnlyList<(double Lat, double Lon)> ring)
-    {
-        // Drop the closing duplicate vertex if present.
-        int count = ring.Count;
-        if (count >= 2 && ring[0] == ring[count - 1])
-            count--;
-        double sumLat = 0, sumLon = 0;
-        for (int i = 0; i < count; i++)
-        {
-            sumLat += ring[i].Lat;
-            sumLon += ring[i].Lon;
-        }
-        return (sumLat / count, sumLon / count);
-    }
-
-
-
     // ── Coordinate projection ──────────────────────────────────────────
 
-    /// <summary>
-    /// Interpolates a position at a relative distance (0.0–1.0) along a polyline.
-    /// </summary>
-    private static (double Lat, double Lon) InterpolateAlongPolyline(
-        IReadOnlyList<(double Lat, double Lon)> coords, double fraction)
-    {
-        if (coords.Count < 2)
-            return coords[0];
-
-        fraction = Math.Clamp(fraction, 0.0, 1.0);
-
-        // Compute total length of the polyline (in degrees — approximate but fine for interpolation)
-        double totalLength = 0;
-        for (int i = 1; i < coords.Count; i++)
-        {
-            double dLat = coords[i].Lat - coords[i - 1].Lat;
-            double dLon = coords[i].Lon - coords[i - 1].Lon;
-            totalLength += Math.Sqrt(dLat * dLat + dLon * dLon);
-        }
-
-        if (totalLength <= 0)
-            return coords[0];
-
-        double targetLength = totalLength * fraction;
-        double accumulated = 0;
-
-        for (int i = 1; i < coords.Count; i++)
-        {
-            double dLat = coords[i].Lat - coords[i - 1].Lat;
-            double dLon = coords[i].Lon - coords[i - 1].Lon;
-            double segmentLength = Math.Sqrt(dLat * dLat + dLon * dLon);
-
-            if (accumulated + segmentLength >= targetLength)
-            {
-                double t = segmentLength > 0 ? (targetLength - accumulated) / segmentLength : 0;
-                return (
-                    coords[i - 1].Lat + t * dLat,
-                    coords[i - 1].Lon + t * dLon);
-            }
-
-            accumulated += segmentLength;
-        }
-
-        return coords[^1];
-    }
-
     private static Polygon? CreatePolygonFromGeometry(FeatureGeometry geometry)
-    {
-        var shell = BuildLinearRing(geometry.Coordinates);
+    {        var shell = BuildLinearRing(geometry.Coordinates);
         if (shell is null)
             return null;
 
@@ -849,7 +636,55 @@ public sealed class MapsuiDisplayListRenderer
         return result;
     }
 
-    // ── SVG symbol processing ──────────────────────────────────────────
+    /// <summary>
+    /// Builds an NTS polygon from already-projected EPSG:3857 ring coordinates
+    /// carried by an <see cref="Scene.AreaPaintOp"/>. Mirrors
+    /// <see cref="CreatePolygonFromGeometry"/> (closing + minimum-vertex guards)
+    /// but skips the lat/lon → EPSG:3857 projection, which the IR already
+    /// performed, so degenerate rings are dropped identically to the legacy path.
+    /// </summary>
+    private static Polygon? CreatePolygonFromWorld(
+        IReadOnlyList<(double X, double Y)> shell,
+        IReadOnlyList<IReadOnlyList<(double X, double Y)>> holes)
+    {
+        var shellRing = BuildLinearRingFromWorld(shell);
+        if (shellRing is null)
+            return null;
+
+        if (holes.Count == 0)
+            return new Polygon(shellRing);
+
+        var holeRings = new List<LinearRing>(holes.Count);
+        foreach (var hole in holes)
+        {
+            var ring = BuildLinearRingFromWorld(hole);
+            if (ring is not null)
+                holeRings.Add(ring);
+        }
+
+        return holeRings.Count == 0
+            ? new Polygon(shellRing)
+            : new Polygon(shellRing, holeRings.ToArray());
+    }
+
+    private static LinearRing? BuildLinearRingFromWorld(IReadOnlyList<(double X, double Y)> coords)
+    {
+        if (coords.Count < 3)
+            return null;
+
+        var ring = new List<Coordinate>(coords.Count + 1);
+        foreach (var (x, y) in coords)
+            ring.Add(new Coordinate(x, y));
+
+        // Close the ring if not already closed.
+        if (ring.Count > 0 && !ring[0].Equals2D(ring[^1]))
+            ring.Add(new Coordinate(ring[0].X, ring[0].Y));
+
+        if (ring.Count < 4)
+            return null;
+
+        return new LinearRing(ring.ToArray());
+    }
 
     /// <summary>
     /// Returns a cached <see cref="SymbolEntry"/> for the given symbol name,
@@ -970,96 +805,6 @@ public sealed class MapsuiDisplayListRenderer
         }
 
         return null;
-    }
-
-    // ── S-100 Color resolution ─────────────────────────────────────────
-
-    /// <summary>
-    /// Builds a color resolver function from the given palette.
-    /// Falls back to black for unknown tokens.
-    /// </summary>
-    private static Func<string?, MapsuiColor> BuildColorResolver(ColorPalette? palette)
-    {
-        return token =>
-        {
-            if (string.IsNullOrEmpty(token))
-                return MapsuiColor.Black;
-
-            if (palette is not null && palette.TryResolve(token, out var hex))
-                return HexToColor(hex);
-
-            // S-100 Part 9 instructions may also carry inline hex literals
-            // (e.g. the S-421 RouteActionPoint XSL emits <foreground>AA44A8</foreground>).
-            // Treat any 6- or 8-digit hex string (with or without a leading '#')
-            // as a literal colour before giving up.
-            if (TryParseHexLiteral(token, out var literal))
-                return literal;
-
-            return MapsuiColor.Black;
-        };
-    }
-
-    private static MapsuiColor HexToColor(string hex)
-    {
-        if (TryParseHexLiteral(hex, out var color))
-            return color;
-
-        return MapsuiColor.Black;
-    }
-
-    /// <summary>
-    /// Parses a literal hex colour in the formats <c>RRGGBB</c>,
-    /// <c>#RRGGBB</c>, <c>RRGGBBAA</c>, or <c>#RRGGBBAA</c>.  Returns false
-    /// for anything else so the caller can fall back to a palette token
-    /// lookup.
-    /// </summary>
-    private static bool TryParseHexLiteral(string value, out MapsuiColor color)
-    {
-        color = MapsuiColor.Black;
-        if (string.IsNullOrEmpty(value)) return false;
-
-        var span = value.AsSpan();
-        if (span[0] == '#') span = span[1..];
-        if (span.Length != 6 && span.Length != 8) return false;
-
-        if (!int.TryParse(span[..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
-            !int.TryParse(span.Slice(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
-            !int.TryParse(span.Slice(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
-        {
-            return false;
-        }
-
-        int a = 255;
-        if (span.Length == 8 &&
-            !int.TryParse(span.Slice(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a))
-        {
-            return false;
-        }
-
-        color = new MapsuiColor(r, g, b, a);
-        return true;
-    }
-
-    private static MapsuiColor ResolveSymbolColor(string? symbolRef, Func<string?, MapsuiColor> resolveColor)
-    {
-        if (string.IsNullOrEmpty(symbolRef))
-            return MapsuiColor.Black;
-
-        // Symbol names like QUESMRK1, SAFCON03, BOYCAR01 etc.
-        // Map by prefix/known names to approximate colours
-        if (symbolRef.StartsWith("SAFCON", StringComparison.Ordinal))
-            return resolveColor("SNDG1");     // Sounding symbols — use sounding colour
-        if (symbolRef.StartsWith("BOYCAR", StringComparison.Ordinal) ||
-            symbolRef.StartsWith("BOYLAT", StringComparison.Ordinal))
-            return resolveColor("CHBLK");     // Buoy symbols — black
-        if (symbolRef.StartsWith("BCNLAT", StringComparison.Ordinal))
-            return resolveColor("CHBLK");     // Beacon symbols — black
-        if (symbolRef == "QUESMRK1")
-            return new MapsuiColor(200, 0, 200, 120); // Default/unknown — faint magenta
-        if (symbolRef.StartsWith("LIGHTS", StringComparison.Ordinal))
-            return resolveColor("LITYW");     // Lights — yellow
-
-        return resolveColor("OUTLW");
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -11,6 +11,17 @@ This library bridges the S-100 portrayal pipeline output to Mapsui map layers, i
 - **`MapsuiDisplayListRenderer`** — product-agnostic vector renderer that consumes a list of `DrawingInstruction`s plus an `IFeatureGeometryProvider` and produces a `MemoryLayer` of styled point/line/area/text features. Used by every S-100 vector product (S-101, S-124, S-129, S-421); no per-spec subclass is required.
 - **`ProjNetCrsTransformFactory`** — `ICrsTransformFactory` implementation using [ProjNet](https://github.com/NetTopologySuite/ProjNet4GeoAPI) for coordinate transformations between UTM, WGS84, and Web Mercator.
 
+`MapsuiDisplayListRenderer` lowers the display list through the **shared,
+backend-agnostic vector rendering core** in
+`EncDotNet.S100.Renderers.Skia.Scene` (`VectorSceneBuilder` → `VectorScene` of
+`PaintOp`s). All S-100 Part 9 portrayal-correctness logic — draw ordering,
+colour/symbol/line-style resolution, mm→px conversion, text-anchor selection,
+and the `lat/lon → EPSG:3857` projection half — lives in that core and is shared
+with the headless `SkiaDisplayListRenderer`; this renderer only constructs
+Mapsui `IFeature`/style objects from the resolved IR. Pattern fills are the one
+exception: they are not yet part of the IR and keep their dedicated pattern
+collection / priority-clip / insert phase here.
+
 `MapsuiDisplayListRenderer` honours the relevant S-100 Part 9 conventions:
 
 - Pen widths and text/symbol offsets specified in millimetres on the nominal display surface are converted to screen pixels using the standard `1 px = 0.32 mm` ratio (S-100 Part 9 §3.10.4).

--- a/src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj
+++ b/src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -4,14 +4,45 @@ Coverage and vector rendering to [SkiaSharp](https://github.com/mono/SkiaSharp) 
 
 ## Overview
 
-This library renders S-100 coverage and vector data to SkiaSharp bitmaps. It handles pure rasterization without map projection. Key types include:
+This library renders S-100 coverage and vector data to SkiaSharp bitmaps. It handles pure rasterization without a map control. Key types include:
 
 - **`SkiaCoverageRenderer`** — `ICoverageRenderer<SKBitmap>` implementation that maps coverage grid cells to pixel colors.
 - **`SkiaSvgRasterizer`** — rasterizes SVG portrayal symbols to tiled pattern bitmaps.
 - **`SkiaColorExtensions`** — helpers for converting between `RgbaColor` and `SKColor`.
+
+### Shared vector rendering core (`Scene` namespace)
+
+The `EncDotNet.S100.Renderers.Skia.Scene` namespace hosts a **backend-agnostic
+S-100 Part 9 vector rendering core** consumed by both this library's headless
+renderer and `EncDotNet.S100.Renderers.Mapsui`. It lowers a display list into a
+resolved, projected intermediate representation (IR) so the portrayal-correctness
+logic lives in exactly one place:
+
+- **`VectorSceneBuilder`** — lowers a `DrawingInstruction` list +
+  `IFeatureGeometryProvider` into an ordered `VectorScene` of `PaintOp`s:
+  applies S-100 Part 9 draw ordering, colour/symbol/line-style resolution,
+  mm→px conversion (`1 px = 0.32 mm`), text-anchor selection, and the
+  `lat/lon → EPSG:3857` projection half.
+- **`PaintOp` / `VectorScene`** — the IR. `PaintOp` coordinates are EPSG:3857
+  metres; all sizes are logical display pixels (resolution-independent). See the
+  `PaintOp` XML docs for the full unit contract.
+- **`SkiaDisplayListRenderer`** — `VectorScene` + `Viewport` → `SKBitmap`. The
+  vector analogue of `SkiaCoverageRenderer`, suitable for a tile-serving web API
+  with no Mapsui/GUI dependency. It supplies the second projection half
+  (`EPSG:3857 → screen`) via a `Viewport`-derived affine.
+- **`WebMercator`** — EPSG:3857 forward projection (matches Mapsui's
+  `SphericalMercator.FromLonLat`; a parity test asserts agreement).
+- **`ScaleVisibility`** — shared S-100 Part 9 §11.1 scale-visibility rule.
+- **`ColorResolver`** — S-100 colour-token resolution (palette + inline hex).
+
+**Scope (spike):** the IR currently covers point, line, solid-area, and text
+ops. Pattern fills, antimeridian crossing, and Web-Mercator pole limits are not
+yet represented in the IR — pattern fills remain handled by the Mapsui renderer's
+dedicated pattern collection / priority-clip / insert phase.
 
 ## Installation
 
 ```sh
 dotnet add package EncDotNet.S100.Renderers.Skia
 ```
+

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/ColorResolver.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/ColorResolver.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Renderers.Skia.Scene;
+
+/// <summary>
+/// S-100 colour-token resolution shared by the vector rendering backends.
+/// Resolves a token through a <see cref="ColorPalette"/>, falling back to an
+/// inline hex literal (e.g. the S-421 RouteActionPoint <c>&lt;foreground&gt;</c>
+/// emits a bare <c>AA44A8</c>) and finally to opaque black.
+/// </summary>
+public static class ColorResolver
+{
+    /// <summary>
+    /// Builds a colour resolver from the given palette. The returned delegate
+    /// maps a (possibly null) S-100 colour token to a resolved
+    /// <see cref="RgbaColor"/>.
+    /// </summary>
+    public static Func<string?, RgbaColor> Create(ColorPalette? palette)
+    {
+        return token =>
+        {
+            if (string.IsNullOrEmpty(token))
+                return Black;
+
+            if (palette is not null && palette.TryResolve(token, out var hex))
+                return HexToColor(hex);
+
+            if (TryParseHexLiteral(token, out var literal))
+                return literal;
+
+            return Black;
+        };
+    }
+
+    /// <summary>Opaque black.</summary>
+    public static RgbaColor Black { get; } = new(0, 0, 0, 255);
+
+    /// <summary>
+    /// Returns <paramref name="color"/> with its alpha attenuated by
+    /// <paramref name="transparency"/> (0 = unchanged opaque, 1 = fully
+    /// transparent). When <paramref name="transparency"/> is null the colour is
+    /// returned unchanged.
+    /// </summary>
+    public static RgbaColor ApplyTransparency(RgbaColor color, double? transparency)
+    {
+        if (!transparency.HasValue)
+            return color;
+        var t = Math.Clamp(transparency.Value, 0.0, 1.0);
+        var a = (byte)Math.Round(color.A * (1.0 - t));
+        return new RgbaColor(color.R, color.G, color.B, a);
+    }
+
+    /// <summary>
+    /// Heuristic fallback colour for a symbol that has no resolvable SVG, keyed
+    /// off the S-100 symbol name prefix (mirrors the legacy renderer's
+    /// dot-fallback palette).
+    /// </summary>
+    public static RgbaColor ResolveSymbolColor(string? symbolRef, Func<string?, RgbaColor> resolveColor)
+    {
+        if (string.IsNullOrEmpty(symbolRef))
+            return Black;
+
+        if (symbolRef.StartsWith("SAFCON", StringComparison.Ordinal))
+            return resolveColor("SNDG1");
+        if (symbolRef.StartsWith("BOYCAR", StringComparison.Ordinal) ||
+            symbolRef.StartsWith("BOYLAT", StringComparison.Ordinal))
+            return resolveColor("CHBLK");
+        if (symbolRef.StartsWith("BCNLAT", StringComparison.Ordinal))
+            return resolveColor("CHBLK");
+        if (symbolRef == "QUESMRK1")
+            return new RgbaColor(200, 0, 200, 120);
+        if (symbolRef.StartsWith("LIGHTS", StringComparison.Ordinal))
+            return resolveColor("LITYW");
+
+        return resolveColor("OUTLW");
+    }
+
+    private static RgbaColor HexToColor(string hex) =>
+        TryParseHexLiteral(hex, out var color) ? color : Black;
+
+    private static bool TryParseHexLiteral(string value, out RgbaColor color)
+    {
+        color = Black;
+        if (string.IsNullOrEmpty(value)) return false;
+
+        var span = value.AsSpan();
+        if (span[0] == '#') span = span[1..];
+        if (span.Length != 6 && span.Length != 8) return false;
+
+        if (!int.TryParse(span[..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
+            !int.TryParse(span.Slice(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
+            !int.TryParse(span.Slice(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+        {
+            return false;
+        }
+
+        int a = 255;
+        if (span.Length == 8 &&
+            !int.TryParse(span.Slice(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a))
+        {
+            return false;
+        }
+
+        color = new RgbaColor((byte)r, (byte)g, (byte)b, (byte)a);
+        return true;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/PaintOp.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/PaintOp.cs
@@ -1,0 +1,218 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Renderers.Skia.Scene;
+
+/// <summary>
+/// A backend-agnostic, fully-resolved S-100 Part 9 paint operation — the
+/// intermediate representation (IR) produced by <see cref="VectorSceneBuilder"/>
+/// and consumed by both the headless <see cref="SkiaDisplayListRenderer"/> and
+/// the Mapsui display-list renderer.
+/// </summary>
+/// <remarks>
+/// <para><b>Unit contract.</b> All coordinate values
+/// (<c>World…</c> members) are in <b>EPSG:3857 Web-Mercator metres</b> — the
+/// first half of the S-100 Part 9 projection (<c>lat/lon → EPSG:3857</c>).
+/// The second half (<c>EPSG:3857 → screen pixels</c>) is intentionally left to
+/// each backend: Mapsui performs it per-frame via its <c>Navigator</c>; the
+/// Skia backend applies a <see cref="Viewport"/>-derived affine.</para>
+/// <para>All <i>size</i> values (stroke widths, dash lengths, offsets, font
+/// size, symbol scale) are already expressed in <b>logical display pixels</b>
+/// under the S-100 Part 9 §3.10.4 convention <c>1 px = 0.32 mm</c>. They are
+/// resolution-independent device pixels — <i>not</i> world metres and
+/// <i>not</i> physical output pixels. A backend that draws geometry through a
+/// world→screen canvas transform must realise strokes, symbols, and text in
+/// device pixels (i.e. reset/compensate the transform for size realisation),
+/// otherwise sizes would scale with zoom.</para>
+/// <para>All colours are already resolved to <see cref="RgbaColor"/> (palette
+/// token lookup + transparency applied). Resources (symbols, pattern tiles)
+/// are resolved to processed content rather than catalogue names.</para>
+/// </remarks>
+public abstract class PaintOp
+{
+    /// <summary>
+    /// Identifier of the originating dataset feature (the S-100 feature
+    /// reference), carried through so backends can tag rendered output for
+    /// pick / hit-testing.
+    /// </summary>
+    public required string FeatureReference { get; init; }
+
+    /// <summary>
+    /// Minimum display scale denominator at which this op is visible (the most
+    /// zoomed-out limit; S-100 Part 9 §11.1). Null means no lower bound.
+    /// Carried as a denominator (not a backend resolution) so each backend
+    /// applies the same inclusion semantics via
+    /// <see cref="ScaleVisibility.IsVisibleAtScale"/>.
+    /// </summary>
+    public double? ScaleMinimum { get; init; }
+
+    /// <summary>
+    /// Maximum display scale denominator at which this op is visible (the most
+    /// zoomed-in limit; S-100 Part 9 §11.1). Null means no upper bound.
+    /// </summary>
+    public double? ScaleMaximum { get; init; }
+}
+
+/// <summary>
+/// Resolved intrinsic metrics for a point symbol, carried in the IR so the
+/// Skia backend does not re-derive symbol geometry independently of the
+/// Mapsui backend (S-100 Part 9 §11.5 pivot placement).
+/// </summary>
+/// <param name="ProcessedSvg">
+/// SVG content with CSS classes already resolved to inline attributes (output
+/// of <c>SvgProcessor.Process</c>), ready to hand to a rasteriser.
+/// </param>
+/// <param name="Scale">
+/// Final symbol scale factor to apply to the rasterised SVG (already folds in
+/// the per-instruction scale, the renderer-global scale, and the legacy 0.6
+/// nominal factor).
+/// </param>
+/// <param name="PivotRelativeX">
+/// Pivot offset as a fraction of symbol width, +X = pivot left of centre
+/// (S-100 Part 9 §11.5). Backends shift the symbol by this fraction so the
+/// pivot — not the bounding-box centre — lands on the anchor.
+/// </param>
+/// <param name="PivotRelativeY">
+/// Pivot offset as a fraction of symbol height, screen-space +Y = down.
+/// </param>
+public readonly record struct ResolvedSymbol(
+    string ProcessedSvg,
+    double Scale,
+    double PivotRelativeX,
+    double PivotRelativeY);
+
+/// <summary>A resolved point-symbol placement.</summary>
+public sealed class PointPaintOp : PaintOp
+{
+    /// <summary>Symbol anchor in EPSG:3857 metres.</summary>
+    public required (double X, double Y) World { get; init; }
+
+    /// <summary>
+    /// The resolved SVG symbol, or <see langword="null"/> when no symbol could
+    /// be resolved (the backend falls back to a coloured dot of
+    /// <see cref="FallbackColor"/>).
+    /// </summary>
+    public ResolvedSymbol? Symbol { get; init; }
+
+    /// <summary>
+    /// Fallback dot colour used when <see cref="Symbol"/> is
+    /// <see langword="null"/> (resolved from the symbol name heuristic).
+    /// </summary>
+    public RgbaColor FallbackColor { get; init; }
+
+    /// <summary>Fallback-dot scale factor (used only when <see cref="Symbol"/> is null).</summary>
+    public double FallbackScale { get; init; }
+
+    /// <summary>Symbol rotation in degrees clockwise from north, or null for upright.</summary>
+    public double? Rotation { get; init; }
+
+    /// <summary>Local horizontal offset from the anchor, in display pixels.</summary>
+    public double OffsetXpx { get; init; }
+
+    /// <summary>Local vertical offset from the anchor, in display pixels (screen-space +Y = down).</summary>
+    public double OffsetYpx { get; init; }
+}
+
+/// <summary>A resolved polyline stroke.</summary>
+public sealed class LinePaintOp : PaintOp
+{
+    /// <summary>Projected polyline vertices in EPSG:3857 metres.</summary>
+    public required IReadOnlyList<(double X, double Y)> World { get; init; }
+
+    /// <summary>Resolved stroke colour.</summary>
+    public RgbaColor Color { get; init; }
+
+    /// <summary>Stroke width in display pixels (already clamped to a 1 px minimum).</summary>
+    public double WidthPx { get; init; }
+
+    /// <summary>
+    /// Dash pattern as an alternating [on, off, …] array in display pixels, or
+    /// <see langword="null"/> for a solid stroke (or when
+    /// <see cref="DefaultDash"/> applies).
+    /// </summary>
+    public IReadOnlyList<float>? DashArrayPx { get; init; }
+
+    /// <summary>
+    /// When true and <see cref="DashArrayPx"/> is null, the stroke is dashed but
+    /// no explicit S-100 dash array was available (it came from an external
+    /// line-style's dash flag). Backends apply their built-in default dash:
+    /// the Mapsui adapter sets <c>PenStyle.Dash</c>; the Skia backend uses a
+    /// width-derived default.
+    /// </summary>
+    public bool DefaultDash { get; init; }
+}
+
+/// <summary>A resolved solid-colour area fill (with optional outline).</summary>
+/// <remarks>
+/// Pattern fills are intentionally <b>not</b> represented here in the current
+/// vertical slice; they continue to be handled by the Mapsui renderer's
+/// dedicated pattern collection / priority-clip / insert phase. See the split
+/// vector-renderer plan for the deferral rationale.
+/// </remarks>
+public sealed class AreaPaintOp : PaintOp
+{
+    /// <summary>Exterior ring in EPSG:3857 metres (closed or auto-closed by the backend).</summary>
+    public required IReadOnlyList<(double X, double Y)> WorldShell { get; init; }
+
+    /// <summary>Interior (hole) rings in EPSG:3857 metres.</summary>
+    public IReadOnlyList<IReadOnlyList<(double X, double Y)>> WorldHoles { get; init; } = [];
+
+    /// <summary>Resolved fill colour (transparency already folded into the alpha channel).</summary>
+    public RgbaColor Fill { get; init; }
+
+    /// <summary>Resolved outline colour.</summary>
+    public RgbaColor OutlineColor { get; init; }
+
+    /// <summary>Outline width in display pixels.</summary>
+    public double OutlineWidthPx { get; init; }
+}
+
+/// <summary>A resolved text label. The anchor is already selected (Part 9 §11.4/§11.5).</summary>
+public sealed class TextPaintOp : PaintOp
+{
+    /// <summary>Anchor position in EPSG:3857 metres.</summary>
+    public required (double X, double Y) World { get; init; }
+
+    /// <summary>The literal text to render.</summary>
+    public required string Text { get; init; }
+
+    /// <summary>Font size in display pixels (already folds in the renderer-global text scale).</summary>
+    public double FontSizePx { get; init; }
+
+    /// <summary>Resolved foreground colour (transparency already applied).</summary>
+    public RgbaColor ForeColor { get; init; }
+
+    /// <summary>Resolved background colour, or null when the label has no background box.</summary>
+    public RgbaColor? BackColor { get; init; }
+
+    /// <summary>Horizontal alignment relative to the anchor.</summary>
+    public TextHorizontalAlignment HorizontalAlignment { get; init; } = TextHorizontalAlignment.Center;
+
+    /// <summary>Vertical alignment relative to the anchor.</summary>
+    public TextVerticalAlignment VerticalAlignment { get; init; } = TextVerticalAlignment.Center;
+
+    /// <summary>Horizontal offset from the anchor, in display pixels.</summary>
+    public double OffsetXpx { get; init; }
+
+    /// <summary>Vertical offset from the anchor, in display pixels (screen-space +Y = down).</summary>
+    public double OffsetYpx { get; init; }
+}
+
+/// <summary>
+/// An ordered, backend-agnostic list of resolved <see cref="PaintOp"/>s — the
+/// output of <see cref="VectorSceneBuilder"/>. Ops are already in S-100 Part 9
+/// draw order (areas → lines → points → text within ascending drawing
+/// priority, under-radar before over-radar).
+/// </summary>
+public sealed class VectorScene
+{
+    /// <summary>Creates a scene from an ordered op list.</summary>
+    public VectorScene(IReadOnlyList<PaintOp> ops)
+    {
+        ArgumentNullException.ThrowIfNull(ops);
+        Ops = ops;
+    }
+
+    /// <summary>The resolved paint operations, in draw order.</summary>
+    public IReadOnlyList<PaintOp> Ops { get; }
+}

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/ScaleVisibility.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/ScaleVisibility.cs
@@ -1,0 +1,41 @@
+namespace EncDotNet.S100.Renderers.Skia.Scene;
+
+/// <summary>
+/// Shared S-100 Part 9 §11.1 scale-visibility semantics. Centralised so the
+/// headless Skia backend (which evaluates a single fixed scale per render) and
+/// the Mapsui backend (which evaluates per-frame via <c>Min/MaxVisible</c>)
+/// agree on the inclusion rule, including at the boundaries.
+/// </summary>
+public static class ScaleVisibility
+{
+    /// <summary>
+    /// S-100 Part 9 scale denominator → Mapsui resolution (m/px in EPSG:3857)
+    /// at 96 DPI: 1 px = 0.28 mm = 0.00028 m on the nominal display surface,
+    /// so resolution ≈ scaleDenominator × 0.00028. Exposed so the Mapsui
+    /// adapter and this helper derive their bounds from the same constant.
+    /// </summary>
+    public const double DenomToResolutionMetres = 0.00028;
+
+    /// <summary>
+    /// Returns whether an op is visible at the given display scale denominator.
+    /// </summary>
+    /// <remarks>
+    /// Per the S-100 Part 9 §11.1 convention (and the field docs on
+    /// <c>DrawingInstruction</c>), <c>ScaleMinimum</c> is the most zoomed-out
+    /// limit — the <i>largest</i> allowed denominator — and <c>ScaleMaximum</c>
+    /// is the most zoomed-in limit — the <i>smallest</i> allowed denominator.
+    /// An op is therefore visible when
+    /// <c>ScaleMaximum ≤ denominator ≤ ScaleMinimum</c> (bounds inclusive,
+    /// matching Mapsui's inclusive <c>Min/MaxVisible</c> comparison).
+    /// </remarks>
+    public static bool IsVisibleAtScale(PaintOp op, double scaleDenominator)
+    {
+        ArgumentNullException.ThrowIfNull(op);
+
+        if (op.ScaleMaximum.HasValue && scaleDenominator < op.ScaleMaximum.Value)
+            return false;
+        if (op.ScaleMinimum.HasValue && scaleDenominator > op.ScaleMinimum.Value)
+            return false;
+        return true;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -1,0 +1,287 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using SkiaSharp;
+using Svg.Skia;
+
+namespace EncDotNet.S100.Renderers.Skia.Scene;
+
+/// <summary>
+/// A headless, direct-SkiaSharp renderer for the S-100 Part 9 vector
+/// intermediate representation produced by <see cref="VectorSceneBuilder"/>.
+/// Rasterises a <see cref="VectorScene"/> against a <see cref="Viewport"/> into
+/// a standalone <see cref="SKBitmap"/> — the vector analogue of
+/// <see cref="SkiaCoverageRenderer"/>, suitable for a tile-serving web API with
+/// no Mapsui / GUI dependency.
+/// </summary>
+/// <remarks>
+/// <para>The renderer supplies the second half of the S-100 projection that the
+/// Mapsui backend delegates to its navigator: it projects the
+/// <see cref="Viewport"/> geographic bounds to EPSG:3857 and maps that
+/// rectangle linearly to pixels. Geometry is transformed world→screen, but
+/// stroke widths, symbol sizes, and text sizes are realised in display pixels
+/// per the IR unit contract (see <see cref="PaintOp"/>).</para>
+/// <para><b>Scope.</b> This vertical slice renders point, line, solid-area, and
+/// text ops. Pattern fills are not yet represented in the IR. Antimeridian
+/// crossing and Web-Mercator pole limits are out of scope.</para>
+/// </remarks>
+public sealed class SkiaDisplayListRenderer
+{
+    /// <summary>Background colour cleared before painting. Defaults to transparent.</summary>
+    public RgbaColor Background { get; set; } = RgbaColor.Transparent;
+
+    /// <summary>
+    /// Renders the scene at the requested viewport, returning a new bitmap of
+    /// <see cref="Viewport.WidthPixels"/> × <see cref="Viewport.HeightPixels"/>.
+    /// The caller owns the returned bitmap.
+    /// </summary>
+    public SKBitmap Render(VectorScene scene, Viewport viewport)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(viewport);
+
+        var bitmap = new SKBitmap(
+            viewport.WidthPixels, viewport.HeightPixels, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(Background.ToSkia());
+
+        var transform = WorldToScreen.Create(viewport);
+        double denom = viewport.ScaleDenominator;
+
+        foreach (var op in scene.Ops)
+        {
+            if (!ScaleVisibility.IsVisibleAtScale(op, denom))
+                continue;
+
+            switch (op)
+            {
+                case AreaPaintOp area:
+                    DrawArea(canvas, area, transform);
+                    break;
+                case LinePaintOp line:
+                    DrawLine(canvas, line, transform);
+                    break;
+                case PointPaintOp point:
+                    DrawPoint(canvas, point, transform);
+                    break;
+                case TextPaintOp text:
+                    DrawText(canvas, text, transform);
+                    break;
+            }
+        }
+
+        canvas.Flush();
+        return bitmap;
+    }
+
+    private static void DrawArea(SKCanvas canvas, AreaPaintOp op, WorldToScreen t)
+    {
+        using var path = new SKPath { FillType = SKPathFillType.EvenOdd };
+        AddRing(path, op.WorldShell, t);
+        foreach (var hole in op.WorldHoles)
+            AddRing(path, hole, t);
+
+        using var fill = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Fill,
+            Color = op.Fill.ToSkia(),
+        };
+        canvas.DrawPath(path, fill);
+
+        if (op.OutlineWidthPx > 0 && op.OutlineColor.A > 0)
+        {
+            using var outline = new SKPaint
+            {
+                IsAntialias = true,
+                Style = SKPaintStyle.Stroke,
+                Color = op.OutlineColor.ToSkia(),
+                StrokeWidth = (float)op.OutlineWidthPx,
+            };
+            canvas.DrawPath(path, outline);
+        }
+    }
+
+    private static void DrawLine(SKCanvas canvas, LinePaintOp op, WorldToScreen t)
+    {
+        if (op.World.Count < 2)
+            return;
+
+        using var path = new SKPath();
+        var (sx, sy) = t.Project(op.World[0]);
+        path.MoveTo(sx, sy);
+        for (int i = 1; i < op.World.Count; i++)
+        {
+            var (px, py) = t.Project(op.World[i]);
+            path.LineTo(px, py);
+        }
+
+        using var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            Color = op.Color.ToSkia(),
+            StrokeWidth = (float)op.WidthPx,
+            StrokeCap = SKStrokeCap.Round,
+            StrokeJoin = SKStrokeJoin.Round,
+        };
+
+        if (op.DashArrayPx is { Count: > 0 })
+        {
+            paint.PathEffect = SKPathEffect.CreateDash(op.DashArrayPx.ToArray(), 0f);
+        }
+        else if (op.DefaultDash)
+        {
+            float d = (float)Math.Max(op.WidthPx * 3.0, 3.0);
+            paint.PathEffect = SKPathEffect.CreateDash([d, d], 0f);
+        }
+
+        canvas.DrawPath(path, paint);
+        paint.PathEffect?.Dispose();
+    }
+
+    private static void DrawPoint(SKCanvas canvas, PointPaintOp op, WorldToScreen t)
+    {
+        var (cx, cy) = t.Project(op.World);
+        cx += (float)op.OffsetXpx;
+        cy += (float)op.OffsetYpx;
+
+        if (op.Symbol is { } symbol)
+        {
+            using var svg = SKSvg.CreateFromSvg(symbol.ProcessedSvg);
+            var picture = svg?.Picture;
+            if (picture is not null)
+            {
+                var bounds = picture.CullRect;
+                // S-100 SVG user units are millimetres rasterised by Svg.Skia at
+                // 96 DPI (≈3.78 px/mm); fold that into the symbol scale so the on
+                // screen size matches the Mapsui ImageStyle convention.
+                float scale = (float)(symbol.Scale * 96.0 / 25.4);
+                float w = bounds.Width * scale;
+                float h = bounds.Height * scale;
+
+                // Place the bbox centre on the anchor, then shift by the pivot
+                // fraction so the pivot — not the bbox centre — lands on it.
+                float pivotShiftX = (float)(symbol.PivotRelativeX * w);
+                float pivotShiftY = (float)(symbol.PivotRelativeY * h);
+
+                canvas.Save();
+                canvas.Translate(cx + pivotShiftX, cy + pivotShiftY);
+                if (op.Rotation is { } rot)
+                    canvas.RotateDegrees((float)rot);
+                canvas.Scale(scale);
+                canvas.Translate(-(bounds.Left + bounds.Width / 2f), -(bounds.Top + bounds.Height / 2f));
+                canvas.DrawPicture(picture);
+                canvas.Restore();
+                return;
+            }
+        }
+
+        // Fallback: a small filled dot, sized like the legacy SymbolStyle dot.
+        float radius = (float)Math.Max(op.FallbackScale * 12.0, 1.0);
+        using var dot = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Fill,
+            Color = op.FallbackColor.ToSkia(),
+        };
+        canvas.DrawCircle(cx, cy, radius, dot);
+    }
+
+    private static void DrawText(SKCanvas canvas, TextPaintOp op, WorldToScreen t)
+    {
+        var (ax, ay) = t.Project(op.World);
+
+        using var font = new SKFont(SKTypeface.Default, (float)op.FontSizePx);
+        using var paint = new SKPaint { IsAntialias = true };
+
+        font.MeasureText(op.Text, out var textBounds, paint);
+        float textWidth = textBounds.Width;
+        float textHeight = textBounds.Height;
+
+        // Resolve the anchor according to alignment (screen +Y = down).
+        float x = op.HorizontalAlignment switch
+        {
+            TextHorizontalAlignment.Start => ax,
+            TextHorizontalAlignment.End => ax - textWidth,
+            _ => ax - textWidth / 2f,
+        };
+        float baseline = op.VerticalAlignment switch
+        {
+            TextVerticalAlignment.Top => ay - textBounds.Top,
+            TextVerticalAlignment.Bottom => ay - textBounds.Bottom,
+            _ => ay - textBounds.MidY,
+        };
+
+        x += (float)op.OffsetXpx;
+        baseline += (float)op.OffsetYpx;
+
+        if (op.BackColor is { } back)
+        {
+            using var bg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = back.ToSkia() };
+            const float pad = 1.5f;
+            var rect = new SKRect(
+                x + textBounds.Left - pad,
+                baseline + textBounds.Top - pad,
+                x + textBounds.Left + textWidth + pad,
+                baseline + textBounds.Top + textHeight + pad);
+            canvas.DrawRect(rect, bg);
+        }
+
+        paint.Color = op.ForeColor.ToSkia();
+        canvas.DrawText(op.Text, x, baseline, SKTextAlign.Left, font, paint);
+    }
+
+    private static void AddRing(SKPath path, IReadOnlyList<(double X, double Y)> ring, WorldToScreen t)
+    {
+        if (ring.Count < 3)
+            return;
+        var (sx, sy) = t.Project(ring[0]);
+        path.MoveTo(sx, sy);
+        for (int i = 1; i < ring.Count; i++)
+        {
+            var (px, py) = t.Project(ring[i]);
+            path.LineTo(px, py);
+        }
+        path.Close();
+    }
+}
+
+/// <summary>
+/// A linear EPSG:3857-world → screen-pixel affine derived from a
+/// <see cref="Viewport"/>. The viewport's geographic bounds are projected to
+/// EPSG:3857 and mapped to the pixel rectangle (origin top-left, +Y down).
+/// </summary>
+internal readonly struct WorldToScreen
+{
+    private readonly double _minX;
+    private readonly double _maxY;
+    private readonly double _scaleX;
+    private readonly double _scaleY;
+
+    private WorldToScreen(double minX, double maxY, double scaleX, double scaleY)
+    {
+        _minX = minX;
+        _maxY = maxY;
+        _scaleX = scaleX;
+        _scaleY = scaleY;
+    }
+
+    public static WorldToScreen Create(Viewport viewport)
+    {
+        var (minX, minY) = WebMercator.FromLonLat(viewport.MinLongitude, viewport.MinLatitude);
+        var (maxX, maxY) = WebMercator.FromLonLat(viewport.MaxLongitude, viewport.MaxLatitude);
+
+        double spanX = maxX - minX;
+        double spanY = maxY - minY;
+        double scaleX = spanX != 0 ? viewport.WidthPixels / spanX : 0;
+        double scaleY = spanY != 0 ? viewport.HeightPixels / spanY : 0;
+        return new WorldToScreen(minX, maxY, scaleX, scaleY);
+    }
+
+    public (float X, float Y) Project((double X, double Y) world)
+    {
+        float sx = (float)((world.X - _minX) * _scaleX);
+        float sy = (float)((_maxY - world.Y) * _scaleY);
+        return (sx, sy);
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/VectorSceneBuilder.cs
@@ -1,0 +1,397 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Portrayals;
+
+namespace EncDotNet.S100.Renderers.Skia.Scene;
+
+/// <summary>
+/// A resolved point-symbol asset: the processed (class-resolved) SVG content
+/// plus the S-100 Part 9 §11.5 pivot offset expressed as a fraction of symbol
+/// size in screen-space orientation (+Y = down).
+/// </summary>
+/// <param name="ProcessedSvg">Processed SVG content (no <c>svg-content://</c> prefix).</param>
+/// <param name="PivotRelativeX">Pivot-to-centre offset as a fraction of width (+X = pivot left of centre).</param>
+/// <param name="PivotRelativeY">Pivot-to-centre offset as a fraction of height (+Y = pivot above centre, screen +Y down).</param>
+public readonly record struct SymbolAsset(
+    string ProcessedSvg,
+    double PivotRelativeX,
+    double PivotRelativeY);
+
+/// <summary>
+/// Lowers a backend-agnostic S-100 Part 9 display list (a list of
+/// <see cref="DrawingInstruction"/>s plus an <see cref="IFeatureGeometryProvider"/>)
+/// into a resolved <see cref="VectorScene"/>: instructions are sorted into
+/// Part 9 draw order, colours/symbols/line-styles are resolved, sizes are
+/// converted from millimetres to display pixels (<c>1 px = 0.32 mm</c>), and
+/// geometry is projected to EPSG:3857. The result is consumed by both the
+/// headless <see cref="SkiaDisplayListRenderer"/> and the Mapsui renderer so
+/// the S-100 portrayal-correctness logic lives in exactly one place.
+/// </summary>
+/// <remarks>
+/// <b>Scope (vertical slice).</b> Pattern fills (<c>AreaInstruction</c> with an
+/// <c>AreaFillReference</c>) are deliberately skipped — they remain the
+/// responsibility of the Mapsui renderer's pattern collection / priority-clip /
+/// insert phase. Only point, line, solid-colour area, and text instructions are
+/// lowered here.
+/// </remarks>
+public sealed class VectorSceneBuilder
+{
+    /// <summary>
+    /// Size, in millimetres, of one S-100 portrayal pixel on the nominal display
+    /// surface (S-100 Part 9 §3.10.4 — 1 px = 0.32 mm). Used to convert
+    /// spec-defined millimetre sizes to display pixels.
+    /// </summary>
+    public const double S100PixelSizeMm = 0.32;
+
+    /// <summary>Resolves an S-100 colour token to an <see cref="RgbaColor"/>. Required.</summary>
+    public required Func<string?, RgbaColor> ResolveColor { get; init; }
+
+    /// <summary>
+    /// Resolves a symbol name to a processed-SVG asset, or null when the symbol
+    /// cannot be resolved (the op then carries a fallback dot). Optional.
+    /// </summary>
+    public Func<string, SymbolAsset?>? SymbolResolver { get; init; }
+
+    /// <summary>Resolves a line-style name to its catalogue definition. Optional.</summary>
+    public Func<string, LineStyle?>? LineStyleProvider { get; init; }
+
+    /// <summary>Global scale factor applied to all point symbols (default 1.0).</summary>
+    public double SymbolScale { get; init; } = 1.0;
+
+    /// <summary>Global scale factor applied to all text labels (default 1.0).</summary>
+    public double TextScale { get; init; } = 1.0;
+
+    /// <summary>
+    /// Convenience helper that produces a <see cref="SymbolAsset"/> from raw SVG
+    /// content by recovering the pivot (<see cref="SvgPivotMetrics.TryParse"/>)
+    /// and processing CSS classes (<see cref="SvgProcessor.Process"/>). Returns
+    /// null when the content is null/empty or processing fails.
+    /// </summary>
+    public static SymbolAsset? ResolveSymbolAsset(string? svgContent, ColorPalette? palette)
+    {
+        if (string.IsNullOrEmpty(svgContent))
+            return null;
+        try
+        {
+            var pivot = SvgPivotMetrics.TryParse(svgContent);
+            var processed = SvgProcessor.Process(svgContent, palette);
+            return new SymbolAsset(
+                processed,
+                pivot?.RelativeOffset.X ?? 0.0,
+                pivot?.RelativeOffset.Y ?? 0.0);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Builds a resolved scene from the supplied display list and geometry.</summary>
+    public VectorScene Build(
+        IReadOnlyList<DrawingInstruction> instructions,
+        IFeatureGeometryProvider geometryProvider)
+    {
+        ArgumentNullException.ThrowIfNull(instructions);
+        ArgumentNullException.ThrowIfNull(geometryProvider);
+
+        var sorted = instructions
+            .OrderBy(i => i.Plane == EncDotNet.S100.Pipelines.Vector.DisplayPlane.OverRadar ? 1 : 0)
+            .ThenBy(i => i switch
+            {
+                AreaInstruction => 0,
+                LineInstruction => 1,
+                PointInstruction => 2,
+                TextInstruction => 3,
+                _ => 4,
+            })
+            .ThenBy(i => i.DrawingPriority)
+            .ToList();
+
+        var ops = new List<PaintOp>(sorted.Count);
+
+        foreach (var instruction in sorted)
+        {
+            var geom = geometryProvider.GetGeometry(instruction.FeatureReference);
+
+            bool hasAugmentedLine = instruction is LineInstruction { CoordinatesOverride: not null };
+            if (!hasAugmentedLine && (geom is null || geom.Coordinates.Count == 0))
+                continue;
+
+            PaintOp? op = instruction switch
+            {
+                // Pattern fills are handled by the Mapsui pattern phase, not here.
+                AreaInstruction { AreaFillReference: not null } => null,
+                AreaInstruction area when geom is not null => BuildArea(area, geom),
+                LineInstruction line => BuildLine(line, geom),
+                PointInstruction point when geom is not null => BuildPoint(point, geom),
+                TextInstruction text when geom is not null => BuildText(text, geom),
+                _ => null,
+            };
+
+            if (op is not null)
+                ops.Add(op);
+        }
+
+        return new VectorScene(ops);
+    }
+
+    private AreaPaintOp? BuildArea(AreaInstruction instruction, FeatureGeometry geometry)
+    {
+        if (instruction.FillColor is null)
+            return null;
+
+        if (geometry.Coordinates.Count < 3)
+            return null;
+
+        var fill = ResolveColor(instruction.FillColor);
+        if (instruction.Transparency.HasValue)
+        {
+            byte alpha = (byte)(255 * (1.0 - instruction.Transparency.Value));
+            fill = new RgbaColor(fill.R, fill.G, fill.B, alpha);
+        }
+
+        var holes = new List<IReadOnlyList<(double, double)>>(geometry.InteriorRings.Count);
+        foreach (var ring in geometry.InteriorRings)
+        {
+            if (ring.Count >= 3)
+                holes.Add(Project(ring));
+        }
+
+        return new AreaPaintOp
+        {
+            FeatureReference = instruction.FeatureReference,
+            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMaximum = instruction.ScaleMaximum,
+            WorldShell = Project(geometry.Coordinates),
+            WorldHoles = holes,
+            Fill = fill,
+            // Matches the legacy renderer's faint area outline.
+            OutlineColor = new RgbaColor(0, 0, 0, 40),
+            OutlineWidthPx = 0.5,
+        };
+    }
+
+    private LinePaintOp? BuildLine(LineInstruction instruction, FeatureGeometry? geometry)
+    {
+        var coords = instruction.CoordinatesOverride ?? geometry?.Coordinates;
+        if (coords is null || coords.Count < 2)
+            return null;
+
+        string? colorToken = instruction.LineColor;
+        double width = instruction.LineWidth;
+        bool dashed = instruction.Dashes is { Count: > 0 };
+
+        if (colorToken is null && instruction.LineStyleReference is not null && LineStyleProvider is not null)
+        {
+            var externalStyle = LineStyleProvider(instruction.LineStyleReference);
+            if (externalStyle is not null)
+            {
+                colorToken = externalStyle.Color;
+                if (externalStyle.Width > 0)
+                    width = externalStyle.Width;
+                if (externalStyle.DashPattern is { Length: > 0 })
+                    dashed = true;
+            }
+        }
+
+        var widthPx = width > 0 ? (width / S100PixelSizeMm) : 0.0;
+        widthPx = Math.Max(widthPx, 1.0);
+
+        IReadOnlyList<float>? dashArray = null;
+        bool defaultDash = false;
+        if (dashed && instruction.Dashes is { Count: > 0 })
+        {
+            var onMm = instruction.DashOnLengthMm > 0
+                ? instruction.DashOnLengthMm
+                : instruction.Dashes[0].Length;
+            var gapMm = instruction.Dashes[0].Length;
+            var onPx = (float)(onMm / S100PixelSizeMm);
+            var gapPx = (float)(gapMm / S100PixelSizeMm);
+            dashArray = [Math.Max(onPx, 1f), Math.Max(gapPx, 1f)];
+        }
+        else if (dashed)
+        {
+            defaultDash = true;
+        }
+
+        return new LinePaintOp
+        {
+            FeatureReference = instruction.FeatureReference,
+            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMaximum = instruction.ScaleMaximum,
+            World = Project(coords),
+            Color = ResolveColor(colorToken),
+            WidthPx = widthPx,
+            DashArrayPx = dashArray,
+            DefaultDash = defaultDash,
+        };
+    }
+
+    private PointPaintOp BuildPoint(PointInstruction instruction, FeatureGeometry geometry)
+    {
+        double lat, lon;
+        if (instruction.CoordinateOverride is { } anchor)
+        {
+            (lat, lon) = (anchor.Latitude, anchor.Longitude);
+        }
+        else
+        {
+            (lat, lon) = geometry.Coordinates[0];
+        }
+
+        var symOffsetXpx = instruction.LocalOffsetX / S100PixelSizeMm;
+        var symOffsetYpx = instruction.LocalOffsetY / S100PixelSizeMm;
+
+        SymbolAsset? asset = null;
+        if (!string.IsNullOrEmpty(instruction.SymbolReference) && SymbolResolver is not null)
+            asset = SymbolResolver(instruction.SymbolReference);
+
+        ResolvedSymbol? symbol = asset is { } a
+            ? new ResolvedSymbol(
+                a.ProcessedSvg,
+                0.6 * instruction.SymbolScale * SymbolScale,
+                a.PivotRelativeX,
+                a.PivotRelativeY)
+            : null;
+
+        return new PointPaintOp
+        {
+            FeatureReference = instruction.FeatureReference,
+            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMaximum = instruction.ScaleMaximum,
+            World = WebMercator.FromLonLat(lon, lat),
+            Symbol = symbol,
+            FallbackColor = ColorResolver.ResolveSymbolColor(instruction.SymbolReference, ResolveColor),
+            FallbackScale = 0.15 * instruction.SymbolScale * SymbolScale,
+            Rotation = instruction.Rotation,
+            OffsetXpx = symOffsetXpx,
+            OffsetYpx = symOffsetYpx,
+        };
+    }
+
+    private TextPaintOp? BuildText(TextInstruction instruction, FeatureGeometry geometry)
+    {
+        var coords = geometry.Coordinates;
+        if (string.IsNullOrEmpty(instruction.Text))
+            return null;
+
+        double lat, lon;
+        if (instruction.CoordinateOverride is { } anchor)
+        {
+            (lat, lon) = (anchor.Latitude, anchor.Longitude);
+        }
+        else if (coords.Count == 0)
+        {
+            return null;
+        }
+        else if (instruction.LinePlacementPosition.HasValue && coords.Count >= 2
+            && geometry.Type == GeometryType.Curve)
+        {
+            (lat, lon) = InterpolateAlongPolyline(coords, instruction.LinePlacementPosition.Value);
+        }
+        else if (geometry.Type == GeometryType.Surface && coords.Count >= 3)
+        {
+            (lat, lon) = ComputeRingCentroid(coords);
+        }
+        else if (geometry.Type == GeometryType.Curve && coords.Count >= 2)
+        {
+            (lat, lon) = coords[coords.Count / 2];
+        }
+        else
+        {
+            (lat, lon) = coords[0];
+        }
+
+        var foreColor = ColorResolver.ApplyTransparency(
+            ResolveColor(instruction.FontColor), instruction.FontTransparency);
+
+        RgbaColor? backColor = null;
+        if (!string.IsNullOrEmpty(instruction.BackgroundColor))
+        {
+            var bgBase = ResolveColor(instruction.BackgroundColor);
+            backColor = ColorResolver.ApplyTransparency(bgBase, instruction.BackgroundTransparency ?? 0.5);
+        }
+
+        return new TextPaintOp
+        {
+            FeatureReference = instruction.FeatureReference,
+            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMaximum = instruction.ScaleMaximum,
+            World = WebMercator.FromLonLat(lon, lat),
+            Text = instruction.Text,
+            FontSizePx = instruction.FontSize * TextScale,
+            ForeColor = foreColor,
+            BackColor = backColor,
+            HorizontalAlignment = instruction.HorizontalAlignment,
+            VerticalAlignment = instruction.VerticalAlignment,
+            OffsetXpx = (instruction.OffsetXmm ?? 0) / S100PixelSizeMm,
+            OffsetYpx = (instruction.OffsetYmm ?? 0) / S100PixelSizeMm,
+        };
+    }
+
+    private static IReadOnlyList<(double X, double Y)> Project(
+        IReadOnlyList<(double Latitude, double Longitude)> coords)
+    {
+        var result = new (double, double)[coords.Count];
+        for (int i = 0; i < coords.Count; i++)
+            result[i] = WebMercator.FromLonLat(coords[i].Longitude, coords[i].Latitude);
+        return result;
+    }
+
+    private static (double Lat, double Lon) InterpolateAlongPolyline(
+        IReadOnlyList<(double Lat, double Lon)> coords, double fraction)
+    {
+        if (coords.Count < 2)
+            return coords[0];
+
+        fraction = Math.Clamp(fraction, 0.0, 1.0);
+
+        double totalLength = 0;
+        for (int i = 1; i < coords.Count; i++)
+        {
+            double dLat = coords[i].Lat - coords[i - 1].Lat;
+            double dLon = coords[i].Lon - coords[i - 1].Lon;
+            totalLength += Math.Sqrt(dLat * dLat + dLon * dLon);
+        }
+
+        if (totalLength <= 0)
+            return coords[0];
+
+        double targetLength = totalLength * fraction;
+        double accumulated = 0;
+
+        for (int i = 1; i < coords.Count; i++)
+        {
+            double dLat = coords[i].Lat - coords[i - 1].Lat;
+            double dLon = coords[i].Lon - coords[i - 1].Lon;
+            double segmentLength = Math.Sqrt(dLat * dLat + dLon * dLon);
+
+            if (accumulated + segmentLength >= targetLength)
+            {
+                double t = segmentLength > 0 ? (targetLength - accumulated) / segmentLength : 0;
+                return (
+                    coords[i - 1].Lat + t * dLat,
+                    coords[i - 1].Lon + t * dLon);
+            }
+
+            accumulated += segmentLength;
+        }
+
+        return coords[^1];
+    }
+
+    private static (double Lat, double Lon) ComputeRingCentroid(
+        IReadOnlyList<(double Lat, double Lon)> ring)
+    {
+        int count = ring.Count;
+        if (count >= 2 && ring[0] == ring[count - 1])
+            count--;
+        double sumLat = 0, sumLon = 0;
+        for (int i = 0; i < count; i++)
+        {
+            sumLat += ring[i].Lat;
+            sumLon += ring[i].Lon;
+        }
+        return (sumLat / count, sumLon / count);
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/WebMercator.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/WebMercator.cs
@@ -1,0 +1,32 @@
+namespace EncDotNet.S100.Renderers.Skia.Scene;
+
+/// <summary>
+/// Spherical Web-Mercator (EPSG:3857) forward projection used by the shared
+/// vector rendering core. Reimplemented here so the core has no dependency on
+/// Mapsui (whose <c>SphericalMercator.FromLonLat</c> this matches).
+/// </summary>
+/// <remarks>
+/// Uses the WGS-84 semi-major axis as the sphere radius
+/// (<c>6378137 m</c>), the standard EPSG:3857 definition. A numeric parity
+/// test asserts agreement with Mapsui's projection within a tight metre
+/// tolerance, so refactoring the Mapsui path onto this implementation does not
+/// shift the visual-regression baselines.
+/// </remarks>
+public static class WebMercator
+{
+    /// <summary>EPSG:3857 sphere radius (WGS-84 semi-major axis), in metres.</summary>
+    public const double EarthRadius = 6378137.0;
+
+    private const double DegToRad = Math.PI / 180.0;
+
+    /// <summary>
+    /// Projects a WGS-84 (longitude, latitude) pair, in degrees, to EPSG:3857
+    /// metres (x = easting, y = northing).
+    /// </summary>
+    public static (double X, double Y) FromLonLat(double longitude, double latitude)
+    {
+        double x = EarthRadius * longitude * DegToRad;
+        double y = EarthRadius * Math.Log(Math.Tan(Math.PI / 4.0 + latitude * DegToRad / 2.0));
+        return (x, y);
+    }
+}

--- a/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
@@ -1,0 +1,262 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using Mapsui.Projections;
+using SkiaSharp;
+
+namespace EncDotNet.S100.VisualRegression.Tests;
+
+/// <summary>
+/// Unit / parity tests for the headless direct-Skia vector renderer and the
+/// shared S-100 Part 9 rendering core it consumes
+/// (<see cref="VectorSceneBuilder"/> → <see cref="VectorScene"/> →
+/// <see cref="SkiaDisplayListRenderer"/>). These validate the seam directly
+/// rather than via the Mapsui visual-regression baselines, per the deliberate
+/// "honest parity" scoping of the split-renderer spike.
+/// </summary>
+public sealed class SkiaDisplayListRendererTests
+{
+    private static readonly RgbaColor White = new(255, 255, 255, 255);
+    private static readonly RgbaColor Black = new(0, 0, 0, 255);
+
+    // ── Projection parity ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0.0, 0.0)]
+    [InlineData(-122.3321, 47.6062)]   // Seattle
+    [InlineData(151.2093, -33.8688)]   // Sydney
+    [InlineData(179.9, 70.0)]          // near-antimeridian, high latitude
+    [InlineData(-179.9, -60.0)]
+    public void WebMercator_MatchesMapsui_WithinTightTolerance(double lon, double lat)
+    {
+        var (x, y) = WebMercator.FromLonLat(lon, lat);
+        var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
+
+        // EPSG:3857 eastings/northings span ±2.0036e7 m; a 1e-3 m tolerance is
+        // ~12 orders of magnitude tighter than a display pixel at any usable
+        // chart scale, so the reimplementation is render-equivalent to Mapsui's.
+        Assert.Equal(mx, x, 3);
+        Assert.Equal(my, y, 3);
+    }
+
+    // ── Scale-visibility boundary agreement ────────────────────────────
+
+    [Fact]
+    public void IsVisibleAtScale_IsInclusiveAtBothBounds()
+    {
+        // ScaleMaximum = most zoomed-in (smallest denom); ScaleMinimum = most
+        // zoomed-out (largest denom). Visible iff ScaleMaximum ≤ denom ≤ ScaleMinimum.
+        var op = MakeLine(ScaleMinimum: 50_000, ScaleMaximum: 10_000);
+
+        Assert.False(ScaleVisibility.IsVisibleAtScale(op, 9_999));    // too zoomed in
+        Assert.True(ScaleVisibility.IsVisibleAtScale(op, 10_000));    // lower bound inclusive
+        Assert.True(ScaleVisibility.IsVisibleAtScale(op, 30_000));
+        Assert.True(ScaleVisibility.IsVisibleAtScale(op, 50_000));    // upper bound inclusive
+        Assert.False(ScaleVisibility.IsVisibleAtScale(op, 50_001));   // too zoomed out
+    }
+
+    [Fact]
+    public void IsVisibleAtScale_NullBoundsAlwaysVisible()
+    {
+        var op = MakeLine(ScaleMinimum: null, ScaleMaximum: null);
+        Assert.True(ScaleVisibility.IsVisibleAtScale(op, 1));
+        Assert.True(ScaleVisibility.IsVisibleAtScale(op, 10_000_000));
+    }
+
+    [Fact]
+    public void Render_OmitsOpsOutsideScaleRange()
+    {
+        var scene = new VectorScene([
+            new AreaPaintOp
+            {
+                FeatureReference = "F1",
+                ScaleMinimum = 10_000,   // only visible when zoomed in to ≤ 1:10000
+                WorldShell = SquareAround(0.005, 0.005, 0.004),
+                Fill = Black,
+            },
+        ]);
+
+        // Viewport scale denominator (50_000) is more zoomed-out than the op's
+        // ScaleMinimum (10_000) upper bound → the area must be culled.
+        using var bitmap = Render(scene, MakeViewport(denom: 50_000));
+        Assert.True(IsBlank(bitmap, White), "Op outside its scale range should not be drawn.");
+    }
+
+    // ── Resolution-independent sizing (the IR unit contract) ───────────
+
+    [Fact]
+    public void StrokeWidth_IsConstantAcrossZoomLevels()
+    {
+        const double widthPx = 6.0;
+
+        // A horizontal line across the middle of the viewport, in world space.
+        var wide = RenderLineAndMeasureCentreWidth(widthPx, geoSpan: 0.02);
+        var zoomed = RenderLineAndMeasureCentreWidth(widthPx, geoSpan: 0.002);
+
+        // Stroke width is realised in display pixels per the IR contract, so a
+        // 10× zoom must NOT change the on-screen stroke thickness.
+        Assert.InRange(wide, widthPx - 1.5, widthPx + 1.5);
+        Assert.InRange(zoomed, widthPx - 1.5, widthPx + 1.5);
+        Assert.InRange(Math.Abs(wide - zoomed), 0, 1);
+    }
+
+    // ── End-to-end smoke: all four op kinds produce output ─────────────
+
+    [Fact]
+    public void Render_PointLineAreaText_ProducesOutput()
+    {
+        var scene = new VectorScene([
+            new AreaPaintOp
+            {
+                FeatureReference = "area",
+                WorldShell = SquareAround(0.005, 0.005, 0.003),
+                Fill = new RgbaColor(200, 220, 255, 255),
+            },
+            new LinePaintOp
+            {
+                FeatureReference = "line",
+                World = [Project(0.001, 0.005), Project(0.009, 0.005)],
+                Color = new RgbaColor(0, 128, 0, 255),
+                WidthPx = 3.0,
+            },
+            new PointPaintOp
+            {
+                FeatureReference = "point",
+                World = Project(0.005, 0.005),
+                FallbackColor = new RgbaColor(255, 0, 0, 255),
+                FallbackScale = 0.5,
+            },
+            new TextPaintOp
+            {
+                FeatureReference = "text",
+                World = Project(0.005, 0.008),
+                Text = "X",
+                FontSizePx = 24,
+                ForeColor = Black,
+            },
+        ]);
+
+        using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+        Assert.False(IsBlank(bitmap, White), "Scene with four op kinds rendered nothing.");
+
+        // The red fallback dot sits on the projected anchor at the viewport
+        // centre, validating WorldToScreen placement.
+        var centre = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+        Assert.True(centre.Red > 150 && centre.Green < 100 && centre.Blue < 100,
+            $"Expected a red dot at the centre, got {centre}.");
+    }
+
+    [Fact]
+    public void Render_SolidArea_FillsInteriorWithFillColour()
+    {
+        var fill = new RgbaColor(10, 80, 200, 255);
+        var scene = new VectorScene([
+            new AreaPaintOp
+            {
+                FeatureReference = "area",
+                WorldShell = SquareAround(0.005, 0.005, 0.004),
+                Fill = fill,
+            },
+        ]);
+
+        using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+        var centre = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+        Assert.InRange((int)centre.Blue, 170, 230);
+        Assert.True(centre.Blue > centre.Red && centre.Blue > centre.Green);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static double RenderLineAndMeasureCentreWidth(double widthPx, double geoSpan)
+    {
+        double midLat = geoSpan / 2.0;
+        var scene = new VectorScene([
+            new LinePaintOp
+            {
+                FeatureReference = "line",
+                World = [Project(0.0, midLat), Project(geoSpan, midLat)],
+                Color = Black,
+                WidthPx = widthPx,
+            },
+        ]);
+
+        var viewport = new Viewport
+        {
+            MinLongitude = 0.0,
+            MaxLongitude = geoSpan,
+            MinLatitude = 0.0,
+            MaxLatitude = geoSpan,
+            WidthPixels = 200,
+            HeightPixels = 200,
+            ScaleDenominator = 25_000,
+        };
+
+        using var bitmap = Render(scene, viewport);
+
+        // Count opaque-black pixels in the centre column; the round-capped
+        // horizontal stroke is widthPx tall there.
+        int col = bitmap.Width / 2;
+        int run = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            var p = bitmap.GetPixel(col, y);
+            if (p.Red < 80 && p.Green < 80 && p.Blue < 80 && p.Alpha > 128)
+                run++;
+        }
+        return run;
+    }
+
+    private static SKBitmap Render(VectorScene scene, Viewport viewport)
+    {
+        var renderer = new SkiaDisplayListRenderer { Background = White };
+        return renderer.Render(scene, viewport);
+    }
+
+    private static Viewport MakeViewport(double denom) => new()
+    {
+        MinLongitude = 0.0,
+        MaxLongitude = 0.01,
+        MinLatitude = 0.0,
+        MaxLatitude = 0.01,
+        WidthPixels = 200,
+        HeightPixels = 200,
+        ScaleDenominator = denom,
+    };
+
+    private static LinePaintOp MakeLine(double? ScaleMinimum, double? ScaleMaximum) => new()
+    {
+        FeatureReference = "F",
+        World = [Project(0.001, 0.005), Project(0.009, 0.005)],
+        Color = Black,
+        WidthPx = 2.0,
+        ScaleMinimum = ScaleMinimum,
+        ScaleMaximum = ScaleMaximum,
+    };
+
+    private static (double X, double Y) Project(double lon, double lat) =>
+        WebMercator.FromLonLat(lon, lat);
+
+    private static IReadOnlyList<(double X, double Y)> SquareAround(
+        double lon, double lat, double half)
+    {
+        return
+        [
+            Project(lon - half, lat - half),
+            Project(lon + half, lat - half),
+            Project(lon + half, lat + half),
+            Project(lon - half, lat + half),
+        ];
+    }
+
+    private static bool IsBlank(SKBitmap bitmap, RgbaColor background)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red != background.R || p.Green != background.G || p.Blue != background.B)
+                return false;
+        }
+        return true;
+    }
+}

--- a/tests/EncDotNet.S100.VisualRegression.Tests/SkiaHeadlessRealDataTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/SkiaHeadlessRealDataTests.cs
@@ -1,0 +1,92 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+using SkiaSharp;
+
+namespace EncDotNet.S100.VisualRegression.Tests;
+
+/// <summary>
+/// End-to-end tests that render real committed GML fixtures through the new
+/// headless, backend-agnostic Skia vector core
+/// (<c>GmlDatasetProcessorBase.RenderHeadlessAsync</c> →
+/// <c>VectorSceneBuilder</c> → <c>SkiaDisplayListRenderer</c>), with no Mapsui
+/// in the pipeline. These prove the shared core lowers and rasterises actual
+/// dataset display lists, not just synthetic scenes.
+/// </summary>
+/// <remarks>
+/// Set the <c>SKIA_DUMP_DIR</c> environment variable to a writable directory to
+/// also emit the rendered PNGs there (used for manual visual inspection).
+/// </remarks>
+public sealed class SkiaHeadlessRealDataTests
+{
+    private static PortrayalCatalogueManager CreateCatalogueManager()
+    {
+        var manager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                manager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+        return manager;
+    }
+
+    private static IInteroperabilityAuthorityProvider CreateAuthorityProvider() =>
+        new InteroperabilityAuthorityProvider(new InteroperabilityAuthority());
+
+    private static void MaybeDump(SKBitmap bitmap, string name)
+    {
+        var dir = Environment.GetEnvironmentVariable("SKIA_DUMP_DIR");
+        if (string.IsNullOrEmpty(dir))
+            return;
+        Directory.CreateDirectory(dir);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var fs = File.Create(Path.Combine(dir, name));
+        data.SaveTo(fs);
+    }
+
+    private static void AssertNonBlank(SKBitmap bitmap)
+    {
+        // White background — assert at least one non-white pixel was painted.
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red != 255 || p.Green != 255 || p.Blue != 255)
+                return;
+        }
+        Assert.Fail("Headless Skia render produced a blank (all-white) bitmap.");
+    }
+
+    [Fact]
+    public async Task S201_AtonLight_RendersThroughSkiaCore()
+    {
+        var path = Path.Combine(TestHelpers.DatasetsRoot, "S201", "aton_light.gml");
+        using var manager = CreateCatalogueManager();
+
+        var processor = new S201DatasetProcessor(path, manager, CreateAuthorityProvider());
+        using var bitmap = await processor.RenderHeadlessAsync(800, 600);
+
+        Assert.Equal(800, bitmap.Width);
+        Assert.Equal(600, bitmap.Height);
+        AssertNonBlank(bitmap);
+        MaybeDump(bitmap, "s201_aton_light.png");
+    }
+
+    [Fact]
+    public async Task S124_NavwarnSurface_RendersThroughSkiaCore()
+    {
+        var path = Path.Combine(TestHelpers.DatasetsRoot, "S124", "navwarn_surface.gml");
+        using var manager = CreateCatalogueManager();
+
+        var processor = new S124DatasetProcessor(path, manager, CreateAuthorityProvider());
+        using var bitmap = await processor.RenderHeadlessAsync(800, 600);
+
+        AssertNonBlank(bitmap);
+        MaybeDump(bitmap, "s124_navwarn_surface.png");
+    }
+}


### PR DESCRIPTION
## Summary

Prototype/spike that splits the S-100 Part 9 vector renderer so the portrayal-correctness logic becomes a backend-agnostic shared **core** that both the existing `MapsuiDisplayListRenderer` and a new headless direct-SkiaSharp renderer consume. The end goal is a headless (non-Mapsui) vector rasterizer suitable for a tile-serving web API — symmetric with the existing direct-Skia `SkiaCoverageRenderer`.

## What changed

**New shared core** — `EncDotNet.S100.Renderers.Skia/Scene/` (namespace `…Renderers.Skia.Scene`):
- `VectorSceneBuilder` — lowers a display list (`DrawingInstruction`s + `IFeatureGeometryProvider`) into an immutable `VectorScene` of resolved, world-space (EPSG:3857) `PaintOp`s. Owns Part 9 draw ordering, colour/symbol/line-style/text resolution, mm→px conversion (`1 px = 0.32 mm`), text-anchor selection, and the `lat/lon → EPSG:3857` projection half.
- `PaintOp` (Point/Line/Area/Text) IR, `WebMercator` (forward + inverse), `ScaleVisibility`, `ColorResolver`.
- `SkiaDisplayListRenderer` — new headless `VectorScene + Viewport → SKBitmap` renderer.
- `HeadlessVectorRenderer` — **source-agnostic** entry point: lowers any Part-9 display list, auto-fits a `Viewport` from the scene's EPSG:3857 paint-op bounds (no Mapsui dependency), and rasterizes to an `SKBitmap`.

**Mapsui renderer refactor** — `MapsuiDisplayListRenderer` now builds a `VectorScene` and emits Mapsui `IFeature`/styles from it; the S-100-correctness logic is no longer duplicated here. The pattern-fill collection / priority-clip / insert phase is intentionally left byte-for-byte unchanged.

**Headless entry points**:
- `GmlDatasetProcessorBase.RenderHeadlessAsync(width, height, …)` renders a GML dataset straight to an `SKBitmap` through the core.
- `S101DatasetProcessor.RenderHeadlessAsync(width, height, …)` runs the Lua vector pipeline under the render gate and renders an **S-101 (ISO 8211) ENC cell** to an `SKBitmap` through the same core.

Both delegate to `HeadlessVectorRenderer`, so GML and ISO-8211 products share one headless render path. This is the basis for a future tile API.

## Design

**Seam B (world-space EPSG:3857 IR):** `PaintOp` geometry stays in EPSG:3857 metres; the `EPSG:3857 → screen` affine is per-backend. Mapsui keeps its Navigator (viewer untouched); Skia applies a `Viewport`-derived affine. Sizes (widths, dashes, offsets, font size, symbol scale) are carried in logical display px and realized in device px by each backend.

**Source-agnostic auto-fit:** every `PaintOp` carries EPSG:3857 world coords, so the headless viewport is fit from `scene.Ops` directly — no per-product geometry coupling. Auto-fit sets `HonorScaleVisibility = false` (a fitted denominator is not the dataset compilation scale and would wrongly cull scale-ranged S-101 detail); the flag defaults `true` so explicit-viewport rendering still culls.

## Scope (deliberate, this is a spike)

- **Pattern area-fills are deferred** — not yet in the IR. The Mapsui path retains full pattern fidelity via its unchanged pattern phase; the headless Skia path renders dominant **solid** depth-area fills but omits pattern overlays for now.
- Antimeridian / Web-Mercator pole limits are out of scope.
- Skia symbol-scale and text baseline/alignment are validated at unit/smoke level, not pixel-parity vs the Mapsui baselines.

## Validation

- **Mapsui-via-IR parity:** the full VisualRegression suite holds against the committed baselines (42 passed / 5 skipped) — the desktop viewer path is visually unchanged. Verified the live Avalonia viewer renders an S-101 cell (8422 instructions) through the refactored renderer with no errors.
- **New Skia core tests** (`SkiaDisplayListRendererTests`, 11): Web-Mercator vs Mapsui `SphericalMercator` parity, scale-visibility boundaries, stroke-width zoom-constancy, and all four op kinds incl. anchor placement.
- **Real-data end-to-end** (`SkiaHeadlessRealDataTests`): committed S-201 and S-124 GML fixtures **and an S-101 ISO 8211 cell** rendered through the headless core (non-blank assertions; opt-in PNG dump via `SKIA_DUMP_DIR`). The S-101 cell renders solid depth-area fills, lines, harbour SVG symbols, and text labels.
- Full `Pipelines.Tests` suite green (495 passed / 1 skipped).

## Follow-ups (not in this PR)

- Fold pattern-clip + `IPatternClipCache` into the core so headless S-101 gains pattern overlays and the Mapsui pattern phase is driven from the IR.
- Optional explicit-extent (DataCoverage) option for S-101 headless to avoid cropping pattern-only edge features.
- Antimeridian/pole handling; tighten Skia symbol/text pixel parity; wire a tile endpoint.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>