### PR TITLE
Stop writing settings updates to the status bar

### DIFF
--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -302,8 +302,6 @@ internal static class Strings
     public static string Status_Error => Get(nameof(Status_Error));
     public static string Status_RenderingTimeStep => Get(nameof(Status_RenderingTimeStep));
     public static string Status_RenderingAtTime => Get(nameof(Status_RenderingAtTime));
-    public static string Status_SwitchingPalette => Get(nameof(Status_SwitchingPalette));
-    public static string Status_PaletteApplied => Get(nameof(Status_PaletteApplied));
     public static string Status_FeatureNoDetails => Get(nameof(Status_FeatureNoDetails));
     public static string Status_FeatureSummary => Get(nameof(Status_FeatureSummary));
     public static string Status_FeatureSummaryWithMore => Get(nameof(Status_FeatureSummaryWithMore));
@@ -391,6 +389,7 @@ internal static class Strings
     public static string Toast_DatasetCancelled => Get(nameof(Toast_DatasetCancelled));
     public static string Toast_Cancel => Get(nameof(Toast_Cancel));
     public static string Toast_ExchangeSetLoading => Get(nameof(Toast_ExchangeSetLoading));
+    public static string Toast_SettingsApplied => Get(nameof(Toast_SettingsApplied));
 
     // MCP server
     public static string Status_McpRunning => Get(nameof(Status_McpRunning));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -801,12 +801,6 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Status_RenderingAtTime" xml:space="preserve">
     <value>Rendering at {0:u}...</value>
   </data>
-  <data name="Status_SwitchingPalette" xml:space="preserve">
-    <value>Switching to {0} palette...</value>
-  </data>
-  <data name="Status_PaletteApplied" xml:space="preserve">
-    <value>{0} palette applied.</value>
-  </data>
   <data name="Status_FeatureNoDetails" xml:space="preserve">
     <value>Feature {0} (no details available)</value>
   </data>
@@ -1045,6 +1039,9 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   </data>
   <data name="Toast_ExchangeSetLoading" xml:space="preserve">
     <value>Loading Exchange Set</value>
+  </data>
+  <data name="Toast_SettingsApplied" xml:space="preserve">
+    <value>Settings applied.</value>
   </data>
 
   <!-- MCP server -->

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -497,7 +497,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         using var __cmd = ViewerObservability.BeginCommand("palette.change");
 
         var palette = _settingsVm.SelectedPalette;
-        SetStatus(string.Format(Strings.Status_SwitchingPalette, palette));
 
         foreach (var (entry, proc) in _processors.ToArray())
         {
@@ -518,9 +517,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             }
         }
 
-        SetStatus(string.Format(Strings.Status_PaletteApplied, palette));
-        _toasts.ShowSuccess(Strings.Toast_Success,
-            string.Format(Strings.Status_PaletteApplied, palette));
+        _toasts.ShowSuccess(Strings.Toast_Success, Strings.Toast_SettingsApplied);
     }
 
     public void RemoveEntry(DatasetEntry entry)


### PR DESCRIPTION
## Summary

The viewer wrote settings-change progress and completion text to the left side of the status bar, and raised a success toast worded specifically as "{0} palette applied." All settings changes (palette, display scale, ECDIS display, mariner settings) funnel through `ReRenderAllAsync`, so that palette-specific wording was misleading whenever a non-palette setting changed. Now that these updates are surfaced as proper toast notifications, the status-bar writes are redundant.

This PR removes the two `SetStatus(...)` calls from `ReRenderAllAsync` and rewords the success toast to a generic "Settings applied." so it reads correctly for any setting change. The now-unused `Status_SwitchingPalette` and `Status_PaletteApplied` strings are dropped and a new `Toast_SettingsApplied` string is added, keeping `Strings.resx` and `Strings.cs` in sync per the viewer localization rules.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

UI-only string/notification change; no test hooks exist for status-bar/toast text. Verified with `dotnet build` of the viewer project.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

No public API or documented behaviour changed.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.