### PR TITLE
Move CRS transform to Mapsui-free EncDotNet.S100.Crs.ProjNet package (#189, PR1/2)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -45,6 +45,7 @@ jobs:
             tools/EncDotNet.S100.PerfRunner \
             tools/EncDotNet.S100.PerfReport \
             tools/perf \
+            src/EncDotNet.S100.Crs.ProjNet \
             src/EncDotNet.S100.Diagnostics.Export \
             Directory.Packages.props
 

--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -22,6 +22,7 @@
     <Project Path="src/EncDotNet.S100.Datasets.S421/EncDotNet.S100.Datasets.S421.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.S57/EncDotNet.S100.Datasets.S57.csproj" />
     <Project Path="src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj" />
+    <Project Path="src/EncDotNet.S100.Crs.ProjNet/EncDotNet.S100.Crs.ProjNet.csproj" />
     <Project Path="src/EncDotNet.S100.ExchangeSets/EncDotNet.S100.ExchangeSets.csproj" />
     <Project Path="src/EncDotNet.S100.Features/EncDotNet.S100.Features.csproj" />
     <Project Path="src/EncDotNet.S100.Hdf5.PureHdf/EncDotNet.S100.Hdf5.PureHdf.csproj" />

--- a/src/EncDotNet.S100.Crs.ProjNet/EncDotNet.S100.Crs.ProjNet.csproj
+++ b/src/EncDotNet.S100.Crs.ProjNet/EncDotNet.S100.Crs.ProjNet.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <Description>ProjNet-backed implementation of the EncDotNet.S100.Core ICrsTransformFactory abstraction (WGS84 UTM zones and EPSG:4326 ↔ EPSG:3857). Mapsui-free, so headless consumers (the EncDotNet.S100 facade and the s100 CLI) can reproject coverage products without linking a map renderer.</Description>
+    <PackageTags>S-100;CRS;projection;ProjNet;EPSG;IHO;hydrography</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ProjNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EncDotNet.S100.Crs.ProjNet/ProjNetCrsTransformFactory.cs
+++ b/src/EncDotNet.S100.Crs.ProjNet/ProjNetCrsTransformFactory.cs
@@ -1,15 +1,22 @@
+using System;
 using EncDotNet.S100.Pipelines;
-using ProjNet.CoordinateSystems;
-using ProjNet.CoordinateSystems.Transformations;
+using global::ProjNet.CoordinateSystems;
+using global::ProjNet.CoordinateSystems.Transformations;
 
-namespace EncDotNet.S100.Renderers.Mapsui;
+namespace EncDotNet.S100.Crs.ProjNet;
 
 /// <summary>
 /// Creates CRS transforms backed by ProjNet.
 /// Supports WGS84 UTM zones (EPSG:326xx, EPSG:327xx) and EPSG:4326 ↔ EPSG:3857.
 /// </summary>
+/// <remarks>
+/// This is the only <see cref="ICrsTransformFactory"/> implementation in the
+/// repository. It depends solely on ProjNet (no map renderer), so headless
+/// consumers can reproject coverage products without linking Mapsui.
+/// </remarks>
 public sealed class ProjNetCrsTransformFactory : ICrsTransformFactory
 {
+    /// <inheritdoc />
     public ICrsTransform Create(string sourceCrs, string targetCrs)
     {
         if (string.Equals(sourceCrs, targetCrs, StringComparison.OrdinalIgnoreCase))

--- a/src/EncDotNet.S100.Crs.ProjNet/README.md
+++ b/src/EncDotNet.S100.Crs.ProjNet/README.md
@@ -1,0 +1,37 @@
+# EncDotNet.S100.Crs.ProjNet
+
+ProjNet-backed implementation of the `ICrsTransformFactory` /
+`ICrsTransform` abstraction declared in **EncDotNet.S100.Core**
+(`EncDotNet.S100.Pipelines` namespace).
+
+## Overview
+
+`ProjNetCrsTransformFactory` creates coordinate transforms using
+[ProjNet](https://github.com/NetTopologySuite/ProjNet4GeoAPI). It supports:
+
+- **WGS84 UTM zones** — EPSG:326xx (northern hemisphere) and EPSG:327xx
+  (southern hemisphere), the CRS S-102 / S-104 / S-111 coverage products
+  are typically georeferenced in.
+- **EPSG:4326 ↔ EPSG:3857** — geographic ↔ Web Mercator, the projection
+  used to lay coverage rasters onto a slippy-map viewport.
+
+Identical source/target CRS short-circuit to `IdentityCrsTransform`.
+
+## Why a separate package?
+
+This implementation depends **only on ProjNet** — no map renderer. It
+previously lived inside `EncDotNet.S100.Renderers.Mapsui`, which made
+Mapsui a transitive dependency of otherwise-headless consumers (the
+`EncDotNet.S100` facade and the `s100` CLI). Hosting it here lets those
+consumers reproject coverage products without linking Mapsui.
+
+## Usage
+
+```csharp
+using EncDotNet.S100.Crs.ProjNet;
+using EncDotNet.S100.Pipelines;
+
+ICrsTransformFactory factory = new ProjNetCrsTransformFactory();
+ICrsTransform toWebMercator = factory.Create("EPSG:32608", "EPSG:3857");
+var (x, y) = toWebMercator.Transform(easting, northing);
+```

--- a/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
+++ b/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Mapsui.Nts" />
     <PackageReference Include="Mapsui.Rendering.Skia" />
     <PackageReference Include="Mapsui.Tiling" />
-    <PackageReference Include="ProjNet" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -9,7 +9,10 @@ This library bridges the S-100 portrayal pipeline output to Mapsui map layers, i
 - **`MapsuiCoverageRenderer`** — `ICoverageRenderer<ILayer>` implementation that renders coverage data as a georeferenced raster overlay (S-102 / S-104 / S-111).
 - **`MapsuiCoverageArrowRenderer`** — renders current arrows (e.g. from S-111 data) as a georeferenced raster layer.
 - **`MapsuiDisplayListRenderer`** — product-agnostic vector renderer that consumes a list of `DrawingInstruction`s plus an `IFeatureGeometryProvider` and produces a `MemoryLayer` of styled point/line/area/text features. Used by every S-100 vector product (S-101, S-124, S-129, S-421); no per-spec subclass is required.
-- **`ProjNetCrsTransformFactory`** — `ICrsTransformFactory` implementation using [ProjNet](https://github.com/NetTopologySuite/ProjNet4GeoAPI) for coordinate transformations between UTM, WGS84, and Web Mercator.
+
+> **CRS transforms** moved to the Mapsui-free **`EncDotNet.S100.Crs.ProjNet`**
+> package (`ProjNetCrsTransformFactory`) so headless consumers can reproject
+> coverage products without linking a map renderer.
 
 `MapsuiDisplayListRenderer` lowers the display list through the **shared,
 backend-agnostic vector rendering core** in

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -230,7 +230,7 @@ public partial class App : Application
             new EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory(
                 sp.GetRequiredService<PortrayalCatalogueManager>(),
                 new EncDotNet.S100.Scripting.MoonSharp.MoonSharpLuaEngine(),
-                new EncDotNet.S100.Renderers.Mapsui.ProjNetCrsTransformFactory(),
+                new EncDotNet.S100.Crs.ProjNet.ProjNetCrsTransformFactory(),
                 sp.GetRequiredService<EncDotNet.S100.Features.FeatureCatalogueManager>(),
                 sp.GetRequiredService<EncDotNet.S100.Datasets.Pipelines.Interoperability.IInteroperabilityAuthorityProvider>(),
                 sp.GetRequiredService<EncDotNet.S100.Renderers.Mapsui.IPatternClipCache>(),

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -71,6 +71,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Diagnostics.Export\EncDotNet.S100.Diagnostics.Export.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />

--- a/src/EncDotNet.S100/EncDotNet.S100.csproj
+++ b/src/EncDotNet.S100/EncDotNet.S100.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />

--- a/src/EncDotNet.S100/S100PipelineHost.cs
+++ b/src/EncDotNet.S100/S100PipelineHost.cs
@@ -1,11 +1,11 @@
 using System;
 using System.IO;
 using EncDotNet.S100.Core;
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Portrayals;
-using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Specifications;
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFeatureCatalogueReuseTests.cs
@@ -3,6 +3,7 @@ using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
 using Xunit;

--- a/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
+++ b/tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Skia\EncDotNet.S100.Renderers.Skia.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />

--- a/tests/EncDotNet.S100.Pipelines.Tests/MapsuiCoverageRendererCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/MapsuiCoverageRendererCacheTests.cs
@@ -1,5 +1,6 @@
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Renderers.Mapsui;
 using Mapsui;
 using Mapsui.Layers;

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101DiskPatternClipCacheProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101DiskPatternClipCacheProcessorTests.cs
@@ -1,6 +1,7 @@
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Specifications;

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PortrayalInstructionCacheProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PortrayalInstructionCacheProcessorTests.cs
@@ -2,6 +2,7 @@ using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Pipelines.Vector.Caching;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Specifications;

--- a/tests/EncDotNet.S100.VisualRegression/EncDotNet.S100.VisualRegression.csproj
+++ b/tests/EncDotNet.S100.VisualRegression/EncDotNet.S100.VisualRegression.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />

--- a/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
+++ b/tests/EncDotNet.S100.VisualRegression/RenderHarness.cs
@@ -3,6 +3,7 @@ using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting;
 using EncDotNet.S100.Scripting.MoonSharp;

--- a/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+++ b/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
@@ -28,10 +28,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
-    <ProjectReference Include="..\..\src\EncDotNet.S100.Renderers.Mapsui\EncDotNet.S100.Renderers.Mapsui.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
   </ItemGroup>

--- a/tools/EncDotNet.S100.Cli/Infrastructure/ProcessorFactoryBuilder.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/ProcessorFactoryBuilder.cs
@@ -1,8 +1,8 @@
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Features;
 using EncDotNet.S100.Portrayals;
-using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Scripting.MoonSharp;
 using EncDotNet.S100.Specifications;
 

--- a/tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj
+++ b/tools/EncDotNet.S100.PerfRunner/EncDotNet.S100.PerfRunner.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Diagnostics.Export\EncDotNet.S100.Diagnostics.Export.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.ExchangeSets\EncDotNet.S100.ExchangeSets.csproj" />

--- a/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
+++ b/tools/EncDotNet.S100.PerfRunner/SharedInfrastructure.cs
@@ -1,5 +1,5 @@
+using EncDotNet.S100.Crs.ProjNet;
 using EncDotNet.S100.Portrayals;
-using EncDotNet.S100.Renderers.Mapsui;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Scripting;
 using EncDotNet.S100.Scripting.MoonSharp;


### PR DESCRIPTION
## Summary

PR1 of 2 for #189 (decouple the dataset pipeline factory + CRS transform from Mapsui).

`ProjNetCrsTransformFactory` — the only `ICrsTransformFactory` implementation — previously lived inside `EncDotNet.S100.Renderers.Mapsui` even though it depends solely on ProjNet (no Mapsui). That made Mapsui a transitive dependency of otherwise-headless consumers.

This PR relocates it (and the internal `ProjNetCrsTransform`) into a new **Mapsui-free, packable** package `EncDotNet.S100.Crs.ProjNet` (`net8.0;net10.0`, references Core + ProjNet). The `ICrsTransform`/`ICrsTransformFactory` abstractions already live in Core — only the implementation moved.

## Changes
- **New package** `EncDotNet.S100.Crs.ProjNet` (owns `ProjNetCrsTransformFactory`/`ProjNetCrsTransform`, namespace `EncDotNet.S100.Crs.ProjNet`; ProjNet `using`s are `global::`-qualified to avoid the trailing-`.ProjNet` namespace clash). README + registered in the solution.
- Dropped the now-unused `ProjNet` package reference from `EncDotNet.S100.Renderers.Mapsui`; updated its README.
- Rewired consumers: facade `S100PipelineHost`, CLI `ProcessorFactoryBuilder` (also drops its direct Renderers.Mapsui project reference), Viewer `App.axaml.cs`, PerfRunner `SharedInfrastructure`, and the affected test projects.

## Scope note
This PR **does not** by itself remove Mapsui from the CLI/facade output — `EncDotNet.S100.Datasets.Pipelines` still references Renderers.Mapsui because the per-spec processors implement the Mapsui-typed `RenderAsync`. That is the **stacked follow-up PR2** (the portrayal-output render seam), which will make Pipelines Mapsui-free and add a `MapsuiDatasetRenderer`.

## Verification
- `dotnet build` (full solution) — green.
- `dotnet test` `EncDotNet.S100.Pipelines.Tests` — 499 passed, 1 skipped.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes: #189