### PR TITLE
Async-ify catalogue/asset layer (closes #182)

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Coverage/CoveragePipeline.cs
@@ -15,7 +15,7 @@ namespace EncDotNet.S100.Pipelines.Coverage;
 /// </summary>
 public class CoveragePipeline
 {
-    public Task<StyledCoverageLayer> ProcessAsync(
+    public async Task<StyledCoverageLayer> ProcessAsync(
         ICoverageSource source,
         ICoveragePortrayalCatalogue catalogue,
         MarinerSettings? mariner = null,
@@ -40,6 +40,18 @@ public class CoveragePipeline
         {
             var settings = mariner ?? MarinerSettings.Default;
             var metadata = source.Metadata;
+
+            // Pre-warm the catalogue so the synchronous Resolve*Scheme
+            // calls below can read entirely from cached state. We only
+            // trigger a switch when the catalogue is still at its empty
+            // Default palette (catalogue uninitialised); when the dataset
+            // processor has already invoked SwitchPaletteAsync the active
+            // palette is already populated and we leave it untouched.
+            if (catalogue.ActivePalette.Colors.Count == 0)
+            {
+                await catalogue.SwitchPaletteAsync(PaletteType.Day, cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
             // Stage 1 — resolve colour and symbol schemes from catalogue
             CoverageColorScheme? colorScheme;
@@ -76,7 +88,7 @@ public class CoveragePipeline
                 SymbolScheme = symbolScheme,
             };
 
-            return Task.FromResult(layer);
+            return layer;
         }
         catch
         {

--- a/src/EncDotNet.S100.Core/Pipelines/IPortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/IPortrayalCatalogue.cs
@@ -9,7 +9,21 @@ public interface IPortrayalCatalogue
 
     /// <summary>The edition of the underlying portrayal catalogue (matches <see cref="PortrayalCatalogue.Version"/>).</summary>
     string Edition { get; }
+
+    /// <summary>The currently active colour palette.</summary>
     ColorPalette ActivePalette { get; }
-    void SwitchPalette(PaletteType type);
+
+    /// <summary>
+    /// Switches the active colour palette to <paramref name="type"/>.
+    /// </summary>
+    /// <remarks>
+    /// Asynchronous because catalogues that load palettes lazily from
+    /// <see cref="IAssetSource"/> may need to fetch the colour profile
+    /// XML on first access. Cached implementations complete
+    /// synchronously through the <see cref="ValueTask"/> fast path.
+    /// </remarks>
+    /// <param name="type">The palette mood (Day, Dusk, or Night).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default);
 }
  

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Caching/DiskPortrayalInstructionCache.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Caching/DiskPortrayalInstructionCache.cs
@@ -106,11 +106,41 @@ public sealed class DiskPortrayalInstructionCache : IPortrayalInstructionCache
             _misses++;
         }
 
-        // Run the portrayal pipeline OUTSIDE the lock so a single multi-second
-        // miss does not stall hits or unrelated computes on other processors
-        // sharing this cache. Concurrent misses on the same key merely duplicate
-        // work (rare); the last writer wins and the result is identical.
         var produced = factory();
+
+        lock (_gate)
+        {
+            TryWrite(path, produced);
+        }
+
+        return produced;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<DrawingInstruction>> GetOrComputeAsync(
+        string key,
+        Func<CancellationToken, ValueTask<IReadOnlyList<DrawingInstruction>>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var path = GetEntryPath(key);
+
+        lock (_gate)
+        {
+            var cached = TryRead(path);
+            if (cached is not null)
+            {
+                _hits++;
+                TouchAccessTime(path);
+                return cached;
+            }
+
+            _misses++;
+        }
+
+        var produced = await factory(cancellationToken).ConfigureAwait(false);
 
         lock (_gate)
         {

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Caching/IPortrayalInstructionCache.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Caching/IPortrayalInstructionCache.cs
@@ -63,6 +63,16 @@ public interface IPortrayalInstructionCache
         Func<IReadOnlyList<DrawingInstruction>> factory);
 
     /// <summary>
+    /// Async counterpart to <see cref="GetOrCompute"/>. Used by callers that
+    /// drive the portrayal pipeline asynchronously (the standard render path)
+    /// so the factory can <c>await</c> instead of blocking.
+    /// </summary>
+    ValueTask<IReadOnlyList<DrawingInstruction>> GetOrComputeAsync(
+        string key,
+        Func<CancellationToken, ValueTask<IReadOnlyList<DrawingInstruction>>> factory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Number of <see cref="GetOrCompute"/> calls served from the cache (the
     /// portrayal run was skipped). Exposed for diagnostics and tests.
     /// </summary>

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Caching/InMemoryPortrayalInstructionCache.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Caching/InMemoryPortrayalInstructionCache.cs
@@ -82,6 +82,41 @@ public sealed class InMemoryPortrayalInstructionCache : IPortrayalInstructionCac
         // work (rare); the last store wins and the result is identical.
         var produced = factory();
 
+        Store(key, produced);
+
+        return produced;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<DrawingInstruction>> GetOrComputeAsync(
+        string key,
+        Func<CancellationToken, ValueTask<IReadOnlyList<DrawingInstruction>>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(key, out var existing))
+            {
+                _hits++;
+                Touch(existing.Node);
+                return existing.Value;
+            }
+
+            _misses++;
+        }
+
+        var produced = await factory(cancellationToken).ConfigureAwait(false);
+
+        Store(key, produced);
+
+        return produced;
+    }
+
+    private void Store(string key, IReadOnlyList<DrawingInstruction> produced)
+    {
         lock (_gate)
         {
             if (!_entries.ContainsKey(key))
@@ -92,8 +127,6 @@ public sealed class InMemoryPortrayalInstructionCache : IPortrayalInstructionCac
                 EvictIfNeeded();
             }
         }
-
-        return produced;
     }
 
     private void Touch(LinkedListNode<string> node)

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/ILuaRuleSource.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/ILuaRuleSource.cs
@@ -6,19 +6,41 @@ namespace EncDotNet.S100.Pipelines.Vector;
 /// Capability interface for catalogues that supply Lua portrayal rules
 /// (S-100 Part 9A). A catalogue implements this interface as part of
 /// <see cref="IVectorPortrayalCatalogue"/>; products that ship no Lua rules
-/// (e.g. the GML/XSLT products) return <see langword="null"/> from
-/// <see cref="GetLuaSource"/> and an empty <see cref="ContextParameters"/>.
+/// (e.g. the GML/XSLT products) return an empty list from
+/// <see cref="GetLuaSourceNamesAsync"/> and an empty
+/// <see cref="ContextParameters"/>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This is the Core seam through which the generic
 /// <see cref="Lua.LuaRuleExecutor"/> obtains everything it needs from a
-/// catalogue: raw module source (for the MoonSharp <c>require()</c> loader and
-/// <c>main.lua</c>) and the declared context-parameter set (to initialise the
-/// Lua side and to filter mariner overrides). It deliberately does not expose a
-/// compiled script type, preserving per-render sandbox isolation.
+/// catalogue: the manifest-declared list of Lua rule files and the raw
+/// source for each one (for the MoonSharp <c>require()</c> loader and
+/// <c>main.lua</c>), plus the declared context-parameter set (to initialise
+/// the Lua side and to filter mariner overrides). It deliberately does not
+/// expose a compiled script type, preserving per-render sandbox isolation.
+/// </para>
+/// <para>
+/// The interface is purely asynchronous so the catalogue stays an
+/// unopinionated data source. The MoonSharp <c>require()</c> module loader
+/// is itself synchronous (we do not own MoonSharp), so the executor — not
+/// the catalogue — is responsible for awaiting all source files into a
+/// local snapshot dictionary before invoking the Lua engine, and capturing
+/// that dictionary inside the sync loader callback.
+/// </para>
 /// </remarks>
 public interface ILuaRuleSource
 {
+    /// <summary>
+    /// Returns the bare file names (e.g. <c>"main.lua"</c>,
+    /// <c>"S100Scripting.lua"</c>) of every Lua rule file declared in the
+    /// portrayal catalogue manifest. The returned list is intended to be
+    /// memoized by the catalogue; the executor uses it to drive
+    /// <see cref="GetLuaSourceAsync"/> calls before kicking off the
+    /// synchronous MoonSharp engine.
+    /// </summary>
+    ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Returns the raw Lua source for the given bare file name inside the
     /// portrayal catalogue's <c>Rules/</c> directory (e.g. <c>"main.lua"</c>,
@@ -26,7 +48,7 @@ public interface ILuaRuleSource
     /// not present — honouring the MoonSharp module loader's
     /// "missing module → return null" contract.
     /// </summary>
-    string? GetLuaSource(string fileName);
+    ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// The context parameters declared by the catalogue (S-100 Part 9A), used

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IPortrayalAssetSource.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IPortrayalAssetSource.cs
@@ -7,17 +7,33 @@ namespace EncDotNet.S100.Pipelines.Vector;
 /// these via per-feature provider callbacks.
 /// </summary>
 /// <remarks>
+/// <para>
+/// All members are asynchronous because uncached lookups perform I/O against
+/// the underlying <see cref="IAssetSource"/>. Implementations are expected
+/// to memoize decoded results, so the second access for the same name on a
+/// given catalogue completes synchronously through the
+/// <see cref="ValueTask{TResult}"/> fast path.
+/// </para>
+/// <para>
+/// Renderers (Skia, Mapsui) are themselves synchronous, so dataset
+/// processors are responsible for awaiting these methods before the
+/// synchronous render phase and capturing the results in local resolver
+/// closures. See <c>CataloguePreWarm</c> in
+/// <c>EncDotNet.S100.Datasets.Pipelines</c> for the shared helper.
+/// </para>
+/// <para>
 /// Implementations should throw <see cref="KeyNotFoundException"/> when the
 /// named asset is not present in the loaded catalogue.
+/// </para>
 /// </remarks>
 public interface IPortrayalAssetSource
 {
     /// <summary>Resolves an SVG symbol by name from the catalogue resources.</summary>
-    SvgSymbol GetSymbol(string symbolName);
+    ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default);
 
     /// <summary>Resolves a line style by name from the catalogue resources.</summary>
-    LineStyle GetLineStyle(string name);
+    ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>Resolves an area fill by name from the catalogue resources.</summary>
-    AreaFill GetAreaFill(string name);
+    ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorRuleExecutor.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IVectorRuleExecutor.cs
@@ -24,7 +24,9 @@ public interface IVectorRuleExecutor
     /// <param name="cancellationToken">
     /// Signals that the render has been cancelled. Script interpreters are
     /// generally not interruptible mid-evaluation, so implementations honour
-    /// the token at coarse boundaries; the method remains synchronous.
+    /// the token at coarse boundaries; the asynchronous shape exists to allow
+    /// implementations to await catalogue asset loads (compiled XSLT, Lua
+    /// source) before driving the synchronous engine.
     /// </param>
-    IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<DrawingInstruction>> ExecuteAsync(MarinerSettings mariner, CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/IXsltRuleSource.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/IXsltRuleSource.cs
@@ -8,15 +8,24 @@ namespace EncDotNet.S100.Pipelines.Vector;
 /// one of its loaded rules has <see cref="PortrayalRuleType.Xslt"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// The single member is asynchronous because uncached lookups perform I/O
+/// against the underlying <see cref="IAssetSource"/> (the XSLT XML must be
+/// read and compiled). Implementations are expected to memoize compiled
+/// transforms, so subsequent accesses for the same rule complete
+/// synchronously through the <see cref="ValueTask{TResult}"/> fast path.
+/// </para>
+/// <para>
 /// Implementations should throw <see cref="KeyNotFoundException"/> from
-/// <see cref="GetCompiledRule"/> when the named rule is not present in
+/// <see cref="GetCompiledRuleAsync"/> when the named rule is not present in
 /// the loaded catalogue, just as <see cref="IPortrayalAssetSource"/>
 /// methods do for missing symbols, line styles, or area fills. The
 /// "this product never has XSLT" assertion belongs in the rule list,
 /// not in the type system.
+/// </para>
 /// </remarks>
 public interface IXsltRuleSource
 {
     /// <summary>Returns the compiled XSLT transform for the named rule.</summary>
-    XslCompiledTransform GetCompiledRule(string ruleName);
+    ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Lua/ILuaVectorRuleExecutor.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Lua/ILuaVectorRuleExecutor.cs
@@ -4,7 +4,7 @@ namespace EncDotNet.S100.Pipelines.Vector.Lua;
 /// Diagnostic extension of <see cref="IVectorRuleExecutor"/> for Lua-based
 /// portrayal engines (S-100 Part 9A). Exposes the raw pre-parse emit stream
 /// (<see cref="EmittedInstruction"/>) in addition to the typed
-/// <see cref="IVectorRuleExecutor.Execute"/> output.
+/// <see cref="IVectorRuleExecutor.ExecuteAsync"/> output.
 /// </summary>
 /// <remarks>
 /// The raw surface is intentionally kept off the shared
@@ -21,6 +21,6 @@ public interface ILuaVectorRuleExecutor : IVectorRuleExecutor
     /// </summary>
     /// <param name="mariner">Mariner-configurable display preferences (S-100 Part 9 §4.2).</param>
     /// <param name="cancellationToken">Honoured at coarse boundaries before Lua invocation.</param>
-    IReadOnlyList<EmittedInstruction> ExecuteRaw(
+    Task<IReadOnlyList<EmittedInstruction>> ExecuteRawAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default);
 }

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Lua/LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Lua/LuaRuleExecutor.cs
@@ -78,7 +78,7 @@ public sealed class LuaRuleExecutor : ILuaVectorRuleExecutor
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<DrawingInstruction> Execute(
+    public async Task<IReadOnlyList<DrawingInstruction>> ExecuteAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(mariner);
@@ -93,7 +93,13 @@ public sealed class LuaRuleExecutor : ILuaVectorRuleExecutor
 
         try
         {
-            var (emitted, provider) = ExecuteRawCore(mariner);
+            // Async pre-warm — load every Lua module declared by the catalogue
+            // so the synchronous MoonSharp require() loader can resolve modules
+            // without blocking. The snapshot dictionary is captured by the
+            // sync loader callback inside ExecuteRawCore.
+            var luaSources = await LoadLuaSourcesAsync(cancellationToken).ConfigureAwait(false);
+
+            var (emitted, provider) = ExecuteRawCore(mariner, luaSources);
 
             Telemetry.LuaFeaturesCount.Add(
                 emitted.Count,
@@ -139,22 +145,48 @@ public sealed class LuaRuleExecutor : ILuaVectorRuleExecutor
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<EmittedInstruction> ExecuteRaw(
+    public async Task<IReadOnlyList<EmittedInstruction>> ExecuteRawAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(mariner);
         cancellationToken.ThrowIfCancellationRequested();
-        return ExecuteRawCore(mariner).Emitted;
+        var luaSources = await LoadLuaSourcesAsync(cancellationToken).ConfigureAwait(false);
+        return ExecuteRawCore(mariner, luaSources).Emitted;
+    }
+
+    /// <summary>
+    /// Awaits every Lua rule file declared in the portrayal catalogue
+    /// manifest into a local snapshot dictionary so the synchronous MoonSharp
+    /// <c>require()</c> module loader (registered inside
+    /// <see cref="ExecuteRawCore"/>) can perform its lookups against an
+    /// in-memory map. This is the sync↔async bridge for Lua portrayal:
+    /// catalogues serve content asynchronously, the executor freezes the set
+    /// before driving the synchronous engine.
+    /// </summary>
+    private async Task<IReadOnlyDictionary<string, string>> LoadLuaSourcesAsync(CancellationToken cancellationToken)
+    {
+        var names = await _source.GetLuaSourceNamesAsync(cancellationToken).ConfigureAwait(false);
+        var dict = new Dictionary<string, string>(names.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in names)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var src = await _source.GetLuaSourceAsync(name, cancellationToken).ConfigureAwait(false);
+            if (src is not null)
+            {
+                dict[name] = src;
+            }
+        }
+        return dict;
     }
 
     private (IReadOnlyList<EmittedInstruction> Emitted, ILuaDataProvider Provider) ExecuteRawCore(
-        MarinerSettings mariner)
+        MarinerSettings mariner, IReadOnlyDictionary<string, string> luaSources)
     {
         var provider = _providerFactory.Create(mariner);
 
         using var lua = _luaEngine.CreateContext();
 
-        // 1. Resolve require() modules from the catalogue's cached source.
+        // 1. Resolve require() modules from the pre-loaded snapshot.
         //    Normalise the module name here (MoonSharp may pass it bare or with
         //    a .lua extension) so each catalogue need not repeat the logic.
         lua.SetModuleLoader(moduleName =>
@@ -162,16 +194,18 @@ public sealed class LuaRuleExecutor : ILuaVectorRuleExecutor
             var fileName = moduleName.EndsWith(".lua", StringComparison.OrdinalIgnoreCase)
                 ? moduleName
                 : $"{moduleName}.lua";
-            return _source.GetLuaSource(fileName);
+            return luaSources.TryGetValue(fileName, out var src) ? src : null;
         });
 
         // 2. Register the product's Host* functions.
         provider.RegisterHostFunctions(lua);
 
         // 3. Load main.lua (which require()s the S-100 scripting framework).
-        var mainSource = _source.GetLuaSource("main.lua")
-            ?? throw new InvalidOperationException(
+        if (!luaSources.TryGetValue("main.lua", out var mainSource))
+        {
+            throw new InvalidOperationException(
                 $"{_productTag} portrayal catalogue is missing required rule file 'main.lua'.");
+        }
         ExecuteScript(lua, mainSource, "main.lua");
 
         // 4. Run the provider's post-load shims/patches, in order.

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/VectorPipeline.cs
@@ -36,7 +36,7 @@ public class VectorPipeline
         _luaExecutor = luaExecutor;
     }
 
-    public Task<IVectorLayer> ProcessAsync(
+    public async Task<IVectorLayer> ProcessAsync(
         IFeatureXmlSource source,
         IVectorPortrayalCatalogue catalogue,
         Viewport? viewport = null,
@@ -64,7 +64,7 @@ public class VectorPipeline
             // display-list assembly; its internal telemetry spans cover those
             // sub-stages. It is render-bound, so it is constructed per call.
             var xsltExecutor = new XsltRuleExecutor(source, catalogue, viewport);
-            var instructions = xsltExecutor.Execute(marinerSettings, cancellationToken).ToList();
+            var instructions = (await xsltExecutor.ExecuteAsync(marinerSettings, cancellationToken).ConfigureAwait(false)).ToList();
             activity?.SetTag("s100.pipeline.feature_types.count", xsltExecutor.LastFeatureTypeCount);
             activity?.SetTag("s100.pipeline.rules.count", xsltExecutor.LastRuleCount);
 
@@ -76,7 +76,7 @@ public class VectorPipeline
                 using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.lua"))
                 {
                     var stageStart = Stopwatch.GetTimestamp();
-                    instructions.AddRange(_luaExecutor.Execute(marinerSettings, cancellationToken));
+                    instructions.AddRange(await _luaExecutor.ExecuteAsync(marinerSettings, cancellationToken).ConfigureAwait(false));
                     RecordStageDuration(stageStart, "lua");
                     PipelineMetrics.StageInstructionsCount.Record(
                         instructions.Count,
@@ -116,7 +116,7 @@ public class VectorPipeline
                 Instructions = sorted,
             };
 
-            return Task.FromResult(layer);
+            return layer;
         }
         catch
         {

--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Xslt/XsltRuleExecutor.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Xslt/XsltRuleExecutor.cs
@@ -74,7 +74,7 @@ public sealed class XsltRuleExecutor : IVectorRuleExecutor
 
     /// <inheritdoc />
     /// <remarks>The <paramref name="mariner"/> argument is ignored; see the type remarks.</remarks>
-    public IReadOnlyList<DrawingInstruction> Execute(MarinerSettings mariner, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<DrawingInstruction>> ExecuteAsync(MarinerSettings mariner, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var stageTag = new KeyValuePair<string, object?>(TelemetryTags.PipelineStage, "vector");
@@ -112,7 +112,7 @@ public sealed class XsltRuleExecutor : IVectorRuleExecutor
         using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.xslt"))
         {
             var stageStart = Stopwatch.GetTimestamp();
-            drawingInstructionsDoc = RunXsltRules(featureDoc, applicableRules, _catalogue, _viewport, cancellationToken);
+            drawingInstructionsDoc = await RunXsltRulesAsync(featureDoc, applicableRules, _catalogue, _viewport, cancellationToken).ConfigureAwait(false);
             RecordStageDuration(stageStart, "xslt");
         }
 
@@ -156,7 +156,7 @@ public sealed class XsltRuleExecutor : IVectorRuleExecutor
 
     // ── Stage 3: XSLT transformation ───────────────────────────────────
 
-    private static XDocument RunXsltRules(
+    private static async Task<XDocument> RunXsltRulesAsync(
         XDocument featureDoc,
         IReadOnlyList<PortrayalRule> rules,
         IVectorPortrayalCatalogue catalogue,
@@ -196,7 +196,7 @@ public sealed class XsltRuleExecutor : IVectorRuleExecutor
                 args.AddParam("displayScale", string.Empty, viewport.ScaleDenominator);
             }
 
-            var transform = catalogue.GetCompiledRule(rule.Name);
+            var transform = await catalogue.GetCompiledRuleAsync(rule.Name, cancellationToken).ConfigureAwait(false);
             var resultFragment = new XDocument();
 
             var transformStart = Stopwatch.GetTimestamp();

--- a/src/EncDotNet.S100.Datasets.Pipelines/AssetSourceHelpers.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/AssetSourceHelpers.cs
@@ -23,11 +23,19 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 internal static class AssetSourceHelpers
 {
     /// <summary>
-    /// Opens <paramref name="relativePath"/> from <paramref name="source"/>
-    /// and returns a seekable stream positioned at the start. Non-seekable
-    /// streams (e.g. <c>ZipArchiveEntry.Open()</c>) are copied into a
-    /// <see cref="MemoryStream"/>; the original stream is disposed.
+    /// Opens <paramref name="relativePath"/> from <paramml="source"/>
+    /// synchronously and returns a seekable stream positioned at the start.
+    /// Prefer <see cref="OpenSeekableAsync"/> on new code paths.
     /// </summary>
+    /// <remarks>
+    /// SYNC BRIDGE: this helper exists because the per-spec dataset
+    /// processor constructors (S-101, S-102, ..., S-421) are synchronous —
+    /// their underlying parsers don't expose async loading. Open is a
+    /// one-shot cost paid once per dataset, not in the render hot path,
+    /// and <see cref="IAssetSource.OpenAsync"/> for <c>FileSystemAssetSource</c>
+    /// / <c>ZipAssetSource</c> is effectively synchronous (memory-backed
+    /// reads, no network I/O), so the awaiter-result bridge is bounded.
+    /// </remarks>
     public static Stream OpenSeekable(
         IAssetSource source,
         string relativePath,
@@ -46,6 +54,39 @@ internal static class AssetSourceHelpers
         {
             var buffer = new MemoryStream();
             stream.CopyTo(buffer);
+            buffer.Position = 0;
+            return buffer;
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Opens <paramref name="relativePath"/> from <paramref name="source"/>
+    /// and returns a seekable stream positioned at the start. Non-seekable
+    /// streams (e.g. <c>ZipArchiveEntry.Open()</c>) are copied into a
+    /// <see cref="MemoryStream"/>; the original stream is disposed.
+    /// </summary>
+    public static async Task<Stream> OpenSeekableAsync(
+        IAssetSource source,
+        string relativePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        var stream = await source.OpenAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        if (stream.CanSeek)
+        {
+            return stream;
+        }
+
+        try
+        {
+            var buffer = new MemoryStream();
+            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
             buffer.Position = 0;
             return buffer;
         }

--- a/src/EncDotNet.S100.Datasets.Pipelines/CataloguePreWarm.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/CataloguePreWarm.cs
@@ -1,0 +1,124 @@
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Pre-warms catalogue assets referenced by a list of drawing instructions
+/// so the synchronous Skia / Mapsui renderer's resolver lambdas can read
+/// from in-memory dicts without async I/O.
+/// </summary>
+/// <remarks>
+/// Walks <see cref="DrawingInstruction"/> subtypes for unique
+/// <c>SymbolReference</c> / <c>LineStyleReference</c> / <c>AreaFillReference</c>
+/// / <c>OutlineStyleReference</c> names, awaits each catalogue
+/// <c>Get*Async</c> call, and stores the result (or null on
+/// <see cref="KeyNotFoundException"/>) in the returned dicts. Renderer
+/// callers then close over those dicts in their sync resolver lambdas.
+/// </remarks>
+internal static class CataloguePreWarm
+{
+    /// <summary>
+    /// Pre-warms every symbol / line-style / area-fill referenced by the
+    /// given instruction list against <paramref name="catalogue"/>.
+    /// </summary>
+    public static async Task<PreWarmResult> ForInstructionsAsync(
+        IPortrayalAssetSource catalogue,
+        IReadOnlyList<DrawingInstruction> instructions,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+        ArgumentNullException.ThrowIfNull(instructions);
+
+        var symbolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var lineNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var areaNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var ins in instructions)
+        {
+            switch (ins)
+            {
+                case PointInstruction p when !string.IsNullOrEmpty(p.SymbolReference):
+                    symbolNames.Add(p.SymbolReference);
+                    break;
+                case LineInstruction l when !string.IsNullOrEmpty(l.LineStyleReference):
+                    lineNames.Add(l.LineStyleReference);
+                    break;
+                case AreaInstruction a:
+                    if (!string.IsNullOrEmpty(a.AreaFillReference))
+                        areaNames.Add(a.AreaFillReference);
+                    if (!string.IsNullOrEmpty(a.OutlineStyleReference))
+                        lineNames.Add(a.OutlineStyleReference);
+                    break;
+            }
+        }
+
+        var symbols = new Dictionary<string, SvgSymbol?>(symbolNames.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in symbolNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try { symbols[name] = await catalogue.GetSymbolAsync(name, cancellationToken).ConfigureAwait(false); }
+            // Catch generously: a missing or malformed catalogue asset must
+            // never block a render — the renderer treats null the same as
+            // "not in catalogue" (the pre-PR-async behaviour).
+            catch (Exception) { symbols[name] = null; }
+        }
+
+        var lineStyles = new Dictionary<string, LineStyle?>(lineNames.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in lineNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try { lineStyles[name] = await catalogue.GetLineStyleAsync(name, cancellationToken).ConfigureAwait(false); }
+            catch (Exception) { lineStyles[name] = null; }
+        }
+
+        var areaFills = new Dictionary<string, AreaFill?>(areaNames.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in areaNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try { areaFills[name] = await catalogue.GetAreaFillAsync(name, cancellationToken).ConfigureAwait(false); }
+            catch (Exception) { areaFills[name] = null; }
+        }
+
+        // Second-order pre-warm: pattern-fill area definitions reference
+        // an SVG symbol via AreaFill.PatternSymbol that the renderer pulls
+        // through the same SymbolProvider lambda. Walk every loaded
+        // AreaFill for a non-empty PatternSymbol and pre-fetch it.
+        foreach (var fill in areaFills.Values)
+        {
+            if (fill?.PatternSymbol is { Length: > 0 } sym && !symbols.ContainsKey(sym))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try { symbols[sym] = await catalogue.GetSymbolAsync(sym, cancellationToken).ConfigureAwait(false); }
+                catch (Exception) { symbols[sym] = null; }
+            }
+        }
+
+        return new PreWarmResult(symbols, lineStyles, areaFills);
+    }
+
+    /// <summary>
+    /// The outcome of a pre-warm pass: lookup-by-name dicts for symbols,
+    /// line styles, and area fills (null entries indicate "not in catalogue").
+    /// </summary>
+    public sealed record PreWarmResult(
+        IReadOnlyDictionary<string, SvgSymbol?> Symbols,
+        IReadOnlyDictionary<string, LineStyle?> LineStyles,
+        IReadOnlyDictionary<string, AreaFill?> AreaFills)
+    {
+        /// <summary>Sync resolver returning SVG content for the given symbol name, or null.</summary>
+        public string? ResolveSymbolSvg(string name)
+            => Symbols.TryGetValue(name, out var s) ? s?.SvgContent : null;
+
+        /// <summary>Sync resolver returning the symbol record for the given name, or null.</summary>
+        public SvgSymbol? ResolveSymbol(string name)
+            => Symbols.TryGetValue(name, out var s) ? s : null;
+
+        /// <summary>Sync resolver returning the line style for the given name, or null.</summary>
+        public LineStyle? ResolveLineStyle(string name)
+            => LineStyles.TryGetValue(name, out var s) ? s : null;
+
+        /// <summary>Sync resolver returning the area fill for the given name, or null.</summary>
+        public AreaFill? ResolveAreaFill(string name)
+            => AreaFills.TryGetValue(name, out var s) ? s : null;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -441,17 +441,6 @@ public sealed class DatasetPipelineFactory
     }
 
     /// <summary>
-    /// Convenience method: creates a processor and renders with default context.
-    /// </summary>
-    /// <remarks>
-    /// This synchronous facade blocks on the async render path; it is intended
-    /// for batch / CLI callers that have no synchronization context. UI callers
-    /// should await <see cref="IDatasetProcessor.RenderAsync"/> directly.
-    /// </remarks>
-    public DatasetResult Process(string path) =>
-        CreateProcessor(path).RenderAsync().GetAwaiter().GetResult();
-
-    /// <summary>
     /// Creates a processor for a dataset stored inside <paramref name="source"/>
     /// at <paramref name="relativePath"/>. Used by exchange-set bulk loading
     /// where dataset bytes may live inside a ZIP archive.

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -144,7 +144,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
 
         var catalogue = _catalogue;
         context?.EcdisDisplay?.ApplyTo(catalogue);
-        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         var featureSource = CreateFeatureXmlSource();
         var pipeline = new PortrayalPipeline();
@@ -155,6 +155,8 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
         Console.WriteLine($"[{Spec.Name.Replace("-", "")}] {_fileName}: {Features.Count} features, "
             + $"{instructions.Count} drawing instructions");
 
+        var prewarm = await CataloguePreWarm.ForInstructionsAsync(catalogue, instructions, cancellationToken).ConfigureAwait(false);
+
         var renderer = new MapsuiDisplayListRenderer
         {
             LayerName = $"{Spec.Name}: {_fileName}",
@@ -163,21 +165,9 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
             AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
-            SymbolProvider = symbolName =>
-            {
-                try { return catalogue.GetSymbol(symbolName).SvgContent; }
-                catch { return null; }
-            },
-            AreaFillProvider = fillName =>
-            {
-                try { return catalogue.GetAreaFill(fillName); }
-                catch { return null; }
-            },
-            LineStyleProvider = name =>
-            {
-                try { return catalogue.GetLineStyle(name); }
-                catch { return null; }
-            },
+            SymbolProvider = name => prewarm.ResolveSymbolSvg(name),
+            AreaFillProvider = name => prewarm.ResolveAreaFill(name),
+            LineStyleProvider = name => prewarm.ResolveLineStyle(name),
         };
 
         var geometryProvider = new GmlFeatureGeometryProvider<TFeature>(Features);
@@ -264,7 +254,7 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
 
         var catalogue = _catalogue;
         context?.EcdisDisplay?.ApplyTo(catalogue);
-        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         var featureSource = CreateFeatureXmlSource();
         var pipeline = new PortrayalPipeline();
@@ -272,32 +262,22 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IHe
             .ConfigureAwait(false);
         var instructions = PostProcessInstructions(((IVectorLayer)portrayalLayer).Instructions);
 
+        var prewarm = await CataloguePreWarm.ForInstructionsAsync(catalogue, instructions, cancellationToken).ConfigureAwait(false);
+
         var geometryProvider = new GmlFeatureGeometryProvider<TFeature>(Features);
 
         return HeadlessVectorRenderer.Render(
             instructions,
             geometryProvider,
             catalogue.ActivePalette,
-            symbolProvider: name =>
-            {
-                try { return catalogue.GetSymbol(name).SvgContent; }
-                catch { return null; }
-            },
-            lineStyleProvider: name =>
-            {
-                try { return catalogue.GetLineStyle(name); }
-                catch { return null; }
-            },
+            symbolProvider: name => prewarm.ResolveSymbolSvg(name),
+            lineStyleProvider: name => prewarm.ResolveLineStyle(name),
             symbolScale: context?.SymbolScale ?? 1.0,
             textScale: context?.TextScale ?? 1.0,
             widthPixels: widthPixels,
             heightPixels: heightPixels,
             background: bg,
-            areaFillProvider: name =>
-            {
-                try { return catalogue.GetAreaFill(name); }
-                catch { return null; }
-            },
+            areaFillProvider: name => prewarm.ResolveAreaFill(name),
             hiddenCategories: context?.HiddenInstructionCategories
                 ?? DrawingInstructionCategory.None);
     }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -436,7 +436,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
                     "S-101 feature catalogue is required to render the dataset but none was provided.");
 
             var s101Cat = _catalogue;
-            s101Cat.SwitchPalette(context?.Palette ?? PaletteType.Day);
+            await s101Cat.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
             (context?.EcdisDisplay ?? UnfilteredEcdisDisplay).ApplyTo(s101Cat);
             var palette = s101Cat.ActivePalette;
 
@@ -450,30 +450,20 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
 
             var geometryProvider = new S101FeatureGeometryProvider(_dataset);
 
+            var prewarm = await CataloguePreWarm.ForInstructionsAsync(s101Cat, prepared, cancellationToken).ConfigureAwait(false);
+
             return HeadlessVectorRenderer.Render(
                 prepared,
                 geometryProvider,
                 palette,
-                symbolProvider: name =>
-                {
-                    try { return s101Cat.GetSymbol(name).SvgContent; }
-                    catch { return null; }
-                },
-                lineStyleProvider: name =>
-                {
-                    try { return s101Cat.GetLineStyle(name); }
-                    catch { return null; }
-                },
+                symbolProvider: name => prewarm.ResolveSymbolSvg(name),
+                lineStyleProvider: name => prewarm.ResolveLineStyle(name),
                 symbolScale: context?.SymbolScale ?? 1.0,
                 textScale: context?.TextScale ?? 1.0,
                 widthPixels: widthPixels,
                 heightPixels: heightPixels,
                 background: background ?? new RgbaColor(255, 255, 255, 255),
-                areaFillProvider: name =>
-                {
-                    try { return s101Cat.GetAreaFill(name); }
-                    catch { return null; }
-                },
+                areaFillProvider: name => prewarm.ResolveAreaFill(name),
                 hiddenCategories: context?.HiddenInstructionCategories
                     ?? DrawingInstructionCategory.None);
         }
@@ -497,7 +487,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         // pipeline runs so XSLT rules (if any) see the active colour profile.
         var s101Cat = _catalogue;
         var paletteType = context?.Palette ?? PaletteType.Day;
-        s101Cat.SwitchPalette(paletteType);
+        await s101Cat.SwitchPaletteAsync(paletteType, cancellationToken).ConfigureAwait(false);
 
         // Normalize null ECDIS display to the canonical unfiltered state
         // and always apply it, so the catalogue's display-mode / viewing-
@@ -531,23 +521,19 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
             // portrayal-content hash (dataset + FC/PC content + assemblies) into
             // the per-render cacheKey so it self-invalidates on any change.
             var instructionKey = $"{await GetPortrayalContentHashAsync(cancellationToken).ConfigureAwait(false)}|{cacheKey}";
-            prepared = _instructionCache.GetOrCompute(instructionKey, () =>
+            prepared = await _instructionCache.GetOrComputeAsync(instructionKey, async ct =>
             {
                 // Drive the unified VectorPipeline with the S-101 Lua rule
                 // executor (Part 9A). XSLT rules in the S-101 catalogue (if
-                // any) are also honoured by the pipeline. Run synchronously
-                // inside the (synchronous) cache factory: the render gate
-                // already serializes this work and no UI sync context is
-                // captured on this path (the pipeline uses ConfigureAwait(false)
-                // throughout).
+                // any) are also honoured by the pipeline.
                 var executor = new S101LuaRuleExecutor(_luaEngine, _dataset, s101Cat, fc);
                 var featureSource = new S101FeatureXmlSource(_dataset);
                 var pipeline = new PortrayalPipeline(executor);
-                var portrayalLayer = pipeline
-                    .ProcessAsync(featureSource, s101Cat, mariner: mariner, cancellationToken: cancellationToken)
-                    .GetAwaiter().GetResult();
+                var portrayalLayer = await pipeline
+                    .ProcessAsync(featureSource, s101Cat, mariner: mariner, cancellationToken: ct)
+                    .ConfigureAwait(false);
                 return ((IVectorLayer)portrayalLayer).Instructions;
-            });
+            }, cancellationToken).ConfigureAwait(false);
             _cachedPortrayalKey = cacheKey;
             _cachedPortrayalInstructions = prepared;
             PortrayalCacheMisses++;
@@ -576,9 +562,11 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         // constant within this processor).
         var patternClipKey = $"{_patternClipScope}|{await GetPortrayalContentHashAsync(cancellationToken).ConfigureAwait(false)}|{cacheKey}";
 
-        var areaLayer = CreateRenderer(s101Cat, palette, context, suffix: "areas", patternClipCacheKey: patternClipKey)
+        var prewarm = await CataloguePreWarm.ForInstructionsAsync(s101Cat, prepared, cancellationToken).ConfigureAwait(false);
+
+        var areaLayer = CreateRenderer(s101Cat, palette, context, suffix: "areas", patternClipCacheKey: patternClipKey, prewarm: prewarm)
             .Render(areaInstructions, geometryProvider);
-        var lineLayer = CreateRenderer(s101Cat, palette, context, suffix: "lines", patternClipCacheKey: null)
+        var lineLayer = CreateRenderer(s101Cat, palette, context, suffix: "lines", patternClipCacheKey: null, prewarm: prewarm)
             .Render(otherInstructions, geometryProvider);
 
         // PR-L2 R-101-102-B: tag every Mapsui IFeature with its S-101
@@ -833,7 +821,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         ColorPalette palette,
         RenderContext? context,
         string suffix,
-        string? patternClipCacheKey)
+        string? patternClipCacheKey,
+        CataloguePreWarm.PreWarmResult prewarm)
     {
         return new MapsuiDisplayListRenderer
         {
@@ -847,34 +836,9 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
             PatternClipCacheKey = patternClipCacheKey,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
-            SymbolProvider = symbolName =>
-            {
-                try
-                {
-                    var svg = catalogue.GetSymbol(symbolName);
-                    return svg.SvgContent;
-                }
-                catch
-                {
-                    return null;
-                }
-            },
-            AreaFillProvider = fillName =>
-            {
-                try
-                {
-                    return catalogue.GetAreaFill(fillName);
-                }
-                catch
-                {
-                    return null;
-                }
-            },
-            LineStyleProvider = name =>
-            {
-                try { return catalogue.GetLineStyle(name); }
-                catch { return null; }
-            },
+            SymbolProvider = name => prewarm.ResolveSymbolSvg(name),
+            AreaFillProvider = name => prewarm.ResolveAreaFill(name),
+            LineStyleProvider = name => prewarm.ResolveLineStyle(name),
         };
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -121,7 +121,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await _catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
         var metadata = _source.Metadata;
 
         var viewport = new EncDotNet.S100.Pipelines.Viewport
@@ -196,7 +196,7 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
         cancellationToken.ThrowIfCancellationRequested();
 
-        _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await _catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         var styledLayer = (StyledCoverageLayer)await _pipeline
             .ProcessAsync(_source, _catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)

--- a/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S104DatasetProcessor.cs
@@ -153,7 +153,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
     {
         var source = _source!;
         var catalogue = _catalogue!;
-        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         DateTime selectedTime;
         if (context is S104RenderContext { TimeStep: { } timeStep })
@@ -257,7 +257,7 @@ public sealed class S104DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
 
         var source = _source;
         var catalogue = _catalogue!;
-        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         if (context is S104RenderContext { TimeStep: { } timeStep })
             source.SelectTime(timeStep);

--- a/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S111DatasetProcessor.cs
@@ -171,7 +171,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
 
         if (_stationSeries is not null)
         {
-            return RenderStationSeries(_stationSeries, context);
+            return await RenderStationSeriesAsync(_stationSeries, context, cancellationToken).ConfigureAwait(false);
         }
         return await RenderGriddedAsync(context, cancellationToken).ConfigureAwait(false);
     }
@@ -181,7 +181,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         var source = _source!;
         var catalogue = _catalogue!;
         var provider = _provider!;
-        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         DateTime selectedTime;
         if (context is S111RenderContext { TimeStep: { } timeStep })
@@ -221,21 +221,18 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         // removed because it obscured the base chart.
         var layers = new List<ILayer>();
 
+        // NOTE: pre-warm every catalogue symbol so the synchronous Mapsui
+        // arrow renderer's SymbolProvider lambda reads from a memory dict.
+        // The symbol set is small (one entry per S-111 speed band).
+        var symbolSvgs = await PreWarmProviderSymbolsAsync(provider, cancellationToken).ConfigureAwait(false);
+
         var arrowRenderer = new MapsuiCoverageArrowRenderer(_crsTransformFactory)
         {
             LayerName = $"S-111 Arrows: {_fileName}",
             Palette = catalogue.ActivePalette,
             BaseSymbolScale = context?.SymbolScale ?? 1.0,
             SymbolProvider = symbolName =>
-            {
-                var item = provider.Catalogue.Symbols
-                    .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase));
-                if (item is null) return null;
-
-                using var stream = provider.FetchAssetAsync(item, "Symbols").GetAwaiter().GetResult();
-                using var reader = new StreamReader(stream);
-                return reader.ReadToEnd();
-            },
+                symbolSvgs.TryGetValue(symbolName, out var svg) ? svg : null,
         };
         var arrowLayer = arrowRenderer.Render(styledLayer, viewport);
         MRect extent;
@@ -323,7 +320,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         var source = _source;
         var catalogue = _catalogue;
         var provider = _provider;
-        catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+        await catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
 
         if (context is S111RenderContext { TimeStep: { } timeStep })
             source.SelectTime(timeStep);
@@ -334,20 +331,14 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
             .ProcessAsync(source, catalogue, context?.Mariner ?? MarinerSettings.Default, cancellationToken)
             .ConfigureAwait(false);
 
+        var symbolSvgs = await PreWarmProviderSymbolsAsync(provider, cancellationToken).ConfigureAwait(false);
+
         var arrowRenderer = new SkiaCoverageArrowRenderer
         {
             Palette = catalogue.ActivePalette,
             BaseSymbolScale = context?.SymbolScale ?? 1.0,
             SymbolProvider = symbolName =>
-            {
-                var item = provider.Catalogue.Symbols
-                    .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase));
-                if (item is null) return null;
-
-                using var stream = provider.FetchAssetAsync(item, "Symbols").GetAwaiter().GetResult();
-                using var reader = new StreamReader(stream);
-                return reader.ReadToEnd();
-            },
+                symbolSvgs.TryGetValue(symbolName, out var svg) ? svg : null,
         };
 
         var nativeToWgs84 = _crsTransformFactory.Create(
@@ -397,7 +388,7 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
     /// table; otherwise (DCF 8) a hardcoded palette is used.
     /// Rebuilt per <see cref="S111RenderContext.TimeStep"/>.
     /// </summary>
-    private DatasetResult RenderStationSeries(S111StationSeriesDataset ds, RenderContext? context)
+    private async Task<DatasetResult> RenderStationSeriesAsync(S111StationSeriesDataset ds, RenderContext? context, CancellationToken cancellationToken)
     {
         DateTime selectedTime;
         if (context is S111RenderContext { TimeStep: { } timeStep })
@@ -415,13 +406,15 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
         CoverageColorScheme? colorScheme = null;
         CoverageSymbolScheme? symbolScheme = null;
         Dictionary<string, string>? svgCache = null;
+        Dictionary<string, string>? prewarmedSvgs = null;
         if (_catalogue is not null && _provider is not null)
         {
-            _catalogue.SwitchPalette(context?.Palette ?? PaletteType.Day);
+            await _catalogue.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
             var mariner = context?.Mariner ?? MarinerSettings.Default;
             colorScheme = _catalogue.ResolveColorScheme(mariner);
             symbolScheme = _catalogue.ResolveSymbolScheme(mariner);
             svgCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            prewarmedSvgs = await PreWarmProviderSymbolsAsync(_provider, cancellationToken).ConfigureAwait(false);
         }
 
         var nativeToMerc = _crsTransformFactory.Create($"EPSG:{ds.HorizontalCRS ?? 4326}", "EPSG:3857");
@@ -507,13 +500,8 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
                 {
                     if (!svgCache.TryGetValue(symbolRef, out svgSource))
                     {
-                        var item = _provider.Catalogue.Symbols
-                            .FirstOrDefault(s => s.Id.Equals(symbolRef, StringComparison.OrdinalIgnoreCase));
-                        if (item is not null)
+                        if (prewarmedSvgs is not null && prewarmedSvgs.TryGetValue(symbolRef, out var rawSvg))
                         {
-                            using var stream = _provider.FetchAssetAsync(item, "Symbols").GetAwaiter().GetResult();
-                            using var reader = new StreamReader(stream);
-                            var rawSvg = reader.ReadToEnd();
                             // Process SVG through palette color resolver and
                             // wrap with the svg-content:// URI scheme that
                             // Mapsui's ImageStyle expects.
@@ -1096,5 +1084,33 @@ public sealed class S111DatasetProcessor : IDatasetProcessor, IHeadlessImageRend
             ImmutableArray.Create(finding),
             RulesEvaluated: 1,
             RulesWithFindings: 1);
+    }
+
+    /// <summary>
+    /// Pre-warms every symbol declared by the given portrayal catalogue
+    /// provider into a name → SVG-content dict so the synchronous arrow
+    /// renderer's <c>SymbolProvider</c> lambda can resolve symbols without
+    /// async I/O. Bounded to the catalogue's symbol manifest, which is small.
+    /// </summary>
+    private static async Task<Dictionary<string, string>> PreWarmProviderSymbolsAsync(
+        PortrayalCatalogueProvider provider, CancellationToken cancellationToken)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in provider.Catalogue.Symbols)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                using var stream = await provider.FetchAssetAsync(item, "Symbols", cancellationToken).ConfigureAwait(false);
+                using var reader = new StreamReader(stream);
+                dict[item.Id] = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Skip symbols that fail to load; the renderer treats missing
+                // entries the same as before — no symbol rendered for that name.
+            }
+        }
+        return dict;
     }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -128,7 +128,7 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
 
         // Set up palette
         var paletteType = context?.Palette ?? PaletteType.Day;
-        _catalogue.SwitchPalette(paletteType);
+        await _catalogue.SwitchPaletteAsync(paletteType, cancellationToken).ConfigureAwait(false);
         context?.EcdisDisplay?.ApplyTo(_catalogue);
         var palette = _catalogue.ActivePalette;
 
@@ -144,6 +144,8 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
             .ConfigureAwait(false);
         var prepared = ((IVectorLayer)portrayalLayer).Instructions;
 
+        var prewarm = await CataloguePreWarm.ForInstructionsAsync(_catalogue, prepared, cancellationToken).ConfigureAwait(false);
+
         // Render to Mapsui layer
         var vectorRenderer = new MapsuiDisplayListRenderer
         {
@@ -153,21 +155,9 @@ public sealed class S131DatasetProcessor : IDatasetProcessor
             AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
-            SymbolProvider = symbolName =>
-            {
-                try { return _catalogue.GetSymbol(symbolName).SvgContent; }
-                catch { return null; }
-            },
-            AreaFillProvider = fillName =>
-            {
-                try { return _catalogue.GetAreaFill(fillName); }
-                catch { return null; }
-            },
-            LineStyleProvider = name =>
-            {
-                try { return _catalogue.GetLineStyle(name); }
-                catch { return null; }
-            },
+            SymbolProvider = name => prewarm.ResolveSymbolSvg(name),
+            AreaFillProvider = name => prewarm.ResolveAreaFill(name),
+            LineStyleProvider = name => prewarm.ResolveLineStyle(name),
         };
 
         var geometryProvider = new GmlFeatureGeometryProvider<S131Feature>(_dataset.Features);

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -136,7 +136,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IHeadlessImageRende
 
         var s101Cat = _catalogue;
         var paletteType = context?.Palette ?? PaletteType.Day;
-        s101Cat.SwitchPalette(paletteType);
+        await s101Cat.SwitchPaletteAsync(paletteType, cancellationToken).ConfigureAwait(false);
         var palette = s101Cat.ActivePalette;
 
         var executor = new S101LuaRuleExecutor(_luaEngine, _translatedDataset, s101Cat, fc);
@@ -147,6 +147,8 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IHeadlessImageRende
         var prepared = ((IVectorLayer)portrayalLayer).Instructions;
         Console.WriteLine($"[S57] Pipeline produced {prepared.Count} drawing instructions");
 
+        var prewarm = await CataloguePreWarm.ForInstructionsAsync(s101Cat, prepared, cancellationToken).ConfigureAwait(false);
+
         var vectorRenderer = new MapsuiDisplayListRenderer
         {
             LayerName = $"S-57: {_fileName}",
@@ -155,21 +157,9 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IHeadlessImageRende
             AssetCache = _renderAssetCache,
             SymbolScale = context?.SymbolScale ?? 1.0,
             TextScale = context?.TextScale ?? 1.0,
-            SymbolProvider = symbolName =>
-            {
-                try { return s101Cat.GetSymbol(symbolName).SvgContent; }
-                catch { return null; }
-            },
-            AreaFillProvider = fillName =>
-            {
-                try { return s101Cat.GetAreaFill(fillName); }
-                catch { return null; }
-            },
-            LineStyleProvider = name =>
-            {
-                try { return s101Cat.GetLineStyle(name); }
-                catch { return null; }
-            },
+            SymbolProvider = name => prewarm.ResolveSymbolSvg(name),
+            AreaFillProvider = name => prewarm.ResolveAreaFill(name),
+            LineStyleProvider = name => prewarm.ResolveLineStyle(name),
         };
         var geometryProvider = new S101FeatureGeometryProvider(_translatedDataset);
         var mapLayer = vectorRenderer.Render(prepared, geometryProvider);
@@ -355,7 +345,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IHeadlessImageRende
                     "S-101 feature catalogue is required to render S-57 datasets but none was provided.");
 
             var s101Cat = _catalogue;
-            s101Cat.SwitchPalette(context?.Palette ?? PaletteType.Day);
+            await s101Cat.SwitchPaletteAsync(context?.Palette ?? PaletteType.Day, cancellationToken).ConfigureAwait(false);
             var palette = s101Cat.ActivePalette;
 
             var executor = new S101LuaRuleExecutor(_luaEngine, _translatedDataset, s101Cat, fc);
@@ -368,30 +358,20 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IHeadlessImageRende
 
             var geometryProvider = new S101FeatureGeometryProvider(_translatedDataset);
 
+            var prewarm = await CataloguePreWarm.ForInstructionsAsync(s101Cat, prepared, cancellationToken).ConfigureAwait(false);
+
             return HeadlessVectorRenderer.Render(
                 prepared,
                 geometryProvider,
                 palette,
-                symbolProvider: name =>
-                {
-                    try { return s101Cat.GetSymbol(name).SvgContent; }
-                    catch { return null; }
-                },
-                lineStyleProvider: name =>
-                {
-                    try { return s101Cat.GetLineStyle(name); }
-                    catch { return null; }
-                },
+                symbolProvider: name => prewarm.ResolveSymbolSvg(name),
+                lineStyleProvider: name => prewarm.ResolveLineStyle(name),
                 symbolScale: context?.SymbolScale ?? 1.0,
                 textScale: context?.TextScale ?? 1.0,
                 widthPixels: widthPixels,
                 heightPixels: heightPixels,
                 background: background ?? new RgbaColor(255, 255, 255, 255),
-                areaFillProvider: name =>
-                {
-                    try { return s101Cat.GetAreaFill(name); }
-                    catch { return null; }
-                },
+                areaFillProvider: name => prewarm.ResolveAreaFill(name),
                 hiddenCategories: context?.HiddenInstructionCategories
                     ?? DrawingInstructionCategory.None);
         }

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaRuleExecutor.cs
@@ -51,14 +51,14 @@ public sealed class S101LuaRuleExecutor : ILuaVectorRuleExecutor
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<DrawingInstruction> Execute(
+    public Task<IReadOnlyList<DrawingInstruction>> ExecuteAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default)
-        => _inner.Execute(mariner, cancellationToken);
+        => _inner.ExecuteAsync(mariner, cancellationToken);
 
     /// <inheritdoc/>
-    public IReadOnlyList<EmittedInstruction> ExecuteRaw(
+    public Task<IReadOnlyList<EmittedInstruction>> ExecuteRawAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default)
-        => _inner.ExecuteRaw(mariner, cancellationToken);
+        => _inner.ExecuteRawAsync(mariner, cancellationToken);
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -57,9 +57,10 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     public CatalogueRef? CatalogueRef => _provider.Catalogue.CatalogueRef;
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
-    public void SwitchPalette(PaletteType type)
+    /// <inheritdoc/>
+    public async ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
-        EnsurePalettesLoaded();
+        await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         if (!_cache.Palettes.TryGetValue(type, out var palette))
         {
@@ -79,7 +80,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── Palettes ───────────────────────────────────────────────────────
 
-    private void EnsurePalettesLoaded()
+    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
     {
         if (_cache.PalettesLoaded)
         {
@@ -93,6 +94,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var paletteName = item.Description.Name;
             if (string.IsNullOrEmpty(paletteName))
             {
@@ -111,7 +113,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
             {
                 try
                 {
-                    using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                    using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                     var palette = ColorProfileReader.Read(stream, paletteName);
                     _cache.Palettes[paletteType.Value] = palette;
                 }
@@ -130,7 +132,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
                     if (_cache.Palettes.ContainsKey(type)) continue;
                     try
                     {
-                        using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                        using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                         var palette = ColorProfileReader.Read(stream, name);
                         if (palette.Colors.Count > 0)
                         {
@@ -224,29 +226,40 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── XSLT ───────────────────────────────────────────────────────────
 
-    public XslCompiledTransform GetCompiledRule(string ruleName)
+    public ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default)
     {
         if (_cache.CompiledXslt.TryGetValue(ruleName, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Xslt);
-            return cached;
+            return new ValueTask<XslCompiledTransform>(cached);
         }
 
+        return new ValueTask<XslCompiledTransform>(LoadAndCacheXsltAsync(ruleName, cancellationToken));
+    }
+
+    private async Task<XslCompiledTransform> LoadAndCacheXsltAsync(string ruleName, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Xslt);
         var ruleFile = FindRuleFile(ruleName);
-        var transform = LoadXsltRule(ruleFile);
+        var transform = await LoadXsltRuleAsync(ruleFile, cancellationToken).ConfigureAwait(false);
         _cache.CompiledXslt[ruleName] = transform;
         return transform;
     }
 
-    private XslCompiledTransform LoadXsltRule(RuleFile ruleFile)
+    private async Task<XslCompiledTransform> LoadXsltRuleAsync(RuleFile ruleFile, CancellationToken cancellationToken)
     {
         using var activity = Diagnostics.Telemetry.ActivitySource.StartActivity("s100.xslt.compile");
         activity?.SetTag(TelemetryTags.XsltRule, ruleFile.Id);
         var start = Stopwatch.GetTimestamp();
 
-        using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
-        using var reader = XmlReader.Create(stream);
+        using var stream = await _provider.FetchAssetAsync(ruleFile, cancellationToken).ConfigureAwait(false);
+        // Buffer to memory so the synchronous XslCompiledTransform.Load can
+        // operate over a seekable stream without doing async I/O on the
+        // original asset stream.
+        using var buffered = new MemoryStream();
+        await stream.CopyToAsync(buffered, cancellationToken).ConfigureAwait(false);
+        buffered.Position = 0;
+        using var reader = XmlReader.Create(buffered);
 
         var transform = new XslCompiledTransform();
         transform.Load(reader);
@@ -271,6 +284,21 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     private IReadOnlyList<LuaContextParameter>? _contextParameters;
 
     /// <summary>
+    /// Returns every Lua rule file declared in the portrayal catalogue
+    /// manifest (filtered to <c>.lua</c> extension), e.g.
+    /// <c>main.lua</c>, <c>S100Scripting.lua</c>.
+    /// </summary>
+    public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default)
+    {
+        var names = _provider.Catalogue.RuleFiles
+            .Where(rf => Path.GetExtension(rf.FileName).Equals(".lua", StringComparison.OrdinalIgnoreCase))
+            .Select(rf => rf.FileName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return new ValueTask<IReadOnlyList<string>>(names);
+    }
+
+    /// <summary>
     /// Returns the raw Lua source for the given bare filename inside the
     /// portrayal catalogue's <c>Rules/</c> directory (e.g. <c>"main.lua"</c>,
     /// <c>"S100Scripting.lua"</c>), caching the decoded string so subsequent
@@ -289,24 +317,28 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     /// per execution to preserve sandbox isolation (S-100 Part 9A).
     /// </para>
     /// </remarks>
-    public string? GetLuaSource(string fileName)
+    public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(fileName);
 
         if (_cache.LuaSources.TryGetValue(fileName, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordLuaSourceHit(ProductTag);
-            return cached;
+            return new ValueTask<string?>(cached);
         }
 
+        return new ValueTask<string?>(LoadLuaSourceAsync(fileName, cancellationToken));
+    }
+
+    private async Task<string?> LoadLuaSourceAsync(string fileName, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordLuaSourceMiss(ProductTag);
         string? source;
         try
         {
-            using var stream = _provider.FetchRuleAsync(fileName)
-                .GetAwaiter().GetResult();
+            using var stream = await _provider.FetchRuleAsync(fileName, cancellationToken).ConfigureAwait(false);
             using var reader = new StreamReader(stream);
-            source = reader.ReadToEnd();
+            source = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -322,29 +354,34 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── Symbols ────────────────────────────────────────────────────────
 
-    public SvgSymbol GetSymbol(string symbolName)
+    public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default)
     {
         if (_cache.Symbols.TryGetValue(symbolName, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Svg);
-            return cached;
+            return new ValueTask<SvgSymbol>(cached);
         }
 
+        return new ValueTask<SvgSymbol>(LoadAndCacheSymbolAsync(symbolName, cancellationToken));
+    }
+
+    private async Task<SvgSymbol> LoadAndCacheSymbolAsync(string symbolName, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Svg);
-        var symbol = LoadSymbol(symbolName);
+        var symbol = await LoadSymbolAsync(symbolName, cancellationToken).ConfigureAwait(false);
         _cache.Symbols[symbolName] = symbol;
         return symbol;
     }
 
-    private SvgSymbol LoadSymbol(string symbolName)
+    private async Task<SvgSymbol> LoadSymbolAsync(string symbolName, CancellationToken cancellationToken)
     {
         var catalogItem = _provider.Catalogue.Symbols
             .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Symbol '{symbolName}' not found in the portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "Symbols").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "Symbols", cancellationToken).ConfigureAwait(false);
         using var reader = new StreamReader(stream);
-        var svgContent = reader.ReadToEnd();
+        var svgContent = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
 
         return new SvgSymbol
         {
@@ -355,53 +392,63 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── Line styles ────────────────────────────────────────────────────
 
-    public LineStyle GetLineStyle(string name)
+    public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default)
     {
         if (_cache.LineStyles.TryGetValue(name, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.LineStyle);
-            return cached;
+            return new ValueTask<LineStyle>(cached);
         }
 
+        return new ValueTask<LineStyle>(LoadAndCacheLineStyleAsync(name, cancellationToken));
+    }
+
+    private async Task<LineStyle> LoadAndCacheLineStyleAsync(string name, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.LineStyle);
-        var style = LoadLineStyle(name);
+        var style = await LoadLineStyleAsync(name, cancellationToken).ConfigureAwait(false);
         _cache.LineStyles[name] = style;
         return style;
     }
 
-    private LineStyle LoadLineStyle(string name)
+    private async Task<LineStyle> LoadLineStyleAsync(string name, CancellationToken cancellationToken)
     {
         var catalogItem = _provider.Catalogue.LineStyles
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Line style '{name}' not found in the portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "LineStyles").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "LineStyles", cancellationToken).ConfigureAwait(false);
         return LineStyleReader.Read(stream, name);
     }
 
     // ── Area fills ─────────────────────────────────────────────────────
 
-    public AreaFill GetAreaFill(string name)
+    public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default)
     {
         if (_cache.AreaFills.TryGetValue(name, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.AreaFill);
-            return cached;
+            return new ValueTask<AreaFill>(cached);
         }
 
+        return new ValueTask<AreaFill>(LoadAndCacheAreaFillAsync(name, cancellationToken));
+    }
+
+    private async Task<AreaFill> LoadAndCacheAreaFillAsync(string name, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.AreaFill);
-        var fill = LoadAreaFill(name);
+        var fill = await LoadAreaFillAsync(name, cancellationToken).ConfigureAwait(false);
         _cache.AreaFills[name] = fill;
         return fill;
     }
 
-    private AreaFill LoadAreaFill(string name)
+    private async Task<AreaFill> LoadAreaFillAsync(string name, CancellationToken cancellationToken)
     {
         var catalogItem = _provider.Catalogue.AreaFills
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Area fill '{name}' not found in the portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "AreaFills").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "AreaFills", cancellationToken).ConfigureAwait(false);
         return AreaFillReader.Read(stream, name);
     }
 

--- a/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
@@ -77,9 +77,9 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
 
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
-    public void SwitchPalette(PaletteType type)
+    public async ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
-        EnsurePalettesLoaded();
+        await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         if (_cache.Palettes.TryGetValue(type, out var palette))
         {
@@ -98,7 +98,10 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
     public CoverageColorScheme ResolveColorScheme(MarinerSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
-        EnsurePalettesLoaded();
+        // Pre-warm contract: the dataset processor is responsible for
+        // calling SwitchPaletteAsync (which awaits EnsurePalettesLoadedAsync
+        // and the bundled Lua source) before invoking ResolveColorScheme.
+        // This method now reads only from the in-memory cache.
 
         var (fourShades, safetyContour, shallowContour, deepContour) = ClampParameters(settings);
 
@@ -133,7 +136,10 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
             feature = { Code = 'BathymetryCoverage' }
             """);
 
-        string luaSource = GetLuaSource();
+        string luaSource = _cachedLuaSource
+            ?? throw new InvalidOperationException(
+                "S-102 portrayal catalogue Lua source has not been pre-warmed; " +
+                "call SwitchPaletteAsync before ResolveColorScheme.");
         lua.Execute(luaSource);
 
         // Invoke BathymetryCoverage(feature, featurePortrayal, contextParameters)
@@ -160,8 +166,33 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
     /// (<c>&lt;palette name="Day|Dusk|Night"&gt;</c>) so a single
     /// manifest entry yields all three palettes.
     /// </summary>
-    private void EnsurePalettesLoaded()
+    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
     {
+        // Pre-warm the bundled BathymetryCoverage.lua source alongside
+        // the palettes so the synchronous ResolveColorScheme path can
+        // execute without async I/O. NOTE: pairing palette + Lua warm
+        // here keeps the catalogue's "ready for sync coverage colour
+        // resolution" contract a single async call (SwitchPaletteAsync).
+        if (_cachedLuaSource is null)
+        {
+            var ruleFile = _provider.Catalogue.RuleFiles
+                .FirstOrDefault(r => r.FileName.Contains("BathymetryCoverage", StringComparison.OrdinalIgnoreCase));
+            if (ruleFile is not null)
+            {
+                try
+                {
+                    using var stream = await _provider.FetchAssetAsync(ruleFile, cancellationToken).ConfigureAwait(false);
+                    using var reader = new StreamReader(stream);
+                    _cachedLuaSource = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Leave _cachedLuaSource null — ResolveColorScheme will throw
+                    // a clear InvalidOperationException when invoked.
+                }
+            }
+        }
+
         if (_cache.PalettesLoaded)
         {
             if (ActivePalette.Colors.Count == 0 &&
@@ -175,6 +206,7 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
 
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var manifestName = item.Description.Name;
             if (string.IsNullOrEmpty(manifestName))
             {
@@ -193,7 +225,7 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
             {
                 try
                 {
-                    using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                    using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                     var palette = ColorProfileReader.Read(stream, manifestName);
                     _cache.Palettes[paletteType.Value] = palette;
                 }
@@ -212,7 +244,7 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
                     if (_cache.Palettes.ContainsKey(type)) continue;
                     try
                     {
-                        using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                        using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                         var palette = ColorProfileReader.Read(stream, name);
                         if (palette.Colors.Count > 0)
                         {
@@ -273,28 +305,9 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
     }
 
     // ── Lua source ─────────────────────────────────────────────────────
-
-    private string GetLuaSource()
-    {
-        if (_cachedLuaSource is not null)
-        {
-            return _cachedLuaSource;
-        }
-
-        var ruleFile = _provider.Catalogue.RuleFiles
-            .FirstOrDefault(r => r.FileName.Contains("BathymetryCoverage", StringComparison.OrdinalIgnoreCase));
-
-        if (ruleFile is null)
-        {
-            throw new InvalidOperationException(
-                "The S-102 portrayal catalogue does not contain a BathymetryCoverage rule file.");
-        }
-
-        using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
-        using var reader = new StreamReader(stream);
-        _cachedLuaSource = reader.ReadToEnd();
-        return _cachedLuaSource;
-    }
+    // Pre-warmed via EnsurePalettesLoadedAsync; ResolveColorScheme
+    // reads _cachedLuaSource directly. The historical synchronous
+    // GetLuaSource() helper has been removed.
 
     // ── Drawing-instruction parser ─────────────────────────────────────
 

--- a/src/EncDotNet.S100.Datasets.S104/S104PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S104/S104PortrayalCatalogue.cs
@@ -124,16 +124,12 @@ public class S104PortrayalCatalogue : ICoveragePortrayalCatalogue
     /// <summary>Gets the currently active color palette.</summary>
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
-    /// <summary>
-    /// Switches the active palette. Unlike the previous implementation
-    /// (which returned a stub <see cref="ColorPalette.FromType"/> and
-    /// left the band table unchanged), this actually swaps the band
-    /// table returned by <see cref="ResolveColorScheme"/>.
-    /// </summary>
-    public void SwitchPalette(PaletteType type)
+    /// <inheritdoc/>
+    public ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
         _activePaletteType = type;
         ActivePalette = ColorPalette.FromType(type);
+        return ValueTask.CompletedTask;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
@@ -66,9 +66,10 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
 
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
-    public void SwitchPalette(PaletteType type)
+    public async ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
-        EnsurePalettesLoaded();
+        await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureSpeedBandsLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         if (!_cache.Palettes.TryGetValue(type, out var palette))
         {
@@ -91,18 +92,15 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
     /// </summary>
     public CoverageColorScheme? ResolveColorScheme(MarinerSettings settings)
     {
-        // Touch the palette / band table so callers still pay the
-        // one-time load cost they previously did (keeps the asset-cache
-        // metrics and the PR-4 contract — see S111PaletteCacheTests —
-        // unchanged when SwitchPalette is the first call).
-        EnsurePalettesLoaded();
-        _ = EnsureSpeedBandsLoaded();
+        // Pre-warm contract: SwitchPaletteAsync warms palettes and the
+        // speed-band table so this sync method runs on cached state.
         return null;
     }
 
     public CoverageSymbolScheme ResolveSymbolScheme(MarinerSettings settings)
     {
-        var bands = EnsureSpeedBandsLoaded();
+        var bands = _bands ?? throw new InvalidOperationException(
+            "S-111 speed bands have not been pre-warmed; call SwitchPaletteAsync before ResolveSymbolScheme.");
 
         var symbolBands = new List<SymbolBand>(bands.Count);
         foreach (var band in bands)
@@ -136,7 +134,7 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
     /// first access. Subsequent calls are a no-op thanks to the sticky
     /// <see cref="IPortrayalAssetCache.PalettesLoaded"/> flag.
     /// </summary>
-    private void EnsurePalettesLoaded()
+    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
     {
         if (_cache.PalettesLoaded)
         {
@@ -158,8 +156,8 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
             (PaletteType.Night, "Night"),
         })
         {
-            using var stream = _provider.FetchAssetAsync(colorProfileItem, "ColorProfiles")
-                .GetAwaiter().GetResult();
+            cancellationToken.ThrowIfCancellationRequested();
+            using var stream = await _provider.FetchAssetAsync(colorProfileItem, "ColorProfiles", cancellationToken).ConfigureAwait(false);
             var palette = ColorProfileReader.Read(stream, name);
             if (palette.Colors.Count > 0)
             {
@@ -182,7 +180,7 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
     /// <c>Rules/select_arrow.xsl</c> on first access; sticky on
     /// <see cref="_bandsLoaded"/>.
     /// </summary>
-    private IReadOnlyList<S111SpeedBandReader.SpeedBand> EnsureSpeedBandsLoaded()
+    private async ValueTask<IReadOnlyList<S111SpeedBandReader.SpeedBand>> EnsureSpeedBandsLoadedAsync(CancellationToken cancellationToken)
     {
         if (_bandsLoaded && _bands is not null)
         {
@@ -194,7 +192,7 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
             ?? throw new InvalidOperationException(
                 "S-111 portrayal catalogue does not contain a select_arrow rule file.");
 
-        using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(ruleFile, cancellationToken).ConfigureAwait(false);
         _bands = S111SpeedBandReader.Read(stream);
         _bandsLoaded = true;
         return _bands;

--- a/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S125/S125PortrayalCatalogue.cs
@@ -13,6 +13,6 @@ public sealed class S125PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S125PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
     public override SpecRef Spec => new("S-125", default);
-    protected override System.Xml.XmlResolver CreateXmlResolver() =>
-        new FetchRuleFallbackXmlResolver(Provider);
+    protected override System.Xml.XmlResolver CreateXmlResolver(IReadOnlyDictionary<string, byte[]> registeredBytes) =>
+        new FetchRuleFallbackXmlResolver(Provider, registeredBytes);
 }

--- a/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S129/S129PortrayalCatalogue.cs
@@ -14,16 +14,19 @@ public sealed class S129PortrayalCatalogue : GmlPortrayalCatalogueBase
     public S129PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
     public override SpecRef Spec => new("S-129", default);
 
-    protected override XmlResolver CreateXmlResolver() => new S129XmlResolver(Provider);
+    protected override XmlResolver CreateXmlResolver(IReadOnlyDictionary<string, byte[]> registeredBytes) =>
+        new S129XmlResolver(Provider, registeredBytes);
 
     private sealed class S129XmlResolver : AssetSourceXmlResolver
     {
-        public S129XmlResolver(PortrayalCatalogueProvider provider) : base(provider) { }
+        public S129XmlResolver(PortrayalCatalogueProvider provider, IReadOnlyDictionary<string, byte[]> registeredBytes)
+            : base(provider, registeredBytes) { }
 
         protected override object? ResolveUnregistered(Uri absoluteUri, string fileName)
         {
-            // S-129 XSLT rules reference templates in sub-directories.
-            // Try to resolve by extracting path segments.
+            // SYNC BRIDGE: see GmlPortrayalCatalogueBase.FetchRuleFallbackXmlResolver
+            // — XmlResolver.GetEntity is sync .NET API contract during XSLT
+            // compile; the unregistered sub-paths cannot be enumerated upfront.
             var segments = absoluteUri.LocalPath.Replace('\\', '/').Split('/');
             for (int i = 0; i < segments.Length; i++)
             {

--- a/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131LuaRuleExecutor.cs
@@ -56,14 +56,14 @@ public sealed class S131LuaRuleExecutor : ILuaVectorRuleExecutor
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<DrawingInstruction> Execute(
+    public Task<IReadOnlyList<DrawingInstruction>> ExecuteAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default)
-        => _inner.Execute(mariner, cancellationToken);
+        => _inner.ExecuteAsync(mariner, cancellationToken);
 
     /// <inheritdoc/>
-    public IReadOnlyList<EmittedInstruction> ExecuteRaw(
+    public Task<IReadOnlyList<EmittedInstruction>> ExecuteRawAsync(
         MarinerSettings mariner, CancellationToken cancellationToken = default)
-        => _inner.ExecuteRaw(mariner, cancellationToken);
+        => _inner.ExecuteRawAsync(mariner, cancellationToken);
 }
 
 /// <summary>

--- a/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
@@ -29,12 +29,6 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 {
     private readonly PortrayalCatalogueProvider _provider;
     private readonly ILuaEngine? _luaEngine;
-
-    // PR-3 (asset-caching audit §6): see S101PortrayalCatalogue for the
-    // long-form rationale + thread-safety note. Identical model: the
-    // catalogue still owns the loading logic but storage lives on the
-    // provider's IPortrayalAssetCache so two S-131 catalogue wrappers
-    // for the same SpecRef share their decoded assets.
     private readonly IPortrayalAssetCache _cache;
 
     private IReadOnlyList<PortrayalRule>? _rules;
@@ -67,9 +61,9 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
     /// <inheritdoc/>
-    public void SwitchPalette(PaletteType type)
+    public async ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
-        EnsurePalettesLoaded();
+        await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         if (!_cache.Palettes.TryGetValue(type, out var palette))
             throw new KeyNotFoundException($"Color palette '{type}' not found in the S-131 portrayal catalogue.");
@@ -89,7 +83,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── Palettes ───────────────────────────────────────────────────────
 
-    private void EnsurePalettesLoaded()
+    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
     {
         if (_cache.PalettesLoaded)
         {
@@ -101,6 +95,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var paletteName = item.Description.Name;
             if (string.IsNullOrEmpty(paletteName))
                 paletteName = Path.GetFileNameWithoutExtension(item.FileName);
@@ -117,7 +112,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
             {
                 try
                 {
-                    using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                    using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                     var palette = ColorProfileReader.Read(stream, paletteName);
                     _cache.Palettes[paletteType.Value] = palette;
                 }
@@ -133,7 +128,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
                     if (_cache.Palettes.ContainsKey(type)) continue;
                     try
                     {
-                        using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                        using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                         var palette = ColorProfileReader.Read(stream, name);
                         if (palette.Colors.Count > 0)
                             _cache.Palettes[type] = palette;
@@ -208,18 +203,26 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     // ── XSLT ───────────────────────────────────────────────────────────
 
     /// <inheritdoc/>
-    public XslCompiledTransform GetCompiledRule(string ruleName)
+    public ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default)
     {
         if (_cache.CompiledXslt.TryGetValue(ruleName, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Xslt);
-            return cached;
+            return new ValueTask<XslCompiledTransform>(cached);
         }
 
+        return new ValueTask<XslCompiledTransform>(LoadAndCacheXsltAsync(ruleName, cancellationToken));
+    }
+
+    private async Task<XslCompiledTransform> LoadAndCacheXsltAsync(string ruleName, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Xslt);
         var ruleFile = FindRuleFile(ruleName);
-        using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
-        using var reader = XmlReader.Create(stream);
+        using var stream = await _provider.FetchAssetAsync(ruleFile, cancellationToken).ConfigureAwait(false);
+        using var buffered = new MemoryStream();
+        await stream.CopyToAsync(buffered, cancellationToken).ConfigureAwait(false);
+        buffered.Position = 0;
+        using var reader = XmlReader.Create(buffered);
         var transform = new XslCompiledTransform();
         transform.Load(reader);
         _cache.CompiledXslt[ruleName] = transform;
@@ -240,42 +243,48 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     private IReadOnlyList<LuaContextParameter>? _contextParameters;
 
     /// <summary>
+    /// Returns every Lua rule file declared in the portrayal catalogue
+    /// manifest (filtered to <c>.lua</c> extension), e.g. <c>main.lua</c>,
+    /// <c>S100Scripting.lua</c>.
+    /// </summary>
+    public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default)
+    {
+        var names = _provider.Catalogue.RuleFiles
+            .Where(rf => Path.GetExtension(rf.FileName).Equals(".lua", StringComparison.OrdinalIgnoreCase))
+            .Select(rf => rf.FileName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return new ValueTask<IReadOnlyList<string>>(names);
+    }
+
+    /// <summary>
     /// Returns the raw Lua source for the given bare filename inside the
     /// portrayal catalogue's <c>Rules/</c> directory (e.g. <c>"main.lua"</c>,
     /// <c>"S100Scripting.lua"</c>), caching the decoded string so subsequent
     /// reads do not re-open the underlying <see cref="Core.IAssetSource"/>.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Returns <see langword="null"/> (and caches <see langword="null"/>) if
-    /// the file cannot be fetched, so the MoonSharp module loader's
-    /// "missing module → return null" contract is preserved without retrying
-    /// failed lookups on every <c>require()</c> call.
-    /// </para>
-    /// <para>
-    /// This caches only the immutable <see cref="string"/> source. The
-    /// compiled Lua <c>Script</c> instance is intentionally constructed
-    /// per execution to preserve sandbox isolation (S-100 Part 9A).
-    /// </para>
-    /// </remarks>
-    public string? GetLuaSource(string fileName)
+    public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(fileName);
 
         if (_cache.LuaSources.TryGetValue(fileName, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordLuaSourceHit(ProductTag);
-            return cached;
+            return new ValueTask<string?>(cached);
         }
 
+        return new ValueTask<string?>(LoadLuaSourceAsync(fileName, cancellationToken));
+    }
+
+    private async Task<string?> LoadLuaSourceAsync(string fileName, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordLuaSourceMiss(ProductTag);
         string? source;
         try
         {
-            using var stream = _provider.FetchRuleAsync(fileName)
-                .GetAwaiter().GetResult();
+            using var stream = await _provider.FetchRuleAsync(fileName, cancellationToken).ConfigureAwait(false);
             using var reader = new StreamReader(stream);
-            source = reader.ReadToEnd();
+            source = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -289,62 +298,77 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     // ── Symbols ────────────────────────────────────────────────────────
 
     /// <inheritdoc/>
-    public SvgSymbol GetSymbol(string symbolName)
+    public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default)
     {
         if (_cache.Symbols.TryGetValue(symbolName, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Svg);
-            return cached;
+            return new ValueTask<SvgSymbol>(cached);
         }
 
+        return new ValueTask<SvgSymbol>(LoadSymbolAsync(symbolName, cancellationToken));
+    }
+
+    private async Task<SvgSymbol> LoadSymbolAsync(string symbolName, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Svg);
         var catalogItem = _provider.Catalogue.Symbols
             .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Symbol '{symbolName}' not found in the S-131 portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "Symbols").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "Symbols", cancellationToken).ConfigureAwait(false);
         using var reader = new StreamReader(stream);
-        var svgContent = reader.ReadToEnd();
+        var svgContent = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         var symbol = new SvgSymbol { Name = symbolName, SvgContent = svgContent };
         _cache.Symbols[symbolName] = symbol;
         return symbol;
     }
 
     /// <inheritdoc/>
-    public LineStyle GetLineStyle(string name)
+    public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default)
     {
         if (_cache.LineStyles.TryGetValue(name, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.LineStyle);
-            return cached;
+            return new ValueTask<LineStyle>(cached);
         }
 
+        return new ValueTask<LineStyle>(LoadLineStyleAsync(name, cancellationToken));
+    }
+
+    private async Task<LineStyle> LoadLineStyleAsync(string name, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.LineStyle);
         var catalogItem = _provider.Catalogue.LineStyles
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Line style '{name}' not found in the S-131 portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "LineStyles").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "LineStyles", cancellationToken).ConfigureAwait(false);
         var lineStyle = LineStyleReader.Read(stream, name);
         _cache.LineStyles[name] = lineStyle;
         return lineStyle;
     }
 
     /// <inheritdoc/>
-    public AreaFill GetAreaFill(string name)
+    public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default)
     {
         if (_cache.AreaFills.TryGetValue(name, out var cached))
         {
             Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.AreaFill);
-            return cached;
+            return new ValueTask<AreaFill>(cached);
         }
 
+        return new ValueTask<AreaFill>(LoadAreaFillAsync(name, cancellationToken));
+    }
+
+    private async Task<AreaFill> LoadAreaFillAsync(string name, CancellationToken cancellationToken)
+    {
         Portrayals.Diagnostics.PortrayalCacheMetrics.RecordMiss(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.AreaFill);
         var catalogItem = _provider.Catalogue.AreaFills
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Area fill '{name}' not found in the S-131 portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "AreaFills").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "AreaFills", cancellationToken).ConfigureAwait(false);
         var fill = AreaFillReader.Read(stream, name);
         _cache.AreaFills[name] = fill;
         return fill;

--- a/src/EncDotNet.S100.Datasets.S201/S201PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S201/S201PortrayalCatalogue.cs
@@ -24,6 +24,6 @@ public sealed class S201PortrayalCatalogue : GmlPortrayalCatalogueBase
     public override SpecRef Spec => new("S-201", default);
 
     /// <inheritdoc/>
-    protected override System.Xml.XmlResolver CreateXmlResolver() =>
-        new FetchRuleFallbackXmlResolver(Provider);
+    protected override System.Xml.XmlResolver CreateXmlResolver(IReadOnlyDictionary<string, byte[]> registeredBytes) =>
+        new FetchRuleFallbackXmlResolver(Provider, registeredBytes);
 }

--- a/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
@@ -21,17 +21,18 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
 
     public override SpecRef Spec => new("S-411", default);
 
-    protected override System.Xml.XmlResolver CreateXmlResolver() =>
-        new FetchRuleFallbackXmlResolver(Provider);
+    protected override System.Xml.XmlResolver CreateXmlResolver(IReadOnlyDictionary<string, byte[]> registeredBytes) =>
+        new FetchRuleFallbackXmlResolver(Provider, registeredBytes);
 
     /// <summary>
     /// S-411 1.2.1 PC ships no day/dusk/night colour profiles with
     /// multi-palette fallback; only load explicitly named palettes.
     /// </summary>
-    protected override void LoadPalettes(Dictionary<PaletteType, ColorPalette> palettes)
+    protected override async Task LoadPalettesAsync(Dictionary<PaletteType, ColorPalette> palettes, CancellationToken cancellationToken)
     {
         foreach (var item in Provider.Catalogue.ColorProfiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var paletteName = item.Description.Name;
             if (string.IsNullOrEmpty(paletteName))
                 paletteName = Path.GetFileNameWithoutExtension(item.FileName);
@@ -48,7 +49,7 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
 
             try
             {
-                using var stream = Provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                using var stream = await Provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                 var palette = ColorProfileReader.Read(stream, paletteName);
                 palettes[paletteType.Value] = palette;
             }
@@ -59,7 +60,7 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
     /// <summary>
     /// Only the master <c>mainRule</c> top-level template is included; the
     /// per-class top-level templates are still loadable on demand via
-    /// <see cref="GetCompiledRule"/>.
+    /// <see cref="GetCompiledRuleAsync"/>.
     /// </summary>
     protected override IReadOnlyList<PortrayalRule> BuildRules()
     {
@@ -84,7 +85,7 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
     /// which produces the display-list dialect expected by this codebase's
     /// <c>Part9DisplayListReader</c>. All other rules delegate to base.
     /// </summary>
-    public override XslCompiledTransform GetCompiledRule(string ruleName)
+    public override ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default)
     {
         if (!_adapterLoaded && ruleName.Equals(DefaultTopLevelRuleId, StringComparison.OrdinalIgnoreCase))
         {
@@ -92,7 +93,7 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
             _adapterLoaded = true;
         }
 
-        return base.GetCompiledRule(ruleName);
+        return base.GetCompiledRuleAsync(ruleName, cancellationToken);
     }
 
     private static XslCompiledTransform LoadAdapterRule()

--- a/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S421/S421PortrayalCatalogue.cs
@@ -13,6 +13,6 @@ public sealed class S421PortrayalCatalogue : GmlPortrayalCatalogueBase
 {
     public S421PortrayalCatalogue(PortrayalCatalogueProvider provider) : base(provider) { }
     public override SpecRef Spec => new("S-421", default);
-    protected override System.Xml.XmlResolver CreateXmlResolver() =>
-        new FetchRuleFallbackXmlResolver(Provider);
+    protected override System.Xml.XmlResolver CreateXmlResolver(IReadOnlyDictionary<string, byte[]> registeredBytes) =>
+        new FetchRuleFallbackXmlResolver(Provider, registeredBytes);
 }

--- a/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
+++ b/src/EncDotNet.S100.Features/FeatureCatalogueManager.cs
@@ -183,6 +183,9 @@ public sealed class FeatureCatalogueManager : IDisposable, ICatalogueProvider<Fe
         {
             try
             {
+                // SYNC BRIDGE: FC bundled IAssetSource is in-process
+                // resource-backed; this fallback runs once per spec inside
+                // a sync OpenRawCatalogue called from sync GetCatalogue.
                 stream = source.OpenAsync(FeatureCatalogueAssetName).GetAwaiter().GetResult();
             }
             catch

--- a/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
+++ b/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
@@ -18,7 +18,7 @@ namespace EncDotNet.S100.Portrayals;
 /// Subclasses typically only need to supply <see cref="Spec"/> and,
 /// where necessary, override <see cref="CreateXmlResolver"/> (for specs
 /// whose XSLT includes reference unregistered sub-templates) or
-/// <see cref="GetCompiledRule"/> (for specs that inject an adapter rule).
+/// <see cref="GetCompiledRuleAsync"/> (for specs that inject an adapter rule).
 /// </remarks>
 public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 {
@@ -73,10 +73,10 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// <summary>Gets the currently active color palette.</summary>
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
-    /// <summary>Switches the active color palette to the given type.</summary>
-    public void SwitchPalette(PaletteType type)
+    /// <inheritdoc/>
+    public async ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
-        EnsurePalettesLoaded();
+        await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         if (_cache.Palettes.TryGetValue(type, out var palette))
         {
@@ -96,7 +96,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     // ── Palettes ───────────────────────────────────────────────────────
 
-    private void EnsurePalettesLoaded()
+    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
     {
         if (_cache.PalettesLoaded)
         {
@@ -107,7 +107,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
             return;
         }
         _cache.PalettesLoaded = true;
-        LoadPalettes(((PortrayalAssetCache)_cache).PalettesDictionary);
+        await LoadPalettesAsync(((PortrayalAssetCache)_cache).PalettesDictionary, cancellationToken).ConfigureAwait(false);
 
         if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
         {
@@ -120,10 +120,11 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     /// Override to change the palette loading strategy (e.g. skip the
     /// multi-palette-in-one-file fallback for specs that don't use it).
     /// </summary>
-    protected virtual void LoadPalettes(Dictionary<PaletteType, ColorPalette> palettes)
+    protected virtual async Task LoadPalettesAsync(Dictionary<PaletteType, ColorPalette> palettes, CancellationToken cancellationToken)
     {
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var paletteName = item.Description.Name;
             if (string.IsNullOrEmpty(paletteName))
             {
@@ -142,7 +143,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
             {
                 try
                 {
-                    using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                    using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                     var palette = ColorProfileReader.Read(stream, paletteName);
                     palettes[paletteType.Value] = palette;
                 }
@@ -159,7 +160,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
                     if (palettes.ContainsKey(type)) continue;
                     try
                     {
-                        using var stream = _provider.FetchAssetAsync(item, "ColorProfiles").GetAwaiter().GetResult();
+                        using var stream = await _provider.FetchAssetAsync(item, "ColorProfiles", cancellationToken).ConfigureAwait(false);
                         var palette = ColorProfileReader.Read(stream, name);
                         if (palette.Colors.Count > 0)
                         {
@@ -217,11 +218,15 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     // ── XSLT ───────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Returns the compiled XSLT transform for the given rule name,
-    /// loading and caching it on first access. Override to intercept
-    /// specific rules (e.g. inject an adapter transform).
+    /// Returns the compiled XSLT transform for the given rule name, loading
+    /// and caching it on first access. Override to intercept specific rules
+    /// (e.g. inject an adapter transform).
     /// </summary>
-    public virtual XslCompiledTransform GetCompiledRule(string ruleName)
+    /// <param name="ruleName">The rule identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The compiled XSLT transform.</returns>
+    /// <exception cref="KeyNotFoundException">No such rule in the catalogue.</exception>
+    public virtual async ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default)
     {
         if (_cache.CompiledXslt.TryGetValue(ruleName, out var cached))
         {
@@ -234,7 +239,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
             .FirstOrDefault(r => r.Id.Equals(ruleName, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Rule '{ruleName}' not found in the portrayal catalogue.");
 
-        var transform = LoadXsltRule(ruleFile);
+        var transform = await LoadXsltRuleAsync(ruleFile, cancellationToken).ConfigureAwait(false);
         _cache.CompiledXslt[ruleName] = transform;
         return transform;
     }
@@ -248,22 +253,56 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
         _cache.CompiledXslt[ruleName] = transform;
     }
 
-    /// <summary>Loads and compiles an XSLT rule file with telemetry.</summary>
-    protected XslCompiledTransform LoadXsltRule(RuleFile ruleFile)
+    /// <summary>
+    /// Loads and compiles an XSLT rule file with telemetry.
+    /// </summary>
+    /// <remarks>
+    /// Pre-fetches every registered rule file's bytes into a memory dict
+    /// before invoking <see cref="XslCompiledTransform.Load(XmlReader, XsltSettings, XmlResolver)"/>,
+    /// because <see cref="XmlResolver.GetEntity(Uri, string?, Type?)"/> is
+    /// a synchronous .NET API contract during XSLT compile and we cannot
+    /// await inside it. The pre-fetch is bounded to the (small) set of
+    /// declared rule files; <see cref="FetchRuleFallbackXmlResolver"/>
+    /// handles the unregistered-include case via a documented sync bridge.
+    /// </remarks>
+    protected async Task<XslCompiledTransform> LoadXsltRuleAsync(RuleFile ruleFile, CancellationToken cancellationToken)
     {
         using var activity = Diagnostics.Telemetry.ActivitySource.StartActivity("s100.xslt.compile");
         activity?.SetTag(TelemetryTags.XsltRule, ruleFile.Id);
         var start = Stopwatch.GetTimestamp();
 
-        using var stream = _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
+        var primaryBytes = await ReadAllBytesAsync(ruleFile, cancellationToken).ConfigureAwait(false);
 
-        var resolver = CreateXmlResolver();
+        // Pre-fetch every other registered rule file so AssetSourceXmlResolver
+        // can serve xsl:include / xsl:import lookups synchronously from memory.
+        var registeredBytes = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rf in _provider.Catalogue.RuleFiles)
+        {
+            if (registeredBytes.ContainsKey(rf.FileName)) continue;
+            if (string.Equals(rf.Id, ruleFile.Id, StringComparison.OrdinalIgnoreCase))
+            {
+                registeredBytes[rf.FileName] = primaryBytes;
+                continue;
+            }
+            try
+            {
+                registeredBytes[rf.FileName] = await ReadAllBytesAsync(rf, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort pre-warm: a missing sibling rule file is left
+                // for the resolver's unregistered-fallback path.
+            }
+        }
+
+        var resolver = CreateXmlResolver(registeredBytes);
         var settings = new XmlReaderSettings
         {
             DtdProcessing = DtdProcessing.Prohibit,
         };
 
-        using var reader = XmlReader.Create(stream, settings, ruleFile.FileName);
+        using var primaryStream = new MemoryStream(primaryBytes, writable: false);
+        using var reader = XmlReader.Create(primaryStream, settings, ruleFile.FileName);
 
         var transform = new XslCompiledTransform();
         transform.Load(reader, XsltSettings.TrustedXslt, resolver);
@@ -274,29 +313,45 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
         return transform;
     }
 
+    private async Task<byte[]> ReadAllBytesAsync(RuleFile ruleFile, CancellationToken cancellationToken)
+    {
+        using var stream = await _provider.FetchAssetAsync(ruleFile, cancellationToken).ConfigureAwait(false);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        return ms.ToArray();
+    }
+
     /// <summary>
     /// Creates an <see cref="XmlResolver"/> used to resolve
     /// <c>xsl:include</c>/<c>xsl:import</c> URIs during XSLT compilation.
     /// </summary>
     /// <remarks>
-    /// The default implementation resolves filenames against the catalogue's
-    /// registered rule files. Override to add fallback resolution strategies
-    /// (e.g. <see cref="PortrayalCatalogueProvider.FetchRuleAsync"/> for
-    /// specs whose sub-templates are not registered as rule files).
+    /// The default implementation resolves filenames against the pre-fetched
+    /// rule-file bytes dictionary. Override to add fallback resolution
+    /// strategies (e.g. <see cref="PortrayalCatalogueProvider.FetchRuleAsync"/>
+    /// for specs whose sub-templates are not registered as rule files).
     /// </remarks>
-    protected virtual XmlResolver CreateXmlResolver()
+    protected virtual XmlResolver CreateXmlResolver(IReadOnlyDictionary<string, byte[]> registeredBytes)
     {
-        return new AssetSourceXmlResolver(_provider);
+        return new AssetSourceXmlResolver(_provider, registeredBytes);
     }
 
     // ── Lua ────────────────────────────────────────────────
 
     /// <summary>
     /// GML portrayal catalogues use XSLT only and ship no Lua rules, so this
-    /// always returns <see langword="null"/> (honouring the module loader's
+    /// always returns an empty list.
+    /// </summary>
+    public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default)
+        => new(Array.Empty<string>());
+
+    /// <summary>
+    /// GML portrayal catalogues ship no Lua rules, so this always returns
+    /// <see langword="null"/> (honouring the module loader's
     /// "missing module → null" contract).
     /// </summary>
-    public string? GetLuaSource(string fileName) => null;
+    public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default)
+        => new((string?)null);
 
     /// <summary>
     /// GML portrayal catalogues declare no Lua context parameters.
@@ -305,23 +360,32 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     // ── Symbols ────────────────────────────────────────────────────────
 
-    /// <summary>Returns the SVG symbol with the given name, loading and caching it on first access.</summary>
-    public SvgSymbol GetSymbol(string symbolName)
+    /// <summary>
+    /// Returns the SVG symbol with the given name, loading and caching it
+    /// on first access.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">No such symbol in the catalogue.</exception>
+    public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default)
     {
         if (_cache.Symbols.TryGetValue(symbolName, out var cached))
         {
             Diagnostics.PortrayalCacheMetrics.RecordHit(Spec.Name, Diagnostics.PortrayalAssetKinds.Svg);
-            return cached;
+            return new ValueTask<SvgSymbol>(cached);
         }
 
+        return new ValueTask<SvgSymbol>(LoadSymbolAsync(symbolName, cancellationToken));
+    }
+
+    private async Task<SvgSymbol> LoadSymbolAsync(string symbolName, CancellationToken cancellationToken)
+    {
         Diagnostics.PortrayalCacheMetrics.RecordMiss(Spec.Name, Diagnostics.PortrayalAssetKinds.Svg);
         var catalogItem = _provider.Catalogue.Symbols
             .FirstOrDefault(s => s.Id.Equals(symbolName, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Symbol '{symbolName}' not found in the portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "Symbols").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "Symbols", cancellationToken).ConfigureAwait(false);
         using var reader = new StreamReader(stream);
-        var svgContent = reader.ReadToEnd();
+        var svgContent = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
 
         var symbol = new SvgSymbol
         {
@@ -335,21 +399,30 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     // ── Line styles ────────────────────────────────────────────────────
 
-    /// <summary>Returns the line style with the given name, loading and caching it on first access.</summary>
-    public LineStyle GetLineStyle(string name)
+    /// <summary>
+    /// Returns the line style with the given name, loading and caching it
+    /// on first access.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">No such line style in the catalogue.</exception>
+    public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default)
     {
         if (_cache.LineStyles.TryGetValue(name, out var cached))
         {
             Diagnostics.PortrayalCacheMetrics.RecordHit(Spec.Name, Diagnostics.PortrayalAssetKinds.LineStyle);
-            return cached;
+            return new ValueTask<LineStyle>(cached);
         }
 
+        return new ValueTask<LineStyle>(LoadLineStyleAsync(name, cancellationToken));
+    }
+
+    private async Task<LineStyle> LoadLineStyleAsync(string name, CancellationToken cancellationToken)
+    {
         Diagnostics.PortrayalCacheMetrics.RecordMiss(Spec.Name, Diagnostics.PortrayalAssetKinds.LineStyle);
         var catalogItem = _provider.Catalogue.LineStyles
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Line style '{name}' not found in the portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "LineStyles").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "LineStyles", cancellationToken).ConfigureAwait(false);
         var style = LineStyleReader.Read(stream, name);
 
         _cache.LineStyles[name] = style;
@@ -358,21 +431,30 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     // ── Area fills ─────────────────────────────────────────────────────
 
-    /// <summary>Returns the area fill with the given name, loading and caching it on first access.</summary>
-    public AreaFill GetAreaFill(string name)
+    /// <summary>
+    /// Returns the area fill with the given name, loading and caching it
+    /// on first access.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">No such area fill in the catalogue.</exception>
+    public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default)
     {
         if (_cache.AreaFills.TryGetValue(name, out var cached))
         {
             Diagnostics.PortrayalCacheMetrics.RecordHit(Spec.Name, Diagnostics.PortrayalAssetKinds.AreaFill);
-            return cached;
+            return new ValueTask<AreaFill>(cached);
         }
 
+        return new ValueTask<AreaFill>(LoadAreaFillAsync(name, cancellationToken));
+    }
+
+    private async Task<AreaFill> LoadAreaFillAsync(string name, CancellationToken cancellationToken)
+    {
         Diagnostics.PortrayalCacheMetrics.RecordMiss(Spec.Name, Diagnostics.PortrayalAssetKinds.AreaFill);
         var catalogItem = _provider.Catalogue.AreaFills
             .FirstOrDefault(s => s.Id.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException($"Area fill '{name}' not found in the portrayal catalogue.");
 
-        using var stream = _provider.FetchAssetAsync(catalogItem, "AreaFills").GetAwaiter().GetResult();
+        using var stream = await _provider.FetchAssetAsync(catalogItem, "AreaFills", cancellationToken).ConfigureAwait(false);
         var fill = AreaFillReader.Read(stream, name);
 
         _cache.AreaFills[name] = fill;
@@ -383,16 +465,25 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     /// <summary>
     /// Default <see cref="XmlResolver"/> that resolves <c>xsl:include</c>/
-    /// <c>xsl:import</c> URIs against the catalogue's registered rule files.
+    /// <c>xsl:import</c> URIs against the pre-fetched rule-file bytes.
     /// </summary>
+    /// <remarks>
+    /// <see cref="XmlResolver.GetEntity(Uri, string?, Type?)"/> is invoked
+    /// synchronously by <see cref="XslCompiledTransform.Load(XmlReader, XsltSettings, XmlResolver)"/>
+    /// — a .NET API contract we don't own. The base resolver therefore
+    /// reads from a memory dict that <see cref="LoadXsltRuleAsync"/>
+    /// pre-fetched on the async hot path; no sync I/O happens here.
+    /// </remarks>
     protected class AssetSourceXmlResolver : XmlResolver
     {
         private readonly PortrayalCatalogueProvider _provider;
+        private readonly IReadOnlyDictionary<string, byte[]> _registeredBytes;
 
-        /// <summary>Creates a resolver backed by the given provider.</summary>
-        public AssetSourceXmlResolver(PortrayalCatalogueProvider provider)
+        /// <summary>Creates a resolver backed by the given provider and pre-fetched rule bytes.</summary>
+        public AssetSourceXmlResolver(PortrayalCatalogueProvider provider, IReadOnlyDictionary<string, byte[]> registeredBytes)
         {
             _provider = provider;
+            _registeredBytes = registeredBytes;
         }
 
         /// <summary>Gets the underlying provider (for subclass use).</summary>
@@ -403,12 +494,9 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
         {
             var fileName = Path.GetFileName(absoluteUri.LocalPath);
 
-            var ruleFile = _provider.Catalogue.RuleFiles
-                .FirstOrDefault(r => r.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
-
-            if (ruleFile is not null)
+            if (_registeredBytes.TryGetValue(fileName, out var bytes))
             {
-                return _provider.FetchAssetAsync(ruleFile).GetAwaiter().GetResult();
+                return new MemoryStream(bytes, writable: false);
             }
 
             return ResolveUnregistered(absoluteUri, fileName);
@@ -433,8 +521,8 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
     protected sealed class FetchRuleFallbackXmlResolver : AssetSourceXmlResolver
     {
         /// <summary>Creates a resolver with fetch-rule fallback.</summary>
-        public FetchRuleFallbackXmlResolver(PortrayalCatalogueProvider provider)
-            : base(provider)
+        public FetchRuleFallbackXmlResolver(PortrayalCatalogueProvider provider, IReadOnlyDictionary<string, byte[]> registeredBytes)
+            : base(provider, registeredBytes)
         {
         }
 
@@ -443,6 +531,13 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
         {
             try
             {
+                // SYNC BRIDGE: XmlResolver.GetEntity is a synchronous .NET
+                // API contract invoked during XSLT compile. The unregistered
+                // sub-template names aren't known up front (the rule file
+                // list doesn't include them), so we cannot pre-warm this
+                // path the way LoadXsltRuleAsync pre-warms registered rules.
+                // The bridge is bounded to one-time XSLT cold-compile lookups
+                // per rule, and there is no async equivalent in the BCL.
                 return Provider.FetchRuleAsync(fileName).GetAwaiter().GetResult();
             }
             catch (FileNotFoundException)

--- a/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalCatalogueManager.cs
@@ -196,6 +196,9 @@ public sealed class PortrayalCatalogueManager : IDisposable, ICatalogueProvider<
             () =>
             {
                 var source = FileSystemAssetSource.Create(path);
+                // SYNC BRIDGE: GetProvider is the sync cache-miss path
+                // invoked from many sync init / detection sites. The
+                // underlying provider open is one-shot per spec slot.
                 var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
                 provider.AttachAssetCache(GetOrCreateAssetCache(spec));
                 return provider;

--- a/src/EncDotNet.S100.Specifications/Specification.cs
+++ b/src/EncDotNet.S100.Specifications/Specification.cs
@@ -42,11 +42,15 @@ public static class Specification
     }
 
     /// <summary>
-    /// Tries to open the bundled Feature Catalogue XML for the given product specification.
-    /// Returns null if no bundled catalogue is available.
+    /// Synchronous sibling of <see cref="TryOpenFeatureCatalogueAsync"/>.
     /// </summary>
-    /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102", "S-104", "S-111").</param>
-    /// <returns>A stream containing the Feature Catalogue XML, or null if not found.</returns>
+    /// <remarks>
+    /// SYNC BRIDGE: bundled FC streams come from <c>EmbeddedAssetSource</c>,
+    /// which is backed by an in-process resource read and therefore has
+    /// no real async work. This sync facade lets the many sync callers
+    /// (validator constructors, viewer init paths, listed-value indexes)
+    /// open the catalogue without each chasing async-up-the-stack.
+    /// </remarks>
     public static Stream? TryOpenFeatureCatalogue(string productSpec)
     {
         ArgumentException.ThrowIfNullOrEmpty(productSpec);
@@ -55,6 +59,28 @@ public static class Specification
         {
             var source = CreateAssetSource(productSpec, "fc");
             return source.OpenAsync("FeatureCatalogue.xml").GetAwaiter().GetResult();
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Tries to open the bundled Feature Catalogue XML for the given product specification.
+    /// Returns null if no bundled catalogue is available.
+    /// </summary>
+    /// <param name="productSpec">The product specification identifier (e.g. "S-101", "S-102", "S-104", "S-111").</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A stream containing the Feature Catalogue XML, or null if not found.</returns>
+    public static async Task<Stream?> TryOpenFeatureCatalogueAsync(string productSpec, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+
+        try
+        {
+            var source = CreateAssetSource(productSpec, "fc");
+            return await source.OpenAsync("FeatureCatalogue.xml", cancellationToken).ConfigureAwait(false);
         }
         catch (FileNotFoundException)
         {

--- a/src/EncDotNet.S100.Viewer/Services/CatalogueSpecDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/CatalogueSpecDetection.cs
@@ -93,6 +93,9 @@ internal static class CatalogueSpecDetection
         try
         {
             using var source = Specifications.Specification.CreatePortrayalCatalogueSource(spec);
+            // SYNC BRIDGE: bundled PC bytes come from EmbeddedAssetSource
+            // (an in-process resource read) and this helper is called from
+            // the viewer's sync MainWindow init path before app load.
             using var stream = source.OpenAsync("portrayal_catalogue.xml").GetAwaiter().GetResult();
             var catalogue = PortrayalCatalogueReader.Read(stream);
             return string.IsNullOrEmpty(catalogue.Version) ? null : catalogue.Version;

--- a/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
@@ -222,6 +222,7 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
     }
 
     /// <summary>
+    /// <summary>
     /// Opens the dataset bytes for <paramref name="entry"/> — either from
     /// disk (plain entry) or from its <see cref="DatasetEntry.Source"/>
     /// asset source (exchange-set entry). The returned stream must be
@@ -231,11 +232,11 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
     {
         if (entry.IsFromExchangeSet)
         {
-            // IAssetSource.OpenAsync is effectively synchronous for the
-            // FileSystem / Zip backings used by the viewer (see
-            // ZipAssetSource.OpenAsync), so blocking here is benign and
-            // keeps TryProject synchronous like the rest of the catalog
-            // event chain.
+            // SYNC BRIDGE: IAssetSource.OpenAsync for FileSystem / Zip
+            // backings is effectively synchronous (no real I/O latency),
+            // and TryProject is called from the synchronous DatasetLoaded
+            // event chain. Async-up-the-stack would require flipping the
+            // event signature, which is not justified for a one-shot open.
             return entry.Source!.OpenAsync(entry.RelativePath!).GetAwaiter().GetResult();
         }
         return File.OpenRead(entry.FilePath);

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111ArrowRenderingTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111ArrowRenderingTests.cs
@@ -37,7 +37,7 @@ public sealed class S111ArrowRenderingTests : IDisposable
         _source = FileSystemAssetSource.Create(PortrayalPath);
         _provider = PortrayalCatalogueProvider.OpenAsync(_source).GetAwaiter().GetResult();
         _catalogue = new S111PortrayalCatalogue(_provider);
-        _catalogue.SwitchPalette(PaletteType.Day);
+        _catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         // Pre-load the bundled arrow SVGs synchronously in the ctor so
         // individual tests avoid xUnit1031 .GetResult() warnings.
@@ -156,11 +156,11 @@ public sealed class S111ArrowRenderingTests : IDisposable
     {
         var renderer = CreateRenderer();
 
-        _catalogue.SwitchPalette(PaletteType.Day);
+        _catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         renderer.Palette = _catalogue.ActivePalette;
         var daySvg = renderer.GetResolvedSvg("SCAROW01");
 
-        _catalogue.SwitchPalette(PaletteType.Night);
+        _catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         renderer.Palette = _catalogue.ActivePalette;
         var nightSvg = renderer.GetResolvedSvg("SCAROW01");
 

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111CoverageSourceTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111CoverageSourceTests.cs
@@ -164,6 +164,7 @@ public class S111CoverageSourceTests : IDisposable
         var source = FileSystemAssetSource.Create(portrayalPath);
         using var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
         var catalogue = new S111PortrayalCatalogue(provider);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         var scheme = catalogue.ResolveSymbolScheme(MarinerSettings.Default);
 

--- a/tests/EncDotNet.S100.Datasets.S421.Tests/S421RendererIntegrationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S421.Tests/S421RendererIntegrationTests.cs
@@ -33,7 +33,7 @@ public class S421RendererIntegrationTests
             featureDoc = XDocument.Load(reader);
 
         var rule = catalogue.Rules.First();
-        var transform = catalogue.GetCompiledRule(rule.Name);
+        var transform = catalogue.GetCompiledRuleAsync(rule.Name).AsTask().GetAwaiter().GetResult();
 
         var displayList = new XDocument();
         using (var input = featureDoc.CreateReader())
@@ -78,7 +78,7 @@ public class S421RendererIntegrationTests
             Palette = catalogue.ActivePalette,
             SymbolProvider = name =>
             {
-                try { return catalogue.GetSymbol(name).SvgContent; }
+                try { return catalogue.GetSymbolAsync(name).AsTask().GetAwaiter().GetResult().SvgContent; }
                 catch { return null; }
             },
         };

--- a/tests/EncDotNet.S100.Pipelines.Tests/CacheCounterTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CacheCounterTests.cs
@@ -35,9 +35,9 @@ public sealed class CacheCounterTests
             "s100.lua.source.cache.miss.count", misses);
 
         const string fileName = "S100Scripting.lua";
-        _ = catalogue.GetLuaSource(fileName);
-        _ = catalogue.GetLuaSource(fileName);
-        _ = catalogue.GetLuaSource(fileName);
+        _ = catalogue.GetLuaSourceAsync(fileName).AsTask().GetAwaiter().GetResult();
+        _ = catalogue.GetLuaSourceAsync(fileName).AsTask().GetAwaiter().GetResult();
+        _ = catalogue.GetLuaSourceAsync(fileName).AsTask().GetAwaiter().GetResult();
 
         listener.Dispose();
         KeyValuePair<string, object?>[][] hitSnap;
@@ -73,8 +73,8 @@ public sealed class CacheCounterTests
 
         // Find a real symbol id to ensure we hit the cache miss/hit path.
         var symbolId = provider.Catalogue.Symbols.First().Id;
-        _ = catalogue.GetSymbol(symbolId);
-        _ = catalogue.GetSymbol(symbolId);
+        _ = catalogue.GetSymbolAsync(symbolId).AsTask().GetAwaiter().GetResult();
+        _ = catalogue.GetSymbolAsync(symbolId).AsTask().GetAwaiter().GetResult();
 
         listener.Dispose();
         KeyValuePair<string, object?>[][] hitSnap;

--- a/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CoveragePipelineTests.cs
@@ -294,6 +294,7 @@ public class CoveragePipelineTests
         public string Edition => "1.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
         public void SwitchPalette(PaletteType type) { }
+        public ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public MarinerSettings? LastSettings { get; private set; }
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs
@@ -31,9 +31,9 @@ public class LuaSourceCacheTests
         // not leak in.
         var openCountBefore = counting.GetOpenCount("Rules/main.lua");
 
-        var first = catalogue.GetLuaSource("main.lua");
-        var second = catalogue.GetLuaSource("main.lua");
-        var third = catalogue.GetLuaSource("main.lua");
+        var first = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var second = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var third = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
 
         Assert.NotNull(first);
         Assert.NotEmpty(first!);
@@ -59,9 +59,9 @@ public class LuaSourceCacheTests
         const string missing = "definitely-not-a-real-rule.lua";
         var openCountBefore = counting.GetOpenCount($"Rules/{missing}");
 
-        var a = catalogue.GetLuaSource(missing);
-        var b = catalogue.GetLuaSource(missing);
-        var c = catalogue.GetLuaSource(missing);
+        var a = catalogue.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult();
+        var b = catalogue.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult();
+        var c = catalogue.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult();
 
         Assert.Null(a);
         Assert.Null(b);
@@ -85,9 +85,9 @@ public class LuaSourceCacheTests
 
         var openCountBefore = counting.GetOpenCount("Rules/main.lua");
 
-        var first = catalogue.GetLuaSource("main.lua");
-        var second = catalogue.GetLuaSource("main.lua");
-        var third = catalogue.GetLuaSource("main.lua");
+        var first = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var second = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var third = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
 
         Assert.NotNull(first);
         Assert.NotEmpty(first!);
@@ -116,8 +116,8 @@ public class LuaSourceCacheTests
         var providerB = await PortrayalCatalogueProvider.OpenAsync(countingB);
         var catalogueB = new S101PortrayalCatalogue(providerB);
 
-        var srcA = catalogueA.GetLuaSource("main.lua");
-        var srcB = catalogueB.GetLuaSource("main.lua");
+        var srcA = catalogueA.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var srcB = catalogueB.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
 
         Assert.NotNull(srcA);
         Assert.NotNull(srcB);

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101FeatureNameTextTests.cs
@@ -117,10 +117,10 @@ public class S101FeatureNameTextTests
         var pcProvider = PortrayalCatalogueProvider.OpenAsync(pcSource).GetAwaiter().GetResult();
         var luaEngine = new MoonSharpLuaEngine();
         var catalogue = new S101PortrayalCatalogue(pcProvider, luaEngine);
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         var executor = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
-        var emitted = executor.ExecuteRaw(MarinerSettings.Default);
+        var emitted = executor.ExecuteRawAsync(MarinerSettings.Default).GetAwaiter().GetResult();
 
         // Classify named features: featureName (NATC=48) holds an empty
         // top-level marker followed by a `name` sibling sub-attribute

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101LegacyFeatureNameDispatchTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101LegacyFeatureNameDispatchTests.cs
@@ -107,10 +107,10 @@ public class S101LegacyFeatureNameDispatchTests
         var pcProvider = PortrayalCatalogueProvider.OpenAsync(pcSource).GetAwaiter().GetResult();
         var luaEngine = new MoonSharpLuaEngine();
         var catalogue = new S101PortrayalCatalogue(pcProvider, luaEngine);
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         var executor = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
-        return executor.ExecuteRaw(MarinerSettings.Default);
+        return executor.ExecuteRawAsync(MarinerSettings.Default).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PatternFillDiagnosticTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PatternFillDiagnosticTests.cs
@@ -124,10 +124,10 @@ public class S101PatternFillDiagnosticTests
         {
             try
             {
-                var areaFill = catalogue.GetAreaFill(fillName);
+                var areaFill = catalogue.GetAreaFillAsync(fillName).AsTask().GetAwaiter().GetResult();
                 if (areaFill.PatternSymbol is null) continue;
 
-                var svgContent = catalogue.GetSymbol(areaFill.PatternSymbol).SvgContent;
+                var svgContent = catalogue.GetSymbolAsync(areaFill.PatternSymbol).AsTask().GetAwaiter().GetResult().SvgContent;
                 var processed = SvgProcessor.Process(svgContent, palette);
 
                 // Dump SVG and area fill details
@@ -375,10 +375,10 @@ public class S101PatternFillDiagnosticTests
             {
                 try
                 {
-                    var areaFill = catalogue.GetAreaFill(symbolRef);
+                    var areaFill = catalogue.GetAreaFillAsync(symbolRef).AsTask().GetAwaiter().GetResult();
                     if (areaFill.PatternSymbol is not null)
                     {
-                        var svgContent = catalogue.GetSymbol(areaFill.PatternSymbol).SvgContent;
+                        var svgContent = catalogue.GetSymbolAsync(areaFill.PatternSymbol).AsTask().GetAwaiter().GetResult().SvgContent;
                         var processed = SvgProcessor.Process(svgContent, palette);
                         var png = SkiaSvgRasterizer.RasterizePatternTile(processed, areaFill);
                         if (png is not null)
@@ -446,12 +446,12 @@ public class S101PatternFillDiagnosticTests
         var provider = PortrayalCatalogueProvider.OpenAsync(pcSource).GetAwaiter().GetResult();
         var luaEngine = new MoonSharpLuaEngine();
         var catalogue = new S101PortrayalCatalogue(provider, luaEngine);
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var palette = catalogue.ActivePalette;
 
         // Run Lua portrayal
         var portrayal = new S101LuaRuleExecutor(luaEngine, dataset, catalogue, fc);
-        var emitted = portrayal.ExecuteRaw(MarinerSettings.Default);
+        var emitted = portrayal.ExecuteRawAsync(MarinerSettings.Default).GetAwaiter().GetResult();
 
         // Dump raw emit strings for key features
         var rawLines = new List<string> { "=== Raw Lua Emit Strings ===" };

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PipelineTests.cs
@@ -265,7 +265,7 @@ public class S101PipelineTests
         public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
-        public void SwitchPalette(PaletteType type) { }
+        public ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public IReadOnlyList<PortrayalRule> Rules { get; }
         public ViewingGroupController ViewingGroups { get; }
@@ -274,21 +274,24 @@ public class S101PipelineTests
 
         public DisplayPlaneController DisplayPlanes { get; } = new();
 
-        public XslCompiledTransform GetCompiledRule(string ruleName) =>
-            _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
+        public ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default) =>
+            new(_xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName));
 
-        public string? GetLuaSource(string fileName) => null;
+        public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default) =>
+            new(Array.Empty<string>());
+        public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default) =>
+            new((string?)null);
 
         public IReadOnlyList<EncDotNet.S100.Pipelines.Vector.Lua.LuaContextParameter> ContextParameters => [];
 
-        public SvgSymbol GetSymbol(string symbolName) =>
-            new() { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" };
+        public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default) =>
+            new(new SvgSymbol { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" });
 
-        public LineStyle GetLineStyle(string name) =>
-            new() { Name = name, Width = 1.0f, Color = "#000000" };
+        public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new LineStyle { Name = name, Width = 1.0f, Color = "#000000" });
 
-        public AreaFill GetAreaFill(string name) =>
-            new() { Name = name, Color = "#C8C8C8" };
+        public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new AreaFill { Name = name, Color = "#C8C8C8" });
     }
 
     #endregion

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102CoveragePipelineIntegrationTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102CoveragePipelineIntegrationTests.cs
@@ -40,8 +40,12 @@ public class S102CoveragePipelineIntegrationTests : IDisposable
         _provider.Dispose();
     }
 
-    private S102PortrayalCatalogue CreateCatalogue() =>
-        new(_engine, _provider);
+    private S102PortrayalCatalogue CreateCatalogue()
+    {
+        var c = new S102PortrayalCatalogue(_engine, _provider);
+        c.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        return c;
+    }
 
     [Fact]
     public async Task EndToEnd_ReadsHdf5_ProducesStyledLayer()

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102PortrayalCatalogueTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102PortrayalCatalogueTests.cs
@@ -45,13 +45,18 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
         _source.Dispose();
     }
 
-    private S102PortrayalCatalogue CreateCatalogue() => new(_engine, _provider);
+    private S102PortrayalCatalogue CreateCatalogue()
+    {
+        var c = new S102PortrayalCatalogue(_engine, _provider);
+        c.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        return c;
+    }
 
     [Fact]
     public void DayPalette_LoadsAllSixDepthTokens()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         foreach (var token in new[] { "DEPDW", "DEPMD", "DEPMS", "DEPVS", "DEPIT", "NODTA" })
         {
@@ -68,14 +73,14 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     public void DuskAndNightPalettes_Load_AndDifferFromDay()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         Assert.True(catalogue.ActivePalette.TryResolve("DEPVS", out var dayHex));
 
-        catalogue.SwitchPalette(PaletteType.Dusk);
+        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
         Assert.True(catalogue.ActivePalette.TryResolve("DEPVS", out var duskHex));
         Assert.NotEqual(dayHex, duskHex);
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         Assert.True(catalogue.ActivePalette.TryResolve("DEPVS", out var nightHex));
         Assert.Equal(NightDEPVS, nightHex, StringComparer.OrdinalIgnoreCase);
     }
@@ -137,7 +142,7 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     public void NightPalette_SwitchAppliesToResolvedScheme()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings { FourShades = false, SafetyContour = 30.0 });
 
@@ -148,7 +153,7 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     public void NoDataColor_IsPopulatedFromActivePaletteNODTA()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings { FourShades = false, SafetyContour = 30.0 });
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/S104PortrayalCatalogueTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S104PortrayalCatalogueTests.cs
@@ -33,7 +33,7 @@ public sealed class S104PortrayalCatalogueTests
     public void Day_palette_returns_existing_blue_green_diverging_scheme()
     {
         var catalogue = new S104PortrayalCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings());
 
@@ -54,10 +54,10 @@ public sealed class S104PortrayalCatalogueTests
     {
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var day = catalogue.ResolveColorScheme(new MarinerSettings());
 
-        catalogue.SwitchPalette(PaletteType.Dusk);
+        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
         var dusk = catalogue.ResolveColorScheme(new MarinerSettings());
 
         Assert.Equal(day.Bands.Count, dusk.Bands.Count);
@@ -72,10 +72,10 @@ public sealed class S104PortrayalCatalogueTests
     {
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var day = catalogue.ResolveColorScheme(new MarinerSettings());
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         var night = catalogue.ResolveColorScheme(new MarinerSettings());
 
         Assert.Equal(day.Bands.Count, night.Bands.Count);
@@ -93,13 +93,13 @@ public sealed class S104PortrayalCatalogueTests
         // the Day band table regardless.
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var dayFirst = catalogue.ResolveColorScheme(new MarinerSettings()).Bands[0].Color;
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         var nightFirst = catalogue.ResolveColorScheme(new MarinerSettings()).Bands[0].Color;
 
-        catalogue.SwitchPalette(PaletteType.Dusk);
+        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
         var duskFirst = catalogue.ResolveColorScheme(new MarinerSettings()).Bands[0].Color;
 
         Assert.NotEqual(dayFirst, nightFirst);
@@ -112,13 +112,13 @@ public sealed class S104PortrayalCatalogueTests
     {
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var dayNoData = catalogue.ResolveColorScheme(new MarinerSettings()).NoDataColor;
 
-        catalogue.SwitchPalette(PaletteType.Dusk);
+        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
         var duskNoData = catalogue.ResolveColorScheme(new MarinerSettings()).NoDataColor;
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         var nightNoData = catalogue.ResolveColorScheme(new MarinerSettings()).NoDataColor;
 
         Assert.False(string.IsNullOrEmpty(dayNoData));

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs
@@ -41,16 +41,16 @@ public class S111PaletteCacheTests
         // Switch through every palette, in arbitrary order, including a
         // switch back to Day — none of these should re-open the asset
         // after the first one.
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
-        catalogue.SwitchPalette(PaletteType.Dusk);
+        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
         var after = counting.GetOpenCount(S111ColorProfileRelativePath);
@@ -75,7 +75,7 @@ public class S111PaletteCacheTests
         var provider = manager.GetProvider("S-111");
         var catalogue = new S111PortrayalCatalogue(provider);
 
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var afterSwitch = counting.GetOpenCount(S111ColorProfileRelativePath);
 
         // The defensive ActivePalette.Colors.Count == 0 re-load was the

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111PortrayalCatalogueTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111PortrayalCatalogueTests.cs
@@ -47,13 +47,18 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
         _source.Dispose();
     }
 
-    private S111PortrayalCatalogue CreateCatalogue() => new(_provider);
+    private S111PortrayalCatalogue CreateCatalogue()
+    {
+        var c = new S111PortrayalCatalogue(_provider);
+        c.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        return c;
+    }
 
     [Fact]
     public void Day_palette_loads_all_nine_speed_band_tokens()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
 
         for (int i = 1; i <= 9; i++)
         {
@@ -68,10 +73,10 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     public void Dusk_palette_loads_and_differs_from_Day_for_at_least_one_band()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var dayColors = ReadBandColors(catalogue);
 
-        catalogue.SwitchPalette(PaletteType.Dusk);
+        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
         var duskColors = ReadBandColors(catalogue);
 
         Assert.Equal(dayColors.Count, duskColors.Count);
@@ -85,10 +90,10 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     public void Night_palette_loads_and_differs_from_Day_for_at_least_one_band()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         var dayColors = ReadBandColors(catalogue);
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         var nightColors = ReadBandColors(catalogue);
 
         Assert.Equal(dayColors.Count, nightColors.Count);
@@ -140,10 +145,10 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     public void SwitchPalette_to_Night_then_ActivePalette_reflects_change()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPalette(PaletteType.Day);
+        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
         Assert.True(catalogue.ActivePalette.TryResolve("SCBN1", out var dayBand1));
 
-        catalogue.SwitchPalette(PaletteType.Night);
+        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
         Assert.True(catalogue.ActivePalette.TryResolve("SCBN1", out var nightBand1));
 
         Assert.NotEqual(dayBand1, nightBand1);

--- a/tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs
@@ -65,8 +65,8 @@ public class SpecLevelAssetCacheTests
         // Lua source: the most representative asset, also exercises the
         // PR-2 cache that we just lifted.
         var openMainLuaBefore = counting.GetOpenCount("Rules/main.lua");
-        var srcA = catalogueA.GetLuaSource("main.lua");
-        var srcB = catalogueB.GetLuaSource("main.lua");
+        var srcA = catalogueA.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var srcB = catalogueB.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
         Assert.NotNull(srcA);
         Assert.Same(srcA, srcB);
         Assert.Equal(openMainLuaBefore + 1, counting.GetOpenCount("Rules/main.lua"));
@@ -78,8 +78,8 @@ public class SpecLevelAssetCacheTests
         {
             var xsltAssetPath = $"Rules/{xsltRule.FileName}";
             var openXsltBefore = counting.GetOpenCount(xsltAssetPath);
-            var transformA = catalogueA.GetCompiledRule(xsltRule.Id);
-            var transformB = catalogueB.GetCompiledRule(xsltRule.Id);
+            var transformA = catalogueA.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
+            var transformB = catalogueB.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
             Assert.Same(transformA, transformB);
             Assert.Equal(openXsltBefore + 1, counting.GetOpenCount(xsltAssetPath));
         }
@@ -90,8 +90,8 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"Symbols/{symbol.FileName}";
             var openBefore = counting.GetOpenCount(assetPath);
-            var svgA = catalogueA.GetSymbol(symbol.Id);
-            var svgB = catalogueB.GetSymbol(symbol.Id);
+            var svgA = catalogueA.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
+            var svgB = catalogueB.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
             Assert.Same(svgA, svgB);
             Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
         }
@@ -102,8 +102,8 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"LineStyles/{lineStyle.FileName}";
             var openBefore = counting.GetOpenCount(assetPath);
-            var lsA = catalogueA.GetLineStyle(lineStyle.Id);
-            var lsB = catalogueB.GetLineStyle(lineStyle.Id);
+            var lsA = catalogueA.GetLineStyleAsync(lineStyle.Id).AsTask().GetAwaiter().GetResult();
+            var lsB = catalogueB.GetLineStyleAsync(lineStyle.Id).AsTask().GetAwaiter().GetResult();
             Assert.Same(lsA, lsB);
             Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
         }
@@ -114,8 +114,8 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"AreaFills/{areaFill.FileName}";
             var openBefore = counting.GetOpenCount(assetPath);
-            var afA = catalogueA.GetAreaFill(areaFill.Id);
-            var afB = catalogueB.GetAreaFill(areaFill.Id);
+            var afA = catalogueA.GetAreaFillAsync(areaFill.Id).AsTask().GetAwaiter().GetResult();
+            var afB = catalogueB.GetAreaFillAsync(areaFill.Id).AsTask().GetAwaiter().GetResult();
             Assert.Same(afA, afB);
             Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
         }
@@ -136,9 +136,9 @@ public class SpecLevelAssetCacheTests
         const string missing = "definitely-not-a-real-rule.lua";
         var openCountBefore = counting.GetOpenCount($"Rules/{missing}");
 
-        Assert.Null(catalogueA.GetLuaSource(missing));
-        Assert.Null(catalogueB.GetLuaSource(missing));
-        Assert.Null(catalogueA.GetLuaSource(missing));
+        Assert.Null(catalogueA.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult());
+        Assert.Null(catalogueB.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult());
+        Assert.Null(catalogueA.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult());
 
         var attempts = counting.GetOpenCount($"Rules/{missing}") - openCountBefore;
         // At most one underlying open across both catalogues: PR-2's
@@ -169,8 +169,8 @@ public class SpecLevelAssetCacheTests
         var xsltAssetPath = $"Rules/{xsltRule!.FileName}";
         var openBefore = counting.GetOpenCount(xsltAssetPath);
 
-        var transformA = catalogueA.GetCompiledRule(xsltRule.Id);
-        var transformB = catalogueB.GetCompiledRule(xsltRule.Id);
+        var transformA = catalogueA.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
+        var transformB = catalogueB.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
         Assert.Same(transformA, transformB);
 
         // Exactly one underlying open of the XSLT rule across both
@@ -184,8 +184,8 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"Symbols/{symbol.FileName}";
             var symOpenBefore = counting.GetOpenCount(assetPath);
-            var svgA = catalogueA.GetSymbol(symbol.Id);
-            var svgB = catalogueB.GetSymbol(symbol.Id);
+            var svgA = catalogueA.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
+            var svgB = catalogueB.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
             Assert.Same(svgA, svgB);
             Assert.Equal(symOpenBefore + 1, counting.GetOpenCount(assetPath));
         }
@@ -213,8 +213,8 @@ public class SpecLevelAssetCacheTests
         var s101OpenBefore = s101Counting.GetOpenCount("Rules/main.lua");
         var s131OpenBefore = s131Counting.GetOpenCount("Rules/main.lua");
 
-        var s101Src = s101Catalogue.GetLuaSource("main.lua");
-        var s131Src = s131Catalogue.GetLuaSource("main.lua");
+        var s101Src = s101Catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var s131Src = s131Catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
 
         Assert.NotNull(s101Src);
         Assert.NotNull(s131Src);

--- a/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
@@ -218,7 +218,7 @@ public sealed class TelemetrySmokeTests
         public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
-        public void SwitchPalette(PaletteType type) { }
+        public ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public IReadOnlyList<PortrayalRule> Rules { get; }
         public ViewingGroupController ViewingGroups { get; }
@@ -227,21 +227,25 @@ public sealed class TelemetrySmokeTests
 
         public DisplayPlaneController DisplayPlanes { get; } = new();
 
-        public XslCompiledTransform GetCompiledRule(string ruleName) =>
-            _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
+        public ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default) =>
+            new(_xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName));
 
-        public string? GetLuaSource(string fileName) => null;
+        public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default) =>
+            new(Array.Empty<string>());
+
+        public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default) =>
+            new((string?)null);
 
         public IReadOnlyList<EncDotNet.S100.Pipelines.Vector.Lua.LuaContextParameter> ContextParameters => [];
 
-        public SvgSymbol GetSymbol(string symbolName) =>
-            new() { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" };
+        public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default) =>
+            new(new SvgSymbol { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" });
 
-        public LineStyle GetLineStyle(string name) =>
-            new() { Name = name, Width = 1.0f, Color = "#000000" };
+        public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new LineStyle { Name = name, Width = 1.0f, Color = "#000000" });
 
-        public AreaFill GetAreaFill(string name) =>
-            new() { Name = name, Color = "#C8C8C8" };
+        public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new AreaFill { Name = name, Color = "#C8C8C8" });
     }
 
     #endregion

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorPipelineTests.cs
@@ -634,7 +634,7 @@ public class VectorPipelineTests
         public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
-        public void SwitchPalette(PaletteType type) { }
+        public ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public IReadOnlyList<PortrayalRule> Rules { get; }
         public ViewingGroupController ViewingGroups { get; }
@@ -643,21 +643,25 @@ public class VectorPipelineTests
 
         public DisplayPlaneController DisplayPlanes { get; } = new();
 
-        public XslCompiledTransform GetCompiledRule(string ruleName) =>
-            _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
+        public ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default) =>
+            new(_xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName));
 
-        public string? GetLuaSource(string fileName) => null;
+        public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default) =>
+            new(Array.Empty<string>());
+
+        public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default) =>
+            new((string?)null);
 
         public IReadOnlyList<EncDotNet.S100.Pipelines.Vector.Lua.LuaContextParameter> ContextParameters => [];
 
-        public SvgSymbol GetSymbol(string symbolName) =>
-            new() { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" };
+        public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default) =>
+            new(new SvgSymbol { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" });
 
-        public LineStyle GetLineStyle(string name) =>
-            new() { Name = name, Width = 1.0f, Color = "#000000" };
+        public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new LineStyle { Name = name, Width = 1.0f, Color = "#000000" });
 
-        public AreaFill GetAreaFill(string name) =>
-            new() { Name = name, Color = "#C8C8C8" };
+        public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new AreaFill { Name = name, Color = "#C8C8C8" });
     }
 
     #endregion

--- a/tests/EncDotNet.S100.Pipelines.Tests/XsltRuleExecutorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/XsltRuleExecutorTests.cs
@@ -46,7 +46,7 @@ public class XsltRuleExecutorTests
 
         // The mariner argument is ignored by the XSLT engine; pass an explicit
         // non-default value to confirm it has no effect.
-        var instructions = executor.Execute(new MarinerSettings { FourShades = true });
+        var instructions = executor.ExecuteAsync(new MarinerSettings { FourShades = true }).GetAwaiter().GetResult();
 
         var inst = Assert.IsType<PointInstruction>(Assert.Single(instructions));
         Assert.Equal("1", inst.FeatureReference);
@@ -73,7 +73,7 @@ public class XsltRuleExecutorTests
             xsltRules: new() { ["BuoyRule"] = xslt });
 
         var executor = new XsltRuleExecutor(source, catalogue);
-        executor.Execute(MarinerSettings.Default);
+        executor.ExecuteAsync(MarinerSettings.Default).GetAwaiter().GetResult();
 
         Assert.Equal(2, executor.LastFeatureTypeCount);
 
@@ -93,7 +93,7 @@ public class XsltRuleExecutorTests
         cts.Cancel();
 
         Assert.ThrowsAny<OperationCanceledException>(
-            () => executor.Execute(MarinerSettings.Default, cts.Token));
+            () => executor.ExecuteAsync(MarinerSettings.Default, cts.Token).GetAwaiter().GetResult());
     }
 
     private static XslCompiledTransform CompileXslt(string xslt)
@@ -121,26 +121,29 @@ public class XsltRuleExecutorTests
         public SpecRef Spec => new("S-101", default);
         public string Edition => "1.2.0";
         public ColorPalette ActivePalette => ColorPalette.Default;
-        public void SwitchPalette(PaletteType type) { }
+        public ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public IReadOnlyList<PortrayalRule> Rules { get; } = rules;
         public ViewingGroupController ViewingGroups { get; } = new();
         public DisplayModeController DisplayModes { get; } = new();
         public DisplayPlaneController DisplayPlanes { get; } = new();
 
-        public XslCompiledTransform GetCompiledRule(string ruleName) =>
-            _xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName);
+        public ValueTask<XslCompiledTransform> GetCompiledRuleAsync(string ruleName, CancellationToken cancellationToken = default) =>
+            new(_xsltRules.TryGetValue(ruleName, out var t) ? t : throw new KeyNotFoundException(ruleName));
 
-        public string? GetLuaSource(string fileName) => null;
+        public ValueTask<IReadOnlyList<string>> GetLuaSourceNamesAsync(CancellationToken cancellationToken = default) =>
+            new(Array.Empty<string>());
+        public ValueTask<string?> GetLuaSourceAsync(string fileName, CancellationToken cancellationToken = default) =>
+            new((string?)null);
         public IReadOnlyList<LuaContextParameter> ContextParameters => [];
 
-        public SvgSymbol GetSymbol(string symbolName) =>
-            new() { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" };
+        public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default) =>
+            new(new SvgSymbol { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" });
 
-        public LineStyle GetLineStyle(string name) =>
-            new() { Name = name, Width = 1.0f, Color = "#000000" };
+        public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new LineStyle { Name = name, Width = 1.0f, Color = "#000000" });
 
-        public AreaFill GetAreaFill(string name) =>
-            new() { Name = name, Color = "#C8C8C8" };
+        public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new AreaFill { Name = name, Color = "#C8C8C8" });
     }
 }


### PR DESCRIPTION
Closes #182.

Makes the three Core capability interfaces purely async and routes the catalogue/asset load path through them, eliminating **35 of the 42** `GetAwaiter().GetResult()` sites — every one on the render hot path.

## Core interface changes (breaking)

- `IPortrayalAssetSource`: sync `GetSymbol`/`GetLineStyle`/`GetAreaFill` → `GetSymbolAsync`/`GetLineStyleAsync`/`GetAreaFillAsync` returning `ValueTask<T>`
- `IXsltRuleSource`: `GetCompiledRule` → `GetCompiledRuleAsync`
- `ILuaRuleSource`: `GetLuaSource(string)` → `GetLuaSourceNamesAsync` + `GetLuaSourceAsync` (catalogue serves content; sync MoonSharp bridge moves into `LuaRuleExecutor`)
- `IVectorRuleExecutor.ExecuteAsync`, `ILuaVectorRuleExecutor.ExecuteRawAsync`
- `IPortrayalCatalogue.SwitchPaletteAsync`
- `IPortrayalInstructionCache.GetOrComputeAsync` added (eliminates inline blocking wait at S101DatasetProcessor:548)

## Sync ↔ async bridges

`LuaRuleExecutor` pre-loads every declared Lua module into a snapshot dict via the async API, then captures the dict in its synchronous MoonSharp `SetModuleLoader` callback.

`GmlPortrayalCatalogueBase.LoadXsltRuleAsync` pre-fetches every registered rule file's bytes before invoking `XslCompiledTransform.Load`, and feeds the byte dictionary to a memory-backed `XmlResolver`. `xsl:include` resolution serves from memory.

Dataset processors gain a pre-warm phase via the new `CataloguePreWarm.ForInstructionsAsync`, which walks emitted `DrawingInstruction`s for unique symbol/line-style/area-fill names, awaits each `Get*Async`, and returns dicts the synchronous Skia/Mapsui resolver lambdas close over. Second-order pattern-fill symbols are pre-warmed too.

## Remaining sync sites

10 `GetAwaiter().GetResult()` calls remain, each annotated `// SYNC BRIDGE:`:

- **3 sites** — `XmlResolver.GetEntity` callbacks in `GmlPortrayalCatalogueBase` and `S129PortrayalCatalogue`. `XslCompiledTransform.Load` only invokes the sync `GetEntity`, never `GetEntityAsync` — there's also no `LoadAsync` overload. BCL limitation; cannot be eliminated without abandoning `XslCompiledTransform`.
- **5 sites** — catalogue-manager / dataset-processor open paths over in-process `IAssetSource`s. Tracked in #200.
- **2 sites** — viewer Avalonia event-chain sync paths. Tracked in #201.

All remaining sites are bounded to one-shot cold-init or sync-API contracts; none are on the render hot path.

## Other

- Removed `DatasetPipelineFactory.Process(string)` (sync facade with no external consumers).

## Verification

- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 2752 passed, 0 failed, 8 pre-existing data-fixture skips

60 files changed, +1069/-560.