### PR TITLE
Add S-101 sequential update support

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -428,6 +428,72 @@ public sealed class DatasetPipelineFactory
     }
 
     /// <summary>
+    /// Creates an S-101 dataset processor for the base cell at
+    /// <paramref name="baseRelativePath"/> with the in-set sequential update
+    /// files at <paramref name="updateRelativePaths"/> applied (best-effort)
+    /// before portrayal. Used by exchange-set bulk loading to collapse a cell and
+    /// its updates into a single up-to-date dataset. S-101 / S-100 Part 10a.
+    /// </summary>
+    /// <param name="source">The asset source backing the exchange set.</param>
+    /// <param name="baseRelativePath">Source-relative path of the base cell (<c>….000</c>).</param>
+    /// <param name="updateRelativePaths">Source-relative paths of the update files, in ascending update-number order.</param>
+    public IDatasetProcessor CreateS101ProcessorWithUpdates(
+        IAssetSource source,
+        string baseRelativePath,
+        IReadOnlyList<string> updateRelativePaths)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(baseRelativePath);
+        ArgumentNullException.ThrowIfNull(updateRelativePaths);
+
+        return new S101DatasetProcessor(
+            source,
+            baseRelativePath,
+            updateRelativePaths,
+            _catalogueManager,
+            _luaEngine,
+            _featureCatalogueManager,
+            _sharedInstructionCache);
+    }
+
+    /// <summary>
+    /// Creates an S-101 dataset processor for the base cell file at
+    /// <paramref name="baseFilePath"/> with the sibling sequential update files
+    /// at <paramref name="updateFilePaths"/> applied (best-effort) before
+    /// portrayal. Used by command-line callers pointed at a loose base cell on
+    /// the local file system; the update files must live in the same directory
+    /// as the base cell. See <see cref="S101FilesystemUpdateDiscovery"/> for
+    /// locating the updates. S-101 / S-100 Part 10a.
+    /// </summary>
+    /// <param name="baseFilePath">Path to the base cell file (<c>….000</c>).</param>
+    /// <param name="updateFilePaths">Paths of the sibling update files, in ascending update-number order.</param>
+    public IDatasetProcessor CreateS101ProcessorWithUpdates(
+        string baseFilePath,
+        IReadOnlyList<string> updateFilePaths)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(baseFilePath);
+        ArgumentNullException.ThrowIfNull(updateFilePaths);
+
+        var fullBase = Path.GetFullPath(baseFilePath);
+        var directory = Path.GetDirectoryName(fullBase)
+            ?? throw new ArgumentException(
+                "Base cell path must include a directory.", nameof(baseFilePath));
+        var source = FileSystemAssetSource.Create(directory);
+
+        var baseRelative = Path.GetFileName(fullBase);
+        var updateRelatives = updateFilePaths.Select(Path.GetFileName).ToList();
+
+        return new S101DatasetProcessor(
+            source,
+            baseRelative,
+            updateRelatives,
+            _catalogueManager,
+            _luaEngine,
+            _featureCatalogueManager,
+            _sharedInstructionCache);
+    }
+
+    /// <summary>
     /// Normalizes an exchange-set product identifier (e.g. <c>"S-101"</c>,
     /// <c>"S101"</c>, <c>"s-101"</c>) to the canonical spec strings used
     /// by <see cref="CreateProcessor(string)"/>'s switch (<c>"S-101"</c>, etc.).

--- a/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
@@ -64,13 +64,19 @@ public sealed class ExchangeSetLoader
         ArgumentNullException.ThrowIfNull(exchangeSet);
 
         var datasets = exchangeSet.Catalogue.DatasetDiscoveryMetadata;
