### PR TITLE
Add EncDotNet.S100 convenience facade package (#207)

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/EncDotNet.S100.Scripting.MoonSharp/EncDotNet.S100.Scripting.MoonSharp.csproj" />
     <Project Path="src/EncDotNet.S100.Specifications/EncDotNet.S100.Specifications.csproj" />
     <Project Path="src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj" />
+    <Project Path="src/EncDotNet.S100/EncDotNet.S100.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/EncDotNet.S100.Diagnostics.Export.Tests/EncDotNet.S100.Diagnostics.Export.Tests.csproj" />
@@ -58,6 +59,7 @@
     <Project Path="tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Tests/EncDotNet.S100.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Core.Tests/EncDotNet.S100.Core.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Features.Tests/EncDotNet.S100.Features.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Mcp.Tools.Tests/EncDotNet.S100.Mcp.Tools.Tests.csproj" />

--- a/src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj
+++ b/src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <Description>Per-spec IDatasetProcessor implementations, the DatasetPipelineFactory (file -&gt; processor detection), the headless image-render capability, the S-98 interoperability authority, and the validation runner for IHO S-100 product datasets. Consumed by the EncDotNet.S100 convenience package, the viewer, and the s100 CLI.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EncDotNet.S100.Datasets.Pipelines/README.md
+++ b/src/EncDotNet.S100.Datasets.Pipelines/README.md
@@ -4,6 +4,15 @@ Per-spec `IDatasetProcessor` implementations, the S-98 interoperability
 authority, and the validation runner consumed by the viewer and the
 MCP server.
 
+> **Looking for the easy path?** Most consumers should use the
+> [`EncDotNet.S100`](../EncDotNet.S100/README.md) facade package, which wires this
+> factory to the bundled feature and portrayal catalogues and exposes a small
+> "open → render / read features" API. Use this package directly only when you
+> need full control over catalogues, CRS handling, or the pipeline itself.
+
+This package is published to NuGet (`IsPackable=true`) so the facade — and
+advanced à-la-carte consumers — can depend on it.
+
 ## Overview
 
 Each supported product ships an `IDatasetProcessor` that owns a parsed

--- a/src/EncDotNet.S100/EncDotNet.S100.csproj
+++ b/src/EncDotNet.S100/EncDotNet.S100.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <Description>Batteries-included on-ramp for IHO S-100 nautical data: open a dataset, read its features through the bundled feature catalogue, and render it to an image with the bundled portrayal catalogue — no hand-wiring of catalogues or pipelines. Wraps EncDotNet.S100.Specifications + EncDotNet.S100.Datasets.Pipelines behind a small, format-agnostic API. Advanced users can still drop down to the readers + injected catalogues.</Description>
+    <PackageTags>S-100;S-101;S-102;ENC;nautical;hydrography;IHO;ECDIS</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="EncDotNet.S100.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/EncDotNet.S100/FacadeRenderContextBuilder.cs
+++ b/src/EncDotNet.S100/FacadeRenderContextBuilder.cs
@@ -1,0 +1,58 @@
+using System;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// Maps facade <see cref="S100RendererOptions"/> onto the spec-specific
+/// <see cref="RenderContext"/> the dataset processors expect. Mirrors the
+/// mapping the <c>s100</c> CLI performs so the facade drives identical pipelines.
+/// </summary>
+internal static class FacadeRenderContextBuilder
+{
+    public static RenderContext Build(IDatasetProcessor processor, S100RendererOptions options)
+    {
+        var palette = options.Palette;
+        var symbolScale = options.SymbolScale;
+        var textScale = options.TextScale;
+        var hidden = options.HiddenCategories;
+        DateTime? timeStep = ResolveTimeStep(processor, options.TimeStep);
+
+        return processor.Spec.Name switch
+        {
+            "S-101" => new S101RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-102" => new S102RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-104" => new S104RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-111" => new S111RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-122" => new S122RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-124" => new S124RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-125" => new S125RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-127" => new S127RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-129" => new S129RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-201" => new S201RenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            "S-411" => new S411RenderContext(timeStep) { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+            _ => new GenericRenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hidden },
+        };
+    }
+
+    private static DateTime? ResolveTimeStep(IDatasetProcessor processor, int timeStepIndex)
+    {
+        if (processor is not ITimeAwareDatasetProcessor timeAware)
+            return null;
+
+        var times = timeAware.AvailableTimes;
+        if (times.Count == 0)
+            return null;
+
+        int idx = Math.Clamp(timeStepIndex, 0, times.Count - 1);
+        return times[idx];
+    }
+
+    /// <summary>
+    /// Concrete fallback for specs without their own context record (e.g. S-128,
+    /// S-131, S-421), which consume only the shared <see cref="RenderContext"/>
+    /// properties.
+    /// </summary>
+    private sealed record GenericRenderContext : RenderContext;
+}

--- a/src/EncDotNet.S100/IS100DatasetRenderer.cs
+++ b/src/EncDotNet.S100/IS100DatasetRenderer.cs
@@ -1,0 +1,49 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// Renders an S-100 <see cref="S100Layer"/> to a result of type
+/// <typeparamref name="TResult"/>. The result type is a parameter so the same
+/// abstraction can produce encoded image bytes (<see cref="PngS100DatasetRenderer"/>),
+/// and — in future — richer results such as bitmaps or Mapsui layer collections,
+/// without changing the contract.
+/// </summary>
+/// <typeparam name="TResult">The rendered result type (e.g. <c>byte[]</c> of PNG data).</typeparam>
+public interface IS100DatasetRenderer<TResult>
+{
+    /// <summary>Renders a single layer.</summary>
+    /// <param name="layer">The dataset + portrayal lens to render.</param>
+    /// <param name="options">Render options, or <c>null</c> for defaults.</param>
+    /// <param name="cancellationToken">Cancellation token observed cooperatively.</param>
+    /// <returns>The rendered result.</returns>
+    /// <exception cref="System.NotSupportedException">
+    /// The layer's dataset shape cannot be rendered to an image.
+    /// </exception>
+    Task<TResult> RenderAsync(
+        S100Layer layer,
+        S100RendererOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Convenience helpers over <see cref="IS100DatasetRenderer{TResult}"/>.
+/// </summary>
+public static class S100DatasetRendererExtensions
+{
+    /// <summary>
+    /// Renders <paramref name="dataset"/> using the bundled feature and portrayal
+    /// catalogues for its product specification — the one-call on-ramp.
+    /// </summary>
+    public static Task<TResult> RenderAsync<TResult>(
+        this IS100DatasetRenderer<TResult> renderer,
+        S100Dataset dataset,
+        S100RendererOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        System.ArgumentNullException.ThrowIfNull(renderer);
+        System.ArgumentNullException.ThrowIfNull(dataset);
+        return renderer.RenderAsync(new S100Layer { Dataset = dataset }, options, cancellationToken);
+    }
+}

--- a/src/EncDotNet.S100/NonDisposingAssetSource.cs
+++ b/src/EncDotNet.S100/NonDisposingAssetSource.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// Wraps a caller-supplied <see cref="IAssetSource"/> so that disposing the
+/// wrapper (as the portrayal-catalogue manager does when a host is torn down)
+/// does not dispose the underlying source. This keeps ownership of a custom
+/// <see cref="S100PortrayalCatalogue"/>'s asset source with the caller, so the
+/// catalogue can be reused across renders even though each custom-catalogue
+/// render builds (and disposes) a transient host.
+/// </summary>
+internal sealed class NonDisposingAssetSource(IAssetSource inner) : IAssetSource
+{
+    private readonly IAssetSource _inner = inner;
+
+    public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+        => _inner.OpenAsync(relativePath, cancellationToken);
+
+    public void Dispose()
+    {
+        // Intentionally does not dispose the caller-owned inner source.
+    }
+}

--- a/src/EncDotNet.S100/PngS100DatasetRenderer.cs
+++ b/src/EncDotNet.S100/PngS100DatasetRenderer.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using SkiaSharp;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// Renders an S-100 layer to PNG image bytes. This is the batteries-included
+/// renderer: with the bundled catalogues the simple path is a single call —
+/// <c>await new PngS100DatasetRenderer().RenderAsync(dataset)</c>.
+/// </summary>
+/// <remarks>
+/// A single instance may be reused to render many datasets and layers; it caches
+/// the bundled pipeline host so repeated renders reuse warmed catalogue parse
+/// caches. The renderer is thread-safe for sequential reuse; concurrent calls on
+/// one instance are not supported. Dispose to release the cached host.
+/// </remarks>
+public sealed class PngS100DatasetRenderer : IS100DatasetRenderer<byte[]>, IDisposable
+{
+    private S100PipelineHost? _bundledHost;
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public Task<byte[]> RenderAsync(
+        S100Layer layer,
+        S100RendererOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(layer);
+        ArgumentNullException.ThrowIfNull(layer.Dataset);
+
+        options ??= new S100RendererOptions();
+        return RenderCoreAsync(layer, options, cancellationToken);
+    }
+
+    private async Task<byte[]> RenderCoreAsync(
+        S100Layer layer,
+        S100RendererOptions options,
+        CancellationToken cancellationToken)
+    {
+        var dataset = layer.Dataset;
+
+        // Only a caller-supplied (non-bundled) catalogue is an override. An
+        // explicit Bundled(...) catalogue is equivalent to leaving it null, so it
+        // still reuses the cached bundled host and its warmed parse caches.
+        bool usesOverrides =
+            layer.FeatureCatalogue is { IsBundled: false }
+            || layer.PortrayalCatalogue is { CustomSource: not null };
+        S100PipelineHost host;
+        bool disposeHost;
+        if (usesOverrides)
+        {
+            host = S100PipelineHost.Create(
+                dataset.SpecName,
+                featureOverride: layer.FeatureCatalogue is { IsBundled: false } fc ? fc : null,
+                portrayalOverride: layer.PortrayalCatalogue is { CustomSource: not null } pc ? pc : null);
+            disposeHost = true;
+        }
+        else
+        {
+            host = _bundledHost ??= S100PipelineHost.Create();
+            disposeHost = false;
+        }
+
+        IDatasetProcessor? processor = null;
+        try
+        {
+            processor = host.CreateProcessor(dataset.Path);
+
+            if (processor is not IHeadlessImageRenderer headless)
+            {
+                throw new NotSupportedException(
+                    $"Headless image rendering is not supported for {processor.Spec.Name}.");
+            }
+
+            var context = FacadeRenderContextBuilder.Build(processor, options);
+
+            using var bitmap = await headless
+                .RenderHeadlessAsync(options.Width, options.Height, context, options.Background, cancellationToken)
+                .ConfigureAwait(false);
+
+            return EncodePng(bitmap);
+        }
+        finally
+        {
+            (processor as IDisposable)?.Dispose();
+            if (disposeHost)
+                host.Dispose();
+        }
+    }
+
+    private static byte[] EncodePng(SKBitmap bitmap)
+    {
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    /// <summary>Releases the cached bundled pipeline host.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _bundledHost?.Dispose();
+        _bundledHost = null;
+    }
+}

--- a/src/EncDotNet.S100/README.md
+++ b/src/EncDotNet.S100/README.md
@@ -1,0 +1,116 @@
+# EncDotNet.S100
+
+The batteries-included on-ramp for IHO S-100 nautical data. Open a dataset, read
+its features, and render it to an image **without hand-wiring feature or portrayal
+catalogues** — the official catalogues bundled in
+[`EncDotNet.S100.Specifications`](../EncDotNet.S100.Specifications/README.md) are
+discovered and wired for you.
+
+## Install
+
+```sh
+dotnet add package EncDotNet.S100
+```
+
+That single package transitively brings in the readers, the pipeline factory, the
+Lua/MoonSharp portrayal engine, the bundled specifications, and the headless Skia
+renderer.
+
+## Quickstart — render a dataset to PNG
+
+```csharp
+using EncDotNet.S100;
+
+using var dataset = S100Dataset.Open("chart.000");      // detects the product spec
+using var renderer = new PngS100DatasetRenderer();
+byte[] png = await renderer.RenderAsync(dataset);        // bundled FC + PC
+File.WriteAllBytes("out.png", png);
+```
+
+`RenderAsync(dataset)` is the one-call path: it uses the bundled feature and
+portrayal catalogues for the dataset's product specification.
+
+### Render options
+
+```csharp
+using EncDotNet.S100.Pipelines; // PaletteType
+
+byte[] png = await renderer.RenderAsync(dataset, new S100RendererOptions
+{
+    Width = 2048,
+    Height = 1536,
+    Palette = PaletteType.Night,
+    SymbolScale = 1.25,
+    TimeStep = 0,            // time-aware products (S-104, S-111)
+});
+```
+
+## Read features
+
+Feature access lives on the **feature catalogue**, because decoding a feature's
+type name and attributes presupposes one:
+
+```csharp
+var fc = S100FeatureCatalogue.Bundled(dataset.Spec.Name);
+
+foreach (var summary in fc.EnumerateFeatures(dataset))
+    Console.WriteLine($"{summary.FeatureRef}: {summary.FeatureType}");
+
+FeatureInfo? info = fc.GetFeature(dataset, someFeatureRef);
+```
+
+## Custom catalogues
+
+A **layer** pairs a dataset with the catalogues used to interpret and portray it.
+Supply your own to override the bundled defaults:
+
+```csharp
+var layer = new S100Layer
+{
+    Dataset = dataset,
+    PortrayalCatalogue = S100PortrayalCatalogue.FromAssetSource(myPortrayalSource),
+    FeatureCatalogue = S100FeatureCatalogue.FromStream(myFeatureCatalogueXml),
+};
+
+byte[] png = await renderer.RenderAsync(layer);
+```
+
+When `FeatureCatalogue` / `PortrayalCatalogue` are left `null`, the bundled
+catalogue for the dataset's product specification is used.
+
+## Layering — the grow-up story
+
+`S100Layer` is the composable unit, so growing from a single chart to a stacked
+view (e.g. an S-101 chart under S-102 bathymetry and S-411 sea ice) is "add more
+layers." The single-layer render path ships today; an additive multi-layer
+composite overload (shared viewport + S-98 paint ordering) is a planned
+fast-follow and does not change this API shape.
+
+## Renderers are generic in their result
+
+`IS100DatasetRenderer<TResult>` is parameterised on the result type.
+`PngS100DatasetRenderer` implements `IS100DatasetRenderer<byte[]>` (PNG bytes).
+The same abstraction extends to other encoders (JPEG/WebP), to in-memory bitmaps,
+and — once the Mapsui decoupling
+([#189](https://github.com/philliphoff/EncDotNet.S100/issues/189)) lands — to a
+Mapsui layer renderer, without changing the contract.
+
+> **Mapsui note.** The public API of this package is Mapsui-free (it returns
+> `byte[]`, `FeatureSummary`, and `FeatureInfo` — never Mapsui types). Mapsui is
+> currently a *transitive* dependency of the underlying pipeline; when #189 lands
+> it drops out with no change to this package's API.
+
+## À-la-carte (advanced)
+
+This facade is purely additive. Advanced users who need full control can keep
+using a per-spec reader with an injected catalogue, or drive
+`DatasetPipelineFactory`
+([`EncDotNet.S100.Datasets.Pipelines`](../EncDotNet.S100.Datasets.Pipelines/README.md))
+directly.
+
+## Reuse and disposal
+
+- `S100Dataset` and `PngS100DatasetRenderer` are `IDisposable`; dispose them.
+- A `PngS100DatasetRenderer` instance may render many datasets sequentially; it
+  caches the bundled pipeline host so repeated renders reuse warmed catalogue
+  parse caches. Concurrent use of one instance is not supported.

--- a/src/EncDotNet.S100/S100Dataset.cs
+++ b/src/EncDotNet.S100/S100Dataset.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// An opened S-100 dataset — the raw data plus its detected product
+/// specification. A dataset carries no rendering or feature-decoding behaviour:
+/// rendering is performed by an <see cref="IS100DatasetRenderer{TResult}"/>, and
+/// feature access (which presupposes a feature catalogue) lives on
+/// <see cref="S100FeatureCatalogue"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Open(string)"/> is the batteries-included entry point: it detects
+/// the product specification from the file and (lazily, on first access to a
+/// data property) parses the dataset against the catalogues bundled in
+/// <c>EncDotNet.S100.Specifications</c>. Advanced users who need a caller-supplied
+/// catalogue can construct the per-spec reader directly instead.
+/// </para>
+/// </remarks>
+public sealed class S100Dataset : IDisposable
+{
+    private readonly string _detectedSpec;
+    private S100PipelineHost? _host;
+    private IDatasetProcessor? _processor;
+    private bool _disposed;
+
+    private S100Dataset(string path, string detectedSpec)
+    {
+        Path = path;
+        _detectedSpec = detectedSpec;
+    }
+
+    /// <summary>
+    /// Opens the dataset file at <paramref name="path"/>, detecting its S-100
+    /// product specification.
+    /// </summary>
+    /// <param name="path">Path to a loose S-100 dataset file (ISO 8211, HDF5, or GML).</param>
+    /// <returns>An opened dataset.</returns>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">The file does not exist.</exception>
+    /// <exception cref="NotSupportedException">
+    /// The file is not a recognised S-100 product specification.
+    /// </exception>
+    public static S100Dataset Open(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        if (!File.Exists(path))
+            throw new FileNotFoundException("S-100 dataset file not found.", path);
+
+        var spec = DatasetPipelineFactory.DetectProductSpec(path)
+            ?? throw new NotSupportedException(
+                $"Could not detect an S-100 product specification for: {System.IO.Path.GetFileName(path)}");
+
+        return new S100Dataset(path, spec);
+    }
+
+    /// <summary>The path of the dataset file this instance was opened from.</summary>
+    internal string Path { get; }
+
+    /// <summary>
+    /// The detected product specification name (e.g. <c>"S-101"</c>) without the
+    /// edition, available without parsing the dataset.
+    /// </summary>
+    internal string SpecName => _detectedSpec;
+
+    /// <summary>
+    /// The product specification (name and edition) the dataset declares
+    /// conformance to. The edition is read from the dataset itself.
+    /// </summary>
+    public SpecRef Spec => Processor.Spec;
+
+    /// <summary>
+    /// Whether this dataset can be rendered to a standalone image by the
+    /// headless renderers (vector products and gridded coverages can; some
+    /// shapes such as fixed-station time series cannot).
+    /// </summary>
+    public bool CanRenderHeadless => Processor is IHeadlessImageRenderer;
+
+    /// <summary>
+    /// The available time steps for time-aware products (S-104, S-111), in
+    /// dataset order; empty for static products.
+    /// </summary>
+    public IReadOnlyList<DateTime> AvailableTimes =>
+        Processor is ITimeAwareDatasetProcessor timeAware
+            ? timeAware.AvailableTimes
+            : Array.Empty<DateTime>();
+
+    /// <summary>
+    /// The processor parsed against the bundled catalogues, created lazily and
+    /// reused for this dataset's data operations.
+    /// </summary>
+    internal IDatasetProcessor Processor
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_processor is null)
+            {
+                _host = S100PipelineHost.Create();
+                _processor = _host.CreateProcessor(Path);
+            }
+
+            return _processor;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        (_processor as IDisposable)?.Dispose();
+        _host?.Dispose();
+        _processor = null;
+        _host = null;
+    }
+}

--- a/src/EncDotNet.S100/S100FeatureCatalogue.cs
+++ b/src/EncDotNet.S100/S100FeatureCatalogue.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// A feature catalogue (ISO 19110 / S-100 Part 5) — the lens through which an
+/// <see cref="S100Dataset"/>'s features are read. Because decoding a feature's
+/// type name and attributes presupposes a feature catalogue, feature access
+/// lives here rather than on <see cref="S100Dataset"/>.
+/// </summary>
+/// <remarks>
+/// Use <see cref="Bundled(string)"/> for the official catalogue shipped in
+/// <c>EncDotNet.S100.Specifications</c>, or <see cref="FromStream(Stream)"/> to
+/// supply your own.
+/// </remarks>
+public sealed class S100FeatureCatalogue : IDisposable
+{
+    private readonly byte[]? _customXml;
+    private S100PipelineHost? _host;
+    private bool _disposed;
+
+    private S100FeatureCatalogue(byte[]? customXml) => _customXml = customXml;
+
+    /// <summary>Whether this is the bundled catalogue for its product specification.</summary>
+    internal bool IsBundled => _customXml is null;
+
+    /// <summary>
+    /// The official feature catalogue bundled in
+    /// <c>EncDotNet.S100.Specifications</c> for the given product specification.
+    /// </summary>
+    /// <param name="productSpec">Product specification name (e.g. <c>"S-101"</c>).</param>
+    public static S100FeatureCatalogue Bundled(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        return new S100FeatureCatalogue(customXml: null);
+    }
+
+    /// <summary>
+    /// A caller-supplied feature catalogue read from <paramref name="featureCatalogueXml"/>.
+    /// The stream is buffered, so the caller may dispose it immediately after this call.
+    /// </summary>
+    public static S100FeatureCatalogue FromStream(Stream featureCatalogueXml)
+    {
+        ArgumentNullException.ThrowIfNull(featureCatalogueXml);
+        using var buffer = new MemoryStream();
+        featureCatalogueXml.CopyTo(buffer);
+        return new S100FeatureCatalogue(buffer.ToArray());
+    }
+
+    /// <summary>
+    /// Opens a fresh read-only stream over the custom catalogue XML, or <c>null</c>
+    /// for the bundled catalogue (which is resolved from the specifications package).
+    /// </summary>
+    internal Stream? OpenStream() =>
+        _customXml is null ? null : new MemoryStream(_customXml, writable: false);
+
+    /// <summary>
+    /// Enumerates a lightweight summary of every feature in <paramref name="dataset"/>,
+    /// with type names resolved through this catalogue.
+    /// </summary>
+    /// <param name="dataset">The dataset to read features from.</param>
+    /// <returns>One <see cref="FeatureSummary"/> per feature; empty for coverage products.</returns>
+    public IReadOnlyList<FeatureSummary> EnumerateFeatures(S100Dataset dataset)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        return Read(dataset, processor => new List<FeatureSummary>(processor.EnumerateFeatures()));
+    }
+
+    /// <summary>
+    /// Returns information about the feature identified by <paramref name="featureRef"/>,
+    /// decoded against this catalogue, or <c>null</c> if it cannot be found.
+    /// </summary>
+    /// <param name="dataset">The dataset to read the feature from.</param>
+    /// <param name="featureRef">The feature reference string (dataset-specific id).</param>
+    public FeatureInfo? GetFeature(S100Dataset dataset, string featureRef)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        ArgumentException.ThrowIfNullOrEmpty(featureRef);
+        return Read(dataset, processor => processor.GetFeatureInfo(featureRef));
+    }
+
+    private TResult Read<TResult>(S100Dataset dataset, Func<IDatasetProcessor, TResult> read)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        // The bundled catalogue for the dataset's own spec is exactly what the
+        // dataset already parsed, so reuse its processor and skip a second parse.
+        if (IsBundled)
+            return read(dataset.Processor);
+
+        _host ??= S100PipelineHost.Create(dataset.SpecName, featureOverride: this);
+        var processor = _host.CreateProcessor(dataset.Path);
+        try
+        {
+            return read(processor);
+        }
+        finally
+        {
+            (processor as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Releases the catalogue parse cache held for a caller-supplied catalogue.
+    /// A no-op for the bundled catalogue (which holds no per-instance resources).
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _host?.Dispose();
+        _host = null;
+    }
+}

--- a/src/EncDotNet.S100/S100Layer.cs
+++ b/src/EncDotNet.S100/S100Layer.cs
@@ -1,0 +1,28 @@
+namespace EncDotNet.S100;
+
+/// <summary>
+/// A renderable layer: an <see cref="S100Dataset"/> viewed through a portrayal
+/// lens (a feature catalogue plus a portrayal catalogue). The layer is the
+/// composable unit of rendering — a single layer renders one dataset, and (as the
+/// API grows) an ordered list of layers composites a multi-product stack
+/// (e.g. an S-101 chart under S-102 bathymetry and S-411 sea ice) into one image.
+/// </summary>
+public sealed class S100Layer
+{
+    /// <summary>The dataset to render.</summary>
+    public required S100Dataset Dataset { get; init; }
+
+    /// <summary>
+    /// The feature catalogue to interpret the dataset with. When <c>null</c>, the
+    /// catalogue bundled in <c>EncDotNet.S100.Specifications</c> for the dataset's
+    /// product specification is used.
+    /// </summary>
+    public S100FeatureCatalogue? FeatureCatalogue { get; init; }
+
+    /// <summary>
+    /// The portrayal catalogue (symbology) to render the dataset with. When
+    /// <c>null</c>, the catalogue bundled in <c>EncDotNet.S100.Specifications</c>
+    /// for the dataset's product specification is used.
+    /// </summary>
+    public S100PortrayalCatalogue? PortrayalCatalogue { get; init; }
+}

--- a/src/EncDotNet.S100/S100PipelineHost.cs
+++ b/src/EncDotNet.S100/S100PipelineHost.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// Internal bootstrap that wires a <see cref="DatasetPipelineFactory"/> seeded
+/// with the feature and portrayal catalogues this on-ramp should use. Mirrors the
+/// bootstrap the in-repo viewer and <c>s100</c> CLI perform, so the facade drives
+/// exactly the same pipelines.
+/// </summary>
+/// <remarks>
+/// A host owns long-lived <see cref="PortrayalCatalogueManager"/> /
+/// <see cref="FeatureCatalogueManager"/> instances whose parse caches survive for
+/// the host's lifetime. The data and renderer facades keep a host alive and reuse
+/// it across calls so repeated work runs against warm catalogue caches; the
+/// per-dataset processors built from the host are transient and disposed after
+/// use.
+/// </remarks>
+internal sealed class S100PipelineHost : IDisposable
+{
+    private readonly PortrayalCatalogueManager _portrayalManager;
+    private readonly DatasetPipelineFactory _factory;
+    private bool _disposed;
+
+    private S100PipelineHost(
+        PortrayalCatalogueManager portrayalManager,
+        FeatureCatalogueManager featureManager)
+    {
+        _portrayalManager = portrayalManager;
+        _factory = new DatasetPipelineFactory(
+            portrayalManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            featureManager,
+            new InteroperabilityAuthorityProvider(new InteroperabilityAuthority()));
+    }
+
+    /// <summary>
+    /// Creates a host whose catalogues are the official ones bundled in
+    /// <c>EncDotNet.S100.Specifications</c>, optionally overriding the feature
+    /// and/or portrayal catalogue for a single product specification.
+    /// </summary>
+    /// <param name="overrideSpec">
+    /// The product specification whose catalogues the overrides apply to (e.g.
+    /// <c>"S-101"</c>), or <c>null</c> when no overrides are supplied.
+    /// </param>
+    /// <param name="featureOverride">
+    /// A caller-supplied feature catalogue for <paramref name="overrideSpec"/>, or
+    /// <c>null</c> to use the bundled one.
+    /// </param>
+    /// <param name="portrayalOverride">
+    /// A caller-supplied portrayal catalogue for <paramref name="overrideSpec"/>,
+    /// or <c>null</c> to use the bundled one.
+    /// </param>
+    public static S100PipelineHost Create(
+        string? overrideSpec = null,
+        S100FeatureCatalogue? featureOverride = null,
+        S100PortrayalCatalogue? portrayalOverride = null)
+    {
+        var portrayalManager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                portrayalManager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+
+        if (overrideSpec is not null && portrayalOverride?.CustomSource is { } pcSource)
+            portrayalManager.SetSource(overrideSpec, new NonDisposingAssetSource(pcSource));
+
+        var featureManager = new FeatureCatalogueManager(spec =>
+        {
+            if (overrideSpec is not null
+                && featureOverride is not null
+                && string.Equals(spec, overrideSpec, StringComparison.OrdinalIgnoreCase)
+                && featureOverride.OpenStream() is { } overrideStream)
+            {
+                return overrideStream;
+            }
+
+            return Specification.TryOpenFeatureCatalogue(spec);
+        });
+
+        return new S100PipelineHost(portrayalManager, featureManager);
+    }
+
+    /// <summary>Creates the dataset processor for the file at <paramref name="path"/>.</summary>
+    public IDatasetProcessor CreateProcessor(string path) => _factory.CreateProcessor(path);
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _portrayalManager.Dispose();
+    }
+}

--- a/src/EncDotNet.S100/S100PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100/S100PortrayalCatalogue.cs
@@ -1,0 +1,43 @@
+using System;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// A portrayal catalogue (S-100 Part 9) — the symbology rules used to render an
+/// <see cref="S100Dataset"/>. Use <see cref="Bundled(string)"/> for the official
+/// catalogue shipped in <c>EncDotNet.S100.Specifications</c>, or
+/// <see cref="FromAssetSource(IAssetSource)"/> to supply your own.
+/// </summary>
+public sealed class S100PortrayalCatalogue
+{
+    private S100PortrayalCatalogue(IAssetSource? customSource) => CustomSource = customSource;
+
+    /// <summary>
+    /// The caller-supplied portrayal-catalogue asset source, or <c>null</c> when this
+    /// is the bundled catalogue (resolved from the specifications package).
+    /// </summary>
+    internal IAssetSource? CustomSource { get; }
+
+    /// <summary>
+    /// The official portrayal catalogue bundled in
+    /// <c>EncDotNet.S100.Specifications</c> for the given product specification.
+    /// </summary>
+    /// <param name="productSpec">Product specification name (e.g. <c>"S-101"</c>).</param>
+    public static S100PortrayalCatalogue Bundled(string productSpec)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(productSpec);
+        return new S100PortrayalCatalogue(customSource: null);
+    }
+
+    /// <summary>
+    /// A caller-supplied portrayal catalogue backed by <paramref name="source"/>
+    /// (a folder or ZIP asset source containing the catalogue XML and its
+    /// referenced rule, symbol, and palette assets).
+    /// </summary>
+    public static S100PortrayalCatalogue FromAssetSource(IAssetSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return new S100PortrayalCatalogue(source);
+    }
+}

