### PR TITLE
Add own-ship row and helm controls to Vessels list

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -172,6 +172,25 @@ public partial class App : Application
                 pickReport.TakeHelmRequested += (_, mmsi) => pirateCoordinator.Engage(mmsi);
             }
 
+            // Take/release the helm from the Vessels panel. Engage hides the
+            // followed target, so after engaging refresh the list and select
+            // the own-ship row (HandleHelmEngaged) to keep the Release button
+            // reachable; disengage just refreshes the label/command state.
+            var vesselList = s_services.GetService<VesselListViewModel>();
+            if (vesselList is not null)
+            {
+                vesselList.TakeHelmRequested += (_, mmsi) =>
+                {
+                    pirateCoordinator.Engage(mmsi);
+                    vesselList.HandleHelmEngaged();
+                };
+                vesselList.ReleaseHelmRequested += (_, _) =>
+                {
+                    pirateCoordinator.Disengage();
+                    vesselList.HandleHelmDisengaged();
+                };
+            }
+
             // If the user turns the own-ship overlay off while pirate mode
             // is active, disengage: otherwise the followed AIS target stays
             // excluded (hidden) while own-ship is also hidden, making the
@@ -484,7 +503,11 @@ public partial class App : Application
         services.AddSingleton<CatalogPanelViewModel>();
         services.AddSingleton<LayerStackViewModel>();
         services.AddSingleton<FeatureSearchViewModel>();
-        services.AddSingleton<VesselListViewModel>();
+        services.AddSingleton<VesselListViewModel>(sp => new VesselListViewModel(
+            sp.GetServices<EncDotNet.S100.DynamicSources.IDynamicFeatureSource>(),
+            sp.GetRequiredService<IMapHostAccessor>(),
+            sp.GetService<EncDotNet.S100.Viewer.Services.DynamicSources.PirateModeController>(),
+            sp.GetService<EncDotNet.S100.Viewer.Services.DynamicSources.Ais.ExcludingAisFeatureSource>()?.Inner));
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<IMarinerSettingsProvider, MarinerSettingsProvider>();
         services.AddSingleton<ITimeFormatProvider, TimeFormatProvider>();

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -420,6 +420,69 @@ public partial class MainWindow : ShadUI.Window
         {
             Opened += async (_, _) => await RunStartupAutomationAsync(datasetPaths);
         }
+        else if (options?.HasExplicitViewport != true)
+        {
+            // Interactive launch with no CLI-driven viewport: if the
+            // own-ship overlay is enabled, frame the map on the own-ship
+            // rather than leaving it at the whole-world default.
+            Opened += async (_, _) => await FrameOnOwnShipAtStartupAsync();
+        }
+    }
+
+    /// <summary>
+    /// Interactive-launch framing: when the own-ship overlay is enabled,
+    /// centre and zoom the map on the own-ship instead of the whole-world
+    /// default. If the overlay is enabled but no fix has arrived yet, waits
+    /// briefly for the first fix (via <see cref="OwnShipSource.Changed"/>)
+    /// before framing, then gives up quietly. No-op when the overlay is
+    /// disabled or an explicit CLI viewport was supplied.
+    /// </summary>
+    private async Task FrameOnOwnShipAtStartupAsync()
+    {
+        var source = ResolveOrFallback<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource>(
+            static () => null!);
+        if (source is null || !source.IsEnabled) return;
+
+        if (TryFrameOnOwnShip(source)) return;
+
+        // No fix yet: wait once for the first published feature, with a
+        // short timeout so launch isn't blocked if no fix ever arrives.
+        var tcs = new TaskCompletionSource();
+        void OnChanged(object? sender, EncDotNet.S100.DynamicSources.DynamicFeaturesChanged e) => tcs.TrySetResult();
+        source.Changed += OnChanged;
+        try
+        {
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+            if (completed == tcs.Task)
+            {
+                await Dispatcher.UIThread.InvokeAsync(() => TryFrameOnOwnShip(source));
+            }
+        }
+        finally
+        {
+            source.Changed -= OnChanged;
+        }
+    }
+
+    /// <summary>
+    /// Centres and zooms the map on the own-ship's current fix, if one is
+    /// published. Returns <see langword="true"/> when framing was applied.
+    /// </summary>
+    private bool TryFrameOnOwnShip(
+        EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.OwnShipSource source)
+    {
+        if (MapControl.Map?.Navigator is not { } nav) return false;
+
+        var feature = source.CurrentFeatures.FirstOrDefault();
+        if (feature?.Coordinates is not { Count: > 0 } coords) return false;
+
+        var (lat, lon) = coords[0];
+        var (x, y) = SphericalMercator.FromLonLat(lon, lat);
+        // Harbour-scale resolution (~web-mercator zoom 13): close enough to
+        // see the own-ship and its surroundings without losing context.
+        const double resolution = 156543.03392804097 / (1 << 13);
+        nav.CenterOnAndZoomTo(new MPoint(x, y), resolution, duration: 0);
+        return true;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -184,6 +184,20 @@ draught). Each detail field appears only once the
 corresponding AIS report has been received. The split between the
 list and the properties sub-pane is draggable and persisted.
 
+When the simulated own-ship overlay is enabled, the own ship also
+appears in the list as a **top-pinned row** (marked with a distinct
+own-ship pictogram and the name *Own ship*), so it stays visible and
+selectable alongside the AIS targets. While own-ship is *helming* a
+live AIS target (see *Pirate mode* below), its row shows a
+**"Helming &lt;target&gt;"** subtitle — or **"Waiting for &lt;target&gt;"**
+while armed but before the target's first report has been adopted —
+so it is always clear which vessel you are driving. From the detail
+pane you can **Take the helm** of a selected AIS target, or
+**Release the helm** from the own-ship row to revert to simulated
+control (own-ship keeps the target's last position and course; no
+snap-back). Engaging the helm hides the followed target and
+auto-selects the own-ship row so the release control stays reachable.
+
 Range and bearing are shown only when the own-ship overlay is
 enabled (**Settings → simulated own-ship**); with it off, the list
 still shows vessels but omits the per-row range/bearing line and
@@ -283,6 +297,11 @@ persisted and takes effect immediately (no restart). This gate is
 authoritative for the synthetic source — when it is off, no own-ship
 feature is published regardless of the layer-visibility toggle.
 
+When the overlay is enabled and a fix is available, an interactive
+launch **frames the map on the own ship** (centre + harbour-scale
+zoom) instead of opening at the whole-world default. An explicit
+`--bbox` / `--center` / `--zoom` on the command line still wins.
+
 The own-ship glyph adapts to zoom:
 
 - **Zoomed in** (when the vessel is ≥ ~6 mm on screen) — a
@@ -306,14 +325,17 @@ Stack panel and is persisted between sessions.
 ### Pirate mode (follow an AIS target)
 
 You can make own-ship **impersonate a live AIS target**: pick a vessel
-and choose **Take the helm** in the Pick Report. Own-ship then adopts
-the target's position, course, speed, heading, and dimensions,
-dead-reckoning smoothly between the target's reports. The followed
-target is hidden from the AIS overlay (no double-draw); turning the
-own-ship overlay off disengages pirate mode so the vessel can't
-disappear. The selection is persisted and re-armed at the next launch.
-Switching back to the simulated source leaves own-ship at the last
-adopted fix (no teleport). See
+and choose **Take the helm** — either from the Pick Report or from the
+**Vessels** panel's detail pane. Own-ship then adopts the target's
+position, course, speed, heading, and dimensions, dead-reckoning
+smoothly between the target's reports. While helming, the own-ship row
+in the Vessels list shows a *Helming &lt;target&gt;* label, and a
+**Release the helm** button there (or turning the own-ship overlay off)
+disengages. The followed target is hidden from the AIS overlay (no
+double-draw); turning the own-ship overlay off disengages pirate mode
+so the vessel can't disappear. The selection is persisted and re-armed
+at the next launch. Switching back to the simulated source leaves
+own-ship at the last adopted fix (no teleport). See
 [`docs/design/steerable-own-ship.md`](../../docs/design/steerable-own-ship.md).
 
 ### Picking dynamic features

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -473,9 +473,17 @@ internal static class Strings
     public static string Pane_Vessels => Get(nameof(Pane_Vessels));
     public static string Tooltip_Vessels => Get(nameof(Tooltip_Vessels));
     public static string Tooltip_VesselRow => Get(nameof(Tooltip_VesselRow));
