### PR TITLE
Publish all packable libraries via self-maintaining solution pack (#206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,10 @@ jobs:
       - name: Pack NuGet packages
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          dotnet pack src/EncDotNet.S100.Core/EncDotNet.S100.Core.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Datasets.S102/EncDotNet.S100.Datasets.S102.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Datasets.S111/EncDotNet.S100.Datasets.S111.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Portrayals/EncDotNet.S100.Portrayals.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
-          dotnet pack src/EncDotNet.S100.Scripting.MoonSharp/EncDotNet.S100.Scripting.MoonSharp.csproj --no-build --configuration Release --output nupkgs -p:Version=$VERSION
+        # Pack every packable project in the solution. Projects opt out via
+        # <IsPackable>false</IsPackable> (hosts, tooling, tests), so new
+        # Datasets.SXXX libraries are published automatically with no edit here.
+        run: dotnet pack EncDotNet.S100.slnx --no-build --configuration Release --output nupkgs -p:Version=$VERSION
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4

--- a/src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj
+++ b/src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/EncDotNet.S100.Datasets.S129.Fusion/EncDotNet.S100.Datasets.S129.Fusion.csproj
+++ b/src/EncDotNet.S100.Datasets.S129.Fusion/EncDotNet.S100.Datasets.S129.Fusion.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EncDotNet.S100.Diagnostics.Export/EncDotNet.S100.Diagnostics.Export.csproj
+++ b/src/EncDotNet.S100.Diagnostics.Export/EncDotNet.S100.Diagnostics.Export.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
   </ItemGroup>

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.DynamicSources.Ais\EncDotNet.S100.DynamicSources.Ais.csproj" />

--- a/src/EncDotNet.S100.DynamicSources.Ais/EncDotNet.S100.DynamicSources.Ais.csproj
+++ b/src/EncDotNet.S100.DynamicSources.Ais/EncDotNet.S100.DynamicSources.Ais.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj
+++ b/src/EncDotNet.S100.Mcp.Tools/EncDotNet.S100.Mcp.Tools.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EncDotNet.S100.Mcp/EncDotNet.S100.Mcp.csproj
+++ b/src/EncDotNet.S100.Mcp/EncDotNet.S100.Mcp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- 1591: tolerate missing XML comments on private/internal members. -->
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <IsPackable>false</IsPackable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Branding\AppIcon.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+++ b/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
     <AssemblyName>s100</AssemblyName>
     <RootNamespace>EncDotNet.S100.Cli</RootNamespace>
     <!--

--- a/tools/EncDotNet.S100.PerfReport/EncDotNet.S100.PerfReport.csproj
+++ b/tools/EncDotNet.S100.PerfReport/EncDotNet.S100.PerfReport.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj
+++ b/tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The CI "Pack NuGet packages" step hand-maintained an allowlist of 11 `dotnet pack` calls. The solution actually ships 14 product readers + S-57 + `Specifications`, but only 3 readers (S101/S102/S111) were published, so an external developer could consume just 3 of 14 readers from NuGet. The allowlist also drifted silently every time a new product is added.

This replaces the allowlist with a single solution-level `dotnet pack EncDotNet.S100.slnx` that respects `IsPackable`, so every packable library is published automatically and new `Datasets.SXXX` projects are included by default with no workflow edit.

To make inclusion-by-default safe, every genuinely non-shippable project is now marked `<IsPackable>false</IsPackable>`:
- Hosts: AppHost, Viewer, Mcp
- Ancillary libs: Mcp.Tools, Diagnostics.Export, DynamicSources.Ais (+ AisStreamIo driver), Datasets.S129.Fusion
- Tooling: tools/Cli, tools/PerfReport, tools/PerfRunner

(Test projects and Datasets.Pipelines were already `IsPackable=false`.)

The published set grows from 11 to 24 packages, closing the product-reader gap: S104, S122, S124, S125, S127, S128, S129, S131, S201, S411, S421 and S57 now ship alongside Specifications.

**Scope note:** the ancillary libraries (Mcp.Tools, DynamicSources.Ais*, Diagnostics.Export, S129.Fusion) are intentionally marked non-packable for now, keeping the published surface to the framework libs + product readers + Specifications. They can be opted back in later by removing the flag.

### Notes for reviewers

- **Self-maintaining package count:** the published count is now derived from `IsPackable`, not a fixed list. It is 24 today; adding a new `Datasets.SXXX` will increase it automatically. A changing package count on a new product is expected behaviour, not a regression.
- **Redistributing `Specifications`:** this package embeds official IHO Feature/Portrayal Catalogues. Redistribution was considered and introduces no new distribution surface: the exact same content already ships publicly in this repo and in the released Viewer artifacts (app bundle / DMG / archives). NuGet is just another channel for already-public content. If IHO terms ever required restricting this content, that constraint would apply repo-wide rather than to the NuGet package alone.

Fixes: #206

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

No unit tests apply to a packaging/CI change. Verified manually instead: `dotnet build -c Release` succeeds, the solution-level `dotnet pack` produces exactly the 24 expected packages (no host/test/tooling packages), and every `EncDotNet.S100.*` package dependency resolves within the published set (no broken dependencies introduced by the new `IsPackable=false` projects).

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

N/A — no API or behavioural changes; only project packaging flags and the CI workflow.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None for consumers. New packages become available; the existing 11 packages are unchanged.