### PR TITLE
Stabilize flaky Viewer tests and S-57 visual-regression boundary (#215, #177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,16 @@ jobs:
           name: test-results-${{ matrix.name }}
           path: TestResults/*.trx
 
+      - name: Upload visual regression diffs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rendering-snapshots-${{ matrix.name }}
+          path: |
+            tests/EncDotNet.S100.VisualRegression.Tests/Snapshots/**/*.received.png
+            tests/EncDotNet.S100.VisualRegression.Tests/Snapshots/**/*.diff.png
+          if-no-files-found: ignore
+
   publish:
     needs: build
     strategy:

--- a/tests/EncDotNet.S100.Viewer.Tests/DebouncedSettingsSaverTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DebouncedSettingsSaverTests.cs
@@ -31,20 +31,28 @@ public sealed class DebouncedSettingsSaverTests
     {
         var saves = 0;
         using var fired = new ManualResetEventSlim();
+        // A wide window so a rapid synchronous burst of requests cannot
+        // realistically straddle it, even under heavy CI scheduler load.
+        const int delayMilliseconds = 1000;
         using var saver = new DebouncedSettingsSaver(
             () => { Interlocked.Increment(ref saves); fired.Set(); },
-            delayMilliseconds: 100);
+            delayMilliseconds: delayMilliseconds);
 
+        // Issue the requests as a rapid synchronous burst (no sleeps): each
+        // RequestSave restarts the single debounce timer, so only the final
+        // one survives and fires exactly once. The previous version spaced
+        // the calls with Thread.Sleep(10); under CI starvation a sleep could
+        // exceed the 100 ms window, letting the timer fire mid-burst and then
+        // re-arm — producing a second save (flaky, issue #215).
         for (int i = 0; i < 10; i++)
         {
             saver.RequestSave();
-            Thread.Sleep(10);
         }
 
         Assert.True(fired.Wait(TimeSpan.FromSeconds(5)), "Saver did not fire within 5 s");
-        // Give any (incorrectly) scheduled extra fires a chance to land
-        // before asserting coalescence. The debounce window is 100 ms,
-        // so 300 ms is plenty without being painfully slow.
+        // Give any (incorrectly) scheduled extra fire a chance to land before
+        // asserting coalescence. A spurious second timer would fire at roughly
+        // the same instant as the first, so a short margin is sufficient.
         Thread.Sleep(300);
 
         Assert.Equal(1, saves);

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DeferredAisFeatureSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/DeferredAisFeatureSourceTests.cs
@@ -149,8 +149,14 @@ public class DeferredAisFeatureSourceTests
             notifier.Publish(SnapshotWithSpan(8 - i * 0.5, 8 - i * 0.5));
         }
 
-        // Wait long enough for the trailing call to fire.
-        await Task.Delay(200);
+        // Wait deterministically for the single trailing debounced call to
+        // land rather than racing a fixed delay (issue #215).
+        Assert.True(
+            await fakeSub.AreaUpdatedSignal.WaitAsync(TimeSpan.FromSeconds(5)),
+            "Debounced UpdateArea did not fire within 5 s");
+        // A short margin to surface any (incorrect) extra debounced fire
+        // before asserting that the burst coalesced to exactly one call.
+        await Task.Delay(100);
 
         Assert.Single(fakeSub.AreaUpdates);
     }
@@ -314,6 +320,13 @@ internal sealed class FakeAisSubscription : IAisSubscription
     public bool SupportsAreaUpdate { get; set; } = true;
     public List<BoundingBox?> AreaUpdates { get; } = new();
 
+    /// <summary>
+    /// Released once per <see cref="TryUpdateArea"/> call so tests can wait
+    /// deterministically for a (debounced) area update to land instead of
+    /// racing a fixed delay.
+    /// </summary>
+    public SemaphoreSlim AreaUpdatedSignal { get; } = new(0);
+
     public event EventHandler<AisPositionReport>? PositionReportReceived;
     public event EventHandler<AisStaticVoyageData>? StaticVoyageDataReceived;
     public event EventHandler<AisTargetLost>? TargetLost;
@@ -323,6 +336,7 @@ internal sealed class FakeAisSubscription : IAisSubscription
         if (!SupportsAreaUpdate) return false;
         AreaUpdates.Add(area);
         _active = _active with { Area = area };
