### PR TITLE
Add CONTRIBUTING, SECURITY, and SUPPORT for external contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,123 @@
+name: Bug report
+description: Report a defect in EncDotNet.S100 libraries, the viewer, or tooling.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the
+        sections below so we can reproduce and triage quickly.
+
+        **Do not attach real ENC data files.** Use small synthetic fixtures or
+        describe the data structure instead.
+
+        For security vulnerabilities, do **not** use this form — see
+        [SECURITY.md](https://github.com/philliphoff/EncDotNet.S100/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear, concise description of the bug.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the project is affected? Pick the closest match.
+      options:
+        - "S-100 framework / Core / ExchangeSets / Features / Portrayals / Specifications"
+        - "S-101 ENC"
+        - "S-102 bathymetry"
+        - "S-104 water level"
+        - "S-111 surface currents"
+        - "S-122 marine protected areas"
+        - "S-124 navigational warnings"
+        - "S-125 marine aids to navigation"
+        - "S-127 marine resources and services"
+        - "S-128 catalogue of nautical products"
+        - "S-129 under keel clearance"
+        - "S-131 marine harbour infrastructure"
+        - "S-201 IALA aids to navigation information"
+        - "S-411 sea ice"
+        - "S-421 route plans"
+        - "Renderers (Skia / Mapsui)"
+        - "Viewer (Avalonia desktop app)"
+        - "Tooling (RenderS102, TestS101Lua, etc.)"
+        - "Build / CI / packaging"
+        - "Docs"
+        - "Other / unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reliably reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include exception messages, stack traces, or rendering output as appropriate.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release tag, NuGet package version, or commit SHA.
+      placeholder: e.g. v0.15.0 or commit abc1234
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      multiple: true
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet
+    attributes:
+      label: .NET SDK version
+      description: Output of `dotnet --version`.
+      placeholder: e.g. 10.0.100
+
+  - type: textarea
+    id: data
+    attributes:
+      label: Dataset / fixture (optional)
+      description: |
+        Describe the data needed to reproduce. Attach a small **synthetic**
+        fixture if helpful. Do not attach real ENC data.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, related issues, or anything else.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or general discussion
+    url: https://github.com/philliphoff/EncDotNet.S100/discussions
+    about: For "how do I…?" questions, usage help, and ideas, please use Discussions.
+  - name: Security vulnerability
+    url: https://github.com/philliphoff/EncDotNet.S100/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories — please do not open a public issue.
+  - name: Support
+    url: https://github.com/philliphoff/EncDotNet.S100/blob/main/SUPPORT.md
+    about: Where to ask questions vs. file bugs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,82 @@
+name: Feature request
+description: Suggest a new feature, product, or capability for EncDotNet.S100.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature! Please describe the problem you're
+        trying to solve before jumping to a specific design — that helps us
+        consider alternatives.
+
+        For questions or open-ended discussion, use
+        [Discussions](https://github.com/philliphoff/EncDotNet.S100/discussions)
+        instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? Who benefits and how?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A concise description of what you'd like to see. APIs, UI, behavior, etc.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the project would this touch? Pick the closest match.
+      options:
+        - "S-100 framework / Core / ExchangeSets / Features / Portrayals / Specifications"
+        - "S-101 ENC"
+        - "S-102 bathymetry"
+        - "S-104 water level"
+        - "S-111 surface currents"
+        - "S-122 marine protected areas"
+        - "S-124 navigational warnings"
+        - "S-125 marine aids to navigation"
+        - "S-127 marine resources and services"
+        - "S-128 catalogue of nautical products"
+        - "S-129 under keel clearance"
+        - "S-131 marine harbour infrastructure"
+        - "S-201 IALA aids to navigation information"
+        - "S-411 sea ice"
+        - "S-421 route plans"
+        - "Renderers (Skia / Mapsui)"
+        - "Viewer (Avalonia desktop app)"
+        - "Tooling (RenderS102, TestS101Lua, etc.)"
+        - "Build / CI / packaging"
+        - "Docs"
+        - "New product specification"
+        - "Other / cross-cutting"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why you discarded them.
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec references (optional)
+      description: |
+        For spec-derived behavior, cite the relevant section(s)
+        (e.g. "S-104 §10.2.3 WaterLevel attribute names").
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Use cases, examples, mockups, related issues, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to EncDotNet.S100
+
+Thanks for your interest in contributing! EncDotNet.S100 is a managed,
+cross-platform implementation of the IHO S-100 Universal Hydrographic Data
+Model for .NET. This guide covers everything you need to build, test, and
+submit changes.
+
+By participating you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/) or later.
+- A git client.
+- No native dependencies are required — HDF5 (PureHDF) and Lua (MoonSharp)
+  are fully managed, so everything runs on macOS, Windows, and Linux.
+
+## Getting started
+
+```bash
+git clone https://github.com/philliphoff/EncDotNet.S100.git
+cd EncDotNet.S100
+dotnet build
+```
+
+## Building
+
+```bash
+dotnet build
+```
+
+The solution targets **.NET 10** with `<Nullable>enable</Nullable>` and
+`<ImplicitUsings>enable</ImplicitUsings>` throughout. CI builds on
+`ubuntu-latest`, so avoid platform-specific APIs unless they are gated to the
+appropriate runtime identifier.
+
+## Testing
+
+```bash
+dotnet test --configuration Release
+```
+
+Test conventions:
+
+- Every new public API or bug fix must be accompanied by an xunit test in the
+  appropriate project under `tests/`.
+- Tests that require optional external data files (real HDF5, S-101 datasets,
+  etc.) must use [`Xunit.SkippableFact`](https://github.com/AArnott/Xunit.SkippableFact)
+  via `Skip.If(...)` so CI does not fail when those files are absent.
+- **Never commit real ENC data files to the repository.** Use small synthetic
+  test fixtures, or skip tests that require live data. Synthetic GML fixtures
+  live under `tests/datasets/<SXXX>/`.
+
+## Package management
+
+All NuGet versions are managed centrally via **Central Package Management** in
+`Directory.Packages.props`:
+
+- Do **not** add `Version` attributes to individual `.csproj` files.
+- Add or update versions in `Directory.Packages.props` instead.
+- Before introducing any new dependency, run the `gh-advisory-database`
+  security check and confirm the package is free of known advisories.
+
+## Spec routing (skills & instructions)
+
+This repository is organized around individual IHO S-100 product
+specifications. Per-spec **skills** live under `.github/skills/<spec>/SKILL.md`
+and matching **instructions** under `.github/instructions/`. Before designing
+or implementing any non-trivial change that touches a spec's semantics
+(encoding, attribute names, feature-catalogue rules, portrayal pipelines),
+consult the matching skill/instruction file:
+
+| Area | Skill / instruction |
+|---|---|
+| S-100 framework, exchange sets, portrayal engine | `s100-framework` |
+| S-101 ENC, ISO 8211, Lua portrayal | `s101-enc` |
+| S-102 bathymetry | `s102-bathymetry` |
+| S-104 water level | `s104-water-level` |
+| S-111 surface currents | `s111-surface-currents` |
+| S-122 marine protected areas | `s122-marine-protected-areas` |
+| S-124 navigational warnings | `s124-nav-warnings` |
+| S-125 marine aids to navigation | `s125-aton` |
+| S-127 marine resources and services | `s127-marine-services` |
+| S-128 catalogue of nautical products | `s128-catalogue` |
+| S-129 under keel clearance | `s129-ukc` |
+| S-131 marine harbour infrastructure | `s131-marine-harbour` |
+| S-201 IALA aids to navigation information | `s201-aton-information` |
+| S-411 sea ice | `s411-sea-ice` |
+| S-421 route plans | `s421-route-plans` |
+
+For cross-spec changes (e.g. a change to `CoveragePipeline` affecting
+S-102/S-104/S-111), reconcile the guidance from all affected specs before
+writing code. Cite the relevant spec section number(s) in PR descriptions and
+in XML doc comments for spec-derived constants, enums, attribute names, and
+group paths.
+
+## Coding style
+
+- Follow existing C# conventions: `PascalCase` for types/methods/properties,
+  `camelCase` for locals and parameters, `_camelCase` for private fields.
+- Nullable reference types are enabled everywhere — avoid `!` suppression;
+  prefer null-checks or `ArgumentNullException.ThrowIfNull`.
+- All public APIs must carry XML doc comments (`<summary>`, `<param>`,
+  `<returns>`).
+- Only comment code that genuinely needs clarification.
+
+## Documentation
+
+- Each library has a `README.md` in its `src/<project>/` directory. Update it
+  when adding types, removing APIs, or changing behaviour.
+- Conceptual guides live under `docs/` in DocFX Markdown. Add or update pages
+  there for user-facing features.
+- When editing the viewer (`src/EncDotNet.S100.Viewer/**`), follow the
+  localization and UI rules in `.github/instructions/viewer.instructions.md`
+  (every user-facing string lives in `Resources/Strings.resx`).
+
+## Branch & pull-request workflow
+
+1. Create a topic branch off `main` (e.g. `fix-s104-trend-flag` or
+   `feature/s127-pilot-boarding`).
+2. Make focused, surgical changes that fully address one concern.
+3. Ensure `dotnet build` and `dotnet test --configuration Release` pass
+   locally.
+4. Open a pull request against `main`. The
+   [pull request template](.github/pull_request_template.md) includes a
+   checklist for spec alignment, tests, documentation, dependencies, and
+   breaking changes — please fill it out.
+5. CI must pass before review. Keep PRs small and well-scoped where possible.
+
+## Reporting bugs & requesting features
+
+Use the issue templates under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/). For questions and
+general discussion, see [SUPPORT.md](SUPPORT.md). To report a security
+vulnerability, follow [SECURITY.md](SECURITY.md) — please do **not** open a
+public issue for security problems.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE) that covers this project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+We take the security of EncDotNet.S100 seriously. Thank you for helping keep
+the project and its users safe.
+
+## Supported versions
+
+EncDotNet.S100 is pre-1.0 and under active development. Security fixes are
+applied to the latest released version and shipped in a new release. Please
+make sure you are running the most recent release before reporting an issue.
+
+| Version | Supported |
+|---|---|
+| Latest release | :white_check_mark: |
+| Older releases | :x: |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's built-in security advisory
+workflow:
+
+1. Go to the
+   [Security tab](https://github.com/philliphoff/EncDotNet.S100/security/advisories)
+   of the repository.
+2. Click **"Report a vulnerability"** to open a private advisory.
+3. Provide as much detail as you can, including:
+   - A description of the vulnerability and its impact.
+   - Steps to reproduce, or a proof-of-concept.
+   - Affected version(s) and platform(s).
+   - Any suggested mitigation, if known.
+
+This channel is private to the maintainers, so details are not disclosed
+publicly while the issue is being investigated and fixed.
+
+## What to expect
+
+- We will acknowledge your report as soon as we are able to review it.
+- We will investigate, keep you informed of progress, and work on a fix.
+- Once a fix is released, we will publish a security advisory and credit the
+  reporter (unless you prefer to remain anonymous).
+
+## Dependencies
+
+This project uses Central Package Management (`Directory.Packages.props`) and
+runs `gh-advisory-database` security checks before introducing new
+dependencies. If you find a vulnerability that stems from a third-party
+package, please include the package name and version in your report.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,41 @@
+# Support
+
+Thanks for using EncDotNet.S100! This page explains where to go depending on
+what you need.
+
+## Questions & general discussion
+
+For "how do I…?" questions, usage help, ideas, and general discussion, please
+use [GitHub Discussions](https://github.com/philliphoff/EncDotNet.S100/discussions).
+This keeps the issue tracker focused on actionable bugs and feature work and
+makes answers discoverable for others.
+
+Before asking, it can help to check:
+
+- The [README](README.md) and the per-library `README.md` files under
+  `src/<project>/`.
+- The [project documentation](https://philliphoff.github.io/EncDotNet.S100/).
+- Existing [issues](https://github.com/philliphoff/EncDotNet.S100/issues) and
+  [discussions](https://github.com/philliphoff/EncDotNet.S100/discussions) in
+  case your question has already been answered.
+
+## Bug reports & feature requests
+
+- Found a bug? Open a
+  [bug report](https://github.com/philliphoff/EncDotNet.S100/issues/new?template=bug_report.yml).
+- Want a new feature or product? Open a
+  [feature request](https://github.com/philliphoff/EncDotNet.S100/issues/new?template=feature_request.yml).
+
+When filing an issue, include the version, platform, and a minimal way to
+reproduce. **Never attach real ENC data** — use small synthetic fixtures or
+describe the data instead.
+
+## Security issues
+
+Please do **not** file security vulnerabilities as public issues. Follow the
+private reporting process in [SECURITY.md](SECURITY.md).
+
+## Contributing
+
+Interested in contributing code or docs? See [CONTRIBUTING.md](CONTRIBUTING.md)
+to get started.


### PR DESCRIPTION
Partial scaffolding for issue #208. Before inviting external contributors we need standard onboarding files; this PR lands the three text-only ones. CODE_OF_CONDUCT and the `.github/ISSUE_TEMPLATE/` set are deferred to a follow-up (the user will add the CoC themselves; CHANGELOG was dropped in planning since release notes already live in GitHub Releases).

## What's here

- **CONTRIBUTING.md** — written to match this repo's actual workflow: .NET 10 SDK, build with `dotnet build`, test with `dotnet test --configuration Release`, Central Package Management via `Directory.Packages.props` (no `Version=` on `.csproj`), the per-spec skill/instruction routing table (S-100 framework + S-101/102/104/111/122/124/125/127/128/129/131/201/411/421), the xunit + `Xunit.SkippableFact` test convention, the never-commit-real-ENC-data rule, viewer localization pointer, and the `gh-advisory-database` dependency check.
- **SECURITY.md** — private vulnerability reports go through the repo's Security tab (GitHub private advisories), not public issues. Includes a supported-versions note (latest release only, pre-1.0).
- **SUPPORT.md** — questions to Discussions, bugs/features to the issue templates, security to SECURITY.md.

## Notes for reviewers

- Tone and structure track the existing `.github/pull_request_template.md` and `.github/copilot-instructions.md` (concise, spec-aware, plain ASCII).
- Docs only; no build, test, or runtime impact.

Fixes: #208