--- a/src/EncDotNet.S100/S100RendererOptions.cs
+++ b/src/EncDotNet.S100/S100RendererOptions.cs
@@ -1,0 +1,46 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100;
+
+/// <summary>
+/// Format-agnostic options controlling how a dataset is rendered (output size,
+/// colour palette, symbol/text scaling, time step, background, and instruction
+/// suppression). Format-specific options (e.g. JPEG quality) belong on the
+/// concrete renderer that produces that format.
+/// </summary>
+public sealed class S100RendererOptions
+{
+    /// <summary>Output image width in pixels. Default 1024.</summary>
+    public int Width { get; init; } = 1024;
+
+    /// <summary>Output image height in pixels. Default 768.</summary>
+    public int Height { get; init; } = 768;
+
+    /// <summary>Colour palette (Day/Dusk/Night). Default <see cref="PaletteType.Day"/>.</summary>
+    public PaletteType Palette { get; init; } = PaletteType.Day;
+
+    /// <summary>Global symbol scale factor. Default 1.0.</summary>
+    public double SymbolScale { get; init; } = 1.0;
+
+    /// <summary>Global text scale factor. Default 1.0.</summary>
+    public double TextScale { get; init; } = 1.0;
+
+    /// <summary>
+    /// Zero-based time-step index for time-aware products (S-104, S-111); clamped
+    /// to the available range and ignored by static products. Default 0.
+    /// </summary>
+    public int TimeStep { get; init; }
+
+    /// <summary>
+    /// Background fill colour. When <c>null</c>, an opaque white background is used.
+    /// </summary>
+    public RgbaColor? Background { get; init; }
+
+    /// <summary>
+    /// Drawing-instruction categories (areas, lines, points, text) to suppress
+    /// from the output. Default <see cref="DrawingInstructionCategory.None"/>.
+    /// </summary>
+    public DrawingInstructionCategory HiddenCategories { get; init; }
+        = DrawingInstructionCategory.None;
+}

