### PR TITLE
Add consumer quickstart guide and runnable sample (#204)

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -74,5 +74,6 @@
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/EncDotNet.S100.Samples.Ais/EncDotNet.S100.Samples.Ais.csproj" />
+    <Project Path="samples/EncDotNet.S100.Samples.Quickstart/EncDotNet.S100.Samples.Quickstart.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ end users without requiring native dependencies, commercial S-52
 assets, or platform-specific tooling. Everything runs on macOS,
 Windows, and Linux out of the box.
 
+## Getting started
+
+New here? **[docs/getting-started.md](docs/getting-started.md)** walks you from
+zero to a rendered PNG in a few minutes — via either the batteries-included
+`EncDotNet.S100` library facade or the standalone `s100` command-line tool.
+
+```csharp
+using EncDotNet.S100;
+
+using var dataset = S100Dataset.Open("chart.000");   // detects the spec
+using var renderer = new PngS100DatasetRenderer();
+byte[] png = await renderer.RenderAsync(dataset);     // bundled FC + PC
+File.WriteAllBytes("out.png", png);
+```
+
+The runnable
+[`samples/EncDotNet.S100.Samples.Quickstart`](samples/EncDotNet.S100.Samples.Quickstart)
+console project demonstrates this end-to-end against a bundled synthetic
+fixture — `dotnet run` it with no setup.
+
 ## Supported standards
 
 Every supported product ships a reader, a portrayal pipeline, and a

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,142 @@
+# Getting started
+
+This guide gets a supported S-100 dataset onto your screen — as a PNG — in a
+few minutes, with **no prior S-100 knowledge required**. There are two paths:
+
+- **[Library path](#library-path)** — render (or read features from) a dataset
+  in ~20 lines of C# using the batteries-included `EncDotNet.S100` facade.
+- **[CLI path](#cli-path)** — download the standalone `s100` tool and render
+  from the command line, no .NET installation required.
+
+If you just want to see it run, the
+[`EncDotNet.S100.Samples.Quickstart`](../samples/EncDotNet.S100.Samples.Quickstart)
+console sample does the library path end-to-end against a bundled synthetic
+fixture — clone the repo and `dotnet run` it.
+
+## Library path
+
+The [`EncDotNet.S100`](../src/EncDotNet.S100/README.md) package is the
+on-ramp: open a dataset, read its features, and render it to an image
+**without hand-wiring feature or portrayal catalogues** — the official
+catalogues bundled in
+[`EncDotNet.S100.Specifications`](../src/EncDotNet.S100.Specifications/README.md)
+are discovered and wired for you.
+
+### 1. Install
+
+```sh
+dotnet add package EncDotNet.S100
+```
+
+That single package transitively brings in the readers, the pipeline factory,
+the Lua/MoonSharp portrayal engine, the bundled specifications, and the
+headless Skia renderer.
+
+### 2. Render a dataset to PNG
+
+```csharp
+using EncDotNet.S100;
+
+// Detects the product specification from the file (ISO 8211, HDF5, or GML).
+using var dataset = S100Dataset.Open("chart.000");
+Console.WriteLine($"Opened {dataset.Spec}");
+
+// Read features through the bundled feature catalogue
+// (empty for coverage products such as S-102/104/111).
+using var featureCatalogue = S100FeatureCatalogue.Bundled(dataset.Spec.Name);
+foreach (var feature in featureCatalogue.EnumerateFeatures(dataset))
+    Console.WriteLine($"  {feature.FeatureRef}: {feature.FeatureTypeName ?? feature.FeatureType}");
+
+// Render to PNG through the bundled portrayal catalogue.
+using var renderer = new PngS100DatasetRenderer();
+byte[] png = await renderer.RenderAsync(dataset);
+File.WriteAllBytes("out.png", png);
+```
+
+`RenderAsync(dataset)` is the one-call path: it uses the bundled feature and
+portrayal catalogues for the dataset's product specification.
+
+### 3. Render options
+
+```csharp
+using EncDotNet.S100.Pipelines; // PaletteType
+
+byte[] png = await renderer.RenderAsync(dataset, new S100RendererOptions
+{
+    Width = 2048,
+    Height = 1536,
+    Palette = PaletteType.Night,
+    SymbolScale = 1.25,
+    TimeStep = 0,            // time-aware products (S-104, S-111)
+});
+```
+
+Not every dataset shape can be rasterised headlessly (for example, fixed-station
+time series). Guard with `dataset.CanRenderHeadless` before rendering, and use
+`dataset.AvailableTimes` to discover the time steps of S-104 / S-111 products.
+
+For custom catalogues and the full API, see the
+[`EncDotNet.S100` README](../src/EncDotNet.S100/README.md).
+
+## CLI path
+
+[`s100`](cli.md) is a cross-platform console tool that renders any supported
+dataset to PNG using the same portrayal pipelines as the library, through the
+Mapsui-free Skia headless renderer.
+
+### 1. Install (standalone download)
+
+Each [GitHub Release](https://github.com/philliphoff/EncDotNet.S100/releases)
+attaches a **self-contained, per-platform archive** that bundles the .NET
+runtime and native libraries — **no .NET installation required**.
+
+```bash
+# macOS / Linux
+tar -xzf s100-<version>-<rid>.tar.gz
+./s100 list-specs
+```
+
+On Windows, extract `s100-<version>-win-x64.zip` and run `s100.exe`. See
+[docs/cli.md](cli.md) for the per-platform asset names and the macOS Gatekeeper
+note.
+
+### 2. Inspect and render
+
+```bash
+# Show the detected spec, bounds, and (for time-series) the available time steps
+s100 info dataset.h5
+
+# Render to a 1024x768 PNG (auto-detects the spec)
+s100 render dataset.h5 out.png
+
+# Render the 7th time step at night palette on a larger canvas
+s100 render currents.h5 currents.png --time-step 6 --palette night -w 2048 -h 1536
+```
+
+See [docs/cli.md](cli.md) for the full option and exit-code reference.
+
+## Where to get sample data
+
+This repository **does not** ship real ENC data, and you should never commit
+real ENC data to it either. To try the tools with real-world data, use one of
+the freely available official sample sets:
+
+- **IHO / product-specification test data** — the IHO and the test-bed working
+  groups publish sample datasets and exchange sets alongside several S-100
+  product specifications (S-101, S-102, S-104, S-111, S-12x, …). Start from the
+  [IHO S-100 page](https://iho.int/en/s-100-edition-5-2-0) and the per-product
+  specification repositories.
+- **Synthetic fixtures in this repo** — the small hand-authored GML/HDF5
+  fixtures under [`tests/datasets/`](../tests/datasets) are safe to experiment
+  with and are exactly what the test suite and the quickstart sample use. They
+  are deliberately minimal and are **not** navigationally meaningful.
+
+The quickstart sample reuses one of these synthetic S-124 fixtures so it runs
+with no downloads at all.
+
+## Next steps
+
+- [Command-line rendering](cli.md) — the full `s100` reference.
+- [Documentation index](index.md) — per-product libraries and conceptual guides.
+- [Typed data models](typed-data-models.md) — strongly-typed projections over
+  the schema-agnostic feature bags.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ pipeline, and a normative validation rule pack.
 
 ## Guides
 
+- [Getting started](getting-started.md) — render a supported dataset to PNG in a few minutes via the `EncDotNet.S100` facade or the standalone `s100` CLI, with pointers to sample data and a runnable console sample.
 - [Typed data models](typed-data-models.md) — strongly-typed object-graph projections layered on top of the schema-agnostic feature bags exposed by each dataset reader.
 - [Observability](observability.md) — span tree, metrics catalogue, and OpenTelemetry / Aspire recipes for inspecting pipeline activity.
 - [MCP server](mcp-server.md) — Model Context Protocol surface (`list_datasets`, `describe_feature`, `sample_coverage`, `render_to_image`) used by AI agents to query loaded datasets.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,5 +1,7 @@
 - name: Documentation
   href: index.md
+- name: Getting started
+  href: getting-started.md
 - name: Typed data models
   href: typed-data-models.md
 - name: Observability

--- a/samples/EncDotNet.S100.Samples.Quickstart/EncDotNet.S100.Samples.Quickstart.csproj
+++ b/samples/EncDotNet.S100.Samples.Quickstart/EncDotNet.S100.Samples.Quickstart.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>EncDotNet.S100.Samples.Quickstart</RootNamespace>
+    <AssemblyName>EncDotNet.S100.Samples.Quickstart</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Consumers would reference the published NuGet package instead:
+        <PackageReference Include="EncDotNet.S100" />
+      In-repo the sample uses a project reference so it builds in CI.
+    -->
+    <ProjectReference Include="..\..\src\EncDotNet.S100\EncDotNet.S100.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Reuse the existing small SYNTHETIC S-124 fixture from the test suite as
+      the single source of truth (it is hand-authored test data, not real ENC
+      data). It is copied to the output directory as sample-navwarn.gml.
+    -->
+    <None Include="..\..\tests\datasets\S124\navwarn_point.gml" Link="sample-navwarn.gml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/EncDotNet.S100.Samples.Quickstart/Program.cs
+++ b/samples/EncDotNet.S100.Samples.Quickstart/Program.cs
@@ -1,0 +1,44 @@
+// EncDotNet.S100 quickstart sample.
+//
+// Demonstrates the batteries-included facade end-to-end: open a dataset, read
+// its features through the bundled feature catalogue, and render it to a PNG
+// through the bundled portrayal catalogue — no hand-wiring of catalogues or
+// pipelines.
+//
+// Run with the bundled synthetic S-124 fixture:
+//     dotnet run --project samples/EncDotNet.S100.Samples.Quickstart
+//
+// Or point it at your own dataset (ISO 8211 .000, HDF5 .h5, or GML):
+//     dotnet run --project samples/EncDotNet.S100.Samples.Quickstart -- path/to/dataset out.png
+
+using EncDotNet.S100;
+
+string datasetPath = args.Length > 0
+    ? args[0]
+    : Path.Combine(AppContext.BaseDirectory, "sample-navwarn.gml");
+string outputPath = args.Length > 1 ? args[1] : "out.png";
+
+// 1. Open the dataset. The product specification is detected from the file.
+using var dataset = S100Dataset.Open(datasetPath);
+Console.WriteLine($"Opened {Path.GetFileName(datasetPath)} — {dataset.Spec}");
+
+// 2. Enumerate features through the bundled feature catalogue (empty for
+//    coverage products such as S-102/104/111).
+using var featureCatalogue = S100FeatureCatalogue.Bundled(dataset.Spec.Name);
+var features = featureCatalogue.EnumerateFeatures(dataset);
+Console.WriteLine($"Features: {features.Count}");
+foreach (var feature in features)
+    Console.WriteLine($"  {feature.FeatureRef}: {feature.FeatureTypeName ?? feature.FeatureType}");
+
+// 3. Render to PNG using the bundled portrayal catalogue.
+if (dataset.CanRenderHeadless)
+{
+    using var renderer = new PngS100DatasetRenderer();
+    byte[] png = await renderer.RenderAsync(dataset);
+    File.WriteAllBytes(outputPath, png);
+    Console.WriteLine($"Wrote {png.Length:N0} bytes to {outputPath}");
+}
+else
+{
+    Console.WriteLine("This dataset shape cannot be rendered headlessly; skipping PNG output.");
+}

--- a/samples/EncDotNet.S100.Samples.Quickstart/README.md
+++ b/samples/EncDotNet.S100.Samples.Quickstart/README.md
@@ -1,0 +1,52 @@
+# EncDotNet.S100.Samples.Quickstart
+
+A minimal console sample showing the **`EncDotNet.S100`** convenience facade
+end-to-end: open a dataset, read its features, and render it to a PNG — without
+hand-wiring feature or portrayal catalogues.
+
+It ships with a small **synthetic** S-124 (Navigational Warnings) GML fixture
+(`sample-navwarn.gml`, reused from the test suite at
+`tests/datasets/S124/navwarn_point.gml`) so it runs with **zero setup and no
+downloads**. The fixture is hand-authored test data, not a real navigational
+warning.
+
+## Run
+
+```bash
+# Uses the bundled synthetic S-124 fixture, writes out.png
+dotnet run --project samples/EncDotNet.S100.Samples.Quickstart
+```
+
+Point it at your own dataset (ISO 8211 `.000`, HDF5 `.h5`, or GML) instead:
+
+```bash
+dotnet run --project samples/EncDotNet.S100.Samples.Quickstart -- path/to/dataset out.png
+```
+
+## Expected output
+
+```
+Opened sample-navwarn.gml — S-124/0.0.0
+Features: 2
+  f1: NAVWARN Part
+  f2: NAVWARN Part
+Wrote 7,242 bytes to out.png
+```
+
+## What it demonstrates
+
+1. `S100Dataset.Open(path)` — detects the product specification from the file.
+2. `S100FeatureCatalogue.Bundled(spec).EnumerateFeatures(dataset)` — reads
+   feature summaries through the bundled feature catalogue.
+3. `new PngS100DatasetRenderer().RenderAsync(dataset)` — renders to PNG bytes
+   through the bundled portrayal catalogue.
+
+A real consumer references the published package rather than the in-repo
+project:
+
+```sh
+dotnet add package EncDotNet.S100
+```
+
+See [docs/getting-started.md](../../docs/getting-started.md) for the full
+quickstart, including the CLI path and where to find sample data.


### PR DESCRIPTION
Closes #204.

Adds the top-of-funnel "get something on screen in a few minutes" on-ramp for newcomers — both the library and CLI paths — plus the first quickstart-oriented runnable sample.

## What's included

- **`docs/getting-started.md`** — a quickstart covering:
  - **Library path** via the batteries-included `EncDotNet.S100` facade: `dotnet add package EncDotNet.S100`, then ~20 lines to open a dataset, enumerate features, and render to PNG with the bundled feature/portrayal catalogues, plus a render-options note.
  - **CLI path**: download the standalone `s100` archive and run `s100 info` / `s100 render` (links `docs/cli.md`).
  - **Where to get sample data** without committing real ENC data (official IHO/spec test sets + the repo's synthetic fixtures under `tests/datasets/`).
- **`samples/EncDotNet.S100.Samples.Quickstart/`** — a minimal `net10.0` console project (`IsPackable=false`) that references the facade and demonstrates the library path end-to-end. It defaults to a small **synthetic** S-124 GML fixture so `dotnet run` works with zero setup; an optional arg points it at any dataset. The fixture is **reused** from the test suite (`tests/datasets/S124/navwarn_point.gml`, linked + copied to output) to keep a single source of truth — never real ENC data. Registered in `EncDotNet.S100.slnx` so it builds in CI.
- Links from `docs/index.md` (Guides), `docs/toc.yml`, and the root `README.md` (new "Getting started" section). Filename is `getting-started.md` consistently; no `quickstart.md` references.

## Verification

- `dotnet build EncDotNet.S100.slnx -c Release` → **0 errors**.
- Ran the sample locally: prints the detected spec (`S-124`) and 2 features, and writes a 1024×768 `out.png`.
- Only source files are committed (`bin`/`obj`/`out.png` are gitignored).

## Dependency note

The library quickstart depends on the `EncDotNet.S100` convenience facade from **#207 (PR #212)**, which is already merged to `main`; this branch is rebased on top of it, so the sample's project reference resolves and CI builds it.