-        var total = datasets.Count;
+
+        // Group S-101 base cells with their in-set sequential updates so each
+        // cell is loaded once at its up-to-date state (S-100 Part 10a). Non-S-101
+        // datasets pass through unchanged.
+        var plan = S101ExchangeSetUpdatePlan.Build(datasets);
+        var total = plan.Count;
 
         for (var i = 0; i < total; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var metadata = datasets[i];
+            var item = plan[i];
+            var metadata = item.Base;
             var relativePath = metadata.RelativePath;
             progress?.Report(new ExchangeSetProgress(i + 1, total, relativePath));
 
@@ -78,10 +84,28 @@ public sealed class ExchangeSetLoader
             Exception? error = null;
             try
             {
-                processor = _factory.CreateProcessor(
-                    exchangeSet.Source,
-                    relativePath,
-                    metadata.ProductSpecification?.ProductIdentifier);
+                switch (item.Kind)
+                {
+                    case S101LoadItemKind.BaseWithUpdates:
+                        var updatePaths = item.Updates.Select(u => u.RelativePath).ToList();
+                        processor = _factory.CreateS101ProcessorWithUpdates(
+                            exchangeSet.Source, relativePath, updatePaths);
+                        break;
+
+                    case S101LoadItemKind.OrphanUpdate:
+                        error = new InvalidOperationException(
+                            $"S-101 update '{relativePath}' has no base cell in this exchange set; " +
+                            "updates are only applied when bundled with their base.");
+                        break;
+
+                    case S101LoadItemKind.Single:
+                    default:
+                        processor = _factory.CreateProcessor(
+                            exchangeSet.Source,
+                            relativePath,
+                            metadata.ProductSpecification?.ProductIdentifier);
+                        break;
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/EncDotNet.S100.Datasets.Pipelines/README.md
+++ b/src/EncDotNet.S100.Datasets.Pipelines/README.md
@@ -43,6 +43,29 @@ processor wrapped in an `IDatasetProcessor`. `ExchangeSetLoader`
 walks an S-100 exchange-set catalogue and yields one processor per
 dataset entry.
 
+### S-101 sequential updates (S-100 Part 10a)
+
+An S-101 cell may ship as a base (`….000`) plus ordered update files
+(`….001`, `….002`, …). Updates are folded into the base to produce an
+"up-to-date" dataset before portrayal. The merge engine lives in
+`EncDotNet.S100.Datasets.S101` (`S101UpdateApplicator`); this library
+supplies the two ways callers locate the pieces:
+
+- **From an exchange set** — `S101ExchangeSetUpdatePlan.Build(...)`
+  groups a catalogue's entries so each base cell is paired with its
+  in-set updates (ordered by `updateNumber`). `ExchangeSetLoader` and
+  the viewer use this, then call
+  `DatasetPipelineFactory.CreateS101ProcessorWithUpdates(source, baseRelativePath, updateRelativePaths)`.
+- **From a loose file** — `S101FilesystemUpdateDiscovery.FindSequentialUpdates(baseFilePath)`
+  finds sibling update files in the base cell's directory. The CLI
+  uses this, then calls
+  `DatasetPipelineFactory.CreateS101ProcessorWithUpdates(baseFilePath, updateFilePaths)`.
+
+Application is **best-effort**: a missing, out-of-order, or unreadable
+update is recorded in `S101DatasetProcessor.UpdateReport` but never
+prevents the (partially) updated cell from rendering. Cross-exchange-set
+/ cross-directory application is intentionally not supported.
+
 ## Mapsui-free render seam (issue #189)
 
 This package is **Mapsui-free** so headless consumers (the

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -24,6 +24,7 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSource, IHeadlessImageRenderer
 {
     private readonly S101Dataset _dataset;
+    private readonly S101UpdateReport? _updateReport;
     private readonly PortrayalCatalogueProvider _provider;
     private readonly S101PortrayalCatalogue _catalogue;
     private readonly PortrayalCatalogueManager _catalogueManager;
@@ -113,6 +114,12 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
 
     public SpecRef Spec => new("S-101", default);
 
+    /// <summary>
+    /// Outcome of applying sequential updates when this processor was constructed
+    /// for a base cell plus in-set update files; otherwise <see langword="null"/>.
+    /// </summary>
+    public S101UpdateReport? UpdateReport => _updateReport;
+
     public S101DatasetProcessor(
         string path,
         PortrayalCatalogueManager catalogueManager,
@@ -145,6 +152,32 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
     {
     }
 
+    /// <summary>
+    /// Initializes a new <see cref="S101DatasetProcessor"/> for a base cell at
+    /// <paramref name="baseRelativePath"/> with the sequential update files at
+    /// <paramref name="updateRelativePaths"/> applied (best-effort) before
+    /// portrayal. Used by exchange-set bulk loading to collapse a cell and its
+    /// in-set updates into a single up-to-date dataset; the apply outcome is
+    /// exposed via <see cref="UpdateReport"/>. S-101 / S-100 Part 10a.
+    /// </summary>
+    public S101DatasetProcessor(
+        IAssetSource source,
+        string baseRelativePath,
+        IReadOnlyList<string> updateRelativePaths,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        FeatureCatalogueManager featureCatalogueManager,
+        IPortrayalInstructionCache? sharedInstructionCache = null)
+        : this(
+            PrepareWithUpdates(source, baseRelativePath, updateRelativePaths),
+            AssetSourceHelpers.GetFileName(baseRelativePath),
+            catalogueManager,
+            luaEngine,
+            featureCatalogueManager,
+            sharedInstructionCache)
+    {
+    }
+
     private S101DatasetProcessor(
         Stream datasetStream,
         string fileName,
@@ -152,27 +185,34 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager,
         IPortrayalInstructionCache? sharedInstructionCache)
+        : this(
+            PrepareFromStream(datasetStream),
+            fileName,
+            catalogueManager,
+            luaEngine,
+            featureCatalogueManager,
+            sharedInstructionCache)
     {
-        ArgumentNullException.ThrowIfNull(datasetStream);
+    }
+
+    private S101DatasetProcessor(
+        PreparedDataset prepared,
+        string fileName,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        FeatureCatalogueManager featureCatalogueManager,
+        IPortrayalInstructionCache? sharedInstructionCache)
+    {
         _fileName = fileName;
         _luaEngine = luaEngine;
         _provider = catalogueManager.GetProvider("S-101");
         _catalogueManager = catalogueManager;
         _catalogue = new S101PortrayalCatalogue(_provider, _luaEngine);
 
-        // Buffer the raw dataset bytes once so we can (a) parse the document and
-        // (b) compute a content hash for the disk clip-cache scope key. S-101
-        // cells are small enough (a few MB) that buffering is cheap, and the
-        // content hash makes the persisted clip auto-invalidate when the cell's
-        // bytes change.
-        byte[] datasetBytes;
-        using (datasetStream)
-        {
-            datasetBytes = ReadAllBytes(datasetStream);
-        }
-        _dataset = S101Dataset.Open(new MemoryStream(datasetBytes, writable: false));
+        _dataset = prepared.Dataset;
+        _updateReport = prepared.Report;
 
-        _patternClipScope = BuildDatasetScopeKey(datasetBytes, _dataset);
+        _patternClipScope = BuildDatasetScopeKey(prepared.ScopeBytes, _dataset);
 
         // When a shared instruction cache is injected use it (persistent,
         // cross-cell, process-global); otherwise fall back to a bounded
@@ -183,6 +223,90 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         _featureCatalogueManager = featureCatalogueManager;
 
         Diagnostics.CatalogueResolutionDiagnostics.Report(this, Spec, _catalogue.CatalogueRef, "portrayal");
+    }
+
+    /// <summary>A parsed dataset paired with the bytes used for the cache scope key and an optional update report.</summary>
+    private readonly record struct PreparedDataset(S101Dataset Dataset, byte[] ScopeBytes, S101UpdateReport? Report);
+
+    /// <summary>
+    /// Buffers and parses a single dataset stream (no updates). S-101 cells are
+    /// small enough that buffering the raw bytes for content hashing is cheap.
+    /// </summary>
+    private static PreparedDataset PrepareFromStream(Stream datasetStream)
+    {
+        ArgumentNullException.ThrowIfNull(datasetStream);
+        byte[] datasetBytes;
+        using (datasetStream)
+        {
+            datasetBytes = ReadAllBytes(datasetStream);
+        }
+        var dataset = S101Dataset.Open(new MemoryStream(datasetBytes, writable: false));
+        return new PreparedDataset(dataset, datasetBytes, Report: null);
+    }
+
+    /// <summary>
+    /// Reads a base cell plus its update files from <paramref name="source"/> and
+    /// applies them (best-effort) into a single up-to-date dataset. A file that
+    /// fails to read, or an invalid / non-contiguous update, is recorded in the
+    /// returned report and never aborts the load.
+    /// </summary>
+    private static PreparedDataset PrepareWithUpdates(
+        IAssetSource source,
+        string baseRelativePath,
+        IReadOnlyList<string> updateRelativePaths)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(baseRelativePath);
+        ArgumentNullException.ThrowIfNull(updateRelativePaths);
+
+        var baseBytes = ReadAsset(source, baseRelativePath);
+        var baseDocument = S101Dataset.Open(new MemoryStream(baseBytes, writable: false)).Document;
+
+        var scopeStream = new MemoryStream();
+        scopeStream.Write(baseBytes, 0, baseBytes.Length);
+
+        var readMessages = new List<S101UpdateMessage>();
+        var updates = new List<S101Document>(updateRelativePaths.Count);
+        foreach (var updatePath in updateRelativePaths)
+        {
+            try
+            {
+                var updateBytes = ReadAsset(source, updatePath);
+                scopeStream.Write(updateBytes, 0, updateBytes.Length);
+                updates.Add(S101Dataset.Open(new MemoryStream(updateBytes, writable: false)).Document);
+            }
+            catch (Exception ex)
+            {
+                readMessages.Add(new S101UpdateMessage(
+                    S101UpdateSeverity.Error,
+                    $"Failed to read update '{AssetSourceHelpers.GetFileName(updatePath)}': {ex.Message}."));
+            }
+        }
+
+        updates.Sort((a, b) => a.Identification.UpdateNumber.CompareTo(b.Identification.UpdateNumber));
+
+        var merged = S101UpdateApplicator.Apply(baseDocument, updates, out var report);
+
+        if (readMessages.Count > 0)
+        {
+            report = new S101UpdateReport
+            {
+                BaseUpdateNumber = report.BaseUpdateNumber,
+                AppliedThroughUpdateNumber = report.AppliedThroughUpdateNumber,
+                Inserted = report.Inserted,
+                Deleted = report.Deleted,
+                Modified = report.Modified,
+                Messages = [.. readMessages, .. report.Messages],
+            };
+        }
+
+        return new PreparedDataset(S101Dataset.FromDocument(merged), scopeStream.ToArray(), report);
+    }
+
+    private static byte[] ReadAsset(IAssetSource source, string relativePath)
+    {
+        using var stream = AssetSourceHelpers.OpenSeekable(source, relativePath);
+        return ReadAllBytes(stream);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101ExchangeSetUpdatePlan.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101ExchangeSetUpdatePlan.cs
@@ -1,0 +1,149 @@
+using EncDotNet.S100.ExchangeSets;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Kind of a single <see cref="S101ExchangeSetLoadItem"/> produced when planning
+/// how to load S-101 cells (and their sequential updates) from an exchange set.
+/// </summary>
+public enum S101LoadItemKind
+{
+    /// <summary>A dataset loaded individually (non-S-101, or an S-101 base with no in-set updates).</summary>
+    Single = 0,
+
+    /// <summary>An S-101 base cell with one or more in-set update files to apply.</summary>
+    BaseWithUpdates = 1,
+
+    /// <summary>An S-101 update file with no matching base cell in the same exchange set.</summary>
+    OrphanUpdate = 2,
+}
+
+/// <summary>
+/// One planned load operation: either a single dataset, an S-101 base cell with
+/// its ordered in-set updates, or an orphan update with no base.
+/// </summary>
+/// <param name="Kind">The item kind.</param>
+/// <param name="Base">The base (or single) dataset's discovery metadata.</param>
+/// <param name="Updates">
+/// Ordered (ascending update number) update metadata for
+/// <see cref="S101LoadItemKind.BaseWithUpdates"/>; empty otherwise.
+/// </param>
+public sealed record S101ExchangeSetLoadItem(
+    S101LoadItemKind Kind,
+    DatasetDiscoveryMetadata Base,
+    IReadOnlyList<DatasetDiscoveryMetadata> Updates);
+
+/// <summary>
+/// Groups an exchange set's catalogue entries so that each S-101 base cell is
+/// loaded together with the sequential update files (<c>….001</c>, <c>….002</c>,
+/// …) that target the same cell <b>within the same exchange set</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Updates are matched to their base by cell name (the dataset file name without
+/// its numeric extension) and ordered by update number (from the catalogue's
+/// <c>updateNumber</c>, falling back to the file extension). Non-S-101 datasets,
+/// and S-101 base cells with no in-set updates, are emitted as
+/// <see cref="S101LoadItemKind.Single"/> items in catalogue order; an S-101
+/// update with no matching base is emitted as
+/// <see cref="S101LoadItemKind.OrphanUpdate"/> (surfaced as a best-effort
+/// warning by the loader). Cross-exchange-set application is intentionally not
+/// supported here. S-101 / S-100 Part 10a.
+/// </para>
+/// </remarks>
+public static class S101ExchangeSetUpdatePlan
+{
+    /// <summary>
+    /// Builds the ordered load plan for <paramref name="datasets"/>.
+    /// </summary>
+    /// <param name="datasets">The exchange set catalogue's dataset discovery metadata, in catalogue order.</param>
+    /// <returns>One <see cref="S101ExchangeSetLoadItem"/> per load operation, in catalogue order.</returns>
+    public static IReadOnlyList<S101ExchangeSetLoadItem> Build(IReadOnlyList<DatasetDiscoveryMetadata> datasets)
+    {
+        ArgumentNullException.ThrowIfNull(datasets);
+
+        // Group S-101 entries by cell name (file stem, case-insensitive).
+        var cellGroups = new Dictionary<string, List<DatasetDiscoveryMetadata>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var metadata in datasets)
+        {
+            if (!IsS101(metadata))
+                continue;
+
+            var cellName = GetCellName(metadata);
+            if (!cellGroups.TryGetValue(cellName, out var members))
+            {
+                members = [];
+                cellGroups[cellName] = members;
+            }
+            members.Add(metadata);
+        }
+
+        var emittedCells = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var plan = new List<S101ExchangeSetLoadItem>(datasets.Count);
+
+        foreach (var metadata in datasets)
+        {
+            if (!IsS101(metadata))
+            {
+                plan.Add(new S101ExchangeSetLoadItem(S101LoadItemKind.Single, metadata, []));
+                continue;
+            }
+
+            var cellName = GetCellName(metadata);
+            var members = cellGroups[cellName];
+            var baseEntry = members.FirstOrDefault(m => GetUpdateNumber(m) == 0);
+
+            if (baseEntry is null)
+            {
+                // No base in this set: every member is an orphan update. Emit each
+                // at its own position so the warning maps to the right file.
+                plan.Add(new S101ExchangeSetLoadItem(S101LoadItemKind.OrphanUpdate, metadata, []));
+                continue;
+            }
+
+            // Emit the whole cell once, at the position of its base entry.
+            if (!ReferenceEquals(metadata, baseEntry))
+                continue;
+
+            if (!emittedCells.Add(cellName))
+                continue;
+
+            var updates = members
+                .Where(m => !ReferenceEquals(m, baseEntry) && GetUpdateNumber(m) > 0)
+                .OrderBy(GetUpdateNumber)
+                .ToList();
+
+            plan.Add(updates.Count == 0
+                ? new S101ExchangeSetLoadItem(S101LoadItemKind.Single, baseEntry, [])
+                : new S101ExchangeSetLoadItem(S101LoadItemKind.BaseWithUpdates, baseEntry, updates));
+        }
+
+        return plan;
+    }
+
+    private static bool IsS101(DatasetDiscoveryMetadata metadata) =>
+        DatasetPipelineFactory.MapProductIdentifierToSpec(metadata.ProductSpecification?.ProductIdentifier) == "S-101";
+
+    private static string GetCellName(DatasetDiscoveryMetadata metadata) =>
+        Path.GetFileNameWithoutExtension(metadata.FileName);
+
+    /// <summary>
+    /// Resolves the update number: the catalogue's <c>updateNumber</c> when
+    /// present, otherwise the numeric file extension (<c>.000</c> → 0).
+    /// </summary>
+    private static int GetUpdateNumber(DatasetDiscoveryMetadata metadata)
+    {
+        if (metadata.UpdateNumber is { } declared)
+            return declared;
+
+        var ext = Path.GetExtension(metadata.FileName);
+        if (ext.Length == 4 &&
+            int.TryParse(ext.AsSpan(1), System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var fromExt))
+        {
+            return fromExt;
+        }
+
+        return 0;
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101FilesystemUpdateDiscovery.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101FilesystemUpdateDiscovery.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Discovers S-101 sequential update files (<c>….001</c>, <c>….002</c>, …) that
+/// sit alongside a base cell (<c>….000</c>) on the local file system, so a
+/// command-line caller pointed at a loose base cell can render it at its
+/// up-to-date state. This is the file-system analogue of
+/// <see cref="S101ExchangeSetUpdatePlan"/> (which groups updates from an
+/// exchange-set catalogue). S-101 / S-100 Part 10a.
+/// </summary>
+/// <remarks>
+/// Matching is by cell name (the file name without its numeric extension,
+/// case-insensitive) within the base cell's own directory only; updates that
+/// live elsewhere are not considered. Every sibling with a positive numeric
+/// extension is returned in ascending update-number order — gaps are
+/// intentionally not filtered out here so the applicator can surface a
+/// best-effort warning when the sequence is non-contiguous.
+/// </remarks>
+public static class S101FilesystemUpdateDiscovery
+{
+    /// <summary>
+    /// Finds the sequential update files that target the base cell at
+    /// <paramref name="baseFilePath"/>.
+    /// </summary>
+    /// <param name="baseFilePath">Path to a base cell (a <c>….000</c> file).</param>
+    /// <returns>
+    /// The full paths of the sibling update files, ordered by ascending update
+    /// number. Empty when <paramref name="baseFilePath"/> is not a <c>….000</c>
+    /// base cell, its directory cannot be resolved, or no updates are present.
+    /// </returns>
+    public static IReadOnlyList<string> FindSequentialUpdates(string baseFilePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(baseFilePath);
+
+        // Only a base cell (….000) can carry sequential updates.
+        if (!string.Equals(Path.GetExtension(baseFilePath), ".000", StringComparison.OrdinalIgnoreCase))
+            return Array.Empty<string>();
+
+        var fullBase = Path.GetFullPath(baseFilePath);
+        var directory = Path.GetDirectoryName(fullBase);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            return Array.Empty<string>();
+
+        var cellName = Path.GetFileNameWithoutExtension(fullBase);
+
+        var updates = new List<(int Number, string Path)>();
+        foreach (var candidate in Directory.EnumerateFiles(directory))
+        {
+            if (!string.Equals(
+                    Path.GetFileNameWithoutExtension(candidate),
+                    cellName,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (TryParseUpdateNumber(candidate, out var number) && number > 0)
+                updates.Add((number, candidate));
+        }
+
+        return updates
+            .OrderBy(u => u.Number)
+            .Select(u => u.Path)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Parses the numeric S-101 file extension (<c>.001</c> → 1). Returns
+    /// <see langword="false"/> when the extension is not exactly three digits.
+    /// </summary>
+    private static bool TryParseUpdateNumber(string path, out int number)
+    {
+        number = 0;
+        var ext = Path.GetExtension(path);
+        return ext.Length == 4
+            && int.TryParse(
+                ext.AsSpan(1),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out number);
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj
+++ b/src/EncDotNet.S100.Datasets.S101/EncDotNet.S100.Datasets.S101.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="EncDotNet.S100.Pipelines.Tests" />
+    <InternalsVisibleTo Include="EncDotNet.S100.Datasets.S101.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -11,6 +11,7 @@ This library reads S-101 datasets encoded in ISO 8211 format and executes the S-
 - **`S101LuaRuleExecutor`** — `ILuaVectorRuleExecutor` implementation that wraps the product-agnostic `LuaRuleExecutor` from `EncDotNet.S100.Core`, supplying the S-101 seams: the `S101LuaDataProvider` host bridge, the mariner→context-parameter bindings, a feature-anchor provider for augmented line tessellation, and the SAFCON contour-label transform.
 - **`S101PortrayalCatalogue`** — `IVectorPortrayalCatalogue` implementation that loads XSLT/Lua rules, symbols, line styles, area fills, and color palettes.
 - **`S101VectorSource`** — `IVectorSource` implementation for the vector pipeline.
+- **`S101UpdateApplicator`**, **`S101Document.ApplyChanges`** — sequential update support (see below).
 - **`DrawingInstructionParser`** (in `EncDotNet.S100.Core`) — parses the semicolon-separated key:value strings emitted by the Lua portrayal pipeline into the unified `DrawingInstruction` hierarchy. Honours text alignment (`TextAlignHorizontal` / `TextAlignVertical`), mm offsets (`LocalOffset`), foreground / background colour with optional transparency, line placement, and the `AugmentedPoint:GeographicCRS,…` anchor override used by SOUNDG / DepthNoBottomFound rules. Augmented line geometry (`AugmentedRay`, `ArcByRadius`, `AugmentedPath`) is fully supported — sector-light limit lines and arcs, directional-light rays, and all-around-light circles are tessellated into polylines and carried through `LineInstruction.CoordinatesOverride` to the renderer.
 
 ## Bundled-adapter Lua patches
@@ -147,6 +148,37 @@ tell which layer of the pipeline a problem came from.
 | SRID | Surface | Ring-based polygon geometry |
 | FRID | Feature | Object class, attributes, spatial associations |
 | IRID | Information type | Metadata records referenced by features |
+
+Every record-id field also carries `RVER` (record version) and `RUIN`
+(record update instruction), and the feature/information association and
+attribute fields carry their inline per-element update instructions
+(`SAUI` / `FAUI` / `IUIN` / `ATIN`). These are read into the model to
+drive sequential update application.
+
+## Sequential updates
+
+Like S-57, an S-101 cell is distributed as a base dataset (`….000`,
+application profile `1`) plus ordered update files (`….001`, `….002`, …,
+application profile `2`). Updates carry record- and element-level
+insert / delete / modify instructions (S-100 Part 10a) that must be
+applied in sequence to obtain the up-to-date cell.
+
+- **`S101Document.ApplyChanges(update)`** merges one update document into
+  a new document (pure; the design mirrors `EncDotNet.S57.S57Document.ApplyChanges`).
+- **`S101UpdateApplicator.Apply(base, orderedUpdates, out report)`** folds
+  an ordered update list onto a base cell and returns an `S101UpdateReport`.
+  Application is **best-effort**: an unreadable file, or an invalid /
+  non-contiguous update, is recorded in the report and never prevents the
+  (partially) updated dataset from being used.
+- **`S101Dataset.OpenWithUpdates(basePath, updatePaths)`** opens a base
+  cell and applies its update files, exposing the outcome via
+  `S101Dataset.UpdateReport`.
+
+Within an exchange set, `ExchangeSetLoader` groups each S-101 base cell
+with the update files that target it **in the same set**
+(`S101ExchangeSetUpdatePlan`) and emits a single up-to-date processor per
+cell; updates with no in-set base surface as a best-effort warning.
+Cross-exchange-set application is not yet supported.
 
 ## Installation
 

--- a/src/EncDotNet.S100.Datasets.S101/S101Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101Dataset.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace EncDotNet.S100.Datasets.S101;
 
 /// <summary>
@@ -6,13 +8,21 @@ namespace EncDotNet.S100.Datasets.S101;
 /// </summary>
 public sealed class S101Dataset
 {
-    private S101Dataset(S101Document document)
+    private S101Dataset(S101Document document, S101UpdateReport? updateReport = null)
     {
         Document = document;
+        UpdateReport = updateReport;
     }
 
     /// <summary>The underlying parsed S-101 document.</summary>
     public S101Document Document { get; }
+
+    /// <summary>
+    /// Outcome of applying sequential updates when the dataset was opened via
+    /// <see cref="OpenWithUpdates(string, IReadOnlyList{string})"/>; otherwise
+    /// <see langword="null"/>.
+    /// </summary>
+    public S101UpdateReport? UpdateReport { get; }
 
     /// <summary>Dataset name from the DSID record.</summary>
     public string DatasetName => Document.Identification.DatasetName;
@@ -40,6 +50,64 @@ public sealed class S101Dataset
         ArgumentNullException.ThrowIfNull(stream);
         var doc = S101DocumentReader.ReadFromStream(stream);
         return new S101Dataset(doc);
+    }
+
+    /// <summary>
+    /// Opens an S-101 base cell and applies a set of sequential update files
+    /// (best-effort) to produce an up-to-date dataset.
+    /// </summary>
+    /// <param name="basePath">Path to the base cell (<c>….000</c>).</param>
+    /// <param name="updatePaths">
+    /// Paths to the update files (<c>….001</c>, <c>….002</c>, …). They are read,
+    /// ordered by update number, and applied in sequence. A file that fails to
+    /// read, or a non-contiguous / invalid update, is recorded in
+    /// <see cref="UpdateReport"/> and never prevents the dataset from opening.
+    /// </param>
+    /// <returns>
+    /// The dataset reflecting the base plus every successfully applied update,
+    /// with <see cref="UpdateReport"/> populated.
+    /// </returns>
+    public static S101Dataset OpenWithUpdates(string basePath, IReadOnlyList<string> updatePaths)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(basePath);
+        ArgumentNullException.ThrowIfNull(updatePaths);
+
+        var baseDoc = S101DocumentReader.ReadFromFile(basePath);
+
+        var readMessages = new List<S101UpdateMessage>();
+        var updates = new List<S101Document>(updatePaths.Count);
+        foreach (var path in updatePaths)
+        {
+            try
+            {
+                updates.Add(S101DocumentReader.ReadFromFile(path));
+            }
+            catch (Exception ex)
+            {
+                readMessages.Add(new S101UpdateMessage(
+                    S101UpdateSeverity.Error,
+                    $"Failed to read update '{System.IO.Path.GetFileName(path)}': {ex.Message}."));
+            }
+        }
+
+        updates.Sort((a, b) => a.Identification.UpdateNumber.CompareTo(b.Identification.UpdateNumber));
+
+        var merged = S101UpdateApplicator.Apply(baseDoc, updates, out var report);
+
+        if (readMessages.Count > 0)
+        {
+            report = new S101UpdateReport
+            {
+                BaseUpdateNumber = report.BaseUpdateNumber,
+                AppliedThroughUpdateNumber = report.AppliedThroughUpdateNumber,
+                Inserted = report.Inserted,
+                Deleted = report.Deleted,
+                Modified = report.Modified,
+                Messages = readMessages.Concat(report.Messages).ToImmutableArray(),
+            };
+        }
+
+        return new S101Dataset(merged, report);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Datasets.S101/S101Document.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101Document.cs
@@ -3,6 +3,39 @@ using System.Collections.Immutable;
 namespace EncDotNet.S100.Datasets.S101;
 
 /// <summary>
+/// Record update instruction (<c>RUIN</c>) — and the per-element variants
+/// <c>SAUI</c> / <c>FAUI</c> / <c>IUIN</c> / <c>ATIN</c> — that drive sequential
+/// update application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Numeric values match the ISO 8211 encoding used by S-101 (S-100 Part 10a):
+/// <c>1 = Insert</c>, <c>2 = Delete</c>, <c>3 = Modify</c>. <see cref="None"/>
+/// (<c>0</c>) is a non-spec sentinel meaning "no instruction recorded" — used
+/// for records built in memory (for example the S-57 → S-101 translator) and as
+/// the safe default before a value is read.
+/// </para>
+/// <para>
+/// Mirrors <c>EncDotNet.S57.S57UpdateInstruction</c> so the two product
+/// pipelines share a vocabulary; see the design note in the session plan.
+/// </para>
+/// </remarks>
+public enum S101UpdateInstruction : byte
+{
+    /// <summary>No update instruction recorded (in-memory / base data default).</summary>
+    None = 0,
+
+    /// <summary>Insert a new record/attribute/association (<c>RUIN = 1</c>).</summary>
+    Insert = 1,
+
+    /// <summary>Delete the referenced record/attribute/association (<c>RUIN = 2</c>).</summary>
+    Delete = 2,
+
+    /// <summary>Modify the referenced record/attribute/association (<c>RUIN = 3</c>).</summary>
+    Modify = 3,
+}
+
+/// <summary>
 /// Parsed S-101 dataset document built directly from ISO 8211 records.
 /// </summary>
 /// <remarks>
@@ -63,10 +96,34 @@ public sealed class S101Document
 
     /// <summary>Maps numeric role codes to their feature catalogue acronyms.</summary>
     public required ImmutableDictionary<ushort, string> RoleCatalogue { get; init; }
+
+    /// <summary>
+    /// Applies a single sequential update document onto this document and returns
+    /// a new, merged <see cref="S101Document"/> (this instance is not mutated).
+    /// </summary>
+    /// <param name="update">
+    /// An update dataset (application profile <c>2</c>) parsed into the same
+    /// <see cref="S101Document"/> shape. Record-level <c>RUIN</c> and the inlined
+    /// per-element instructions (<c>SAUI</c> / <c>FAUI</c> / <c>IUIN</c> /
+    /// <c>ATIN</c>) drive insert / delete / modify per S-100 Part 10a.
+    /// </param>
+    /// <returns>A new document reflecting the applied changes.</returns>
+    /// <remarks>
+    /// Mirrors <c>EncDotNet.S57.S57Document.ApplyChanges</c>: there is no separate
+    /// update document type, and merging is a pure document-to-document operation.
+    /// This single-step merge does not validate edition/update preconditions; use
+    /// <see cref="S101UpdateApplicator.Apply(S101Document, IReadOnlyList{S101Document}, out S101UpdateReport)"/>
+    /// for sequenced, best-effort application with a report.
+    /// </remarks>
+    public S101Document ApplyChanges(S101Document update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        return S101UpdateApplicator.ApplySingle(this, update, messages: null);
+    }
 }
 
 /// <summary>DSID — Dataset Identification record.</summary>
-public sealed class S101DatasetIdentification
+public sealed record S101DatasetIdentification
 {
     /// <summary>Record name (RCNM) value identifying this as a DSID record.</summary>
     public byte RecordName { get; init; }
@@ -100,6 +157,40 @@ public sealed class S101DatasetIdentification
 
     /// <summary>Dataset language code (e.g. <c>eng</c>).</summary>
     public string DatasetLanguage { get; init; } = "";
+
+    /// <summary>Dataset abstract (DSID/DSAB), when present.</summary>
+    public string DatasetAbstract { get; init; } = "";
+
+    /// <summary>
+    /// Producer-supplied dataset edition string (DSID/DSED), when present.
+    /// </summary>
+    /// <remarks>
+    /// Populated inconsistently across producers (some emit e.g. <c>1.0</c>,
+    /// others leave it empty), so it is captured for reference but is not the
+    /// authoritative edition source for update sequencing — prefer the exchange
+    /// catalogue's <c>editionNumber</c>. S-100 Part 10a.
+    /// </remarks>
+    public string DatasetEdition { get; init; } = "";
+
+    /// <summary>
+    /// Update number of this dataset within its edition: <c>0</c> for a base
+    /// cell, <c>1..n</c> for sequential updates.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the dataset file extension carried in DSID/DSNM
+    /// (<c>….000</c> = base, <c>….001</c> = update 1, …). This is the reliable
+    /// per-dataset update number and matches the exchange catalogue's
+    /// <c>updateNumber</c>. S-100 Part 10a / S-101.
+    /// </remarks>
+    public int UpdateNumber { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when this dataset is a sequential update
+    /// (application profile <c>2</c>) rather than a base/new dataset
+    /// (application profile <c>1</c>), per DSID/PROF.
+    /// </summary>
+    /// <remarks>S-100 Part 10a — application profile distinguishes base vs update datasets.</remarks>
+    public bool IsUpdate => ApplicationProfile == "2";
 }
 
 /// <summary>DSSI — Dataset Structure Information record.</summary>
@@ -126,6 +217,12 @@ public sealed class S101PointRecord
 
     /// <summary>X coordinate (longitude × CMFX).</summary>
     public int X { get; init; }
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). <see cref="S101UpdateInstruction.Insert"/> for base cells. S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>
@@ -141,6 +238,12 @@ public sealed class S101MultiPointRecord
     /// <summary>3D coordinates: Y (× CMFY), X (× CMFX), Z (× CMFZ) — typically depth.</summary>
     public ImmutableArray<(int Y, int X, int Z)> Points { get; init; }
         = ImmutableArray<(int, int, int)>.Empty;
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>CRID + PTAS + C2IL — Curve segment with start/end point refs and intermediate coordinates.</summary>
@@ -154,6 +257,12 @@ public sealed class S101CurveSegmentRecord
 
     /// <summary>Intermediate coordinates between begin and end points, in (Y, X) order.</summary>
     public ImmutableArray<(int Y, int X)> IntermediateCoordinates { get; init; }
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>Point-topology association from the PTAS field.</summary>
@@ -170,6 +279,12 @@ public sealed class S101CompositeCurveRecord
 
     /// <summary>Curve component associations in traversal order.</summary>
     public ImmutableArray<S101CurveUsage> CurveComponents { get; init; }
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>Curve usage from the CUCO field.</summary>
@@ -186,6 +301,12 @@ public sealed class S101SurfaceRecord
 
     /// <summary>Ring associations: exterior (USAG = 1) or interior (USAG = 2) rings of curves.</summary>
     public ImmutableArray<S101RingAssociation> RingAssociations { get; init; }
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>Ring association from the RIAS field.</summary>
@@ -224,6 +345,12 @@ public sealed class S101FeatureRecord
 
     /// <summary>Associations to information type records.</summary>
     public ImmutableArray<S101InformationAssociation> InformationAssociations { get; init; }
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). <see cref="S101UpdateInstruction.Insert"/> for base cells. S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>IRID + ATTR — Information type record.</summary>
@@ -237,28 +364,56 @@ public sealed class S101InformationRecord
 
     /// <summary>Flat list of attributes; complex attributes use the same marker convention as feature records.</summary>
     public ImmutableArray<S101Attribute> Attributes { get; init; }
+
+    /// <summary>Record version (RVER); increments as the record is updated. S-100 Part 10a.</summary>
+    public int RecordVersion { get; init; }
+
+    /// <summary>Record update instruction (RUIN). S-100 Part 10a.</summary>
+    public S101UpdateInstruction UpdateInstruction { get; init; }
 }
 
 /// <summary>Attribute value from the ATTR field.</summary>
 /// <param name="NumericCode">Numeric attribute code resolved against <see cref="S101Document.AttributeTypeCatalogue"/>.</param>
-/// <param name="Index">Sequence index within a complex attribute (1 marks the start of an instance).</param>
+/// <param name="Index">Sequence index within a complex attribute (1 marks the start of an instance); maps to ATIX.</param>
 /// <param name="Value">Attribute value as a string; numeric and enumerated values are stringified.</param>
-public readonly record struct S101Attribute(ushort NumericCode, ushort Index, string Value);
+/// <param name="ParentIndex">Parent attribute index for nested/complex attributes (PAIX); 0 when top-level.</param>
+/// <param name="UpdateInstruction">Per-attribute update instruction (ATIN) used during update application; <see cref="S101UpdateInstruction.None"/> in base cells.</param>
+public readonly record struct S101Attribute(
+    ushort NumericCode,
+    ushort Index,
+    string Value,
+    ushort ParentIndex = 0,
+    S101UpdateInstruction UpdateInstruction = S101UpdateInstruction.None);
 
 /// <summary>Spatial association from the SPAS field.</summary>
 /// <param name="RecordName">RCNM of the referenced spatial record (110 / 120 / 125 / 130).</param>
 /// <param name="RecordId">RCID of the referenced spatial record.</param>
 /// <param name="Orientation">Orientation: 1 = forward, 2 = reverse.</param>
-public readonly record struct S101SpatialAssociation(byte RecordName, uint RecordId, byte Orientation);
+/// <param name="UpdateInstruction">Per-pointer update instruction (SAUI) used during update application; <see cref="S101UpdateInstruction.None"/> in base cells.</param>
+public readonly record struct S101SpatialAssociation(
+    byte RecordName,
+    uint RecordId,
+    byte Orientation,
+    S101UpdateInstruction UpdateInstruction = S101UpdateInstruction.None);
 
 /// <summary>Feature association from the FACS field: links a feature to another feature.</summary>
 /// <param name="NumericCode">Numeric association code resolved against <see cref="S101Document.FeatureAssociationCatalogue"/>.</param>
 /// <param name="RecordId">RCID of the associated feature record.</param>
 /// <param name="RoleCode">Numeric role code resolved against <see cref="S101Document.RoleCatalogue"/>.</param>
-public readonly record struct S101FeatureAssociation(ushort NumericCode, uint RecordId, ushort RoleCode);
+/// <param name="UpdateInstruction">Per-pointer update instruction (FAUI) used during update application; <see cref="S101UpdateInstruction.None"/> in base cells.</param>
+public readonly record struct S101FeatureAssociation(
+    ushort NumericCode,
+    uint RecordId,
+    ushort RoleCode,
+    S101UpdateInstruction UpdateInstruction = S101UpdateInstruction.None);
 
 /// <summary>Information association from the INAS field: links a feature to an information type record.</summary>
 /// <param name="NumericCode">Numeric association code resolved against <see cref="S101Document.InformationAssociationCatalogue"/>.</param>
 /// <param name="RecordId">RCID of the associated information type record.</param>
 /// <param name="RoleCode">Numeric role code resolved against <see cref="S101Document.RoleCatalogue"/>.</param>
-public readonly record struct S101InformationAssociation(ushort NumericCode, uint RecordId, ushort RoleCode);
+/// <param name="UpdateInstruction">Per-pointer update instruction (IUIN) used during update application; <see cref="S101UpdateInstruction.None"/> in base cells.</param>
+public readonly record struct S101InformationAssociation(
+    ushort NumericCode,
+    uint RecordId,
+    ushort RoleCode,
+    S101UpdateInstruction UpdateInstruction = S101UpdateInstruction.None);

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentReader.cs
@@ -180,6 +180,8 @@ internal static class S101DocumentReader
         reader.TryGetSubfield<string>("DSTL", out var dstl);
         reader.TryGetSubfield<string>("DSRD", out var dsrd);
         reader.TryGetSubfield<string>("DSLG", out var dslg);
+        reader.TryGetSubfield<string>("DSAB", out var dsab);
+        reader.TryGetSubfield<string>("DSED", out var dsed);
 
         return new S101DatasetIdentification
         {
@@ -194,7 +196,64 @@ internal static class S101DocumentReader
             DatasetTitle = dstl ?? "",
             DatasetReferenceDate = dsrd ?? "",
             DatasetLanguage = dslg ?? "",
+            DatasetAbstract = dsab ?? "",
+            DatasetEdition = dsed ?? "",
+            UpdateNumber = ParseUpdateNumber(dsnm),
         };
+    }
+
+    /// <summary>
+    /// Derives the update number from the dataset file extension carried in
+    /// DSID/DSNM (<c>….000</c> = base, <c>….001</c> = update 1, …). Returns
+    /// <c>0</c> when no numeric three-digit extension is present.
+    /// </summary>
+    /// <remarks>S-100 Part 10a / S-101 dataset file naming.</remarks>
+    private static int ParseUpdateNumber(string? datasetName)
+    {
+        if (string.IsNullOrEmpty(datasetName))
+            return 0;
+
+        var ext = Path.GetExtension(datasetName);
+        if (ext.Length == 4 &&
+            int.TryParse(ext.AsSpan(1), System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var update))
+        {
+            return update;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Reads the record update instruction (RUIN / SAUI / FAUI / IUIN / ATIN)
+    /// from the supplied reader, mapping the ISO 8211 byte value to
+    /// <see cref="S101UpdateInstruction"/>. Returns
+    /// <see cref="S101UpdateInstruction.None"/> when absent. S-100 Part 10a.
+    /// </summary>
+    private static S101UpdateInstruction ReadUpdateInstruction(Iso8211FieldReader reader, string subfield)
+    {
+        if (reader.TryGetSubfield<byte>(subfield, out var value) &&
+            Enum.IsDefined(typeof(S101UpdateInstruction), (S101UpdateInstruction)value))
+        {
+            return (S101UpdateInstruction)value;
+        }
+
+        return S101UpdateInstruction.None;
+    }
+
+    private static S101UpdateInstruction ReadUpdateInstruction(Iso8211SubfieldGroup group, string subfield)
+    {
+        try
+        {
+            var value = group.GetSubfield<byte>(subfield);
+            return Enum.IsDefined(typeof(S101UpdateInstruction), (S101UpdateInstruction)value)
+                ? (S101UpdateInstruction)value
+                : S101UpdateInstruction.None;
+        }
+        catch (KeyNotFoundException)
+        {
+            return S101UpdateInstruction.None;
+        }
     }
 
     private static S101DatasetStructureInfo ParseDssi(Iso8211Record record, Iso8211DataDescriptiveRecord ddr)
@@ -225,6 +284,8 @@ internal static class S101DocumentReader
         var pridDef = ddr.GetFieldDefinition("PRID")!;
         var pridReader = new Iso8211FieldReader(pridDef, pridField.Data);
         var rcid = pridReader.GetSubfield<uint>("RCID");
+        pridReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(pridReader, "RUIN");
 
         int y = 0, x = 0;
         var c2it = record.GetFieldByTag("C2IT");
@@ -236,7 +297,7 @@ internal static class S101DocumentReader
             x = c2itReader.GetSubfield<int>("XCOO");
         }
 
-        return new S101PointRecord { RecordId = rcid, Y = y, X = x };
+        return new S101PointRecord { RecordId = rcid, Y = y, X = x, RecordVersion = rver, UpdateInstruction = ruin };
     }
 
     /// <summary>
@@ -256,6 +317,8 @@ internal static class S101DocumentReader
         var mridDef = ddr.GetFieldDefinition("MRID")!;
         var mridReader = new Iso8211FieldReader(mridDef, mridField.Data);
         var rcid = mridReader.GetSubfield<uint>("RCID");
+        mridReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(mridReader, "RUIN");
 
         var coords = ImmutableArray.CreateBuilder<(int Y, int X, int Z)>();
         var c3ilField = record.GetFieldByTag("C3IL");
@@ -277,6 +340,8 @@ internal static class S101DocumentReader
         {
             RecordId = rcid,
             Points = coords.ToImmutable(),
+            RecordVersion = rver,
+            UpdateInstruction = ruin,
         };
     }
 
@@ -288,6 +353,8 @@ internal static class S101DocumentReader
         var cridDef = ddr.GetFieldDefinition("CRID")!;
         var cridReader = new Iso8211FieldReader(cridDef, cridField.Data);
         var rcid = cridReader.GetSubfield<uint>("RCID");
+        cridReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(cridReader, "RUIN");
 
         // PTAS — point topology associations (start/end)
         var ptas = ImmutableArray.CreateBuilder<S101PointAssociation>();
@@ -323,6 +390,8 @@ internal static class S101DocumentReader
             RecordId = rcid,
             PointAssociations = ptas.ToImmutable(),
             IntermediateCoordinates = coords.ToImmutable(),
+            RecordVersion = rver,
+            UpdateInstruction = ruin,
         };
     }
 
@@ -334,6 +403,8 @@ internal static class S101DocumentReader
         var ccidDef = ddr.GetFieldDefinition("CCID")!;
         var ccidReader = new Iso8211FieldReader(ccidDef, ccidField.Data);
         var rcid = ccidReader.GetSubfield<uint>("RCID");
+        ccidReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(ccidReader, "RUIN");
 
         var components = ImmutableArray.CreateBuilder<S101CurveUsage>();
         foreach (var cucoField in record.GetFieldsByTag("CUCO"))
@@ -353,6 +424,8 @@ internal static class S101DocumentReader
         {
             RecordId = rcid,
             CurveComponents = components.ToImmutable(),
+            RecordVersion = rver,
+            UpdateInstruction = ruin,
         };
     }
 
@@ -364,6 +437,8 @@ internal static class S101DocumentReader
         var sridDef = ddr.GetFieldDefinition("SRID")!;
         var sridReader = new Iso8211FieldReader(sridDef, sridField.Data);
         var rcid = sridReader.GetSubfield<uint>("RCID");
+        sridReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(sridReader, "RUIN");
 
         var rings = ImmutableArray.CreateBuilder<S101RingAssociation>();
         foreach (var riasField in record.GetFieldsByTag("RIAS"))
@@ -384,6 +459,8 @@ internal static class S101DocumentReader
         {
             RecordId = rcid,
             RingAssociations = rings.ToImmutable(),
+            RecordVersion = rver,
+            UpdateInstruction = ruin,
         };
     }
 
@@ -396,6 +473,8 @@ internal static class S101DocumentReader
         var fridReader = new Iso8211FieldReader(fridDef, fridField.Data);
         var rcid = fridReader.GetSubfield<uint>("RCID");
         fridReader.TryGetSubfield<ushort>("NFTC", out var nftc);
+        fridReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(fridReader, "RUIN");
 
         // FOID
         ushort agen = 0;
@@ -421,10 +500,13 @@ internal static class S101DocumentReader
             {
                 var natc = group.GetSubfield<ushort>("NATC");
                 var atix = group.GetSubfield<ushort>("ATIX");
+                ushort paix = 0;
+                try { paix = group.GetSubfield<ushort>("PAIX"); } catch (KeyNotFoundException) { }
+                var atin = ReadUpdateInstruction(group, "ATIN");
                 string atvl;
                 try { atvl = group.GetSubfield<string>("ATVL"); }
                 catch (KeyNotFoundException) { atvl = ""; }
-                attributes.Add(new S101Attribute(natc, atix, atvl));
+                attributes.Add(new S101Attribute(natc, atix, atvl, paix, atin));
             }
         }
 
@@ -439,7 +521,8 @@ internal static class S101DocumentReader
                 var rrnm = group.GetSubfield<byte>("RRNM");
                 var rrid = group.GetSubfield<uint>("RRID");
                 var ornt = group.GetSubfield<byte>("ORNT");
-                spatials.Add(new S101SpatialAssociation(rrnm, rrid, ornt));
+                var saui = ReadUpdateInstruction(group, "SAUI");
+                spatials.Add(new S101SpatialAssociation(rrnm, rrid, ornt, saui));
             }
         }
 
