### PR TITLE
Bundle and sign s100 CLI in platform app bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,20 @@ jobs:
           --runtime ${{ matrix.rid }}
           ${{ matrix.rid == 'osx-arm64' && '-p:PublishSingleFile=false' || '' }}
 
+      - name: Publish s100 CLI
+        # Publish the `s100` command-line tool self-contained into a `cli/`
+        # subfolder of the viewer's publish output. This single location flows
+        # into every platform archive and, for macOS, into the .app bundle's
+        # Contents/MacOS/cli/ where the recursive signing loop below signs it.
+        # Must run after "Publish Viewer" because dotnet publish cleans its
+        # own output directory; the cli/ subfolder is unaffected by that.
+        run: >
+          dotnet publish tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+          --configuration Release
+          --runtime ${{ matrix.rid }}
+          --self-contained true
+          --output src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/cli
+
       - name: Create macOS .app bundle
         if: matrix.rid == 'osx-arm64'
         run: |
@@ -199,6 +213,11 @@ jobs:
             --entitlements "$ENTITLEMENTS" \
             --sign "$APPLE_SIGNING_IDENTITY" \
             "$APP"
+          # Verify the seal recursively. This fails the build before
+          # notarization if any nested Mach-O (e.g. the bundled s100 CLI
+          # or its native dylibs) was left unsigned.
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          codesign --verify --strict --verbose=2 "$APP/Contents/MacOS/cli/s100"
 
       - name: Notarize macOS .app bundle
         if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -8,6 +8,22 @@ datasets).
 
 The command name is **`s100`**.
 
+## Distribution
+
+The `s100` executable ships **inside the S-100 Viewer application bundle** so a
+single download provides both the GUI and the command-line tool. CI publishes
+it self-contained (per platform RID) into a `cli/` subfolder of the viewer's
+publish output:
+
+| Platform | Location of `s100` |
+|---|---|
+| macOS | `EncDotNet.S100.Viewer.app/Contents/MacOS/cli/s100` (code-signed, notarized, and hardened-runtime alongside the viewer) |
+| Windows | `cli/s100.exe` next to the published viewer |
+| Linux | `cli/s100` next to the published viewer |
+
+On macOS the bundled `s100` binary and its native libraries are signed by the
+same step that signs the viewer, so it runs without Gatekeeper prompts.
+
 ## Commands
 
 ### `s100 render <dataset> <output>`


### PR DESCRIPTION
## Why

The new `s100` command-line tool was built but never shipped with the desktop distribution, so users who downloaded the Viewer had no way to get the CLI. This bundles `s100` into every platform's app distribution from a single publish location.

## Approach

The `publish` job in `ci.yml` previously packaged only the Viewer. It now also publishes `tools/EncDotNet.S100.Cli` self-contained (per RID) into a `cli/` subfolder of the viewer's publish output. That single location flows automatically into both targets:

- **macOS**: the existing `cp -a "$PUBLISH_DIR"/.` copies it into `EncDotNet.S100.Viewer.app/Contents/MacOS/cli/`, where the recursive `codesign` loop already signs the `s100` Mach-O host and its native dylibs with hardened runtime, entitlements, and a timestamp before the bundle is sealed and notarized.
- **Windows/Linux**: it lands in the tarball as `cli/s100[.exe]`.

Isolating the CLI in its own subfolder avoids DLL and native-asset collisions with the viewer's publish output (single-file on Windows/Linux, multi-file on macOS). `--self-contained true` is required since end users won't have the .NET runtime installed.

I also added a post-sign `codesign --verify` check (deep/strict on the bundle, plus an explicit check on `cli/s100`) so the build fails before notarization if any nested binary is left unsigned.

## Notes for reviewers

- The CLI publish step is ordered after the viewer publish on purpose: `dotnet publish` cleans its own output dir, but the `cli/` subfolder is unaffected.
- This ships a second self-contained .NET runtime inside the bundle, so distribution size grows. That is the trade-off for a no-prerequisites CLI alongside the GUI.
- CI steps can't run locally, but I validated the YAML and confirmed the exact publish command produces a runnable Mach-O `s100` with all native dylibs present (`libSkiaSharp.dylib`, etc.), each of which the signing loop covers.
- `tools/EncDotNet.S100.Cli/README.md` gains a Distribution section documenting the per-platform locations.