+    public static string Tooltip_OwnShipRow => Get(nameof(Tooltip_OwnShipRow));
     public static string Vessels_Empty_Disabled => Get(nameof(Vessels_Empty_Disabled));
     public static string Vessels_Empty_NoData => Get(nameof(Vessels_Empty_NoData));
     public static string Vessels_Unnamed => Get(nameof(Vessels_Unnamed));
+    public static string Vessels_OwnShip_Name => Get(nameof(Vessels_OwnShip_Name));
+    public static string Vessels_OwnShip_HelmingFormat => Get(nameof(Vessels_OwnShip_HelmingFormat));
+    public static string Vessels_OwnShip_WaitingFormat => Get(nameof(Vessels_OwnShip_WaitingFormat));
+    public static string Vessels_TakeHelm => Get(nameof(Vessels_TakeHelm));
+    public static string Vessels_ReleaseHelm => Get(nameof(Vessels_ReleaseHelm));
+    public static string Tooltip_VesselTakeHelm => Get(nameof(Tooltip_VesselTakeHelm));
+    public static string Tooltip_VesselReleaseHelm => Get(nameof(Tooltip_VesselReleaseHelm));
     public static string Vessels_DistanceFormat => Get(nameof(Vessels_DistanceFormat));
     public static string Vessels_BearingFormat => Get(nameof(Vessels_BearingFormat));
     public static string Vessels_DistanceBearingFormat => Get(nameof(Vessels_DistanceBearingFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1291,6 +1291,35 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   <data name="Vessels_Unnamed" xml:space="preserve">
     <value>Unnamed vessel</value>
   </data>
+  <data name="Vessels_OwnShip_Name" xml:space="preserve">
+    <value>Own ship</value>
+    <comment>Name of the own-ship row pinned to the top of the Vessels list.</comment>
+  </data>
+  <data name="Vessels_OwnShip_HelmingFormat" xml:space="preserve">
+    <value>Helming {0}</value>
+    <comment>{0} = the impersonated AIS target's name or MMSI. Shown on the own-ship row while pirate mode has adopted a fix.</comment>
+  </data>
+  <data name="Vessels_OwnShip_WaitingFormat" xml:space="preserve">
+    <value>Waiting for {0}</value>
+    <comment>{0} = the target's name or MMSI. Shown on the own-ship row while armed for pirate mode but before the target's first report has been adopted.</comment>
+  </data>
+  <data name="Vessels_TakeHelm" xml:space="preserve">
+    <value>Take the helm</value>
+    <comment>Button in the Vessels detail pane: own-ship impersonates the selected AIS target (pirate mode).</comment>
+  </data>
+  <data name="Vessels_ReleaseHelm" xml:space="preserve">
+    <value>Release the helm</value>
+    <comment>Button in the Vessels detail pane: stop impersonating; own-ship reverts to simulated control at the target's last fix.</comment>
+  </data>
+  <data name="Tooltip_VesselTakeHelm" xml:space="preserve">
+    <value>Own-ship adopts this AIS target's position, course, speed, and dimensions, updating as the target reports.</value>
+  </data>
+  <data name="Tooltip_VesselReleaseHelm" xml:space="preserve">
+    <value>Stop impersonating the target. Own-ship keeps its current position and course under your manual control.</value>
+  </data>
+  <data name="Tooltip_OwnShipRow" xml:space="preserve">
+    <value>Your own ship. Select to centre the map on it; use the helm controls to steer.</value>
+  </data>
   <data name="Vessels_DistanceFormat" xml:space="preserve">
     <value>{0:0.0} NM</value>
     <comment>{0} = distance in nautical miles.</comment>

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/IHelmStatusProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/IHelmStatusProvider.cs
@@ -1,0 +1,29 @@
+namespace EncDotNet.S100.Viewer.Services.DynamicSources;
+
+/// <summary>
+/// Read-only view of "pirate mode" (own-ship impersonating a live AIS
+/// target) for UI consumers that need to reflect the helm state without
+/// taking a dependency on the concrete <see cref="PirateModeController"/>.
+/// Implemented by the controller; the Vessels panel binds to it to label
+/// the own-ship row and gate its take/release-helm commands.
+/// </summary>
+internal interface IHelmStatusProvider
+{
+    /// <summary>
+    /// <see langword="true"/> while a target is being followed (armed),
+    /// regardless of whether a fix has been adopted yet.
+    /// </summary>
+    bool IsActive { get; }
+
+    /// <summary>MMSI of the followed target, or <see langword="null"/>
+    /// when inactive.</summary>
+    uint? FollowedMmsi { get; }
+
+    /// <summary>
+    /// UTC of the most recently applied AIS correction, or
+    /// <see langword="null"/> when none has been applied since the last
+    /// follow began. Distinguishes "helming" (a fix has landed) from
+    /// "armed, waiting" (still at the previous own-ship fix).
+    /// </summary>
+    DateTimeOffset? LastFixUtc { get; }
+}

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/PirateModeController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/PirateModeController.cs
@@ -72,7 +72,7 @@ internal enum PirateFollowOutcome
 /// course/speed — a documented edge.
 /// </para>
 /// </remarks>
-internal sealed class PirateModeController : IDisposable
+internal sealed class PirateModeController : IDisposable, IHelmStatusProvider
 {
     private const double KnotsToMetresPerSecond = 0.514_444_444;
 

--- a/src/EncDotNet.S100.Viewer/Services/DynamicSources/PirateModeController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DynamicSources/PirateModeController.cs
@@ -23,20 +23,36 @@ internal enum PirateFollowOutcome
 }
 
 /// <summary>
-/// Drives "pirate mode": own-ship impersonates a selected live AIS
-/// target. Subscribes to the <i>raw</i> AIS source so it always sees the
-/// followed target (even though that target is hidden from the overlay by
-/// <see cref="ExcludingAisFeatureSource"/>), and on every matching report
-/// pushes an absolute correction into <see cref="IOwnShipHelm"/>. The
-/// steerable provider dead-reckons between reports, so own-ship motion is
-/// smooth even when AIS updates are seconds-to-minutes apart.
+/// Drives "take the helm" mode: own-ship adopts a selected live AIS
+/// target's current fix and geometry <em>once</em>, then detaches so the
+/// user has full helm control of a simulated copy. Subsequent AIS reports
+/// for the original target are deliberately ignored — pressing port /
+/// starboard / changing speed must not be silently overwritten by the
+/// next AIS update.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>Adopt-and-detach.</b> <see cref="Follow"/> snapshots the target's
+/// fix and geometry into the helm. From that point on the user is
+/// driving a simulated vessel — the original AIS target keeps reporting
+/// independently (and is hidden from the overlay via
+/// <see cref="ExcludingAisFeatureSource"/> while helming so the two do
+/// not visually overlap). <see cref="Stop"/> releases the exclusion and
+/// the geometry override; the helmed copy stays at its current position
+/// and reverts to the user's configured own-ship geometry.
+/// </para>
+/// <para>
+/// <b>Armed-waiting.</b> If the target is not present in the AIS
+/// snapshot at <see cref="Follow"/> time (e.g. the zoom-gated source has
+/// not activated yet), the controller stays armed and adopts the very
+/// first report it sees for that MMSI. After that first adoption, the
+/// adoption gate closes and subsequent reports no longer touch the helm.
+/// </para>
 /// <para>
 /// <b>Two AIS surfaces.</b> The controller reads the raw, undecorated
 /// source; the overlay / vessel list / pick read the decorated
 /// (excluding) source. Subscribing to the decorator would starve the
-/// controller of the very target it follows.
+/// controller of the very target it needs to snapshot.
 /// </para>
 /// <para>
 /// <b>Geometry.</b> The followed target's
@@ -56,12 +72,6 @@ internal enum PirateFollowOutcome
 /// can never get "stuck" set after a stop. The helm and geometry services
 /// do not call back into this controller, so holding the lock across them
 /// cannot deadlock.
-/// </para>
-/// <para>
-/// <b>Target loss / staleness.</b> When the target drops out of the AIS
-/// snapshot (stale-sweep / <c>TargetLost</c>), the controller stops
-/// issuing corrections; the helm keeps dead-reckoning the last known
-/// motion and <see cref="LastFixUtc"/> lets the UI surface staleness.
 /// </para>
 /// <para>
 /// <b>Motion semantics.</b> Missing motion components (a target that
@@ -118,23 +128,25 @@ internal sealed class PirateModeController : IDisposable, IHelmStatusProvider
         get { lock (_gate) return _active ? _followedMmsi : null; }
     }
 
-    /// <summary>UTC of the most recently applied AIS correction, or
-    /// <see langword="null"/> when none has been applied since the last
-    /// <see cref="Follow"/>. Lets the UI surface a staleness warning.</summary>
+    /// <summary>UTC of the adopted AIS fix (set once when the target is
+    /// snapshotted into the helm), or <see langword="null"/> until the
+    /// initial adoption lands.</summary>
     public DateTimeOffset? LastFixUtc
     {
         get { lock (_gate) return _lastFixUtc; }
     }
 
     /// <summary>
-    /// Begins (or re-targets) impersonation of the AIS target identified
-    /// by <paramref name="mmsi"/>. Hides the target from the overlay,
-    /// adopts its current fix/geometry immediately when present, and
-    /// tracks subsequent reports.
+    /// Begins (or re-targets) helming of the AIS target identified by
+    /// <paramref name="mmsi"/>: hides the target from the overlay, then
+    /// snapshots its current fix/geometry into the helm if present and
+    /// detaches. If the target is not yet present, stays armed and adopts
+    /// the first subsequent report. After adoption, further AIS updates
+    /// for the target are intentionally ignored — the user is now driving.
     /// </summary>
     /// <returns>
     /// <see cref="PirateFollowOutcome.AppliedFix"/> when the target was
-    /// already known and own-ship jumped to it; otherwise
+    /// already known and own-ship snapshotted from it; otherwise
     /// <see cref="PirateFollowOutcome.ArmedWaiting"/>.
     /// </returns>
     public PirateFollowOutcome Follow(uint mmsi)
@@ -187,6 +199,12 @@ internal sealed class PirateModeController : IDisposable, IHelmStatusProvider
             var followedId = _followedFeatureId;
             if (followedId is null) return;
 
+            // Adopt-and-detach: once the initial snapshot has landed,
+            // ignore further AIS updates so the user's helm commands are
+            // not silently overwritten. Only the armed-waiting case still
+            // needs to react to incoming reports.
+            if (_lastFixUtc is not null) return;
+
             // A Reset carries no ids; always re-read. Otherwise act only
             // when our target is among the touched ids.
             if (e.Kind != DynamicSourceChangeKind.Reset
@@ -200,10 +218,12 @@ internal sealed class PirateModeController : IDisposable, IHelmStatusProvider
     }
 
     /// <summary>
-    /// Applies the followed target's current fix to the helm. Must be
-    /// called while holding <see cref="_gate"/>; performs its side effects
-    /// (geometry override, then helm correction) under the lock so a
-    /// concurrent <see cref="Stop"/> or re-target cannot interleave.
+    /// Snapshots the followed target's current fix into the helm. Must
+    /// be called while holding <see cref="_gate"/>; performs its side
+    /// effects (geometry override, then helm correction) under the lock
+    /// so a concurrent <see cref="Stop"/> or re-target cannot interleave.
+    /// Sets <see cref="_lastFixUtc"/> on success, which closes the
+    /// adoption gate so subsequent AIS reports are ignored.
     /// </summary>
     /// <returns><see langword="true"/> when a fix was applied.</returns>
     private bool ApplyFixLocked()
@@ -228,7 +248,6 @@ internal sealed class PirateModeController : IDisposable, IHelmStatusProvider
 
         var (lat, lon) = feature.Coordinates[0];
         double? cog = feature.Motion?.CourseOverGroundDeg;
-        double? heading = feature.Motion?.HeadingDeg;
         double? sogMs = feature.Motion?.SpeedOverGroundKn is { } kn
             ? kn * KnotsToMetresPerSecond
             : null;
@@ -237,7 +256,14 @@ internal sealed class PirateModeController : IDisposable, IHelmStatusProvider
         // correction already sees the adopted dimensions. A target with no
         // dimensions overrides with null (pictogram), not the user's size.
         _geometryOverride.SetOverride(feature.VesselGeometry);
-        _helm.SetState(lat, lon, cog, sogMs, heading);
+
+        // Heading is deliberately passed as null so the steerable
+        // provider mirrors course → heading. The helm panel only
+        // commands course; pinning gyro heading to the adopted AIS
+        // heading would leave the arrow stuck at that bearing as the
+        // user steers (course rotates, heading does not), both during
+        // helming and after release.
+        _helm.SetState(lat, lon, cog, sogMs, headingDeg: null);
         _lastFixUtc = feature.LastUpdated;
         return true;
     }

