### PR TITLE
Fix S-128 GML 1.0 catalogues rendering blank (#243)

### DIFF
--- a/src/EncDotNet.S100.Core/Gml/GmlCoordinateParser.cs
+++ b/src/EncDotNet.S100.Core/Gml/GmlCoordinateParser.cs
@@ -129,12 +129,14 @@ public static class GmlCoordinateParser
         {
             exteriorRing = ParseRingCoordinates(exterior, gmlNs);
         }
-        else
+
+        // Additive producer-bug fallback: only when the standard parse above
+        // yielded no exterior vertices. Some datasets (e.g. S-128 GML 1.0
+        // IC-ENC/DK catalogues) emit <gml:Polygon><gml:posList> directly,
+        // omitting the <gml:exterior>/<gml:LinearRing> wrapper. Conformant
+        // surfaces never reach this branch.
+        if (exteriorRing.IsDefaultOrEmpty)
         {
-            // Producer-bug compensation: some datasets (e.g. S-128 GML 1.0
-            // IC-ENC/DK catalogues) emit <gml:Polygon><gml:posList> directly,
-            // omitting the <gml:exterior>/<gml:LinearRing> wrapper. Fall back to
-            // a direct posList/pos sequence under the surface container.
             exteriorRing = ParseRingCoordinates(surfaceContainer, gmlNs);
         }
 
@@ -159,11 +161,13 @@ public static class GmlCoordinateParser
     /// Parses a sequence of <c>gml:pos</c> elements into coordinate pairs.
     /// </summary>
     /// <remarks>
-    /// A conformant <c>gml:pos</c> carries a full coordinate (≥ 2 ordinates);
-    /// in that case each element yields one pair. As a producer-bug
-    /// compensation (seen in S-128 GML 1.0 IC-ENC datasets) where every
-    /// <c>gml:pos</c> carries a <em>single</em> ordinate, the ordinates are
-    /// flattened across elements and paired up (lat, lon).
+    /// The conformant interpretation — each <c>gml:pos</c> carries a full
+    /// position (≥ 2 ordinates) and yields one coordinate — is attempted
+    /// first and is the only path taken by standard data. <em>Only</em> when
+    /// that yields zero vertices is an additive producer-bug fallback tried:
+    /// some S-128 GML 1.0 IC-ENC datasets split each coordinate's ordinates
+    /// across consecutive single-value <c>gml:pos</c> elements, so the
+    /// ordinates are flattened and paired up (lat, lon).
     /// </remarks>
     private static ImmutableArray<(double, double)> ParsePosSequence(IEnumerable<XElement> posElements)
     {
@@ -171,23 +175,28 @@ public static class GmlCoordinateParser
         if (elements.Count == 0)
             return ImmutableArray<(double, double)>.Empty;
 
-        bool allSingleOrdinate = elements.All(e =>
-            e.Value.Split(Separators, StringSplitOptions.RemoveEmptyEntries).Length == 1);
-
-        // Every <gml:pos> held exactly one ordinate: re-interpret as a flat
-        // ordinate stream and pair the values into (lat, lon) coordinates.
-        if (allSingleOrdinate)
-        {
-            var flattened = string.Join(' ', elements.Select(e => e.Value));
-            return ParsePosList(flattened);
-        }
-
+        // Standard path (unchanged for conformant data): each gml:pos is a
+        // full position.
         var coords = ImmutableArray.CreateBuilder<(double, double)>();
         foreach (var pos in elements)
         {
             var coord = ParsePos(pos.Value);
             if (coord is not null) coords.Add(coord.Value);
         }
-        return coords.ToImmutable();
+        if (coords.Count > 0)
+            return coords.ToImmutable();
+
+        // Additive fallback: the standard parse produced no vertices. If every
+        // gml:pos holds exactly one ordinate, re-interpret them as a flat
+        // ordinate stream and pair the values into (lat, lon) coordinates.
+        bool allSingleOrdinate = elements.All(e =>
+            e.Value.Split(Separators, StringSplitOptions.RemoveEmptyEntries).Length == 1);
+        if (allSingleOrdinate)
+        {
+            var flattened = string.Join(' ', elements.Select(e => e.Value));
+            return ParsePosList(flattened);
+        }
+
+        return ImmutableArray<(double, double)>.Empty;
     }
 }

