### PR TITLE
Add s100 CLI for headless dataset-to-PNG rendering

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -57,6 +57,7 @@
     <Project Path="tests/EncDotNet.S100.DynamicSources.Ais.Tests/EncDotNet.S100.DynamicSources.Ais.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Features.Tests/EncDotNet.S100.Features.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj" />
@@ -66,6 +67,7 @@
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj" />
+    <Project Path="tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj" />
     <Project Path="tools/EncDotNet.S100.PerfReport/EncDotNet.S100.PerfReport.csproj" />
   </Folder>
   <Folder Name="/samples/">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,62 @@
+# Command-line rendering (`s100`)
+
+`EncDotNet.S100.Cli` is a cross-platform .NET console tool, invoked as **`s100`**,
+that renders any supported S-100 dataset to a PNG image. It drives the same
+portrayal pipelines as the Avalonia viewer, but rasterises through the
+Mapsui-free Skia *headless* renderers so it can run without a UI — making it
+suitable for batch scripts (e.g. generating sea-ice or surface-current
+previews).
+
+The tool is structured with **subcommands** so its scope can grow (tiling,
+batch, validation, …) without breaking existing usage.
+
+## Quick start
+
+```bash
+# Render a dataset to a 1024x768 PNG (auto-detects the spec)
+dotnet run --project tools/EncDotNet.S100.Cli -- render dataset.h5 out.png
+
+# Inspect a time-series dataset and list its time steps
+dotnet run --project tools/EncDotNet.S100.Cli -- info currents.h5
+
+# Render the 7th time step at night-palette, larger canvas
+dotnet run --project tools/EncDotNet.S100.Cli -- \
+    render currents.h5 currents.png --time-step 6 --palette night -w 2048 -h 1536
+```
+
+## How it works
+
+1. `DatasetPipelineFactory.DetectProductSpec` sniffs the file (extension +
+   content) to determine the product specification.
+2. `DatasetPipelineFactory.CreateProcessor` builds the matching
+   `IDatasetProcessor`, wired to the portrayal and feature catalogues bundled in
+   `EncDotNet.S100.Specifications`.
+3. The CLI feature-tests the processor for `IHeadlessImageRenderer`. If present,
+   it builds a spec-specific `RenderContext` (palette, scales, and — for
+   time-series specs implementing `ITimeAwareDatasetProcessor` — a `DateTime`
+   resolved from `--time-step`) and calls `RenderHeadlessAsync`.
+4. The resulting `SKBitmap` is encoded to PNG and written to the output path.
+
+Vector specs (S-101 and all GML products) render through
+`HeadlessVectorRenderer`; coverage specs (S-102/104/111) render through
+`CoverageHeadlessRenderer`, which fits the coverage extent into the requested
+pixel size (preserving aspect, letter-boxed) and overlays oriented arrows via
+`SkiaCoverageArrowRenderer` for S-111.
+
+## Capabilities and limitations
+
+- **Supported (headless):** S-101; S-122/124/125/127/128/129/131/201/411/421;
+  S-102; S-104 and S-111 *gridded* coverages.
+- **PNG output only** in v1.
+- **Pattern area-fills are omitted** on the vector headless path (points, lines,
+  solid fills, and text render).
+- **Fixed-station coverage** (S-104/S-111 data coding format 3 / 8) is **not**
+  supported headlessly; the CLI returns a descriptive error.
+- **S-57 is not supported.**
+- **Mapsui is linked but does no rendering.** The CLI transitively references
+  the Mapsui renderer for the spec-detection factory and the
+  `ProjNetCrsTransformFactory`. No Mapsui code runs on the headless render path;
+  fully decoupling these is tracked as follow-up work.
+
+See the project README under `tools/EncDotNet.S100.Cli/README.md` for the full
+option reference and exit codes.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -6,6 +6,8 @@
   href: observability.md
 - name: MCP server
   href: mcp-server.md
+- name: Command-line rendering
+  href: cli.md
 - name: Design notes
   items:
     - name: Dynamic feature sources

