### PR TITLE
Headless renderer: tiled pattern area-fills (#192)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -232,11 +232,15 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A newly allocated bitmap owned by the caller.</returns>
     /// <remarks>
-    /// Pattern area-fills are not yet represented in the shared IR, so areas with
-    /// an area-fill reference are omitted here; all point, line, solid-colour
-    /// area, and text portrayal is rendered. Use <see cref="RenderAsync"/> (the
-    /// Mapsui path) for full pattern-fill fidelity. The viewport is auto-fitted
-    /// to the dataset extent and padded to the output aspect ratio.
+    /// Tiled-symbol pattern area-fills are rasterised through
+    /// <see cref="SkiaSvgRasterizer.RasterizePatternTile"/> and tiled across
+    /// the polygon, anchored to a global world-space origin so adjacent
+    /// polygons sharing a pattern align seamlessly. Unlike the Mapsui path,
+    /// the headless renderer does not perform NetTopologySuite
+    /// priority-clipping of overlapping patterns or land-occlusion, so
+    /// patterns may visibly bleed across opaque overlay fills. The viewport
+    /// is auto-fitted to the dataset extent and padded to the output aspect
+    /// ratio.
     /// </remarks>
     public async Task<SKBitmap> RenderHeadlessAsync(
         int widthPixels,
@@ -288,7 +292,12 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
             textScale: context?.TextScale ?? 1.0,
             widthPixels: widthPixels,
             heightPixels: heightPixels,
-            background: bg);
+            background: bg,
+            areaFillProvider: name =>
+            {
+                try { return catalogue.GetAreaFill(name); }
+                catch { return null; }
+            });
     }
 
     /// <inheritdoc/>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -401,13 +401,18 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A newly allocated bitmap owned by the caller.</returns>
     /// <remarks>
