### PR TITLE
Add setting to disable simulated own-ship overlay (off by default)

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -140,6 +140,16 @@ public partial class App : Application
             settingsVm.OwnShipGeometryChanged += () => ownShipGeom.NotifyChanged();
         }
 
+        // Toggle the simulated own-ship overlay live from Settings. The
+        // source's IsEnabled gate empties (or republishes) the feature,
+        // so flipping the checkbox shows/hides the glyph without a
+        // restart.
+        var ownShipSource = s_services.GetService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>();
+        if (ownShipSource is not null)
+        {
+            settingsVm.OwnShipOverlayEnabledChanged += enabled => ownShipSource.IsEnabled = enabled;
+        }
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = s_services.GetRequiredService<MainWindow>();
@@ -320,7 +330,8 @@ public partial class App : Application
         services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>(sp =>
             new EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource(
                 sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipPositionProvider>(),
-                sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipVesselGeometryProvider>()));
+                sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipVesselGeometryProvider>(),
+                initiallyEnabled: sp.GetRequiredService<ViewerSettings>().OwnShipOverlayEnabled));
         services.AddSingleton<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>(sp =>
             sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>());
 

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -216,6 +216,13 @@ dead-reckoning provider (Solent, course 090° T, 5 m/s). The
 abstraction is shaped so a future NMEA / AIS adapter can plug in
 without renderer changes.
 
+Because this position is simulated, the overlay is **disabled by
+default**. Tick **Show simulated own-ship position** in the **Own
+Vessel** section of the Settings panel to display it; the choice is
+persisted and takes effect immediately (no restart). This gate is
+authoritative for the synthetic source — when it is off, no own-ship
+feature is published regardless of the layer-visibility toggle.
+
 The own-ship glyph adapts to zoom:
 
 - **Zoomed in** (when the vessel is ≥ ~6 mm on screen) — a
@@ -232,9 +239,9 @@ Vessel** section of the Settings panel. Edits take effect
 immediately. See
 [`docs/design/own-ship-symbology.md`](../../docs/design/own-ship-symbology.md).
 
-Own-ship visibility is controlled by its row in the **Dynamic
-Arrows** plane of the Layer Stack panel and is persisted between
-sessions.
+Own-ship visibility (once the simulated overlay is enabled) is
+controlled by its row in the **Dynamic Arrows** plane of the Layer
+Stack panel and is persisted between sessions.
 
 ### Picking dynamic features
 
@@ -418,7 +425,7 @@ application-data location. Persisted across sessions:
 - Day / Dusk / Night palette and ECDIS display category.
 - Per-spec viewing-group overrides and display-plane toggles.
 - Mariner depth / distance units and contour values.
-- Own-ship visibility and vessel geometry.
+- Simulated own-ship overlay enable, visibility, and vessel geometry.
 - MCP server enable / disable.
 
 Older settings shapes are migrated forward silently; missing values

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -421,6 +421,8 @@ internal static class Strings
 
     // Own-vessel dimensions (own-ship symbology PR)
     public static string Settings_OwnVesselSection => Get(nameof(Settings_OwnVesselSection));
+    public static string Settings_OwnVessel_OverlayEnabled => Get(nameof(Settings_OwnVessel_OverlayEnabled));
+    public static string Settings_OwnVessel_OverlayEnabled_Tooltip => Get(nameof(Settings_OwnVessel_OverlayEnabled_Tooltip));
     public static string Settings_OwnVesselSection_Help => Get(nameof(Settings_OwnVesselSection_Help));
     public static string Settings_OwnVessel_Length => Get(nameof(Settings_OwnVessel_Length));
     public static string Settings_OwnVessel_Length_Tooltip => Get(nameof(Settings_OwnVessel_Length_Tooltip));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1127,6 +1127,13 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   </data>
 
   <!-- Own-vessel dimensions (own-ship symbology PR) -->
+  <data name="Settings_OwnVessel_OverlayEnabled" xml:space="preserve">
+    <value>Show simulated own-ship position</value>
+    <comment>Checkbox label that enables or disables the mocked own-location overlay. Off by default.</comment>
+  </data>
+  <data name="Settings_OwnVessel_OverlayEnabled_Tooltip" xml:space="preserve">
+    <value>Show a simulated own-ship position glyph that dead-reckons across the chart. Intended for demonstration until a real GPS / NMEA source is connected. Disabled by default.</value>
+  </data>
   <data name="Settings_OwnVesselSection" xml:space="preserve">
     <value>Own Vessel</value>
     <comment>Heading of the Settings panel section that configures own-ship hull dimensions and the GPS antenna position.</comment>

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/OwnShipSource.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/OwnShip/OwnShipSource.cs
@@ -78,10 +78,33 @@ internal sealed class OwnShipSource : IDynamicFeatureSource, INotifyPropertyChan
     public OwnShipSource(
         IOwnShipPositionProvider provider,
         IOwnShipVesselGeometryProvider? geometryProvider)