--- a/samples/s411-previews/README.md
+++ b/samples/s411-previews/README.md
@@ -1,0 +1,72 @@
+# S-411 sea-ice preview generator (sample)
+
+A proof-of-concept Bash script that generates **S-411 sea-ice "quicklook"
+previews** using the [`s100` CLI](../../tools/EncDotNet.S100.Cli/README.md).
+
+It mirrors the idea behind the
+[BSIS Ice Portal](https://www.bsis-ice.de/IcePortal/ILP_S411.shtml) previews:
+download the published S-411 exchange-set ZIPs, extract the GML dataset, and
+rasterise a PNG. Here the rendering is done entirely by `s100 render` — so the
+same machinery the desktop viewer uses also drives an unattended batch job.
+
+## Prerequisites
+
+- .NET 10 SDK
+- `bash`, `curl`, `unzip`
+- A built CLI:
+
+  ```bash
+  dotnet build tools/EncDotNet.S100.Cli -c Release
+  ```
+
+## Usage
+
+From anywhere in the repo:
+
+```bash
+# Render the default region set into ./s411-previews
+samples/s411-previews/s411_previews.sh
+
+# Choose an output directory and explicit regions
+samples/s411-previews/s411_previews.sh /tmp/out north-atlantic hudson-bay
+```
+
+Available region keys: `north-atlantic`, `canada-east`, `hudson-bay`,
+`alaska`, `nw-greenland`. Add more by extending the `region_zip` lookup with
+file names from the BSIS portal.
+
+### Environment overrides
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `S100` | runs the Release DLL via `dotnet` | Command used to invoke the CLI (e.g. a published `s100` binary). |
+| `WIDTH` / `HEIGHT` | `1600` | Output size in pixels. |
+| `PALETTE` | `day` | `day` \| `dusk` \| `night`. |
+
+```bash
+# Use an installed global tool and a larger night-palette canvas
+S100="s100" WIDTH=2048 HEIGHT=2048 PALETTE=night \
+  samples/s411-previews/s411_previews.sh
+```
+
+## Output
+
+```
+<out-dir>/
+  data/<region>.zip          downloaded exchange set
+  data/<region>/...          extracted contents
+  previews/<region>.png      rendered preview
+```
+
+## Notes & caveats
+
+- **The ZIP file names on the BSIS portal are dated and rotate** (often daily).
+  The keys here point at a snapshot; if a download 404s, refresh the file name
+  from <https://www.bsis-ice.de/IcePortal/ILP_S411.shtml>.
+- Previews include the full S-411 **egg-code text labels**, so dense ice can
+  look busier than the BSIS previews (which render solid colour only). Label
+  suppression is tracked as a CLI enhancement.
+- This is sample/PoC code, not a supported product. Generated output under the
+  chosen directory is intentionally not committed.
+- Data © the respective ice services (CIS, DMI, Met.no, US NWS/NIC, AARI, SHN,
+  …) via the BSIS Ice Portal; respect their terms of use.

--- a/samples/s411-previews/s411_previews.sh
+++ b/samples/s411-previews/s411_previews.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# PoC: generate S-411 sea-ice "quicklook" preview images using the s100 CLI.
+#
+# Mirrors the idea behind the BSIS Ice Portal previews
+# (https://www.bsis-ice.de/IcePortal/ILP_S411.shtml): download the published
+# S-411 exchange-set ZIPs, extract the GML dataset, and rasterise a PNG preview.
+# Here the rendering is done entirely by the EncDotNet.S100 `s100` CLI.
+#
+# Usage:
+#   ./s411_previews.sh [OUT_DIR] [REGION ...]
+#
+#   OUT_DIR   Directory for downloaded data + previews (default: ./s411-previews)
+#   REGION    One or more region keys (see REGIONS below). Default: a small set.
+#
+# Environment:
+#   S100        Command used to invoke the CLI. Defaults to running the built
+#               Release DLL via `dotnet`. Override to point at a published
+#               binary, e.g.  S100="/usr/local/bin/s100"
+#   WIDTH/HEIGHT  Output size in pixels (default 1600x1600).
+#   PALETTE       day | dusk | night (default day).
+#
+set -euo pipefail
+
+BASE_URL="https://www.bsis-ice.de/IcePortal/S411"
+
+# region-key -> zip file name on the BSIS portal.
+# (A representative subset; add more from ILP_S411.shtml as needed.)
+# Implemented as a case lookup for portability with bash 3.2 (macOS default),
+# which lacks associative arrays.
+region_zip() {
+  case "$1" in
+    north-atlantic) echo "S411_MetNo_ice20260605.zip" ;;
+    canada-east)    echo "S411_cis_SGRDREC_20260601T1800Z_pl_a.zip" ;;
+    hudson-bay)     echo "S411_cis_SGRDRHB_20260601T1800Z_pl_a.zip" ;;
+    alaska)         echo "S411_NWS_full_20260605.zip" ;;
+    nw-greenland)   echo "S411_DMI_202606032145_NorthWest_RIC.zip" ;;
+    *)              echo "" ;;
+  esac
+}
+
+OUT_DIR="${1:-./s411-previews}"
+shift || true
+SELECTED=("$@")
+if [[ ${#SELECTED[@]} -eq 0 ]]; then
+  SELECTED=(north-atlantic hudson-bay nw-greenland)
+fi
+
+WIDTH="${WIDTH:-1600}"
+HEIGHT="${HEIGHT:-1600}"
+PALETTE="${PALETTE:-day}"
+
+# Default invocation: run the built Release DLL. Override via $S100.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEFAULT_DLL="$REPO_ROOT/tools/EncDotNet.S100.Cli/bin/Release/net10.0/s100.dll"
+S100="${S100:-dotnet "$DEFAULT_DLL"}"
+
+mkdir -p "$OUT_DIR/data" "$OUT_DIR/previews"
+
+echo "Output dir : $OUT_DIR"
+echo "CLI        : $S100"
+echo "Size       : ${WIDTH}x${HEIGHT}  palette=$PALETTE"
+echo "Regions    : ${SELECTED[*]}"
+echo
+
+render_region() {
+  local key="$1"
+  local zip_name
+  zip_name="$(region_zip "$key")"
+  if [[ -z "$zip_name" ]]; then
+    echo "  ! unknown region '$key' — skipping"
+    return 0
+  fi
+
+  local zip_path="$OUT_DIR/data/$key.zip"
+  local extract_dir="$OUT_DIR/data/$key"
+  local preview="$OUT_DIR/previews/$key.png"
+
+  echo "[$key]"
+  echo "  downloading $zip_name"
+  if ! curl -fsSL -o "$zip_path" "$BASE_URL/$zip_name"; then
+    echo "  ! download failed — skipping"
+    return 0
+  fi
+
+  rm -rf "$extract_dir"
+  mkdir -p "$extract_dir"
+  unzip -q -o "$zip_path" -d "$extract_dir"
+
+  # S-411 exchange set: the dataset GML lives under data/.
+  local gml
+  gml="$(find "$extract_dir" -type f -name '*.gml' | head -1)"
+  if [[ -z "$gml" ]]; then
+    echo "  ! no .gml found in exchange set — skipping"
+    return 0
+  fi
+  echo "  dataset $gml"
+
+  # shellcheck disable=SC2086
+  if $S100 render "$gml" "$preview" --width "$WIDTH" --height "$HEIGHT" --palette "$PALETTE"; then
+    echo "  -> $preview"
+  else
+    echo "  ! render failed"
+  fi
+  echo
+}
+
+for key in "${SELECTED[@]}"; do
+  render_region "$key"
+done
+
+echo "Done. Previews in: $OUT_DIR/previews"

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -36,7 +36,7 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// <typeparam name="TFeature">
 /// The concrete feature type constrained to <see cref="IGmlFeature"/>.
 /// </typeparam>
-public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
+public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHeadlessImageRenderer
     where TFeature : IGmlFeature
 {
     private readonly GmlPortrayalCatalogueBase _catalogue;
@@ -249,6 +249,15 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
         cancellationToken.ThrowIfCancellationRequested();
 
+        var bg = background ?? new RgbaColor(255, 255, 255, 255);
+
+        // Honour the same pre-render gate as the Mapsui path (e.g. S-411
+        // time-window suppression). When the gate fires, the dataset
+        // contributes no portrayal for this context, so emit a blank
+        // background-filled bitmap rather than rendering stale content.
+        if (CheckPreRender(context) is not null)
+            return HeadlessVectorRenderer.RenderBlank(widthPixels, heightPixels, bg);
+
         var catalogue = _catalogue;
         context?.EcdisDisplay?.ApplyTo(catalogue);
         catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
@@ -279,7 +288,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor
             textScale: context?.TextScale ?? 1.0,
             widthPixels: widthPixels,
             heightPixels: heightPixels,
-            background: background ?? new RgbaColor(255, 255, 255, 255));
+            background: bg);
     }
 
     /// <inheritdoc/>

--- a/src/EncDotNet.S100.Datasets.Pipelines/IHeadlessImageRenderer.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/IHeadlessImageRenderer.cs
@@ -1,0 +1,59 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Pipelines;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Capability implemented by dataset processors that can rasterise their
+/// portrayal to a standalone <see cref="SKBitmap"/> through the headless,
+/// backend-agnostic Skia core (vector products via
+/// <c>HeadlessVectorRenderer</c>; coverage products via the direct Skia
+/// coverage / arrow renderers) — bypassing Mapsui entirely.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a separate capability interface rather than a member of
+/// <see cref="IDatasetProcessor"/> because headless rendering is not universal:
+/// some processor shapes (e.g. S-104 / S-111 fixed-station datasets, S-57) do
+/// not yet have a Mapsui-free render path. Callers should feature-test with
+/// <c>processor is IHeadlessImageRenderer</c> and surface a clear "headless
+/// rendering not supported" message when the cast fails.
+/// </para>
+/// <para>
+/// Implementations that <em>do</em> implement this interface but encounter an
+/// unsupported dataset <em>shape</em> at render time (e.g. a fixed-station
+/// coverage variant) throw <see cref="System.NotSupportedException"/> with a
+/// descriptive message.
+/// </para>
+/// </remarks>
+public interface IHeadlessImageRenderer
+{
+    /// <summary>
+    /// Renders the dataset to a standalone <see cref="SKBitmap"/> of the
+    /// requested pixel dimensions, bypassing Mapsui.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <param name="context">
+    /// Optional spec-specific render context (palette, symbol/text scale,
+    /// ECDIS display, selected time step). When <c>null</c> the processor
+    /// renders with its defaults.
+    /// </param>
+    /// <param name="background">
+    /// Optional background fill; defaults to opaque white when <c>null</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    /// <exception cref="System.NotSupportedException">
+    /// Thrown when this processor implements the capability in general but the
+    /// specific dataset shape cannot be rendered headlessly.
+    /// </exception>
+    Task<SKBitmap> RenderHeadlessAsync(
+        int widthPixels,
+        int heightPixels,
+        RenderContext? context = null,
+        RgbaColor? background = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/ITimeAwareDatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ITimeAwareDatasetProcessor.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Capability implemented by dataset processors whose portrayal varies over a
+/// discrete set of forecast / observation time steps (S-104 water levels,
+/// S-111 surface currents, and S-411 sea ice). Lets callers (e.g. the CLI)
+/// map a user-supplied time-step index to a concrete <see cref="DateTime"/>
+/// without reflecting over concrete processor types.
+/// </summary>
+public interface ITimeAwareDatasetProcessor
+{
+    /// <summary>
+    /// The ordered, distinct set of time steps available in the dataset.
+    /// Empty when the dataset carries no temporal dimension.
+    /// </summary>
+    IReadOnlyList<DateTime> AvailableTimes { get; }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -23,7 +23,7 @@ using SkiaSharp;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
-public sealed class S101DatasetProcessor : IDatasetProcessor
+public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRenderer
 {
     private readonly S101Dataset _dataset;
     private readonly PortrayalCatalogueProvider _provider;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -13,13 +13,15 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Skia;
 using EncDotNet.S100.Scripting;
 using EncDotNet.S100.Validation;
 using Mapsui;
+using SkiaSharp;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
-public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
+public sealed class S102DatasetProcessor : IDatasetProcessor, IHeadlessImageRenderer, IDisposable
 {
     private readonly S102Dataset _dataset;
     private readonly S102CoverageSource _source;
@@ -169,6 +171,52 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IDisposable
     }
 
     public FeatureInfo? GetFeatureInfo(string featureRef) => null;
+
+    /// <summary>
+    /// Renders the bathymetric surface to a standalone <see cref="SKBitmap"/>
+    /// through the headless, Mapsui-free Skia coverage core
+    /// (<see cref="CoverageHeadlessRenderer"/> → <see cref="SkiaCoverageRenderer"/>).
+    /// The depth-band colour fill is fitted to the requested pixel rectangle,
+    /// preserving aspect against <paramref name="background"/>.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <param name="context">Optional render context (palette, mariner settings).</param>
+    /// <param name="background">Optional background fill; defaults to opaque white.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    public async Task<SKBitmap> RenderHeadlessAsync(
+        int widthPixels,
+        int heightPixels,
+        RenderContext? context = null,
+        RgbaColor? background = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+
+        var styledLayer = (StyledCoverageLayer)await _pipeline
+            .ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
+            .ConfigureAwait(false);
+
+        var extent = _source.Metadata.Extent;
+        var renderer = new CoverageHeadlessRenderer
+        {
+            Background = background ?? new RgbaColor(255, 255, 255, 255),
+        };
+
+        return renderer.Render(
+            styledLayer,
+            extent.WestLongitude,
+            extent.EastLongitude,
+            extent.SouthLatitude,
+            extent.NorthLatitude,
+            widthPixels,
+            heightPixels);
+    }
 
     /// <summary>
     /// Samples the bathymetric surface at the supplied geographic

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -14,12 +14,14 @@ using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Skia;
 using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
 using Mapsui.Styles;
 using NetTopologySuite.Geometries;
+using SkiaSharp;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -29,7 +31,7 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// stations → station-glyph point layer; see S-104 Edition 2.0.0
 /// §10.2.3 / §10.2.7).
 /// </summary>
-public sealed class S104DatasetProcessor : IDatasetProcessor
+public sealed class S104DatasetProcessor : IDatasetProcessor, IHeadlessImageRenderer, ITimeAwareDatasetProcessor
 {
     // dcf2 only
     private readonly S104CoverageSource? _source;
@@ -216,6 +218,70 @@ public sealed class S104DatasetProcessor : IDatasetProcessor
                     SourceFeatureType: "s104.color-band"),
             },
         };
+    }
+
+    /// <summary>
+    /// Renders the gridded water-level surface to a standalone
+    /// <see cref="SKBitmap"/> through the headless, Mapsui-free Skia coverage
+    /// core. The selected time step is taken from the
+    /// <see cref="S104RenderContext.TimeStep"/> (defaulting to the first
+    /// available step). Fixed-station (dcf8) datasets have no coverage colour
+    /// fill and therefore throw <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <param name="context">Optional render context (palette, time step, mariner settings).</param>
+    /// <param name="background">Optional background fill; defaults to opaque white.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown for fixed-station (dcf8) datasets, which are not renderable
+    /// through the headless coverage path.
+    /// </exception>
+    public async Task<SKBitmap> RenderHeadlessAsync(
+        int widthPixels,
+        int heightPixels,
+        RenderContext? context = null,
+        RgbaColor? background = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_stationSeries is not null || _source is null)
+            throw new NotSupportedException(
+                "Headless rendering is not supported for S-104 fixed-station " +
+                "(data coding format 8) datasets; only gridded surfaces can be " +
+                "rendered to an image.");
+
+        var source = _source;
+        var catalogue = _catalogue!;
+        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+
+        if (context is S104RenderContext { TimeStep: { } timeStep })
+            source.SelectTime(timeStep);
+        else
+            source.SelectTime(source.AvailableTimes[0]);
+
+        var styledLayer = (StyledCoverageLayer)await new PortrayalPipeline()
+            .ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
+            .ConfigureAwait(false);
+
+        var extent = source.Metadata.Extent;
+        var renderer = new CoverageHeadlessRenderer
+        {
+            Background = background ?? new RgbaColor(255, 255, 255, 255),
+        };
+
+        return renderer.Render(
+            styledLayer,
+            extent.WestLongitude,
+            extent.EastLongitude,
+            extent.SouthLatitude,
+            extent.NorthLatitude,
+            widthPixels,
+            heightPixels);
     }
 
     // ---- dcf8 station series rendering ---------------------------------

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -15,6 +15,7 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Skia;
 using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
