### PR TITLE
Make git tag the source of truth for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,22 @@ jobs:
       - name: Restore
         run: dotnet restore
 
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          # The git tag is the source of truth for the released version. On a
+          # tag build (refs/tags/v*) derive the version from the tag name; on
+          # branch/PR builds fall back to the dev placeholder in props.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(grep -oE '<Version>[^<]+' src/Directory.Build.props | sed 's/<Version>//')"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Build
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build --no-restore --configuration Release -p:Version=${{ steps.version.outputs.version }}
 
       - name: Test
         run: dotnet test --no-build --configuration Release --logger trx --results-directory TestResults
@@ -50,18 +64,20 @@ jobs:
           if-no-files-found: ignore
 
       - name: Pack NuGet packages
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          dotnet pack src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Datasets.S111/EncDotNet.S100.Datasets.S111.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Portrayals/EncDotNet.S100.Portrayals.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj --no-build --configuration Release --output nupkgs
-          dotnet pack src/EncDotNet.S100.Scripting.MoonSharp/EncDotNet.S100.Scripting.MoonSharp.csproj --no-build --configuration Release --output nupkgs
+          dotnet pack src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Datasets.S111/EncDotNet.S100.Datasets.S111.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Portrayals/EncDotNet.S100.Portrayals.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+          dotnet pack src/EncDotNet.S100.Scripting.MoonSharp/EncDotNet.S100.Scripting.MoonSharp.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4
@@ -139,11 +155,26 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          # The git tag is the source of truth for the released version. On a
+          # tag build (refs/tags/v*) derive the version from the tag name; on
+          # branch/PR builds fall back to the dev placeholder in props.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(grep -oE '<Version>[^<]+' src/Directory.Build.props | sed 's/<Version>//')"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Publish Viewer
         run: >
           dotnet publish src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
           --configuration Release
           --runtime ${{ matrix.rid }}
+          -p:Version=${{ steps.version.outputs.version }}
           ${{ matrix.rid == 'osx-arm64' && '-p:PublishSingleFile=false' || '' }}
 
       - name: Publish s100 CLI
@@ -158,6 +189,7 @@ jobs:
           --configuration Release
           --runtime ${{ matrix.rid }}
           --self-contained true
+          -p:Version=${{ steps.version.outputs.version }}
           --output src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/cli
 
       - name: Create macOS .app bundle
@@ -263,21 +295,10 @@ jobs:
           echo "::warning::Stapling failed after 5 attempts. The app is still notarized; Gatekeeper will verify online."
           exit 1
 
-      - name: Read viewer version
-        if: matrix.rid == 'osx-arm64'
-        id: viewer_version
-        run: |
-          VERSION=$(grep -oE '<Version>[^<]+' src/Directory.Build.props | sed 's/<Version>//')
-          if [ -z "$VERSION" ]; then
-            echo "::error::Could not read <Version> from src/Directory.Build.props"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Build macOS DMG
         if: matrix.rid == 'osx-arm64'
         env:
-          VERSION: ${{ steps.viewer_version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Build a styled DMG with the branding background image, icon
           # positions and Applications drop link. We delegate to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,46 @@ on:
 permissions:
   contents: write
 
+# Serialize releases so two concurrent runs can't race to compute the same
+# next version (the loser would otherwise fail on tag push).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
+      # Always release from main HEAD regardless of the ref the workflow was
+      # dispatched against. Full history + tags are needed to determine the
+      # latest released version. RELEASE_TOKEN (a PAT) is required so the tag
+      # push triggers the tag-driven CI build/publish workflow.
       - uses: actions/checkout@v5
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Ensure tags are present
+        run: git fetch --tags --force origin
 
       - name: Read current version
         id: current
         run: |
-          VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/Directory.Build.props)
+          # The git tag is the source of truth for the released version. Take
+          # the highest final SemVer release tag (vMAJOR.MINOR.PATCH); ignore
+          # prerelease/experimental tags. Seed from 0.0.0 if none exist yet.
+          CURRENT_TAG=$(
+            git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname |
+            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+            head -n1
+          )
+          if [ -z "$CURRENT_TAG" ]; then
+            VERSION="0.0.0"
+          else
+            VERSION="${CURRENT_TAG#v}"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Compute next version
@@ -42,15 +68,17 @@ jobs:
           esac
           echo "version=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
 
-      - name: Update version in Directory.Build.props
+      - name: Create and push tag
         run: |
-          sed -i "s|<Version>${{ steps.current.outputs.version }}</Version>|<Version>${{ steps.next.outputs.version }}</Version>|" src/Directory.Build.props
-
-      - name: Commit and tag
-        run: |
+          NEXT="v${{ steps.next.outputs.version }}"
+          if git rev-parse -q --verify "refs/tags/${NEXT}" >/dev/null; then
+            echo "::error::Tag ${NEXT} already exists."
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/Directory.Build.props
-          git commit -m "Release v${{ steps.next.outputs.version }}"
-          git tag "v${{ steps.next.outputs.version }}"
-          git push origin main --tags
+          # Tag-only release: no commit to main is required. The tag is the
+          # single source of truth for the version; CI derives the build,
+          # package, and release version from the tag name.
+          git tag -a "${NEXT}" -m "Release ${NEXT}"
+          git push origin "refs/tags/${NEXT}"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <Version>0.13.0</Version>
+    <Version>0.0.0-dev</Version>
     <Authors>Phillip Hoff</Authors>
     <Description>Libraries for manipulating S-100 based nautical charts.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

The `main` branch ruleset now requires changes to go through a pull request, which broke the release workflow: it committed a version bump to `Directory.Build.props` and pushed directly to `main`, getting rejected with `GH013` (the tag pushed, but `main` did not, leaving a half-released state).

This switches to a **tag-only release flow** where the git tag is the single source of truth for the version, so no push to `main` is needed at all.

- **`release.yml`**: now computes the next version from the highest final SemVer release tag (`v[0-9].[0-9].[0-9]`, seeded at `0.0.0` when none exist), then creates an annotated `vNEXT` tag at `main` HEAD and pushes only the tag. It always checks out `main` regardless of the dispatch ref, guards against an existing tag, and keeps `RELEASE_TOKEN` so the tag event still triggers CI. Added a `release` concurrency group so two runs can't race to the same version.
- **`ci.yml`**: a tag-aware "Determine version" step in the `build` and `publish` jobs derives the version from the tag name on tag builds, falling back to the props placeholder for branch/PR builds. That version is threaded through `dotnet build`, every `dotnet pack`, and the Viewer/CLI `dotnet publish` via `-p:Version`. The macOS DMG-naming step now uses it instead of grepping props.
- **`Directory.Build.props`**: `<Version>` becomes `0.0.0-dev` since it is no longer the release source of truth (it only labels dev/PR artifacts now).

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

CI-only change; no unit tests apply. Verified locally that `dotnet pack -p:Version=9.9.9` produces `EncDotNet.S100.Core.9.9.9.nupkg` and that the `0.0.0-dev` fallback packs cleanly.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

N/A — no public API or user-facing behaviour change.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (none added)

## Breaking changes

None. Note for reviewers: this assumes no tag ruleset blocks the `RELEASE_TOKEN` actor from creating `v*` tags. Since the original failure only rejected `main` and the `v0.14.0` tag pushed successfully, that path is already known to work.