--- a/tests/EncDotNet.S100.Tests/EncDotNet.S100.Tests.csproj
+++ b/tests/EncDotNet.S100.Tests/EncDotNet.S100.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100\EncDotNet.S100.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\datasets\S124\navwarn_surface.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S124\navwarn_surface.gml" />
+    <Content Include="..\datasets\S125\aton_point.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S125\aton_point.gml" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Tests/FacadeTests.cs
+++ b/tests/EncDotNet.S100.Tests/FacadeTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using EncDotNet.S100;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Specifications;
+using Xunit;
+
+namespace EncDotNet.S100.Tests;
+
+/// <summary>
+/// Exercises the batteries-included facade end-to-end against committed synthetic
+/// GML fixtures: open → identify, enumerate/get features through the bundled
+/// feature catalogue, and render to PNG through the bundled portrayal catalogue.
+/// </summary>
+public sealed class FacadeTests
+{
+    private static readonly string S124Surface =
+        System.IO.Path.Combine(AppContext.BaseDirectory, "TestData", "S124", "navwarn_surface.gml");
+
+    private static readonly string S125Point =
+        System.IO.Path.Combine(AppContext.BaseDirectory, "TestData", "S125", "aton_point.gml");
+
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    [SkippableFact]
+    public void Open_DetectsSpec_AndReportsHeadlessCapability()
+    {
+        Skip.IfNot(File.Exists(S124Surface), "S-124 surface fixture not present.");
+
+        using var ds = S100Dataset.Open(S124Surface);
+
+        Assert.Equal("S-124", ds.Spec.Name);
+        Assert.True(ds.CanRenderHeadless);
+        Assert.Empty(ds.AvailableTimes);
+    }
+
+    [Fact]
+    public void Open_MissingFile_Throws()
+    {
+        Assert.Throws<FileNotFoundException>(() => S100Dataset.Open("does-not-exist.gml"));
+    }
+
+    [SkippableFact]
+    public void BundledFeatureCatalogue_EnumeratesFeatures_AndResolvesOne()
+    {
+        Skip.IfNot(File.Exists(S124Surface), "S-124 surface fixture not present.");
+
+        using var ds = S100Dataset.Open(S124Surface);
+        var fc = S100FeatureCatalogue.Bundled(ds.Spec.Name);
+
+        var features = fc.EnumerateFeatures(ds);
+        Assert.NotEmpty(features);
+
+        var first = features[0];
+        var info = fc.GetFeature(ds, first.FeatureRef);
+        Assert.NotNull(info);
+        Assert.Equal(first.FeatureRef, info!.FeatureRef);
+    }
+
+    [SkippableFact]
+    public async Task PngRenderer_BundledDefaults_ProducesPngBytes()
+    {
+        Skip.IfNot(File.Exists(S124Surface), "S-124 surface fixture not present.");
+
+        using var ds = S100Dataset.Open(S124Surface);
+        using var renderer = new PngS100DatasetRenderer();
+
+        byte[] png = await renderer.RenderAsync(ds);
+
+        AssertIsPng(png);
+    }
+
+    [SkippableFact]
+    public async Task PngRenderer_ExplicitLayerWithBundledCatalogues_ProducesPng()
+    {
+        Skip.IfNot(File.Exists(S124Surface), "S-124 surface fixture not present.");
+
+        using var ds = S100Dataset.Open(S124Surface);
+        using var renderer = new PngS100DatasetRenderer();
+
+        var layer = new S100Layer
+        {
+            Dataset = ds,
+            FeatureCatalogue = S100FeatureCatalogue.Bundled(ds.Spec.Name),
+            PortrayalCatalogue = S100PortrayalCatalogue.Bundled(ds.Spec.Name),
+        };
+
+        byte[] png = await renderer.RenderAsync(layer, new S100RendererOptions { Width = 256, Height = 256 });
+
+        AssertIsPng(png);
+    }
+
+    [SkippableFact]
+    public async Task PngRenderer_ReusedAcrossDatasets_ProducesPngForEach()
+    {
+        Skip.IfNot(File.Exists(S124Surface) && File.Exists(S125Point),
+            "S-124 and S-125 fixtures not both present.");
+
+        using var renderer = new PngS100DatasetRenderer();
+
+        using (var a = S100Dataset.Open(S124Surface))
+            AssertIsPng(await renderer.RenderAsync(a, new S100RendererOptions { Width = 256, Height = 256 }));
+
+        using (var b = S100Dataset.Open(S125Point))
+            AssertIsPng(await renderer.RenderAsync(b, new S100RendererOptions { Width = 256, Height = 256 }));
+    }
+
+    [SkippableFact]
+    public async Task PngRenderer_CustomPortrayalCatalogue_IsReusableAcrossRenders()
+    {
+        Skip.IfNot(File.Exists(S124Surface), "S-124 surface fixture not present.");
+
+        // A caller-supplied portrayal catalogue must survive being used by a
+        // transient host (whose teardown must NOT dispose the caller's source),
+        // so the same instance can drive a second render.
+        var pc = S100PortrayalCatalogue.FromAssetSource(
+            Specification.CreatePortrayalCatalogueSource("S-124"));
+
+        using var renderer = new PngS100DatasetRenderer();
+        var options = new S100RendererOptions { Width = 256, Height = 256 };
+
+        using (var ds = S100Dataset.Open(S124Surface))
+        {
+            var layer = new S100Layer { Dataset = ds, PortrayalCatalogue = pc };
+            AssertIsPng(await renderer.RenderAsync(layer, options));
+            AssertIsPng(await renderer.RenderAsync(layer, options));
+        }
+    }
+
+    private static void AssertIsPng(byte[] bytes)
+    {
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > PngSignature.Length, "Rendered output is too small to be a PNG.");
+        Assert.True(bytes.Take(PngSignature.Length).SequenceEqual(PngSignature),
+            "Rendered output does not start with the PNG signature.");
+    }
+}