-    /// Pattern area-fills are not yet represented in the shared IR, so areas with
-    /// an area-fill reference (e.g. shallow-water diamonds, quality-of-bathymetry
-    /// overlays) are omitted here; the dominant solid depth-area colour fills,
-    /// lines, soundings/symbols, and text are rendered. Use <see cref="RenderAsync"/>
-    /// (the Mapsui path) for full pattern-fill fidelity. Unlike that path, this
-    /// produces a single bitmap (no S-102 interleave split) and draw order follows
-    /// the shared core's S-100 Part 9 ordering.
+    /// Tiled-symbol pattern area-fills (e.g. shallow-water diamonds,
+    /// quality-of-bathymetry overlays) are rasterised through
+    /// <see cref="SkiaSvgRasterizer.RasterizePatternTile"/> and tiled across
+    /// the polygon, anchored to a global world-space origin so adjacent
+    /// polygons sharing a pattern align seamlessly. Unlike the Mapsui path,
+    /// the headless renderer does not perform NetTopologySuite
+    /// priority-clipping of overlapping patterns or land-occlusion, so
+    /// patterns may visibly bleed across opaque overlay fills. Use
+    /// <see cref="RenderAsync"/> (the Mapsui path) for full pattern-fill
+    /// fidelity. Unlike that path, this produces a single bitmap (no S-102
+    /// interleave split) and draw order follows the shared core's S-100
+    /// Part 9 ordering.
     /// </remarks>
     public async Task<SKBitmap> RenderHeadlessAsync(
         int widthPixels,
@@ -463,7 +468,12 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
                 textScale: context?.TextScale ?? 1.0,
                 widthPixels: widthPixels,
                 heightPixels: heightPixels,
-                background: background ?? new RgbaColor(255, 255, 255, 255));
+                background: background ?? new RgbaColor(255, 255, 255, 255),
+                areaFillProvider: name =>
+                {
+                    try { return s101Cat.GetAreaFill(name); }
+                    catch { return null; }
+                });
         }
         finally
         {

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -1,14 +1,15 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Skia;
 using SkiaSharp;
 
 namespace EncDotNet.S100.Renderers.Skia.Scene;
 
 /// <summary>
 /// Source-agnostic entry point for headless vector rendering: lowers any
-/// S-100 Part 9 display list (point/line/solid-area/text) through the shared
-/// <see cref="VectorSceneBuilder"/> and rasterises it with
+/// S-100 Part 9 display list (point/line/solid-area/pattern-area/text) through
+/// the shared <see cref="VectorSceneBuilder"/> and rasterises it with
 /// <see cref="SkiaDisplayListRenderer"/>, auto-fitting the viewport to the
 /// resolved scene's EPSG:3857 extent. Works for any vector product (S-101
 /// ISO 8211, S-12x / S-201 / S-421 GML, …) because it depends only on the
@@ -16,12 +17,16 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 /// <see cref="IFeatureGeometryProvider"/> contract — not on Mapsui.
 /// </summary>
 /// <remarks>
-/// Pattern area-fills are not yet represented in the IR and are therefore
-/// omitted (see <see cref="VectorSceneBuilder"/>). Draw order follows the
-/// shared core's S-100 Part 9 ordering (areas → lines → points → text within a
-/// plane), which is the same ordering each Mapsui layer applies — but a single
-/// headless bitmap does not reproduce the S-101 processor's two-layer
-/// area/non-area split (that split exists only to interleave S-102).
+/// Tiled pattern area-fills are supported when an <c>areaFillProvider</c> is
+/// supplied (see <see cref="Render"/>); the renderer rasterises each
+/// referenced pattern tile via <see cref="SkiaSvgRasterizer.RasterizePatternTile"/>
+/// and tiles it across the polygon. Draw order follows the shared core's
+/// S-100 Part 9 ordering (solid areas → pattern areas → lines → points →
+/// text within a plane) — the same ordering each Mapsui layer applies —
+/// but a single headless bitmap does not reproduce the S-101 processor's
+/// two-layer area/non-area split (that split exists only to interleave
+/// S-102), nor the Mapsui pattern phase's NetTopologySuite priority-clipping
+/// against higher-priority patterns and opaque solid fills.
 /// </remarks>
 public static class HeadlessVectorRenderer
 {
@@ -40,6 +45,13 @@ public static class HeadlessVectorRenderer
     /// <param name="widthPixels">Output bitmap width.</param>
     /// <param name="heightPixels">Output bitmap height.</param>
     /// <param name="background">Background fill colour.</param>
+    /// <param name="areaFillProvider">
+    /// Optional resolver for area-fill catalogue entries by name. When supplied
+    /// together with <paramref name="symbolProvider"/>, area instructions with
+    /// an <c>AreaFillReference</c> are rasterised into tiled pattern fills via
+    /// <see cref="SkiaSvgRasterizer.RasterizePatternTile"/>. When omitted,
+    /// pattern areas are skipped (matching legacy behaviour).
+    /// </param>
     /// <returns>A newly allocated bitmap owned by the caller.</returns>
     public static SKBitmap Render(
         IReadOnlyList<DrawingInstruction> instructions,
@@ -51,7 +63,8 @@ public static class HeadlessVectorRenderer
         double textScale,
         int widthPixels,
         int heightPixels,
-        RgbaColor background)
+        RgbaColor background,
+        Func<string, AreaFill?>? areaFillProvider = null)
     {
         ArgumentNullException.ThrowIfNull(instructions);
         ArgumentNullException.ThrowIfNull(geometryProvider);
@@ -65,6 +78,7 @@ public static class HeadlessVectorRenderer
                 ? null
                 : name => VectorSceneBuilder.ResolveSymbolAsset(symbolProvider(name), palette),
             LineStyleProvider = lineStyleProvider,
+            PatternResolver = BuildPatternResolver(symbolProvider, areaFillProvider, palette),
             SymbolScale = symbolScale,
             TextScale = textScale,
         };
@@ -78,6 +92,53 @@ public static class HeadlessVectorRenderer
             HonorScaleVisibility = false,
         };
         return renderer.Render(scene, viewport);
