### PR TITLE
docs: documentation review round — onboarding, CLI billing, NuGet READMEs

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,18 @@
+<Project>
+
+  <!--
+    Pack each packable library's own README.md as the NuGet package readme so it
+    is shown on nuget.org. Applied here (rather than in every .csproj) so every
+    current and future packable project that ships a README.md picks it up
+    automatically. Imported after the SDK default items, so the existing
+    README.md None item is updated rather than re-included (avoiding NETSDK1022).
+  -->
+  <PropertyGroup Condition="'$(IsPackable)' != 'false' And Exists('$(MSBuildProjectDirectory)/README.md')">
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' != 'false' And Exists('$(MSBuildProjectDirectory)/README.md')">
+    <None Update="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Hydrographic Data Model for .NET. It provides:
 - A **cross-platform desktop viewer** (Avalonia + Mapsui) that loads
   any combination of supported products from an exchange set or as
   loose files and renders them, time-aligned, on an interactive map.
+- A **standalone command-line tool** (`s100`) that renders any
+  supported dataset to a PNG from the shell — self-contained, with no
+  .NET install required — for batch and headless scripting.
 - An **optional MCP server** that exposes loaded datasets to AI
   agents (`list_datasets`, `describe_feature`, `sample_coverage`,
   `render_to_image`).
@@ -136,6 +139,27 @@ product looks like in the viewer.
 | S-411 Sea Ice | ![S-411 Sea Ice](readme/S411Screenshot.png) |
 | S-421 Route Plan | ![S-421 Route Plan](readme/S421Screenshot.png) |
 | S-57 (via S-101) | ![S-57 rendered via S-101 pipeline](docs/images/s57-viewer-us4fl1lt.png) |