@@ -456,7 +539,8 @@ internal static class S101DocumentReader
                 var rrid = group.GetSubfield<uint>("RRID");
                 ushort narc = 0;
                 try { narc = group.GetSubfield<ushort>("NARC"); } catch (KeyNotFoundException) { }
-                featureAssociations.Add(new S101FeatureAssociation(nfac, rrid, narc));
+                var faui = ReadUpdateInstruction(group, "FAUI");
+                featureAssociations.Add(new S101FeatureAssociation(nfac, rrid, narc, faui));
             }
         }
 
@@ -473,7 +557,8 @@ internal static class S101DocumentReader
                 var rrid = group.GetSubfield<uint>("RRID");
                 ushort narc = 0;
                 try { narc = group.GetSubfield<ushort>("NARC"); } catch (KeyNotFoundException) { }
-                informationAssociations.Add(new S101InformationAssociation(niac, rrid, narc));
+                var iuin = ReadUpdateInstruction(group, "IUIN");
+                informationAssociations.Add(new S101InformationAssociation(niac, rrid, narc, iuin));
             }
         }
 
@@ -488,6 +573,8 @@ internal static class S101DocumentReader
             SpatialAssociations = spatials.ToImmutable(),
             FeatureAssociations = featureAssociations.ToImmutable(),
             InformationAssociations = informationAssociations.ToImmutable(),
