### PR TITLE
docs: document Linux runtime dependencies for the s100 CLI

### DIFF
--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -34,6 +34,30 @@ binary (for example when copied between machines), clear the attribute with:
 xattr -d com.apple.quarantine ./s100
 ```
 
+#### Linux runtime dependencies
+
+The self-contained archive bundles the .NET runtime and SkiaSharp's native
+libraries, but it does **not** bundle the handful of system shared libraries
+those components load from the OS. Minimal/server and container base images
+(for example `ubuntu`, `debian`, `mcr.microsoft.com/dotnet/runtime-deps`) often
+omit them, so install them before running `s100`:
+
+| Package | Required on | Why |
+|---|---|---|
+| `libicu` (`libicu74` on Ubuntu 24.04, `libicu72` on Debian 12) | **all** Linux | .NET globalization. Without it **every** command aborts at startup with a `Couldn't find a valid ICU package` failure. |
+| `libfontconfig1` | **x64** (hard requirement); recommended on arm64 | The x64 `libSkiaSharp.so` lists `libfontconfig.so.1` as a required (`NEEDED`) dependency, so any Skia/`render` command fails to load it with a `SKImageInfo` type-initializer error until it is installed. The arm64 native library does not link fontconfig, so it loads without it — but installing fontconfig (plus a font package) is still recommended for correct text rendering and to silence the `Fontconfig error: Cannot load default config file` warning. |
+
+Debian/Ubuntu:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libicu74 libfontconfig1 fontconfig
+# Debian 12: use libicu72 instead of libicu74
+```
+
+`s100 list-specs` and `s100 info` need only `libicu`; `s100 render` (the Skia
+path) additionally needs `libfontconfig1` on x64.
+
 ### Inside the Viewer application bundle
 
 The `s100` executable also ships **inside the S-100 Viewer application bundle**


### PR DESCRIPTION
## Summary

Linux has been a recurring pain point for this project: the self-contained `s100` CLI archives bundle the .NET runtime and SkiaSharp's native libraries, but not the handful of system shared libraries those components load from the OS. On minimal/server and container base images this surfaces as confusing startup or render-time crashes.

I verified the actual requirements by pulling the latest CI-built CLI archives (`s100-cli-linux-x64` / `-linux-arm64`) and exercising them in clean Docker containers (`ubuntu:24.04`, `debian:12`, both x64 and arm64), then documented the findings in the CLI README (`tools/EncDotNet.S100.Cli/README.md`).

Findings:

- **`libicu` is required on all Linux.** Without it every command aborts at startup with `Couldn't find a valid ICU package`.
- **`libfontconfig1` is a hard requirement on x64.** `ldd` shows the x64 `libSkiaSharp.so` lists `libfontconfig.so.1` as `NEEDED`, so any Skia/`render` command fails to load it with an `SKImageInfo` type-initializer error until it is installed. The arm64 native library does not link fontconfig, so it loads without it (a benign `Fontconfig error: Cannot load default config file` warning aside), but installing fontconfig is still recommended for correct text rendering.

With `libicu` + `libfontconfig1` installed, both coverage (S-102) and vector+text (S-57 via S-101) renders produce valid PNGs on x64 and arm64; the S-102 output is byte-identical across architectures.

The new README subsection includes the package table, the `apt-get install` line, and a note on which commands need which libs.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A

## Tests

Docs-only change; verification was done manually in Docker containers (not automated). No xunit tests apply.

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (here: `tools/EncDotNet.S100.Cli/README.md`)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A)

## Breaking changes

None.