--- a/src/EncDotNet.S100.Viewer/ViewModels/VesselListItem.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/VesselListItem.cs
@@ -25,6 +25,64 @@ internal sealed class VesselListItem : ViewModelBase
     /// </summary>
     public required string Id { get; init; }
 
+    private bool _isOwnShip;
+    /// <summary>
+    /// Whether this row represents the simulated own ship (the vessel the
+    /// user is helming) rather than a received AIS target. Own-ship rows
+    /// are pinned to the top of the list and carry no range/bearing (they
+    /// are the reference point), and they expose the helm controls.
+    /// </summary>
+    public bool IsOwnShip
+    {
+        get => _isOwnShip;
+        set => SetProperty(ref _isOwnShip, value);
+    }
+
+    private uint? _mmsi;
+    /// <summary>
+    /// Numeric MMSI for an AIS target row, or <see langword="null"/> for
+    /// the own-ship row (or before an MMSI has been received). Drives the
+    /// "take the helm" affordance, which impersonates a target by MMSI.
+    /// </summary>
+    public uint? Mmsi
+    {
+        get => _mmsi;
+        set => SetProperty(ref _mmsi, value);
+    }
+
+    private bool _isHelming;
+    /// <summary>
+    /// Whether the own-ship row is actively impersonating a live AIS
+    /// target (pirate mode engaged <em>and</em> a fix has been adopted).
+    /// <see langword="false"/> while merely armed-and-waiting for the
+    /// target's first report. Only meaningful when <see cref="IsOwnShip"/>.
+    /// </summary>
+    public bool IsHelming
+    {
+        get => _isHelming;
+        set => SetProperty(ref _isHelming, value);
+    }
+
+    private string? _helmingText;
+    /// <summary>
+    /// Subtitle shown on the own-ship row while it is impersonating (or
+    /// waiting to impersonate) a target — e.g. "Helming ATLANTIC" or
+    /// "Waiting for 123456789". <see langword="null"/> when not following.
+    /// </summary>
+    public string? HelmingText
+    {
+        get => _helmingText;
+        set => SetProperty(ref _helmingText, value);
+    }
+
+    private bool _hasHelmingText;
+    /// <summary>Whether <see cref="HelmingText"/> should be shown.</summary>
+    public bool HasHelmingText
+    {
+        get => _hasHelmingText;
+        set => SetProperty(ref _hasHelmingText, value);
+    }
+
     private string _name = string.Empty;
     /// <summary>Display name (vessel name, else MMSI, else a placeholder).</summary>
     public string Name

