### PR TITLE
Fix S-101 portrayal Lua require failures for legacy feature class names (#240)

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -46,12 +46,18 @@ Catalogue report the **pre-2.0.0** names (`BuoyLateral`,
 falls back to **DEFAULT** (`QUESMRK1`) symbology.
 
 `S101LegacyFeatureNames.Normalize` maps the legacy class names to their
-2.0.0 equivalents so the correct rule runs. Because simple attribute
-names are stable across these editions, only the feature **class** name
-needs remapping. The shim is applied **only** at the portrayal boundary
-(`S101LuaDataProvider.HostFeatureGetCode`); feature names are left
-as-authored everywhere else (document reader, vector source,
-validation, info panels).
+2.0.0 equivalents so the correct rule runs. This covers both the
+word-reordered buoy/beacon classes (`BuoyLateral` → `LateralBuoy`,
+`BeaconCardinal` → `CardinalBeacon`, …) and classes that were **merged**
+in 2.0.0: `RestrictedAreaNavigational` / `RestrictedAreaRegulatory` →
+`RestrictedArea`, `TrafficSeparationZone` / `TrafficSeparationLine` →
+`SeparationZoneOrLine`, and `BuoyEmergencyWreckMarking` /
+`BuoyNewDangerMarking` → `EmergencyWreckMarkingBuoy`. Because simple
+attribute names are stable across these editions, only the feature
+**class** name needs remapping. The shim is applied **only** at the
+portrayal boundary (`S101LuaDataProvider.HostFeatureGetCode`); feature
+names are left as-authored everywhere else (document reader, vector
+source, validation, info panels).
 
 `MooringWarpingFacility` was structurally removed in 2.0.0, so it is
 mapped conditionally on `categoryOfMooringWarpingFacility`

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -63,7 +63,10 @@ source, validation, info panels).
 mapped conditionally on `categoryOfMooringWarpingFacility`
 (dolphin → `Dolphin`, bollard → `Bollard`, post/pile → `Pile`,
 mooring buoy → `MooringBuoy`); categories without a clean 2.0.0
-equivalent are left unchanged and stay on DEFAULT. These conditional
+equivalent — and instances with an absent or empty category — are
+routed to the `Default` rule module so the dispatcher's `require`
+always resolves (DEFAULT symbology) instead of throwing
+`module 'MooringWarpingFacility' not found`. These conditional
 targets are approximations — only the class name is aliased, not the
 attributes the 2.0.0 rule reads — so symbology may be generic, and a
 target rule that rejects the feature's geometric primitive simply

--- a/src/EncDotNet.S100.Datasets.S101/S101LegacyFeatureNames.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LegacyFeatureNames.cs
@@ -12,12 +12,16 @@ namespace EncDotNet.S100.Datasets.S101;
 /// <para>
 /// Between S-101 1.x and 2.0.0 several compound feature class names were
 /// re-ordered (for example <c>BuoyLateral</c> became <c>LateralBuoy</c> and
-/// <c>BeaconCardinal</c> became <c>CardinalBeacon</c>). Because the S-100
-/// Part 9A Lua portrayal dispatcher (<c>main.lua</c>) loads and invokes a rule
-/// module whose file name and global function name both equal the feature's
-/// class code (<c>require(feature.Code)</c> then <c>_G[feature.Code](...)</c>),
-/// a dataset that reports a legacy class code finds no matching 2.0.0 rule
-/// module and falls back to DEFAULT symbology.
+/// <c>BeaconCardinal</c> became <c>CardinalBeacon</c>), and a few classes were
+/// merged: the 1.x <c>RestrictedAreaNavigational</c> and
+/// <c>RestrictedAreaRegulatory</c> classes became a single
+/// <c>RestrictedArea</c>, and <c>TrafficSeparationZone</c> /
+/// <c>TrafficSeparationLine</c> became <c>SeparationZoneOrLine</c>. Because the
+/// S-100 Part 9A Lua portrayal dispatcher (<c>main.lua</c>) loads and invokes a
+/// rule module whose file name and global function name both equal the
+/// feature's class code (<c>require(feature.Code)</c> then
+/// <c>_G[feature.Code](...)</c>), a dataset that reports a legacy class code
+/// finds no matching 2.0.0 rule module and falls back to DEFAULT symbology.
 /// </para>
 /// <para>
 /// Simple attribute names are stable across these editions, so re-mapping only
@@ -65,6 +69,21 @@ public static class S101LegacyFeatureNames
             ["BuoySpecialPurposeGeneral"] = "SpecialPurposeGeneralBuoy",
             // The "new danger marking" buoy was renamed "emergency wreck marking".
             ["BuoyNewDangerMarking"] = "EmergencyWreckMarkingBuoy",
+            // The 1.x compound order "Buoy*" was also reversed for this class.
+            ["BuoyEmergencyWreckMarking"] = "EmergencyWreckMarkingBuoy",
+
+            // Restricted areas: S-101 1.x split RestrictedArea into the separate
+            // RestrictedAreaNavigational and RestrictedAreaRegulatory classes;
+            // 2.0.0 merged them back into a single RestrictedArea discriminated
+            // by categoryOfRestrictedArea/restriction.
+            ["RestrictedAreaNavigational"] = "RestrictedArea",
+            ["RestrictedAreaRegulatory"] = "RestrictedArea",
+
+            // Traffic separation: S-101 1.x had separate TrafficSeparationZone
+            // (area) and TrafficSeparationLine (curve) classes; 2.0.0 merged them
+            // into SeparationZoneOrLine (whose rule handles both primitives).
+            ["TrafficSeparationZone"] = "SeparationZoneOrLine",
+            ["TrafficSeparationLine"] = "SeparationZoneOrLine",
 
             // Beacons (S-101 2.0.0 reverses the compound order).
             ["BeaconCardinal"] = "CardinalBeacon",

--- a/src/EncDotNet.S100.Datasets.S101/S101LegacyFeatureNames.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LegacyFeatureNames.cs
@@ -34,13 +34,17 @@ namespace EncDotNet.S100.Datasets.S101;
 /// <c>MooringWarpingFacility</c> was structurally removed in S-101 2.0.0 and
 /// split into several distinct feature classes, so it is mapped conditionally
 /// on the legacy <c>categoryOfMooringWarpingFacility</c> enumerant. Categories
-/// without a clean 2.0.0 equivalent are left unchanged (and therefore portrayed
-/// with DEFAULT symbology). The conditional targets are approximations: only
-/// the class name is aliased, not the attributes the 2.0.0 rule reads (for
-/// example <c>Dolphin.lua</c> inspects <c>categoryOfDolphin</c>), so the
-/// resulting symbology may be generic. A target rule that rejects the legacy
-/// feature's geometric primitive simply errors inside the dispatcher's
-/// <c>pcall</c> and falls back to DEFAULT — i.e. no worse than today.
+/// without a clean 2.0.0 equivalent (tie-up wall, chain/wire/cable) — and
+/// instances with an absent or empty category — are routed to the <c>Default</c>
+/// rule module so the dispatcher's <c>require</c> always resolves and the
+/// feature is portrayed with DEFAULT symbology, rather than failing
+/// <c>require</c> with <c>module 'MooringWarpingFacility' not found</c>. The
+/// conditional category targets are approximations: only the class name is
+/// aliased, not the attributes the 2.0.0 rule reads (for example
+/// <c>Dolphin.lua</c> inspects <c>categoryOfDolphin</c>), so the resulting
+/// symbology may be generic. A target rule that rejects the legacy feature's
+/// geometric primitive simply errors inside the dispatcher's <c>pcall</c> and
+/// falls back to DEFAULT — i.e. no worse than today.
 /// </para>
 /// <para>References: S-101 Feature Catalogue (Edition 1.x and 2.0.0); S-100
 /// Part 9A (Portrayal — Lua rules engine).</para>
@@ -51,6 +55,15 @@ public static class S101LegacyFeatureNames
     /// <c>MooringWarpingFacility</c> feature class.</summary>
     private const string MooringWarpingFacility = "MooringWarpingFacility";
     private const string MooringWarpingCategoryAttribute = "categoryOfMooringWarpingFacility";
+
+    /// <summary>
+    /// Name of the S-100 Part 9A <c>Default</c> portrayal rule module, used as
+    /// an explicit fallback so a feature whose class has no clean 2.0.0 rule
+    /// still dispatches a real module (the dispatcher's <c>require('Default')</c>
+    /// resolves and <c>Default(...)</c> emits the DEFAULT symbol) instead of
+    /// throwing <c>module '…' not found</c> from a failed <c>require</c>.
+    /// </summary>
+    private const string DefaultRuleModule = "Default";
 
     /// <summary>
     /// Legacy S-101 1.x feature class name → S-101 2.0.0 feature class name.
@@ -97,7 +110,8 @@ public static class S101LegacyFeatureNames
     /// Legacy <c>categoryOfMooringWarpingFacility</c> enumerant (stringified
     /// integer code) → S-101 2.0.0 feature class name. Categories without a
     /// clean 2.0.0 equivalent (tie-up wall = 4, chain/wire/cable = 6) are
-    /// intentionally absent so the feature is left on DEFAULT symbology.
+    /// intentionally absent so the feature is routed to the <c>Default</c> rule
+    /// module (DEFAULT symbology) instead.
     /// </summary>
     private static readonly FrozenDictionary<string, string> MooringWarpingByCategory =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -122,10 +136,14 @@ public static class S101LegacyFeatureNames
     /// Optional callback that resolves the first value of a simple attribute on
     /// the feature being normalized, used to disambiguate the removed
     /// <c>MooringWarpingFacility</c> class via
-    /// <c>categoryOfMooringWarpingFacility</c>. When <see langword="null"/>,
-    /// <c>MooringWarpingFacility</c> is left unchanged.
+    /// <c>categoryOfMooringWarpingFacility</c>. When the category has no clean
+    /// 2.0.0 mapping — or when this callback is <see langword="null"/> or
+    /// returns <see langword="null"/> — <c>MooringWarpingFacility</c> is routed
+    /// to the <c>Default</c> rule module so its <c>require</c> still resolves.
     /// </param>
-    /// <returns>The normalized feature class name.</returns>
+    /// <returns>The normalized feature class name (a 2.0.0 feature class name,
+    /// the input unchanged, or <c>Default</c> for a category-less
+    /// <c>MooringWarpingFacility</c>).</returns>
     public static string Normalize(string featureCode, Func<string, string?>? categoryLookup = null)
     {
         if (string.IsNullOrEmpty(featureCode))
@@ -138,15 +156,21 @@ public static class S101LegacyFeatureNames
             return renamed;
         }
 
-        if (categoryLookup is not null &&
-            string.Equals(featureCode, MooringWarpingFacility, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(featureCode, MooringWarpingFacility, StringComparison.OrdinalIgnoreCase))
         {
-            var category = categoryLookup(MooringWarpingCategoryAttribute);
+            var category = categoryLookup?.Invoke(MooringWarpingCategoryAttribute);
             if (category is not null &&
                 MooringWarpingByCategory.TryGetValue(category.Trim(), out var mapped))
             {
                 return mapped;
             }
+
+            // No clean per-category 2.0.0 equivalent (e.g. tie-up wall, chain/
+            // wire/cable, or an absent/empty category): route explicitly to the
+            // Default rule module so the dispatcher's require() resolves and the
+            // feature is portrayed with DEFAULT symbology, rather than failing
+            // require() with "module 'MooringWarpingFacility' not found".
+            return DefaultRuleModule;
         }
 
         return featureCode;

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101LegacyFeatureNamesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101LegacyFeatureNamesTests.cs
@@ -89,30 +89,30 @@ public class S101LegacyFeatureNamesTests
     [InlineData("6")]   // chain/wire/cable — no clean 2.0.0 equivalent
     [InlineData("99")]  // unknown enumerant
     [InlineData("")]    // present but empty
-    public void Normalize_MooringWarpingFacility_UnmappedCategory_ReturnsUnchanged(string category)
+    public void Normalize_MooringWarpingFacility_UnmappedCategory_RoutesToDefault(string category)
     {
         var result = S101LegacyFeatureNames.Normalize(
             "MooringWarpingFacility",
             code => category);
 
-        Assert.Equal("MooringWarpingFacility", result);
+        Assert.Equal("Default", result);
     }
 
     [Fact]
-    public void Normalize_MooringWarpingFacility_NullLookupResult_ReturnsUnchanged()
+    public void Normalize_MooringWarpingFacility_NullLookupResult_RoutesToDefault()
     {
         var result = S101LegacyFeatureNames.Normalize(
             "MooringWarpingFacility",
             code => null);
 
-        Assert.Equal("MooringWarpingFacility", result);
+        Assert.Equal("Default", result);
     }
 
     [Fact]
-    public void Normalize_MooringWarpingFacility_NoLookup_ReturnsUnchanged()
+    public void Normalize_MooringWarpingFacility_NoLookup_RoutesToDefault()
     {
         Assert.Equal(
-            "MooringWarpingFacility",
+            "Default",
             S101LegacyFeatureNames.Normalize("MooringWarpingFacility"));
     }
 

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101LegacyFeatureNamesTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101LegacyFeatureNamesTests.cs
@@ -17,12 +17,25 @@ public class S101LegacyFeatureNamesTests
     [InlineData("BuoySafeWater", "SafeWaterBuoy")]
     [InlineData("BuoySpecialPurposeGeneral", "SpecialPurposeGeneralBuoy")]
     [InlineData("BuoyNewDangerMarking", "EmergencyWreckMarkingBuoy")]
+    [InlineData("BuoyEmergencyWreckMarking", "EmergencyWreckMarkingBuoy")]
     [InlineData("BeaconCardinal", "CardinalBeacon")]
     [InlineData("BeaconIsolatedDanger", "IsolatedDangerBeacon")]
     [InlineData("BeaconLateral", "LateralBeacon")]
     [InlineData("BeaconSafeWater", "SafeWaterBeacon")]
     [InlineData("BeaconSpecialPurposeGeneral", "SpecialPurposeGeneralBeacon")]
     public void Normalize_LegacyBuoyOrBeacon_ReturnsRenamed(string legacy, string expected)
+    {
+        Assert.Equal(expected, S101LegacyFeatureNames.Normalize(legacy));
+    }
+
+    [Theory]
+    [InlineData("RestrictedAreaNavigational", "RestrictedArea")]
+    [InlineData("RestrictedAreaRegulatory", "RestrictedArea")]
+    [InlineData("TrafficSeparationZone", "SeparationZoneOrLine")]
+    [InlineData("TrafficSeparationLine", "SeparationZoneOrLine")]
+    [InlineData("restrictedareanavigational", "RestrictedArea")]
+    [InlineData("TRAFFICSEPARATIONLINE", "SeparationZoneOrLine")]
+    public void Normalize_LegacyMergedArea_ReturnsRenamed(string legacy, string expected)
     {
         Assert.Equal(expected, S101LegacyFeatureNames.Normalize(legacy));
     }


### PR DESCRIPTION
## Summary
Rendering real-world S-101 ENCs logged many `[Lua] Error … module 'X' not found` messages from the portrayal pipeline, causing several feature classes to fall back to **DEFAULT** symbology instead of their intended portrayal (issue #240).

**Root cause:** the affected IC-ENC datasets honestly declare an **earlier edition** (the repro cells' DSID reports product specification `INT.IHO.S-101.1.0`), but we portray everything with the bundled **Edition 2.0.0** Portrayal Catalogue. Several feature classes were **renamed/merged** between 1.x and 2.0.0, so the S-100 Part 9A dispatcher's `require(feature.Code)` finds no 2.0.0 rule module. This is exactly the mismatch the existing `S101LegacyFeatureNames.Normalize` shim already bridges for buoys/beacons — these classes were simply missing from the map.

The fix stays entirely at the C# portrayal boundary (`S101LuaDataProvider` → `S101LegacyFeatureNames`); upstream `main.lua` is **not** edited.

## Changes
Added legacy → 2.0.0 mappings to `S101LegacyFeatureNames.SimpleRenames`:

| Legacy (1.x) | 2.0.0 |
|---|---|
| `RestrictedAreaNavigational`, `RestrictedAreaRegulatory` | `RestrictedArea` |
| `TrafficSeparationZone`, `TrafficSeparationLine` | `SeparationZoneOrLine` |
| `BuoyEmergencyWreckMarking` | `EmergencyWreckMarkingBuoy` |

For the structurally-removed `MooringWarpingFacility`, instances whose `categoryOfMooringWarpingFacility` has no clean 2.0.0 equivalent (tie-up wall, chain/wire/cable) — or is absent/empty — are now routed explicitly to the always-resolvable `Default` rule module, so `require` succeeds and the feature is portrayed with DEFAULT symbology **without** the noisy `module not found` log (and with no secondary noise).

Also updated the `S101LegacyFeatureNames` XML-doc remarks and the S-101 README.

## Verification
- Confirmed the merged 2.0.0 rules emit **non-DEFAULT** symbology for the renamed features (dumped emitted drawing instructions), e.g. `RestrictedArea` → `ProhAre` alert + magenta `CHMGD` dashed boundary; `SeparationZoneOrLine` → `TRFCF` line/`ColorFill`; `EmergencyWreckMarkingBuoy` → `BOYPIL60` + `TOPMAR17`.
- Independent full sweep of all **153** IC-ENC S-101 cells on this branch: **0** `module not found` for all six classes; OK 98 → 102; FAIL 0. The remaining WARNs are unrelated (`valueOfSounding`/`defaultClearanceDepth` — tracked separately).
- `dotnet test` — 71 tests pass in `Datasets.S101.Tests` (new rename cases + updated MWF→`Default` cases); S101 pipeline/dispatch tests green.

## Follow-up
Filed #244 to consider bundling the S-101 Edition 1.0 Portrayal Catalogue and adding UX (CLI flag + Viewer selector) to choose the PC edition per dataset, so 1.x data can be portrayed with edition-accurate symbology instead of the approximating shim.

Fixes #240