### PR TITLE
Map S100DatasetNotSupportedException to exit 4 in CLI render/info (dcf1)

### DIFF
--- a/tests/EncDotNet.S100.Cli.Tests/UnsupportedDataCodingFormatTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/UnsupportedDataCodingFormatTests.cs
@@ -1,0 +1,110 @@
+using EncDotNet.S100.Cli.Infrastructure;
+using PureHDF;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Verifies that a recognised dataset using a data coding format the reader
+/// does not yet implement — data coding format 1 (irregular time series at
+/// fixed stations; S-100 Part 10c §10.2.1) — is reported as a graceful
+/// "not supported" render with the dedicated exit code 4, rather than
+/// crashing as a generic error (exit 1). Regression test for issue #253.
+/// </summary>
+/// <remarks>
+/// The S-104/S-111 readers recognise dcf1 and throw
+/// <c>S100DatasetNotSupportedException</c>, which does NOT derive from
+/// <see cref="NotSupportedException"/>. The CLI render/info commands gained a
+/// dedicated catch for it so it maps to exit 4 alongside the dcf8 fixed-station
+/// path (which throws a plain <see cref="NotSupportedException"/>).
+/// </remarks>
+public sealed class UnsupportedDataCodingFormatTests
+{
+    [Fact]
+    public void Render_dcf1_s111_returns_exit_4_and_writes_no_png()
+    {
+        var dataset = Path.Combine(Path.GetTempPath(), $"s111-dcf1-{Guid.NewGuid():N}.h5");
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        try
+        {
+            WriteDcf1S111(dataset);
+
+            int exit = CliApp.Build().Run(["render", dataset, output]);
+
+            Assert.Equal(4, exit);
+            Assert.False(File.Exists(output));
+        }
+        finally
+        {
+            if (File.Exists(dataset)) File.Delete(dataset);
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_dcf1_s104_returns_exit_4_and_writes_no_png()
+    {
+        var dataset = Path.Combine(Path.GetTempPath(), $"s104-dcf1-{Guid.NewGuid():N}.h5");
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        try
+        {
+            WriteDcf1S104(dataset);
+
+            int exit = CliApp.Build().Run(["render", dataset, output]);
+
+            Assert.Equal(4, exit);
+            Assert.False(File.Exists(output));
+        }
+        finally
+        {
+            if (File.Exists(dataset)) File.Delete(dataset);
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    /// <summary>
+    /// Writes a minimal S-111 file whose <c>/SurfaceCurrent</c> container
+    /// declares <c>dataCodingFormat = 1</c> (irregular time series at fixed
+    /// stations; S-100 Part 10c §10.2.1). The reader rejects the format before
+    /// reading any instance, so no <c>SurfaceCurrent.NN</c> group is required.
+    /// </summary>
+    private static void WriteDcf1S111(string path)
+    {
+        var file = new H5File
+        {
+            Attributes = new Dictionary<string, object>
+            {
+                ["productSpecification"] = "INT.IHO.S-111.2.0",
+            },
+            ["SurfaceCurrent"] = new H5Group
+            {
+                Attributes = new Dictionary<string, object> { ["dataCodingFormat"] = (byte)1 },
+            },
+        };
+
+        file.Write(path);
+    }
+
+    /// <summary>
+    /// Writes a minimal S-104 file whose <c>/WaterLevel</c> container declares
+    /// <c>dataCodingFormat = 1</c> (irregular time series at fixed stations;
+    /// S-100 Part 10c §10.2.1). The reader rejects the format before reading
+    /// any instance, so no <c>WaterLevel.NN</c> group is required.
+    /// </summary>
+    private static void WriteDcf1S104(string path)
+    {
+        var file = new H5File
+        {
+            Attributes = new Dictionary<string, object>
+            {
+                ["horizontalCRS"] = 4326,
+                ["productSpecification"] = "INT.IHO.S-104.2.0",
+            },
+            ["WaterLevel"] = new H5Group
+            {
+                Attributes = new Dictionary<string, object> { ["dataCodingFormat"] = (byte)1 },
+            },
+        };
+
+        file.Write(path);
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/InfoCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/InfoCommand.cs
@@ -60,6 +60,24 @@ internal sealed class InfoCommand : Command<DatasetCommandSettings>
 
             return 0;
         }
+        catch (NotSupportedException ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 4;
+        }
+        catch (S100DatasetNotSupportedException ex)
+        {
+            // Recognised-but-not-yet-implemented spec feature (e.g. data coding
+            // format 1). Does not derive from NotSupportedException, so it needs
+            // its own catch to map to exit 4 rather than the generic exit-1 path.
+            // See issue #253.
+            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 4;
+        }
         catch (S100DatasetSchemaException ex)
         {
             AnsiConsole.MarkupLineInterpolated($"[yellow]Non-conforming dataset:[/] {ex.Message}");

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -161,6 +161,19 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 AnsiConsole.WriteException(ex);
             return 4;
         }
+        catch (S100DatasetNotSupportedException ex)
+        {
+            // Distinct from NotSupportedException (e.g. the dcf8 headless path):
+            // readers raise this for recognised-but-not-yet-implemented spec
+            // features such as data coding format 1 (irregular fixed-station
+            // time series). It does not derive from NotSupportedException, so it
+            // needs its own catch to avoid falling through to the generic exit-1
+            // path. See issue #253.
+            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 4;
+        }
         catch (S100DatasetSchemaException ex)
         {
             AnsiConsole.MarkupLineInterpolated($"[yellow]Non-conforming dataset:[/] {ex.Message}");

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -148,6 +148,6 @@ headless render path.
 | `1` | Unhandled error (use `--debug` for a stack trace). |
 | `2` | Product specification could not be detected. |
 | `3` | The detected spec does not support headless rendering. |
-| `4` | The dataset is recognised but its shape is unsupported (e.g. fixed-station coverage). |
+| `4` | The dataset is recognised but its shape or encoding is unsupported — e.g. a fixed-station coverage, or a data coding format the reader does not yet implement (such as dcf1, irregular time series at fixed stations). |
 | `5` | The dataset is recognised but non-conforming (a required attribute, dataset, or group is missing or malformed). |
 | non-zero | Argument validation failure (missing file, bad palette, etc.). |


### PR DESCRIPTION
Fixes #253.

## Problem

S-104/S-111 datasets using **data coding format 1** (irregular time series at fixed stations; S-100 Part 10c §10.2.1) crashed the CLI with **exit 1** instead of being classified as a graceful "unsupported" render (**exit 4**), the way dcf3/dcf8 datasets already are. This affected 420 real-world IC-ENC datasets (S-111×408, S-104×12) found during validation.

## Root cause

The S-104/S-111 readers correctly recognise dcf1 and throw `S100DatasetNotSupportedException`, but that type derives from `System.Exception`, **not** `System.NotSupportedException`. So `RenderCommand`'s `catch (NotSupportedException) → exit 4` missed it and it fell through to the generic `catch (Exception) → exit 1`. `InfoCommand` had the same gap.

## Fix (pure crash→graceful classification — readers unchanged)

- `RenderCommand.cs`: added `catch (S100DatasetNotSupportedException) → exit 4` ahead of the generic catch.
- `InfoCommand.cs`: added `catch (NotSupportedException) → exit 4` and `catch (S100DatasetNotSupportedException) → exit 4` to close the same gap.
- dcf1 rendering itself is **not** implemented (genuinely unsupported) — tracked separately in #256.

### Exception types now mapping to exit 4

| Exception | Source |
|---|---|
| `System.NotSupportedException` | already mapped (e.g. dcf8 headless path) |
| `EncDotNet.S100.Hdf5.S100DatasetNotSupportedException` | **new** — recognised-but-not-yet-implemented spec features (e.g. dcf1) |

## Tests

Added `UnsupportedDataCodingFormatTests` (mirrors `NonConformingDatasetTests` from #242): synthetic dcf1 S-111 and dcf1 S-104 HDF5 files render to **exit 4** and write no PNG. Full CLI suite green (35 passed).

## Docs

Broadened the exit-4 row in the CLI README to cover unsupported data coding formats / not-yet-implemented features.

## Follow-up

Real dcf1 support is substantial (irregular timestamps need a model change in both readers) and blocked on fixed-station headless rendering (#191). Filed #256 to track it.