--- a/src/EncDotNet.S100.Viewer/ViewModels/VesselListViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/VesselListViewModel.cs
@@ -4,12 +4,15 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Windows.Input;
 using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.DynamicSources;
 using EncDotNet.S100.DynamicSources.Ais;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
 using EncDotNet.S100.Viewer.Services.DynamicSources.Ais;
 using EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
 
@@ -76,22 +79,53 @@ internal sealed class VesselListViewModel : ViewModelBase
 
     private readonly IDynamicFeatureSource? _ais;
     private readonly IDynamicFeatureSource? _ownShip;
+    private readonly IHelmStatusProvider? _helmStatus;
+    private readonly IDynamicFeatureSource? _helmTargetSource;
     private readonly IMapHostAccessor _mapHostAccessor;
     private readonly DispatcherTimer? _timer;
     private readonly Dictionary<string, VesselListItem> _itemsById = new(StringComparer.Ordinal);
 
+    private VesselListItem? _ownShipItem;
+    private bool _wasHelmActive;
     private int _dirty;
     private bool _suppressSelectionWrite;
 
     public VesselListViewModel(
         IEnumerable<IDynamicFeatureSource> sources,
         IMapHostAccessor mapHostAccessor)
+        : this(sources, mapHostAccessor, helmStatus: null, helmTargetSource: null)
+    {
+    }
+
+    /// <param name="sources">All registered dynamic feature sources.</param>
+    /// <param name="mapHostAccessor">Accessor for the live map host.</param>
+    /// <param name="helmStatus">
+    /// Read-only pirate-mode status used to label the own-ship row and gate
+    /// the release-helm command. <see langword="null"/> in tests / when no
+    /// helm is wired.
+    /// </param>
+    /// <param name="helmTargetSource">
+    /// The <em>raw</em> (undecorated) AIS source — typically
+    /// <see cref="ExcludingAisFeatureSource.Inner"/> — used to resolve the
+    /// impersonated target's display name, since the decorated source hides
+    /// it. <see langword="null"/> when unavailable.
+    /// </param>
+    public VesselListViewModel(
+        IEnumerable<IDynamicFeatureSource> sources,
+        IMapHostAccessor mapHostAccessor,
+        IHelmStatusProvider? helmStatus,
+        IDynamicFeatureSource? helmTargetSource)
     {
         ArgumentNullException.ThrowIfNull(sources);
         ArgumentNullException.ThrowIfNull(mapHostAccessor);
 
         _mapHostAccessor = mapHostAccessor;
+        _helmStatus = helmStatus;
+        _helmTargetSource = helmTargetSource;
         Vessels = new ObservableCollection<VesselListItem>();
+
+        TakeHelmCommand = new RelayCommand(ExecuteTakeHelm, CanTakeHelm);
+        ReleaseHelmCommand = new RelayCommand(ExecuteReleaseHelm, CanReleaseHelm);
 
         // Resolve the dynamic sources by renderer key. There is at most
         // one of each; FirstOrDefault keeps the panel inert (empty, no
@@ -155,6 +189,8 @@ internal sealed class VesselListViewModel : ViewModelBase
             if (SetProperty(ref _selectedVessel, value))
             {
                 OnPropertyChanged(nameof(HasSelection));
+                TakeHelmCommand.NotifyCanExecuteChanged();
+                ReleaseHelmCommand.NotifyCanExecuteChanged();
                 if (value is not null)
                 {
                     _mapHostAccessor.Current?.CenterOn(value.Latitude, value.Longitude);
@@ -169,6 +205,77 @@ internal sealed class VesselListViewModel : ViewModelBase
     /// the placeholder otherwise.
     /// </summary>
     public bool HasSelection => _selectedVessel is not null;
+
+    /// <summary>
+    /// Takes the helm of the selected AIS target (engages pirate mode).
+    /// Enabled only when a non-own-ship row with a known MMSI is selected.
+    /// The view-model owns no helm services; it raises
+    /// <see cref="TakeHelmRequested"/> so the app can engage the
+    /// pirate-mode coordinator.
+    /// </summary>
+    public RelayCommand TakeHelmCommand { get; }
+
+    /// <summary>
+    /// Releases the helm (disengages pirate mode). Enabled only while a
+    /// target is being followed. Raises <see cref="ReleaseHelmRequested"/>.
+    /// </summary>
+    public RelayCommand ReleaseHelmCommand { get; }
+
+    /// <summary>
+    /// Raised when <see cref="TakeHelmCommand"/> runs, carrying the MMSI of
+    /// the target to impersonate.
+    /// </summary>
+    public event EventHandler<uint>? TakeHelmRequested;
+
+    /// <summary>
+    /// Raised when <see cref="ReleaseHelmCommand"/> runs.
+    /// </summary>
+    public event EventHandler? ReleaseHelmRequested;
+
+    private bool CanTakeHelm()
+        => _helmStatus is not null
+            && _selectedVessel is { IsOwnShip: false, Mmsi: not null };
+
+    private void ExecuteTakeHelm()
+    {
+        if (_selectedVessel is { IsOwnShip: false, Mmsi: { } mmsi })
+        {
+            TakeHelmRequested?.Invoke(this, mmsi);
+        }
+    }
+
+    private bool CanReleaseHelm() => _helmStatus?.IsActive == true;
+
+    private void ExecuteReleaseHelm()
+    {
+        if (CanReleaseHelm())
+        {
+            ReleaseHelmRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the list immediately and, when the own-ship row is
+    /// present, selects it. Called by the app right after the pirate-mode
+    /// coordinator engages from this panel so the own-ship detail pane (and
+    /// the "Release the helm" button) is reachable without the user hunting
+    /// for the row. Runs on the UI thread.
+    /// </summary>
+    internal void HandleHelmEngaged()
+    {
+        Refresh();
+        if (_ownShipItem is not null)
+        {
+            SelectedVessel = _ownShipItem;
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the list immediately after the pirate-mode coordinator
+    /// disengages from this panel so the own-ship row drops its "helming"
+    /// label and the command states update. Runs on the UI thread.
+    /// </summary>
+    internal void HandleHelmDisengaged() => Refresh();
 
     private bool _isEmpty = true;
     /// <summary>
@@ -226,7 +333,8 @@ internal sealed class VesselListViewModel : ViewModelBase
     internal void Refresh()
     {
         var features = _ais?.CurrentFeatures.ToArray() ?? Array.Empty<DynamicFeature>();
-        var own = ResolveOwnShip();
+        var ownFeature = ResolveOwnShipFeature();
+        var own = ownFeature is { } f ? (f.Coordinates[0].Latitude, f.Coordinates[0].Longitude) : ((double, double)?)null;
 
         // When the own-ship overlay is on it is the reference point for
         // both range/bearing and list ordering. When it is off, fall back
@@ -261,6 +369,12 @@ internal sealed class VesselListViewModel : ViewModelBase
             UpdateItem(item, feature, lat, lon, own, sortOrigin);
         }
 
+        // The own ship (the vessel the user is helming) is shown as a
+        // pinned top row whenever the overlay is publishing a fix — even
+        // when no AIS targets are present — so it stays selectable and the
+        // helm can be released from the list.
+        UpdateOwnShipRow(ownFeature, seen);
+
         RemoveVanished(seen);
 
         // Reordering the collection (Move/Insert) can make the ListBox drop
@@ -293,17 +407,32 @@ internal sealed class VesselListViewModel : ViewModelBase
             OnPropertyChanged(nameof(SelectedVessel));
         }
 
+        // When pirate mode has just engaged, the followed AIS target is now
+        // hidden (its row removed, dropping any selection on it). Auto-select
+        // the own-ship row so the user keeps a detail pane — and the
+        // "Release the helm" button — without hunting for it.
+        var helmActive = _helmStatus?.IsActive == true;
+        if (helmActive && !_wasHelmActive && _ownShipItem is not null && _selectedVessel is null)
+        {
+            SelectedVessel = _ownShipItem;
+        }
+        _wasHelmActive = helmActive;
+
+        TakeHelmCommand.NotifyCanExecuteChanged();
+        ReleaseHelmCommand.NotifyCanExecuteChanged();
+
         UpdateEmptyState();
     }
 
     /// <summary>
-    /// Returns the own-ship reference position, or <see langword="null"/>
-    /// when the own-ship overlay is off. "Off" is signalled by the
-    /// own-ship source publishing no feature — <c>OwnShipSource</c> only
-    /// empties its snapshot when disabled, never mid-update, so this is a
-    /// stable enabled/visible signal rather than a transient one.
+    /// Returns the own-ship feature currently published by the own-ship
+    /// source (a single point with a valid position), or
+    /// <see langword="null"/> when the overlay is off / has no fix yet.
+    /// "Off" is signalled by the source publishing no feature —
+    /// <c>OwnShipSource</c> only empties its snapshot when disabled, never
+    /// mid-update, so this is a stable enabled/visible signal.
     /// </summary>
-    private (double Latitude, double Longitude)? ResolveOwnShip()
+    private DynamicFeature? ResolveOwnShipFeature()
     {
         if (_ownShip is null)
         {
@@ -320,11 +449,124 @@ internal sealed class VesselListViewModel : ViewModelBase
             var (lat, lon) = feature.Coordinates[0];
             if (IsValidLatLon(lat, lon))
             {
-                return (lat, lon);
+                return feature;
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Creates / updates / removes the pinned own-ship row from the
+    /// <paramref name="ownFeature"/> fix. Adds its id to
+    /// <paramref name="seen"/> so the shared <see cref="RemoveVanished"/>
+    /// path drops it (and clears any selection on it) when the overlay
+    /// turns off — no duplicated removal logic. Also resolves the
+    /// "helming / waiting" label from the pirate-mode status.
+    /// </summary>
+    private void UpdateOwnShipRow(DynamicFeature? ownFeature, HashSet<string> seen)
+    {
+        if (ownFeature is null)
+        {
+            _ownShipItem = null;
+            return;
+        }
+
+        seen.Add(OwnShipRendererKey);
+
+        if (!_itemsById.TryGetValue(OwnShipRendererKey, out var item))
+        {
+            item = new VesselListItem { Id = OwnShipRendererKey };
+            _itemsById[OwnShipRendererKey] = item;
+        }
+
+        _ownShipItem = item;
+
+        var (lat, lon) = ownFeature.Coordinates[0];
+        item.IsOwnShip = true;
+        item.Mmsi = null;
+        item.Latitude = lat;
+        item.Longitude = lon;
+        // The own ship is the reference point, so it carries no range or
+        // bearing and always sorts first (see Resort).
+        item.SortDistanceMetres = null;
+        item.HasRangeBearing = false;
+        item.DistanceMetres = null;
+        item.DistanceText = string.Empty;
+        item.BearingText = string.Empty;
+        item.RangeBearingText = string.Empty;
+
+        item.Name = Strings.Vessels_OwnShip_Name;
+        item.ShipTypeClass = AisShipTypeClass.Unknown;
+        item.ShipTypeText = string.Empty;
+
+        var sogKn = ownFeature.Motion?.SpeedOverGroundKn;
+        UpdateMotion(item, ownFeature, sogKn);
+        UpdateOwnShipHelmLabel(item);
+
+        item.StateText = item.HasHelmingText ? item.HelmingText! : Strings.Vessels_OwnShip_Name;
+        item.HeaderSubtitle = item.HasHelmingText ? item.HelmingText! : Strings.Vessels_OwnShip_Name;
+
+        // Identity / voyage / dimensions are not meaningful for the
+        // simulated own ship; clear any stale flags.
+        item.MmsiText = string.Empty;
+        item.HasCallSign = false;
+        item.HasImo = false;
+        item.HasVoyage = false;
+        item.HasDestination = false;
+        item.HasEta = false;
+        item.HasDimensionsSection = false;
+        item.HasDimensions = false;
+        item.HasDraught = false;
+    }
+
+    /// <summary>
+    /// Sets the own-ship row's "Helming &lt;target&gt;" / "Waiting for
+    /// &lt;target&gt;" subtitle from the pirate-mode status. Distinguishes
+    /// a fix-adopted follow (helming) from an armed-but-waiting follow.
+    /// </summary>
+    private void UpdateOwnShipHelmLabel(VesselListItem item)
+    {
+        if (_helmStatus is not { IsActive: true } status || status.FollowedMmsi is not { } mmsi)
+        {
+            item.IsHelming = false;
+            item.HelmingText = null;
+            item.HasHelmingText = false;
+            return;
+        }
+
+        var targetLabel = ResolveFollowedTargetLabel(mmsi);
+        var helming = status.LastFixUtc is not null;
+        item.IsHelming = helming;
+        item.HelmingText = string.Format(
+            CultureInfo.CurrentCulture,
+            helming ? Strings.Vessels_OwnShip_HelmingFormat : Strings.Vessels_OwnShip_WaitingFormat,
+            targetLabel);
+        item.HasHelmingText = true;
+    }
+
+    /// <summary>
+    /// Resolves the impersonated target's display name from the raw AIS
+    /// feed (the decorated source hides it), falling back to the MMSI.
+    /// </summary>
+    private string ResolveFollowedTargetLabel(uint mmsi)
+    {
+        var mmsiText = mmsi.ToString(CultureInfo.InvariantCulture);
+        if (_helmTargetSource is null)
+        {
+            return mmsiText;
+        }
+
+        var featureId = AisDynamicFeatureSource.FeatureIdForMmsi(mmsi);
+        foreach (var feature in _helmTargetSource.CurrentFeatures)
+        {
+            if (string.Equals(feature.Id, featureId, StringComparison.Ordinal))
+            {
+                return GetString(feature, "vesselName") ?? mmsiText;
+            }
+        }
+
+        return mmsiText;
     }
 
     private void UpdateItem(
@@ -363,9 +605,16 @@ internal sealed class VesselListViewModel : ViewModelBase
 
     private static void UpdateIdentity(VesselListItem item, DynamicFeature feature)
     {
-        item.MmsiText = feature.Attributes.TryGetValue("mmsi", out var mmsiObj) && mmsiObj is uint mmsi
-            ? mmsi.ToString(CultureInfo.InvariantCulture)
-            : string.Empty;
+        if (feature.Attributes.TryGetValue("mmsi", out var mmsiObj) && mmsiObj is uint mmsi)
+        {
+            item.Mmsi = mmsi;
+            item.MmsiText = mmsi.ToString(CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            item.Mmsi = null;
+            item.MmsiText = string.Empty;
+        }
 
         var callSign = GetString(feature, "callSign");
         item.CallSign = callSign;
@@ -500,6 +749,10 @@ internal sealed class VesselListViewModel : ViewModelBase
         {
             var removed = _itemsById[id];
             _itemsById.Remove(id);
+            if (ReferenceEquals(removed, _ownShipItem))
+            {
+                _ownShipItem = null;
+            }
             if (ReferenceEquals(removed, _selectedVessel))
             {
                 // Clear via the field (not the setter) so dropping a stale
@@ -512,16 +765,18 @@ internal sealed class VesselListViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Reconciles <see cref="Vessels"/> with the nearest-first ordering of
-    /// <see cref="_itemsById"/> (by <see cref="VesselListItem.SortDistanceMetres"/>,
+    /// Reconciles <see cref="Vessels"/> with the desired ordering of
+    /// <see cref="_itemsById"/> — the own-ship row pinned first, then AIS
+    /// targets nearest-first (by <see cref="VesselListItem.SortDistanceMetres"/>,
     /// i.e. distance from the own ship or, when it is off, the viewport
-    /// centre), moving existing rows rather than replacing them so item
+    /// centre) — moving existing rows rather than replacing them so item
     /// identity (and thus selection) is preserved.
     /// </summary>
     private void Resort()
     {
         var ordered = _itemsById.Values
-            .OrderBy(v => v.SortDistanceMetres ?? double.PositiveInfinity)
+            .OrderByDescending(v => v.IsOwnShip)
+            .ThenBy(v => v.SortDistanceMetres ?? double.PositiveInfinity)
             .ThenBy(v => v.Name, StringComparer.CurrentCultureIgnoreCase)
             .ThenBy(v => v.Id, StringComparer.Ordinal)
             .ToList();

--- a/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
@@ -107,13 +107,23 @@
                             <Border Background="Transparent"
                                     ToolTip.Tip="{x:Static loc:Strings.Tooltip_VesselRow}">
                                 <Grid ColumnDefinitions="Auto,*">
-                                    <!-- Ship-type pictogram, tinted by class. -->
+                                    <!-- Own-ship pictogram (pinned top row). -->
+                                    <ic:FluentIcon Grid.Column="0"
+                                                   Icon="MyLocation"
+                                                   IconVariant="Filled"
+                                                   FontSize="22"
+                                                   VerticalAlignment="Top"
+                                                   Margin="0,1,10,0"
+                                                   IsVisible="{Binding IsOwnShip}"
+                                                   Foreground="{DynamicResource AccentBrush}" />
+                                    <!-- AIS target pictogram, tinted by class. -->
                                     <ic:FluentIcon Grid.Column="0"
                                                    Icon="VehicleShip"
                                                    IconVariant="Regular"
                                                    FontSize="22"
                                                    VerticalAlignment="Top"
                                                    Margin="0,1,10,0"
+                                                   IsVisible="{Binding !IsOwnShip}"
                                                    Foreground="{Binding ShipTypeClass,
                                                        Converter={x:Static conv:VesselClassBrushConverter.Instance}}" />
 
@@ -201,6 +211,22 @@
                                            FontSize="12"
                                            Opacity="0.6"
                                            TextWrapping="Wrap" />
+
+                                <!-- Helm controls: take the helm of an AIS
+                                     target, or release it from the own-ship
+                                     row while helming. -->
+                                <Button Content="{x:Static loc:Strings.Vessels_TakeHelm}"
+                                        IsVisible="{Binding !IsOwnShip}"
+                                        HorizontalAlignment="Left"
+                                        Margin="0,6,0,0"
+                                        Command="{Binding $parent[UserControl].((vm:VesselListViewModel)DataContext).TakeHelmCommand}"
+                                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_VesselTakeHelm}" />
+                                <Button Content="{x:Static loc:Strings.Vessels_ReleaseHelm}"
+                                        IsVisible="{Binding IsOwnShip}"
+                                        HorizontalAlignment="Left"
+                                        Margin="0,6,0,0"
+                                        Command="{Binding $parent[UserControl].((vm:VesselListViewModel)DataContext).ReleaseHelmCommand}"
+                                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_VesselReleaseHelm}" />
 
                                 <!-- Identity -->
                                 <TextBlock Classes="section" Text="{x:Static loc:Strings.Vessels_Detail_Identity}" />

--- a/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/PirateModeControllerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DynamicSources/PirateModeControllerTests.cs
@@ -103,7 +103,10 @@ public sealed class PirateModeControllerTests
         Assert.Equal(50.0, call.Lat);
         Assert.Equal(-1.0, call.Lon);
         Assert.Equal(90.0, call.Cog);
-        Assert.Equal(88.0, call.Heading);
+        // Heading is deliberately not adopted from AIS; the helm has no
+        // gyro-heading control, so passing null lets the arrow mirror
+        // course as the user steers.
+        Assert.Null(call.Heading);
         Assert.NotNull(call.SogMs);
         Assert.Equal(10.0 * 0.514_444_444, call.SogMs!.Value, 4);
 
@@ -128,8 +131,12 @@ public sealed class PirateModeControllerTests
     }
 
     [Fact]
-    public void Update_ForFollowedTarget_PushesNewFix()
+    public void Update_AfterAdoption_DoesNotApply()
     {
+        // Adopt-and-detach: once the initial fix has landed, subsequent
+        // AIS updates for the followed target must NOT be applied —
+        // otherwise the user's helm commands would be silently overwritten
+        // on the next AIS tick.
         var raw = Raw(Target(lat: 50.0, lon: -1.0));
         var (controller, helm, _, _) = Build(raw);
         controller.Follow(123);
@@ -141,9 +148,45 @@ public sealed class PirateModeControllerTests
             ChangedIds = new[] { "ais:123" },
         });
 
-        Assert.Equal(2, helm.States.Count);
-        Assert.Equal(51.0, helm.States[1].Lat);
-        Assert.Equal(-2.0, helm.States[1].Lon);
+        Assert.Single(helm.States);
+        Assert.Equal(50.0, helm.States[0].Lat);
+        Assert.Equal(-1.0, helm.States[0].Lon);
+    }
+
+    [Fact]
+    public void Update_WhileArmedWaiting_AdoptsFirstReport()
+    {
+        // Armed-waiting: target was not yet in the AIS snapshot when
+        // Follow ran, so the very next report for that target must
+        // adopt. After that, further reports are ignored.
+        var raw = Raw(); // empty
+        var (controller, helm, geom, _) = Build(raw);
+        controller.Follow(123);
+
+        Assert.Empty(helm.States);
+        Assert.Null(controller.LastFixUtc);
+
+        raw.SetFeatures(new[] { Target(lat: 51.0, lon: -2.0) });
+        raw.RaiseChanged(new DynamicFeaturesChanged
+        {
+            Kind = DynamicSourceChangeKind.Updated,
+            ChangedIds = new[] { "ais:123" },
+        });
+
+        Assert.Single(helm.States);
+        Assert.Equal(51.0, helm.States[0].Lat);
+        Assert.NotNull(controller.LastFixUtc);
+        Assert.Equal(1, geom.SetCount);
+
+        // A second update must not push another fix.
+        raw.SetFeatures(new[] { Target(lat: 52.0, lon: -3.0) });
+        raw.RaiseChanged(new DynamicFeaturesChanged
+        {
+            Kind = DynamicSourceChangeKind.Updated,
+            ChangedIds = new[] { "ais:123" },
+        });
+
+        Assert.Single(helm.States);
     }
 
     [Fact]
@@ -251,8 +294,10 @@ public sealed class PirateModeControllerTests
     }
 
     [Fact]
-    public void Reset_ReReadsSnapshot()
+    public void Reset_AfterAdoption_DoesNotReApply()
     {
+        // Adopt-and-detach: a Reset event after adoption is ignored
+        // just like any other update.
         var raw = Raw(Target(lat: 50, lon: -1));
         var (controller, helm, _, _) = Build(raw);
         controller.Follow(123);
@@ -260,8 +305,24 @@ public sealed class PirateModeControllerTests
         raw.SetFeatures(new[] { Target(lat: 60, lon: -3) });
         raw.RaiseChanged(new DynamicFeaturesChanged { Kind = DynamicSourceChangeKind.Reset });
 
-        Assert.Equal(2, helm.States.Count);
-        Assert.Equal(60.0, helm.States[1].Lat);
+        Assert.Single(helm.States);
+        Assert.Equal(50.0, helm.States[0].Lat);
+    }
+
+    [Fact]
+    public void Reset_WhileArmedWaiting_AdoptsFix()
+    {
+        // Reset carries no ids but must still let armed-waiting adopt
+        // if the target is now present in the new snapshot.
+        var raw = Raw(); // empty
+        var (controller, helm, _, _) = Build(raw);
+        controller.Follow(123);
+
+        raw.SetFeatures(new[] { Target(lat: 60, lon: -3) });
+        raw.RaiseChanged(new DynamicFeaturesChanged { Kind = DynamicSourceChangeKind.Reset });
+
+        Assert.Single(helm.States);
+        Assert.Equal(60.0, helm.States[0].Lat);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewModels/VesselListViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewModels/VesselListViewModelTests.cs
@@ -7,6 +7,7 @@ using EncDotNet.S100.DynamicSources.Ais;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Services.DynamicSources;
 using EncDotNet.S100.Viewer.Services.DynamicSources.Ais;
 using EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip;
 using EncDotNet.S100.Viewer.Tests.DynamicSources;
@@ -110,6 +111,18 @@ public class VesselListViewModelTests
     private static void Raise(FakeDynamicFeatureSource source, DynamicSourceChangeKind kind = DynamicSourceChangeKind.Added)
         => source.RaiseChanged(new DynamicFeaturesChanged { Kind = kind, ChangedIds = Array.Empty<string>() });
 
+    /// <summary>Returns the AIS rows only, excluding the pinned own-ship row.</summary>
+    private static IReadOnlyList<VesselListItem> AisRows(VesselListViewModel vm)
+        => vm.Vessels.Where(v => !v.IsOwnShip).ToList();
+
+    /// <summary>Test double for the pirate-mode helm status.</summary>
+    private sealed class FakeHelmStatus : IHelmStatusProvider
+    {
+        public bool IsActive { get; set; }
+        public uint? FollowedMmsi { get; set; }
+        public DateTimeOffset? LastFixUtc { get; set; }
+    }
+
     /// <summary>
     /// Builds a VM wired to a fresh AIS source and an own-ship source. By
     /// default the own ship is "enabled" (publishing a position feature at
@@ -124,7 +137,9 @@ public class VesselListViewModelTests
         double ownLat = 0,
         double ownLon = 0,
         bool includeOwnShip = true,
-        FakeDynamicFeatureSource? aisSource = null)
+        FakeDynamicFeatureSource? aisSource = null,
+        IHelmStatusProvider? helm = null,
+        FakeDynamicFeatureSource? helmTarget = null)
     {
         var ais = aisSource ?? NewAisSource();
         var ownShip = NewOwnShipSource();
@@ -140,7 +155,9 @@ public class VesselListViewModelTests
             ? new IDynamicFeatureSource[] { ais, ownShip }
             : new IDynamicFeatureSource[] { ais };
 
-        var vm = new VesselListViewModel(sources, accessor);
+        var vm = helm is not null || helmTarget is not null
+            ? new VesselListViewModel(sources, accessor, helm, helmTarget)
+            : new VesselListViewModel(sources, accessor);
         return (vm, ais, ownShip, host);
     }
 
@@ -153,10 +170,11 @@ public class VesselListViewModelTests
         ais.SetFeatures(new[] { Vessel(111, 10, 0, "Far"), Vessel(222, 1, 0, "Near") });
         Raise(ais);
 
-        Assert.Equal(2, vm.Vessels.Count);
-        Assert.Equal("Near", vm.Vessels[0].Name);
-        Assert.Equal("Far", vm.Vessels[1].Name);
-        Assert.True(vm.Vessels[0].DistanceMetres < vm.Vessels[1].DistanceMetres);
+        var rows = AisRows(vm);
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("Near", rows[0].Name);
+        Assert.Equal("Far", rows[1].Name);
+        Assert.True(rows[0].DistanceMetres < rows[1].DistanceMetres);
     }
 
     [Fact]
@@ -167,8 +185,9 @@ public class VesselListViewModelTests
 
         var (vm, _, _, _) = Make(aisSource: ais);
 
-        Assert.Single(vm.Vessels);
-        Assert.Equal("Already", vm.Vessels[0].Name);
+        var rows = AisRows(vm);
+        Assert.Single(rows);
+        Assert.Equal("Already", rows[0].Name);
     }
 
     [Fact]
@@ -192,7 +211,7 @@ public class VesselListViewModelTests
         ais.SetFeatures(new[] { Vessel(1, 12.5, -7.25, "Target") });
         Raise(ais);
 
-        vm.SelectedVessel = vm.Vessels[0];
+        vm.SelectedVessel = AisRows(vm).Single();
 
         var call = Assert.Single(host.CenterOnCalls);
         Assert.Equal(12.5, call.Latitude, 6);
@@ -249,7 +268,7 @@ public class VesselListViewModelTests
         });
         Raise(ais);
 
-        var item = Assert.Single(vm.Vessels);
+        var item = Assert.Single(AisRows(vm));
         Assert.Equal("Cargo", item.ShipTypeText);
         Assert.Equal("123456789", item.MmsiText);
         Assert.True(item.HasCallSign);
@@ -378,8 +397,9 @@ public class VesselListViewModelTests
         ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
         Raise(ais);
 
+        var target = AisRows(vm).Single();
         Assert.False(vm.HasSelection);
-        vm.SelectedVessel = vm.Vessels[0];
+        vm.SelectedVessel = target;
         Assert.True(vm.HasSelection);
         vm.SelectedVessel = null;
         Assert.False(vm.HasSelection);
@@ -417,14 +437,15 @@ public class VesselListViewModelTests
         var (vm, ais, ownShip, _) = Make(ownShipEnabled: false);
         ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
         Raise(ais);
-        Assert.False(vm.Vessels[0].HasRangeBearing);
+        var target = AisRows(vm).Single();
+        Assert.False(target.HasRangeBearing);
 
         // Own-ship overlay toggled on: it publishes a feature and raises.
         ownShip.SetFeatures(new[] { OwnFeature(0, 0) });
         Raise(ownShip);
 
-        Assert.True(vm.Vessels[0].HasRangeBearing);
-        Assert.NotNull(vm.Vessels[0].DistanceMetres);
+        Assert.True(target.HasRangeBearing);
+        Assert.NotNull(target.DistanceMetres);
     }
 
     [Fact]
@@ -434,14 +455,14 @@ public class VesselListViewModelTests
         ais.SetFeatures(new[] { Vessel(1, 1, 0, "Gone") });
         Raise(ais);
 
-        vm.SelectedVessel = vm.Vessels[0];
+        vm.SelectedVessel = AisRows(vm).Single();
         Assert.Single(host.CenterOnCalls);
 
         ais.SetFeatures(Array.Empty<DynamicFeature>());
         Raise(ais, DynamicSourceChangeKind.Removed);
 
         Assert.Null(vm.SelectedVessel);
-        Assert.Empty(vm.Vessels);
+        Assert.Empty(AisRows(vm)); // own-ship row remains, AIS row gone
         Assert.Single(host.CenterOnCalls); // no additional center call on removal
     }
 
