### PR TITLE
Add --no-text / --hide options to `s100 render`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,9 @@ pixel size (preserving aspect, letter-boxed) and overlays oriented arrows via
 - **PNG output only** in v1.
 - **Pattern area-fills are omitted** on the vector headless path (points, lines,
   solid fills, and text render).
+- **Text suppression**: `--no-text` (or `--hide text,...`) drops the chosen
+  drawing-instruction categories from the rendered output, producing cleaner
+  previews for label-dense products such as S-411 sea-ice.
 - **Fixed-station coverage** (S-104/S-111 data coding format 3 / 8) is **not**
   supported headlessly; the CLI returns a descriptive error.
 - **S-57 is not supported.**

--- a/samples/s411-previews/README.md
+++ b/samples/s411-previews/README.md
@@ -42,6 +42,7 @@ file names from the BSIS portal.
 | `S100` | runs the Release DLL via `dotnet` | Command used to invoke the CLI (e.g. a published `s100` binary). |
 | `WIDTH` / `HEIGHT` | `1600` | Output size in pixels. |
 | `PALETTE` | `day` | `day` \| `dusk` \| `night`. |
+| `EXTRA_OPTS` | _empty_ | Extra flags forwarded verbatim to `s100 render` (e.g. `--no-text`). |
 
 ```bash
 # Use an installed global tool and a larger night-palette canvas
@@ -63,9 +64,17 @@ S100="s100" WIDTH=2048 HEIGHT=2048 PALETTE=night \
 - **The ZIP file names on the BSIS portal are dated and rotate** (often daily).
   The keys here point at a snapshot; if a download 404s, refresh the file name
   from <https://www.bsis-ice.de/IcePortal/ILP_S411.shtml>.
-- Previews include the full S-411 **egg-code text labels**, so dense ice can
-  look busier than the BSIS previews (which render solid colour only). Label
-  suppression is tracked as a CLI enhancement.
+- **Clean-fill previews:** to mirror the BSIS portal's text-free look, pass
+  `--no-text` to the CLI (or set `EXTRA_OPTS=--no-text` and have the script
+  forward it). For example:
+
+  ```bash
+  EXTRA_OPTS="--no-text" samples/s411-previews/s411_previews.sh
+  ```
+
+  This suppresses the S-411 egg-code labels at the renderer level while
+  leaving the fills, ice-edge lines, and symbols untouched. Use
+  `--hide text,points` to also drop point symbols.
 - This is sample/PoC code, not a supported product. Generated output under the
   chosen directory is intentionally not committed.
 - Data © the respective ice services (CIS, DMI, Met.no, US NWS/NIC, AARI, SHN,

--- a/samples/s411-previews/s411_previews.sh
+++ b/samples/s411-previews/s411_previews.sh
@@ -19,6 +19,9 @@
 #               binary, e.g.  S100="/usr/local/bin/s100"
 #   WIDTH/HEIGHT  Output size in pixels (default 1600x1600).
 #   PALETTE       day | dusk | night (default day).
+#   EXTRA_OPTS    Extra flags passed verbatim to `s100 render` after the
+#                 standard --width/--height/--palette (e.g. --no-text for
+#                 BSIS-style clean fills, or --hide text,points).
 #
 set -euo pipefail
 
@@ -49,6 +52,7 @@ fi
 WIDTH="${WIDTH:-1600}"
 HEIGHT="${HEIGHT:-1600}"
 PALETTE="${PALETTE:-day}"
+EXTRA_OPTS="${EXTRA_OPTS:-}"
 
 # Default invocation: run the built Release DLL. Override via $S100.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -98,7 +102,7 @@ render_region() {
   echo "  dataset $gml"
 
   # shellcheck disable=SC2086
-  if $S100 render "$gml" "$preview" --width "$WIDTH" --height "$HEIGHT" --palette "$PALETTE"; then
+  if $S100 render "$gml" "$preview" --width "$WIDTH" --height "$HEIGHT" --palette "$PALETTE" $EXTRA_OPTS; then
     echo "  -> $preview"
   else
     echo "  ! render failed"

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/DrawingInstruction.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/DrawingInstruction.cs
@@ -1,6 +1,36 @@
 namespace EncDotNet.S100.Pipelines.Vector;
 
 /// <summary>
+/// Categories of <see cref="DrawingInstruction"/> that can be selectively
+/// suppressed from a rendered scene. Mirrors the four S-100 Part 9 instruction
+/// types (areas → lines → points → text) and is used by callers — typically
+/// the headless render path — that want to hide certain primitive classes
+/// (e.g. text labels at preview scales) without re-running the portrayal
+/// pipeline.
+/// </summary>
+[Flags]
+public enum DrawingInstructionCategory
+{
+    /// <summary>No categories are hidden — render everything.</summary>
+    None = 0,
+
+    /// <summary>Solid-colour and pattern area fills (<see cref="AreaInstruction"/>).</summary>
+    Areas = 1 << 0,
+
+    /// <summary>Line strokes (<see cref="LineInstruction"/>).</summary>
+    Lines = 1 << 1,
+
+    /// <summary>Point symbols (<see cref="PointInstruction"/>).</summary>
+    Points = 1 << 2,
+
+    /// <summary>Text labels (<see cref="TextInstruction"/>).</summary>
+    Text = 1 << 3,
+
+    /// <summary>All renderable categories.</summary>
+    All = Areas | Lines | Points | Text,
+}
+
+/// <summary>
 /// A unified, resource-unresolved S-100 Part 9 drawing instruction. Instances
 /// reference catalogue resources (symbols, line styles, area fills, fonts) by
 /// name, and reference dataset features by id (<see cref="FeatureReference"/>);

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -288,7 +288,9 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
             textScale: context?.TextScale ?? 1.0,
             widthPixels: widthPixels,
             heightPixels: heightPixels,
-            background: bg);
+            background: bg,
+            hiddenCategories: context?.HiddenInstructionCategories
+                ?? DrawingInstructionCategory.None);
     }
 
     /// <inheritdoc/>

--- a/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
@@ -1,5 +1,6 @@
 using System;
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
 
 namespace EncDotNet.S100.Datasets.Pipelines;
 
@@ -35,6 +36,27 @@ public abstract record RenderContext
     /// future use.
     /// </summary>
     public MarinerSettings? Mariner { get; init; }
+
+    /// <summary>
+    /// Bitmask of <see cref="DrawingInstruction"/> categories to suppress from
+    /// the rendered output (S-100 Part 9 instruction types — areas, lines,
+    /// points, text). Hiding text is the canonical use case: at preview
+    /// scales, label-dense products such as S-411 sea-ice draw the full
+    /// "egg-code" labels which obscure the underlying fills, and a flag-driven
+    /// suppression delivers a BSIS-style "clean fill" preview without
+    /// re-running the portrayal pipeline. Defaults to
+    /// <see cref="DrawingInstructionCategory.None"/> (render everything).
+    /// </summary>
+    /// <remarks>
+    /// Honoured by the headless render path
+    /// (<c>HeadlessVectorRenderer.Render</c>); the Mapsui path is not yet
+    /// affected. The filter is applied after the portrayal pipeline produces
+    /// the display list, so suppressing one category never re-flows the
+    /// remaining instructions (areas → lines → points → text ordering and
+    /// scale visibility are preserved).
+    /// </remarks>
+    public DrawingInstructionCategory HiddenInstructionCategories { get; init; }
+        = DrawingInstructionCategory.None;
 }
 
 public sealed record S101RenderContext : RenderContext;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -497,7 +497,9 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
                 textScale: context?.TextScale ?? 1.0,
                 widthPixels: widthPixels,
                 heightPixels: heightPixels,
-                background: background ?? new RgbaColor(255, 255, 255, 255));
+                background: background ?? new RgbaColor(255, 255, 255, 255),
+                hiddenCategories: context?.HiddenInstructionCategories
+                    ?? DrawingInstructionCategory.None);
         }
         finally
         {

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -40,6 +40,15 @@ public static class HeadlessVectorRenderer
     /// <param name="widthPixels">Output bitmap width.</param>
     /// <param name="heightPixels">Output bitmap height.</param>
     /// <param name="background">Background fill colour.</param>
+    /// <param name="hiddenCategories">
+    /// Bitmask of instruction categories to suppress from the output (S-100
+    /// Part 9 instruction types — areas, lines, points, text). Defaults to
+    /// <see cref="DrawingInstructionCategory.None"/> (render everything).
+    /// Hiding categories filters the display list before lowering, so the
+    /// remaining instructions keep their priorities, viewing-group state, and
+    /// extent. The auto-fitted viewport is computed from the filtered scene,
+    /// matching what the user actually sees.
+    /// </param>
     /// <returns>A newly allocated bitmap owned by the caller.</returns>
     public static SKBitmap Render(
         IReadOnlyList<DrawingInstruction> instructions,
@@ -51,12 +60,16 @@ public static class HeadlessVectorRenderer
         double textScale,
         int widthPixels,
         int heightPixels,
-        RgbaColor background)
+        RgbaColor background,
+        DrawingInstructionCategory hiddenCategories = DrawingInstructionCategory.None)
     {
         ArgumentNullException.ThrowIfNull(instructions);
         ArgumentNullException.ThrowIfNull(geometryProvider);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
+
+        if (hiddenCategories != DrawingInstructionCategory.None)
+            instructions = FilterInstructions(instructions, hiddenCategories);
 
         var builder = new VectorSceneBuilder
         {
@@ -213,5 +226,33 @@ public static class HeadlessVectorRenderer
 
         minX = loX; minY = loY; maxX = hiX; maxY = hiY;
         return any;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="instructions"/> with every entry whose
+    /// type is included in <paramref name="hidden"/> removed. The relative
+    /// order of the surviving instructions is preserved so downstream
+    /// priority / S-100 Part 9 type sorting in
+    /// <see cref="VectorSceneBuilder"/> behaves identically.
+    /// </summary>
+    private static IReadOnlyList<DrawingInstruction> FilterInstructions(
+        IReadOnlyList<DrawingInstruction> instructions,
+        DrawingInstructionCategory hidden)
+    {
+        var kept = new List<DrawingInstruction>(instructions.Count);
+        foreach (var inst in instructions)
+        {
+            var category = inst switch
+            {
+                AreaInstruction => DrawingInstructionCategory.Areas,
+                LineInstruction => DrawingInstructionCategory.Lines,
+                PointInstruction => DrawingInstructionCategory.Points,
+                TextInstruction => DrawingInstructionCategory.Text,
+                _ => DrawingInstructionCategory.None,
+            };
+            if ((hidden & category) == 0)
+                kept.Add(inst);
+        }
+        return kept;
     }
 }

--- a/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Cli.Commands;
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
 
 namespace EncDotNet.S100.Cli.Tests;
 
@@ -48,5 +49,33 @@ public sealed class OptionParsingTests
     public void TryParseHexColor_rejects_invalid(string input)
     {
         Assert.False(RenderCommand.TryParseHexColor(input, out _));
+    }
+
+    [Theory]
+    [InlineData("text", DrawingInstructionCategory.Text)]
+    [InlineData("Labels", DrawingInstructionCategory.Text)]
+    [InlineData("points", DrawingInstructionCategory.Points)]
+    [InlineData("symbols", DrawingInstructionCategory.Points)]
+    [InlineData("lines", DrawingInstructionCategory.Lines)]
+    [InlineData("areas", DrawingInstructionCategory.Areas)]
+    [InlineData("fills", DrawingInstructionCategory.Areas)]
+    [InlineData("text,points", DrawingInstructionCategory.Text | DrawingInstructionCategory.Points)]
+    [InlineData(" text , areas ", DrawingInstructionCategory.Text | DrawingInstructionCategory.Areas)]
+    [InlineData("text,text", DrawingInstructionCategory.Text)]
+    public void TryParseHideCategories_accepts_known_tokens(string input, DrawingInstructionCategory expected)
+    {
+        Assert.True(RenderCommand.TryParseHideCategories(input, out var categories, out _));
+        Assert.Equal(expected, categories);
+    }
+
+    [Theory]
+    [InlineData("bogus", "bogus")]
+    [InlineData("text,bogus", "bogus")]
+    [InlineData("nope,text", "nope")]
+    public void TryParseHideCategories_rejects_unknown_tokens(string input, string expectedBadToken)
+    {
+        Assert.False(RenderCommand.TryParseHideCategories(input, out var categories, out var badToken));
+        Assert.Equal(DrawingInstructionCategory.None, categories);
+        Assert.Equal(expectedBadToken, badToken);
     }
 }

--- a/tests/EncDotNet.S100.VisualRegression.Tests/HeadlessVectorRendererFilterTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/HeadlessVectorRendererFilterTests.cs
@@ -1,0 +1,182 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+
+namespace EncDotNet.S100.VisualRegression.Tests;
+
+/// <summary>
+/// Tests for the <see cref="DrawingInstructionCategory"/> suppression filter
+/// honoured by <see cref="HeadlessVectorRenderer.Render"/>. Drives the
+/// renderer with a synthetic four-category display list (one area, one line,
+/// one point, one text) so each category can be asserted in isolation.
+/// </summary>
+public sealed class HeadlessVectorRendererFilterTests
+{
+    private static readonly RgbaColor White = new(255, 255, 255, 255);
+
+    /// <summary>
+    /// Trivial geometry provider that returns the same point/curve/surface
+    /// shapes regardless of feature reference, so the test can focus on
+    /// instruction-category filtering rather than feature lookup mechanics.
+    /// </summary>
+    private sealed class StubGeometryProvider : IFeatureGeometryProvider
+    {
+        public FeatureGeometry? GetGeometry(string featureReference) => featureReference switch
+        {
+            "area" => new FeatureGeometry
+            {
+                Type = GeometryType.Surface,
+                Coordinates =
+                [
+                    (0.001, 0.001),
+                    (0.001, 0.009),
+                    (0.009, 0.009),
+                    (0.009, 0.001),
+                ],
+            },
+            "line" => new FeatureGeometry
+            {
+                Type = GeometryType.Curve,
+                Coordinates = [(0.005, 0.001), (0.005, 0.009)],
+            },
+            "point" or "text" => new FeatureGeometry
+            {
+                Type = GeometryType.Point,
+                Coordinates = [(0.005, 0.005)],
+            },
+            _ => null,
+        };
+    }
+
+    private static IReadOnlyList<DrawingInstruction> BuildAllFourCategories() =>
+    [
+        new AreaInstruction
+        {
+            FeatureReference = "area",
+            FillColor = "FILL",
+        },
+        new LineInstruction
+        {
+            FeatureReference = "line",
+            LineColor = "LINE",
+            LineWidth = 0.32, // mm — translates to a visible stroke on a 200x200 canvas.
+        },
+        new PointInstruction
+        {
+            FeatureReference = "point",
+            // QUESMRK1 has a known purple fallback colour in ColorResolver, so
+            // the point's dot can't be mistaken for the black text glyph.
+            SymbolReference = "QUESMRK1",
+        },
+        new TextInstruction
+        {
+            FeatureReference = "text",
+            Text = "X",
+            FontSize = 24.0,
+            FontColor = "TEXT",
+        },
+    ];
+
+    private static ColorPalette TestPalette() => new(
+        "Test",
+        new Dictionary<string, string>
+        {
+            ["FILL"] = "#FFA0A0", // light red — distinct from text/line.
+            ["LINE"] = "#000080", // navy
+            ["TEXT"] = "#000000", // black
+        });
+
+    private static SKBitmap RenderWith(DrawingInstructionCategory hidden) =>
+        HeadlessVectorRenderer.Render(
+            BuildAllFourCategories(),
+            new StubGeometryProvider(),
+            TestPalette(),
+            symbolProvider: null,
+            lineStyleProvider: null,
+            symbolScale: 1.0,
+            textScale: 1.0,
+            widthPixels: 200,
+            heightPixels: 200,
+            background: White,
+            hiddenCategories: hidden);
+
+    [Fact]
+    public void Hidden_None_Renders_All_Categories()
+    {
+        using var bitmap = RenderWith(DrawingInstructionCategory.None);
+
+        // The fill ("#FFA0A0") covers most of the canvas; we should see at
+        // least one red-ish pixel proving the area was drawn.
+        Assert.True(HasPixelMatching(bitmap, p => p.Red > 200 && p.Green < 200 && p.Blue < 200),
+            "Default render should include the area fill.");
+    }
+
+    [Fact]
+    public void Hidden_All_Produces_Blank_Bitmap()
+    {
+        using var bitmap = RenderWith(DrawingInstructionCategory.All);
+        Assert.True(IsBlank(bitmap, White),
+            "Suppressing all four categories must leave the background untouched.");
+    }
+
+    [Fact]
+    public void Hidden_Text_Removes_Black_Glyph_Pixels_But_Preserves_Fill()
+    {
+        // Black is the text foreground; with text shown there must be at
+        // least one near-black pixel from the glyph. With text hidden the
+        // remaining categories use non-black colours so no near-black pixel
+        // should remain.
+        using var withText = RenderWith(DrawingInstructionCategory.None);
+        using var noText = RenderWith(DrawingInstructionCategory.Text);
+
+        Assert.True(HasPixelMatching(withText, IsNearBlack),
+            "Default render should contain near-black glyph pixels for the text.");
+        Assert.False(HasPixelMatching(noText, IsNearBlack),
+            "Hiding text should remove near-black glyph pixels.");
+
+        // Fills still render (the area's red is unaffected by the text filter).
+        Assert.True(HasPixelMatching(noText, p => p.Red > 200 && p.Green < 200 && p.Blue < 200),
+            "Hiding text must not suppress the area fill.");
+    }
+
+    [Fact]
+    public void Hidden_Combined_Flags_Are_Honoured()
+    {
+        // Hiding both Text and Areas leaves only the line + point (navy +
+        // fallback) — asserting no fill-red and no glyph-black pixels remain.
+        using var bitmap = RenderWith(
+            DrawingInstructionCategory.Text | DrawingInstructionCategory.Areas);
+
+        Assert.False(HasPixelMatching(bitmap, p => p.Red > 200 && p.Green < 200 && p.Blue < 200),
+            "Hiding areas should remove the red fill.");
+        Assert.False(HasPixelMatching(bitmap, IsNearBlack),
+            "Hiding text should remove black glyph pixels.");
+    }
+
+    private static bool IsNearBlack(SKColor p) =>
+        p.Red < 60 && p.Green < 60 && p.Blue < 60 && p.Alpha > 128;
+
+    private static bool HasPixelMatching(SKBitmap bitmap, Func<SKColor, bool> predicate)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            if (predicate(bitmap.GetPixel(x, y)))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsBlank(SKBitmap bitmap, RgbaColor background)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red != background.R || p.Green != background.G || p.Blue != background.B)
+                return false;
+        }
+        return true;
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using EncDotNet.S100.Cli.Infrastructure;
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Datasets.Pipelines;
 using SkiaSharp;
 using Spectre.Console;
@@ -59,6 +60,15 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         [Description("Background colour as a hex string (e.g. #FFFFFF or #80FFFFFF). Default opaque white.")]
         public string? Background { get; init; }
 
+        [CommandOption("--no-text")]
+        [Description("Suppress text/label drawing instructions. Equivalent to --hide text.")]
+        [DefaultValue(false)]
+        public bool NoText { get; init; }
+
+        [CommandOption("--hide")]
+        [Description("Comma-separated list of drawing-instruction categories to suppress: text, points, lines, areas (e.g. --hide text,points). Combines additively with --no-text.")]
+        public string? Hide { get; init; }
+
         public override ValidationResult Validate()
         {
             var baseResult = base.Validate();
@@ -82,6 +92,10 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
 
             if (Background is not null && !TryParseHexColor(Background, out _))
                 return ValidationResult.Error($"Invalid --background colour '{Background}'.");
+
+            if (Hide is not null && !TryParseHideCategories(Hide, out _, out var badToken))
+                return ValidationResult.Error(
+                    $"Invalid --hide value '{badToken}'. Use a comma-separated list of: text, points, lines, areas.");
 
             var dir = Path.GetDirectoryName(Path.GetFullPath(OutputPath));
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
@@ -118,8 +132,15 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
             if (settings.Background is not null && TryParseHexColor(settings.Background, out var bg))
                 background = bg;
 
+            var hidden = DrawingInstructionCategory.None;
+            if (settings.Hide is not null
+                && TryParseHideCategories(settings.Hide, out var parsedHide, out _))
+                hidden |= parsedHide;
+            if (settings.NoText)
+                hidden |= DrawingInstructionCategory.Text;
+
             var renderContext = RenderContextBuilder.Build(
-                processor, palette, settings.SymbolScale, settings.TextScale, settings.TimeStep);
+                processor, palette, settings.SymbolScale, settings.TextScale, settings.TimeStep, hidden);
 
             using var bitmap = headless
                 .RenderHeadlessAsync(settings.Width, settings.Height, renderContext, background)
@@ -198,6 +219,56 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         }
 
         color = new RgbaColor(r, g, b, a);
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a comma-separated list of drawing-instruction category tokens
+    /// (e.g. <c>"text,points"</c>) into a <see cref="DrawingInstructionCategory"/>
+    /// flags value. Tokens are case-insensitive and accept both singular and
+    /// plural forms (e.g. <c>text</c>, <c>label</c>, <c>labels</c>; <c>point</c>
+    /// or <c>points</c>; etc.). Returns <see langword="false"/> on the first
+    /// unrecognised token; the offending token is returned via
+    /// <paramref name="badToken"/>.
+    /// </summary>
+    internal static bool TryParseHideCategories(
+        string value, out DrawingInstructionCategory categories, out string badToken)
+    {
+        categories = DrawingInstructionCategory.None;
+        badToken = string.Empty;
+
+        foreach (var raw in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            switch (raw.ToLowerInvariant())
+            {
+                case "text":
+                case "texts":
+                case "label":
+                case "labels":
+                    categories |= DrawingInstructionCategory.Text;
+                    break;
+                case "point":
+                case "points":
+                case "symbol":
+                case "symbols":
+                    categories |= DrawingInstructionCategory.Points;
+                    break;
+                case "line":
+                case "lines":
+                    categories |= DrawingInstructionCategory.Lines;
+                    break;
+                case "area":
+                case "areas":
+                case "fill":
+                case "fills":
+                    categories |= DrawingInstructionCategory.Areas;
+                    break;
+                default:
+                    badToken = raw;
+                    categories = DrawingInstructionCategory.None;
+                    return false;
+            }
+        }
         return true;
     }
 }

--- a/tools/EncDotNet.S100.Cli/Infrastructure/RenderContextBuilder.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/RenderContextBuilder.cs
@@ -1,13 +1,15 @@
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Datasets.Pipelines;
 
 namespace EncDotNet.S100.Cli.Infrastructure;
 
 /// <summary>
 /// Builds the spec-specific <see cref="RenderContext"/> the dataset processors
-/// expect, mapping CLI options (palette, scales, time-step index) onto the
-/// correct context record. Time-series specs resolve their
-/// <c>--time-step</c> index against <see cref="ITimeAwareDatasetProcessor"/>.
+/// expect, mapping CLI options (palette, scales, time-step index, hidden
+/// instruction categories) onto the correct context record. Time-series specs
+/// resolve their <c>--time-step</c> index against
+/// <see cref="ITimeAwareDatasetProcessor"/>.
 /// </summary>
 internal static class RenderContextBuilder
 {
@@ -16,24 +18,25 @@ internal static class RenderContextBuilder
         PaletteType palette,
         double symbolScale,
         double textScale,
-        int timeStepIndex)
+        int timeStepIndex,
+        DrawingInstructionCategory hiddenCategories = DrawingInstructionCategory.None)
     {
         DateTime? timeStep = ResolveTimeStep(processor, timeStepIndex);
 
         return processor.Spec.Name switch
         {
-            "S-101" => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-102" => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-104" => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-111" => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-122" => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-124" => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-125" => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-127" => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-129" => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-201" => new S201RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            "S-411" => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
-            _ => new GenericRenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale },
+            "S-101" => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-102" => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-104" => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-111" => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-122" => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-124" => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-125" => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-127" => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-129" => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-201" => new S201RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            "S-411" => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
+            _ => new GenericRenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
         };
     }
 

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -40,11 +40,15 @@ and writes a PNG to `<output>`.
 | `--text-scale` | `1.0` | Text scale factor. |
 | `--time-step <index>` | `0` | Zero-based time-step index for time-series datasets (S-104 / S-111). |
 | `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