### PR DESCRIPTION
Fixes #207.

## What & why

Gives external developers a batteries-included on-ramp: `dotnet add package EncDotNet.S100`, then open a dataset and render it to an image (or enumerate features) **without hand-wiring feature/portrayal catalogues**. The official catalogues bundled in `EncDotNet.S100.Specifications` are discovered and wired automatically.

```csharp
using var ds = S100Dataset.Open("chart.000");        // detects the product spec
using var renderer = new PngS100DatasetRenderer();
byte[] png = await renderer.RenderAsync(ds);          // bundled FC + PC
```

## Public surface

- **`S100Dataset`** — `Open(path)`, `Spec`, `CanRenderHeadless`, `AvailableTimes` (data + identity only).
- **`S100FeatureCatalogue`** — `Bundled` / `FromStream`; `EnumerateFeatures(dataset)` / `GetFeature(dataset, ref)`. Feature access lives on the FC because decoding type names/attributes presupposes a catalogue.
- **`S100PortrayalCatalogue`** — `Bundled` / `FromAssetSource`.
- **`S100Layer`** — the composable unit (dataset + portrayal lens).
- **`IS100DatasetRenderer<TResult>`** + **`PngS100DatasetRenderer : IS100DatasetRenderer<byte[]>`**; one-call extension `RenderAsync(dataset)` defaults to the bundled catalogues.