@@ -22,6 +23,7 @@ using Mapsui.Nts;
 using Mapsui.Projections;
 using Mapsui.Styles;
 using NetTopologySuite.Geometries;
+using SkiaSharp;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -33,7 +35,7 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// fixed stations → station-arrow point layer; see S-111 Edition 2.0.0
 /// §10.2.3 / §10.2.7).
 /// </summary>
-public sealed class S111DatasetProcessor : IDatasetProcessor
+public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRenderer, ITimeAwareDatasetProcessor
 {
     // dcf2 only
     private readonly S111CoverageSource? _source;
@@ -280,6 +282,93 @@ public sealed class S111DatasetProcessor : IDatasetProcessor
                 : Array.Empty<string>(),
             StackEntries = stackEntries,
         };
+    }
+
+    /// <summary>
+    /// Renders the gridded surface-current arrows to a standalone
+    /// <see cref="SKBitmap"/> through the headless, Mapsui-free Skia coverage
+    /// core (<see cref="CoverageHeadlessRenderer"/> +
+    /// <see cref="SkiaCoverageArrowRenderer"/>). The selected time step is taken
+    /// from <see cref="S111RenderContext.TimeStep"/> (defaulting to the first
+    /// available step). Fixed-station / ungeorectified (dcf3 / dcf8) datasets
+    /// emit point glyphs rather than a gridded coverage and therefore throw
+    /// <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <param name="context">Optional render context (palette, time step, symbol scale).</param>
+    /// <param name="background">Optional background fill; defaults to opaque white.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown for dcf3 / dcf8 station-series datasets.
+    /// </exception>
+    public async Task<SKBitmap> RenderHeadlessAsync(
+        int widthPixels,
+        int heightPixels,
+        RenderContext? context = null,
+        RgbaColor? background = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_stationSeries is not null || _source is null || _catalogue is null || _provider is null)
+            throw new NotSupportedException(
+                "Headless rendering is not supported for S-111 fixed-station / " +
+                "ungeorectified (data coding format 3 or 8) datasets; only " +
+                "gridded surface-current coverages can be rendered to an image.");
+
+        var source = _source;
+        var catalogue = _catalogue;
+        var provider = _provider;
+        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+
+        if (context is S111RenderContext { TimeStep: { } timeStep })
+            source.SelectTime(timeStep);
+        else
+            source.SelectTime(source.AvailableTimes[0]);
+
+        var styledLayer = (StyledCoverageLayer)await new PortrayalPipeline()
+            .ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
+            .ConfigureAwait(false);
+
+        var arrowRenderer = new SkiaCoverageArrowRenderer
+        {
+            Palette = catalogue.ActivePalette,
+            BaseSymbolScale = context?.SymbolScale ?? 1.0,
+            SymbolProvider = symbolName =>
+            {
+                var item = provider.Catalogue.Symbols
+                    .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase));
+                if (item is null) return null;
+
+                using var stream = provider.FetchAssetAsync(item, "Symbols").GetAwaiter().GetResult();
+                using var reader = new StreamReader(stream);
+                return reader.ReadToEnd();
+            },
+        };
+
+        var nativeToWgs84 = _crsTransformFactory.Create(
+            styledLayer.Georeferencer.CRS, "EPSG:4326");
+
+        var extent = source.Metadata.Extent;
+        var renderer = new CoverageHeadlessRenderer
+        {
+            Background = background ?? new RgbaColor(255, 255, 255, 255),
+            ArrowRenderer = arrowRenderer,
+            NativeToWgs84 = nativeToWgs84,
+        };
+
+        return renderer.Render(
+            styledLayer,
+            extent.WestLongitude,
+            extent.EastLongitude,
+            extent.SouthLatitude,
+            extent.NorthLatitude,
+            widthPixels,
+            heightPixels);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Renderers.Skia/CoverageHeadlessRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/CoverageHeadlessRenderer.cs
@@ -1,0 +1,127 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Renderers.Skia;
+
+/// <summary>
+/// Source-agnostic, Mapsui-free entry point for rendering a
+/// <see cref="StyledCoverageLayer"/> (colour-band fill and/or oriented arrow
+/// symbology) to a standalone <see cref="SKBitmap"/> of caller-requested pixel
+/// dimensions. The coverage's geographic extent is projected to EPSG:3857 and
+/// fitted into the output rectangle preserving aspect (letter-boxed against the
+/// background), so non-square requests do not distort the data.
+/// </summary>
+/// <remarks>
+/// The colour raster produced by <see cref="SkiaCoverageRenderer"/> is one
+/// pixel per grid cell; it is resampled into the fitted destination rectangle.
+/// Grid rows are mapped linearly in latitude, so the Web-Mercator latitude
+/// non-linearity is approximated across the (typically small) coverage extent —
+/// the same approximation the existing direct-Skia coverage path makes. Arrow
+/// symbols are projected exactly through <see cref="WebMercator"/>.
+/// </remarks>
+public sealed class CoverageHeadlessRenderer
+{
+    /// <summary>Background fill painted before the coverage. Defaults to opaque white.</summary>
+    public RgbaColor Background { get; init; } = new(255, 255, 255, 255);
+
+    /// <summary>Colour used for no-data cells in the colour raster. Defaults to transparent.</summary>
+    public RgbaColor NoDataColor { get; init; } = RgbaColor.Transparent;
+
+    /// <summary>
+    /// Optional arrow renderer used when the layer carries a
+    /// <see cref="StyledCoverageLayer.SymbolScheme"/>. When <c>null</c>, arrow
+    /// symbology is skipped even if the layer defines a scheme.
+    /// </summary>
+    public SkiaCoverageArrowRenderer? ArrowRenderer { get; init; }
+
+    /// <summary>
+    /// Transform from the grid's native CRS to WGS84, used to project arrow
+    /// positions. Defaults to identity (geographic grids).
+    /// </summary>
+    public ICrsTransform NativeToWgs84 { get; init; } = IdentityCrsTransform.Instance;
+
+    /// <summary>
+    /// Renders the styled coverage layer to a bitmap of the requested size.
+    /// </summary>
+    /// <param name="layer">The styled coverage layer (colour scheme and/or symbol scheme).</param>
+    /// <param name="westLongitude">Western extent edge in WGS84 degrees.</param>
+    /// <param name="eastLongitude">Eastern extent edge in WGS84 degrees.</param>
+    /// <param name="southLatitude">Southern extent edge in WGS84 degrees.</param>
+    /// <param name="northLatitude">Northern extent edge in WGS84 degrees.</param>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    public SKBitmap Render(
+        StyledCoverageLayer layer,
+        double westLongitude,
+        double eastLongitude,
+        double southLatitude,
+        double northLatitude,
+        int widthPixels,
+        int heightPixels)
+    {
+        ArgumentNullException.ThrowIfNull(layer);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+
+        var bitmap = new SKBitmap(widthPixels, heightPixels, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(Background.ToSkia());
+
+        var (minX, minY) = WebMercator.FromLonLat(westLongitude, southLatitude);
+        var (maxX, maxY) = WebMercator.FromLonLat(eastLongitude, northLatitude);
+        double spanX = maxX - minX;
+        double spanY = maxY - minY;
+        if (spanX <= 0 || spanY <= 0)
+            return bitmap; // Degenerate extent — return the background only.
+
+        // Fit the projected extent into the output rectangle, preserving aspect.
+        double scale = Math.Min(widthPixels / spanX, heightPixels / spanY);
+        double drawW = spanX * scale;
+        double drawH = spanY * scale;
+        double offsetX = (widthPixels - drawW) / 2.0;
+        double offsetY = (heightPixels - drawH) / 2.0;
+
+        (float X, float Y) Project((double X, double Y) world)
+        {
+            float px = (float)(offsetX + (world.X - minX) * scale);
+            float py = (float)(offsetY + (maxY - world.Y) * scale);
+            return (px, py);
+        }
+
+        if (layer.ColorScheme is not null)
+        {
+            var rasterRenderer = new SkiaCoverageRenderer { NoDataColor = NoDataColor };
+            // SkiaCoverageRenderer emits one pixel per grid cell and ignores the
+            // viewport pixel size, so the viewport here only carries the extent.
+            var nativeViewport = new Viewport
+            {
+                MinLongitude = westLongitude,
+                MaxLongitude = eastLongitude,
+                MinLatitude = southLatitude,
+                MaxLatitude = northLatitude,
+                WidthPixels = 1,
+                HeightPixels = 1,
+                ScaleDenominator = 1.0,
+            };
+            using var raster = rasterRenderer.Render(layer, nativeViewport);
+            using var rasterImage = SKImage.FromBitmap(raster);
+            var dest = new SKRect(
+                (float)offsetX,
+                (float)offsetY,
+                (float)(offsetX + drawW),
+                (float)(offsetY + drawH));
+            canvas.DrawImage(rasterImage, dest, new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None));
+        }
+
+        if (layer.SymbolScheme is not null && ArrowRenderer is not null)
+        {
+            ArrowRenderer.Draw(canvas, layer, NativeToWgs84, Project);
+        }
+
+        canvas.Flush();
+        return bitmap;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -81,6 +81,29 @@ public static class HeadlessVectorRenderer
     }
 
     /// <summary>
