### PR TITLE
Add headless render path for S-57 datasets

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -13,10 +13,12 @@ using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Renderers.Skia.Scene;
 using EncDotNet.S100.Scripting;
 using EncDotNet.S100.Validation;
 using Mapsui;
 using Mapsui.Layers;
+using SkiaSharp;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -25,8 +27,11 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// <see cref="S101Document"/> and reusing the S-101 portrayal pipeline.
 /// Symbology is S-101 (not S-52); coverage is breadth-first.
 /// </summary>
-public sealed class S57DatasetProcessor : IDatasetProcessor
+public sealed class S57DatasetProcessor : IDatasetProcessor, IHeadlessImageRenderer
 {
+    // Serialises render calls so the catalogue's mutable palette / ECDIS
+    // state is not mutated mid-build by a concurrent render.
+    private readonly SemaphoreSlim _renderGate = new(1, 1);
     private readonly EncDotNet.S57.S57Document _rawS57Document;
     private readonly S101Dataset _translatedDataset;
     private readonly PortrayalCatalogueProvider _provider;
@@ -108,6 +113,19 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        await _renderGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await RenderCoreAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _renderGate.Release();
+        }
+    }
+
+    private async Task<DatasetResult> RenderCoreAsync(RenderContext? context, CancellationToken cancellationToken)
+    {
         var mariner = MarinerSettings.Default;
 
         var fc = _featureCatalogueManager.GetCatalogue("S-101")
@@ -294,5 +312,85 @@ public sealed class S57DatasetProcessor : IDatasetProcessor
             _validationCached = true;
         }
         return _validationReport;
+    }
+
+    /// <summary>
+    /// Renders this S-57 cell to a standalone <see cref="SKBitmap"/> through
+    /// the headless, backend-agnostic Skia vector core, bypassing Mapsui. The
+    /// S-57 dataset is translated to S-101 in-memory (the same pipeline as
+    /// <see cref="RenderAsync"/>) and the resulting drawing instructions are
+    /// rasterised by <see cref="HeadlessVectorRenderer"/>.
+    /// </summary>
+    /// <param name="widthPixels">Output bitmap width in pixels.</param>
+    /// <param name="heightPixels">Output bitmap height in pixels.</param>
+    /// <param name="context">Optional render context (palette, symbol/text scale).</param>
+    /// <param name="background">Optional background fill; defaults to opaque white.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A newly allocated bitmap owned by the caller.</returns>
+    /// <remarks>
+    /// Same caveats apply as for the S-101 headless path: pattern area-fills
+    /// are not yet represented in the shared IR, so areas with an area-fill
+    /// reference are omitted; the dominant solid depth-area colour fills,
+    /// lines, soundings/symbols, and text are rendered.
+    /// </remarks>
+    public async Task<SKBitmap> RenderHeadlessAsync(
+        int widthPixels,
+        int heightPixels,
+        RenderContext? context = null,
+        RgbaColor? background = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+
+        // Hold the render gate across portrayal prep AND symbol/line-style asset
+        // resolution: the providers close over the mutable catalogue palette
+        // state, so a concurrent render must not mutate it mid-build.
+        await _renderGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var mariner = MarinerSettings.Default;
+            var fc = _featureCatalogueManager.GetCatalogue("S-101")
+                ?? throw new InvalidOperationException(
+                    "S-101 feature catalogue is required to render S-57 datasets but none was provided.");
+
+            var s101Cat = _catalogue;
+            s101Cat.SwitchPalette(context?.Palette ?? PaletteType.Day);
+            var palette = s101Cat.ActivePalette;
+
+            var executor = new S101LuaRuleExecutor(_luaEngine, _translatedDataset, s101Cat, fc);
+            var featureSource = new S101FeatureXmlSource(_translatedDataset);
+            var pipeline = new PortrayalPipeline(executor);
+            var portrayalLayer = await pipeline
+                .ProcessAsync(featureSource, s101Cat, mariner: mariner, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            var prepared = ((IVectorLayer)portrayalLayer).Instructions;
+
+            var geometryProvider = new S101FeatureGeometryProvider(_translatedDataset);
+
+            return HeadlessVectorRenderer.Render(
+                prepared,
+                geometryProvider,
+                palette,
+                symbolProvider: name =>
+                {
+                    try { return s101Cat.GetSymbol(name).SvgContent; }
+                    catch { return null; }
+                },
+                lineStyleProvider: name =>
+                {
+                    try { return s101Cat.GetLineStyle(name); }
+                    catch { return null; }
+                },
+                symbolScale: context?.SymbolScale ?? 1.0,
+                textScale: context?.TextScale ?? 1.0,
+                widthPixels: widthPixels,
+                heightPixels: heightPixels,
+                background: background ?? new RgbaColor(255, 255, 255, 255));
+        }
+        finally
+        {
+            _renderGate.Release();
+        }
     }
 }

--- a/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
+++ b/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Content Include="..\datasets\S127\marine_curve.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\marine_curve.gml" />
+    <Content Include="..\datasets\S57\US5MA1BO\US5MA1BO.000" CopyToOutputDirectory="PreserveNewest" Link="TestData\US5MA1BO.000" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
@@ -71,4 +71,35 @@ public sealed class RenderCommandTests
         int exit = CliApp.Build().Run(["list-specs"]);
         Assert.Equal(0, exit);
     }
