### PR TITLE
Add `s100 validate` CLI command with compiler-style suppression

### DIFF
--- a/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
@@ -78,4 +78,47 @@ public sealed class OptionParsingTests
         Assert.Equal(DrawingInstructionCategory.None, categories);
         Assert.Equal(expectedBadToken, badToken);
     }
+
+    [Theory]
+    [InlineData("S101-R-1.2", new[] { "S101-R-1.2" })]
+    [InlineData(" S101-R-1.2 , S101-R-3.2 ", new[] { "S101-R-1.2", "S101-R-3.2" })]
+    [InlineData("S101-*,,S102-*", new[] { "S101-*", "S102-*" })]
+    public void TryParseSuppressPatterns_splits_and_trims(string input, string[] expected)
+    {
+        Assert.True(ValidateCommand.TryParseSuppressPatterns(input, out var patterns));
+        Assert.Equal(expected, patterns);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(",")]
+    [InlineData("  ,  ")]
+    public void TryParseSuppressPatterns_rejects_empty(string input)
+    {
+        Assert.False(ValidateCommand.TryParseSuppressPatterns(input, out var patterns));
+        Assert.Empty(patterns);
+    }
+
+    [Theory]
+    [InlineData("S101-R-1.2", "S101-R-1.2", true)]   // exact
+    [InlineData("S101-R-1.2", "s101-r-1.2", true)]   // case-insensitive
+    [InlineData("S101-R-1.2", "S101-R-1.3", false)]  // dot is literal, not wildcard
+    [InlineData("S101-R-1.2", "S101-*", true)]       // prefix glob
+    [InlineData("S111-PROJ-UNSUPPORTED", "*-PROJ-UNSUPPORTED", true)] // suffix glob
+    [InlineData("S101-R-1.2", "S101-R-1.*", true)]   // mid glob
+    [InlineData("S102-R-4.1", "S101-*", false)]      // non-match
+    [InlineData("anything", "*", true)]              // match-all
+    public void RuleIdMatches_supports_case_insensitive_globs(string ruleId, string pattern, bool expected)
+    {
+        Assert.Equal(expected, ValidateCommand.RuleIdMatches(ruleId, pattern));
+    }
+
+    [Fact]
+    public void IsSuppressed_matches_any_pattern()
+    {
+        string[] patterns = ["S101-R-1.2", "S102-*"];
+        Assert.True(ValidateCommand.IsSuppressed("S101-R-1.2", patterns));
+        Assert.True(ValidateCommand.IsSuppressed("S102-R-9.9", patterns));
+        Assert.False(ValidateCommand.IsSuppressed("S104-R-1.1", patterns));
+    }
 }

--- a/tests/EncDotNet.S100.Cli.Tests/ValidateCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/ValidateCommandTests.cs
@@ -69,6 +69,57 @@ public sealed class ValidateCommandTests
         Assert.NotEqual(0, exit);
     }
 