+        AreaUpdatedSignal.Release();
         return true;
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/OpenDatasetToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/OpenDatasetToolTests.cs
@@ -160,6 +160,12 @@ public class OpenDatasetToolTests
                     // both adds together. This removes the timing race where a
                     // delayed second add could be mistaken for a failed load
                     // (issue #215).
+                    //
+                    // NOTE: collapsing the adds means this test now exercises
+                    // the fast path, not the quiet-window settle path. That
+                    // path is still covered deterministically by
+                    // ExchangeSet_partial_failure_settles_via_quiet_window
+                    // below (1 add dispatched as 2 -> settles via quiet window).
                     _ = Task.Run(async () =>
                     {
                         await Task.Delay(20);

--- a/tests/EncDotNet.S100.Viewer.Tests/OpenDatasetToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/OpenDatasetToolTests.cs
@@ -151,11 +151,19 @@ public class OpenDatasetToolTests
                 {
                     // Fire-and-forget adds after the trigger returns, like
                     // the real exchange-set service; 2 datasets dispatched.
+                    // The two adds are issued as a single synchronous burst
+                    // (no await between them) so the tool's quiescence quiet
+                    // window can never open *between* them: the fast path
+                    // (added >= dispatched) resolves deterministically. If the
+                    // whole continuation is starved past the quiet window, the
+                    // tool simply keeps waiting up to maxWaitMs and still sees
+                    // both adds together. This removes the timing race where a
+                    // delayed second add could be mistaken for a failed load
+                    // (issue #215).
                     _ = Task.Run(async () =>
                     {
                         await Task.Delay(20);
                         catalog.Add("a.000", "S-101");
-                        await Task.Delay(20);
                         catalog.Add("b.000", "S-102");
                     });
                     return Task.FromResult(2);

--- a/tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using EncDotNet.S100.VisualRegression;
 
 namespace EncDotNet.S100.VisualRegression.Tests;
@@ -27,10 +28,26 @@ public sealed class S57RenderingTests
         });
 
         // S-57 is translated in-memory to S-101 and rendered through the full
-        // portrayal stack; the resulting raster drifts slightly across platforms
-        // (notably font/anti-aliasing on win-arm64, observed ~5.93% vs the
-        // committed baseline). Allow a modest 8% tolerance for this end-to-end
-        // snapshot so platform pixel jitter doesn't fail CI.
-        return TestHelpers.VerifyBitmap(bitmap, maxDifferentPixelFraction: 0.08);
+        // portrayal stack. The committed baseline was baked on win-x64. Measured
+        // differences vs that baseline are confined to the anti-aliased fringe of
+        // thin vector strokes (depth-contour lines and the diagonal
+        // quality-of-data hatching) — geometry, colour, and symbology are
+        // identical, and the worst per-channel delta is a partial-coverage ~47.
+        //
+        //   linux-x64 / osx-arm64 : 2.383% (byte-identical renders)
+        //   win-arm64             : 5.93%  (different Skia AA/raster path)
+        //
+        // Keep the strict 5% bound everywhere — it preserves the test's power on
+        // the platforms that actually run it in CI (linux-x64 has ~2.6% of
+        // headroom) — and relax to 8% ONLY on win-arm64, whose heterogeneous
+        // runner rasterisation lands ~5.93% off the baseline (issue #177). We use
+        // ProcessArchitecture (not OSArchitecture) so an x64 process emulated on
+        // an arm64 OS is not over-relaxed.
+        var maxDifferentPixelFraction =
+            OperatingSystem.IsWindows()
+            && RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? 0.08
+                : 0.05;
+        return TestHelpers.VerifyBitmap(bitmap, maxDifferentPixelFraction);
     }
 }

--- a/tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs
@@ -43,6 +43,10 @@ public sealed class S57RenderingTests
         // runner rasterisation lands ~5.93% off the baseline (issue #177). We use
         // ProcessArchitecture (not OSArchitecture) so an x64 process emulated on
         // an arm64 OS is not over-relaxed.
+        //
+        // DELIBERATE per-RID tolerance — do NOT "tidy" this back to a single
+        // global 0.08 (that is what #186 did and it weakened the test on every
+        // platform; #177 restores the strict 5% everywhere except win-arm64).
         var maxDifferentPixelFraction =
             OperatingSystem.IsWindows()
             && RuntimeInformation.ProcessArchitecture == Architecture.Arm64


### PR DESCRIPTION
## Summary

CI-stabilization for two distinct flakes. Both are test/threshold changes — no production behavior changes.