Internal `S100PipelineHost` replicates the CLI/viewer wiring; `FacadeRenderContextBuilder` mirrors the CLI render-context mapping exactly, so the facade drives identical pipelines.

## Design decisions

- **Mapsui-free public API (B1).** The facade returns `byte[]` / `FeatureSummary` / `FeatureInfo` — never Mapsui types. Mapsui stays a *transitive* dependency of the underlying pipeline; when #189 lands it drops out with **zero API change** here. No #189 work is pulled into this PR.
- **Generic renderer** (`IS100DatasetRenderer<TResult>`) so future encoders (JPEG/WebP), in-memory bitmaps, or a Mapsui layer renderer slot in without changing the contract.
- **Layering-shaped, single-layer now.** `S100Layer` ships day-one so the multi-layer composite overload (`IReadOnlyList<S100Layer>`) is purely additive/non-breaking later. **Deferred to #213** (it needs a shared target viewport threaded into every layer plus S-98 cross-product paint ordering, intersecting #189 and the S-98 work — out of scope here).
- **À-la-carte path preserved.** Advanced users keep using per-spec readers with injected catalogues, or drive `DatasetPipelineFactory` directly. Documented in the README.
- Flipped **`EncDotNet.S100.Datasets.Pipelines` to `IsPackable=true`** (the facade depends on it).

