### PR TITLE
Ship s100 CLI as standalone per-RID release archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,24 @@ jobs:
           -p:Version=${{ steps.version.outputs.version }}
           --output src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/cli
 
+      - name: Archive standalone s100 CLI (Linux)
+        # Package the self-contained `s100` CLI as its own per-RID release
+        # asset so users can download just the command-line tool without the
+        # viewer. The osx-arm64 archive is produced later, after the CLI is
+        # code-signed and notarized.
+        if: startsWith(matrix.rid, 'linux-')
+        shell: bash
+        run: >
+          tar -czf "s100-${{ steps.version.outputs.version }}-${{ matrix.rid }}.tar.gz"
+          -C "src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/cli" .
+
+      - name: Archive standalone s100 CLI (Windows)
+        if: startsWith(matrix.rid, 'win-')
+        shell: pwsh
+        run: |
+          $cli = "src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/cli"
+          Compress-Archive -Path "$cli/*" -DestinationPath "s100-${{ steps.version.outputs.version }}-${{ matrix.rid }}.zip"
+
       - name: Create macOS .app bundle
         if: matrix.rid == 'osx-arm64'
         run: |
@@ -295,6 +313,77 @@ jobs:
           echo "::warning::Stapling failed after 5 attempts. The app is still notarized; Gatekeeper will verify online."
           exit 1
 
+      - name: Sign standalone macOS s100 CLI
+        # The bundled CLI inside the .app is signed by the recursive loop above,
+        # but the standalone copy at .../publish/cli is a separate set of files
+        # and must be signed independently for its own release archive.
+        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          CLI="src/EncDotNet.S100.Viewer/bin/Release/net10.0/osx-arm64/publish/cli"
+          ENTITLEMENTS="src/EncDotNet.S100.Viewer/entitlements.plist"
+          MAIN_EXE="s100"
+          # Remove debug symbols; codesign treats .pdb as unsigned code objects.
+          find "$CLI" -name '*.pdb' -delete
+          # Sign every nested Mach-O (native dylibs such as libSkiaSharp.dylib)
+          # before the host executable.
+          find "$CLI" -type f ! -name "$MAIN_EXE" | while read -r f; do
+            if file "$f" | grep -q "Mach-O"; then
+              codesign --force --options runtime --timestamp \
+                --entitlements "$ENTITLEMENTS" \
+                --sign "$APPLE_SIGNING_IDENTITY" "$f"
+            fi
+          done
+          # Sign the host executable last with hardened runtime + entitlements.
+          codesign --force --options runtime --timestamp \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$APPLE_SIGNING_IDENTITY" "$CLI/s100"
+          codesign --verify --strict --verbose=2 "$CLI/s100"
+
+      - name: Notarize standalone macOS s100 CLI
+        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          CLI="src/EncDotNet.S100.Viewer/bin/Release/net10.0/osx-arm64/publish/cli"
+          # notarytool accepts .zip/.dmg/.pkg but not .tar.gz, so submit a
+          # throwaway .zip. The ticket is registered server-side against each
+          # binary's cdhash, so the distributed .tar.gz (identical signed
+          # binaries) passes Gatekeeper's online check on first run. A bare CLI
+          # cannot be stapled, so we rely on that online verification.
+          ditto -c -k --keepParent "$CLI" s100-cli-notarize.zip
+          xcrun notarytool submit s100-cli-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait \
+            --output-format json | tee cli-notarization-result.json
+          STATUS=$(python3 -c "import json,sys; print(json.load(sys.stdin)['status'])" < cli-notarization-result.json)
+          ID=$(python3 -c "import json,sys; print(json.load(sys.stdin)['id'])" < cli-notarization-result.json)
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "::error::CLI notarization failed with status: $STATUS"
+            xcrun notarytool log "$ID" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_PASSWORD"
+            exit 1
+          fi
+
+      - name: Archive standalone macOS s100 CLI
+        if: matrix.rid == 'osx-arm64'
+        run: >
+          tar -czf "s100-${{ steps.version.outputs.version }}-osx-arm64.tar.gz"
+          -C "src/EncDotNet.S100.Viewer/bin/Release/net10.0/osx-arm64/publish/cli" .
+
+      - name: Upload standalone s100 CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: s100-cli-${{ matrix.rid }}
+          path: s100-*-${{ matrix.rid }}.*
+
       - name: Build macOS DMG
         if: matrix.rid == 'osx-arm64'
         env:
@@ -385,16 +474,21 @@ jobs:
         if: matrix.rid == 'osx-arm64'
         run: tar -czf "${{ matrix.artifact }}.tar.gz" EncDotNet.S100.Viewer.app
 
-      - name: Archive published app
-        if: matrix.rid != 'osx-arm64'
+      - name: Archive published app (Linux)
+        if: startsWith(matrix.rid, 'linux-')
         shell: bash
         run: tar -czf "${{ matrix.artifact }}.tar.gz" -C "src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish" .