+    /// Produces a blank bitmap of the requested size filled with
+    /// <paramref name="background"/>. Used when a pre-render gate (e.g. an
+    /// S-411 time-window suppression) means the dataset contributes no
+    /// portrayal for the current context.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width.</param>
+    /// <param name="heightPixels">Output bitmap height.</param>
+    /// <param name="background">Background fill colour.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    public static SKBitmap RenderBlank(int widthPixels, int heightPixels, RgbaColor background)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+
+        var bitmap = new SKBitmap(
+            widthPixels, heightPixels, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(background.ToSkia());
+        canvas.Flush();
+        return bitmap;
+    }
+
+    /// <summary>
     /// Builds a <see cref="Viewport"/> fitted to a resolved scene's EPSG:3857
     /// extent, padded so the projected aspect ratio matches the requested pixel
     /// rectangle (the renderer scales X and Y independently, so matching the

--- a/src/EncDotNet.S100.Renderers.Skia/SkiaCoverageArrowRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/SkiaCoverageArrowRenderer.cs
@@ -1,0 +1,189 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+using Svg.Skia;
+
+namespace EncDotNet.S100.Renderers.Skia;
+
+/// <summary>
+/// Draws oriented overlay symbols (e.g. S-111 surface-current arrows) from a
+/// <see cref="StyledCoverageLayer.SymbolScheme"/> directly onto an
+/// <see cref="SKCanvas"/>, with no Mapsui dependency. This is the headless,
+/// direct-Skia analogue of <c>MapsuiCoverageArrowRenderer</c>: it shares the
+/// same per-band scaling contract (S-111 Ed 2.0.0,
+/// <c>content/S111/pc/Rules/select_arrow.xsl</c>) and palette-token SVG
+/// processing, but rasterises each arrow with <see cref="SKSvg"/> and projects
+/// grid-cell centres through <see cref="WebMercator"/> instead of Mapsui's
+/// navigator.
+/// </summary>
+public sealed class SkiaCoverageArrowRenderer
+{
+    private readonly Dictionary<string, SKSvg?> _svgCache = new(StringComparer.OrdinalIgnoreCase);
+    private ColorPalette? _cachedFor;
+
+    /// <summary>
+    /// The colour palette used to resolve SVG CSS fill/stroke tokens
+    /// (e.g. <c>fSCBN1</c> → palette token <c>SCBN1</c>).
+    /// </summary>
+    public ColorPalette? Palette { get; init; }
+
+    /// <summary>
+    /// Returns raw SVG content for a symbol reference name
+    /// (e.g. <c>"SCAROW01"</c>), or <c>null</c> when unavailable.
+    /// </summary>
+    public required Func<string, string?> SymbolProvider { get; init; }
+
+    /// <summary>
+    /// Multiplier applied to each band's scale factor. Callers fold the
+    /// user-facing <c>RenderContext.SymbolScale</c> into this value so the
+    /// symbol-scale preference continues to affect arrow size.
+    /// </summary>
+    public double BaseSymbolScale { get; init; } = 1.0;
+
+    /// <summary>
+    /// Target maximum number of arrows along the longest grid axis; the
+    /// renderer strides the grid so no more than roughly
+    /// <c>MaxArrowsPerAxis²</c> arrows are emitted. Set to 0 to disable
+    /// subsampling.
+    /// </summary>
+    public int MaxArrowsPerAxis { get; init; } = 80;
+
+    /// <summary>
+    /// Draws the layer's symbol scheme onto <paramref name="canvas"/>. Each
+    /// selected grid cell becomes one rotated, palette-coloured symbol placed
+    /// at its projected pixel position. No-ops when the layer has no symbol
+    /// scheme.
+    /// </summary>
+    /// <param name="canvas">Target canvas (already sized / cleared by the caller).</param>
+    /// <param name="layer">The styled coverage layer carrying the symbol scheme.</param>
+    /// <param name="nativeToWgs84">
+    /// Transform from the grid's native CRS to WGS84 (EPSG:4326); pass
+    /// <see cref="IdentityCrsTransform.Instance"/> for geographic grids.
+    /// </param>
+    /// <param name="project">
+    /// Projects an EPSG:3857 (x, y) world coordinate to an output pixel.
+    /// </param>
+    public void Draw(
+        SKCanvas canvas,
+        StyledCoverageLayer layer,
+        ICrsTransform nativeToWgs84,
+        Func<(double X, double Y), (float X, float Y)> project)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentNullException.ThrowIfNull(layer);
+        ArgumentNullException.ThrowIfNull(nativeToWgs84);
+        ArgumentNullException.ThrowIfNull(project);
+
+        var symbolScheme = layer.SymbolScheme;
+        if (symbolScheme is null)
+            return;
+
+        var sampled = layer.Coverage;
+        var georeferencer = layer.Georeferencer;
+        var valueData = sampled.GetField(symbolScheme.ValueFieldName);
+        var rotationData = sampled.GetField(symbolScheme.RotationFieldName);
+        int srcRows = valueData.GetLength(0);
+        int srcCols = valueData.GetLength(1);
+
+        float noDataValue = layer.NoDataValue;
+        bool noDataIsNaN = float.IsNaN(noDataValue);
+
+        int stride = 1;
+        if (MaxArrowsPerAxis > 0)
+        {
+            int longestAxis = Math.Max(srcRows, srcCols);
+            stride = Math.Max(1, (longestAxis + MaxArrowsPerAxis - 1) / MaxArrowsPerAxis);
+        }
+
+        for (int r = 0; r < srcRows; r += stride)
+        for (int c = 0; c < srcCols; c += stride)
+        {
+            float value = valueData[r, c];
+            bool isNoData = noDataIsNaN ? float.IsNaN(value) : value == noDataValue;
+            if (isNoData) continue;
+
+            float direction = rotationData[r, c];
+            bool dirNoData = noDataIsNaN ? float.IsNaN(direction) : direction == noDataValue;
+            if (dirNoData) continue;
+
+            var band = symbolScheme.Resolve(value);
+            if (band is null) continue;
+
+            var picture = GetPicture(band.SymbolRef);
+            if (picture is null) continue;
+
+            var (nativeX, nativeY) = georeferencer.ToNative(r, c);
+            double lon, lat;
+            if (nativeToWgs84.IsIdentity) { lon = nativeX; lat = nativeY; }
+            else { (lon, lat) = nativeToWgs84.Transform(nativeX, nativeY); }
+            var (mx, my) = WebMercator.FromLonLat(lon, lat);
+            var (px, py) = project((mx, my));
+
+            double bandScale = band.ScaleByValue
+                ? band.ScaleFactor * value
+                : band.ScaleFactor;
+            float scale = (float)(BaseSymbolScale * bandScale);
+            if (scale <= 0) continue;
+
+            var bounds = picture.CullRect;
+
+            canvas.Save();
+            canvas.Translate(px, py);
+            // surfaceCurrentDirection is degrees true (0=N, 90=E), which matches
+            // Skia's clockwise-from-up rotation convention.
+            canvas.RotateDegrees(direction);
+            canvas.Scale(scale);
+            // Centre the symbol's bbox on the (now rotated/scaled) origin.
+            canvas.Translate(-(bounds.Left + bounds.Width / 2f), -(bounds.Top + bounds.Height / 2f));
+            canvas.DrawPicture(picture);
+            canvas.Restore();
+        }
+    }
+
+    private SKPicture? GetPicture(string symbolRef)
+    {
+        if (!ReferenceEquals(_cachedFor, Palette))
+        {
+            DisposePictures();
+            _cachedFor = Palette;
+        }
+
+        if (_svgCache.TryGetValue(symbolRef, out var cached))
+            return cached?.Picture;
+
+        SKSvg? svg = null;
+        try
+        {
+            var raw = SymbolProvider(symbolRef);
+            if (raw is not null)
+            {
+                var processed = SvgProcessor.Process(raw, Palette);
+                // The SKSvg owns its Picture; it must be kept alive (cached) for
+                // as long as the Picture may be drawn, hence it is NOT disposed
+                // here. It is released in DisposePictures.
+                var created = SKSvg.CreateFromSvg(processed);
+                if (created?.Picture is not null)
+                    svg = created;
+                else
+                    created?.Dispose();
+            }
+        }
+        catch
+        {
+            // Symbol not found or malformed — cache the miss so we do not
+            // repeatedly retry the same broken symbol.
+        }
+
+        _svgCache[symbolRef] = svg;
+        return svg?.Picture;
+    }
+
+    private void DisposePictures()
+    {
+        foreach (var svg in _svgCache.Values)
+            svg?.Dispose();
+        _svgCache.Clear();
+    }
+}