+| `--no-text` | off | Suppress text/label drawing instructions. Shorthand for `--hide text`. |
+| `--hide <list>` | _none_ | Comma-separated list of drawing-instruction categories to suppress: `text`, `points`, `lines`, `areas` (e.g. `--hide text,points`). Combines additively with `--no-text`. Useful for label-dense products such as S-411 sea-ice, where the egg-code text overlaps fills at preview scales — `--no-text` yields a BSIS-style "clean fill" preview. |
 | `--debug` | off | Print full stack traces on error. |
 
 ```bash
 s100 render currents.h5 currents.png --time-step 6 --palette night
 s100 render warnings.gml warnings.png --width 2048 --height 1536
+s100 render seaice.gml seaice.png --no-text                # clean fill preview
+s100 render chart.gml chart.png --hide text,points         # hide text + symbols
 ```
 
 ### `s100 info <dataset>`


### PR DESCRIPTION
## Summary

Label-dense products like S-411 sea-ice charts draw the full WMO egg-code
labels for every ice polygon, which overlap heavily and obscure the
underlying fills at preview scales. The BSIS Ice Portal works around this
by rendering solid colour fills only. This PR teaches `s100 render` to do
the same: a new `--no-text` flag (and a more general `--hide <list>`)
suppresses selected drawing-instruction categories on the headless vector
path, no portrayal re-run needed.