+    }
+
+    /// <summary>
+    /// Builds a tile resolver that rasterises pattern fills via
+    /// <see cref="SkiaSvgRasterizer.RasterizePatternTile"/>. Tiles are cached
+    /// per render invocation so multiple polygons sharing the same pattern do
+    /// not re-rasterise it. Returns <see langword="null"/> when either of the
+    /// upstream providers is unavailable (patterns then remain skipped).
+    /// </summary>
+    private static Func<string, byte[]?>? BuildPatternResolver(
+        Func<string, string?>? symbolProvider,
+        Func<string, AreaFill?>? areaFillProvider,
+        ColorPalette palette)
+    {
+        if (symbolProvider is null || areaFillProvider is null)
+            return null;
+
+        var cache = new Dictionary<string, byte[]?>(StringComparer.Ordinal);
+        return fillName =>
+        {
+            if (cache.TryGetValue(fillName, out var cached))
+                return cached;
+
+            byte[]? tile = null;
+            try
+            {
+                var areaFill = areaFillProvider(fillName);
+                if (areaFill?.PatternSymbol is { } symbolName)
+                {
+                    var svgContent = symbolProvider(symbolName);
+                    if (!string.IsNullOrEmpty(svgContent))
+                    {
+                        var processed = SvgProcessor.Process(svgContent, palette);
+                        tile = SkiaSvgRasterizer.RasterizePatternTile(processed, areaFill);
+                    }
+                }
+            }
+            catch
+            {
+                // Bad area fill / symbol — drop the pattern silently, matching
+                // the Mapsui ProducePatternTile behaviour.
+                tile = null;
+            }
+
+            cache[fillName] = tile;
+            return tile;
+        };
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/PaintOp.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/PaintOp.cs
@@ -144,10 +144,11 @@ public sealed class LinePaintOp : PaintOp
 
 /// <summary>A resolved solid-colour area fill (with optional outline).</summary>
 /// <remarks>
-/// Pattern fills are intentionally <b>not</b> represented here in the current
-/// vertical slice; they continue to be handled by the Mapsui renderer's
-/// dedicated pattern collection / priority-clip / insert phase. See the split
-/// vector-renderer plan for the deferral rationale.
+/// Tiled-symbol pattern fills are represented separately as
+/// <see cref="PatternAreaPaintOp"/>. The Mapsui renderer still drives its own
+/// pattern collection / priority-clip / insert phase (so it ignores
+/// <see cref="PatternAreaPaintOp"/> in the IR) — only the headless Skia
+/// backend lowers patterns through this IR today.
 /// </remarks>
 public sealed class AreaPaintOp : PaintOp
 {
@@ -165,6 +166,44 @@ public sealed class AreaPaintOp : PaintOp
 
     /// <summary>Outline width in display pixels.</summary>
     public double OutlineWidthPx { get; init; }
+}
+
+/// <summary>
+/// A resolved tiled-symbol pattern area fill (S-100 Part 9 §11.3 area fills with
+/// a referenced <c>AreaFill</c>). The op carries the pre-rasterised pattern
+/// tile as PNG bytes and the pattern reference so backends can cache the
+/// decoded image across ops sharing the same pattern.
+/// </summary>
+/// <remarks>
+/// <para>The tile bytes are encoded as PNG — a renderer-neutral raster format
+/// chosen to mirror the Mapsui pattern phase's existing
+/// <see cref="SkiaSvgRasterizer.RasterizePatternTile"/> output. A future
+/// non-Skia backend can decode the same bytes.</para>
+/// <para>The headless Skia backend draws the tile via a repeat-tiled
+/// <c>SKShader</c> anchored at world (0,0) projected to screen space, matching
+/// the Mapsui <c>AnchoredPatternFillStyle</c> contract so the pattern is
+/// seamless across overlapping polygons that share a global tile grid.</para>
+/// <para><b>Known limitation.</b> Unlike the Mapsui pattern phase, the
+/// headless lowering does not perform NetTopologySuite priority-clipping:
+/// lower-priority pattern ops are simply drawn before higher-priority ones and
+/// are not clipped by non-patterned solid colour fills (e.g. land). Patterns
+/// may therefore visibly bleed across opaque overlay areas in headless
+/// renders. Acceptance per issue #192 is "as closely as practical"; tighter
+/// clipping is a separate refinement.</para>
+/// </remarks>
+public sealed class PatternAreaPaintOp : PaintOp
+{
+    /// <summary>The portrayal-catalogue area-fill name (e.g. <c>DIAMOND1</c>).</summary>
+    public required string PatternReference { get; init; }
+
+    /// <summary>Exterior ring in EPSG:3857 metres (closed or auto-closed by the backend).</summary>
+    public required IReadOnlyList<(double X, double Y)> WorldShell { get; init; }
+
+    /// <summary>Interior (hole) rings in EPSG:3857 metres.</summary>
+    public IReadOnlyList<IReadOnlyList<(double X, double Y)>> WorldHoles { get; init; } = [];
+
+    /// <summary>The pre-rasterised pattern tile as PNG bytes.</summary>
+    public required byte[] TilePng { get; init; }
 }
 
 /// <summary>A resolved text label. The anchor is already selected (Part 9 §11.4/§11.5).</summary>

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -20,9 +20,9 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 /// rectangle linearly to pixels. Geometry is transformed world→screen, but
 /// stroke widths, symbol sizes, and text sizes are realised in display pixels
 /// per the IR unit contract (see <see cref="PaintOp"/>).</para>
-/// <para><b>Scope.</b> This vertical slice renders point, line, solid-area, and
-/// text ops. Pattern fills are not yet represented in the IR. Antimeridian
-/// crossing and Web-Mercator pole limits are out of scope.</para>
+/// <para><b>Scope.</b> This renders point, line, solid-area, tiled pattern-area,
+/// and text ops. Antimeridian crossing and Web-Mercator pole limits are out
+/// of scope.</para>
 /// </remarks>
 public sealed class SkiaDisplayListRenderer
 {
@@ -58,30 +58,51 @@ public sealed class SkiaDisplayListRenderer
         var transform = WorldToScreen.Create(viewport);
         double denom = viewport.ScaleDenominator;
 
-        foreach (var op in scene.Ops)
-        {
-            if (HonorScaleVisibility && !ScaleVisibility.IsVisibleAtScale(op, denom))
-                continue;
+        // Per-render cache of decoded pattern tiles, keyed by pattern
+        // reference. Real S-101 cells can have many polygons sharing a single
+        // pattern (e.g. quality-of-bathymetry overlays) so decoding the PNG
+        // once and reusing the SKImage across ops is a meaningful saving.
+        Dictionary<string, SKImage?>? patternImages = null;
 
-            switch (op)
+        try
+        {
+            foreach (var op in scene.Ops)
             {
-                case AreaPaintOp area:
-                    DrawArea(canvas, area, transform);
-                    break;
-                case LinePaintOp line:
-                    DrawLine(canvas, line, transform);
-                    break;
-                case PointPaintOp point:
-                    DrawPoint(canvas, point, transform);
-                    break;
-                case TextPaintOp text:
-                    DrawText(canvas, text, transform);
-                    break;
+                if (HonorScaleVisibility && !ScaleVisibility.IsVisibleAtScale(op, denom))
+                    continue;
+
+                switch (op)
+                {
+                    case AreaPaintOp area:
+                        DrawArea(canvas, area, transform);
+                        break;
+                    case PatternAreaPaintOp pattern:
+                        patternImages ??= new Dictionary<string, SKImage?>(StringComparer.Ordinal);
+                        DrawPatternArea(canvas, pattern, transform, patternImages);
+                        break;
+                    case LinePaintOp line:
+                        DrawLine(canvas, line, transform);
+                        break;
+                    case PointPaintOp point:
+                        DrawPoint(canvas, point, transform);
+                        break;
+                    case TextPaintOp text:
+                        DrawText(canvas, text, transform);
+                        break;
+                }
+            }
+
+            canvas.Flush();
+            return bitmap;
+        }
+        finally
+        {
+            if (patternImages is not null)
+            {
+                foreach (var img in patternImages.Values)
+                    img?.Dispose();
             }
         }
-
-        canvas.Flush();
-        return bitmap;
     }
 
     private static void DrawArea(SKCanvas canvas, AreaPaintOp op, WorldToScreen t)
@@ -110,6 +131,53 @@ public sealed class SkiaDisplayListRenderer
             };
             canvas.DrawPath(path, outline);
         }