+            RecordVersion = rver,
+            UpdateInstruction = ruin,
         };
     }
 
@@ -500,6 +587,8 @@ internal static class S101DocumentReader
         var iridReader = new Iso8211FieldReader(iridDef, iridField.Data);
         var rcid = iridReader.GetSubfield<uint>("RCID");
         iridReader.TryGetSubfield<ushort>("NITC", out var nitc);
+        iridReader.TryGetSubfield<ushort>("RVER", out var rver);
+        var ruin = ReadUpdateInstruction(iridReader, "RUIN");
 
         var attributes = ImmutableArray.CreateBuilder<S101Attribute>();
         foreach (var attrField in record.GetFieldsByTag("ATTR"))
@@ -510,10 +599,13 @@ internal static class S101DocumentReader
             {
                 var natc = group.GetSubfield<ushort>("NATC");
                 var atix = group.GetSubfield<ushort>("ATIX");
+                ushort paix = 0;
+                try { paix = group.GetSubfield<ushort>("PAIX"); } catch (KeyNotFoundException) { }
+                var atin = ReadUpdateInstruction(group, "ATIN");
                 string atvl;
                 try { atvl = group.GetSubfield<string>("ATVL"); }
                 catch (KeyNotFoundException) { atvl = ""; }
-                attributes.Add(new S101Attribute(natc, atix, atvl));
+                attributes.Add(new S101Attribute(natc, atix, atvl, paix, atin));
             }
         }
 
@@ -522,6 +614,8 @@ internal static class S101DocumentReader
             RecordId = rcid,
             InformationTypeCode = nitc,
             Attributes = attributes.ToImmutable(),
+            RecordVersion = rver,
+            UpdateInstruction = ruin,
         };
     }
 }

