### PR TITLE
Fix S-102 edition 2.1 cells rendering blank

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S102DatasetProcessor.cs
@@ -208,17 +208,35 @@ public sealed class S102DatasetProcessor : IDatasetProcessor, ICoveragePortrayal
             .ConfigureAwait(false);
 
         var extent = _source.Metadata.Extent;
+
+        // The grid extent is expressed in the dataset's native CRS, which for
+        // S-102 may be a projected UTM zone (EPSG:326xx/327xx) — typical of
+        // Edition 2.1 cells. CoverageHeadlessRenderer expects WGS84 lon/lat
+        // (it projects through Web Mercator), so reproject the native extent
+        // corners to WGS84 first; the transform is identity for geographic
+        // (EPSG:4326) grids. ProjNet uses lon-first/lat-second ordering, matching
+        // CoveragePickHelper. (See issue #239.)
+        int crs = _dataset.HorizontalCRS ?? 4326;
+        var nativeToWgs84 = _crsTransformFactory.Create($"EPSG:{crs}", "EPSG:4326");
+        var (west, south) = nativeToWgs84.IsIdentity
+            ? (extent.WestLongitude, extent.SouthLatitude)
+            : nativeToWgs84.Transform(extent.WestLongitude, extent.SouthLatitude);
+        var (east, north) = nativeToWgs84.IsIdentity
+            ? (extent.EastLongitude, extent.NorthLatitude)
+            : nativeToWgs84.Transform(extent.EastLongitude, extent.NorthLatitude);
+
         var renderer = new CoverageHeadlessRenderer
         {
             Background = background ?? new RgbaColor(255, 255, 255, 255),
+            NativeToWgs84 = nativeToWgs84,
         };
 
         return renderer.Render(
             styledLayer,
-            extent.WestLongitude,
-            extent.EastLongitude,
-            extent.SouthLatitude,
-            extent.NorthLatitude,
+            west,
+            east,
+            south,
+            north,
             widthPixels,
             heightPixels);
     }

--- a/src/EncDotNet.S100.Datasets.S102/README.md
+++ b/src/EncDotNet.S100.Datasets.S102/README.md
@@ -7,7 +7,10 @@ Reader and coverage portrayal pipeline for S-102 Bathymetric Surface datasets.
 This library reads S-102 datasets from HDF5 files and provides coverage data (depth and uncertainty grids) for the portrayal pipeline. Key types include:
 
 - **`S102Dataset`** — root model containing horizontal CRS and bathymetric coverages.
-- **`S102DatasetReader`** — reads an S-102 dataset from an `IHdf5File`.
+- **`S102DatasetReader`** — reads an S-102 dataset from an `IHdf5File`. The
+  horizontal CRS is resolved from the Edition 3.0.0 `horizontalCRS` root
+  attribute, falling back to the Edition 2.1 `horizontalDatumValue` attribute
+  when the former is absent, so both editions georeference correctly.
 - **`S102CoverageSource`** — `ICoverageSource` adapter for the coverage pipeline.
 - **`S102PortrayalCatalogue`** — coverage portrayal catalogue for depth shading.
 - **`BathymetryCoverage`**, **`BathymetryValue`** — bathymetric data models. `BathymetryCoverage.GroupPath` carries the HDF5 instance path (e.g. `/BathymetryCoverage/BathymetryCoverage.01`) and is used by the validation rule pack as the per-coverage `RelatedFeatureId`.

--- a/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102DatasetReader.cs
@@ -20,8 +20,16 @@ public static class S102DatasetReader
 
         var root = file.Root;
 