--- a/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
+++ b/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\EncDotNet.S100.Cli\EncDotNet.S100.Cli.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\datasets\S127\marine_curve.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\marine_curve.gml" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
@@ -1,0 +1,52 @@
+using EncDotNet.S100.Cli.Commands;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Unit tests for the option-parsing helpers on <see cref="RenderCommand"/>.
+/// </summary>
+public sealed class OptionParsingTests
+{
+    [Theory]
+    [InlineData("day", PaletteType.Day)]
+    [InlineData("Day", PaletteType.Day)]
+    [InlineData("DUSK", PaletteType.Dusk)]
+    [InlineData("night", PaletteType.Night)]
+    public void TryParsePalette_accepts_known_palettes(string input, PaletteType expected)
+    {
+        Assert.True(RenderCommand.TryParsePalette(input, out var palette));
+        Assert.Equal(expected, palette);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("twilight")]
+    public void TryParsePalette_rejects_unknown(string input)
+    {
+        Assert.False(RenderCommand.TryParsePalette(input, out _));
+    }
+
+    [Fact]
+    public void TryParseHexColor_parses_rrggbb_as_opaque()
+    {
+        Assert.True(RenderCommand.TryParseHexColor("#102030", out var c));
+        Assert.Equal(new RgbaColor(0x10, 0x20, 0x30, 0xFF), c);
+    }
+
+    [Fact]
+    public void TryParseHexColor_parses_aarrggbb()
+    {
+        Assert.True(RenderCommand.TryParseHexColor("80FF0000", out var c));
+        Assert.Equal(new RgbaColor(0xFF, 0x00, 0x00, 0x80), c);
+    }
+
+    [Theory]
+    [InlineData("12345")]
+    [InlineData("xyzxyz")]
+    [InlineData("#1234567")]
+    public void TryParseHexColor_rejects_invalid(string input)
+    {
+        Assert.False(RenderCommand.TryParseHexColor(input, out _));
+    }
+}

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
@@ -1,0 +1,74 @@
+using EncDotNet.S100.Cli.Infrastructure;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// End-to-end smoke tests that run the <c>s100</c> CLI in-process against a
+/// committed synthetic dataset fixture.
+/// </summary>
+public sealed class RenderCommandTests
+{
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    private static string FixturePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", fileName);
+
+    [Fact]
+    public void Render_writes_a_valid_png_at_requested_dimensions()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--width", "640", "--height", "480"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            var bytes = File.ReadAllBytes(output);
+            Assert.True(bytes.Length > PngSignature.Length);
+            Assert.Equal(PngSignature, bytes[..PngSignature.Length]);
+
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+            Assert.Equal(640, bitmap!.Width);
+            Assert.Equal(480, bitmap.Height);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_with_missing_dataset_returns_nonzero()
+    {
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(["render", "does-not-exist.gml", output]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Render_with_bad_palette_returns_nonzero()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(["render", dataset, output, "--palette", "bogus"]);
+        Assert.NotEqual(0, exit);
+    }
+
+    [Fact]
+    public void ListSpecs_returns_success()
+    {
+        int exit = CliApp.Build().Run(["list-specs"]);
+        Assert.Equal(0, exit);
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/DatasetCommandSettings.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/DatasetCommandSettings.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// Shared settings for commands that take a dataset path as their first
+/// argument. Validates that the dataset file exists before the command runs.
+/// </summary>
+internal class DatasetCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<dataset>")]
+    [Description("Path to the S-100 dataset file (.h5, .000, or .gml).")]
+    public string DatasetPath { get; init; } = string.Empty;
+
+    [CommandOption("--debug")]
+    [Description("Show full stack traces on error.")]
+    public bool Debug { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        if (string.IsNullOrWhiteSpace(DatasetPath))
+            return Spectre.Console.ValidationResult.Error("A dataset path is required.");
+
+        if (!File.Exists(DatasetPath))
+            return Spectre.Console.ValidationResult.Error($"Dataset file not found: {DatasetPath}");
+
+        return Spectre.Console.ValidationResult.Success();
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/InfoCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/InfoCommand.cs
@@ -1,0 +1,74 @@
+using EncDotNet.S100.Cli.Infrastructure;
+using EncDotNet.S100.Datasets.Pipelines;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// <c>s100 info &lt;dataset&gt;</c> — reports the detected product specification,
+/// edition, whether the dataset can be rendered headlessly, and (for
+/// time-series datasets) the available time steps with their indices.
+/// </summary>
+internal sealed class InfoCommand : Command<DatasetCommandSettings>
+{
+    public override int Execute(CommandContext context, DatasetCommandSettings settings)
+    {
+        var (factory, catalogueManager) = ProcessorFactoryBuilder.Build();
+        try
+        {
+            var spec = DatasetPipelineFactory.DetectProductSpec(settings.DatasetPath);
+            if (spec is null)
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]Could not detect an S-100 product specification for:[/] {settings.DatasetPath}");
+                return 2;
+            }
+
+            var processor = factory.CreateProcessor(settings.DatasetPath);
+
+            var table = new Table().Border(TableBorder.Rounded);
+            table.AddColumn("Property");
+            table.AddColumn("Value");
+
+            table.AddRow("Dataset", Markup.Escape(settings.DatasetPath));
+            table.AddRow("Specification", Markup.Escape(processor.Spec.Name));
+            table.AddRow("Edition", Markup.Escape(processor.Spec.Edition.ToString()));
+            table.AddRow("Headless render", processor is IHeadlessImageRenderer ? "[green]yes[/]" : "[yellow]no[/]");
+
+            if (processor is ITimeAwareDatasetProcessor timeAware && timeAware.AvailableTimes.Count > 0)
+            {
+                table.AddRow("Time steps", timeAware.AvailableTimes.Count.ToString());
+            }
+
+            AnsiConsole.Write(table);
+
+            if (processor is ITimeAwareDatasetProcessor ta && ta.AvailableTimes.Count > 0)
+            {
+                var timeTable = new Table().Border(TableBorder.Rounded).Title("Available time steps");
+                timeTable.AddColumn("Index");
+                timeTable.AddColumn("Time (UTC)");
+                for (int i = 0; i < ta.AvailableTimes.Count; i++)
+                {
+                    timeTable.AddRow(
+                        i.ToString(),
+                        ta.AvailableTimes[i].ToString("yyyy-MM-dd HH:mm:ss"));
+                }
+                AnsiConsole.Write(timeTable);
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 1;
+        }
+        finally
+        {
+            catalogueManager.Dispose();
+        }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/ListSpecsCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/ListSpecsCommand.cs
@@ -1,0 +1,49 @@
+using EncDotNet.S100.Specifications;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// <c>s100 list-specs</c> — lists the S-100 product specifications the CLI knows
+/// about and whether each supports the headless image-render path.
+/// </summary>
+internal sealed class ListSpecsCommand : Command<ListSpecsCommand.Settings>
+{
+    /// <summary>
+    /// Specs whose processors expose the headless Skia render path. Coverage
+    /// specs (S-102/104/111) support gridded datasets only; fixed-station
+    /// (data coding format 3 / 8) datasets are rejected at render time.
+    /// </summary>
+    private static readonly HashSet<string> HeadlessSpecs = new(StringComparer.Ordinal)
+    {
+        "S-101", "S-102", "S-104", "S-111",
+        "S-122", "S-124", "S-125", "S-127", "S-128", "S-129", "S-131", "S-201", "S-411", "S-421",
+    };
+
+    internal sealed class Settings : CommandSettings
+    {
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Spec");
+        table.AddColumn("Portrayal");
+        table.AddColumn("Headless render");
+
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            table.AddRow(
+                spec,
+                Specification.HasPortrayalCatalogue(spec) ? "[green]yes[/]" : "[grey]no[/]",
+                HeadlessSpecs.Contains(spec) ? "[green]yes[/]" : "[yellow]no[/]");
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine(
+            "[grey]Coverage specs (S-102/104/111) render gridded datasets only; " +
+            "fixed-station datasets are not supported headlessly.[/]");
+        return 0;
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -1,0 +1,203 @@
+using System.ComponentModel;
+using System.Globalization;
+using EncDotNet.S100.Cli.Infrastructure;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines;
+using SkiaSharp;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// <c>s100 render &lt;dataset&gt; &lt;output&gt;</c> — detects the dataset's product
+/// specification, runs its portrayal pipeline through the Mapsui-free Skia
+/// headless renderer, and writes a PNG image.
+/// </summary>
+internal sealed class RenderCommand : Command<RenderCommand.Settings>
+{
+    /// <summary>Maximum supported output dimension (per axis), to guard against OOM.</summary>
+    private const int MaxDimension = 16384;
+
+    internal sealed class Settings : DatasetCommandSettings
+    {
+        [CommandArgument(1, "<output>")]
+        [Description("Path of the PNG image to write.")]
+        public string OutputPath { get; init; } = string.Empty;
+
+        [CommandOption("-w|--width")]
+        [Description("Output image width in pixels (default 1024).")]
+        [DefaultValue(1024)]
+        public int Width { get; init; }
+
+        [CommandOption("-h|--height")]
+        [Description("Output image height in pixels (default 768).")]
+        [DefaultValue(768)]
+        public int Height { get; init; }
+
+        [CommandOption("--palette")]
+        [Description("Colour palette: day, dusk, or night (default day).")]
+        [DefaultValue("day")]
+        public string Palette { get; init; } = "day";
+
+        [CommandOption("--symbol-scale")]
+        [Description("Symbol scale factor (default 1.0).")]
+        [DefaultValue(1.0)]
+        public double SymbolScale { get; init; }
+
+        [CommandOption("--text-scale")]
+        [Description("Text scale factor (default 1.0).")]
+        [DefaultValue(1.0)]
+        public double TextScale { get; init; }
+
+        [CommandOption("--time-step")]
+        [Description("Zero-based time-step index for time-series datasets (S-104/S-111). Default 0.")]
+        [DefaultValue(0)]
+        public int TimeStep { get; init; }
+
+        [CommandOption("--background")]
+        [Description("Background colour as a hex string (e.g. #FFFFFF or #80FFFFFF). Default opaque white.")]
+        public string? Background { get; init; }
+
+        public override ValidationResult Validate()
+        {
+            var baseResult = base.Validate();
+            if (!baseResult.Successful)
+                return baseResult;
+
+            if (string.IsNullOrWhiteSpace(OutputPath))
+                return ValidationResult.Error("An output path is required.");
+
+            if (Width <= 0 || Height <= 0)
+                return ValidationResult.Error("--width and --height must be positive.");
+
+            if (Width > MaxDimension || Height > MaxDimension)
+                return ValidationResult.Error($"--width and --height must not exceed {MaxDimension}.");
+
+            if (!TryParsePalette(Palette, out _))
+                return ValidationResult.Error($"Unknown palette '{Palette}'. Use day, dusk, or night.");
+
+            if (TimeStep < 0)
+                return ValidationResult.Error("--time-step must be zero or greater.");
+
+            if (Background is not null && !TryParseHexColor(Background, out _))
+                return ValidationResult.Error($"Invalid --background colour '{Background}'.");
+
+            var dir = Path.GetDirectoryName(Path.GetFullPath(OutputPath));
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                return ValidationResult.Error($"Output directory does not exist: {dir}");
+
+            return ValidationResult.Success();
+        }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var (factory, catalogueManager) = ProcessorFactoryBuilder.Build();
+        try
+        {
+            var spec = DatasetPipelineFactory.DetectProductSpec(settings.DatasetPath);
+            if (spec is null)
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]Could not detect an S-100 product specification for:[/] {settings.DatasetPath}");
+                return 2;
+            }
+
+            var processor = factory.CreateProcessor(settings.DatasetPath);
+
+            if (processor is not IHeadlessImageRenderer headless)
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]Headless image rendering is not supported for {spec}.[/]");
+                return 3;
+            }
+
+            TryParsePalette(settings.Palette, out var palette);
+            RgbaColor? background = null;
+            if (settings.Background is not null && TryParseHexColor(settings.Background, out var bg))
+                background = bg;
+
+            var renderContext = RenderContextBuilder.Build(
+                processor, palette, settings.SymbolScale, settings.TextScale, settings.TimeStep);
+
+            using var bitmap = headless
+                .RenderHeadlessAsync(settings.Width, settings.Height, renderContext, background)
+                .GetAwaiter().GetResult();
+
+            WritePng(bitmap, settings.OutputPath);
+
+            AnsiConsole.MarkupLineInterpolated(
+                $"[green]Wrote[/] {settings.OutputPath} ([grey]{spec}, {bitmap.Width}x{bitmap.Height}[/])");
+            return 0;
+        }
+        catch (NotSupportedException ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 4;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 1;
+        }
+        finally
+        {
+            catalogueManager.Dispose();
+        }
+    }
+
+    private static void WritePng(SKBitmap bitmap, string outputPath)
+    {
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(outputPath);
+        data.SaveTo(stream);
+    }
+
+    internal static bool TryParsePalette(string value, out PaletteType palette)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "day": palette = PaletteType.Day; return true;
+            case "dusk": palette = PaletteType.Dusk; return true;
+            case "night": palette = PaletteType.Night; return true;
+            default: palette = PaletteType.Day; return false;
+        }
+    }
+
+    internal static bool TryParseHexColor(string value, out RgbaColor color)
+    {
+        color = default;
+        var hex = value.Trim().TrimStart('#');
+
+        if (hex.Length is not (6 or 8))
+            return false;
+
+        if (!uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var packed))
+            return false;
+
+        byte r, g, b, a;
+        if (hex.Length == 6)
+        {
+            r = (byte)((packed >> 16) & 0xFF);
+            g = (byte)((packed >> 8) & 0xFF);
+            b = (byte)(packed & 0xFF);
+            a = 255;
+        }
+        else
+        {
+            a = (byte)((packed >> 24) & 0xFF);
+            r = (byte)((packed >> 16) & 0xFF);
+            g = (byte)((packed >> 8) & 0xFF);
+            b = (byte)(packed & 0xFF);
+        }
+
+        color = new RgbaColor(r, g, b, a);
+        return true;
+    }
+}