--- a/src/EncDotNet.S100.Core/Gml/GmlCoordinateParser.cs
+++ b/src/EncDotNet.S100.Core/Gml/GmlCoordinateParser.cs
@@ -129,6 +129,14 @@ public static class GmlCoordinateParser
         {
             exteriorRing = ParseRingCoordinates(exterior, gmlNs);
         }
+        else
+        {
+            // Producer-bug compensation: some datasets (e.g. S-128 GML 1.0
+            // IC-ENC/DK catalogues) emit <gml:Polygon><gml:posList> directly,
+            // omitting the <gml:exterior>/<gml:LinearRing> wrapper. Fall back to
+            // a direct posList/pos sequence under the surface container.
+            exteriorRing = ParseRingCoordinates(surfaceContainer, gmlNs);
+        }
 
         foreach (var interior in surfaceContainer.Descendants(gmlNs + "interior"))
         {
@@ -144,8 +152,38 @@ public static class GmlCoordinateParser
         if (posList is not null)
             return ParsePosList(posList.Value);
 
+        return ParsePosSequence(ringContainer.Descendants(gmlNs + "pos"));
+    }
+
+    /// <summary>
+    /// Parses a sequence of <c>gml:pos</c> elements into coordinate pairs.
+    /// </summary>
+    /// <remarks>
+    /// A conformant <c>gml:pos</c> carries a full coordinate (≥ 2 ordinates);
+    /// in that case each element yields one pair. As a producer-bug
+    /// compensation (seen in S-128 GML 1.0 IC-ENC datasets) where every
+    /// <c>gml:pos</c> carries a <em>single</em> ordinate, the ordinates are
+    /// flattened across elements and paired up (lat, lon).
+    /// </remarks>
+    private static ImmutableArray<(double, double)> ParsePosSequence(IEnumerable<XElement> posElements)
+    {
+        var elements = posElements as IReadOnlyList<XElement> ?? posElements.ToArray();
+        if (elements.Count == 0)
+            return ImmutableArray<(double, double)>.Empty;
+
+        bool allSingleOrdinate = elements.All(e =>
+            e.Value.Split(Separators, StringSplitOptions.RemoveEmptyEntries).Length == 1);
+
+        // Every <gml:pos> held exactly one ordinate: re-interpret as a flat
+        // ordinate stream and pair the values into (lat, lon) coordinates.
+        if (allSingleOrdinate)
+        {
+            var flattened = string.Join(' ', elements.Select(e => e.Value));
+            return ParsePosList(flattened);
+        }
+
         var coords = ImmutableArray.CreateBuilder<(double, double)>();
-        foreach (var pos in ringContainer.Descendants(gmlNs + "pos"))
+        foreach (var pos in elements)
         {
             var coord = ParsePos(pos.Value);
             if (coord is not null) coords.Add(coord.Value);

--- a/src/EncDotNet.S100.Datasets.S128/README.md
+++ b/src/EncDotNet.S100.Datasets.S128/README.md
@@ -70,6 +70,27 @@ samples surface, edge cases here may need expanding.
    present and parsed coords clearly fall outside as-is but inside when
    swapped, the reader globally flips axes. Skipped silently when no
    envelope is declared (the upstream 2.0.0 sample omits it).
+5. **`gml:gmlId` identifier fallback.** Some S-128 **GML 1.0** IC-ENC/DK
+   catalogue datasets key features with the non-standard `gml:gmlId`
+   attribute instead of `gml:id`. The reader accepts either; without this
+   the feature identifier is empty and the geometry provider drops the
+   feature (rendering blank — see issue #243).
+6. **Exterior-less polygons.** Some GML 1.0 datasets emit
+   `<gml:Polygon><gml:posList>…` directly, omitting the
+   `<gml:exterior>/<gml:LinearRing>` wrapper. The shared
+   `GmlCoordinateParser` falls back to a direct `posList`/`pos` sequence
+   under the surface as the exterior ring.
+7. **Single-ordinate `<gml:pos>` rings.** Some GML 1.0 datasets split each
+   coordinate's ordinates across consecutive single-value `<gml:pos>`
+   elements (`<gml:pos>41.68</gml:pos><gml:pos>21.61</gml:pos>…`). The
+   shared `GmlCoordinateParser` detects this and flattens the ordinates
+   into (lat, lon) pairs.
+
+> **Note on GML 1.0 datasets.** Compensations 5–7 recover *geometry* from
+> the older S-128 GML 1.0 encoding so those catalogues are no longer blank.
+> Full *portrayal* of GML 1.0 feature classes (`ElectronicChart`,
+> `PaperChart`, …) and a reliable axis order for lon-lat datasets that ship
+> no `<gml:Envelope>` are tracked separately in issue #247.
 
 ## Status heuristic
 

--- a/src/EncDotNet.S100.Datasets.S128/S128DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128DatasetReader.cs
@@ -160,7 +160,7 @@ internal static class S128DatasetReader
 
     private static S128Feature ParseFeature(XElement element, XNamespace s100Ns)
     {
-        var id = element.Attribute(GmlNamespaces.Gml + "id")?.Value ?? "";
+        var id = ReadGmlId(element);
         var (geometryType, points, curves, exteriorRing, interiorRings) = ParseGeometry(element, s100Ns);
         var (simple, complex) = ParseAttributes(element, s100Ns);
         var refs = ParseReferences(element);
@@ -182,7 +182,7 @@ internal static class S128DatasetReader
 
     private static S128InformationType ParseInformationType(XElement element, XNamespace s100Ns)
     {
-        var id = element.Attribute(GmlNamespaces.Gml + "id")?.Value ?? "";
+        var id = ReadGmlId(element);
         var (simple, complex) = ParseAttributes(element, s100Ns);
         return new S128InformationType
         {
@@ -194,6 +194,18 @@ internal static class S128DatasetReader
     }
 
     // ── Geometry ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads the GML identifier of an element, accepting the non-standard
+    /// <c>gml:gmlId</c> spelling as a producer-bug fallback. Some S-128 GML 1.0
+    /// IC-ENC/DK catalogue datasets emit <c>gml:gmlId</c> instead of the
+    /// conformant <c>gml:id</c>; without this fallback those features carry an
+    /// empty identifier and are dropped by the geometry provider.
+    /// </summary>
+    private static string ReadGmlId(XElement element) =>
+        element.Attribute(GmlNamespaces.Gml + "id")?.Value
+        ?? element.Attribute(GmlNamespaces.Gml + "gmlId")?.Value
+        ?? "";
 
     private static (GmlGeometryType, ImmutableArray<(double, double)>, ImmutableArray<ImmutableArray<(double, double)>>, ImmutableArray<(double, double)>, ImmutableArray<ImmutableArray<(double, double)>>)
         ParseGeometry(XElement featureElement, XNamespace s100Ns)

--- a/src/EncDotNet.S100.Datasets.S128/S128DatasetReader.cs
+++ b/src/EncDotNet.S100.Datasets.S128/S128DatasetReader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Xml.Linq;
 using S100Diag = EncDotNet.S100.Datasets.S128.Diagnostics;
 using EncDotNet.S100.Gml;
@@ -98,6 +99,21 @@ internal static class S128DatasetReader
             foreach (var f in features) swapped.Add(SwapFeatureAxes(f));
             features = swapped;
         }
+        else if (envelope is null && HasGeometry(features))
+        {
+            // No <gml:Envelope> anchor: the axis-order heuristic cannot run, so
+            // coordinates are assumed to be lat-lon (S-100 Part 10b §6.2). Some
+            // GML 1.0 producers emit lon-lat, which would render a mirrored
+            // chart with no other signal. Surface a diagnostic warning so the
+            // assumption is never silent. See issue #247.
+            __activity?.SetTag("s100.s128.axisOrderAssumed", true);
+            __activity?.AddEvent(new ActivityEvent(
+                "s100.s128.axisOrderAssumed",
+                tags: new ActivityTagsCollection
+                {
+                    ["message"] = "Dataset has geometry but no gml:Envelope; axis order assumed lat-lon and could not be verified.",
+                }));
+        }
 
         return new S128Dataset
         {
@@ -107,6 +123,11 @@ internal static class S128DatasetReader
             InformationTypes = infoTypes.ToImmutable(),
         };
     }
+
+    private static bool HasGeometry(IEnumerable<S128Feature> features) =>
+        features.Any(f => !f.ExteriorRing.IsDefaultOrEmpty
+            || !f.Points.IsDefaultOrEmpty
+            || (!f.Curves.IsDefaultOrEmpty && f.Curves.Length > 0));
 
     /// <summary>
     /// Returns all member/imember candidate elements found beneath the dataset

--- a/tests/EncDotNet.S100.Datasets.S128.Tests/S128DatasetReaderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S128.Tests/S128DatasetReaderTests.cs
@@ -242,4 +242,112 @@ public class S128DatasetReaderTests
         Assert.Single(ds.Features);
         Assert.Equal("DistributorInformation", ds.Features[0].FeatureType);
     }
+
+    /// <summary>
+    /// Variant A producer bug (S-128 GML 1.0 IC-ENC/DK): polygons encoded as
+    /// <c>&lt;gml:Polygon&gt;&lt;gml:posList&gt;</c> with no
+    /// <c>&lt;gml:exterior&gt;/&lt;gml:LinearRing&gt;</c> wrapper, and features
+    /// keyed by the non-standard <c>gml:gmlId</c>. The reader must still parse
+    /// the exterior ring and populate the feature identifier (otherwise the
+    /// geometry provider drops the feature and the dataset renders blank — see
+    /// issue #243).
+    /// </summary>
+    [Fact]
+    public void Reader_ParsesExteriorlessPolygon_AndGmlIdFallback()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/gml/1.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/1.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <member>
+                <S128:ElectronicChart gml:gmlId="GST.ElectronicChart.DK1">
+                  <geometry>
+                    <S100:surfaceProperty>
+                      <gml:Polygon>
+                        <gml:posList>50.4 -2.0 50.8 -2.0 50.8 -1.0 50.4 -1.0 50.4 -2.0</gml:posList>
+                      </gml:Polygon>
+                    </S100:surfaceProperty>
+                  </geometry>
+                </S128:ElectronicChart>
+              </member>
+            </S128:Dataset>
+            """;
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(gml));
+        var ds = S128Dataset.Open(stream);
+
+        var f = ds.Features.Single();
+        Assert.Equal("ElectronicChart", f.FeatureType);
+        Assert.Equal("GST.ElectronicChart.DK1", f.Id);
+        Assert.Equal(GmlGeometryType.Surface, f.GeometryType);
+        Assert.Equal(5, f.ExteriorRing.Length);
+        Assert.All(f.ExteriorRing, p =>
+        {
+            Assert.InRange(p.Latitude, 50.0, 51.0);
+            Assert.InRange(p.Longitude, -3.0, 0.0);
+        });
+    }
+
+    /// <summary>
+    /// Variant B producer bug (S-128 GML 1.0 IC-ENC): each ordinate is emitted
+    /// in its own single-value <c>&lt;gml:pos&gt;</c> element rather than as
+    /// full coordinate tuples. The reader must flatten and pair the ordinates
+    /// into (lat, lon) coordinates (otherwise the ring is empty and the dataset
+    /// renders blank — see issue #243).
+    /// </summary>
+    [Fact]
+    public void Reader_ParsesSingleOrdinatePosElements()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/gml/1.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/1.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <member>
+                <S128:ElectronicChart gml:id="E001">
+                  <geometry>
+                    <S100:surfaceProperty>
+                      <gml:Surface gml:id="S1">
+                        <gml:patches>
+                          <gml:PolygonPatch>
+                            <gml:exterior>
+                              <gml:LinearRing>
+                                <gml:pos>41.68</gml:pos><gml:pos>21.61</gml:pos>
+                                <gml:pos>41.68</gml:pos><gml:pos>22.90</gml:pos>
+                                <gml:pos>40.10</gml:pos><gml:pos>22.90</gml:pos>
+                                <gml:pos>40.10</gml:pos><gml:pos>21.61</gml:pos>
+                                <gml:pos>41.68</gml:pos><gml:pos>21.61</gml:pos>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                          </gml:PolygonPatch>
+                        </gml:patches>
+                      </gml:Surface>
+                    </S100:surfaceProperty>
+                  </geometry>
+                </S128:ElectronicChart>
+              </member>
+            </S128:Dataset>
+            """;
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(gml));
+        var ds = S128Dataset.Open(stream);
+
+        var f = ds.Features.Single();
+        Assert.Equal(GmlGeometryType.Surface, f.GeometryType);
+        Assert.Equal(5, f.ExteriorRing.Length);
+        Assert.All(f.ExteriorRing, p =>
+        {
+            Assert.InRange(p.Latitude, 40.0, 42.0);
+            Assert.InRange(p.Longitude, 21.0, 23.0);
+        });
+    }
 }