--- a/src/EncDotNet.S100.Datasets.S101/S101UpdateApplicator.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101UpdateApplicator.cs
@@ -1,0 +1,485 @@
+using System.Collections.Immutable;
+
+namespace EncDotNet.S100.Datasets.S101;
+
+/// <summary>Severity of a message produced while applying S-101 sequential updates.</summary>
+public enum S101UpdateSeverity
+{
+    /// <summary>Informational note (e.g. an update was applied cleanly).</summary>
+    Info = 0,
+
+    /// <summary>A recoverable problem; application continued best-effort.</summary>
+    Warning = 1,
+
+    /// <summary>A problem that prevented an update (or part of it) from being applied.</summary>
+    Error = 2,
+}
+
+/// <summary>A single diagnostic emitted during update application.</summary>
+/// <param name="Severity">Message severity.</param>
+/// <param name="Text">Human-readable description.</param>
+/// <param name="UpdateNumber">Update number the message relates to, when known.</param>
+public readonly record struct S101UpdateMessage(
+    S101UpdateSeverity Severity,
+    string Text,
+    int? UpdateNumber = null);
+
+/// <summary>
+/// Structured outcome of applying one or more S-101 sequential updates onto a base
+/// cell. Application is <b>best-effort</b>: a failed or invalid update is recorded
+/// here and never prevents the (partially) updated document from being used.
+/// </summary>
+public sealed class S101UpdateReport
+{
+    /// <summary>Update number of the base cell the chain started from (0 for a base cell).</summary>
+    public int BaseUpdateNumber { get; init; }
+
+    /// <summary>The highest update number successfully applied (equals <see cref="BaseUpdateNumber"/> if none applied).</summary>
+    public int AppliedThroughUpdateNumber { get; init; }
+
+    /// <summary>Number of records inserted across all applied updates.</summary>
+    public int Inserted { get; init; }
+
+    /// <summary>Number of records deleted across all applied updates.</summary>
+    public int Deleted { get; init; }
+
+    /// <summary>Number of records modified across all applied updates.</summary>
+    public int Modified { get; init; }
+
+    /// <summary>Diagnostics gathered during application.</summary>
+    public ImmutableArray<S101UpdateMessage> Messages { get; init; } = ImmutableArray<S101UpdateMessage>.Empty;
+
+    /// <summary><see langword="true"/> when no <see cref="S101UpdateSeverity.Error"/> or warning was recorded.</summary>
+    public bool Success => !Messages.Any(m => m.Severity >= S101UpdateSeverity.Warning);
+}
+
+/// <summary>
+/// Applies S-101 sequential updates (application profile <c>2</c>) onto a base
+/// cell (profile <c>1</c>) to produce an "up-to-date" document, mirroring the
+/// pure document-to-document merge of <c>EncDotNet.S57.S57Document.ApplyChanges</c>.
+/// </summary>
+/// <remarks>
+/// Records are keyed by record id (RCID) within each record class. Record-level
+/// <c>RUIN</c> selects insert / delete / modify; for feature and information
+/// records, <c>Modify</c> merges attributes and associations using their inlined
+/// per-element instructions (<c>ATIN</c> / <c>SAUI</c> / <c>FAUI</c> / <c>IUIN</c>).
+/// Spatial records (point / multi-point / curve / composite-curve / surface) carry
+/// no inline element instructions, so <c>Modify</c> replaces the record wholesale.
+/// </remarks>
+public static class S101UpdateApplicator
+{
+    /// <summary>
+    /// Applies an ordered list of update documents onto <paramref name="baseDocument"/>,
+    /// best-effort, and reports the outcome.
+    /// </summary>
+    /// <param name="baseDocument">The base cell (application profile <c>1</c>).</param>
+    /// <param name="orderedUpdates">
+    /// Update documents in ascending update-number order. The list may be empty
+    /// (returns the base unchanged).
+    /// </param>
+    /// <param name="report">Receives a structured, best-effort outcome report.</param>
+    /// <returns>
+    /// The merged document. On any failure, the most up-to-date usable document
+    /// produced so far (at minimum the base) is returned and the failure is noted
+    /// in <paramref name="report"/>.
+    /// </returns>
+    public static S101Document Apply(
+        S101Document baseDocument,
+        IReadOnlyList<S101Document> orderedUpdates,
+        out S101UpdateReport report)
+    {
+        ArgumentNullException.ThrowIfNull(baseDocument);
+        ArgumentNullException.ThrowIfNull(orderedUpdates);
+
+        var messages = new List<S101UpdateMessage>();
+        var counts = new ApplyCounts();
+
+        var baseUpdateNumber = baseDocument.Identification.UpdateNumber;
+        var current = baseDocument;
+        var appliedThrough = baseUpdateNumber;
+        var expectedNext = baseUpdateNumber + 1;
+
+        foreach (var update in orderedUpdates)
+        {
+            var updateNumber = update.Identification.UpdateNumber;
+
+            if (!update.Identification.IsUpdate)
+            {
+                messages.Add(new S101UpdateMessage(
+                    S101UpdateSeverity.Warning,
+                    $"Skipped '{update.Identification.DatasetName}': not an update dataset (application profile is '{update.Identification.ApplicationProfile}').",
+                    updateNumber));
+                continue;
+            }
+
+            if (updateNumber != expectedNext)
+            {
+                // Gap or out-of-order break the chain; stop best-effort here.
+                messages.Add(new S101UpdateMessage(
+                    S101UpdateSeverity.Warning,
+                    $"Stopped at update {updateNumber}: expected update {expectedNext} (non-contiguous sequence). Earlier updates were applied.",
+                    updateNumber));
+                break;
+            }
+
+            try
+            {
+                current = ApplySingle(current, update, messages, counts);
+                appliedThrough = updateNumber;
+                expectedNext = updateNumber + 1;
+                messages.Add(new S101UpdateMessage(
+                    S101UpdateSeverity.Info, $"Applied update {updateNumber}.", updateNumber));
+            }
+            catch (Exception ex)
+            {
+                messages.Add(new S101UpdateMessage(
+                    S101UpdateSeverity.Error,
+                    $"Failed to apply update {updateNumber}: {ex.Message}. Earlier updates were applied.",
+                    updateNumber));
+                break;
+            }
+        }
+
+        report = new S101UpdateReport
+        {
+            BaseUpdateNumber = baseUpdateNumber,
+            AppliedThroughUpdateNumber = appliedThrough,
+            Inserted = counts.Inserted,
+            Deleted = counts.Deleted,
+            Modified = counts.Modified,
+            Messages = messages.ToImmutableArray(),
+        };
+
+        return current;
+    }
+
+    internal static S101Document ApplySingle(
+        S101Document baseDocument,
+        S101Document update,
+        ICollection<S101UpdateMessage>? messages)
+        => ApplySingle(baseDocument, update, messages, new ApplyCounts());
+
+    private static S101Document ApplySingle(
+        S101Document baseDocument,
+        S101Document update,
+        ICollection<S101UpdateMessage>? messages,
+        ApplyCounts counts)
+    {
+        var points = baseDocument.Points.ToBuilder();
+        var multiPoints = baseDocument.MultiPoints.ToBuilder();
+        var curves = baseDocument.CurveSegments.ToBuilder();
+        var compositeCurves = baseDocument.CompositeCurves.ToBuilder();
+        var surfaces = baseDocument.Surfaces.ToBuilder();
+        var informationTypes = baseDocument.InformationTypes.ToBuilder();
+
+        ApplySpatial(points, update.Points, counts, messages);
+        ApplySpatial(multiPoints, update.MultiPoints, counts, messages);
+        ApplySpatial(curves, update.CurveSegments, counts, messages);
+        ApplySpatial(compositeCurves, update.CompositeCurves, counts, messages);
+        ApplySpatial(surfaces, update.Surfaces, counts, messages);
+
+        ApplyInformationRecords(informationTypes, update.InformationTypes, counts, messages);
+
+        var features = ApplyFeatures(baseDocument.Features, update.Features, counts, messages);
+
+        return new S101Document
+        {
+            Identification = baseDocument.Identification with
+            {
+                UpdateNumber = update.Identification.UpdateNumber,
+                ApplicationProfile = baseDocument.Identification.ApplicationProfile,
+            },
+            StructureInfo = baseDocument.StructureInfo,
+            FeatureTypeCatalogue = baseDocument.FeatureTypeCatalogue,
+            AttributeTypeCatalogue = baseDocument.AttributeTypeCatalogue,
+            Points = points.ToImmutable(),
+            MultiPoints = multiPoints.ToImmutable(),
+            CurveSegments = curves.ToImmutable(),
+            CompositeCurves = compositeCurves.ToImmutable(),
+            Surfaces = surfaces.ToImmutable(),
+            Features = features,
+            InformationTypes = informationTypes.ToImmutable(),
+            InformationTypeCatalogue = baseDocument.InformationTypeCatalogue,
+            InformationAssociationCatalogue = baseDocument.InformationAssociationCatalogue,
+            FeatureAssociationCatalogue = baseDocument.FeatureAssociationCatalogue,
+            RoleCatalogue = baseDocument.RoleCatalogue,
+        };
+    }
+
+    private static void ApplySpatial<T>(
+        ImmutableDictionary<uint, T>.Builder target,
+        ImmutableDictionary<uint, T> updates,
+        ApplyCounts counts,
+        ICollection<S101UpdateMessage>? messages)
+        where T : class
+    {
+        foreach (var (id, record) in updates)
+        {
+            var instruction = GetInstruction(record);
+            switch (instruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (target.Remove(id)) counts.Deleted++;
+                    break;
+
+                case S101UpdateInstruction.Modify:
+                    // Spatial records carry no inline element instructions; replace wholesale.
+                    target[id] = record;
+                    counts.Modified++;
+                    break;
+
+                case S101UpdateInstruction.Insert:
+                case S101UpdateInstruction.None:
+                default:
+                    var existed = target.ContainsKey(id);
+                    target[id] = record;
+                    if (existed) counts.Modified++; else counts.Inserted++;
+                    break;
+            }
+        }
+    }
+
+    private static void ApplyInformationRecords(
+        ImmutableDictionary<uint, S101InformationRecord>.Builder target,
+        ImmutableDictionary<uint, S101InformationRecord> updates,
+        ApplyCounts counts,
+        ICollection<S101UpdateMessage>? messages)
+    {
+        foreach (var (id, record) in updates)
+        {
+            switch (record.UpdateInstruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (target.Remove(id)) counts.Deleted++;
+                    break;
+
+                case S101UpdateInstruction.Modify when target.TryGetValue(id, out var existing):
+                    target[id] = new S101InformationRecord
+                    {
+                        RecordId = existing.RecordId,
+                        InformationTypeCode = record.InformationTypeCode != 0
+                            ? record.InformationTypeCode
+                            : existing.InformationTypeCode,
+                        Attributes = MergeAttributes(existing.Attributes, record.Attributes),
+                        RecordVersion = record.RecordVersion,
+                        UpdateInstruction = S101UpdateInstruction.None,
+                    };
+                    counts.Modified++;
+                    break;
+
+                default:
+                    var existed = target.ContainsKey(id);
+                    target[id] = record;
+                    if (existed) counts.Modified++; else counts.Inserted++;
+                    break;
+            }
+        }
+    }
+
+    private static ImmutableArray<S101FeatureRecord> ApplyFeatures(
+        ImmutableArray<S101FeatureRecord> baseFeatures,
+        ImmutableArray<S101FeatureRecord> updateFeatures,
+        ApplyCounts counts,
+        ICollection<S101UpdateMessage>? messages)
+    {
+        // Preserve dataset order while allowing keyed insert/delete/modify by RCID.
+        var order = new List<uint>(baseFeatures.Length);
+        var byId = new Dictionary<uint, S101FeatureRecord>(baseFeatures.Length);
+        foreach (var f in baseFeatures)
+        {
+            if (!byId.ContainsKey(f.RecordId)) order.Add(f.RecordId);
+            byId[f.RecordId] = f;
+        }
+
+        foreach (var update in updateFeatures)
+        {
+            switch (update.UpdateInstruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (byId.Remove(update.RecordId))
+                    {
+                        order.Remove(update.RecordId);
+                        counts.Deleted++;
+                    }
+                    break;
+
+                case S101UpdateInstruction.Modify when byId.TryGetValue(update.RecordId, out var existing):
+                    byId[update.RecordId] = MergeFeature(existing, update);
+                    counts.Modified++;
+                    break;
+
+                default:
+                    if (byId.ContainsKey(update.RecordId))
+                    {
+                        byId[update.RecordId] = update;
+                        counts.Modified++;
+                    }
+                    else
+                    {
+                        order.Add(update.RecordId);
+                        byId[update.RecordId] = update;
+                        counts.Inserted++;
+                    }
+                    break;
+            }
+        }
+
+        var result = ImmutableArray.CreateBuilder<S101FeatureRecord>(order.Count);
+        foreach (var id in order)
+            result.Add(byId[id]);
+        return result.ToImmutable();
+    }
+
+    private static S101FeatureRecord MergeFeature(S101FeatureRecord existing, S101FeatureRecord update) =>
+        new()
+        {
+            RecordId = existing.RecordId,
+            FeatureTypeCode = update.FeatureTypeCode != 0 ? update.FeatureTypeCode : existing.FeatureTypeCode,
+            ProducingAgency = update.ProducingAgency != 0 ? update.ProducingAgency : existing.ProducingAgency,
+            FeatureIdentificationNumber = update.FeatureIdentificationNumber != 0
+                ? update.FeatureIdentificationNumber
+                : existing.FeatureIdentificationNumber,
+            FeatureIdentificationSubdivision = update.FeatureIdentificationSubdivision != 0
+                ? update.FeatureIdentificationSubdivision
+                : existing.FeatureIdentificationSubdivision,
+            Attributes = MergeAttributes(existing.Attributes, update.Attributes),
+            SpatialAssociations = MergeSpatialAssociations(existing.SpatialAssociations, update.SpatialAssociations),
+            FeatureAssociations = MergeFeatureAssociations(existing.FeatureAssociations, update.FeatureAssociations),
+            InformationAssociations = MergeInformationAssociations(existing.InformationAssociations, update.InformationAssociations),
+            RecordVersion = update.RecordVersion,
+            UpdateInstruction = S101UpdateInstruction.None,
+        };
+
+    private static ImmutableArray<S101Attribute> MergeAttributes(
+        ImmutableArray<S101Attribute> existing,
+        ImmutableArray<S101Attribute> updates)
+    {
+        if (updates.IsDefaultOrEmpty)
+            return existing;
+
+        var list = existing.IsDefault ? new List<S101Attribute>() : new List<S101Attribute>(existing);
+
+        foreach (var u in updates)
+        {
+            var index = list.FindIndex(a => a.NumericCode == u.NumericCode && a.Index == u.Index && a.ParentIndex == u.ParentIndex);
+            switch (u.UpdateInstruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (index >= 0) list.RemoveAt(index);
+                    break;
+
+                default:
+                    var replacement = u with { UpdateInstruction = S101UpdateInstruction.None };
+                    if (index >= 0) list[index] = replacement;
+                    else list.Add(replacement);
+                    break;
+            }
+        }
+
+        return list.ToImmutableArray();
+    }
+
+    private static ImmutableArray<S101SpatialAssociation> MergeSpatialAssociations(
+        ImmutableArray<S101SpatialAssociation> existing,
+        ImmutableArray<S101SpatialAssociation> updates)
+    {
+        if (updates.IsDefaultOrEmpty)
+            return existing;
+
+        var list = existing.IsDefault ? new List<S101SpatialAssociation>() : new List<S101SpatialAssociation>(existing);
+
+        foreach (var u in updates)
+        {
+            var index = list.FindIndex(a => a.RecordName == u.RecordName && a.RecordId == u.RecordId);
+            switch (u.UpdateInstruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (index >= 0) list.RemoveAt(index);
+                    break;
+
+                default:
+                    var replacement = u with { UpdateInstruction = S101UpdateInstruction.None };
+                    if (index >= 0) list[index] = replacement;
+                    else list.Add(replacement);
+                    break;
+            }
+        }
+
+        return list.ToImmutableArray();
+    }
+
+    private static ImmutableArray<S101FeatureAssociation> MergeFeatureAssociations(
+        ImmutableArray<S101FeatureAssociation> existing,
+        ImmutableArray<S101FeatureAssociation> updates)
+    {
+        if (updates.IsDefaultOrEmpty)
+            return existing;
+
+        var list = existing.IsDefault ? new List<S101FeatureAssociation>() : new List<S101FeatureAssociation>(existing);
+
+        foreach (var u in updates)
+        {
+            var index = list.FindIndex(a => a.NumericCode == u.NumericCode && a.RecordId == u.RecordId);
+            switch (u.UpdateInstruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (index >= 0) list.RemoveAt(index);
+                    break;
+
+                default:
+                    var replacement = u with { UpdateInstruction = S101UpdateInstruction.None };
+                    if (index >= 0) list[index] = replacement;
+                    else list.Add(replacement);
+                    break;
+            }
+        }
+
+        return list.ToImmutableArray();
+    }
+
+    private static ImmutableArray<S101InformationAssociation> MergeInformationAssociations(
+        ImmutableArray<S101InformationAssociation> existing,
+        ImmutableArray<S101InformationAssociation> updates)
+    {
+        if (updates.IsDefaultOrEmpty)
+            return existing;
+
+        var list = existing.IsDefault ? new List<S101InformationAssociation>() : new List<S101InformationAssociation>(existing);
+
+        foreach (var u in updates)
+        {
+            var index = list.FindIndex(a => a.NumericCode == u.NumericCode && a.RecordId == u.RecordId);
+            switch (u.UpdateInstruction)
+            {
+                case S101UpdateInstruction.Delete:
+                    if (index >= 0) list.RemoveAt(index);
+                    break;
+
+                default:
+                    var replacement = u with { UpdateInstruction = S101UpdateInstruction.None };
+                    if (index >= 0) list[index] = replacement;
+                    else list.Add(replacement);
+                    break;
+            }
+        }
+
+        return list.ToImmutableArray();
+    }
+
+    private static S101UpdateInstruction GetInstruction<T>(T record) where T : class => record switch
+    {
+        S101PointRecord p => p.UpdateInstruction,
+        S101MultiPointRecord m => m.UpdateInstruction,
+        S101CurveSegmentRecord c => c.UpdateInstruction,
+        S101CompositeCurveRecord cc => cc.UpdateInstruction,
+        S101SurfaceRecord s => s.UpdateInstruction,
+        _ => S101UpdateInstruction.None,
+    };
+
+    private sealed class ApplyCounts
+    {
+        public int Inserted;
+        public int Deleted;
+        public int Modified;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -315,6 +315,9 @@ internal static class Strings
     public static string Status_ExchangeSetCatalogNotFound => Get(nameof(Status_ExchangeSetCatalogNotFound));
     public static string Status_ExchangeSetUnsupportedSpec => Get(nameof(Status_ExchangeSetUnsupportedSpec));
     public static string Status_ExchangeSetCancelled => Get(nameof(Status_ExchangeSetCancelled));
+    public static string Status_ExchangeSetOrphanUpdate => Get(nameof(Status_ExchangeSetOrphanUpdate));
+    public static string Status_ExchangeSetUpdatesApplied => Get(nameof(Status_ExchangeSetUpdatesApplied));
+    public static string Status_ExchangeSetUpdatesPartial => Get(nameof(Status_ExchangeSetUpdatesPartial));
 
     // Exchange-set progress overlay (es3-progress)
     public static string Progress_ExchangeSetTitle => Get(nameof(Progress_ExchangeSetTitle));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -845,6 +845,18 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Status_ExchangeSetCancelled" xml:space="preserve">
     <value>Cancelled after loading {0} of {1} datasets from {2}.</value>
   </data>
+  <data name="Status_ExchangeSetOrphanUpdate" xml:space="preserve">
+    <value>Skipped update {0}: no matching base cell in this exchange set.</value>
+    <comment>{0} = update file relative path. Shown when an S-101 update (.001/.002/…) has no base (.000) in the same exchange set.</comment>
+  </data>
+  <data name="Status_ExchangeSetUpdatesApplied" xml:space="preserve">
+    <value>Applied {0} update(s) to {1}.</value>
+    <comment>{0} = number of S-101 sequential updates applied, {1} = cell display name.</comment>
+  </data>
+  <data name="Status_ExchangeSetUpdatesPartial" xml:space="preserve">
+    <value>Applied {0} update(s) to {1} with warnings: {2}</value>
+    <comment>{0} = updates applied, {1} = cell display name, {2} = first warning/error message from the update report.</comment>
+  </data>
 
   <!-- Exchange-set progress overlay (es3-progress) -->
   <data name="Progress_ExchangeSetTitle" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Datasets.S101;
 using EncDotNet.S100.Interoperability;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Portrayals;
@@ -219,6 +220,34 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     private void SetStatus(string? text) => StatusChanged?.Invoke(text);
 
+    /// <summary>
+    /// Surfaces the outcome of S-101 sequential update application as a
+    /// status message (and, when updates failed to apply cleanly, a
+    /// non-blocking warning toast). Updates are applied best-effort, so
+    /// a partial result never prevents the dataset from rendering.
+    /// S-101 / S-100 Part 10a.
+    /// </summary>
+    private void SurfaceUpdateReport(DatasetEntry entry, S101UpdateReport report)
+    {
+        var appliedCount = report.AppliedThroughUpdateNumber - report.BaseUpdateNumber;
+        var problem = report.Messages
+            .FirstOrDefault(m => m.Severity >= S101UpdateSeverity.Warning);
+
+        if (problem.Severity >= S101UpdateSeverity.Warning)
+        {
+            var msg = string.Format(
+                Strings.Status_ExchangeSetUpdatesPartial,
+                appliedCount, entry.DisplayName, problem.Text);
+            SetStatus(msg);
+            _toasts.ShowWarning(Strings.Toast_Warning, msg);
+        }
+        else if (appliedCount > 0)
+        {
+            SetStatus(string.Format(
+                Strings.Status_ExchangeSetUpdatesApplied, appliedCount, entry.DisplayName));
+        }
+    }
+
     public void Initialize(IMapHost host, ViewerCommandSettings? options)
     {
         ArgumentNullException.ThrowIfNull(host);
@@ -303,10 +332,29 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
         try
         {
-            var processor = await Task.Run(() => fromExchangeSet
-                ? _pipelineFactory.CreateProcessor(entry.Source!, entry.RelativePath!, spec)
-                : _pipelineFactory.CreateProcessor(entry.FilePath), token);
+            var processor = await Task.Run(() =>
+            {
+                if (!fromExchangeSet)
+                    return _pipelineFactory.CreateProcessor(entry.FilePath);
+
+                // Collapse an S-101 base cell and its in-set sequential
+                // updates into a single up-to-date dataset. S-101 / S-100
+                // Part 10a.
+                return entry.HasUpdates
+                    ? _pipelineFactory.CreateS101ProcessorWithUpdates(
+                        entry.Source!, entry.RelativePath!, entry.UpdateRelativePaths)
+                    : _pipelineFactory.CreateProcessor(entry.Source!, entry.RelativePath!, spec);
+            }, token);
             _processors[entry] = processor;
+
+            // Surface any S-101 update-application diagnostics. Updates are
+            // applied best-effort: a partial/failed apply never blocks the
+            // load, but the user is warned so stale or skipped updates are
+            // visible. S-101 / S-100 Part 10a.
+            if (processor is S101DatasetProcessor { UpdateReport: { } updateReport })
+            {
+                SurfaceUpdateReport(entry, updateReport);
+            }
 
             // Surface S-128 catalogues into the Dataset Catalog panel.
             if (processor is S128DatasetProcessor s128)

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -120,7 +120,16 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             }
 
             _status.StatusText = string.Format(Strings.Status_ExchangeSetLoading, folderOrZipPath);
-            progress?.Report(new ExchangeSetProgress(folderOrZipPath, datasets.Count, 0, 0, null));
+
+            // Group S-101 base cells with their in-set sequential updates
+            // (….001/.002/…) so each cell loads as a single up-to-date
+            // dataset rather than one entry per file. Non-S-101 datasets
+            // and S-101 cells with no in-set updates are unaffected.
+            // S-101 / S-100 Part 10a.
+            var plan = S101ExchangeSetUpdatePlan.Build(datasets);
+            activity?.SetTag("s100.exchangeset.plan.count", plan.Count);
+
+            progress?.Report(new ExchangeSetProgress(folderOrZipPath, plan.Count, 0, 0, null));
 
             var tracked = new TrackedExchangeSet(folderOrZipPath, exchangeSet);
             _tracked.Add(tracked);
@@ -129,12 +138,13 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             var assetSource = tracked.ExchangeSet.Source;
             var producer = tracked.ExchangeSet.Catalogue.Contact?.Organization;
             var issueDate = ResolveLatestIssueDate(datasets);
+
             tracked.Header = _datasets.RegisterExchangeSetHeader(
                 assetSource,
                 folderOrZipPath,
                 producer,
                 issueDate,
-                datasets.Count,
+                plan.Count,
                 closeAction: CloseExchangeSetFromHeader);
             exchangeSet = null;
             source = null;
@@ -144,7 +154,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             var skipMessages = new List<string>();
             var cancelled = false;
 
-            foreach (var metadata in datasets)
+            foreach (var item in plan)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -152,7 +162,24 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     break;
                 }
 
+                var metadata = item.Base;
                 var relativePath = metadata.RelativePath;
+
+                // An S-101 update with no base cell in this exchange set
+                // cannot be applied on its own. Per the best-effort policy
+                // we skip it with a warning rather than failing the load.
+                if (item.Kind == S101LoadItemKind.OrphanUpdate)
+                {
+                    var orphanMsg = string.Format(Strings.Status_ExchangeSetOrphanUpdate, relativePath);
+                    _status.StatusText = orphanMsg;
+                    _toasts.ShowWarning(Strings.Toast_Warning, orphanMsg);
+                    skipMessages.Add(orphanMsg);
+                    skipped++;
+                    progress?.Report(new ExchangeSetProgress(
+                        folderOrZipPath, plan.Count, dispatched + skipped, skipped, relativePath));
+                    continue;
+                }
+
                 var spec = DatasetPipelineFactory.MapProductIdentifierToSpec(
                     metadata.ProductSpecification?.ProductIdentifier);
                 if (spec is null)
@@ -166,27 +193,32 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     skipMessages.Add(msg);
                     skipped++;
                     progress?.Report(new ExchangeSetProgress(
-                        folderOrZipPath, datasets.Count, dispatched + skipped, skipped, relativePath));
+                        folderOrZipPath, plan.Count, dispatched + skipped, skipped, relativePath));
                     continue;
                 }