The mechanism is a new `[Flags] DrawingInstructionCategory` (areas / lines
/ points / text / all) threaded through `RenderContext` as
`HiddenInstructionCategories`. `HeadlessVectorRenderer.Render` filters the
display list by instruction type before lowering, so priorities, viewing
groups, and the auto-fitted extent all stay correct. Filtering lives at
the renderer seam rather than in each processor so it Just Works for every
vector spec (S-101 plus all GML processors that derive from
`GmlDatasetProcessorBase`: S-122/124/125/127/128/129/131/201/411/421).

CLI surface:

- `--no-text` shorthand for `--hide text`
- `--hide text,points,lines,areas` (accepts singular/plural and a few
  aliases like `labels`, `symbols`, `fills`). Unknown tokens fail
  validation with a descriptive message.
- The two flags combine additively, so `--no-text --hide points` works.

The Mapsui (viewer) path is intentionally untouched - the issue scopes
this to the headless CLI. Coverage products (S-102/104/111) ignore the
flag because they render through `CoverageHeadlessRenderer`, not
`HeadlessVectorRenderer`.

The S-411 sample script grew a small `EXTRA_OPTS` env hook so users can
do `EXTRA_OPTS="--no-text" samples/s411-previews/s411_previews.sh` for
BSIS-style clean fills without editing the script.