+
+## Command-line tool
+
+`s100` is a cross-platform console tool that renders any supported
+product to a PNG from the shell, driving the same portrayal pipelines
+as the viewer through a headless Skia renderer — no UI required. It is
+suited to batch and scripted previews (sea-ice, surface-current, and
+chart thumbnails).
+
+```sh
+s100 render dataset.h5 out.png --palette night -w 2048 -h 1536
+s100 info dataset.h5          # detected spec, edition, and time steps
+s100 list-specs               # supported products
+```
+
+Each [release](https://github.com/philliphoff/EncDotNet.S100/releases)
+attaches a self-contained, per-platform archive that bundles the .NET
+runtime and native libraries, so **no .NET installation is required** —
+download, extract, and run. The same executable also ships inside the
+viewer application bundle. See [docs/cli.md](docs/cli.md) for the full
+command and option reference.
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,13 @@ product looks like in the viewer.
 ## Libraries
 
 For developers consuming EncDotNet.S100 directly, the solution is
-split into focused packages:
+split into focused packages.
+
+### Convenience facade
+
+| Package | Description |
+|---|---|
+| **EncDotNet.S100** | Batteries-included on-ramp: open a dataset, read its features, and render it to an image using the bundled feature and portrayal catalogues — no hand-wiring of catalogues or pipelines. Start here; drop down to the focused packages below only when you need finer control. |
 
 ### Core framework
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 
 **EncDotNet.S100** is a managed, cross-platform implementation of the
 IHO [S-100](https://iho.int/en/s-100-edition-5-2-0) Universal
-Hydrographic Data Model for .NET. It provides:
+Hydrographic Data Model for .NET. In plain terms, it reads and draws
+**electronic nautical charts and related marine data layers** —
+depths, currents, water levels, navigational warnings, aids to
+navigation, and more — and it runs on macOS, Windows, and Linux. It
+provides:
 
 - A set of **reusable libraries** for reading, portraying, rendering,
   and **validating** S-100 product data — from ISO 8211 ENC cells to
@@ -34,9 +38,18 @@ Windows, and Linux out of the box.
 
 ## Getting started
 
-New here? **[docs/getting-started.md](docs/getting-started.md)** walks you from
-zero to a rendered PNG in a few minutes — via either the batteries-included
-`EncDotNet.S100` library facade or the standalone `s100` command-line tool.
+**Just want to look at charts?** Download the desktop viewer from the
+[latest release](https://github.com/philliphoff/EncDotNet.S100/releases)
+— a pre-built, self-contained app for macOS, Windows, and Linux (no
+.NET install required) — and open a file or exchange set. The
+[getting-started guide](docs/getting-started.md#desktop-app) walks
+through it, and the [viewer section](#the-viewer) below tours the
+features.
+
+**Building on top of the data?** **[docs/getting-started.md](docs/getting-started.md)**
+also walks you from zero to a rendered PNG in a few minutes — via either the
+batteries-included `EncDotNet.S100` library facade or the standalone `s100`
+command-line tool.
 
 ```csharp
 using EncDotNet.S100;

--- a/README.md
+++ b/README.md
@@ -195,14 +195,20 @@ split into focused packages.
 
 ### Dynamic feature sources
 
-| Package | Description |
+These ship in the repository but are **not currently published to
+NuGet** — consume them via project reference (or through the viewer).
+
+| Project | Description |
 |---|---|
 | **EncDotNet.S100.DynamicSources.Ais** | Decoder-agnostic AIS dynamic feature source: per-MMSI cache, ITU-R M.1371-aligned aging, projection to `DynamicFeature` with sentinel-collapsed motion. See [its README](src/EncDotNet.S100.DynamicSources.Ais/README.md). |
 | **EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo** | Production driver implementing `IAisMessageSource` over [aisstream.io](https://aisstream.io)'s WebSocket service. BCL-only (no third-party AIS or WebSocket deps). See [its README](src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/README.md). |
 
 ### MCP server
 
-| Package | Description |
+These ship in the repository but are **not currently published to
+NuGet** — consume them via project reference (or through the viewer).
+
+| Project | Description |
 |---|---|
 | **EncDotNet.S100.Mcp.Tools** | Transport-agnostic Model Context Protocol tool surface (`list_datasets`, `describe_feature`, `sample_coverage`). See [its README](src/EncDotNet.S100.Mcp.Tools/README.md). |
 | **EncDotNet.S100.Mcp** | Streamable HTTP host that exposes the `Mcp.Tools` surface plus the viewer-injected `render_to_image` tool; bound to `127.0.0.1` by default, off by default, no authentication. See [its README](src/EncDotNet.S100.Mcp/README.md) and the [agent walkthrough](docs/mcp-server.md). |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ OpenStreetMap basemap. Headline features:
   an overlay marker layer.
 - **Live overlays** through the dynamic-feature-source abstraction —
   an own-ship glyph with true-scale hull + arrowhead + CCRP cross at
-  zoom, plus an **AIS-target overlay** (PR-D3) backed by the
+  zoom, plus an **AIS-target overlay** backed by the
   [aisstream.io](https://aisstream.io) WebSocket service and rendered
   with a per-class palette using the same hull/arrowhead vocabulary.
 - **Optional MCP server** (off by default) exposing the loaded

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,8 +7,13 @@ Mapsui-free Skia *headless* renderers so it can run without a UI — making it
 suitable for batch scripts (e.g. generating sea-ice or surface-current
 previews).
 
-The tool is structured with **subcommands** so its scope can grow (tiling,
-batch, validation, …) without breaking existing usage.
+It offers three subcommands:
+
+| Command | Purpose |
+|---|---|
+| `s100 render <dataset> <output>` | Render a dataset to a PNG image. |
+| `s100 info <dataset>` | Show the detected spec, edition, headless-render capability, and (for time-series datasets) the available time steps. |
+| `s100 list-specs` | List the supported product specifications and which support headless rendering. |
 
 ## Install (standalone download)
 
@@ -38,18 +43,6 @@ attribute with `xattr -d com.apple.quarantine ./s100`.
 The same `s100` executable also ships inside the S-100 Viewer application
 bundle (under `cli/`); see the project README for that layout.
 
-### Future: installable `dotnet tool`
-
-A one-line `dotnet tool install -g` on-ramp remains a possible future addition.
-It was not adopted now because a classic global tool package is RID-agnostic
-(all assemblies land in a single `tools/<tfm>/any/` folder) and does not lay out
-SkiaSharp's `runtimes/<rid>/native/libSkiaSharp.*` native libraries where the
-host resolves them, causing a `DllNotFoundException` on the first render. .NET 8+
-does support **self-contained, RID-specific** tool packages, which would carry
-the native assets correctly, so publishing such a package (one per RID, heavier
-than the framework-dependent global tool) is a viable future complement to the
-standalone archives above.
-
 ## Quick start
 
 ```bash
@@ -66,40 +59,36 @@ dotnet run --project tools/EncDotNet.S100.Cli -- \
 
 ## How it works
 
-1. `DatasetPipelineFactory.DetectProductSpec` sniffs the file (extension +
-   content) to determine the product specification.
-2. `DatasetPipelineFactory.CreateProcessor` builds the matching
-   `IDatasetProcessor`, wired to the portrayal and feature catalogues bundled in
-   `EncDotNet.S100.Specifications`.
-3. The CLI feature-tests the processor for `IHeadlessImageRenderer`. If present,
-   it builds a spec-specific `RenderContext` (palette, scales, and — for
-   time-series specs implementing `ITimeAwareDatasetProcessor` — a `DateTime`
-   resolved from `--time-step`) and calls `RenderHeadlessAsync`.
-4. The resulting `SKBitmap` is encoded to PNG and written to the output path.
+The CLI detects a dataset's product specification from the file, runs that
+spec's portrayal pipeline — the same pipeline the Avalonia viewer uses, wired to
+the feature and portrayal catalogues bundled in the tool — and encodes the
+result to PNG. Vector specs (S-101 and the GML products) and coverage specs
+(S-102/104/111) each rasterise through their own headless Skia renderer; for
+S-111 the current arrows are overlaid on the coverage. No UI or map projection
+stack is involved, so it runs anywhere .NET does.
 
-Vector specs (S-101 and all GML products) render through
-`HeadlessVectorRenderer`; coverage specs (S-102/104/111) render through
-`CoverageHeadlessRenderer`, which fits the coverage extent into the requested
-pixel size (preserving aspect, letter-boxed) and overlays oriented arrows via
-`SkiaCoverageArrowRenderer` for S-111.
+## Render options
 
-## Capabilities and limitations
+| Option | Default | Description |
+|---|---|---|
+| `-w`, `--width` / `-h`, `--height` | `1024` × `768` | Output image size in pixels. |
+| `--palette` | `day` | Colour palette: `day`, `dusk`, or `night`. |
+| `--symbol-scale` / `--text-scale` | `1.0` | Symbol and text scale factors. |
+| `--time-step <index>` | `0` | Zero-based time step for time-series datasets (S-104 / S-111). |
+| `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
+| `--no-text` | off | Suppress text/label drawing instructions (shorthand for `--hide text`). |
+| `--hide <list>` | _none_ | Suppress drawing-instruction categories — any of `text`, `points`, `lines`, `areas` — useful for clean fills on label-dense products such as S-411 sea-ice. |
 
-- **Supported (headless):** S-101; S-122/124/125/127/128/129/131/201/411/421;
-  S-102; S-104 and S-111 *gridded* coverages.
-- **PNG output only** in v1.
-- **Pattern area-fills are omitted** on the vector headless path (points, lines,
-  solid fills, and text render).
-- **Text suppression**: `--no-text` (or `--hide text,...`) drops the chosen
-  drawing-instruction categories from the rendered output, producing cleaner
-  previews for label-dense products such as S-411 sea-ice.
-- **Fixed-station coverage** (S-104/S-111 data coding format 3 / 8) is **not**
-  supported headlessly; the CLI returns a descriptive error.
-- **S-57 is not supported.**
-- **Mapsui is linked but does no rendering.** The CLI transitively references
-  the Mapsui renderer for the spec-detection factory and the
-  `ProjNetCrsTransformFactory`. No Mapsui code runs on the headless render path;
-  fully decoupling these is tracked as follow-up work.
+## Capabilities
+
+- **Headless rendering** for S-101; S-102; S-104 and S-111 *gridded* coverages;
+  and the GML products S-122/124/125/127/128/129/131/201/411/421.
+- **PNG output.**
+- **Text and category suppression** via `--no-text` / `--hide` for cleaner
+  previews of label-dense products.
+- **Fixed-station coverage** (S-104 / S-111 data coding format 3 / 8) is not
+  rendered headlessly; the CLI returns a descriptive error.
+- **S-57 is not supported** by the headless path.
 
 See the project README under `tools/EncDotNet.S100.Cli/README.md` for the full
 option reference and exit codes.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,11 @@
 # Getting started
 
-This guide gets a supported S-100 dataset onto your screen — as a PNG — in a
-few minutes, with **no prior S-100 knowledge required**. There are two paths:
+This guide gets supported S-100 data in front of you in a few minutes, with
+**no prior S-100 knowledge required**. Pick the path that fits you:
 
+- **[Desktop app](#desktop-app)** — download the viewer and open a chart on an
+  interactive map. No coding and no .NET installation required. *Start here if
+  you just want to look at data.*
 - **[Library path](#library-path)** — render (or read features from) a dataset
   in ~20 lines of C# using the batteries-included `EncDotNet.S100` facade.
 - **[CLI path](#cli-path)** — download the standalone `s100` tool and render
@@ -12,6 +15,48 @@ If you just want to see it run, the
 [`EncDotNet.S100.Samples.Quickstart`](../samples/EncDotNet.S100.Samples.Quickstart)
 console sample does the library path end-to-end against a bundled synthetic
 fixture — clone the repo and `dotnet run` it.
+
+## Desktop app
+
+The **S-100 Viewer** is a cross-platform desktop application that loads any
+combination of supported products and renders them, time-aligned, on an
+interactive map over an OpenStreetMap basemap. It needs no .NET installation
+and no commercial chart assets.
+
+### 1. Download
+
+Each [GitHub Release](https://github.com/philliphoff/EncDotNet.S100/releases)
+attaches a pre-built, self-contained app per platform:
+
+| Platform | Asset | First launch |
+|---|---|---|
+| macOS (Apple silicon) | `.dmg` | Signed and Apple-notarized — open the DMG and drag the app to Applications. |
+| Windows | `.zip` | Extract and run the `.exe`. |
+| Linux | `.tar.gz` | Extract and run the executable. |
+
+### 2. Open some data
+
+Launch the app, then either **drag a file onto the window** or use the **File**
+menu. The viewer accepts:
+
+- **Exchange sets** — a folder containing a `CATALOG.XML`, or a `.zip` of one.
+  Every dataset the catalogue lists is loaded at once.
+- **Loose datasets** — an individual `.h5` (S-102 / S-104 / S-111), `.gml`
+  (any GML-encoded product), or `.000` (S-101 / S-57) file.
+
+No data yet? See [Where to get sample data](#where-to-get-sample-data) below.
+
+### 3. Explore
+
+Pan and zoom with the mouse, trackpad, or touch. From the activity bar you can:
+
+- toggle layers and see how products stack in the **Layer Stack**;
+- click features in **Pick Mode** to read their decoded attributes;
+- switch **Day / Dusk / Night** palettes and ECDIS display settings;
+- scrub the **timeline** for time-varying data (water levels, currents, ice).
+
+See the [viewer guide](../src/EncDotNet.S100.Viewer/README.md) for the full
+feature tour.
 
 ## Library path
 
@@ -136,6 +181,8 @@ with no downloads at all.
 
 ## Next steps
 
+- [Viewer guide](../src/EncDotNet.S100.Viewer/README.md) — the desktop app's
+  full feature tour.
 - [Command-line rendering](cli.md) — the full `s100` reference.
 - [Documentation index](index.md) — per-product libraries and conceptual guides.
 - [Typed data models](typed-data-models.md) — strongly-typed projections over

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,9 @@ pipeline, and a normative validation rule pack.
 
 ## Guides
 
-- [Getting started](getting-started.md) — render a supported dataset to PNG in a few minutes via the `EncDotNet.S100` facade or the standalone `s100` CLI, with pointers to sample data and a runnable console sample.
+- [Getting started](getting-started.md) — get S-100 data in front of you in a few minutes: download the desktop viewer, or render a dataset to PNG via the `EncDotNet.S100` facade or the standalone `s100` CLI.
+- [Viewer guide](../src/EncDotNet.S100.Viewer/README.md) — the desktop app's full feature tour: loading data, the layer stack, picking/identifying features, ECDIS display controls, palettes, and the timeline.
+- [Command-line rendering](cli.md) — the `s100` console tool for headless and batch PNG rendering.
 - [Typed data models](typed-data-models.md) — strongly-typed object-graph projections layered on top of the schema-agnostic feature bags exposed by each dataset reader.
 - [Observability](observability.md) — span tree, metrics catalogue, and OpenTelemetry / Aspire recipes for inspecting pipeline activity.
 - [MCP server](mcp-server.md) — Model Context Protocol surface (`list_datasets`, `describe_feature`, `sample_coverage`, `render_to_image`) used by AI agents to query loaded datasets.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -6,7 +6,7 @@ can query the datasets you have loaded in the viewer.
 
 The server is **off by default** and **listens on the loopback
 address only**. There is no authentication; the loopback isolation is
-the only protection in v1.
+the only protection.
 
 ## Field conventions
 
@@ -46,11 +46,9 @@ assume canonical units for these cases.
   (regularly-gridded time-series) surface speeds with `units = "knots"`,
   while data coding format 8 (time series at fixed stations) surface
   speeds with `units = "metres/second"`. The two values come from
-  different paths in `EncDotNet.S100.Datasets.S111` and have not yet
-  been normalised. TODO: pick one canonical unit at the MCP boundary
-  (almost certainly metres/second, matching the strongly-typed
-  `speedMetresPerSecond` field on `SurfaceCurrentSample` /
-  `SurfaceCurrentStationSample`) and rescale the other path.
+  different paths in `EncDotNet.S100.Datasets.S111`. Consult the
+  strongly-typed `speedMetresPerSecond` field on `SurfaceCurrentSample` /
+  `SurfaceCurrentStationSample` when you need a single canonical unit.
 
 ## Enable it
 
@@ -117,7 +115,7 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `sample_coverage` | Samples a depth / water-level / current value at a lat/lon from an S-102 / S-104 / S-111 dataset. |
 | `sample_coverage_along` | Samples a coverage along a polyline / great-circle path. |
 | `render_to_image` *(viewer only, read-only)* | Captures the viewer's current map view as a PNG image, returned as an MCP `ImageContentBlock`. Lets an agent see exactly what the user sees for diagnosis of rendering issues (palette banding, NoData voids, augmented-geometry artefacts, missing features, etc.). |
-| `set_viewport` *(viewer only, **mutating**)* | Drives the live viewer's map navigator to a specified WGS-84 viewport — either a bbox (`south`/`west`/`north`/`east`) or a centre + web-mercator zoom (`centerLat`/`centerLon`/`zoom`). Mixing the two forms is rejected. Antimeridian-crossing bboxes are not supported in v1. The companion of `render_to_image`: drive the navigator with `set_viewport`, then capture with `render_to_image` for scripted measurement runs. |
+| `set_viewport` *(viewer only, **mutating**)* | Drives the live viewer's map navigator to a specified WGS-84 viewport — either a bbox (`south`/`west`/`north`/`east`) or a centre + web-mercator zoom (`centerLat`/`centerLon`/`zoom`). Mixing the two forms is rejected. Antimeridian-crossing bboxes are not supported. The companion of `render_to_image`: drive the navigator with `set_viewport`, then capture with `render_to_image` for scripted measurement runs. |
 | `set_palette` *(viewer only, **mutating**)* | Sets the live viewer's active map palette to `Day`, `Dusk`, or `Night` (case-insensitive). Idempotent — no-op when already at the requested palette. Returns the applied and previous palette so callers can detect no-ops. Lets scripted measurement runs drive palette-change scenarios from outside the GUI. |
 | `set_display_category` *(viewer only, **mutating**)* | Sets the live viewer's active ECDIS display category to `DisplayBase`, `Standard`, `OtherInformation`, or `All` (case-insensitive). Idempotent. Counterpart to the `--display-category` CLI flag, but applicable mid-session. |
 | `set_time_step` *(viewer only, **mutating**)* | Drives the viewer's global time clock to a specific sample for time-aware datasets (S-104 / S-111 / S-411). Supply EITHER `index` (0-based integer into `list_time_steps`) OR `timestamp` (ISO-8601, snapped to the nearest sample). Returns the resolved index and snapped timestamp. Counterpart to the `--time-step` CLI flag, but applicable mid-session. |
@@ -170,11 +168,9 @@ view exactly.
 
 `render_to_image` is **viewer-only**: it is injected into the hosted
 MCP server by `EncDotNet.S100.Viewer` via the
-`S100McpServerOptions.AdditionalTools` extension point. A future
-headless MCP host would need to supply its own equivalent (or
-something domain-appropriate) — the catalog-only
+`S100McpServerOptions.AdditionalTools` extension point. The catalog-only
 `EncDotNet.S100.Mcp.Tools` library deliberately has no rendering
-dependency.
+dependency, so a non-viewer host supplies its own equivalent.
 
 ## Sample agent prompts
 
@@ -192,8 +188,10 @@ dependency.
 - There is no auth. Any local process on the machine can connect,
   including malicious code. Only enable MCP when you trust everything
   running locally.
-- The tools are strictly read-only. No tool can write files, load
-  data, or mutate viewer state.
+- Most tools are read-only, but some **mutate viewer state** (loading
+  or unloading datasets, driving the viewport, palette, or time step) —
+  see the read-only vs mutating breakdown above. None can write
+  arbitrary files.
 
 ## Disable from the UI
 

--- a/docs/typed-data-models.md
+++ b/docs/typed-data-models.md
@@ -90,6 +90,5 @@ When adding a typed model for a new product spec:
 | S-122 | `S122MarineProtectedAreaDataset` | Pass 2 — catalogue of MPAs / restricted areas / VTS areas with typed information-type bindings. |
 | S-127 | `S127MarineServicesDataset` | Pass 2 — marine resources and services. |
 
-Other GML-encoded specs (S-129, S-131, S-411) are intentionally
-deferred to a future pass — the shared abstractions continue to be
-validated against new consumers before being rolled out further.
+Other GML-encoded specs (S-129, S-131, S-411) expose their data through
+the schema-agnostic feature bags rather than a typed root.

--- a/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/README.md
+++ b/src/EncDotNet.S100.DynamicSources.Ais.Drivers.AisStreamIo/README.md
@@ -3,6 +3,9 @@
 `IAisMessageSource` driver targeting [aisstream.io](https://aisstream.io)'s
 free WebSocket AIS streaming service.
 
+> **Packaging:** this library is not currently published to NuGet.
+> Consume it via project reference, or through the desktop viewer.
+
 ## What ships here
 
 | Type | Purpose |

--- a/src/EncDotNet.S100.DynamicSources.Ais/README.md
+++ b/src/EncDotNet.S100.DynamicSources.Ais/README.md
@@ -3,6 +3,9 @@
 Concrete `IDynamicFeatureSource` for AIS targets, plus the
 driver-agnostic `IAisMessageSource` abstraction.
 
+> **Packaging:** this library is not currently published to NuGet.
+> Consume it via project reference, or through the desktop viewer.
+
 ## What ships here
 
 | Type | Purpose |

--- a/src/EncDotNet.S100.Mcp.Tools/README.md
+++ b/src/EncDotNet.S100.Mcp.Tools/README.md
@@ -3,8 +3,11 @@
 Foundation for a Model Context Protocol (MCP) server that exposes
 S-100 datasets to LLM-driven tooling. This project ships **the
 abstraction and the tool surface only** — no MCP protocol code, no
-viewer code, no transport. PR MCP-2 will layer the wire protocol on
-top of this.
+viewer code, no transport. The `EncDotNet.S100.Mcp` library layers the
+wire protocol on top of it.
+
+> **Packaging:** this library is not currently published to NuGet.
+> Consume it via project reference.
 
 ## Field conventions
 

--- a/src/EncDotNet.S100.Mcp/README.md
+++ b/src/EncDotNet.S100.Mcp/README.md
@@ -6,6 +6,10 @@ The library is **UI-agnostic** — host it inside the desktop viewer, a
 CLI tool, or any process that can spin up an ASP.NET Core Kestrel
 listener.
 
+> **Packaging:** this library is not currently published to NuGet.
+> Consume it via project reference, or host it through the desktop
+> viewer.
+
 ## Stance
 
 - **Loopback-only.** The default `BindAddress` is `IPAddress.Loopback`.

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -96,23 +96,17 @@ headless render path.
 | Vector (GML) | S-122, S-124, S-125, S-127, S-128, S-129, S-131, S-201, S-411, S-421 | `HeadlessVectorRenderer` |
 | Coverage (HDF5) | S-102, S-104 (gridded), S-111 (gridded) | `CoverageHeadlessRenderer` |
 
-## Limitations (v1)
+## Limitations
 
 - **PNG output only.**
 - **Vector pattern area-fills are omitted** on the headless path; points,
-  lines, solid-area fills, and text render. (This is a limitation of
-  `HeadlessVectorRenderer`, not the CLI.)
+  lines, solid-area fills, and text render.
 - **Coverage fixed-station datasets are not supported.** S-104 / S-111 datasets
   using data coding format 3 or 8 (time series at fixed stations) emit point
   glyphs through the Mapsui path only; the CLI reports a clear "not supported"
   error.
 - **S-57 renders through the S-101 pipeline.** Datasets are translated to
   `S101Document` in-memory and rasterised with S-101 symbology (not S-52).
-- **Mapsui is linked but not used to render.** The CLI transitively references
-  `EncDotNet.S100.Renderers.Mapsui` for the spec-detection factory and the
-  `ProjNetCrsTransformFactory`, but no Mapsui rendering runs on the headless
-  path. Decoupling the factory and CRS transform from the Mapsui assembly is
-  tracked as follow-up work.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary

Another round of documentation review focused on the **main** docs (root README and the docs it links to), with an eye toward both keeping them high-level and making them approachable for non-developers.

## What changed

**Trim future-plans / why-not language and implementation detail** (`d82b75d`)
- Removed roadmap/"why we didn't do X" prose from the main docs (CLI `dotnet tool` future section, "in v1" qualifiers, Mapsui-decoupling follow-up notes, MCP unit-normalisation TODO) — that belongs in issues, not user docs.
- Replaced the CLI "How it works" internal class walkthrough with a high-level description, and brought the CLI command/option list up to date (all three subcommands + full render-options table).
- Fixed an inaccurate "all tools are read-only" claim in the MCP security notes (the table documents mutating tools).

**Pack each library's README as its NuGet readme** (`c2163bd`)
- Added a `Directory.Build.targets` that wires every packable project's own `README.md` as its `PackageReadmeFile` (shown on nuget.org), applied centrally so current and future packed libraries are covered automatically. Verified the README is embedded and referenced in the nuspec for several packages; `IsPackable=false` projects are unaffected.
- Listed the `EncDotNet.S100` convenience facade in the root README's Libraries section.

**Clarify in-repo (unpublished) libraries** (`d4c9cdc`)
- The MCP and AIS dynamic-source libraries are `IsPackable=false`; relabeled the root README tables as "projects" with a "not currently published to NuGet" note, and added the same note to each library README. Corrected a stale forward-reference in the `Mcp.Tools` README.

**Give the `s100` CLI top-level billing** (`24ee2e8`)
- Added the CLI to the Overview alongside the viewer and facade, plus a dedicated "Command-line tool" section parallel to "The Viewer".

**Add a first-class desktop-viewer onboarding path for non-developers** (`613a196`)
- The previous onboarding routes all assumed a developer with the .NET SDK. Added a **Desktop app** path to the getting-started guide (download → open data → explore), a "just want to look at charts?" download pointer near the top of the root README, a plain-language description in the Overview, and the viewer guide in the docs index + next steps.

## Notes

Design notes under `docs/design/**` were intentionally left untouched — `docs/index.md` scopes them as rationale/open-questions where forward-looking language is appropriate.

Docs-only except for the `Directory.Build.targets` packaging wiring.