--- a/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+++ b/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>s100</AssemblyName>
+    <RootNamespace>EncDotNet.S100.Cli</RootNamespace>
+    <!--
+      Package-ready (a `dotnet tool install -g` global tool invoked as `s100`),
+      but publishing is gated until SkiaSharp native assets and the bundled
+      Specification content are verified to resolve from an installed tool.
+    -->
+    <ToolCommandName>s100</ToolCommandName>
+    <PackAsTool>false</PackAsTool>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="Spectre.Console.Cli" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="EncDotNet.S100.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -1,0 +1,35 @@
+using EncDotNet.S100.Cli.Commands;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Builds the configured <see cref="CommandApp"/> for the <c>s100</c> CLI.
+/// Shared by the executable entry point and the test suite.
+/// </summary>
+internal static class CliApp
+{
+    public static CommandApp Build()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.SetApplicationName("s100");
+
+            config.AddCommand<RenderCommand>("render")
+                .WithDescription("Render an S-100 dataset to a PNG image.")
+                .WithExample("render", "dataset.h5", "out.png")
+                .WithExample("render", "warnings.gml", "out.png", "--width", "2048", "--height", "1536")
+                .WithExample("render", "currents.h5", "out.png", "--time-step", "2", "--palette", "night");
+
+            config.AddCommand<InfoCommand>("info")
+                .WithDescription("Show the detected spec, edition, and available time steps for a dataset.")
+                .WithExample("info", "dataset.h5");
+
+            config.AddCommand<ListSpecsCommand>("list-specs")
+                .WithDescription("List supported product specifications and headless-render capability.")
+                .WithExample("list-specs");
+        });
+        return app;
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Infrastructure/ProcessorFactoryBuilder.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/ProcessorFactoryBuilder.cs
@@ -1,0 +1,48 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Builds a fully-wired <see cref="DatasetPipelineFactory"/> seeded with the
+/// portrayal and feature catalogues bundled in
+/// <c>EncDotNet.S100.Specifications</c>. Mirrors the bootstrap used by the
+/// visual-regression <c>RenderHarness</c> and the Avalonia viewer so the CLI
+/// drives exactly the same pipelines.
+/// </summary>
+internal static class ProcessorFactoryBuilder
+{
+    /// <summary>
+    /// Creates a <see cref="DatasetPipelineFactory"/> and the
+    /// <see cref="PortrayalCatalogueManager"/> it owns. The caller is
+    /// responsible for disposing the returned manager.
+    /// </summary>
+    public static (DatasetPipelineFactory Factory, PortrayalCatalogueManager CatalogueManager) Build()
+    {
+        var catalogueManager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+            {
+                catalogueManager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+            }
+        }
+
+        var featureCatalogueManager =
+            new FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue);
+
+        var factory = new DatasetPipelineFactory(
+            catalogueManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            featureCatalogueManager,
+            new InteroperabilityAuthorityProvider(new InteroperabilityAuthority()));
+
+        return (factory, catalogueManager);
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Infrastructure/RenderContextBuilder.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/RenderContextBuilder.cs
@@ -1,0 +1,59 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Builds the spec-specific <see cref="RenderContext"/> the dataset processors
+/// expect, mapping CLI options (palette, scales, time-step index) onto the
+/// correct context record. Time-series specs resolve their
+/// <c>--time-step</c> index against <see cref="ITimeAwareDatasetProcessor"/>.
+/// </summary>
+internal static class RenderContextBuilder
+{
+    public static RenderContext Build(
+        IDatasetProcessor processor,
+        PaletteType palette,
+        double symbolScale,
+        double textScale,
+        int timeStepIndex)
+    {
+        DateTime? timeStep = ResolveTimeStep(processor, timeStepIndex);
+
+        return processor.Spec.Name switch
+        {
+            "S-101" => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-102" => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-104" => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-111" => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-122" => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-124" => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-125" => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-127" => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-129" => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-201" => new S201RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-411" => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            _ => new GenericRenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+        };
+    }
+
+    private static DateTime? ResolveTimeStep(IDatasetProcessor processor, int timeStepIndex)
+    {
+        if (processor is not ITimeAwareDatasetProcessor timeAware)
+            return null;
+
+        var times = timeAware.AvailableTimes;
+        if (times.Count == 0)
+            return null;
+
+        int idx = Math.Clamp(timeStepIndex, 0, times.Count - 1);
+        return times[idx];
+    }
+
+    /// <summary>
+    /// Concrete fallback for specs without their own context record (e.g. S-421,
+    /// S-128, S-131), which consume only the shared <see cref="RenderContext"/>
+    /// properties.
+    /// </summary>
+    private sealed record GenericRenderContext : RenderContext;
+}