@@ -457,7 +478,7 @@ public class VesselListViewModelTests
         });
         Raise(ais);
 
-        var item = Assert.Single(vm.Vessels);
+        var item = Assert.Single(AisRows(vm));
         Assert.Equal("Good", item.Name);
     }
 
@@ -466,9 +487,9 @@ public class VesselListViewModelTests
     {
         var accessor = new MapHostAccessor { Current = new FakeMapHost() };
 
-        // Only an own-ship-keyed source; no "vessel.ais" source present.
+        // Only an own-ship-keyed source, publishing nothing (overlay off);
+        // no "vessel.ais" source present.
         var other = NewOwnShipSource();
-        other.SetFeatures(new[] { OwnFeature(0, 0) });
 
         var vm = new VesselListViewModel(new IDynamicFeatureSource[] { other }, accessor);
 
@@ -482,13 +503,14 @@ public class VesselListViewModelTests
         ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
         Raise(ais);
 
-        var before = vm.Vessels[0].DistanceMetres;
+        var target = AisRows(vm).Single();
+        var before = target.DistanceMetres;
 
         // Move own ship right next to the target.
         ownShip.SetFeatures(new[] { OwnFeature(1, 0) });
         Raise(ownShip, DynamicSourceChangeKind.Updated);
 
-        var after = vm.Vessels[0].DistanceMetres;
+        var after = target.DistanceMetres;
         Assert.NotNull(before);
         Assert.NotNull(after);
         Assert.True(after < before);
@@ -510,8 +532,9 @@ public class VesselListViewModelTests
     [Fact]
     public void EmptyState_AisActiveButNoData_ShowsWaitingMessage()
     {
-        // An active AIS source with no features yet (e.g. zoom-gated).
-        var (vm, _, _, _) = Make();
+        // An active AIS source with no features yet (e.g. zoom-gated) and
+        // the own-ship overlay off, so the list is genuinely empty.
+        var (vm, _, _, _) = Make(ownShipEnabled: false);
 
         Assert.True(vm.IsEmpty);
         Assert.Equal(Strings.Vessels_Empty_NoData, vm.EmptyMessage);
@@ -530,5 +553,161 @@ public class VesselListViewModelTests
 
         Assert.True(vm.IsEmpty);
         Assert.Equal(Strings.Vessels_Empty_Disabled, vm.EmptyMessage);
+    }
+
+    [Fact]
+    public void OwnShipRow_PinnedFirst_AndMarked_WhenEnabled()
+    {
+        var (vm, ais, _, _) = Make();
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
+        Raise(ais);
+
+        Assert.True(vm.Vessels[0].IsOwnShip);
+        Assert.Equal(Strings.Vessels_OwnShip_Name, vm.Vessels[0].Name);
+        Assert.False(vm.Vessels[0].HasRangeBearing);
+        Assert.Single(AisRows(vm));
+    }
+
+    [Fact]
+    public void OwnShipRow_AbsentWhenOverlayOff()
+    {
+        var (vm, ais, _, _) = Make(ownShipEnabled: false);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
+        Raise(ais);
+
+        Assert.DoesNotContain(vm.Vessels, v => v.IsOwnShip);
+    }
+
+    [Fact]
+    public void OwnShipRow_ShowsHelmingLabel_WhenFollowingWithFix()
+    {
+        var ais = NewAisSource();
+        var helm = new FakeHelmStatus
+        {
+            IsActive = true,
+            FollowedMmsi = 1,
+            LastFixUtc = DateTimeOffset.UnixEpoch,
+        };
+        var (vm, _, _, _) = Make(aisSource: ais, helm: helm, helmTarget: ais);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Bandit") });
+        Raise(ais);
+
+        var own = vm.Vessels.Single(v => v.IsOwnShip);
+        Assert.True(own.IsHelming);
+        Assert.True(own.HasHelmingText);
+        Assert.Contains("Bandit", own.HelmingText);
+    }
+
+    [Fact]
+    public void OwnShipRow_ShowsWaitingLabel_WhenArmedWithoutFix()
+    {
+        var ais = NewAisSource();
+        var helm = new FakeHelmStatus
+        {
+            IsActive = true,
+            FollowedMmsi = 1,
+            LastFixUtc = null,
+        };
+        var (vm, _, _, _) = Make(aisSource: ais, helm: helm, helmTarget: ais);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Bandit") });
+        Raise(ais);
+
+        var own = vm.Vessels.Single(v => v.IsOwnShip);
+        Assert.False(own.IsHelming);
+        Assert.True(own.HasHelmingText);
+        Assert.Contains("Bandit", own.HelmingText);
+    }
+
+    [Fact]
+    public void OwnShipRow_NoHelmingLabel_WhenInactive()
+    {
+        var helm = new FakeHelmStatus { IsActive = false };
+        var (vm, ais, _, _) = Make(helm: helm);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
+        Raise(ais);
+
+        var own = vm.Vessels.Single(v => v.IsOwnShip);
+        Assert.False(own.IsHelming);
+        Assert.False(own.HasHelmingText);
+    }
+
+    [Fact]
+    public void TakeHelmCommand_EnabledForAisRow_RaisesWithMmsi()
+    {
+        var helm = new FakeHelmStatus();
+        var (vm, ais, _, _) = Make(helm: helm);
+        ais.SetFeatures(new[] { Vessel(4242, 1, 0, "Target") });
+        Raise(ais);
+
+        Assert.False(vm.TakeHelmCommand.CanExecute(null)); // nothing selected
+        vm.SelectedVessel = AisRows(vm).Single();
+        Assert.True(vm.TakeHelmCommand.CanExecute(null));
+
+        uint? raised = null;
+        vm.TakeHelmRequested += (_, mmsi) => raised = mmsi;
+        vm.TakeHelmCommand.Execute(null);
+        Assert.Equal(4242u, raised);
+    }
+
+    [Fact]
+    public void TakeHelmCommand_DisabledForOwnShipRow()
+    {
+        var helm = new FakeHelmStatus();
+        var (vm, ais, _, _) = Make(helm: helm);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
+        Raise(ais);
+
+        vm.SelectedVessel = vm.Vessels.Single(v => v.IsOwnShip);
+        Assert.False(vm.TakeHelmCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void ReleaseHelmCommand_EnabledWhileHelming_RaisesEvent()
+    {
+        var helm = new FakeHelmStatus
+        {
+            IsActive = true,
+            FollowedMmsi = 1,
+            LastFixUtc = DateTimeOffset.UnixEpoch,
+        };
+        var (vm, ais, _, _) = Make(helm: helm);
+        Raise(ais);
+
+        Assert.True(vm.ReleaseHelmCommand.CanExecute(null));
+
+        var raised = false;
+        vm.ReleaseHelmRequested += (_, _) => raised = true;
+        vm.ReleaseHelmCommand.Execute(null);
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void ReleaseHelmCommand_DisabledWhenNotHelming()
+    {
+        var helm = new FakeHelmStatus { IsActive = false };
+        var (vm, ais, _, _) = Make(helm: helm);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
+        Raise(ais);
+
+        Assert.False(vm.ReleaseHelmCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void EngagingHelm_AutoSelectsOwnShipRow()
+    {
+        var helm = new FakeHelmStatus { IsActive = false };
+        var (vm, ais, _, _) = Make(helm: helm);
+        ais.SetFeatures(new[] { Vessel(1, 1, 0, "Target") });
+        Raise(ais);
+        Assert.Null(vm.SelectedVessel);
+
+        // App engages pirate mode, then notifies the panel.
+        helm.IsActive = true;
+        helm.FollowedMmsi = 1;
+        helm.LastFixUtc = DateTimeOffset.UnixEpoch;
+        vm.HandleHelmEngaged();
+
+        Assert.NotNull(vm.SelectedVessel);
+        Assert.True(vm.SelectedVessel!.IsOwnShip);
     }
 }


### PR DESCRIPTION
## Summary

When you "take the helm" of another vessel it was hard to keep track of which vessel you were driving or where own-ship had gone, and an enabled own-ship overlay still opened the viewer zoomed out to the whole world. This PR makes the own ship a first-class, visible participant in the Vessels panel and frames the map on it at startup.

Key changes:

- **Own-ship row in the Vessels list.** When the simulated own-ship overlay is enabled, the own ship appears as a top-pinned row (distinct pictogram, name *Own ship*), selectable alongside AIS targets. It reuses the shared row/removal/selection plumbing (keyed by `OwnShipSource.FeatureId`, pinned via a primary sort key) and carries no range/bearing since it is the reference point.
- **Helming indicator.** While own-ship impersonates a target the row shows "Helming &lt;target&gt;", or "Waiting for &lt;target&gt;" while armed before the first fix lands. The target name is resolved from the raw (undecorated) AIS feed because the decorated source hides the followed target.
- **Take/Release the helm from the list.** The detail pane gains a "Take the helm" button (AIS rows) and "Release the helm" button (own-ship row). The view-model owns no helm services; it raises events that `App.axaml.cs` routes to the existing `PirateModeCoordinator`. Engaging auto-selects the own-ship row so the Release control stays reachable after the followed target is hidden.
- **Startup framing.** Interactive launch now centers and zooms on the own ship (harbour scale) when the overlay is enabled, waiting briefly for the first fix if needed. An explicit `--bbox`/`--center`/`--zoom` still wins, and the path is a no-op when the overlay is off.

Stop behavior is intentionally unchanged: releasing the helm leaves own-ship at the target's last fix under simulated control (no teleport, no snap-back).

To keep the view-model testable, helm status is consumed through a new `IHelmStatusProvider` abstraction (implemented by `PirateModeController`) rather than the concrete controller.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is viewer UX only; it touches no S-100 product spec semantics, encoding, or portrayal.

**Spec section references cited in code/docs:** N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Updated the existing `VesselListViewModelTests` for the new own-ship row (AIS-only assertions via a helper) and added 13 tests covering the pinned/marked row, helming vs waiting vs cleared labels, Take/Release command enablement and events, and auto-select on engage. Full viewer suite: 814 passing.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None.