### PR TITLE
Stop S-101 portrayal flooding stdout with valueOfSounding/defaultClearanceDepth fallback "errors" (#241)

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -48,7 +48,10 @@ parameter). When omitted, messages go to `System.Diagnostics.Trace`,
 which is silent on standard output unless a listener is attached — so
 these high-volume, benign fallbacks no longer pollute render/validation
 output. Pass an explicit `Action<string>` to capture or surface them
-(for example behind a verbose/debug flag or in tests).
+(for example behind a verbose/debug flag or in tests). The bundled CLI
+wires this to `--debug`: `s100 render … --debug` mirrors the
+`[Lua]`/`[Host]` diagnostics to **stderr** while keeping stdout (and the
+PNG result) unchanged.
 
 ## Legacy feature-name compatibility
 

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -33,6 +33,23 @@ global rather than editing the bundled catalogue. Current patches:
 
 If upstream fixes a defect, the corresponding patch is dropped.
 
+## Portrayal diagnostics and trace output
+
+The S-100 Part 9A rules emit `Debug.Trace` diagnostics for **expected,
+spec-compliant fallbacks** — most visibly the `OBSTRN07` rule raising
+*"Neither valueOfSounding or defaultClearanceDepth have a value"* for an
+`Obstruction` / `Wreck` / `UnderwaterAwashRock` feature that legitimately
+carries no depth value, after which `main.lua` substitutes Default
+symbology and the cell still renders. These are **not** errors.
+
+`S101LuaDataProvider` therefore routes all Lua/host diagnostic trace
+output through an injectable sink (the optional `trace` constructor
+parameter). When omitted, messages go to `System.Diagnostics.Trace`,
+which is silent on standard output unless a listener is attached — so
+these high-volume, benign fallbacks no longer pollute render/validation
+output. Pass an explicit `Action<string>` to capture or surface them
+(for example behind a verbose/debug flag or in tests).
+
 ## Legacy feature-name compatibility
 
 The bundled Portrayal Catalogue is **S-101 Edition 2.0.0**, whose Lua

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
@@ -22,6 +22,7 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
 
     private readonly S101Document _doc;
     private readonly FeatureCatalogue _fc;
+    private readonly Action<string> _trace;
 
     // Lookup indices built lazily
     private Dictionary<uint, S101FeatureRecord>? _featureById;
@@ -33,12 +34,28 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
     // Collected drawing instruction output
     private readonly List<EmittedInstruction> _emitted = new();
 
-    public S101LuaDataProvider(S101Dataset dataset, FeatureCatalogue featureCatalogue)
+    /// <summary>
+    /// Initialises the provider.
+    /// </summary>
+    /// <param name="dataset">The S-101 dataset to portray.</param>
+    /// <param name="featureCatalogue">The S-101 feature catalogue (ISO 19110).</param>
+    /// <param name="trace">
+    /// Optional sink for host/Lua diagnostic trace output (the S-100 Part 9A
+    /// <c>Debug.Trace</c> / <c>HostDebuggerEntry</c> "trace" channel, plus host
+    /// type-binding diagnostics). When <c>null</c>, messages are routed to
+    /// <see cref="System.Diagnostics.Trace"/>, which is silent on standard output
+    /// unless a listener is attached. This keeps expected, spec-compliant
+    /// portrayal fallbacks (for example the <c>OBSTRN07</c> rule selecting Default
+    /// symbology when a feature legitimately carries neither <c>valueOfSounding</c>
+    /// nor <c>defaultClearanceDepth</c>) from polluting console output.
+    /// </param>
+    public S101LuaDataProvider(S101Dataset dataset, FeatureCatalogue featureCatalogue, Action<string>? trace = null)
     {
         ArgumentNullException.ThrowIfNull(dataset);
         ArgumentNullException.ThrowIfNull(featureCatalogue);
         _doc = dataset.Document;
         _fc = featureCatalogue;
+        _trace = trace ?? (message => System.Diagnostics.Trace.WriteLine(message));
     }
 
     /// <inheritdoc/>