+
+                var updateRelativePaths = item.Updates.Count == 0
+                    ? (IReadOnlyList<string>)Array.Empty<string>()
+                    : item.Updates.Select(u => u.RelativePath).ToList();
 
                 var entry = _datasets.AddFromExchangeSet(
                     tracked.ExchangeSet.Source,
                     relativePath,
                     spec,
-                    displayName: Path.GetFileName(relativePath));
+                    displayName: Path.GetFileName(relativePath),
+                    updateRelativePaths: updateRelativePaths);
                 tracked.Entries.Add(entry);
                 _datasets.RequestLoad(entry);
                 dispatched++;
                 progress?.Report(new ExchangeSetProgress(
-                    folderOrZipPath, datasets.Count, dispatched + skipped, skipped, relativePath));
+                    folderOrZipPath, plan.Count, dispatched + skipped, skipped, relativePath));
             }
 
             if (cancelled)
             {
                 var cancelledMsg = string.Format(
                     Strings.Status_ExchangeSetCancelled,
-                    dispatched, datasets.Count, folderOrZipPath);
+                    dispatched, plan.Count, folderOrZipPath);
                 _status.StatusText = cancelledMsg;
                 _toasts.ShowInfo(Strings.Toast_Info, cancelledMsg);
             }
@@ -201,7 +233,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             {
                 var partialMsg = string.Format(
                     Strings.Status_ExchangeSetLoadedWithErrors,
-                    dispatched, datasets.Count, folderOrZipPath, skipped);
+                    dispatched, plan.Count, folderOrZipPath, skipped);
                 _status.StatusText = partialMsg;
                 _toasts.ShowWarning(Strings.Toast_ExchangeSetLoaded, partialMsg);
             }
@@ -247,7 +279,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             return new ExchangeSetOpenResult
             {
                 SourcePath = folderOrZipPath,
-                Total = datasets.Count,
+                Total = plan.Count,
                 Loaded = dispatched,
                 SkippedUnsupported = skipped,
                 Cancelled = cancelled,

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -39,6 +39,21 @@ internal sealed class DatasetEntry : ViewModelBase
     /// <summary>True when this entry's bytes live inside an exchange-set asset source.</summary>
     public bool IsFromExchangeSet => Source is not null;
 
+    /// <summary>
+    /// Source-relative paths of the S-101 sequential update files
+    /// (<c>….001</c>, <c>….002</c>, …) to apply over the base cell at
+    /// <see cref="RelativePath"/>, in ascending update-number order.
+    /// Empty for plain file loads, non-S-101 datasets, and S-101 cells
+    /// with no in-set updates. When non-empty, the loader builds the
+    /// up-to-date dataset via
+    /// <see cref="EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory.CreateS101ProcessorWithUpdates"/>.
+    /// S-101 / S-100 Part 10a.
+    /// </summary>
+    public IReadOnlyList<string> UpdateRelativePaths { get; }
+
+    /// <summary>True when this entry has in-set S-101 updates to apply.</summary>
+    public bool HasUpdates => UpdateRelativePaths.Count > 0;
+
     private bool _isLoaded;
     public bool IsLoaded
     {
@@ -333,12 +348,14 @@ internal sealed class DatasetEntry : ViewModelBase
         string productSpec,
         IAssetSource? source,
         string? relativePath,
-        string? displayName)
+        string? displayName,
+        IReadOnlyList<string>? updateRelativePaths = null)
     {
         FilePath = filePath;
         ProductSpec = productSpec;
         Source = source;
         RelativePath = relativePath;
+        UpdateRelativePaths = updateRelativePaths ?? Array.Empty<string>();
         DisplayName = displayName ?? System.IO.Path.GetFileName(
             relativePath is { Length: > 0 } ? relativePath : filePath);
         ToggleVisibilityCommand = new RelayCommand(() => IsVisible = !IsVisible);
@@ -566,7 +583,8 @@ internal sealed class DatasetsViewModel : ViewModelBase
         IAssetSource source,
         string relativePath,
         string productSpec,
-        string? displayName = null)
+        string? displayName = null,
+        IReadOnlyList<string>? updateRelativePaths = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentException.ThrowIfNullOrEmpty(relativePath);
@@ -581,7 +599,8 @@ internal sealed class DatasetsViewModel : ViewModelBase
             productSpec: productSpec,
             source: source,
             relativePath: relativePath,
-            displayName: displayName);
+            displayName: displayName,
+            updateRelativePaths: updateRelativePaths);
         Entries.Insert(0, entry);
         return entry;
     }

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
@@ -102,4 +102,89 @@ public sealed class RenderCommandTests
                 File.Delete(output);
         }
     }
