### PR TITLE
Restore net8.0;net10.0 multi-targeting for Renderers.Mapsui and the EncDotNet.S100 facade

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj
+++ b/src/EncDotNet.S100.Datasets.Pipelines/EncDotNet.S100.Datasets.Pipelines.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>Per-spec IDatasetProcessor implementations, the DatasetPipelineFactory (file -&gt; processor detection), the headless image-render capability, the S-98 interoperability authority, and the validation runner for IHO S-100 product datasets. Consumed by the EncDotNet.S100 convenience package, the viewer, and the s100 CLI.</Description>
   </PropertyGroup>

--- a/src/EncDotNet.S100.Datasets.S57/EncDotNet.S100.Datasets.S57.csproj
+++ b/src/EncDotNet.S100.Datasets.S57/EncDotNet.S100.Datasets.S57.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="EncDotNet.Iso8211" />

--- a/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
+++ b/src/EncDotNet.S100.Renderers.Mapsui/EncDotNet.S100.Renderers.Mapsui.csproj
@@ -2,7 +2,8 @@
 
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/EncDotNet.S100/EncDotNet.S100.csproj
+++ b/src/EncDotNet.S100/EncDotNet.S100.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework />
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>Batteries-included on-ramp for IHO S-100 nautical data: open a dataset, read its features through the bundled feature catalogue, and render it to an image with the bundled portrayal catalogue — no hand-wiring of catalogues or pipelines. Wraps EncDotNet.S100.Specifications + EncDotNet.S100.Datasets.Pipelines behind a small, format-agnostic API. Advanced users can still drop down to the readers + injected catalogues.</Description>
     <PackageTags>S-100;S-101;S-102;ENC;nautical;hydrography;IHO;ECDIS</PackageTags>


### PR DESCRIPTION
## Summary

Restores `net8.0` support that was incidentally lost. `EncDotNet.S100.Renderers.Mapsui` and the `EncDotNet.S100` convenience facade had narrowed to **net10.0-only**, cutting off external net8 consumers. This reverts that narrowing by multi-targeting the four projects in the blocking chain.

The narrowing cascaded as follows:
- `Renderers.Mapsui` / `EncDotNet.S100` facade were `net8.0;net10.0` **before #226** (#189 PR2), which narrowed `Renderers.Mapsui` to net10.0-only.
- That cascaded from `Datasets.Pipelines` being net10.0-only, which was net10.0-only only because `Datasets.S57` inherited the `Directory.Build.props` `net10.0` default and **never multi-targeted** (unlike the other ~20 libraries).

The net10.0 status was **incidental, not a deliberate constraint**: `EncDotNet.S57` (0.4.0) and `EncDotNet.Iso8211` (0.4.3) both ship `net8.0` + `net10.0` assets, and there is no net10-only BCL/language API or third-party package pin anywhere in the chain.

## Changes

Four `.csproj` edits, using the established idiom the other multi-target libraries use (`<TargetFramework /><TargetFrameworks>net8.0;net10.0</TargetFrameworks>`):

- `src/EncDotNet.S100.Datasets.S57`
- `src/EncDotNet.S100.Datasets.Pipelines`
- `src/EncDotNet.S100.Renderers.Mapsui`
- `src/EncDotNet.S100` (facade)

No source changes; no `Directory.Build.*` changes.

## Verification

- ✅ Full solution `dotnet build -c Release` — 0 errors (net8 + net10 compiled)
- ✅ `dotnet build -f net8.0 -c Release` on each of the 4 retargeted projects — clean
- ✅ Full `dotnet test -c Release` — all green (only optional-data skips)
- ✅ `dotnet pack` on all 4 packable projects → **each nupkg contains both `lib/net8.0/` and `lib/net10.0/`** (the consumer-facing payoff)
- ✅ `README.md` and `THIRD-PARTY-NOTICES.md` appear exactly once per package (root-level, not duplicated per TFM); none of the 4 projects opt into the #224 `UseSkiaSharpLinuxNoDependencies` swap, so that ItemGroup stays inert
- ✅ #189/#226 facade↔Mapsui decoupling guard (`FacadeMapsuiDecouplingTests`) still passes against the net10 build output

## Test coverage nuance (honest)

net8 receives **compile-time** coverage via the multi-target build (CI already provisions 8.0.x + 10.0.x and builds the whole solution). The test projects remain **net10-only**, matching the existing convention for the other ~20 multi-target libraries — so net8 is **not exercised at runtime** in CI. Adding a net8 runtime test leg is out of scope here.

Refs #189, #226.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>