### PR TITLE
Show in-window menu bar on Windows and Linux

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -146,6 +146,15 @@
 
     <Panel>
     <DockPanel>
+        <!--
+          In-window menu bar. On macOS this control is invisible and the
+          NativeMenu (set in NativeMenuBuilder) is exported to the system
+          menu bar; on Windows and Linux it renders the same menu inline at
+          the top of the window so the File/View menus are reachable there.
+        -->
+        <NativeMenuBar DockPanel.Dock="Top"
+                       IsVisible="{OnPlatform true, macOS=false}" />
+
         <!-- Status bar at bottom -->
         <Border DockPanel.Dock="Bottom"
                 Background="{DynamicResource BackgroundColor}"


### PR DESCRIPTION
## Why

The viewer's menu bar appeared on macOS but was missing on Windows (and Linux). The menu is built as an Avalonia `NativeMenu` and attached via `NativeMenu.SetMenu(window, ...)`. macOS exports a `NativeMenu` to the system menu bar automatically, but on Windows and Linux a `NativeMenu` renders nothing unless a `NativeMenuBar` control exists somewhere in the window's visual tree, which it did not. So the File/View menus were unreachable on those platforms.

## What

Added a single `NativeMenuBar` docked at the top of the main content in `MainWindow.axaml`. It renders the existing menu inline on Windows and Linux, and is hidden on macOS via an `{OnPlatform true, macOS=false}` guard so the system menu bar stays the only menu there.

No menu-building logic changed. All existing items (File, View > Appearance toggles, recent files, key gestures, and toggle-state sync from `NativeMenuBuilder`) carry over to Windows and Linux unchanged.

## Notes for reviewers

- The inline bar uses Avalonia's default `Menu` styling rather than ShadUI's custom chrome, so on Windows it looks like a standard menu bar. Theming it to match ShadUI would be a separate follow-up.
- Verified with a Release build of the viewer project.