+
+    [SkippableFact]
+    public void Render_applies_sibling_updates_for_an_s101_base_cell()
+    {
+        var basePath = FindS101BaseCellWithUpdate();
+        Skip.If(basePath is null,
+            "No S-101 base cell (.000) with a sibling .001 update found under IC-ENC sample data.");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-s101upd-{Guid.NewGuid():N}.png");
+        try
+        {
+            // The default (updates applied) and --no-updates paths must both
+            // render successfully; updates are best-effort and never block.
+            int exit = CliApp.Build().Run(
+                ["render", basePath!, output, "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+            var bytes = File.ReadAllBytes(output);
+            Assert.Equal(PngSignature, bytes[..PngSignature.Length]);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Render_with_no_updates_flag_renders_s101_base_cell()
+    {
+        var basePath = FindS101BaseCellWithUpdate();
+        Skip.If(basePath is null,
+            "No S-101 base cell (.000) with a sibling .001 update found under IC-ENC sample data.");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-s101noupd-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", basePath!, output, "--no-updates", "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    /// <summary>
+    /// Locates an S-101 base cell (<c>….000</c>) that has at least one sibling
+    /// update (<c>….001</c>) under the IC-ENC sample tree, or <c>null</c> when
+    /// none is present. Resolves the root from the <c>ICENC_ROOT</c> environment
+    /// variable, falling back to <c>~/Downloads/IC-ENC</c>.
+    /// </summary>
+    private static string? FindS101BaseCellWithUpdate()
+    {
+        var root = Environment.GetEnvironmentVariable("ICENC_ROOT");
+        if (string.IsNullOrEmpty(root))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            root = Path.Combine(home, "Downloads", "IC-ENC");
+        }
+
+        if (!Directory.Exists(root))
+            return null;
+
+        foreach (var basePath in Directory.EnumerateFiles(root, "*.000", SearchOption.AllDirectories))
+        {
+            var updates = EncDotNet.S100.Datasets.Pipelines.S101FilesystemUpdateDiscovery
+                .FindSequentialUpdates(basePath);
+            if (updates.Count == 0)
+                continue;
+
+            if (EncDotNet.S100.Datasets.Pipelines.DatasetPipelineFactory
+                    .DetectProductSpec(basePath) == "S-101")
+            {
+                return basePath;
+            }
+        }
+
+        return null;
+    }
 }

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101UpdateApplicatorTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101UpdateApplicatorTests.cs
@@ -1,0 +1,206 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace EncDotNet.S100.Datasets.S101.Tests;
+
+/// <summary>
+/// Phase 2 tests for the S-101 sequential-update applicator
+/// (<see cref="S101UpdateApplicator"/> and <see cref="S101Document.ApplyChanges"/>):
+/// record-level insert / delete / modify keyed by RCID, inline attribute and
+/// association merges (ATIN / SAUI / FAUI / IUIN), and best-effort sequencing.
+/// </summary>
+public class S101UpdateApplicatorTests
+{
+    [Fact]
+    public void ApplyChanges_InsertsNewSpatialAndFeatureRecords()
+    {
+        var baseDoc = Doc(updateNumber: 0, profile: "1",
+            points: new[] { Point(1) },
+            features: new[] { Feature(10, instruction: S101UpdateInstruction.Insert) });
+
+        var update = Doc(updateNumber: 1, profile: "2",
+            points: new[] { Point(2, instruction: S101UpdateInstruction.Insert) },
+            features: new[] { Feature(11, instruction: S101UpdateInstruction.Insert) });
+
+        var result = baseDoc.ApplyChanges(update);
+
+        Assert.Equal(2, result.Points.Count);
+        Assert.True(result.Points.ContainsKey(2));
+        Assert.Equal(2, result.Features.Length);
+        Assert.Contains(result.Features, f => f.RecordId == 11);
+        Assert.Equal(1, result.Identification.UpdateNumber);
+    }
+
+    [Fact]
+    public void ApplyChanges_DeletesRecords()
+    {
+        var baseDoc = Doc(updateNumber: 0, profile: "1",
+            points: new[] { Point(1), Point(2) },
+            features: new[] { Feature(10), Feature(11) });
+
+        var update = Doc(updateNumber: 1, profile: "2",
+            points: new[] { Point(2, instruction: S101UpdateInstruction.Delete) },
+            features: new[] { Feature(11, instruction: S101UpdateInstruction.Delete) });
+
+        var result = baseDoc.ApplyChanges(update);
+
+        Assert.Single(result.Points);
+        Assert.False(result.Points.ContainsKey(2));
+        Assert.Single(result.Features);
+        Assert.Equal(10u, result.Features[0].RecordId);
+    }
+
+    [Fact]
+    public void ApplyChanges_ModifyFeature_MergesAttributesByInstruction()
+    {
+        var existing = Feature(10, attributes: new[]
+        {
+            new S101Attribute(1, 1, "keep"),
+            new S101Attribute(2, 1, "old"),
+            new S101Attribute(3, 1, "remove"),
+        });
+
+        var update = Feature(10, instruction: S101UpdateInstruction.Modify, attributes: new[]
+        {
+            new S101Attribute(2, 1, "new", 0, S101UpdateInstruction.Modify),
+            new S101Attribute(3, 1, "remove", 0, S101UpdateInstruction.Delete),
+            new S101Attribute(4, 1, "added", 0, S101UpdateInstruction.Insert),
+        });
+
+        var baseDoc = Doc(0, "1", features: new[] { existing });
+        var result = baseDoc.ApplyChanges(Doc(1, "2", features: new[] { update }));
+
+        var merged = Assert.Single(result.Features);
+        var values = merged.Attributes.ToDictionary(a => a.NumericCode, a => a.Value);
+        Assert.Equal("keep", values[1]);
+        Assert.Equal("new", values[2]);
+        Assert.False(values.ContainsKey(3));
+        Assert.Equal("added", values[4]);
+        Assert.Equal(S101UpdateInstruction.None, merged.UpdateInstruction);
+    }
+
+    [Fact]
+    public void ApplyChanges_ModifyFeature_MergesSpatialAssociations()
+    {
+        var existing = Feature(10, spatials: new[]
+        {
+            new S101SpatialAssociation(120, 100, 1),
+            new S101SpatialAssociation(120, 101, 1),
+        });
+
+        var update = Feature(10, instruction: S101UpdateInstruction.Modify, spatials: new[]
+        {
+            new S101SpatialAssociation(120, 101, 1, S101UpdateInstruction.Delete),
+            new S101SpatialAssociation(120, 102, 2, S101UpdateInstruction.Insert),
+        });
+
+        var result = Doc(0, "1", features: new[] { existing })
+            .ApplyChanges(Doc(1, "2", features: new[] { update }));
+
+        var merged = Assert.Single(result.Features);
+        Assert.Equal(2, merged.SpatialAssociations.Length);
+        Assert.Contains(merged.SpatialAssociations, s => s.RecordId == 100);
+        Assert.Contains(merged.SpatialAssociations, s => s.RecordId == 102);
+        Assert.DoesNotContain(merged.SpatialAssociations, s => s.RecordId == 101);
+    }
+
+    [Fact]
+    public void Apply_SequentialUpdates_FoldInOrder()
+    {
+        var baseDoc = Doc(0, "1", features: new[] { Feature(10) });
+        var u1 = Doc(1, "2", features: new[] { Feature(11, instruction: S101UpdateInstruction.Insert) });
+        var u2 = Doc(2, "2", features: new[] { Feature(10, instruction: S101UpdateInstruction.Delete) });
+
+        var result = S101UpdateApplicator.Apply(baseDoc, new[] { u1, u2 }, out var report);
+
+        Assert.Single(result.Features);
+        Assert.Equal(11u, result.Features[0].RecordId);
+        Assert.Equal(2, report.AppliedThroughUpdateNumber);
+        Assert.Equal(0, report.BaseUpdateNumber);
+        Assert.Equal(1, report.Inserted);
+        Assert.Equal(1, report.Deleted);
+        Assert.True(report.Success);
+    }
+
+    [Fact]
+    public void Apply_NonContiguousUpdate_StopsBestEffortWithWarning()
+    {
+        var baseDoc = Doc(0, "1", features: new[] { Feature(10) });
+        var u1 = Doc(1, "2", features: new[] { Feature(11, instruction: S101UpdateInstruction.Insert) });
+        var u3 = Doc(3, "2", features: new[] { Feature(12, instruction: S101UpdateInstruction.Insert) });
+
+        var result = S101UpdateApplicator.Apply(baseDoc, new[] { u1, u3 }, out var report);
+
+        Assert.Equal(2, result.Features.Length); // base + u1 only
+        Assert.Equal(1, report.AppliedThroughUpdateNumber);
+        Assert.False(report.Success);
+        Assert.Contains(report.Messages, m => m.Severity == S101UpdateSeverity.Warning && m.UpdateNumber == 3);
+    }
+
+    [Fact]
+    public void Apply_EmptyUpdateList_ReturnsBaseUnchanged()
+    {
+        var baseDoc = Doc(0, "1", features: new[] { Feature(10) });
+
+        var result = S101UpdateApplicator.Apply(baseDoc, Array.Empty<S101Document>(), out var report);
+
+        Assert.Same(baseDoc, result);
+        Assert.Equal(0, report.AppliedThroughUpdateNumber);
+        Assert.True(report.Success);
+    }
+
+    // --- builders -----------------------------------------------------------
+
+    private static S101PointRecord Point(uint id, S101UpdateInstruction instruction = S101UpdateInstruction.Insert) =>
+        new() { RecordId = id, X = 0, Y = 0, RecordVersion = 1, UpdateInstruction = instruction };
+
+    private static S101FeatureRecord Feature(
+        uint id,
+        S101UpdateInstruction instruction = S101UpdateInstruction.Insert,
+        IEnumerable<S101Attribute>? attributes = null,
+        IEnumerable<S101SpatialAssociation>? spatials = null) =>
+        new()
+        {
+            RecordId = id,
+            FeatureTypeCode = 1,
+            Attributes = (attributes ?? Enumerable.Empty<S101Attribute>()).ToImmutableArray(),
+            SpatialAssociations = (spatials ?? Enumerable.Empty<S101SpatialAssociation>()).ToImmutableArray(),
+            FeatureAssociations = ImmutableArray<S101FeatureAssociation>.Empty,
+            InformationAssociations = ImmutableArray<S101InformationAssociation>.Empty,
+            RecordVersion = 1,
+            UpdateInstruction = instruction,
+        };
+
+    private static S101Document Doc(
+        int updateNumber,
+        string profile,
+        IEnumerable<S101PointRecord>? points = null,
+        IEnumerable<S101FeatureRecord>? features = null) =>
+        new()
+        {
+            Identification = new S101DatasetIdentification
+            {
+                DatasetName = $"TEST.{updateNumber:D3}",
+                ApplicationProfile = profile,
+                UpdateNumber = updateNumber,
+            },
+            StructureInfo = new S101DatasetStructureInfo
+            {
+                CoordinateMultiplicationFactorX = 1,
+                CoordinateMultiplicationFactorY = 1,
+                CoordinateMultiplicationFactorZ = 1,
+            },
+            FeatureTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            AttributeTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            Points = (points ?? Enumerable.Empty<S101PointRecord>()).ToImmutableDictionary(p => p.RecordId),
+            CurveSegments = ImmutableDictionary<uint, S101CurveSegmentRecord>.Empty,
+            CompositeCurves = ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
+            Surfaces = ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
+            Features = (features ?? Enumerable.Empty<S101FeatureRecord>()).ToImmutableArray(),
+            InformationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty,
+            InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            FeatureAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
+        };
+}

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101UpdateMetadataTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101UpdateMetadataTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace EncDotNet.S100.Datasets.S101.Tests;
+
+/// <summary>
+/// Phase 1 tests for S-101 sequential-update metadata: the
+/// <see cref="S101UpdateInstruction"/> vocabulary, the update fields on
+/// <see cref="S101DatasetIdentification"/>, and the record/association
+/// version + instruction fields read by <see cref="S101DocumentReader"/>
+/// (S-100 Part 10a record fields RVER/RUIN and the per-element SAUI / FAUI /
+/// IUIN / ATIN variants).
+/// </summary>
+public class S101UpdateMetadataTests
+{
+    [Theory]
+    [InlineData(S101UpdateInstruction.None, 0)]
+    [InlineData(S101UpdateInstruction.Insert, 1)]
+    [InlineData(S101UpdateInstruction.Delete, 2)]
+    [InlineData(S101UpdateInstruction.Modify, 3)]
+    public void UpdateInstruction_ByteValues_MatchIso8211Encoding(S101UpdateInstruction instruction, int expected)
+    {
+        Assert.Equal(expected, (byte)instruction);
+    }
+
+    [Theory]
+    [InlineData("1", false)]
+    [InlineData("2", true)]
+    [InlineData("", false)]
+    public void DatasetIdentification_IsUpdate_DerivedFromApplicationProfile(string profile, bool expected)
+    {
+        var dsid = new S101DatasetIdentification { ApplicationProfile = profile };
+
+        Assert.Equal(expected, dsid.IsUpdate);
+    }
+
+    [Fact]
+    public void Records_DefaultUpdateInstruction_IsNone()
+    {
+        var point = new S101PointRecord
+        {
+            RecordId = 1,
+            X = 0,
+            Y = 0,
+        };
+
+        Assert.Equal(S101UpdateInstruction.None, point.UpdateInstruction);
+        Assert.Equal(0, point.RecordVersion);
+    }
+
+    [Fact]
+    public void Associations_DefaultUpdateInstruction_IsNone()
+    {
+        var spatial = new S101SpatialAssociation(110, 5, 1);
+        var feature = new S101FeatureAssociation(1, 5, 0);
+        var info = new S101InformationAssociation(1, 5, 0);
+        var attribute = new S101Attribute(1, 1, "value");
+
+        Assert.Equal(S101UpdateInstruction.None, spatial.UpdateInstruction);
+        Assert.Equal(S101UpdateInstruction.None, feature.UpdateInstruction);
+        Assert.Equal(S101UpdateInstruction.None, info.UpdateInstruction);
+        Assert.Equal(S101UpdateInstruction.None, attribute.UpdateInstruction);
+        Assert.Equal((ushort)0, attribute.ParentIndex);
+    }
+
+    [Fact]
+    public void Associations_CarryUpdateInstruction_WhenProvided()
+    {
+        var spatial = new S101SpatialAssociation(110, 5, 1, S101UpdateInstruction.Delete);
+        var attribute = new S101Attribute(1, 1, "value", 2, S101UpdateInstruction.Modify);
+
+        Assert.Equal(S101UpdateInstruction.Delete, spatial.UpdateInstruction);
+        Assert.Equal(S101UpdateInstruction.Modify, attribute.UpdateInstruction);
+        Assert.Equal((ushort)2, attribute.ParentIndex);
+    }
+
+    [SkippableFact]
+    public void ReadFromFile_BaseCell_HasBaseUpdateMetadata()
+    {
+        var path = FindDatasetFile(".000");
+        Skip.If(path is null, "No S-101 base cell (.000) found under IC-ENC sample data.");
+
+        var document = S101DocumentReader.ReadFromFile(path!);
+
+        Assert.False(document.Identification.IsUpdate);
+        Assert.Equal("1", document.Identification.ApplicationProfile);
+        Assert.Equal(0, document.Identification.UpdateNumber);
+
+        // Base cells encode every record as an Insert (RUIN = 1).
+        Assert.All(document.Features, f => Assert.Equal(S101UpdateInstruction.Insert, f.UpdateInstruction));
+    }
+
+    [SkippableFact]
+    public void ReadFromFile_UpdateCell_HasUpdateMetadata()
+    {
+        var path = FindDatasetFile(".001");
+        Skip.If(path is null, "No S-101 update file (.001) found under IC-ENC sample data.");
+
+        var document = S101DocumentReader.ReadFromFile(path!);
+
+        Assert.True(document.Identification.IsUpdate);
+        Assert.Equal("2", document.Identification.ApplicationProfile);
+        Assert.Equal(1, document.Identification.UpdateNumber);
+
+        // An update typically carries a mix of instructions (insert/delete/modify);
+        // at minimum every parsed feature must carry a recorded instruction.
+        Assert.All(document.Features, f => Assert.NotEqual(S101UpdateInstruction.None, f.UpdateInstruction));
+    }
+
+    [SkippableFact]
+    public void OpenWithUpdates_AppliesSiblingUpdate()
+    {
+        var basePath = FindDatasetFile(".000");
+        Skip.If(basePath is null, "No S-101 base cell (.000) found under IC-ENC sample data.");
+
+        // Find an update (.001) that targets the same cell (same file stem).
+        var stem = Path.GetFileNameWithoutExtension(basePath!);
+        var updatePath = Directory
+            .EnumerateFiles(RootOf(basePath!), stem + ".001", SearchOption.AllDirectories)
+            .FirstOrDefault();
+        Skip.If(updatePath is null, $"No matching .001 update found for base cell '{stem}'.");
+
+        var dataset = S101Dataset.OpenWithUpdates(basePath!, new[] { updatePath! });
+
+        Assert.NotNull(dataset.UpdateReport);
+        Assert.Equal(0, dataset.UpdateReport!.BaseUpdateNumber);
+        Assert.Equal(1, dataset.UpdateReport.AppliedThroughUpdateNumber);
+    }
+
+    private static string RootOf(string path)
+    {
+        var root = Environment.GetEnvironmentVariable("ICENC_ROOT");
+        if (!string.IsNullOrEmpty(root) && Directory.Exists(root))
+            return root;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var defaultRoot = Path.Combine(home, "Downloads", "IC-ENC");
+        return Directory.Exists(defaultRoot) ? defaultRoot : Path.GetDirectoryName(path)!;
+    }
+
+    private static string? FindDatasetFile(string extension)
+    {
+        var root = Environment.GetEnvironmentVariable("ICENC_ROOT");
+        if (string.IsNullOrEmpty(root))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            root = Path.Combine(home, "Downloads", "IC-ENC");
+        }
+
+        if (!Directory.Exists(root))
+            return null;
+
+        return Directory
+            .EnumerateFiles(root, "*" + extension, SearchOption.AllDirectories)
+            .FirstOrDefault(p => Path.GetExtension(p)
+                .Equals(extension, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101ExchangeSetUpdatePlanTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101ExchangeSetUpdatePlanTests.cs
@@ -1,0 +1,98 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.ExchangeSets;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S101ExchangeSetUpdatePlan"/>, which groups S-101
+/// base cells with their in-set sequential updates (S-100 Part 10a) so each cell
+/// is loaded once at its up-to-date state.
+/// </summary>
+public class S101ExchangeSetUpdatePlanTests
+{
+    [Fact]
+    public void Build_BaseWithUpdates_GroupsAndOrders()
+    {
+        var datasets = new[]
+        {
+            S101("101NL00NZ110", 0),
+            S101("101NL00NZ110", 2),
+            S101("101NL00NZ110", 1),
+        };
+
+        var plan = S101ExchangeSetUpdatePlan.Build(datasets);
+
+        var item = Assert.Single(plan);
+        Assert.Equal(S101LoadItemKind.BaseWithUpdates, item.Kind);
+        Assert.Equal("101NL00NZ110.000", item.Base.FileName);
+        Assert.Equal(new[] { 1, 2 }, item.Updates.Select(u => u.UpdateNumber!.Value).ToArray());
+    }
+
+    [Fact]
+    public void Build_BaseWithNoUpdates_IsSingle()
+    {
+        var plan = S101ExchangeSetUpdatePlan.Build(new[] { S101("101GB00ABCDEF", 0) });
+
+        var item = Assert.Single(plan);
+        Assert.Equal(S101LoadItemKind.Single, item.Kind);
+    }
+
+    [Fact]
+    public void Build_UpdateWithNoBase_IsOrphan()
+    {
+        var plan = S101ExchangeSetUpdatePlan.Build(new[] { S101("101IT00600154", 1) });
+
+        var item = Assert.Single(plan);
+        Assert.Equal(S101LoadItemKind.OrphanUpdate, item.Kind);
+        Assert.Equal("101IT00600154.001", item.Base.FileName);
+    }
+
+    [Fact]
+    public void Build_NonS101_PassesThroughIndividually()
+    {
+        var datasets = new[]
+        {
+            NonS101("102NO32904820.h5", "S-102"),
+            NonS101("104DK00.h5", "S-104"),
+        };
+
+        var plan = S101ExchangeSetUpdatePlan.Build(datasets);
+
+        Assert.Equal(2, plan.Count);
+        Assert.All(plan, p => Assert.Equal(S101LoadItemKind.Single, p.Kind));
+    }
+
+    [Fact]
+    public void Build_PreservesCatalogueOrder_AndEmitsCellOnce()
+    {
+        var datasets = new[]
+        {
+            NonS101("102NO32904820.h5", "S-102"),
+            S101("101NL00NZ110", 0),
+            S101("101NL00NZ110", 1),
+            NonS101("104DK00.h5", "S-104"),
+        };
+
+        var plan = S101ExchangeSetUpdatePlan.Build(datasets);
+
+        Assert.Equal(3, plan.Count);
+        Assert.Equal("102NO32904820.h5", plan[0].Base.FileName);
+        Assert.Equal(S101LoadItemKind.BaseWithUpdates, plan[1].Kind);
+        Assert.Equal("104DK00.h5", plan[2].Base.FileName);
+    }
+
+    private static DatasetDiscoveryMetadata S101(string cellName, int updateNumber) =>
+        new()
+        {
+            FileName = $"{cellName}.{updateNumber:D3}",
+            UpdateNumber = updateNumber,
+            ProductSpecification = new ProductSpecification { ProductIdentifier = "S-101" },
+        };
+
+    private static DatasetDiscoveryMetadata NonS101(string fileName, string productId) =>
+        new()
+        {
+            FileName = fileName,
+            ProductSpecification = new ProductSpecification { ProductIdentifier = productId },
+        };
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101FilesystemUpdateDiscoveryTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101FilesystemUpdateDiscoveryTests.cs
@@ -1,0 +1,105 @@
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S101FilesystemUpdateDiscovery"/>, which locates
+/// sibling S-101 sequential update files (<c>….001</c>, <c>….002</c>, …)
+/// alongside an <c>….000</c> base cell on the local file system (S-100 Part
+/// 10a) so a command-line caller can render the cell at its up-to-date state.
+/// </summary>
+public sealed class S101FilesystemUpdateDiscoveryTests : IDisposable
+{
+    private readonly string _dir;
+
+    public S101FilesystemUpdateDiscoveryTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "s101fsupd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    private string Touch(string fileName)
+    {
+        var path = Path.Combine(_dir, fileName);
+        File.WriteAllText(path, string.Empty);
+        return path;
+    }
+
+    [Fact]
+    public void FindSequentialUpdates_orders_updates_ascending()
+    {
+        var basePath = Touch("NL4NZ110.000");
+        Touch("NL4NZ110.002");
+        Touch("NL4NZ110.001");
+        Touch("NL4NZ110.003");
+
+        var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(basePath);
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(_dir, "NL4NZ110.001"),
+                Path.Combine(_dir, "NL4NZ110.002"),
+                Path.Combine(_dir, "NL4NZ110.003"),
+            },
+            updates);
+    }
+
+    [Fact]
+    public void FindSequentialUpdates_ignores_other_cells_and_non_numeric_extensions()
+    {
+        var basePath = Touch("NL4NZ110.000");
+        Touch("NL4NZ110.001");
+        Touch("OTHER.001");          // different cell
+        Touch("NL4NZ110.h5");        // non-numeric extension
+        Touch("NL4NZ110.txt");       // unrelated
+
+        var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(basePath);
+
+        Assert.Equal(new[] { Path.Combine(_dir, "NL4NZ110.001") }, updates);
+    }
+
+    [Fact]
+    public void FindSequentialUpdates_returns_empty_when_no_updates_present()
+    {
+        var basePath = Touch("NL4NZ110.000");
+
+        Assert.Empty(S101FilesystemUpdateDiscovery.FindSequentialUpdates(basePath));
+    }
+
+    [Fact]
+    public void FindSequentialUpdates_keeps_gaps_for_best_effort_application()
+    {
+        // A non-contiguous sequence is returned as-is; the applicator is
+        // responsible for stopping the chain at the gap with a warning.
+        var basePath = Touch("NL4NZ110.000");
+        Touch("NL4NZ110.001");
+        Touch("NL4NZ110.003");
+
+        var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(basePath);
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(_dir, "NL4NZ110.001"),
+                Path.Combine(_dir, "NL4NZ110.003"),
+            },
+            updates);
+    }
+
+    [Fact]
+    public void FindSequentialUpdates_returns_empty_when_path_is_not_a_base_cell()
+    {
+        // Pointed at an update file rather than the .000 base.
+        var updatePath = Touch("NL4NZ110.001");
+        Touch("NL4NZ110.002");
+
+        Assert.Empty(S101FilesystemUpdateDiscovery.FindSequentialUpdates(updatePath));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -38,6 +38,12 @@ public class ExchangeSetServiceLoaderTests
     private static string AllUnsupportedFixture() =>
         Path.Combine(FixturesRoot(), "Synthetic-AllUnsupported");
 
+    private static string S101UpdatesFixture() =>
+        Path.Combine(FixturesRoot(), "Synthetic-S101Updates");
+
+    private static string S101OrphanFixture() =>
+        Path.Combine(FixturesRoot(), "Synthetic-S101Orphan");
+
     private sealed class StubStatus : IStatusPresenter
     {
         public string? StatusText { get; set; }
@@ -192,5 +198,66 @@ public class ExchangeSetServiceLoaderTests
         Assert.Equal(3, progress.Reports[^1].Total);
         Assert.Equal(3, progress.Reports[^1].Completed);
         Assert.Equal(1, progress.Reports[^1].Failed);
+    }
+
+    [Fact]
+    public async Task OpenAsync_S101Updates_CollapsesBaseAndUpdatesIntoOneEntry()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(S101UpdatesFixture());
+
+        // The base cell plus its two updates form a single load item.
+        Assert.Equal(1, result.Total);
+        Assert.Equal(1, result.Loaded);
+        Assert.Equal(0, result.SkippedUnsupported);
+        Assert.False(result.Cancelled);
+
+        var entry = Assert.Single(datasets.Entries);
+        Assert.Equal("S-101", entry.ProductSpec);
+        // The base cell backs the entry; the two updates are carried as
+        // ordered relative paths for the loader to apply.
+        Assert.Equal("S-101/SYNTH101.000", entry.RelativePath);
+        Assert.True(entry.HasUpdates);
+        Assert.Equal(
+            new[] { "S-101/SYNTH101.001", "S-101/SYNTH101.002" },
+            entry.UpdateRelativePaths);
+    }
+
+    [Fact]
+    public async Task OpenAsync_S101Updates_HeaderCountsCollapsedCell()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        await service.OpenAsync(S101UpdatesFixture());
+
+        var header = Assert.Single(datasets.ExchangeSetHeaders);
+        // Three catalogue entries collapse to one renderable cell.
+        Assert.Equal(1, header.DatasetCount);
+        Assert.Equal(1, header.LoadedCount);
+        Assert.Equal(0, header.UnsupportedCount);
+    }
+
+    [Fact]
+    public async Task OpenAsync_S101Orphan_SkipsUpdateWithNoBase()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(S101OrphanFixture());
+
+        // An orphan update cannot be applied on its own; it is skipped
+        // best-effort with a warning and dispatches no dataset entry.
+        Assert.Equal(1, result.Total);
+        Assert.Equal(0, result.Loaded);
+        Assert.Equal(1, result.SkippedUnsupported);
+        Assert.Single(result.SkipMessages);
+        Assert.Contains("SYNTH101.001", result.SkipMessages[0]);
+
+        // No entry dispatched, so the set is released immediately.
+        Assert.Empty(datasets.Entries);
+        Assert.Empty(datasets.ExchangeSetHeaders);
     }
 }

--- a/tests/datasets/ExchangeSets/Synthetic-S101Orphan/CATALOG.XML
+++ b/tests/datasets/ExchangeSets/Synthetic-S101Orphan/CATALOG.XML
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic exchange-set catalogue used by ExchangeSetServiceLoaderTests
+  to exercise the S-101 orphan-update path (S-101 / S-100 Part 10a).
+
+  A single S-101 update (.001) is shipped with no matching base cell
+  (.000) in the same exchange set. Because cross-exchange-set update
+  application is not supported, the loader must skip the orphan with a
+  best-effort warning and dispatch no dataset entry.
+
+  Dataset files referenced by <fileName> are NOT shipped — the test
+  uses a NoopLoader so RequestLoad never opens them.
+-->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc/5.0"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>SYNTH_S101_ORPHAN_v1</S100XC:identifier>
+    <S100XC:dateTime>2026-01-15T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:contact>
+    <S100XC:organization>
+      <gco:CharacterString>Synthetic Hydrographic Office</gco:CharacterString>
+    </S100XC:organization>
+  </S100XC:contact>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-101/SYNTH101.001</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>delta</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>1</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-12</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-101</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.1.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>

--- a/tests/datasets/ExchangeSets/Synthetic-S101Updates/CATALOG.XML
+++ b/tests/datasets/ExchangeSets/Synthetic-S101Updates/CATALOG.XML
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic exchange-set catalogue used by ExchangeSetServiceLoaderTests
+  to exercise S-101 sequential update grouping (S-101 / S-100 Part 10a).
+
+  One S-101 cell is shipped as a base (.000) plus two sequential
+  updates (.001, .002). The loader must collapse these three catalogue
+  entries into a single up-to-date dataset entry whose
+  DatasetEntry.UpdateRelativePaths carries the two update files in
+  ascending order.
+
+  Dataset files referenced by <fileName> are NOT shipped — the test
+  uses a NoopLoader so RequestLoad never opens them.
+-->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc/5.0"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>SYNTH_S101_UPDATES_v1</S100XC:identifier>
+    <S100XC:dateTime>2026-01-15T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:contact>
+    <S100XC:organization>
+      <gco:CharacterString>Synthetic Hydrographic Office</gco:CharacterString>
+    </S100XC:organization>
+  </S100XC:contact>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-101/SYNTH101.000</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-10</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-101</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.1.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-101/SYNTH101.001</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>delta</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>1</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-12</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-101</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.1.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-101/SYNTH101.002</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>delta</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>2</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-14</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-101</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.1.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>

--- a/tools/EncDotNet.S100.Cli/Commands/DatasetCommandSettings.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/DatasetCommandSettings.cs
@@ -17,6 +17,11 @@ internal class DatasetCommandSettings : CommandSettings
     [Description("Show full stack traces on error, and surface host/Lua portrayal diagnostics on stderr.")]
     public bool Debug { get; init; }
 
+    [CommandOption("--no-updates")]
+    [Description("Do not apply sibling S-101 sequential updates (.001, .002, …) found alongside an .000 base cell. By default they are applied best-effort.")]
+    [DefaultValue(false)]
+    public bool NoUpdates { get; init; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         if (string.IsNullOrWhiteSpace(DatasetPath))

--- a/tools/EncDotNet.S100.Cli/Commands/InfoCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/InfoCommand.cs
@@ -26,7 +26,7 @@ internal sealed class InfoCommand : Command<DatasetCommandSettings>
                 return 2;
             }
 
-            var processor = factory.CreateProcessor(settings.DatasetPath);
+            var processor = DatasetProcessorLoader.Create(factory, spec, settings);
 
             var table = new Table().Border(TableBorder.Rounded);
             table.AddColumn("Property");

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -120,7 +120,7 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 return 2;
             }
 