End-to-end smoke against a real CIS regional ice chart
(`canada-east`, 2026-06-01): egg-code text suppressed cleanly while ice
patches and coastline lines remain.

## Spec alignment

This change is portrayal-mechanism-only and does not touch any spec's
feature/portrayal catalogue or encoding semantics. The filter applies
uniformly across every vector spec the headless renderer already
supports.

- [x] N/A - change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

S-100 Part 9 instruction types (areas / lines / points / text) referenced
in XML doc comments on `DrawingInstructionCategory` and the new
`RenderContext.HiddenInstructionCategories` property.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added `HeadlessVectorRendererFilterTests` (4 cases) covering: no filter,
all-categories filter (asserts blank), text-only filter (asserts black
glyph pixels gone but fill preserved), and combined flag filter. Added
13 new theory rows on `OptionParsingTests` for `TryParseHideCategories`
(token aliases, combinations, whitespace handling, bad-token rejection).
All 570 tests in the impacted projects (CLI, Pipelines, VisualRegression)
pass.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour
      changed
- [x] New public APIs have XML doc comments

Updated `tools/EncDotNet.S100.Cli/README.md` option table, `docs/cli.md`
capabilities list, and `samples/s411-previews/README.md` (with a worked
`EXTRA_OPTS="--no-text"` example).

## Dependencies

- [x] No new NuGet dependencies, OR versions added to
      `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. `HeadlessVectorRenderer.Render` gained an optional
`hiddenCategories` parameter that defaults to
`DrawingInstructionCategory.None` (current behaviour).
`RenderContext.HiddenInstructionCategories` defaults to the same.

Closes #193