## Rubber-duck bug fixes

An independent review pass caught three real consumer-facing bugs, all fixed and test-covered:

1. An explicit `S100FeatureCatalogue.Bundled(...)` on a layer could *disable* the bundled FC resolver (override path returned a null stream instead of falling back). Now bundled catalogues are treated as "no override," with a defensive fallback in the host resolver.
2. A caller-supplied portrayal `IAssetSource` (`FromAssetSource`) was being disposed by the transient host that consumed it, making a reusable catalogue single-use. Added **`NonDisposingAssetSource`** so caller-owned sources survive host teardown.
3. A transient host could leak if processor creation threw — moved processor creation inside the `try`/`finally`.

## Tests

`tests/EncDotNet.S100.Tests` — open/identify, feature enumeration + `GetFeature`, PNG rendering (bundled and explicit-catalogue layers), renderer reuse across datasets, and a custom-portrayal-catalogue reuse test (locks in fix #2). Synthetic GML fixtures; `SkippableFact` where a fixture may be absent. **7/7 pass; full solution builds with 0 errors; both packages pack cleanly.**

## Scope boundaries

- **Multi-layer composite** rendering is deferred — tracked in #213.
- **CLI dogfooding** was intentionally skipped to keep the facade minimal.
- **Docs:** `docs/quickstart.md` was **not** touched (that's #204's); the copy-paste example lives only in `src/EncDotNet.S100/README.md`. #204 will build the fuller guide and link to it.

## Branch / merge ordering

This builds on the #206 publishing work (solution-level `dotnet pack` honoring `<IsPackable>`) from **PR #209**, which must land first. As of opening, #209 is already merged to `main`, so this PR is based on `main` and contains those changes transitively — it can merge independently.