+        : this(provider, geometryProvider, initiallyEnabled: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates the source with an explicit initial enabled state.
+    /// </summary>
+    /// <param name="provider">Position provider feeding own-ship fixes.</param>
+    /// <param name="geometryProvider">
+    /// Optional vessel-geometry sidecar provider.
+    /// </param>
+    /// <param name="initiallyEnabled">
+    /// Initial value of <see cref="IsEnabled"/>. When
+    /// <see langword="false"/> the source publishes nothing until it is
+    /// enabled — used to honour the persisted
+    /// <c>ViewerSettings.OwnShipOverlayEnabled</c> gate (off by default)
+    /// so the simulated own-ship overlay is hidden at launch.
+    /// </param>
+    public OwnShipSource(
+        IOwnShipPositionProvider provider,
+        IOwnShipVesselGeometryProvider? geometryProvider,
+        bool initiallyEnabled)
     {
         ArgumentNullException.ThrowIfNull(provider);
         _provider = provider;
         _geometryProvider = geometryProvider;
+        _isEnabled = initiallyEnabled;
 
         Metadata = new DynamicSourceMetadata
         {

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -556,6 +556,7 @@ internal sealed class SettingsViewModel : ViewModelBase
         ResetMcpPortCommand = new RelayCommand(() => McpPort = 0);
 
         var own = settings.OwnShip ?? new OwnShipSettings();
+        _ownShipOverlayEnabled = settings.OwnShipOverlayEnabled;
         _ownShipLength = own.LengthMetres;
         _ownShipBeam = own.BeamMetres;
         _ownShipBowOffset = own.BowOffsetMetres;
@@ -636,6 +637,33 @@ internal sealed class SettingsViewModel : ViewModelBase
     /// the new dimensions.
     /// </summary>
     public event Action? OwnShipGeometryChanged;
+
+    /// <summary>
+    /// Raised when <see cref="OwnShipOverlayEnabled"/> changes. The
+    /// viewer wires this to the singleton <c>OwnShipSource.IsEnabled</c>
+    /// so the simulated own-ship overlay appears / disappears live.
+    /// </summary>
+    public event Action<bool>? OwnShipOverlayEnabledChanged;
+
+    private bool _ownShipOverlayEnabled;
+    /// <summary>
+    /// Whether the simulated ("mocked") own-ship position overlay is
+    /// shown. Defaults to <see langword="false"/>. Persisted to
+    /// <see cref="ViewerSettings.OwnShipOverlayEnabled"/>.
+    /// </summary>
+    public bool OwnShipOverlayEnabled
+    {
+        get => _ownShipOverlayEnabled;
+        set
+        {
+            if (SetProperty(ref _ownShipOverlayEnabled, value))
+            {
+                _settings.OwnShipOverlayEnabled = value;
+                _settings.Save();
+                OwnShipOverlayEnabledChanged?.Invoke(value);
+            }
+        }
+    }
 
     private void EnsureOwnShipSettings()
     {

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -211,6 +211,17 @@ internal sealed class ViewerSettings
     public bool OwnShipVisible { get; set; } = true;
 
     /// <summary>
+    /// Whether the simulated ("mocked") own-ship position overlay is
+    /// active. When <see langword="false"/> (the default) the
+    /// <c>OwnShipSource</c> publishes no features so the synthetic
+    /// own-location glyph never appears. Distinct from the per-source
+    /// layer visibility tracked in <see cref="DynamicSourceVisibility"/>:
+    /// this gate is authoritative for the synthetic source — when it is
+    /// off, nothing is published regardless of layer visibility.
+    /// </summary>
+    public bool OwnShipOverlayEnabled { get; set; } = false;
+
+    /// <summary>
     /// Per-source visibility for dynamic feature sources (PR-D2.1),
     /// keyed by <c>IDynamicFeatureSource.Id</c>. Drives the Layer
     /// Stack panel's visibility toggle for the

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -293,6 +293,9 @@
             <TextBlock Text="{x:Static loc:Strings.Settings_OwnVesselSection_Help}"
                        TextWrapping="Wrap"
                        Opacity="0.75" />
+            <CheckBox IsChecked="{Binding OwnShipOverlayEnabled}"
+                      Content="{x:Static loc:Strings.Settings_OwnVessel_OverlayEnabled}"
+                      ToolTip.Tip="{x:Static loc:Strings.Settings_OwnVessel_OverlayEnabled_Tooltip}" />
             <StackPanel Spacing="6">
                 <TextBlock Text="{x:Static loc:Strings.Settings_OwnVessel_Length}"
                            FontSize="12" />

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/OwnShipSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/OwnShip/OwnShipSourceTests.cs
@@ -150,6 +150,37 @@ public sealed class OwnShipSourceTests
     }
 
     [Fact]
+    public void InitiallyDisabled_SeededProvider_PublishesNothing()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        stub.Push(Fix());
+
+        using var src = new OwnShipSource(stub, geometryProvider: null, initiallyEnabled: false);
+
+        Assert.False(src.IsEnabled);
+        Assert.Empty(src.CurrentFeatures);
+    }
+
+    [Fact]
+    public void InitiallyDisabled_ProviderUpdatesIgnored_UntilEnabled()
+    {
+        var stub = new StubOwnShipPositionProvider();
+        using var src = new OwnShipSource(stub, geometryProvider: null, initiallyEnabled: false);
+
+        var events = new List<DynamicFeaturesChanged>();
+        src.Changed += (_, e) => events.Add(e);
+
+        stub.Push(Fix());
+        Assert.Empty(events);
+        Assert.Empty(src.CurrentFeatures);
+
+        src.IsEnabled = true;
+        Assert.Single(events);
+        Assert.Equal(DynamicSourceChangeKind.Added, events[0].Kind);
+        Assert.Single(src.CurrentFeatures);
+    }
+
+    [Fact]
     public void Metadata_HasExpectedShape()
     {
         var stub = new StubOwnShipPositionProvider();

--- a/tests/EncDotNet.S100.Viewer.Tests/OwnShipSettingsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/OwnShipSettingsTests.cs
@@ -46,4 +46,20 @@ public class OwnShipSettingsTests
         var back = JsonSerializer.Deserialize<ViewerSettings>(json)!;
         Assert.Null(back.OwnShip);
     }
+
+    [Fact]
+    public void ViewerSettings_OwnShipOverlayEnabled_DefaultsToFalse()
+    {
+        var v = new ViewerSettings();
+        Assert.False(v.OwnShipOverlayEnabled);
+    }
+
+    [Fact]
+    public void ViewerSettings_OwnShipOverlayEnabled_RoundTripsThroughJson()
+    {
+        var v = new ViewerSettings { OwnShipOverlayEnabled = true };
+        var json = JsonSerializer.Serialize(v);
+        var back = JsonSerializer.Deserialize<ViewerSettings>(json)!;
+        Assert.True(back.OwnShipOverlayEnabled);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/SettingsViewModelOwnShipOverlayTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/SettingsViewModelOwnShipOverlayTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class SettingsViewModelOwnShipOverlayTests
+{
+    private static ViewerSettings NewSettings()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        return new ViewerSettings { SettingsFilePath = path };
+    }
+
+    [Fact]
+    public void DefaultsTo_False()
+    {
+        var vm = new SettingsViewModel(NewSettings());
+        Assert.False(vm.OwnShipOverlayEnabled);
+    }
+
+    [Fact]
+    public void ReflectsPersistedValue()
+    {
+        var s = NewSettings();
+        s.OwnShipOverlayEnabled = true;
+        var vm = new SettingsViewModel(s);
+        Assert.True(vm.OwnShipOverlayEnabled);
+    }
+
+    [Fact]
+    public void Setting_Persists_To_Settings()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s);
+        vm.OwnShipOverlayEnabled = true;
+        Assert.True(s.OwnShipOverlayEnabled);
+    }
+
+    [Fact]
+    public void Setting_Raises_OwnShipOverlayEnabledChanged()
+    {
+        var vm = new SettingsViewModel(NewSettings());
+        bool? raised = null;
+        vm.OwnShipOverlayEnabledChanged += v => raised = v;
+
+        vm.OwnShipOverlayEnabled = true;
+
+        Assert.Equal(true, raised);
+    }
+
+    [Fact]
+    public void Setting_Same_Value_Does_Not_Raise_Event()
+    {
+        var vm = new SettingsViewModel(NewSettings());
+        var count = 0;
+        vm.OwnShipOverlayEnabledChanged += _ => count++;
+
+        vm.OwnShipOverlayEnabled = false;
+
+        Assert.Equal(0, count);
+    }
+}