--- a/tools/EncDotNet.S100.Cli/Program.cs
+++ b/tools/EncDotNet.S100.Cli/Program.cs
@@ -1,0 +1,3 @@
+using EncDotNet.S100.Cli.Infrastructure;
+
+return CliApp.Build().Run(args);

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -1,0 +1,79 @@
+# EncDotNet.S100.Cli (`s100`)
+
+A small, cross-platform command-line tool that renders any supported S-100
+dataset to a PNG image by running the dataset's portrayal pipeline through the
+Mapsui-free Skia *headless* renderer. It is intended as the basis for batch
+scripts (for example, generating previews of sea-ice or surface-current
+datasets).
+
+The command name is **`s100`**.
+
+## Commands
+
+### `s100 render <dataset> <output>`
+
+Detects the product specification of `<dataset>`, runs its portrayal pipeline,
+and writes a PNG to `<output>`.
+
+| Option | Default | Description |
+|---|---|---|
+| `-w`, `--width` | `1024` | Output image width in pixels. |
+| `-h`, `--height` | `768` | Output image height in pixels. |
+| `--palette` | `day` | Colour palette: `day`, `dusk`, or `night`. |
+| `--symbol-scale` | `1.0` | Symbol scale factor. |
+| `--text-scale` | `1.0` | Text scale factor. |
+| `--time-step <index>` | `0` | Zero-based time-step index for time-series datasets (S-104 / S-111). |
+| `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
+| `--debug` | off | Print full stack traces on error. |
+
+```bash
+s100 render currents.h5 currents.png --time-step 6 --palette night
+s100 render warnings.gml warnings.png --width 2048 --height 1536
+```
+
+### `s100 info <dataset>`
+
+Prints the detected specification, edition, whether the dataset supports
+headless rendering, and — for time-series datasets — the available time steps
+with their indices (use the index with `render --time-step`).
+
+### `s100 list-specs`
+
+Lists the supported product specifications and whether each supports the
+headless render path.
+
+## Supported specifications
+
+| Family | Specs | Path |
+|---|---|---|
+| Vector (ISO 8211) | S-101 | `HeadlessVectorRenderer` |
+| Vector (GML) | S-122, S-124, S-125, S-127, S-128, S-129, S-131, S-201, S-411, S-421 | `HeadlessVectorRenderer` |
+| Coverage (HDF5) | S-102, S-104 (gridded), S-111 (gridded) | `CoverageHeadlessRenderer` |
+
+## Limitations (v1)
+
+- **PNG output only.**
+- **Vector pattern area-fills are omitted** on the headless path; points,
+  lines, solid-area fills, and text render. (This is a limitation of
+  `HeadlessVectorRenderer`, not the CLI.)
+- **Coverage fixed-station datasets are not supported.** S-104 / S-111 datasets
+  using data coding format 3 or 8 (time series at fixed stations) emit point
+  glyphs through the Mapsui path only; the CLI reports a clear "not supported"
+  error.
+- **S-57 is not supported** (no headless path).
+- **Mapsui is linked but not used to render.** The CLI transitively references
+  `EncDotNet.S100.Renderers.Mapsui` for the spec-detection factory and the
+  `ProjNetCrsTransformFactory`, but no Mapsui rendering runs on the headless
+  path. Decoupling the factory and CRS transform from the Mapsui assembly is
+  tracked as follow-up work.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `1` | Unhandled error (use `--debug` for a stack trace). |
+| `2` | Product specification could not be detected. |
+| `3` | The detected spec does not support headless rendering. |
+| `4` | The dataset is recognised but its shape is unsupported (e.g. fixed-station coverage). |
+| non-zero | Argument validation failure (missing file, bad palette, etc.). |


### PR DESCRIPTION
## Summary

Introduces a subcommand-structured **`s100`** console tool that renders any supported S-100 dataset to a PNG image by running its portrayal pipeline through the Mapsui-free Skia *headless* renderers. It is intended as the basis for user batch scripts (e.g. generating sea-ice or surface-current previews) and is structured with subcommands so it can grow without breaking existing usage.

## Library prerequisites

- New `IHeadlessImageRenderer` and `ITimeAwareDatasetProcessor` capability interfaces in `Datasets.Pipelines`.
- `S101DatasetProcessor` and the GML processors (`GmlDatasetProcessorBase`) implement the headless interface; the GML path now honours `CheckPreRender` (e.g. S-411 time-window gating → blank background).
- New `CoverageHeadlessRenderer` (projects the coverage extent to EPSG:3857, aspect-fits/letterboxes into the requested size, resamples the colour raster) and a Mapsui-free `SkiaCoverageArrowRenderer` for S-111 current arrows.
- `RenderHeadlessAsync` added to S-102 / S-104 / S-111 (gridded; fixed-station / dcf3 / dcf8 throws `NotSupportedException`).
- **Bug fix:** the arrow renderer cached an `SKPicture` whose owning `SKSvg` had already been disposed, causing a native use-after-free **segfault**. The `SKSvg` is now kept alive for the cache lifetime.

## CLI (`tools/EncDotNet.S100.Cli`, command `s100`)

- `render <dataset> <output>` — options `--width/-w` (1024), `--height/-h` (768), `--palette` (day/dusk/night), `--symbol-scale`, `--text-scale`, `--time-step <index>`, `--background <hex>`, `--debug`.
- `info <dataset>` — detected spec, edition, headless support, and available time steps (with indices).
- `list-specs` — supported specs and headless-render capability.
- Factory bootstrap mirrors the visual-regression `RenderHarness`; processors are capability-checked with distinct exit codes.

## Tests & docs

- CLI option-parsing unit tests + in-process render smoke tests (PNG signature + decoded dimensions). **15 CLI tests pass**; full Release build clean; `Pipelines.Tests` 495 passed / 1 skipped.
- Project `README.md`, `docs/cli.md` + TOC entry.
- Both projects added to the solution (CI already builds/tests the whole solution).

## Known gaps (tracked as follow-up issues)

- **Mapsui is linked but does no rendering** — kept as a transitive reference for the spec-detection factory and `ProjNetCrsTransformFactory`; full decoupling is follow-up.
- **PNG output only** in v1.
- **Vector pattern area-fills are omitted** on the headless path.
- **Fixed-station coverage** (S-104/S-111 dcf3/dcf8) and **S-57** are unsupported headlessly.

Verified end-to-end renders of S-127 (GML), S-102, S-104, and S-111 (735 distinct colours — arrows confirmed drawing).