@@ -236,8 +253,8 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
     /// </summary>
     public void RegisterHostFunctions(ILuaContext lua)
     {
-        // Debug table — route Trace to host for diagnostics
-        lua.SetGlobal("HostDebugTrace", (Action<string>)(msg => Console.WriteLine($"[Lua] {msg}")));
+        // Debug table — route Trace to the host diagnostic sink
+        lua.SetGlobal("HostDebugTrace", (Action<string>)(msg => _trace($"[Lua] {msg}")));
         lua.Execute("""
             Debug = {
                 Trace = function(msg) if msg then HostDebugTrace(tostring(msg)) end end,
@@ -304,7 +321,7 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
         lua.SetGlobal("HostDebuggerEntry", (Action<string, string?>)((action, message) =>
         {
             if (action == "trace" && message is not null)
-                Console.WriteLine($"[Lua] {message}");
+                _trace($"[Lua] {message}");
         }));
     }
 
@@ -465,7 +482,7 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
         EnsureFeatureTypeLookup();
         if (!_featureTypeByCode!.TryGetValue(code, out var ft))
         {
-            Console.WriteLine($"[Host] FeatureTypeInfo not found: {code}");
+            _trace($"[Host] FeatureTypeInfo not found: {code}");
             return new Dictionary<string, object?>();
         }
 
@@ -473,7 +490,7 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
         if (code == "DepthArea")
         {
             var bindings = (IReadOnlyDictionary<string, object?>)result["AttributeBindings"]!;
-            Console.WriteLine($"[Host] DepthArea bindings: {string.Join(", ", bindings.Keys.Where(k => k != "Type"))}");
+            _trace($"[Host] DepthArea bindings: {string.Join(", ", bindings.Keys.Where(k => k != "Type"))}");
         }
         return result;
     }

--- a/tests/EncDotNet.S100.Cli.Tests/DiagnosticTraceScopeTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/DiagnosticTraceScopeTests.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using EncDotNet.S100.Cli.Infrastructure;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Tests for <see cref="DiagnosticTraceScope"/>, which surfaces host/Lua
+/// portrayal diagnostics on stderr when <c>s100 render … --debug</c> is used
+/// while keeping them silent by default (issue #241).
+/// </summary>
+[Collection(nameof(DiagnosticTraceScopeTests))]
+[CollectionDefinition(nameof(DiagnosticTraceScopeTests), DisableParallelization = true)]
+public sealed class DiagnosticTraceScopeTests
+{
+    [Fact]
+    public void Scope_active_mirrors_trace_to_standard_error()
+    {
+        var originalError = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            using (DiagnosticTraceScope.ToStandardError())
+            {
+                Trace.WriteLine("[Lua] sample diagnostic");
+            }
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.Contains("[Lua] sample diagnostic", writer.ToString());
+    }
+
+    [Fact]
+    public void After_dispose_trace_is_not_written_to_standard_error()
+    {
+        var originalError = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            using (DiagnosticTraceScope.ToStandardError())
+            {
+            }
+
+            Trace.WriteLine("[Lua] after dispose");
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.DoesNotContain("after dispose", writer.ToString());
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101LuaDataProviderTraceTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101LuaDataProviderTraceTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Scripting;
+
+namespace EncDotNet.S100.Datasets.S101.Tests;
+
+/// <summary>
+/// Tests for the diagnostic trace routing of <see cref="S101LuaDataProvider"/>.
+/// </summary>
+/// <remarks>
+/// The S-100 Part 9A portrayal rules emit <c>Debug.Trace</c> diagnostics for
+/// expected, spec-compliant fallbacks — for example the <c>OBSTRN07</c> rule
+/// raising "Neither valueOfSounding or defaultClearanceDepth have a value" for an
+/// Obstruction/Wreck/UnderwaterAwashRock feature that legitimately carries no
+/// depth value, after which <c>main.lua</c> substitutes Default symbology. These
+/// traces must not be written to standard output by default (issue #241).
+/// </remarks>
+public class S101LuaDataProviderTraceTests
+{
+    [Fact]
+    public void DebugTrace_RoutesToInjectedSink()
+    {
+        var captured = new List<string>();
+        var provider = CreateProvider(captured.Add);
+        var context = new RecordingLuaContext();
+
+        provider.RegisterHostFunctions(context);
+        var hostTrace = Assert.IsAssignableFrom<Action<string>>(context.Globals["HostDebugTrace"]);
+
+        hostTrace("Neither valueOfSounding or defaultClearanceDepth have a value");
+
+        var message = Assert.Single(captured);
+        Assert.Equal("[Lua] Neither valueOfSounding or defaultClearanceDepth have a value", message);
+    }
+
+    [Fact]
+    public void DebugTrace_WithoutSink_DoesNotWriteToConsole()
+    {
+        var provider = CreateProvider(trace: null);
+        var context = new RecordingLuaContext();
+        provider.RegisterHostFunctions(context);
+        var hostTrace = Assert.IsAssignableFrom<Action<string>>(context.Globals["HostDebugTrace"]);
+
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            hostTrace("some diagnostic message");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(string.Empty, writer.ToString());
+    }
+
+    private static S101LuaDataProvider CreateProvider(Action<string>? trace)
+    {
+        var document = new S101Document
+        {
+            Identification = new S101DatasetIdentification { DatasetName = "trace-test" },
+            StructureInfo = new S101DatasetStructureInfo
+            {
+                CoordinateMultiplicationFactorX = 10_000_000,
+                CoordinateMultiplicationFactorY = 10_000_000,
+                CoordinateMultiplicationFactorZ = 10,
+            },
+            FeatureTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            AttributeTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            Points = ImmutableDictionary<uint, S101PointRecord>.Empty,
+            CurveSegments = ImmutableDictionary<uint, S101CurveSegmentRecord>.Empty,
+            CompositeCurves = ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
+            Surfaces = ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
+            Features = ImmutableArray<S101FeatureRecord>.Empty,
+            InformationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty,
+            InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            FeatureAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
+        };
+
+        var featureCatalogue = new FeatureCatalogue
+        {
+            Name = "S-101 test",
+            VersionNumber = "1.0.0",
+            VersionDate = "2024-01-01",
+        };
+
+        return new S101LuaDataProvider(S101Dataset.FromDocument(document), featureCatalogue, trace);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ILuaContext"/> that records globals so the host
+    /// bindings can be invoked directly without a real Lua engine.
+    /// </summary>
+    private sealed class RecordingLuaContext : ILuaContext
+    {
+        public Dictionary<string, object?> Globals { get; } = new();
+
+        public void Execute(string source) { }
+
+        public void SetModuleLoader(Func<string, string?> loader) { }
+
+        public void SetGlobal(string name, object? value) => Globals[name] = value;
+
+        public object? GetGlobal(string name) => Globals.TryGetValue(name, out var value) ? value : null;
+
+        public object? Call(string functionName, params object?[] args) => null;
+
+        public object?[] CallMultiReturn(string functionName, params object?[] args) => [];
+
+        public void Dispose() { }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/DatasetCommandSettings.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/DatasetCommandSettings.cs
@@ -14,7 +14,7 @@ internal class DatasetCommandSettings : CommandSettings
     public string DatasetPath { get; init; } = string.Empty;
 
     [CommandOption("--debug")]
-    [Description("Show full stack traces on error.")]
+    [Description("Show full stack traces on error, and surface host/Lua portrayal diagnostics on stderr.")]
     public bool Debug { get; init; }
 
     public override Spectre.Console.ValidationResult Validate()

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -107,6 +107,7 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
 
     public override int Execute(CommandContext context, Settings settings)
     {
+        using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
         var (factory, catalogueManager) = ProcessorFactoryBuilder.Build();
         try
         {

--- a/tools/EncDotNet.S100.Cli/Infrastructure/DiagnosticTraceScope.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/DiagnosticTraceScope.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Routes <see cref="System.Diagnostics.Trace"/> diagnostic output to standard
+/// error for the lifetime of the scope, then restores the previous listener
+/// configuration on disposal.
+/// </summary>
+/// <remarks>
+/// The portrayal pipelines emit host/Lua diagnostics (for example the S-101
+/// <c>S101LuaDataProvider</c> <c>[Lua]</c> / <c>[Host]</c> trace lines, including
+/// the expected, spec-compliant <c>OBSTRN07</c> "Neither valueOfSounding or
+/// defaultClearanceDepth have a value" fallbacks) via <c>Trace.WriteLine</c>.
+/// These are silent by default — the framework <see cref="DefaultTraceListener"/>
+/// does not write to the console — so they never pollute normal command output.
+/// Activating this scope (the CLI does so when <c>--debug</c> is supplied)
+/// surfaces them on stderr for deep-dive diagnostics without affecting the
+/// PNG/stdout result.
+/// </remarks>
+internal sealed class DiagnosticTraceScope : IDisposable
+{
+    private readonly TextWriterTraceListener _listener;
+    private readonly bool _previousAutoFlush;
+
+    private DiagnosticTraceScope()
+    {
+        _previousAutoFlush = Trace.AutoFlush;
+        Trace.AutoFlush = true;
+        _listener = new TextWriterTraceListener(Console.Error, "cli-stderr");
+        Trace.Listeners.Add(_listener);
+    }
+
+    /// <summary>
+    /// Creates a scope that mirrors <see cref="System.Diagnostics.Trace"/> output
+    /// to standard error.
+    /// </summary>
+    public static DiagnosticTraceScope ToStandardError() => new();
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Trace.Listeners.Remove(_listener);
+        _listener.Flush();
+        _listener.Dispose();
+        Trace.AutoFlush = _previousAutoFlush;
+    }
+}


### PR DESCRIPTION
Fixes #241.

## Determination: expected spec fallback, not a binding bug

Verified against a real IC-ENC GB cell (`101GB00GB302045.000`, 46 messages). Direct inspection of the source ISO 8211 feature records shows the depth values are **genuinely absent**, not dropped by the host:

- 26 Wreck/Obstruction features have **no** `valueOfSounding` attribute and no `defaultClearanceDepth`.
- 20 have `valueOfSounding` **present but empty** and no `defaultClearanceDepth`.
- 26 + 20 = 46 — exactly the message count.
- Features that carry a real value (e.g. `valueOfSounding=15.4`) bind correctly and do **not** error.

The binding is correct: `GetSimpleAttributeValues` filters `attr.Value.Length > 0`, so empty values surface as `nil`. `OBSTRN07.lua` then takes its spec-defined `error(...)` path, which `main.lua` catches and replaces with Default symbology — the cell still renders. The visible "Error:" text is part of the Lua message string (`pc/Rules/main.lua`), **not** a host log level.

## The actual defect: log noise

`S101LuaDataProvider` wrote these diagnostics unconditionally to **stdout** via `Console.WriteLine`, producing ~1,226 `[Lua]`/`[Host]` lines across the corpus even without `--debug`.

## Changes

- **`S101LuaDataProvider`**: added an injectable `Action<string>? trace` constructor parameter, defaulting to `System.Diagnostics.Trace.WriteLine` (silent on the console unless a listener is attached). Rerouted `HostDebugTrace`, the `HostDebuggerEntry` trace channel, and the two leftover `[Host]` debug `Console.WriteLine` calls through it.
- **CLI `--debug`**: added `DiagnosticTraceScope`, which the `render` command activates when `--debug` is supplied — it attaches a stderr trace listener so the `[Lua]`/`[Host]` diagnostics remain inspectable on demand, then detaches on dispose.
- Upstream PC Lua rule files left untouched. **No change to portrayal output.**
- Tests: `S101LuaDataProviderTraceTests` (sink receives message; default writes nothing to stdout) and `DiagnosticTraceScopeTests` (scope mirrors to stderr, stops on dispose). Updated the S-101 README and `--debug` help text.

## Verification

On `101GB00GB302045.000`:
- **Default**: stdout = `Wrote … (S-101, 1024x768)`, **0** `[Lua]`/`[Host]` lines anywhere (was 46 on that cell).
- **`--debug`**: stdout unchanged; the diagnostics appear on **stderr**; PNG unchanged.

All 66 S-101 dataset tests + 32 CLI tests pass; S-57 (which reuses the S-101 executor) still builds.