-            var processor = factory.CreateProcessor(settings.DatasetPath);
+            var processor = DatasetProcessorLoader.Create(factory, spec, settings);
 
             if (processor is not IHeadlessImageRenderer headless)
             {

--- a/tools/EncDotNet.S100.Cli/Infrastructure/DatasetProcessorLoader.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/DatasetProcessorLoader.cs
@@ -1,0 +1,69 @@
+using EncDotNet.S100.Cli.Commands;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Pipelines;
+using Spectre.Console;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Builds an <see cref="IDatasetProcessor"/> for a command's dataset path,
+/// applying sibling S-101 sequential updates (<c>….001</c>, <c>….002</c>, …)
+/// when the path is an <c>….000</c> base cell and <c>--no-updates</c> was not
+/// supplied. The apply outcome is summarised to the console so the operator
+/// can see how many updates were folded in and whether any failed. Updates are
+/// applied best-effort and never block rendering. S-101 / S-100 Part 10a.
+/// </summary>
+internal static class DatasetProcessorLoader
+{
+    /// <summary>
+    /// Creates a processor for <paramref name="settings"/>, applying discovered
+    /// S-101 updates unless suppressed.
+    /// </summary>
+    /// <param name="factory">The configured pipeline factory.</param>
+    /// <param name="spec">The detected product specification (e.g. <c>"S-101"</c>).</param>
+    /// <param name="settings">The dataset command settings.</param>
+    public static IDatasetProcessor Create(
+        DatasetPipelineFactory factory,
+        string spec,
+        DatasetCommandSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (spec == "S-101" && !settings.NoUpdates)
+        {
+            var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(settings.DatasetPath);
+            if (updates.Count > 0)
+            {
+                var processor = factory.CreateS101ProcessorWithUpdates(settings.DatasetPath, updates);
+                if (processor is S101DatasetProcessor { UpdateReport: { } report })
+                    ReportUpdateOutcome(report);
+                return processor;
+            }
+        }
+
+        return factory.CreateProcessor(settings.DatasetPath);
+    }
+
+    private static void ReportUpdateOutcome(S101UpdateReport report)
+    {
+        var applied = report.AppliedThroughUpdateNumber - report.BaseUpdateNumber;
+        if (applied > 0)
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[grey]Applied {applied} S-101 update(s) through update {report.AppliedThroughUpdateNumber} (+{report.Inserted}/~{report.Modified}/-{report.Deleted} records).[/]");
+        }
+
+        foreach (var message in report.Messages)
+        {
+            var colour = message.Severity switch
+            {
+                S101UpdateSeverity.Error => "red",
+                S101UpdateSeverity.Warning => "yellow",
+                _ => "grey",
+            };
+            AnsiConsole.MarkupLine($"[{colour}]{Markup.Escape(message.Text)}[/]");
+        }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -100,6 +100,7 @@ and writes a PNG to `<output>`.
 | `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
 | `--no-text` | off | Suppress text/label drawing instructions. Shorthand for `--hide text`. |
 | `--hide <list>` | _none_ | Comma-separated list of drawing-instruction categories to suppress: `text`, `points`, `lines`, `areas` (e.g. `--hide text,points`). Combines additively with `--no-text`. Useful for label-dense products such as S-411 sea-ice, where the egg-code text overlaps fills at preview scales — `--no-text` yields a BSIS-style "clean fill" preview. |
+| `--no-updates` | off | Do not apply S-101 sequential updates. By default, when the dataset is an S-101 base cell (`….000`), any sibling update files (`….001`, `….002`, …) in the same directory are applied best-effort before rendering so the cell is drawn at its up-to-date state (S-100 Part 10a). |
 | `--debug` | off | Print full stack traces on error. |
 
 ```bash
@@ -107,13 +108,25 @@ s100 render currents.h5 currents.png --time-step 6 --palette night
 s100 render warnings.gml warnings.png --width 2048 --height 1536
 s100 render seaice.gml seaice.png --no-text                # clean fill preview
 s100 render chart.gml chart.png --hide text,points         # hide text + symbols
+s100 render NL4NZ110.000 cell.png                          # applies .001/.002/… updates
+s100 render NL4NZ110.000 base.png --no-updates             # render the base cell only
 ```
+
+> **S-101 sequential updates.** When pointed at an S-101 base cell
+> (`….000`), `render` and `info` discover sibling update files
+> (`….001`, `….002`, …) in the same directory and apply them in order
+> before processing the cell, mirroring how an exchange set is loaded
+> in the viewer. Application is best-effort: a missing, out-of-order, or
+> unreadable update is reported but never blocks the command. Pass
+> `--no-updates` to operate on the base cell exactly as named.
 
 ### `s100 info <dataset>`
 
 Prints the detected specification, edition, whether the dataset supports
 headless rendering, and — for time-series datasets — the available time steps
-with their indices (use the index with `render --time-step`).
+with their indices (use the index with `render --time-step`). For an S-101
+base cell, sibling sequential updates are applied first (see `--no-updates`)
+so the reported model reflects the up-to-date cell.
 
 ### `s100 list-specs`
 


### PR DESCRIPTION
## Summary

Implements the S-57-style **sequential update** model for S-101 across the libraries, viewer, and CLI. A base cell (`.000`) plus ordered update files (`.001`, `.002`, …) are now merged into an "up-to-date" dataset before portrayal, per **S-100 Part 10a**.

Updates are applied **best-effort**: a missing, out-of-order, or unreadable update is recorded but never prevents the (partially) updated cell from rendering. Updates are only applied when bundled with the base in the **same exchange set / directory**; cross-set application is intentionally out of scope.

## Changes

### Library (`EncDotNet.S100.Datasets.S101` / `.Pipelines`)
- **`S101UpdateApplicator`** folds update records (insert / modify / delete) into the base `S101Document`, producing an `S101UpdateReport` with per-record severities and inserted/modified/deleted counts.
- **`S101ExchangeSetUpdatePlan`** groups a catalogue's entries into `Single` / `BaseWithUpdates` / `OrphanUpdate`, ordered by update number.
- **`S101FilesystemUpdateDiscovery`** finds sibling update files for a loose `.000` base cell.
- **`DatasetPipelineFactory.CreateS101ProcessorWithUpdates`** overloads (exchange-set source + relative paths; loose base file path + update paths); `ExchangeSetLoader` applies in-set updates per cell.

### Viewer
- Dropping an S-101 exchange set groups base + updates, applies them, renders the merged cell, and surfaces a status line (clean apply) or a non-blocking warning toast (partial / orphan updates).

### CLI
- `render` / `info` auto-discover and apply sibling updates for a `.000` base cell and print the update report; `--no-updates` opts out.

## Testing
- Full solution build: clean.
- New unit tests: update applicator, update metadata, exchange-set plan, filesystem discovery, viewer exchange-set grouping/orphan handling.
- New synthetic CATALOG.XML fixtures (S-101 updates + orphan).
- CLI real-data `SkippableFact` render tests (verified against IC-ENC NL sequence locally).
- Pipelines: 513 passed / 1 skipped; CLI: 37 passed; Viewer: 819 passed.

## Notes / deferred
- Cross-exchange-set / cross-directory update application not supported.
- `CATALOG.031` handling deferred.