--- a/tests/EncDotNet.S100.Datasets.S128.Tests/S128DatasetReaderTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S128.Tests/S128DatasetReaderTests.cs
@@ -350,4 +350,116 @@ public class S128DatasetReaderTests
             Assert.InRange(p.Longitude, 21.0, 23.0);
         });
     }
+
+    /// <summary>
+    /// When a dataset carries geometry but no <c>&lt;gml:Envelope&gt;</c>, the
+    /// axis-order heuristic cannot run and the reader assumes lat-lon. That
+    /// assumption must be surfaced as a diagnostic (never silent) so a
+    /// lon-lat producer cannot yield a plausible-but-mirrored chart unnoticed.
+    /// </summary>
+    [Fact]
+    public void Reader_EmitsAxisOrderWarning_WhenGeometryHasNoEnvelope()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/gml/1.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/1.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <member>
+                <S128:ElectronicChart gml:gmlId="GST.ElectronicChart.DK1">
+                  <geometry>
+                    <S100:surfaceProperty>
+                      <gml:Polygon>
+                        <gml:posList>50.4 -2.0 50.8 -2.0 50.8 -1.0 50.4 -1.0 50.4 -2.0</gml:posList>
+                      </gml:Polygon>
+                    </S100:surfaceProperty>
+                  </geometry>
+                </S128:ElectronicChart>
+              </member>
+            </S128:Dataset>
+            """;
+
+        var activities = new System.Collections.Concurrent.ConcurrentBag<System.Diagnostics.Activity>();
+        using var listener = new System.Diagnostics.ActivityListener
+        {
+            ShouldListenTo = src => src.Name == "EncDotNet.S100.Datasets.S128",
+            Sample = (ref System.Diagnostics.ActivityCreationOptions<System.Diagnostics.ActivityContext> _) =>
+                System.Diagnostics.ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        System.Diagnostics.ActivitySource.AddActivityListener(listener);
+
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(gml)))
+        {
+            _ = S128Dataset.Open(stream);
+        }
+
+        var open = activities.Single(a => a.OperationName == "s100.dataset.open");
+        Assert.Contains(open.Events, e => e.Name == "s100.s128.axisOrderAssumed");
+        Assert.Equal(true, open.GetTagItem("s100.s128.axisOrderAssumed"));
+    }
+
+    /// <summary>
+    /// The axis-order warning must NOT fire when an envelope is present (the
+    /// heuristic can verify the ordering).
+    /// </summary>
+    [Fact]
+    public void Reader_DoesNotEmitAxisOrderWarning_WhenEnvelopePresent()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S128:Dataset xmlns:S128="http://www.iho.int/S128/2.0"
+                          xmlns:gml="http://www.opengis.net/gml/3.2"
+                          xmlns:S100="http://www.iho.int/s100gml/5.0"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                          gml:id="TEST">
+              <gml:boundedBy>
+                <gml:Envelope srsName="EPSG:4326">
+                  <gml:lowerCorner>50.20 -3.00</gml:lowerCorner>
+                  <gml:upperCorner>51.00  0.00</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <S100:DatasetIdentificationInformation>
+                <S100:productIdentifier>S-128</S100:productIdentifier>
+              </S100:DatasetIdentificationInformation>
+              <S128:members>
+                <S128:ElectronicProduct gml:id="F1">
+                  <S128:geometry>
+                  <S100:surfaceProperty><S100:Surface gml:id="s1">
+                    <gml:patches><gml:PolygonPatch>
+                      <gml:exterior><gml:LinearRing>
+                        <gml:posList>50.4 -2.0 50.8 -2.0 50.8 -1.0 50.4 -1.0 50.4 -2.0</gml:posList>
+                      </gml:LinearRing></gml:exterior>
+                    </gml:PolygonPatch></gml:patches>
+                  </S100:Surface></S100:surfaceProperty>
+                  </S128:geometry>
+                </S128:ElectronicProduct>
+              </S128:members>
+            </S128:Dataset>
+            """;
+
+        var activities = new System.Collections.Concurrent.ConcurrentBag<System.Diagnostics.Activity>();
+        using var listener = new System.Diagnostics.ActivityListener
+        {
+            ShouldListenTo = src => src.Name == "EncDotNet.S100.Datasets.S128",
+            Sample = (ref System.Diagnostics.ActivityCreationOptions<System.Diagnostics.ActivityContext> _) =>
+                System.Diagnostics.ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        System.Diagnostics.ActivitySource.AddActivityListener(listener);
+
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(gml)))
+        {
+            _ = S128Dataset.Open(stream);
+        }
+
+        var open = activities.Single(a => a.OperationName == "s100.dataset.open");
+        Assert.DoesNotContain(open.Events, e => e.Name == "s100.s128.axisOrderAssumed");
+        Assert.Null(open.GetTagItem("s100.s128.axisOrderAssumed"));
+    }
 }


