### PR TITLE
Resolve real-world S-100 exchange set dataset paths

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
@@ -71,7 +71,7 @@ public sealed class ExchangeSetLoader
             cancellationToken.ThrowIfCancellationRequested();
 
             var metadata = datasets[i];
-            var relativePath = ExchangeSet.NormalizeFileName(metadata.FileName);
+            var relativePath = metadata.RelativePath;
             progress?.Report(new ExchangeSetProgress(i + 1, total, relativePath));
 
             IDatasetProcessor? processor = null;

--- a/src/EncDotNet.S100.ExchangeSets/CatalogueDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/CatalogueDiscoveryMetadata.cs
@@ -4,6 +4,19 @@ public sealed class CatalogueDiscoveryMetadata
 {
     public required string FileName { get; init; }
 
+    /// <summary>
+    /// The directory of the catalogue file relative to the exchange set
+    /// root, as declared by the catalogue's <c>filePath</c> element.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 17.</remarks>
+    public string? FilePath { get; init; }
+
+    /// <summary>
+    /// The source-relative path of the catalogue file, combining
+    /// <see cref="FilePath"/> and <see cref="FileName"/>.
+    /// </summary>
+    public string RelativePath => ExchangeSet.ResolveRelativePath(FilePath, FileName);
+
     public string? Purpose { get; init; }
 
     public int? EditionNumber { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/DatasetDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/DatasetDiscoveryMetadata.cs
@@ -4,6 +4,23 @@ public sealed class DatasetDiscoveryMetadata
 {
     public required string FileName { get; init; }
 
+    /// <summary>
+    /// The directory of the dataset file relative to the exchange set
+    /// root, as declared by the catalogue's <c>filePath</c> element.
+    /// May be <see langword="null"/> when the file lives at the root or
+    /// the path is folded into <see cref="FileName"/>.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 17.</remarks>
+    public string? FilePath { get; init; }
+
+    /// <summary>
+    /// The source-relative path of the dataset file, combining
+    /// <see cref="FilePath"/> and <see cref="FileName"/> and normalizing
+    /// separators. This is the path to pass to an
+    /// <see cref="EncDotNet.S100.Core.IAssetSource"/>.
+    /// </summary>
+    public string RelativePath => ExchangeSet.ResolveRelativePath(FilePath, FileName);
+
     public string? Description { get; init; }
 
     public bool CompressionFlag { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -55,17 +55,20 @@ public static class ExchangeCatalogueReader
             Certificates = ReadCertificateBlock(root.Element(xc + "certificates")),
             DatasetDiscoveryMetadata = root
                 .Element(xc + "datasetDiscoveryMetadata")?
-                .Elements(xc + "S100_DatasetDiscoveryMetadata")
+                .Elements()
+                .Where(e => e.Name.LocalName.EndsWith("_DatasetDiscoveryMetadata", StringComparison.Ordinal))
                 .Select(e => ReadDatasetDiscovery(e, xc, lan))
                 .ToList() ?? [],
             SupportFileDiscoveryMetadata = root
                 .Element(xc + "supportFileDiscoveryMetadata")?
-                .Elements(xc + "S100_SupportFileDiscoveryMetadata")
+                .Elements()
+                .Where(e => e.Name.LocalName.EndsWith("_SupportFileDiscoveryMetadata", StringComparison.Ordinal))
                 .Select(e => ReadSupportFileDiscovery(e, xc))
                 .ToList() ?? [],
             CatalogueDiscoveryMetadata = root
                 .Element(xc + "catalogueDiscoveryMetadata")?
-                .Elements(xc + "S100_CatalogueDiscoveryMetadata")
+                .Elements()
+                .Where(e => e.Name.LocalName.EndsWith("_CatalogueDiscoveryMetadata", StringComparison.Ordinal))
                 .Select(e => ReadCatalogueDiscovery(e, xc, lan))
                 .ToList() ?? [],
         };
@@ -113,6 +116,7 @@ public static class ExchangeCatalogueReader
         return new DatasetDiscoveryMetadata
         {
             FileName = (string)element.Element(xc + "fileName")!,
+            FilePath = (string?)element.Element(xc + "filePath"),
             Description = ReadCharacterString(element.Element(xc + "description")),
             CompressionFlag = ParseBool(element, "compressionFlag", xc),
             DataProtection = ParseBool(element, "dataProtection", xc),
@@ -148,6 +152,7 @@ public static class ExchangeCatalogueReader
         return new SupportFileDiscoveryMetadata
         {
             FileName = (string)element.Element(xc + "fileName")!,
+            FilePath = (string?)element.Element(xc + "filePath"),
             RevisionStatus = (string?)element.Element(xc + "revisionStatus"),
             EditionNumber = ParseInt(element, "editionNumber", xc),
             IssueDate = (string?)element.Element(xc + "issueDate"),
@@ -174,6 +179,7 @@ public static class ExchangeCatalogueReader
         return new CatalogueDiscoveryMetadata
         {
             FileName = (string)element.Element(xc + "fileName")!,
+            FilePath = (string?)element.Element(xc + "filePath"),
             Purpose = (string?)element.Element(xc + "purpose"),
             EditionNumber = ParseInt(element, "editionNumber", xc),
             Scope = (string?)element.Element(xc + "scope"),

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSet.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSet.cs
@@ -56,7 +56,7 @@ public sealed class ExchangeSet : IDisposable
     public Task<Stream> FetchDatasetAsync(DatasetDiscoveryMetadata dataset, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(dataset);
-        return _source.OpenAsync(NormalizeFileName(dataset.FileName), cancellationToken);
+        return _source.OpenAsync(ResolveRelativePath(dataset.FilePath, dataset.FileName), cancellationToken);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public sealed class ExchangeSet : IDisposable
     public Task<Stream> FetchSupportFileAsync(SupportFileDiscoveryMetadata supportFile, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(supportFile);
-        return _source.OpenAsync(NormalizeFileName(supportFile.FileName), cancellationToken);
+        return _source.OpenAsync(ResolveRelativePath(supportFile.FilePath, supportFile.FileName), cancellationToken);
     }
 
     /// <summary>
@@ -74,24 +74,79 @@ public sealed class ExchangeSet : IDisposable
     public Task<Stream> FetchCatalogueFileAsync(CatalogueDiscoveryMetadata catalogueFile, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(catalogueFile);
-        return _source.OpenAsync(NormalizeFileName(catalogueFile.FileName), cancellationToken);
+        return _source.OpenAsync(ResolveRelativePath(catalogueFile.FilePath, catalogueFile.FileName), cancellationToken);
     }
 
     /// <inheritdoc />
     public void Dispose() => _source.Dispose();
 
     /// <summary>
-    /// Strips the <c>file:/</c> URI prefix that S-100 exchange catalogues may use on file names.
+    /// Normalizes a catalogue-declared file name into a source-relative path:
+    /// strips the <c>file:/</c> URI prefix, converts Windows-style
+    /// backslash separators to forward slashes, and removes any leading
+    /// slashes (which S-100 catalogues occasionally use to denote
+    /// "from the exchange set root" but which would otherwise be treated
+    /// as an absolute path by the underlying asset source).
     /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 17.</remarks>
     public static string NormalizeFileName(string fileName)
     {
         ArgumentException.ThrowIfNullOrEmpty(fileName);
 
-        if (fileName.StartsWith("file:/", StringComparison.OrdinalIgnoreCase))
+        var name = fileName;
+
+        if (name.StartsWith("file:/", StringComparison.OrdinalIgnoreCase))
         {
-            return fileName["file:/".Length..];
+            name = name["file:/".Length..];
         }
 
-        return fileName;
+        name = name.Replace('\\', '/').TrimStart('/');
+
+        return name;
+    }
+
+    /// <summary>
+    /// Resolves the source-relative path of a catalogue entry from its
+    /// optional <c>filePath</c> directory and its <c>fileName</c>.
+    /// </summary>
+    /// <param name="filePath">
+    /// The directory of the file relative to the exchange set root, as
+    /// declared by the catalogue's <c>filePath</c> element. May be
+    /// <see langword="null"/>, empty, Windows-separated, or carry a
+    /// leading slash. When absent, the file is assumed to live at the
+    /// root (or the <paramref name="fileName"/> itself carries the path).
+    /// </param>
+    /// <param name="fileName">The catalogue-declared file name.</param>
+    /// <returns>A normalized, forward-slashed, root-relative path.</returns>
+    /// <remarks>
+    /// S-100 Edition 5.2.1 Part 17. Some producers (e.g. UKHO S-101,
+    /// NOAA S-102) place datasets in sub-directories and declare the
+    /// directory separately via <c>filePath</c> while <c>fileName</c>
+    /// carries only the bare file name; others fold the whole path into
+    /// <c>fileName</c>. Both forms resolve here.
+    /// </remarks>
+    public static string ResolveRelativePath(string? filePath, string fileName)
+    {
+        var normalizedName = NormalizeFileName(fileName);
+
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return normalizedName;
+        }
+
+        var directory = filePath.Replace('\\', '/').Trim().Trim('/');
+        if (directory.Length == 0)
+        {
+            return normalizedName;
+        }
+
+        // Guard against double-prefixing when the file name already
+        // carries the directory portion.
+        if (normalizedName.StartsWith(directory + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return normalizedName;
+        }
+
+        return directory + "/" + normalizedName;
     }
 }

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerifier.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerifier.cs
@@ -40,7 +40,7 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         foreach (var ds in catalogue.DatasetDiscoveryMetadata)
         {
             var result = await VerifyFileAsync(
-                source, ds.FileName, ds.DigitalSignatureValue, ds.DigitalSignatureAlgorithm,
+                source, ds.RelativePath, ds.DigitalSignatureValue, ds.DigitalSignatureAlgorithm,
                 certLookup, trustAnchors, cancellationToken);
             results.Add(result);
         }
@@ -49,7 +49,7 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         foreach (var sf in catalogue.SupportFileDiscoveryMetadata)
         {
             var result = await VerifyFileAsync(
-                source, sf.FileName, sf.DigitalSignatureValue, sf.DigitalSignatureAlgorithm,
+                source, sf.RelativePath, sf.DigitalSignatureValue, sf.DigitalSignatureAlgorithm,
                 certLookup, trustAnchors, cancellationToken);
             results.Add(result);
         }
@@ -58,7 +58,7 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         foreach (var cf in catalogue.CatalogueDiscoveryMetadata)
         {
             var result = await VerifyFileAsync(
-                source, cf.FileName, cf.DigitalSignatureValue, cf.DigitalSignatureAlgorithm,
+                source, cf.RelativePath, cf.DigitalSignatureValue, cf.DigitalSignatureAlgorithm,
                 certLookup, trustAnchors, cancellationToken);
             results.Add(result);
         }

--- a/src/EncDotNet.S100.ExchangeSets/README.md
+++ b/src/EncDotNet.S100.ExchangeSets/README.md
@@ -13,6 +13,32 @@ This library parses S-100 Exchange Set `CATALOG.XML` files and provides access t
 - **`SupportFileDiscoveryMetadata`** — metadata for support files.
 - **`CatalogueDiscoveryMetadata`** — metadata for embedded catalogues.
 
+## File path resolution
+
+Producers lay out exchange sets in different ways, and the catalogue can
+describe a file's location in several forms. `ExchangeSet` normalizes all
+of them into a single source-relative path:
+
+- A separate `<filePath>` directory element combined with a bare
+  `<fileName>` (e.g. UKHO S-101: `filePath=101GB00502793`,
+  `fileName=101GB00502793.000`).
+- A full path folded into `<fileName>`, optionally with a `file:/` URI
+  prefix (e.g. `file:/S-101/DATASET_FILES/101AU005BTB01.000`).
+- Windows-style separators and a leading slash in `<filePath>`
+  (e.g. NOAA S-102: `\S102\PBC_UTM11N_MLLW_LALB`).
+
+Use **`DatasetDiscoveryMetadata.RelativePath`** (and the equivalent on the
+support/catalogue metadata types) — or the static
+`ExchangeSet.ResolveRelativePath(filePath, fileName)` — to obtain the path
+to pass to an `IAssetSource`. `ExchangeSet.NormalizeFileName` handles the
+`file:/` prefix, backslash separators, and leading slashes on a bare file
+name.
+
+The reader also recognizes dataset/support/catalogue discovery items that
+are wrapped in product-specific elements and namespaces
+(e.g. `S102_DatasetDiscoveryMetadata` in `http://www.iho.int/s102/2.0/xc`),
+not just the generic `S100_DatasetDiscoveryMetadata`.
+
 ## Digital Signature Verification
 
 The library implements the S-100 Part 15 Data Protection Scheme for **signature verification**. Exchange sets may include per-file digital signatures (DSA or ECDSA P-256 over SHA-256) embedded in `CATALOG.XML`, along with a certificate block referencing the signing data provider.

--- a/src/EncDotNet.S100.ExchangeSets/SupportFileDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/SupportFileDiscoveryMetadata.cs
@@ -4,6 +4,19 @@ public sealed class SupportFileDiscoveryMetadata
 {
     public required string FileName { get; init; }
 
+    /// <summary>
+    /// The directory of the support file relative to the exchange set
+    /// root, as declared by the catalogue's <c>filePath</c> element.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 17.</remarks>
+    public string? FilePath { get; init; }
+
+    /// <summary>
+    /// The source-relative path of the support file, combining
+    /// <see cref="FilePath"/> and <see cref="FileName"/>.
+    /// </summary>
+    public string RelativePath => ExchangeSet.ResolveRelativePath(FilePath, FileName);
+
     public string? RevisionStatus { get; init; }
 
     public int? EditionNumber { get; init; }

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -152,7 +152,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     break;
                 }
 
-                var relativePath = ExchangeSet.NormalizeFileName(metadata.FileName);
+                var relativePath = metadata.RelativePath;
                 var spec = DatasetPipelineFactory.MapProductIdentifierToSpec(
                     metadata.ProductSpecification?.ProductIdentifier);
                 if (spec is null)

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeSetPathResolutionTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeSetPathResolutionTests.cs
@@ -1,0 +1,91 @@
+using System.Runtime.CompilerServices;
+
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+/// <summary>
+/// Tests covering source-relative path resolution for real-world S-100
+/// exchange set layouts (IC-ENC): a separate <c>filePath</c> directory
+/// element, Windows-style/leading-slash paths, <c>file:/</c> prefixes,
+/// and dataset discovery items wrapped in product-specific elements and
+/// namespaces.
+/// </summary>
+public class ExchangeSetPathResolutionTests
+{
+    private static string GetFixturePath(string fileName, [CallerFilePath] string callerFilePath = "")
+    {
+        return Path.Combine(Path.GetDirectoryName(callerFilePath)!, "..", "datasets", "ExchangeSets", fileName);
+    }
+
+    [Theory]
+    [InlineData("101GB00502793.000", "101GB00502793.000")]
+    [InlineData("file:/S-101/DATASET_FILES/101AU005BTB01.000", "S-101/DATASET_FILES/101AU005BTB01.000")]
+    [InlineData("\\S102\\PBC_UTM11N_MLLW_LALB\\102USA16LGBAC200408.H5", "S102/PBC_UTM11N_MLLW_LALB/102USA16LGBAC200408.H5")]
+    [InlineData("/leading/slash/file.000", "leading/slash/file.000")]
+    public void NormalizeFileName_NormalizesPrefixSeparatorsAndLeadingSlash(string input, string expected)
+    {
+        Assert.Equal(expected, ExchangeSet.NormalizeFileName(input));
+    }
+
+    [Fact]
+    public void ResolveRelativePath_JoinsFilePathAndFileName()
+    {
+        Assert.Equal(
+            "101GB00502793/101GB00502793.000",
+            ExchangeSet.ResolveRelativePath("101GB00502793", "101GB00502793.000"));
+    }
+
+    [Fact]
+    public void ResolveRelativePath_NormalizesWindowsSeparatorsAndLeadingSlash()
+    {
+        Assert.Equal(
+            "S102/PBC_UTM11N_MLLW_LALB/102USA16LGBAC200408.H5",
+            ExchangeSet.ResolveRelativePath("\\S102\\PBC_UTM11N_MLLW_LALB", "102USA16LGBAC200408.H5"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveRelativePath_FallsBackToFileNameWhenFilePathAbsent(string? filePath)
+    {
+        Assert.Equal(
+            "S-101/DATASET_FILES/101AU005BTB01.000",
+            ExchangeSet.ResolveRelativePath(filePath, "file:/S-101/DATASET_FILES/101AU005BTB01.000"));
+    }
+
+    [Fact]
+    public void ResolveRelativePath_DoesNotDoublePrefixWhenFileNameAlreadyCarriesDirectory()
+    {
+        Assert.Equal(
+            "S102/PBC/file.H5",
+            ExchangeSet.ResolveRelativePath("S102/PBC", "S102/PBC/file.H5"));
+    }
+
+    [Fact]
+    public void Read_SeparateFilePath_CapturesFilePathAndResolvesRelativePath()
+    {
+        var catalogue = ExchangeCatalogueReader.Read(GetFixturePath("SeparateFilePath_CATALOG.XML"));
+
+        var dataset = Assert.Single(catalogue.DatasetDiscoveryMetadata);
+        Assert.Equal("101GB00502793.000", dataset.FileName);
+        Assert.Equal("101GB00502793", dataset.FilePath);
+        Assert.Equal("101GB00502793/101GB00502793.000", dataset.RelativePath);
+
+        var support = Assert.Single(catalogue.SupportFileDiscoveryMetadata);
+        Assert.Equal("support/101GB00G2BXXX.TXT", support.RelativePath);
+    }
+
+    [Fact]
+    public void Read_ProductSpecificWrapper_ParsesDatasetsAndResolvesRelativePath()
+    {
+        var catalogue = ExchangeCatalogueReader.Read(GetFixturePath("ProductWrapper_CATALOG.XML"));
+
+        Assert.Equal(2, catalogue.DatasetDiscoveryMetadata.Count);
+
+        var first = catalogue.DatasetDiscoveryMetadata[0];
+        Assert.Equal("102USA16LGBAC200408.H5", first.FileName);
+        Assert.Equal("\\S102\\PBC_UTM11N_MLLW_LALB", first.FilePath);
+        Assert.Equal("S102/PBC_UTM11N_MLLW_LALB/102USA16LGBAC200408.H5", first.RelativePath);
+        Assert.Equal("S-102", first.ProductSpecification?.ProductIdentifier);
+    }
+}

--- a/tests/datasets/ExchangeSets/ProductWrapper_CATALOG.XML
+++ b/tests/datasets/ExchangeSets/ProductWrapper_CATALOG.XML
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Synthetic fixture modelled on NOAA S-102 IC-ENC exchange sets:
+     dataset discovery items wrapped in a product-specific element and
+     namespace (S102_DatasetDiscoveryMetadata), with a Windows-style,
+     leading-backslash filePath. Inner fields remain in the S100XC
+     namespace. -->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc"
+    xmlns:S102XC="http://www.iho.int/s102/2.0/xc"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>TEST_PRODUCT_WRAPPER</S100XC:identifier>
+    <S100XC:dateTime>2020-05-19T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:datasetDiscoveryMetadata>
+    <S102XC:S102_DatasetDiscoveryMetadata>
+      <S100XC:fileName>102USA16LGBAC200408.H5</S100XC:fileName>
+      <S100XC:filePath>\S102\PBC_UTM11N_MLLW_LALB</S100XC:filePath>
+      <S100XC:productSpecification>
+        <S100XC:name>S-102</S100XC:name>
+        <S100XC:productIdentifier>S-102</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S102XC:S102_DatasetDiscoveryMetadata>
+    <S102XC:S102_DatasetDiscoveryMetadata>
+      <S100XC:fileName>102USA16LGBAD200408.H5</S100XC:fileName>
+      <S100XC:filePath>\S102\PBC_UTM11N_MLLW_LALB</S100XC:filePath>
+      <S100XC:productSpecification>
+        <S100XC:name>S-102</S100XC:name>
+        <S100XC:productIdentifier>S-102</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S102XC:S102_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>

--- a/tests/datasets/ExchangeSets/SeparateFilePath_CATALOG.XML
+++ b/tests/datasets/ExchangeSets/SeparateFilePath_CATALOG.XML
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Synthetic fixture modelled on UKHO S-101 IC-ENC exchange sets:
+     a bare fileName plus a separate filePath directory element. -->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>TEST_SEPARATE_FILEPATH</S100XC:identifier>
+    <S100XC:dateTime>2022-02-07T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>101GB00502793.000</S100XC:fileName>
+      <S100XC:filePath>101GB00502793</S100XC:filePath>
+      <S100XC:productSpecification>
+        <S100XC:name>S-101</S100XC:name>
+        <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+  <S100XC:supportFileDiscoveryMetadata>
+    <S100XC:S100_SupportFileDiscoveryMetadata>
+      <S100XC:fileName>101GB00G2BXXX.TXT</S100XC:fileName>
+      <S100XC:filePath>support</S100XC:filePath>
+    </S100XC:S100_SupportFileDiscoveryMetadata>
+  </S100XC:supportFileDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>


### PR DESCRIPTION
## Summary

Real-world S-100 exchange sets (IC-ENC) failed to load in the viewer. Investigation against GB/US/AU/DE datasets surfaced **three distinct bugs** in `EncDotNet.S100.ExchangeSets`, all related to how a dataset's location is described in `CATALOG.XML` and resolved to a source-relative path.

## Root causes (confirmed against real data)

| Dataset | Symptom | Cause |
|---|---|---|
| GB S-101 | `FileNotFound` | catalogue's separate `<filePath>` directory element (`101GB00502793`) was never parsed — only `fileName` was used |
| US S-102 | **0 datasets parsed** | discovery items wrapped in a product-specific element/namespace `S102_DatasetDiscoveryMetadata` (`http://www.iho.int/s102/2.0/xc`); reader only matched `S100_DatasetDiscoveryMetadata` |
| US S-111 | **0 datasets parsed** | same wrapper issue (`S111_DatasetDiscoveryMetadata`) |
| US S-102 | broken path once found | `filePath` = `\S102\PBC_UTM11N_MLLW_LALB` (Windows separators + leading slash) became an absolute path on POSIX |
| AU/DE S-101 | already worked | `file:/`-prefixed full path folded into `fileName` (regression-checked) |

## Changes

- **Parse `<filePath>`** into a new `FilePath` property on the dataset/support/catalogue discovery metadata types, plus a computed **`RelativePath`**.
- Harden **`ExchangeSet.NormalizeFileName`** (strips `file:/`, converts `\`→`/`, trims leading slashes).
- Add **`ExchangeSet.ResolveRelativePath(filePath, fileName)`** that joins the directory and file name (guarding against double-prefixing).
- **`ExchangeCatalogueReader`** now selects discovery items by local-name suffix (`*_DatasetDiscoveryMetadata`, etc.) regardless of namespace; inner fields stay in the S100XC namespace.
- Route the loader (`ExchangeSetLoader`), verifier (`ExchangeSetVerifier`), and viewer (`ExchangeSetService`) through `RelativePath`.
- README documentation for path-resolution behavior.

Spec reference: S-100 Edition 5.2.1 Part 17 (Exchange Sets).

## Tests

- New `ExchangeSetPathResolutionTests` covering `NormalizeFileName`, `ResolveRelativePath`, and both new catalogue layouts, with two synthetic fixtures under `tests/datasets/ExchangeSets/`.
- ExchangeSets tests: **65 passed**; Pipelines tests: **503 passed, 1 skipped**; Viewer builds clean.
- Manually verified all four IC-ENC layouts load in the viewer.