+    [Fact]
+    public void Validate_with_empty_suppress_returns_nonzero()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        int exit = CliApp.Build().Run(["validate", dataset, "--suppress", ","]);
+        Assert.NotEqual(0, exit);
+    }
+
+    [Fact]
+    public void Validate_suppressing_all_rules_drops_findings_and_passes()
+    {
+        // The S-57 cell is translated to S-101 and flagged by the
+        // "S101-as-S57/*" rule family; suppressing that family should leave
+        // no effective findings and flip the dataset to valid (exit 0).
+        var dataset = FixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var (baselineExit, baselineOut) = RunCapturingStdout(["validate", dataset, "--format", "json"]);
+        using var baseline = JsonDocument.Parse(baselineOut);
+        int baselineFindings = baseline.RootElement.GetProperty("findings").GetArrayLength();
+        Skip.If(baselineFindings == 0, "Fixture produced no findings to suppress.");
+        Assert.Equal(6, baselineExit);
+
+        var (exit, stdout) = RunCapturingStdout(
+            ["validate", dataset, "--format", "json", "--suppress", "S101-as-S57/*"]);
+
+        using var doc = JsonDocument.Parse(stdout);
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("valid").GetBoolean());
+        Assert.Equal(0, root.GetProperty("findings").GetArrayLength());
+        Assert.Equal(baselineFindings, root.GetProperty("suppressedCount").GetInt32());
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public void Validate_suppressing_one_rule_keeps_other_errors_failing()
+    {
+        var dataset = FixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var (baselineExit, _) = RunCapturingStdout(["validate", dataset, "--format", "json"]);
+        Skip.IfNot(baselineExit == 6, "Fixture did not produce failing findings.");
+
+        // Suppress just one of several flagged rules; remaining errors keep it failing.
+        int exit = CliApp.Build().Run(
+            ["validate", dataset, "--suppress", "S101-as-S57/S101-R-1.2"]);
+        Assert.Equal(6, exit);
+    }
+
     private static (int Exit, string Stdout) RunCapturingStdout(string[] args)
     {
         var original = Console.Out;

--- a/tests/EncDotNet.S100.Cli.Tests/ValidateCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/ValidateCommandTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using EncDotNet.S100.Cli.Infrastructure;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// End-to-end smoke tests that run the <c>s100 validate</c> command in-process
+/// against a committed synthetic dataset fixture.
+/// </summary>
+public sealed class ValidateCommandTests
+{
+    private static string FixturePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", fileName);
+
+    [Fact]
+    public void Validate_conformant_dataset_returns_success()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        int exit = CliApp.Build().Run(["validate", dataset]);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public void Validate_conformant_dataset_with_strict_returns_success()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        int exit = CliApp.Build().Run(["validate", dataset, "--strict"]);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public void Validate_emits_well_formed_json()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var (exit, stdout) = RunCapturingStdout(["validate", dataset, "--format", "json"]);
+
+        Assert.Equal(0, exit);
+
+        using var doc = JsonDocument.Parse(stdout);
+        var root = doc.RootElement;
+        Assert.Equal("S-127", root.GetProperty("specification").GetString());
+        Assert.True(root.GetProperty("rulesAvailable").GetBoolean());
+        Assert.True(root.GetProperty("valid").GetBoolean());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("findings").ValueKind);
+    }
+
+    [Fact]
+    public void Validate_with_missing_dataset_returns_nonzero()
+    {
+        int exit = CliApp.Build().Run(["validate", "does-not-exist.gml"]);
+        Assert.NotEqual(0, exit);
+    }
+
+    [Fact]
+    public void Validate_with_bad_format_returns_nonzero()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        int exit = CliApp.Build().Run(["validate", dataset, "--format", "bogus"]);
+        Assert.NotEqual(0, exit);
+    }
+
+    private static (int Exit, string Stdout) RunCapturingStdout(string[] args)
+    {
+        var original = Console.Out;
+        var buffer = new StringWriter();
+        Console.SetOut(buffer);
+        try
+        {
+            int exit = CliApp.Build().Run(args);
+            return (exit, buffer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/ValidateCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/ValidateCommand.cs
@@ -1,0 +1,254 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.Json;
+using EncDotNet.S100.Cli.Infrastructure;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Hdf5;
+using EncDotNet.S100.Validation;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// <c>s100 validate &lt;dataset&gt;</c> — detects the dataset's product
+/// specification and runs its normative validation rule pack (if one is
+/// available for the spec) via <see cref="IDatasetProcessor.Validate"/>,
+/// reporting the findings as a table or as JSON.
+/// </summary>
+/// <remarks>
+/// Validation is a pure function of the parsed dataset (independent of
+/// palette, opacity, or time step). Specs without a rule pack — coverage
+/// products and S-101 / S-57 today — report "no rules available" and exit
+/// successfully; this is distinct from a dataset that was evaluated and
+/// found conformant.
+/// </remarks>
+internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
+{
+    /// <summary>Exit code returned when validation produced failing findings.</summary>
+    private const int FindingsExitCode = 6;
+
+    internal sealed class Settings : DatasetCommandSettings
+    {
+        [CommandOption("--format")]
+        [Description("Output format: text or json (default text).")]
+        [DefaultValue("text")]
+        public string Format { get; init; } = "text";
+
+        [CommandOption("--strict")]
+        [Description("Treat warnings as failures: exit non-zero when any warning (not just error) is present.")]
+        [DefaultValue(false)]
+        public bool Strict { get; init; }
+
+        public override ValidationResult Validate()
+        {
+            var baseResult = base.Validate();
+            if (!baseResult.Successful)
+                return baseResult;
+
+            if (!TryParseFormat(Format, out _))
+                return ValidationResult.Error($"Unknown format '{Format}'. Use text or json.");
+
+            return ValidationResult.Success();
+        }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
+        TryParseFormat(settings.Format, out var format);
+        var (factory, catalogueManager) = ProcessorFactoryBuilder.Build();
+        try
+        {
+            var spec = DatasetPipelineFactory.DetectProductSpec(settings.DatasetPath);
+            if (spec is null)
+            {
+                if (format == OutputFormat.Json)
+                    EmitJsonError("spec-not-detected", $"Could not detect an S-100 product specification for: {settings.DatasetPath}");
+                else
+                    AnsiConsole.MarkupLineInterpolated(
+                        $"[red]Could not detect an S-100 product specification for:[/] {settings.DatasetPath}");
+                return 2;
+            }
+
+            var processor = factory.CreateProcessor(settings.DatasetPath);
+            var report = processor.Validate();
+
+            return format == OutputFormat.Json
+                ? EmitJson(processor.Spec, report, settings.Strict)
+                : EmitText(processor.Spec, report, settings.Strict);
+        }
+        catch (NotSupportedException ex)
+        {
+            ReportException("Not supported", ex, format, settings.Debug);
+            return 4;
+        }
+        catch (S100DatasetNotSupportedException ex)
+        {
+            // Recognised-but-not-yet-implemented spec feature (e.g. data coding
+            // format 1). Does not derive from NotSupportedException, so it needs
+            // its own catch to map to exit 4 rather than the generic exit-1 path.
+            // See issue #253.
+            ReportException("Not supported", ex, format, settings.Debug);
+            return 4;
+        }
+        catch (S100DatasetSchemaException ex)
+        {
+            ReportException("Non-conforming dataset", ex, format, settings.Debug, warning: true);
+            return 5;
+        }
+        catch (Exception ex)
+        {
+            ReportException("Error", ex, format, settings.Debug);
+            return 1;
+        }
+        finally
+        {
+            catalogueManager.Dispose();
+        }
+    }
+
+    private static int EmitText(SpecRef spec, ValidationReport? report, bool strict)
+    {
+        if (report is null)
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[grey]No validation rules are available for[/] {Markup.Escape(spec.Name)}.");
+            return 0;
+        }
+
+        if (report.Findings.IsDefaultOrEmpty)
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[green]Valid[/] — {Markup.Escape(spec.Name)} ([grey]{report.RulesEvaluated} rule(s) evaluated, no findings[/])");
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Severity");
+        table.AddColumn("Rule");
+        table.AddColumn("Message");
+        table.AddColumn("Location");
+
+        foreach (var finding in report.Findings)
+        {
+            table.AddRow(
+                SeverityMarkup(finding.Severity),
+                Markup.Escape(finding.RuleId),
+                Markup.Escape(finding.Message),
+                Markup.Escape(FormatLocation(finding)));
+        }
+
+        AnsiConsole.Write(table);
+
+        int errors = report.FindingsOfSeverity(ValidationSeverity.Error).Count();
+        int warnings = report.FindingsOfSeverity(ValidationSeverity.Warning).Count();
+        int infos = report.FindingsOfSeverity(ValidationSeverity.Info).Count();
+
+        AnsiConsole.MarkupLineInterpolated(
+            $"[grey]{report.RulesEvaluated} rule(s) evaluated, {report.RulesWithFindings} with findings:[/] [red]{errors} error(s)[/], [yellow]{warnings} warning(s)[/], [blue]{infos} info[/].");
+
+        return Failed(report, strict) ? FindingsExitCode : 0;
+    }
+
+    private static int EmitJson(SpecRef spec, ValidationReport? report, bool strict)
+    {
+        var payload = new
+        {
+            specification = spec.Name,
+            edition = spec.Edition.ToString(),
+            rulesAvailable = report is not null,
+            rulesEvaluated = report?.RulesEvaluated ?? 0,
+            rulesWithFindings = report?.RulesWithFindings ?? 0,
+            valid = report is null || report.Findings.IsDefaultOrEmpty,
+            findings = (report?.Findings ?? System.Collections.Immutable.ImmutableArray<ValidationFinding>.Empty)
+                .Select(f => new
+                {
+                    ruleId = f.RuleId,
+                    severity = f.Severity.ToString(),
+                    message = f.Message,
+                    datasetId = f.DatasetId,
+                    relatedFeatureId = f.RelatedFeatureId,
+                    point = f.Point is { } p ? new { latitude = p.Latitude, longitude = p.Longitude } : null,
+                    boundingBox = f.BoundingBox is { } b
+                        ? new
+                        {
+                            southLatitude = b.SouthLatitude,
+                            westLongitude = b.WestLongitude,
+                            northLatitude = b.NorthLatitude,
+                            eastLongitude = b.EastLongitude,
+                        }
+                        : null,
+                })
+                .ToArray(),
+        };
+
+        Console.Out.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
+        return report is not null && Failed(report, strict) ? FindingsExitCode : 0;
+    }
+
+    private static bool Failed(ValidationReport report, bool strict) =>
+        report.HasErrors || (strict && report.HasWarnings);
+
+    private static string FormatLocation(ValidationFinding finding)
+    {
+        if (finding.RelatedFeatureId is { Length: > 0 } id)
+            return id;
+        if (finding.Point is { } p)
+            return string.Format(CultureInfo.InvariantCulture, "{0:0.#####}, {1:0.#####}", p.Latitude, p.Longitude);
+        if (finding.BoundingBox is { } b)
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "[{0:0.###}, {1:0.###} – {2:0.###}, {3:0.###}]",
+                b.SouthLatitude, b.WestLongitude, b.NorthLatitude, b.EastLongitude);
+        return string.Empty;
+    }
+
+    private static string SeverityMarkup(ValidationSeverity severity) => severity switch
+    {
+        ValidationSeverity.Error => "[red]error[/]",
+        ValidationSeverity.Warning => "[yellow]warning[/]",
+        _ => "[blue]info[/]",
+    };
+
+    private static void ReportException(
+        string label, Exception ex, OutputFormat format, bool debug, bool warning = false)
+    {
+        if (format == OutputFormat.Json)
+        {
+            EmitJsonError(label.ToLowerInvariant().Replace(' ', '-'), ex.Message);
+            return;
+        }
+
+        var colour = warning ? "yellow" : "red";
+        AnsiConsole.MarkupLineInterpolated($"[{colour}]{label}:[/] {ex.Message}");
+        if (debug)
+            AnsiConsole.WriteException(ex);
+    }
+
+    private static void EmitJsonError(string error, string message) =>
+        Console.Out.WriteLine(JsonSerializer.Serialize(new { error, message }, JsonOptions));
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private enum OutputFormat
+    {
+        Text,
+        Json,
+    }
+
+    private static bool TryParseFormat(string value, out OutputFormat format)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "text": format = OutputFormat.Text; return true;
+            case "json": format = OutputFormat.Json; return true;
+            default: format = OutputFormat.Text; return false;
+        }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/ValidateCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/ValidateCommand.cs
@@ -1,6 +1,8 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using EncDotNet.S100.Cli.Infrastructure;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
@@ -41,6 +43,15 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
         [DefaultValue(false)]
         public bool Strict { get; init; }
 
+        [CommandOption("--suppress")]
+        [Description(
+            "Comma-separated list of rule ids (or glob patterns using '*') whose findings are " +
+            "dropped from the report and ignored by the exit code — e.g. " +
+            "--suppress S101-R-1.2,S101-R-3.2 or --suppress \"S101-*\". Useful for muting a " +
+            "known rule class (such as feature-catalogue-version mismatches) to surface the " +
+            "more-likely-real findings.")]
+        public string? Suppress { get; init; }
+
         public override ValidationResult Validate()
         {
             var baseResult = base.Validate();
@@ -49,6 +60,10 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
 
             if (!TryParseFormat(Format, out _))
                 return ValidationResult.Error($"Unknown format '{Format}'. Use text or json.");
+
+            if (Suppress is not null && !TryParseSuppressPatterns(Suppress, out _))
+                return ValidationResult.Error(
+                    "--suppress must be a comma-separated list of one or more rule ids or patterns.");
 
             return ValidationResult.Success();
         }
@@ -75,9 +90,13 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
             var processor = factory.CreateProcessor(settings.DatasetPath);
             var report = processor.Validate();
 
+            string[] patterns = Array.Empty<string>();
+            if (settings.Suppress is not null)
+                TryParseSuppressPatterns(settings.Suppress, out patterns);
+
             return format == OutputFormat.Json
-                ? EmitJson(processor.Spec, report, settings.Strict)
-                : EmitText(processor.Spec, report, settings.Strict);
+                ? EmitJson(processor.Spec, report, settings.Strict, patterns)
+                : EmitText(processor.Spec, report, settings.Strict, patterns);
         }
         catch (NotSupportedException ex)
         {
@@ -109,7 +128,7 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
         }
     }
 