+
+      - name: Archive published app (Windows)
+        if: startsWith(matrix.rid, 'win-')
+        shell: pwsh
+        run: Compress-Archive -Path "src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/*" -DestinationPath "${{ matrix.artifact }}.zip"
 
       - name: Upload published app
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}.tar.gz
+          path: ${{ matrix.artifact }}.*
 
       - name: Upload macOS DMG
         if: matrix.rid == 'osx-arm64'
@@ -451,4 +545,7 @@ jobs:
           files: |
             artifacts/nupkgs/*.nupkg
             artifacts/Viewer-*/*.tar.gz
+            artifacts/Viewer-*/*.zip
+            artifacts/s100-cli-*/*.tar.gz
+            artifacts/s100-cli-*/*.zip
             artifacts/Viewer-*-dmg/*.dmg

--- a/README.md
+++ b/README.md
@@ -196,7 +196,11 @@ dotnet run --project src/EncDotNet.S100.Viewer
 Pre-built per-platform binaries are attached to every
 [release](https://github.com/philliphoff/EncDotNet.S100/releases).
 The macOS DMG is Developer-ID signed and Apple-notarized; Windows
-and Linux ship as architecture-tagged `tar.gz` archives.
+ships as architecture-tagged `zip` archives and Linux as
+architecture-tagged `tar.gz` archives. The standalone `s100`
+command-line tool is also attached per platform as
+`s100-<version>-<rid>` (`.zip` on Windows, `.tar.gz` on macOS/Linux);
+see [docs/cli.md](docs/cli.md) for install instructions.
 
 ## Observability
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,18 @@ attribute with `xattr -d com.apple.quarantine ./s100`.
 The same `s100` executable also ships inside the S-100 Viewer application
 bundle (under `cli/`); see the project README for that layout.
 
+### Future: installable `dotnet tool`
+
+A one-line `dotnet tool install -g` on-ramp remains a possible future addition.
+It was not adopted now because a classic global tool package is RID-agnostic
+(all assemblies land in a single `tools/<tfm>/any/` folder) and does not lay out
+SkiaSharp's `runtimes/<rid>/native/libSkiaSharp.*` native libraries where the
+host resolves them, causing a `DllNotFoundException` on the first render. .NET 8+
+does support **self-contained, RID-specific** tool packages, which would carry
+the native assets correctly, so publishing such a package (one per RID, heavier
+than the framework-dependent global tool) is a viable future complement to the
+standalone archives above.
+
 ## Quick start
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,34 @@ previews).
 The tool is structured with **subcommands** so its scope can grow (tiling,
 batch, validation, …) without breaking existing usage.
 
+## Install (standalone download)
+
+Each [GitHub Release](https://github.com/philliphoff/EncDotNet.S100/releases)
+attaches a **self-contained, per-platform archive** of `s100`. It bundles the
+.NET runtime and SkiaSharp's native libraries, so **no .NET installation is
+required** — just download, extract, and run.
+
+| Platform | Asset | Run |
+|---|---|---|
+| Windows x64 | `s100-<version>-win-x64.zip` | `s100.exe render dataset.h5 out.png` |
+| Windows arm64 | `s100-<version>-win-arm64.zip` | `s100.exe render dataset.h5 out.png` |
+| macOS (Apple silicon) | `s100-<version>-osx-arm64.tar.gz` | `./s100 render dataset.h5 out.png` |
+| Linux x64 | `s100-<version>-linux-x64.tar.gz` | `./s100 render dataset.h5 out.png` |
+| Linux arm64 | `s100-<version>-linux-arm64.tar.gz` | `./s100 render dataset.h5 out.png` |
+
+```bash
+# macOS / Linux
+tar -xzf s100-<version>-<rid>.tar.gz
+./s100 list-specs
+```
+
+The macOS archive is code-signed and notarized, so Gatekeeper verifies it
+online on first launch. If a copied binary is still quarantined, clear the
+attribute with `xattr -d com.apple.quarantine ./s100`.
+
+The same `s100` executable also ships inside the S-100 Viewer application
+bundle (under `cli/`); see the project README for that layout.
+
 ## Quick start
 
 ```bash

--- a/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+++ b/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
@@ -5,11 +5,14 @@
     <AssemblyName>s100</AssemblyName>
     <RootNamespace>EncDotNet.S100.Cli</RootNamespace>
     <!--
-      Package-ready (a `dotnet tool install -g` global tool invoked as `s100`),
-      but publishing is gated until SkiaSharp native assets and the bundled
-      Specification content are verified to resolve from an installed tool.
+      Distributed as standalone, self-contained, per-RID release archives
+      (`s100-<version>-<rid>.{zip,tar.gz}`) attached to each GitHub Release, not
+      as a `dotnet tool install -g` global tool. A RID-agnostic packed tool does
+      not reliably lay out SkiaSharp's `runtimes/<rid>/native/libSkiaSharp.*`
+      native assets, so a self-contained publish (which lays them out correctly
+      and bundles the .NET runtime) is used instead. `PackAsTool` therefore
+      stays disabled. The `s100` command name comes from `AssemblyName` above.
     -->
-    <ToolCommandName>s100</ToolCommandName>
     <PackAsTool>false</PackAsTool>
   </PropertyGroup>
 

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -10,10 +10,36 @@ The command name is **`s100`**.
 
 ## Distribution
 
-The `s100` executable ships **inside the S-100 Viewer application bundle** so a
-single download provides both the GUI and the command-line tool. CI publishes
-it self-contained (per platform RID) into a `cli/` subfolder of the viewer's
-publish output:
+The `s100` CLI is distributed two ways, both produced by CI on each release:
+
+### Standalone download (recommended)
+
+Each GitHub Release attaches a **self-contained, per-platform archive** that
+bundles the .NET runtime and SkiaSharp's native libraries, so **no .NET
+installation is required**:
+
+| Platform | Asset | Extract & run |
+|---|---|---|
+| Windows x64 | `s100-<version>-win-x64.zip` | `s100.exe render …` |
+| Windows arm64 | `s100-<version>-win-arm64.zip` | `s100.exe render …` |
+| macOS (Apple silicon) | `s100-<version>-osx-arm64.tar.gz` | `./s100 render …` |
+| Linux x64 | `s100-<version>-linux-x64.tar.gz` | `./s100 render …` |
+| Linux arm64 | `s100-<version>-linux-arm64.tar.gz` | `./s100 render …` |
+
+The macOS archive is code-signed and notarized; Gatekeeper verifies the
+notarization online on first run. If macOS still quarantines the extracted
+binary (for example when copied between machines), clear the attribute with:
+
+```bash
+xattr -d com.apple.quarantine ./s100
+```
+
+### Inside the Viewer application bundle
+
+The `s100` executable also ships **inside the S-100 Viewer application bundle**
+so a single viewer download provides both the GUI and the command-line tool. CI
+publishes it self-contained (per platform RID) into a `cli/` subfolder of the
+viewer's publish output:
 
 | Platform | Location of `s100` |
 |---|---|


### PR DESCRIPTION
## Summary

Issue #205 asked to ship the `s100` CLI as an installable `dotnet tool install -g` global tool, gated on verifying that SkiaSharp native assets and the embedded Specifications content resolve from an installed tool. After reproducing the concern, the direction changed: rather than fight the global-tool layout, `s100` now ships as **self-contained, per-RID release archives** attached to each GitHub Release, giving users a zero-prerequisite download (no .NET install required).

**Why not the global tool:** a `PackAsTool=true` package is RID-agnostic, so SkiaSharp's `runtimes/<rid>/native/libSkiaSharp.*` native libraries do not lay out where the host resolves them, producing `DllNotFoundException` on the first Skia call. (The embedded Specifications content was never a real blocker since it is compiled into the managed DLL.) A self-contained publish lays the natives out correctly and bundles the runtime. I verified this locally on osx-arm64 by relocating a published `cli/` folder and running `list-specs`, `info`, and `render` against S-124 GML and S-102 coverage fixtures; both natives and embedded catalogues resolve.

**Approach:**
- Keep `PackAsTool=false`; rewrite the csproj gating comment to document the standalone-archive decision.
- In the `ci.yml` publish job, archive the already self-contained `cli/` output per RID: `.zip` for Windows, `.tar.gz` for macOS/Linux, named `s100-<version>-<rid>`, uploaded as `s100-cli-<rid>`.
- Sign and notarize the macOS standalone CLI independently of the viewer bundle. Because `notarytool` does not accept `.tar.gz`, it notarizes a throwaway `.zip` (the ticket is cdhash-keyed, so the distributed `.tar.gz` passes Gatekeeper online on first run; a bare CLI cannot be stapled). All signing steps are gated on `HAS_SIGNING_SECRETS`.
- Align viewer archives: the Windows viewer switches from `.tar.gz` to `.zip`; macOS/Linux stay `.tar.gz`. Release globs updated accordingly.

Fixes: #205

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally (CLI test project: 29/29 passed)

No new unit tests: the change is CI packaging plus docs. Validated by a local self-contained publish + relocated-folder smoke test (`list-specs`/`info`/`render`) and by parsing the workflow YAML.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (CLI README Distribution section)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (`docs/cli.md` standalone install section; top-level README)
- [ ] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (none added)

## Breaking changes

None for library consumers. Distribution change: the Windows viewer release asset is now a `.zip` instead of a `.tar.gz`.