+    }
+
+    /// <summary>
+    /// Fills the polygon with the op's tiled pattern. The repeat anchor is the
+    /// world (0, 0) point projected to screen space, matching the Mapsui
+    /// <c>AnchoredPatternFillStyle</c> contract so the pattern grid is global
+    /// (overlapping polygons sharing a pattern align seamlessly across their
+    /// boundary, avoiding moiré).
+    /// </summary>
+    private static void DrawPatternArea(
+        SKCanvas canvas,
+        PatternAreaPaintOp op,
+        WorldToScreen t,
+        Dictionary<string, SKImage?> imageCache)
+    {
+        if (op.WorldShell.Count < 3)
+            return;
+
+        if (!imageCache.TryGetValue(op.PatternReference, out var tileImage))
+        {
+            tileImage = SKImage.FromEncodedData(op.TilePng);
+            imageCache[op.PatternReference] = tileImage;
+        }
+        if (tileImage is null)
+            return;
+
+        using var path = new SKPath { FillType = SKPathFillType.EvenOdd };
+        AddRing(path, op.WorldShell, t);
+        foreach (var hole in op.WorldHoles)
+            AddRing(path, hole, t);
+
+        var (anchorX, anchorY) = t.Project((0, 0));
+        var anchorMatrix = SKMatrix.CreateTranslation(anchorX, anchorY);
+        using var shader = tileImage.ToShader(
+            SKShaderTileMode.Repeat, SKShaderTileMode.Repeat, anchorMatrix);
+
+        using var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Fill,
+            Shader = shader,
+        };
+
+        canvas.Save();
+        canvas.ClipPath(path, antialias: true);
+        canvas.DrawRect(path.Bounds, paint);
+        canvas.Restore();
     }
 
     private static void DrawLine(SKCanvas canvas, LinePaintOp op, WorldToScreen t)

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/VectorSceneBuilder.cs
@@ -28,11 +28,12 @@ public readonly record struct SymbolAsset(
 /// the S-100 portrayal-correctness logic lives in exactly one place.
 /// </summary>
 /// <remarks>
-/// <b>Scope (vertical slice).</b> Pattern fills (<c>AreaInstruction</c> with an
-/// <c>AreaFillReference</c>) are deliberately skipped — they remain the
-/// responsibility of the Mapsui renderer's pattern collection / priority-clip /
-/// insert phase. Only point, line, solid-colour area, and text instructions are
-/// lowered here.
+/// <b>Scope.</b> Both solid-colour and tiled-symbol pattern area fills are
+/// lowered into the IR. Pattern fills are emitted as
+/// <see cref="PatternAreaPaintOp"/> only when a <see cref="PatternResolver"/>
+/// is supplied (the headless Skia path); the Mapsui renderer leaves the
+/// resolver unset and continues to drive its own pattern collection /
+/// priority-clip / insert phase, so its output is unchanged.
 /// </remarks>
 public sealed class VectorSceneBuilder
 {
@@ -54,6 +55,17 @@ public sealed class VectorSceneBuilder
 
     /// <summary>Resolves a line-style name to its catalogue definition. Optional.</summary>
     public Func<string, LineStyle?>? LineStyleProvider { get; init; }
+
+    /// <summary>
+    /// Resolves an area-fill name to a pre-rasterised tiled pattern (PNG
+    /// bytes). When set, <c>AreaInstruction</c>s with an
+    /// <c>AreaFillReference</c> are lowered to a
+    /// <see cref="PatternAreaPaintOp"/>; when unset (the Mapsui default),
+    /// pattern instructions are skipped so the Mapsui renderer's existing
+    /// pattern phase remains authoritative. Returning <see langword="null"/>
+    /// for a given name silently drops just that instruction.
+    /// </summary>
+    public Func<string, byte[]?>? PatternResolver { get; init; }
 
     /// <summary>Global scale factor applied to all point symbols (default 1.0).</summary>
     public double SymbolScale { get; init; } = 1.0;
@@ -98,11 +110,15 @@ public sealed class VectorSceneBuilder
             .OrderBy(i => i.Plane == EncDotNet.S100.Pipelines.Vector.DisplayPlane.OverRadar ? 1 : 0)
             .ThenBy(i => i switch
             {
+                // Pattern areas draw after solid areas but before lines/points/text,
+                // mirroring the Mapsui renderer's "insert pattern fills after the
+                // last solid colour fill" ordering.
+                AreaInstruction { AreaFillReference: not null } => 1,
                 AreaInstruction => 0,
-                LineInstruction => 1,
-                PointInstruction => 2,
-                TextInstruction => 3,
-                _ => 4,
+                LineInstruction => 2,
+                PointInstruction => 3,
+                TextInstruction => 4,
+                _ => 5,
             })
             .ThenBy(i => i.DrawingPriority)
             .ToList();
@@ -119,8 +135,11 @@ public sealed class VectorSceneBuilder
 
             PaintOp? op = instruction switch
             {
-                // Pattern fills are handled by the Mapsui pattern phase, not here.
-                AreaInstruction { AreaFillReference: not null } => null,
+                // Pattern fills are lowered only when a resolver is supplied (the
+                // headless path); otherwise they are deferred to the Mapsui
+                // pattern phase, which collects/clips them outside this IR.
+                AreaInstruction { AreaFillReference: { } patternRef } areaPattern when geom is not null
+                    => BuildPatternArea(areaPattern, patternRef, geom),
                 AreaInstruction area when geom is not null => BuildArea(area, geom),
                 LineInstruction line => BuildLine(line, geom),
                 PointInstruction point when geom is not null => BuildPoint(point, geom),
@@ -133,6 +152,38 @@ public sealed class VectorSceneBuilder
         }
 
         return new VectorScene(ops);
+    }
+
+    private PatternAreaPaintOp? BuildPatternArea(
+        AreaInstruction instruction, string patternRef, FeatureGeometry geometry)
+    {
+        if (PatternResolver is null)
+            return null;
+
+        if (geometry.Coordinates.Count < 3)
+            return null;
+
+        var tile = PatternResolver(patternRef);
+        if (tile is null || tile.Length == 0)
+            return null;
+
+        var holes = new List<IReadOnlyList<(double, double)>>(geometry.InteriorRings.Count);
+        foreach (var ring in geometry.InteriorRings)
+        {
+            if (ring.Count >= 3)
+                holes.Add(Project(ring));
+        }
+
+        return new PatternAreaPaintOp
+        {
+            FeatureReference = instruction.FeatureReference,
+            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMaximum = instruction.ScaleMaximum,
+            PatternReference = patternRef,
+            WorldShell = Project(geometry.Coordinates),
+            WorldHoles = holes,
+            TilePng = tile,
+        };
     }
 
     private AreaPaintOp? BuildArea(AreaInstruction instruction, FeatureGeometry geometry)

--- a/tests/EncDotNet.S100.VisualRegression.Tests/PatternAreaFillRenderingTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/PatternAreaFillRenderingTests.cs
@@ -1,0 +1,255 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Skia;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+
+namespace EncDotNet.S100.VisualRegression.Tests;
+
+/// <summary>
+/// Unit tests for tiled-pattern area-fill rendering through the headless
+/// vector core (<see cref="VectorSceneBuilder"/> →
+/// <see cref="PatternAreaPaintOp"/> → <see cref="SkiaDisplayListRenderer"/>).
+/// Issue #192 acceptance: a dataset with patterned area fills renders those
+/// patterns on the headless path.
+/// </summary>
+public sealed class PatternAreaFillRenderingTests
+{
+    private static readonly RgbaColor White = new(255, 255, 255, 255);
+    private static readonly RgbaColor Black = new(0, 0, 0, 255);
+
+    // A tiny SVG used as a pattern symbol — a 4 mm square containing a black
+    // diagonal stroke. After rasterisation through SkiaSvgRasterizer at the
+    // default 1.5 px/mm density the tile is 6 × 6 px with a few black pixels,
+    // which is plenty to detect against a white background.
+    private const string DiagonalSvg =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"4mm\" height=\"4mm\" " +
+        "viewBox=\"0 0 4 4\">" +
+        "<line x1=\"0\" y1=\"0\" x2=\"4\" y2=\"4\" stroke=\"black\" stroke-width=\"0.8\"/>" +
+        "</svg>";
+
+    private static readonly AreaFill DiagonalFill = new()
+    {
+        Name = "DIAG",
+        PatternSymbol = "DIAG_SYM",
+        V1X = 4,
+        V1Y = 0,
+        V2X = 0,
+        V2Y = 4,
+    };
+
+    [Fact]
+    public void Render_PatternArea_FillsInteriorWithTiledPattern()
+    {
+        // The renderer must produce visible (non-background) pattern strokes
+        // inside the polygon when a pattern resolver is wired.
+        var bitmap = RenderPatternedSquare(provideResolver: true);
+
+        Assert.False(IsBlank(bitmap, White),
+            "Patterned area produced no visible (non-background) pixels.");
+
+        int blackish = CountBlackish(bitmap);
+        Assert.True(blackish > 10,
+            $"Expected the tiled diagonal pattern to leave several dark pixels; got {blackish}.");
+    }
+
+    [Fact]
+    public void Render_PatternArea_NoResolver_IsSkipped()
+    {
+        // Without an areaFillProvider, pattern instructions are not lowered
+        // into the IR — preserving the Mapsui-path behaviour where patterns
+        // are rendered by the renderer's dedicated pattern phase instead.
+        var bitmap = RenderPatternedSquare(provideResolver: false);
+
+        Assert.True(IsBlank(bitmap, White),
+            "Pattern area should be skipped when no area-fill provider is supplied.");
+    }
+
+    [Fact]
+    public void Render_PatternArea_AdjacentPolygons_ShareGlobalTileOrigin()
+    {
+        // Two horizontally-adjacent polygons sharing one pattern must align
+        // seamlessly across their shared edge because the tile shader is
+        // anchored to a global world-space origin (mirrors Mapsui's
+        // AnchoredPatternFillRenderer). A per-polygon anchor would produce
+        // a visible discontinuity at the seam — the pattern in each polygon
+        // would start at its own bbox corner, so the vertical phase of the
+        // tile would differ between the two halves.
+        //
+        // Invariant: for each Y row that intersects both polygons, the LEFT
+        // half is dark iff the RIGHT half is dark. (With a per-polygon
+        // anchor, half the rows would mismatch.)
+
+        var instructions = new List<DrawingInstruction>
+        {
+            MakeAreaInstruction("LEFT", priority: 1),
+            MakeAreaInstruction("RIGHT", priority: 1),
+        };
+        var geometry = new InMemoryGeometry();
+        geometry.Add("LEFT", SquareRing(lon: -0.002, lat: 0.0, halfLon: 0.002, halfLat: 0.002));
+        geometry.Add("RIGHT", SquareRing(lon: 0.002, lat: 0.0, halfLon: 0.002, halfLat: 0.002));
+
+        using var bitmap = RenderHeadless(instructions, geometry);
+
+        // Bands well inside each polygon (avoid the polygon edge antialiasing
+        // and the central seam).
+        int leftStart = bitmap.Width / 8;
+        int leftEnd = bitmap.Width * 3 / 8;
+        int rightStart = bitmap.Width * 5 / 8;
+        int rightEnd = bitmap.Width * 7 / 8;
+        int yStart = bitmap.Height / 4;
+        int yEnd = bitmap.Height * 3 / 4;
+
+        int matchingRows = 0;
+        int comparedRows = 0;
+        for (int y = yStart; y < yEnd; y++)
+        {
+            bool leftDark = RowHasDark(bitmap, y, leftStart, leftEnd);
+            bool rightDark = RowHasDark(bitmap, y, rightStart, rightEnd);
+            comparedRows++;
+            if (leftDark == rightDark)
+                matchingRows++;
+        }
+
+        Assert.True(comparedRows > 0);
+        // With a global anchor the match rate is ≈ 100 %; a per-polygon
+        // anchor would put it close to 50 %. Demand strong agreement
+        // (allow a small slack for antialiasing on tile-row boundaries).
+        double matchRate = (double)matchingRows / comparedRows;
+        Assert.True(matchRate >= 0.85,
+            $"Pattern rows should align across polygons sharing a global tile origin; "
+            + $"matched {matchingRows}/{comparedRows} rows ({matchRate:P0}).");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static SKBitmap RenderPatternedSquare(bool provideResolver)
+    {
+        var instructions = new List<DrawingInstruction>
+        {
+            MakeAreaInstruction("S1", priority: 1),
+        };
+        var geometry = new InMemoryGeometry();
+        geometry.Add("S1", SquareRing(lon: 0.0, lat: 0.0, halfLon: 0.004, halfLat: 0.004));
+
+        return RenderHeadless(instructions, geometry,
+            areaFillProvider: provideResolver ? (_ => DiagonalFill) : null,
+            provideAreaFill: provideResolver);
+    }
+
+    private static SKBitmap RenderHeadless(
+        IReadOnlyList<DrawingInstruction> instructions,
+        InMemoryGeometry geometry,
+        Func<string, AreaFill?>? areaFillProvider = null,
+        bool provideAreaFill = true)
+    {
+        // Note: keep the caller's null explicit (don't fall back to a default
+        // resolver) — the "skipped" test relies on actually omitting it.
+        if (provideAreaFill)
+            areaFillProvider ??= (_ => DiagonalFill);
+        else
+            areaFillProvider = null;
+
+        return HeadlessVectorRenderer.Render(
+            instructions,
+            geometry,
+            palette: ColorPalette.Default,
+            symbolProvider: name => name == "DIAG_SYM" ? DiagonalSvg : null,
+            lineStyleProvider: null,
+            symbolScale: 1.0,
+            textScale: 1.0,
+            widthPixels: 200,
+            heightPixels: 200,
+            background: White,
+            areaFillProvider: areaFillProvider);
+    }
+
+    private static AreaInstruction MakeAreaInstruction(string featureRef, int priority) => new()
+    {
+        FeatureReference = featureRef,
+        AreaFillReference = "DIAG",
+        DrawingPriority = priority,
+    };
+
+    private static IReadOnlyList<(double Lat, double Lon)> SquareRing(
+        double lon, double lat, double halfLon, double halfLat)
+    {
+        return
+        [
+            (lat - halfLat, lon - halfLon),
+            (lat - halfLat, lon + halfLon),
+            (lat + halfLat, lon + halfLon),
+            (lat + halfLat, lon - halfLon),
+            (lat - halfLat, lon - halfLon),
+        ];
+    }
+
+    private static bool IsBlank(SKBitmap bitmap, RgbaColor background)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red != background.R || p.Green != background.G || p.Blue != background.B)
+                return false;
+        }
+        return true;
+    }
+
+    private static int CountBlackish(SKBitmap bitmap)
+    {
+        int count = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red < 80 && p.Green < 80 && p.Blue < 80)
+                count++;
+        }
+        return count;
+    }
+
+    private static IReadOnlyList<int> SampleDarkRows(SKBitmap bitmap, int x, int minY, int maxY)
+    {
+        var rows = new List<int>();
+        for (int y = Math.Max(0, minY); y < Math.Min(bitmap.Height, maxY); y++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red < 128 && p.Green < 128 && p.Blue < 128)
+                rows.Add(y);
+        }
+        return rows;
+    }
+
+    private static bool RowHasDark(SKBitmap bitmap, int y, int xStart, int xEnd)
+    {
+        for (int x = xStart; x < xEnd; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red < 128 && p.Green < 128 && p.Blue < 128)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Minimal in-memory geometry provider for these unit tests: stores a
+    /// single ring per feature reference and exposes it as a polygon surface.
+    /// </summary>
+    private sealed class InMemoryGeometry : IFeatureGeometryProvider
+    {
+        private readonly Dictionary<string, FeatureGeometry> _features = new();
+
+        public void Add(string id, IReadOnlyList<(double Lat, double Lon)> ring)
+        {
+            _features[id] = new FeatureGeometry
+            {
+                Type = GeometryType.Surface,
+                Coordinates = ring,
+            };
+        }
+
+        public FeatureGeometry? GetGeometry(string featureRef) =>
+            _features.TryGetValue(featureRef, out var g) ? g : null;
+    }
+}