-        int? horizontalCRS = root.AttributeExists("horizontalCRS")
-            ? (int)root.ReadInt64Attribute("horizontalCRS")
+        // Horizontal CRS is encoded under different root-attribute names across
+        // S-102 editions: Edition 3.0.0 uses `horizontalCRS`, whereas the older
+        // Edition 2.1 (and the S-100 Part 10c gridded-coverage profile it built
+        // on) uses `horizontalDatumValue` (the EPSG code) alongside
+        // `horizontalDatumReference` (= "EPSG"). Resolve whichever is present so
+        // both editions georeference correctly; prefer the newer name when both
+        // exist. (See issue #239.)
+        int? horizontalCRS =
+            root.AttributeExists("horizontalCRS") ? (int)root.ReadInt64Attribute("horizontalCRS")
+            : root.AttributeExists("horizontalDatumValue") ? (int)root.ReadInt64Attribute("horizontalDatumValue")
             : null;
 
         string? epoch = root.AttributeExists("epoch")

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102Edition21Tests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102Edition21Tests.cs
@@ -1,0 +1,165 @@
+using System.Reflection;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S102;
+using EncDotNet.S100.Hdf5.PureHdf;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+using EncDotNet.S100.Crs.ProjNet;
+using PureHDF;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Regression tests for issue #239 — S-102 <b>Edition 2.1</b> cells.
+/// Edition 2.1 encodes the horizontal CRS under the older
+/// <c>horizontalDatumValue</c> root attribute (the S-100 Part 10c
+/// gridded-coverage convention) rather than Edition 3.0.0's
+/// <c>horizontalCRS</c>. These cells are typically UTM-georeferenced, so they
+/// previously resolved no CRS, defaulted to EPSG:4326, and rendered blank.
+/// </summary>
+public class S102Edition21Tests
+{
+    private struct SpecBathyRow
+    {
+        [H5Name("depth")] public float Depth;
+        [H5Name("uncertainty")] public float Uncertainty;
+    }
+
+    /// <summary>
+    /// Writes a synthetic S-102 Edition 2.1 HDF5 cell: UTM Zone 17N
+    /// (EPSG:32617) georeferencing carried via <c>horizontalDatumValue</c>,
+    /// with a small regular grid of real depths.
+    /// </summary>
+    private static string WriteEdition21Utm(
+        int epsg = 32617,
+        double originEasting = 300_000.0,
+        double originNorthing = 4_600_000.0,
+        double spacing = 16.0,
+        int rows = 8,
+        int cols = 8,
+        bool useHorizontalDatumValue = true)
+    {
+        var path = Path.GetTempFileName() + ".h5";
+
+        var values = new SpecBathyRow[rows * cols];
+        for (int i = 0; i < values.Length; i++)
+            values[i] = new SpecBathyRow { Depth = 4.0f + (i % 6), Uncertainty = 0.1f };
+
+        var instance = new H5Group
+        {
+            Attributes = new()
+            {
+                ["gridOriginLatitude"] = originNorthing,
+                ["gridOriginLongitude"] = originEasting,
+                ["gridSpacingLatitudinal"] = spacing,
+                ["gridSpacingLongitudinal"] = spacing,
+                ["numPointsLatitudinal"] = rows,
+                ["numPointsLongitudinal"] = cols,
+            },
+            ["Group_001"] = new H5Group { ["values"] = values },
+        };
+
+        var rootAttributes = new Dictionary<string, object>
+        {
+            ["productSpecification"] = "INT.IHO.S-102.2.1",
+        };
+        if (useHorizontalDatumValue)
+        {
+            rootAttributes["horizontalDatumReference"] = "EPSG";
+            rootAttributes["horizontalDatumValue"] = epsg;
+        }
+        else
+        {
+            rootAttributes["horizontalCRS"] = epsg;
+        }
+
+        var file = new H5File
+        {
+            Attributes = rootAttributes,
+            ["BathymetryCoverage"] = new H5Group { ["BathymetryCoverage.01"] = instance },
+        };
+
+        var options = new H5WriteOptions(
+            FieldNameMapper: f => f.GetCustomAttribute<H5NameAttribute>()?.Name);
+        file.Write(path, options);
+        return path;
+    }
+
+    [Fact]
+    public void Read_Edition21_ResolvesHorizontalCrsFromHorizontalDatumValue()
+    {
+        var path = WriteEdition21Utm(epsg: 32632, useHorizontalDatumValue: true);
+        try
+        {
+            using var hdf = PureHdfFile.Open(path);
+            var dataset = S102DatasetReader.Read(hdf);
+
+            Assert.Equal(32632, dataset.HorizontalCRS);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Read_Edition30_StillPrefersHorizontalCrs()
+    {
+        var path = WriteEdition21Utm(epsg: 32617, useHorizontalDatumValue: false);
+        try
+        {
+            using var hdf = PureHdfFile.Open(path);
+            var dataset = S102DatasetReader.Read(hdf);
+
+            Assert.Equal(32617, dataset.HorizontalCRS);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task RenderHeadless_Edition21Utm_IsNotBlank()
+    {
+        var path = WriteEdition21Utm();
+        using var manager = CreateCatalogueManager();
+        var processor = new S102DatasetProcessor(
+            path,
+            manager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory());
+
+        try
+        {
+            using var bitmap = await processor.RenderHeadlessAsync(256, 256);
+            AssertNonBlank(bitmap);
+        }
+        finally
+        {
+            processor.Dispose();
+            File.Delete(path);
+        }
+    }
+
+    private static PortrayalCatalogueManager CreateCatalogueManager()
+    {
+        var manager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                manager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+        return manager;
+    }
+
+    private static void AssertNonBlank(SKBitmap bitmap)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red != 255 || p.Green != 255 || p.Blue != 255)
+                return;
+        }
+
+        Assert.Fail("Edition 2.1 S-102 cell rendered a blank (all-white) bitmap.");
+    }
+}


### PR DESCRIPTION
## Why

S-102 **edition 2.1** cells rendered a completely blank (all-white) image via `s100 render`, even though the CLI reported success. 82 real IC-ENC cells were affected (DE and GB Clyde trial clusters), all at `INT.IHO.S-102.2.1`. Edition 3.0.0 cells rendered fine.

## Root cause

This is a product-spec-version compatibility gap. The HDF5 root-attribute name for the horizontal CRS changed between editions:

| Convention | Editions | Attribute |
|---|---|---|
| Old | S-102 **2.1** (also S-111/S-104) | `horizontalDatumValue` (+ `horizontalDatumReference`) |
| New | S-102 **3.0.0** | `horizontalCRS` (+ `verticalCS`) |

These edition-2.1 cells are UTM-georeferenced (e.g. DE cell = EPSG:32632, grid origin in UTM metres). Two compounding bugs produced the blank output:

1. `S102DatasetReader` read only the 3.0.0 `horizontalCRS`, so edition-2.1 cells resolved no CRS and silently defaulted to EPSG:4326.
2. `S102DatasetProcessor.RenderHeadlessAsync` passed the native (UTM-metre) extent straight into `CoverageHeadlessRenderer`, which treats those numbers as WGS84 lon/lat and projects through Web Mercator. A UTM northing of ~6.0e6 clamps as a latitude, the projected span collapses, and the renderer returns the bare background.

Because the underlying issue is UTM handling, any 3.0.0 UTM cell would have rendered blank too; edition-2.1 cells just always expose it.

## Approach

- **Reader:** resolve the horizontal CRS from `horizontalCRS`, falling back to `horizontalDatumValue` when the former is absent. This is attribute-driven (no branching on the `productSpecification` version string), so it tolerates either edition. Mirrors how the existing S-111 reader already handles the old name.
- **Headless render:** reproject the native extent corners to WGS84 via the CRS transform factory before handing them to the renderer. The transform is identity for geographic (EPSG:4326) grids, so 3.0.0 cells are unaffected. Uses the same ProjNet lon-first/lat-second convention as `CoveragePickHelper`.

## Tests

Added `S102Edition21Tests` covering both fixes against synthetic PureHDF fixtures (no real ENC data committed):
- Reader resolves `HorizontalCRS` from `horizontalDatumValue` (edition 2.1).
- Reader still prefers `horizontalCRS` (edition 3.0.0).
- A synthetic UTM (EPSG:32617) edition-2.1 grid renders non-blank through the full `RenderHeadlessAsync` path (regression guard).

All 52 S-102 pipeline tests pass and the Release build is clean. Manually verified that the real DE and GB Clyde cells now render, and the AU 3.0.0 cell still renders.

## Follow-up

Filed #245 to consider supporting earlier S-102 Portrayal Catalogue versions; the PC is still pinned to 3.0.0 and applied to all editions.

Fixes: #239