### PR DESCRIPTION
## Summary

The viewer's "own location" overlay is driven by a synthetic dead-reckoning provider (a mock vessel near the Solent), yet it was always published with no way to turn it off, and it showed by default. This adds an explicit enable/disable setting that defaults to **off**, so the simulated glyph no longer appears unless the user opts in.

The gate lives at the dynamic-source layer rather than just layer visibility: a new `ViewerSettings.OwnShipOverlayEnabled` (default `false`) is wired to `OwnShipSource.IsEnabled`, so when it is off the source publishes no features at all (not merely a hidden layer). A new "Show simulated own-ship position" checkbox at the top of the Settings > Own Vessel section toggles it live (republish/reset), so flipping it shows or hides the glyph with no restart. This new gate is authoritative for the synthetic source and is independent of the existing per-source Layer Stack visibility toggle.

`OwnShipSource` gained a constructor overload taking `initiallyEnabled` so the source can start suppressed; the existing constructors keep their default-true behaviour, so current tests and call sites are unaffected.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — viewer UX change, no spec semantics touched.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added coverage for the `OwnShipOverlayEnabled` default/round-trip, the `SettingsViewModel` property (persist + event), and `OwnShipSource` initially-disabled behaviour (seeded provider publishes nothing; updates ignored until enabled). Full viewer suite: 676 passed.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A — covered in viewer README)
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependencies)

## Breaking changes

None. The default-false setting changes first-run behaviour (the mock overlay no longer appears unless enabled), but there are no API or binary breaks.