+
+    [Fact]
+    public void Render_writes_a_valid_png_for_an_s57_cell()
+    {
+        var dataset = FixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-s57-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            var bytes = File.ReadAllBytes(output);
+            Assert.True(bytes.Length > PngSignature.Length);
+            Assert.Equal(PngSignature, bytes[..PngSignature.Length]);
+
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+            Assert.Equal(320, bitmap!.Width);
+            Assert.Equal(240, bitmap.Height);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
 }

--- a/tools/EncDotNet.S100.Cli/Commands/ListSpecsCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/ListSpecsCommand.cs
@@ -14,9 +14,12 @@ internal sealed class ListSpecsCommand : Command<ListSpecsCommand.Settings>
     /// Specs whose processors expose the headless Skia render path. Coverage
     /// specs (S-102/104/111) support gridded datasets only; fixed-station
     /// (data coding format 3 / 8) datasets are rejected at render time.
+    /// S-57 datasets are translated in-memory to S-101 and rendered through
+    /// the S-101 portrayal pipeline.
     /// </summary>
     private static readonly HashSet<string> HeadlessSpecs = new(StringComparer.Ordinal)
     {
+        "S-57",
         "S-101", "S-102", "S-104", "S-111",
         "S-122", "S-124", "S-125", "S-127", "S-128", "S-129", "S-131", "S-201", "S-411", "S-421",
     };
@@ -31,6 +34,14 @@ internal sealed class ListSpecsCommand : Command<ListSpecsCommand.Settings>
         table.AddColumn("Spec");
         table.AddColumn("Portrayal");
         table.AddColumn("Headless render");
+
+        // S-57 is not in Specification.AvailableSpecs (it has no bundled
+        // FC/PC of its own — it borrows S-101's catalogues at render time)
+        // but the CLI does support it, so report it explicitly.
+        table.AddRow(
+            "S-57",
+            "[grey]via S-101[/]",
+            HeadlessSpecs.Contains("S-57") ? "[green]yes[/]" : "[yellow]no[/]");
 
         foreach (var spec in Specification.AvailableSpecs)
         {

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -62,7 +62,7 @@ headless render path.
 
 | Family | Specs | Path |
 |---|---|---|
-| Vector (ISO 8211) | S-101 | `HeadlessVectorRenderer` |
+| Vector (ISO 8211) | S-101, S-57 (translated to S-101) | `HeadlessVectorRenderer` |
 | Vector (GML) | S-122, S-124, S-125, S-127, S-128, S-129, S-131, S-201, S-411, S-421 | `HeadlessVectorRenderer` |
 | Coverage (HDF5) | S-102, S-104 (gridded), S-111 (gridded) | `CoverageHeadlessRenderer` |
 
@@ -76,7 +76,8 @@ headless render path.
   using data coding format 3 or 8 (time series at fixed stations) emit point
   glyphs through the Mapsui path only; the CLI reports a clear "not supported"
   error.
-- **S-57 is not supported** (no headless path).
+- **S-57 renders through the S-101 pipeline.** Datasets are translated to
+  `S101Document` in-memory and rasterised with S-101 symbology (not S-52).
 - **Mapsui is linked but not used to render.** The CLI transitively references
   `EncDotNet.S100.Renderers.Mapsui` for the spec-detection factory and the
   `ProjNetCrsTransformFactory`, but no Mapsui rendering runs on the headless


### PR DESCRIPTION
## Summary

The `s100` CLI supported every spec the codebase ships except S-57, so legacy ENCs could not be rasterised by `s100 render`. This PR fills that gap by giving `S57DatasetProcessor` a headless render path.

S-57 datasets are already translated in-memory to `S101Document`, so the new `RenderHeadlessAsync` simply runs the translated dataset through the existing S-101 portrayal pipeline and rasterises the resulting drawing instructions with `HeadlessVectorRenderer` — no new symbology, no S-52, no Mapsui. A `SemaphoreSlim` render gate is added so concurrent renders cannot mutate the shared S-101 portrayal catalogue's palette state mid-build (mirroring the S-101 processor).

`s100 list-specs` now reports an explicit S-57 row (Portrayal: "via S-101", Headless render: yes); S-57 is not in `Specification.AvailableSpecs` since it borrows the S-101 FC/PC, so it is added directly in the command. The CLI README's "S-57 not supported" limitation is replaced with a note that S-57 renders through the S-101 pipeline.

Closes #188

## Spec alignment

- [x] S-101 ENC (`s101-enc`) — S-57 reuses the S-101 portrayal pipeline; no new spec interpretation.
- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — no new spec-derived constants; the change reuses existing S-101 plumbing.

## Tests

- [x] Added/updated xunit tests under `tests/` — `RenderCommandTests.Render_writes_a_valid_png_for_an_s57_cell` runs the CLI end-to-end against the committed `US5MA1BO.000` fixture.
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally (CLI test suite: 16/16).

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` — `tools/EncDotNet.S100.Cli/README.md` updated.
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed — N/A.
- [x] New public APIs have XML doc comments — `S57DatasetProcessor.RenderHeadlessAsync`.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency — N/A, no new dependencies.

## Breaking changes

None.