Fixes #177
Contributes to #215 *(see note on the second flake below — keep #215 open until verified over time)*

---

## #177 — S-57 VisualRegression boundary on win-arm64 (root-caused with data)

`S57RenderingTests.EncCell_DayPalette` compares a Skia render to a single committed baseline. A prior PR (#186) had already bumped this test's perceptual tolerance to **8% globally**, which weakened it on every platform — exactly what #177 warns against.

I rendered the cell and diffed it vs the committed baseline on two platforms (throwaway tool using the public `RenderHarness` + `PerceptualImageComparer`):

| Platform | diff fraction |
|---|---|
| osx-arm64 | **2.383%** |
| linux-x64 (Ubuntu container) | **2.383%** (byte-identical render to macOS) |
| win-arm64 (from issue, deterministic re-run) | **5.93%** |

Viewing the baseline/received/diff images showed the differences are confined to the **anti-aliased fringe of thin vector strokes** (curved depth contours + the diagonal quality-of-data hatching) — geometry, colour, and symbology are identical; worst per-channel delta is a partial-coverage ~47/255. So this is **environmental rasterization variance**, not nondeterminism or a regression. The baseline was baked on win-x64; osx-arm64/linux-x64 render identically (2.38% off it); win-arm64 Windows uses a different Skia AA path → 5.93%.

**CI fact:** VR tests run only on **linux-x64** (`build` job) and **win-arm64** (`test-arm64` job). linux-x64 is the only non-arm64 platform that runs them, at 2.383%.

### Fix
- **Per-RID tolerance**: restore strict **5% everywhere**, relax to **8% only on win-arm64** (`OperatingSystem.IsWindows() && ProcessArchitecture == Arm64`). Keyed off architecture+OS, not per-machine. Comment documents the deliberate relaxation, the observed ~5.93%, and a "do not collapse back to global 0.08" note.
- **ci.yml**: the `test-arm64` job now uploads `*.received.png`/`*.diff.png` on failure (it previously uploaded only TRX), so the win-arm64 render/diff is inspectable next time.

Verified: S-57 VR **passes at strict 5% on linux-x64** (run in a linux/amd64 container) and on osx-arm64.

---

## #215 — Flaky Viewer tests (timing races, test-only)

- **`OpenDatasetToolTests.ExchangeSet_collects_delayed_adds`** (the named flake, `Expected 2, Actual 1`): the fake dispatched two adds with a 20 ms gap; under CI threadpool starvation the second add could slip past the tool's 150 ms quiescence quiet window, so it settled with count 1. Fix: emit both adds as a **single synchronous burst**, so the quiet window can't open between them and the fast path (`added >= dispatched`) resolves deterministically. The quiet-window settle path remains covered by the sibling `ExchangeSet_partial_failure_settles_via_quiet_window`.
- **`DebouncedSettingsSaverTests.RequestSave_MultipleCallsCoalesceIntoOneFire`** (most-probable second flake): a starved `Thread.Sleep(10)` exceeding the 100 ms window could fire the restart-timer mid-loop and re-arm → a second save. Fix: drop the inter-call sleep (the coalesce contract is a synchronous burst) and **widen the window**. The assertion stays **strict (`Expected 1`)** — only the timing window changed, not what is asserted.
- **`DeferredAisFeatureSourceTests.Debounces_UpdateArea_to_a_single_call`** (defensive): wait on a new `AreaUpdatedSignal` from the fake subscription instead of racing `Task.Delay(200)`.

### ⚠️ Note on the second flake
I could **not reproduce** the second Viewer flake locally, even under load average ~156 on a 16-core box (timers stay accurate; the real flake needs weak-runner starvation). The `DebouncedSettingsSaver`/`DeferredAis` changes are therefore **best-effort hardening of the most likely candidates**, not a confirmed fix. This is why the PR says **Contributes to #215** rather than Fixes — #215 should stay open and be verified over time.

---

## Verification
- `EncDotNet.S100.Viewer.Tests`: 676/676, green and stable across 10 looped runs.
- `EncDotNet.S100.VisualRegression.Tests`: green; S-57 passes at strict 5% on osx-arm64 and (in-container) linux-x64.

## Coordination
- This PR edits `.github/workflows/ci.yml` (adds an on-failure artifact upload to the `test-arm64` job — additive, no matrix/pass-fail change). Flagging for sequencing vs. #23 and #189, which also touch CI/Viewer/Renderers.Skia. Otherwise changes are confined to test code + the VR tolerance logic.