### PR TITLE
Relax S-57 VR tolerance to 8% on linux-arm64 (fix main red from #224×#223 interaction)

### DIFF
--- a/tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs
@@ -34,24 +34,28 @@ public sealed class S57RenderingTests
         // quality-of-data hatching) — geometry, colour, and symbology are
         // identical, and the worst per-channel delta is a partial-coverage ~47.
         //
-        //   linux-x64 / osx-arm64 : 2.383% (byte-identical renders)
-        //   win-arm64             : 5.93%  (different Skia AA/raster path)
+        //   linux-x64 / osx-arm64   : 2.383% (byte-identical renders)
+        //   linux-arm64 / win-arm64 : 5.93%  (arm64 Skia AA/raster path)
         //
-        // Keep the strict 5% bound everywhere — it preserves the test's power on
-        // the platforms that actually run it in CI (linux-x64 has ~2.6% of
-        // headroom) — and relax to 8% ONLY on win-arm64, whose heterogeneous
-        // runner rasterisation lands ~5.93% off the baseline (issue #177). We use
-        // ProcessArchitecture (not OSArchitecture) so an x64 process emulated on
-        // an arm64 OS is not over-relaxed.
+        // Keep the strict 5% bound on the platforms whose render is byte-identical
+        // to the baseline — linux-x64 (the build job, ~2.6% of headroom) and
+        // osx-arm64 — which preserves the test's power where it counts. Relax to
+        // 8% on the arm64 CI runners (linux-arm64 and win-arm64), whose NEON
+        // rasterisation lands ~5.93% off the baseline. linux-arm64 joined
+        // win-arm64 here once the NoDependencies SkiaSharp native (#224) replaced
+        // the previous Linux native build and switched the arm64 leg onto the same
+        // divergent AA path (issues #177, #215, #224). We test ProcessArchitecture
+        // (not OSArchitecture) so an x64 process emulated on an arm64 OS is not
+        // over-relaxed, and exclude macOS, whose arm64 render is byte-identical.
         //
         // DELIBERATE per-RID tolerance — do NOT "tidy" this back to a single
         // global 0.08 (that is what #186 did and it weakened the test on every
-        // platform; #177 restores the strict 5% everywhere except win-arm64).
-        var maxDifferentPixelFraction =
-            OperatingSystem.IsWindows()
-            && RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                ? 0.08
-                : 0.05;
+        // platform); the strict 5% is retained on linux-x64, win-x64, and
+        // osx-arm64.
+        var isArm64CiRunner =
+            RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+            && !OperatingSystem.IsMacOS();
+        var maxDifferentPixelFraction = isArm64CiRunner ? 0.08 : 0.05;
         return TestHelpers.VerifyBitmap(bitmap, maxDifferentPixelFraction);
     }
 }


### PR DESCRIPTION
## Problem

`main` is currently **red**: CI run `27109684684` on `main` HEAD `4b2a66d` fails `test-arm64 (ubuntu-22.04-arm, linux-arm64)` on `S57RenderingTests.EncCell_DayPalette` at **5.93% (28463/480000 px)** against the strict **5.00%** bound. This poisons CI for the whole queue, so it needs to go green independently.

## Root cause — a #224 × #223 interaction

- **#224** (NoDependencies SkiaSharp native + embedded render font for Linux) switched the **linux-arm64** leg onto the arm64 Skia NEON AA/raster path, so it now lands ~5.93% off the win-x64-baked baseline — the *same* divergence #223 had already documented for **win-arm64**.
- **#223**'s per-RID tolerance only relaxed `OperatingSystem.IsWindows() && ProcessArchitecture == Arm64` to 8%, leaving **linux-arm64** pinned at strict 5%. The freshly-diverged linux-arm64 render trips it.

## Fix

Relax to 8% on any **non-macOS arm64** CI runner (linux-arm64 + win-arm64), matching #177's per-RID precedent:

```csharp
var isArm64CiRunner =
    RuntimeInformation.ProcessArchitecture == Architecture.Arm64
var maxDifferentPixelFraction = isArm64CiRunner ? 0.08 : 0.05;
```

- **osx-arm64** stays strict **5%** (byte-identical render).
- **linux-x64 / win-x64** stay strict **5%** (the build job has ~2.6% of headroom) — the test keeps full power on the platforms that render identically to the baseline.
- We test `ProcessArchitecture` (not `OSArchitecture`) so an x64 process emulated on an arm64 OS is not over-relaxed.
- The "do NOT collapse to a global 0.08" guard comment is retained so the per-RID intent survives.

Only `tests/EncDotNet.S100.VisualRegression.Tests/S57RenderingTests.cs` changes (comment + the tolerance predicate).

Refs #177, #215, #224.