### PR DESCRIPTION
## Summary

Investigates and fixes #243: real-world S-128 (Catalogue of Nautical Products) GML datasets that rendered near-blank.

**Determination:** a mix, confirmed with evidence (a diagnostic harness showed `withGeometry=0` on every feature of the blank datasets vs `352/353` for a 2.0.0 dataset — geometry was present in the GML but silently dropped). Of the 7 flagged datasets, **4 had recoverable geometry the reader failed to parse (bug, now fixed)** and **3 are legitimately near-blank** (2 contain only empty `<gml:pos>` placeholders; 1 is a degenerate zero-area polygon — see #247).

## Root causes (S-128 GML 1.0 producer encodings)

1. Polygons encoded as `<gml:Polygon><gml:posList>` with **no** `<gml:exterior>/<gml:LinearRing>` wrapper.
2. Ring ordinates split across consecutive **single-value** `<gml:pos>` elements instead of full coordinate tuples (`ParsePos` needs ≥2 ordinates → empty ring).
3. Features keyed by the non-standard **`gml:gmlId`** attribute → empty feature id → dropped by the geometry provider.

## Changes

- **`GmlCoordinateParser`** (shared Core): two **strictly additive** producer-bug fallbacks that only engage after the standard parse yields a zero-vertex ring, so conformant data is untouched:
  - exterior-less `<gml:Polygon><gml:posList>` → use the direct `posList`/`pos` sequence as the exterior ring;
  - all-single-ordinate `<gml:pos>` rings → flatten and pair into (lat, lon).
- **`S128DatasetReader`**: accept `gml:gmlId` as a fallback for `gml:id`; emit a diagnostic warning (Activity event + `s100.s128.axisOrderAssumed` tag) when a dataset carries geometry but no `<gml:Envelope>` to verify axis ordering, so an assumed lat-lon order is never silent.
- **Tests**: Variant A (exterior-less + `gml:gmlId`), Variant B (single-ordinate `<gml:pos>`), and the axis-order warning (fires without envelope, silent with one).
- **README**: documents the new producer-bug compensations and the GML 1.0 portrayal/axis caveats (tracked in #247).

## Verification

- Whole-solution suite: **2913 passed / 0 failed / 8 skipped** across 29 assemblies — every GML product green (S-122/124/125/127/128/131/201/411/421).
- Re-rendered the real datasets: the 4 recoverable ones render (5.6–28 KB); the 3 legitimately-blank ones stay blank.
- Independently re-verified via the `ic-enc-validate` harness (S-128: OK 3→5, BLANK 7→3, FAIL 0).

The bundled portrayal/feature catalogue under `content/S128/**` is untouched (byte-identical to upstream). Follow-up #247 tracks first-class GML 1.0 edition portrayal, a reliable axis order for envelope-less datasets, and degenerate-geometry data-quality validation.

Closes #243.