-    private static int EmitText(SpecRef spec, ValidationReport? report, bool strict)
+    private static int EmitText(SpecRef spec, ValidationReport? report, bool strict, IReadOnlyList<string> suppressPatterns)
     {
         if (report is null)
         {
@@ -118,10 +137,14 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
             return 0;
         }
 
-        if (report.Findings.IsDefaultOrEmpty)
+        var (kept, suppressedCount) = Partition(report, suppressPatterns);
+
+        if (kept.IsEmpty)
         {
-            AnsiConsole.MarkupLineInterpolated(
-                $"[green]Valid[/] — {Markup.Escape(spec.Name)} ([grey]{report.RulesEvaluated} rule(s) evaluated, no findings[/])");
+            var suffix = suppressedCount > 0
+                ? $" ([grey]{report.RulesEvaluated} rule(s) evaluated; {suppressedCount} finding(s) suppressed[/])"
+                : $" ([grey]{report.RulesEvaluated} rule(s) evaluated, no findings[/])";
+            AnsiConsole.MarkupLineInterpolated($"[green]Valid[/] — {Markup.Escape(spec.Name)}{suffix}");
             return 0;
         }
 
@@ -131,7 +154,7 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
         table.AddColumn("Message");
         table.AddColumn("Location");
 
-        foreach (var finding in report.Findings)
+        foreach (var finding in kept)
         {
             table.AddRow(
                 SeverityMarkup(finding.Severity),
@@ -142,27 +165,39 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
 
         AnsiConsole.Write(table);
 
-        int errors = report.FindingsOfSeverity(ValidationSeverity.Error).Count();
-        int warnings = report.FindingsOfSeverity(ValidationSeverity.Warning).Count();
-        int infos = report.FindingsOfSeverity(ValidationSeverity.Info).Count();
+        int errors = kept.Count(f => f.Severity == ValidationSeverity.Error);
+        int warnings = kept.Count(f => f.Severity == ValidationSeverity.Warning);
+        int infos = kept.Count(f => f.Severity == ValidationSeverity.Info);
+        int rulesWithFindings = kept.Select(f => f.RuleId).Distinct().Count();
 
         AnsiConsole.MarkupLineInterpolated(
-            $"[grey]{report.RulesEvaluated} rule(s) evaluated, {report.RulesWithFindings} with findings:[/] [red]{errors} error(s)[/], [yellow]{warnings} warning(s)[/], [blue]{infos} info[/].");
+            $"[grey]{report.RulesEvaluated} rule(s) evaluated, {rulesWithFindings} with findings:[/] [red]{errors} error(s)[/], [yellow]{warnings} warning(s)[/], [blue]{infos} info[/].");
 
-        return Failed(report, strict) ? FindingsExitCode : 0;
+        if (suppressedCount > 0)
+            AnsiConsole.MarkupLineInterpolated(
+                $"[grey]{suppressedCount} finding(s) suppressed via --suppress {Markup.Escape(string.Join(",", suppressPatterns))}.[/]");
+
+        return Failed(kept, strict) ? FindingsExitCode : 0;
     }
 
-    private static int EmitJson(SpecRef spec, ValidationReport? report, bool strict)
+    private static int EmitJson(SpecRef spec, ValidationReport? report, bool strict, IReadOnlyList<string> suppressPatterns)
     {
+        var kept = report is null
+            ? ImmutableArray<ValidationFinding>.Empty
+            : Partition(report, suppressPatterns).Kept;
+        int suppressedCount = report is null ? 0 : report.Findings.Length - kept.Length;
+
         var payload = new
         {
             specification = spec.Name,
             edition = spec.Edition.ToString(),
             rulesAvailable = report is not null,
             rulesEvaluated = report?.RulesEvaluated ?? 0,
-            rulesWithFindings = report?.RulesWithFindings ?? 0,
-            valid = report is null || report.Findings.IsDefaultOrEmpty,
-            findings = (report?.Findings ?? System.Collections.Immutable.ImmutableArray<ValidationFinding>.Empty)
+            rulesWithFindings = kept.Select(f => f.RuleId).Distinct().Count(),
+            valid = report is null || kept.IsEmpty,
+            suppressedPatterns = suppressPatterns.Count > 0 ? suppressPatterns.ToArray() : null,
+            suppressedCount,
+            findings = kept
                 .Select(f => new
                 {
                     ruleId = f.RuleId,
@@ -185,11 +220,31 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
         };
 
         Console.Out.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
-        return report is not null && Failed(report, strict) ? FindingsExitCode : 0;
+        return report is not null && Failed(kept, strict) ? FindingsExitCode : 0;
     }
 
-    private static bool Failed(ValidationReport report, bool strict) =>
-        report.HasErrors || (strict && report.HasWarnings);
+    /// <summary>
+    /// Splits a report's findings into the set kept after applying the
+    /// <paramref name="suppressPatterns"/> and the count that were suppressed.
+    /// A finding is suppressed when its <see cref="ValidationFinding.RuleId"/>
+    /// matches any pattern (see <see cref="IsSuppressed"/>).
+    /// </summary>
+    private static (ImmutableArray<ValidationFinding> Kept, int Suppressed) Partition(
+        ValidationReport report, IReadOnlyList<string> suppressPatterns)
+    {
+        if (report.Findings.IsDefaultOrEmpty)
+            return (ImmutableArray<ValidationFinding>.Empty, 0);
+
+        if (suppressPatterns.Count == 0)
+            return (report.Findings, 0);
+
+        var kept = report.Findings.Where(f => !IsSuppressed(f.RuleId, suppressPatterns)).ToImmutableArray();
+        return (kept, report.Findings.Length - kept.Length);
+    }
+
+    private static bool Failed(IReadOnlyCollection<ValidationFinding> findings, bool strict) =>
+        findings.Any(f => f.Severity == ValidationSeverity.Error)
+        || (strict && findings.Any(f => f.Severity == ValidationSeverity.Warning));
 
     private static string FormatLocation(ValidationFinding finding)
     {
@@ -250,5 +305,45 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
             case "json": format = OutputFormat.Json; return true;
             default: format = OutputFormat.Text; return false;
         }
+    }
+
+    /// <summary>
+    /// Parses the <c>--suppress</c> value (a comma-separated list of rule ids
+    /// or glob patterns) into its constituent patterns. Empty tokens are
+    /// dropped; returns <see langword="false"/> when no non-empty pattern
+    /// remains so the command can reject a value such as <c>","</c>.
+    /// </summary>
+    internal static bool TryParseSuppressPatterns(string value, out string[] patterns)
+    {
+        patterns = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return patterns.Length > 0;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="ruleId"/> matches any
+    /// of the supplied <paramref name="patterns"/> (see <see cref="RuleIdMatches"/>).
+    /// </summary>
+    internal static bool IsSuppressed(string ruleId, IReadOnlyList<string> patterns)
+    {
+        for (int i = 0; i < patterns.Count; i++)
+        {
+            if (RuleIdMatches(ruleId, patterns[i]))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Case-insensitive glob match of a rule id against a single pattern. The
+    /// only wildcard is <c>*</c>, which matches any run of characters
+    /// (including none); every other character must match literally. A pattern
+    /// with no wildcard therefore behaves as an exact, case-insensitive rule-id
+    /// match (e.g. <c>S101-R-1.2</c>), while <c>S101-*</c> or
+    /// <c>*-PROJ-UNSUPPORTED</c> match a whole class of rules.
+    /// </summary>
+    internal static bool RuleIdMatches(string ruleId, string pattern)
+    {
+        var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+        return Regex.IsMatch(ruleId, regex, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     }
 }

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -26,6 +26,7 @@ internal static class CliApp
                 .WithDescription("Validate an S-100 dataset against its product specification's normative rule pack.")
                 .WithExample("validate", "warnings.gml")
                 .WithExample("validate", "route.gml", "--strict")
+                .WithExample("validate", "chart.000", "--suppress", "S101-R-1.2,S101-R-3.2")
                 .WithExample("validate", "currents.h5", "--format", "json");
 
             config.AddCommand<InfoCommand>("info")

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -22,6 +22,12 @@ internal static class CliApp
                 .WithExample("render", "warnings.gml", "out.png", "--width", "2048", "--height", "1536")
                 .WithExample("render", "currents.h5", "out.png", "--time-step", "2", "--palette", "night");
 
+            config.AddCommand<ValidateCommand>("validate")
+                .WithDescription("Validate an S-100 dataset against its product specification's normative rule pack.")
+                .WithExample("validate", "warnings.gml")
+                .WithExample("validate", "route.gml", "--strict")
+                .WithExample("validate", "currents.h5", "--format", "json");
+
             config.AddCommand<InfoCommand>("info")
                 .WithDescription("Show the detected spec, edition, and available time steps for a dataset.")
                 .WithExample("info", "dataset.h5");

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -1,10 +1,12 @@
 # EncDotNet.S100.Cli (`s100`)
 
-A small, cross-platform command-line tool that renders any supported S-100
-dataset to a PNG image by running the dataset's portrayal pipeline through the
-Mapsui-free Skia *headless* renderer. It is intended as the basis for batch
-scripts (for example, generating previews of sea-ice or surface-current
-datasets).
+A small, cross-platform command-line tool for working with S-100 datasets. Its
+primary command renders any supported dataset to a PNG image by running the
+dataset's portrayal pipeline through the Mapsui-free Skia *headless* renderer;
+it can also report a dataset's product specification (`info`) and validate a
+dataset against its specification's normative rule pack (`validate`). It is
+intended as the basis for batch scripts (for example, generating previews of
+sea-ice or surface-current datasets, or gating a data pipeline on validation).
 
 The command name is **`s100`**.
 
@@ -62,9 +64,9 @@ sudo apt-get install -y fontconfig fonts-dejavu-core   # optional: system label 
 # Debian 12: use libicu72 instead of libicu74
 ```
 
-`s100 list-specs` and `s100 info` need only `libicu`; `s100 render` (the Skia
-path) also needs only `libicu` — text renders via an embedded fallback font even
-with no fontconfig or system fonts installed.
+`s100 list-specs`, `s100 info`, and `s100 validate` need only `libicu`;
+`s100 render` (the Skia path) also needs only `libicu` — text renders via an
+embedded fallback font even with no fontconfig or system fonts installed.
 
 ### Inside the Viewer application bundle
 
@@ -115,6 +117,35 @@ Prints the detected specification, edition, whether the dataset supports
 headless rendering, and — for time-series datasets — the available time steps
 with their indices (use the index with `render --time-step`).
 
+### `s100 validate <dataset>`
+
+Detects the product specification of `<dataset>` and runs that spec's normative
+validation rule pack against the parsed dataset, reporting the findings. Each
+finding carries a spec-traceable rule id (e.g. `S127-R-2.1`), a severity, a
+message, and — where the rule can locate the problem — a feature id or
+geographic position.
+
+Validation is a pure function of the parsed dataset: it does not depend on the
+palette, opacity, or selected time step. Specs without a rule pack today —
+S-101, S-201, and S-57 — report *no rules available* and exit successfully;
+this is distinct from a dataset that was evaluated and found conformant.
+
+| Option | Default | Description |
+|---|---|---|
+| `--format <fmt>` | `text` | Output format: `text` (a findings table) or `json` (machine-readable, for CI). |
+| `--strict` | off | Treat warnings as failures: exit `6` when any warning (not just an error) is present. |
+| `--debug` | off | Print full stack traces on error. |
+
+```bash
+s100 validate warnings.gml                 # human-readable findings table
+s100 validate route.gml --strict           # fail the build on warnings too
+s100 validate currents.h5 --format json    # machine-readable report for CI
+```
+
+By default the command exits `0` when no **error**-severity findings are
+present (warnings and info are reported but do not fail); pass `--strict` to
+also fail on warnings. Exit code `6` signals failing findings.
+
 ### `s100 list-specs`
 
 Lists the supported product specifications and whether each supports the
@@ -150,4 +181,5 @@ headless render path.
 | `3` | The detected spec does not support headless rendering. |
 | `4` | The dataset is recognised but its shape or encoding is unsupported — e.g. a fixed-station coverage, or a data coding format the reader does not yet implement (such as dcf1, irregular time series at fixed stations). |
 | `5` | The dataset is recognised but non-conforming (a required attribute, dataset, or group is missing or malformed). |
+| `6` | `validate` only: the dataset was evaluated and produced failing findings (any error-severity finding, or — with `--strict` — any warning). |
 | non-zero | Argument validation failure (missing file, bad palette, etc.). |

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -133,6 +133,7 @@ this is distinct from a dataset that was evaluated and found conformant.
 | Option | Default | Description |
 |---|---|---|
 | `--format <fmt>` | `text` | Output format: `text` (a findings table) or `json` (machine-readable, for CI). |
+| `--suppress <list>` | _none_ | Comma-separated list of rule ids (or `*` glob patterns) whose findings are dropped from the report **and** ignored by the exit code — e.g. `--suppress S101-R-1.2,S101-R-3.2` or `--suppress "S101-*"`. Compiler-style "no-warn": mute a known rule class (such as a feature-catalogue-version mismatch) to surface the more-likely-real findings. The count of suppressed findings is still reported. |
 | `--strict` | off | Treat warnings as failures: exit `6` when any warning (not just an error) is present. |
 | `--debug` | off | Print full stack traces on error. |
 
@@ -140,11 +141,19 @@ this is distinct from a dataset that was evaluated and found conformant.
 s100 validate warnings.gml                 # human-readable findings table
 s100 validate route.gml --strict           # fail the build on warnings too
 s100 validate currents.h5 --format json    # machine-readable report for CI
+s100 validate chart.000 --suppress S101-R-1.2,S101-R-3.2   # mute a rule class
+s100 validate chart.000 --suppress "S101-*"                # glob: mute a whole spec's rules
 ```
 
-By default the command exits `0` when no **error**-severity findings are
-present (warnings and info are reported but do not fail); pass `--strict` to
-also fail on warnings. Exit code `6` signals failing findings.
+The `--suppress` patterns are matched case-insensitively against each finding's
+rule id; `*` is the only wildcard and matches any run of characters, so a
+pattern with no `*` is an exact rule-id match. Suppressed findings are removed
+from the table/JSON and do not contribute to the exit code, but the trailing
+summary still reports how many were suppressed.
+
+By default the command exits `0` when no **error**-severity findings remain
+after suppression (warnings and info are reported but do not fail); pass
+`--strict` to also fail on warnings. Exit code `6` signals failing findings.
 
 ### `s100 list-specs`
 


### PR DESCRIPTION
## Summary

Adds a `validate` command to the `s100` CLI as a peer of `render`, running the appropriate spec validation rule pack against a dataset and reporting findings. Also adds compiler-style finding suppression so known-noisy rule classes can be muted.

The validation framework already existed in Core (`IDatasetProcessor.Validate()` → `ValidationReport?`); this surfaces it through the CLI.

## `validate` command

```bash
s100 validate chart.000
s100 validate currents.h5 --format json
s100 validate chart.000 --strict          # treat warnings as failures
```

- `--format text|json` — human-readable table (default) or machine-readable JSON.
- `--strict` — warnings count toward the failing exit code.
- Exit codes mirror `render`/`info` (0 success/clean, 1 generic error, 2 spec-not-detected, 4 unsupported, 5 non-conforming) plus a new **6** = failing findings.
- Distinguishes "no rule pack for this spec" (`null` report) from "evaluated, clean" (`ValidationReport.Empty`).

## `--suppress` (compiler-style no-warn)

```bash
s100 validate chart.000 --suppress S101-R-1.2,S101-R-3.2
s100 validate chart.000 --suppress "S101-*"        # glob over a spec's rules
s100 validate currents.h5 --suppress "*-PROJ-UNSUPPORTED"
```

- Comma-separated rule ids; `*` is the only wildcard; matching is case-insensitive.
- Suppressed findings are dropped from output **and** from the pass/fail exit code, but the summary still reports `N finding(s) suppressed`; JSON adds `suppressedCount` + `suppressedPatterns`.
- No-suppress behaviour is byte-identical to before.

## Tests

- E2E tests for `validate` (text/json/strict) and suppression (suppress-all flips to valid/exit 0; partial suppress still fails), guarded with `Skip.If` for optional data fixtures.
- Unit tests for the suppression parser/matcher (`TryParseSuppressPatterns`, `RuleIdMatches`, `IsSuppressed`).
- All CLI tests pass (`dotnet test`).

## Docs

- `tools/EncDotNet.S100.Cli/README.md` updated: command table, `--format`/`--strict`/`--suppress` semantics, exit-code table including code 6.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>