### PR DESCRIPTION
Closes #192.

The headless Skia path (`HeadlessVectorRenderer` → `SkiaDisplayListRenderer`) previously dropped pattern area-fills entirely, leaving a noticeable fidelity gap vs the Mapsui viewer (restricted areas, caution areas, quality-of-bathymetry overlays, etc. all rendered with no fill).

## What changed

- **Shared IR** – new `PatternAreaPaintOp` in `PaintOp.cs` carrying a `PatternReference`, world shell + holes, and PNG tile bytes. Renderer-neutral (the PNG happens to come from Skia today but a future backend could decode it).
- **`VectorSceneBuilder`** – optional `PatternResolver: Func<string, byte[]?>?`. Null = skip pattern lowering (the **Mapsui path is unchanged**, preserving its existing NTS priority-clip pipeline byte-for-byte). Sort tier is split so pattern areas (1) draw after solid areas (0) and before lines / points / text.
- **`SkiaDisplayListRenderer`** – decodes each PNG once per render (cached `Dictionary<PatternReference, SKImage?>`, disposed in `finally`) and fills with a `Repeat`-tiled `SKShader` translated to `transform.Project((0,0))`. This mirrors `AnchoredPatternFillRenderer`'s `viewport.WorldToScreenXY(0, 0)` anchor so tiles seam across polygon boundaries.
- **Wiring** – `S101DatasetProcessor` and `GmlDatasetProcessorBase` pass `name => catalogue.GetAreaFill(name)`, so S-101 and every GML product (S-12x / S-201 / S-411 / S-421) get the fix.
- **Tests** – 3 new tests in `PatternAreaFillRenderingTests`:
  1. A patterned polygon produces dark pixels.
  2. No-resolver path stays a no-op (the original behaviour).
  3. Two adjacent polygons share a global tile origin (≥85% row-match across the seam).

## Deliberate non-goal

NTS priority-clipping of overlapping pattern fills (and land-occlusion clipping) is **not** ported to the headless path. The headless renderer uses simple priority ordering — "later draws on top" — which can let patterns visibly bleed across opaque overlays. This is documented on `PatternAreaPaintOp`, `HeadlessVectorRenderer`, and both processors. The issue asked for parity "as closely as practical"; if visual parity demands clipping later, the IR is ready for it.

## Validation

- `dotnet test --configuration Release`: **all** 900+ tests pass (1 pre-existing skip, plus 5 baseline-data skips).
- End-to-end real-data render of `101GB00GB302045.000` via `s100 render` produces tiled fills for RESARE (magenta "X"), caution areas, and seabed-quality overlays — confirming the pattern path works on a real S-101 trial cell.