### PR TITLE
Add exchange set integrity verification (S-100 Part 15 + S-57 CRC)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- EncDotNet -->
-    <PackageVersion Include="EncDotNet.Iso8211" Version="0.4.3" />
-    <PackageVersion Include="EncDotNet.S57" Version="0.4.0" />
+    <PackageVersion Include="EncDotNet.Iso8211" Version="0.5.0" />
+    <PackageVersion Include="EncDotNet.S57" Version="0.5.0" />
     <!-- Mapping / rendering -->
     <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.323" />
     <PackageVersion Include="Mapsui" Version="5.0.2" />

--- a/src/EncDotNet.S100.Datasets.S57/EncDotNet.S100.Datasets.S57.csproj
+++ b/src/EncDotNet.S100.Datasets.S57/EncDotNet.S100.Datasets.S57.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.ExchangeSets\EncDotNet.S100.ExchangeSets.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Specifications\EncDotNet.S100.Specifications.csproj" />
   </ItemGroup>
 

--- a/src/EncDotNet.S100.Datasets.S57/README.md
+++ b/src/EncDotNet.S100.Datasets.S57/README.md
@@ -76,6 +76,51 @@ rebadgePrefix: "S101-as-S57/")` in
 [`EncDotNet.S100.Datasets.Pipelines`](../EncDotNet.S100.Datasets.Pipelines/README.md)
 and cached on the processor.
 
+## Exchange-set integrity verification
+
+`S57ExchangeSetVerification` integrity-verifies an S-57 / S-63 exchange
+set (a folder containing a `CATALOG.031`) and **maps the result onto the
+same S-100 [`ExchangeSetVerificationResult`](../EncDotNet.S100.ExchangeSets/README.md)
+model** used for native S-100 exchange sets, so both products surface
+uniformly through the CLI (`s100 validate`) and any future viewer wiring.
+
+```csharp
+using EncDotNet.S100.Datasets.S57;
+using EncDotNet.S100.ExchangeSets;
+
+ExchangeSetVerificationResult result =
+    await S57ExchangeSetVerification.VerifyAsync("/path/to/s57set");
+
+bool integrity = result.IntegrityVerified;   // no CRC mismatches / missing files
+bool signed    = result.AllValid;            // strict: every file signature Ok
+```
+
+It is a deliberately thin **adapter**, not a shared interface: the
+upstream S-57 verifier (`EncDotNet.S57` 0.5.0+) is rooted at a directory
+path (`CATALOG.031` plus the files it references), whereas the S-100
+verifier is `IAssetSource`-based. Forcing both behind one interface would
+distort both, so only the *result* is mapped.
+
+Mapping notes:
+
+- Outcomes are mapped **by name** (`S57VerificationOutcome` →
+  [`VerificationOutcome`](../EncDotNet.S100.ExchangeSets/README.md)). The
+  two enums are kept byte-identical; mapping by name means a future
+  divergence fails loudly rather than silently mis-mapping.
+- Both the **signature** dimension (`Outcome`) and the **checksum**
+  dimension (`ChecksumOutcome`) are preserved independently.
+- S-57 integrity uses a CRC-32 (the `CATALOG.031` field), not the SHA-256
+  digest the S-100 model carries, so the per-file CRC values are surfaced
+  through `FileVerificationResult.Detail` and `ComputedSha256` is left
+  `null`.
+- The verdict semantics match S-100: `NoChecksum` / `NotSigned` are
+  **non-failing** (an unsigned-but-intact set has `IntegrityVerified ==
+  true` but `AllValid == false`); only `ChecksumMismatch` / `FileMissing`
+  / `Error` / invalid signatures fail integrity. This is identical to the
+  upstream S-57 `AllValid`.
+- Today the upstream S-57 verifier reports every file as `NotSigned`
+  (S-63 signature verification is a seam); CRC checking is fully wired.
+
 ## Usage
 
 ```csharp

--- a/src/EncDotNet.S100.Datasets.S57/S57ExchangeSetVerification.cs
+++ b/src/EncDotNet.S100.Datasets.S57/S57ExchangeSetVerification.cs
@@ -1,0 +1,157 @@
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S57.ExchangeSets;
+using S57Outcome = EncDotNet.S57.ExchangeSets.S57VerificationOutcome;
+
+namespace EncDotNet.S100.Datasets.S57;
+
+/// <summary>
+/// Adapts the upstream <c>EncDotNet.S57</c> exchange-set verifier (S-57 / S-63
+/// <c>CATALOG.031</c> CRC + digital-signature checks) onto this repository's
+/// S-100 <see cref="ExchangeSetVerificationResult"/> model, so S-57 exchange
+/// sets are integrity-verified and surfaced exactly like S-100 ones.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a deliberately thin <em>adapter</em> rather than a shared interface:
+/// the S-57 verifier is rooted at a directory path (<c>CATALOG.031</c> + the
+/// files it references), whereas the S-100 verifier is
+/// <see cref="EncDotNet.S100.Core.IAssetSource"/>-based. Forcing both behind one
+/// interface would distort both, so the two verifiers stay independent and this
+/// type only maps the <em>result</em>.
+/// </para>
+/// <para>
+/// The mapping is safe because the two outcome enumerations are kept
+/// byte-identical (same names, same ordinals); the mapping is nonetheless done
+/// by name so a future divergence fails loudly rather than silently
+/// mis-mapping. S-57 integrity uses a CRC-32 (<c>CATALOG.031</c> field), not the
+/// SHA-256 digest the S-100 model carries, so the per-file CRC values are
+/// surfaced through <see cref="FileVerificationResult.Detail"/> and
+/// <see cref="FileVerificationResult.ComputedSha256"/> is left
+/// <see langword="null"/>.
+/// </para>
+/// </remarks>
+public static class S57ExchangeSetVerification
+{
+    /// <summary>
+    /// Verifies the S-57 exchange set rooted at <paramref name="rootPath"/>
+    /// (the directory containing its <c>CATALOG.031</c>) and returns the result
+    /// mapped onto the S-100 <see cref="ExchangeSetVerificationResult"/> model.
+    /// </summary>
+    /// <param name="rootPath">
+    /// The exchange-set root directory (the folder that contains
+    /// <c>CATALOG.031</c>).
+    /// </param>
+    /// <param name="allowUntrustedCertificates">
+    /// When <see langword="true"/> (the default), signature checks do not fail
+    /// solely because the signing certificate chains to an untrusted root —
+    /// mirrors the S-100 verifier's
+    /// <see cref="TrustAnchorOptions.AllowUntrustedCertificates"/>.
+    /// </param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The verification result in the S-100 result model.</returns>
+    /// <exception cref="ArgumentException"><paramref name="rootPath"/> is null or empty.</exception>
+    public static async Task<ExchangeSetVerificationResult> VerifyAsync(
+        string rootPath,
+        bool allowUntrustedCertificates = true,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootPath);
+
+        var s57Result = await S57ExchangeSetReader.Read(rootPath)
+            .VerifyAsync(
+                rootPath,
+                new S63TrustAnchorOptions { AllowUntrustedCertificates = allowUntrustedCertificates },
+                logger: null,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return Map(s57Result);
+    }
+
+    /// <summary>
+    /// Maps an <see cref="S57ExchangeSetVerificationResult"/> onto the S-100
+    /// <see cref="ExchangeSetVerificationResult"/> model. Exposed (rather than
+    /// private) so it can be unit-tested directly against synthetic S-57
+    /// results.
+    /// </summary>
+    /// <param name="result">The S-57 verification result to map.</param>
+    /// <returns>The equivalent S-100 result.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="result"/> is null.</exception>
+    public static ExchangeSetVerificationResult Map(S57ExchangeSetVerificationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var files = new List<FileVerificationResult>(result.FileResults.Length);
+        foreach (var file in result.FileResults)
+            files.Add(MapFile(file));
+
+        return new ExchangeSetVerificationResult { FileResults = files };
+    }
+
+    /// <summary>
+    /// Maps a single <see cref="S57FileVerificationResult"/> onto the S-100
+    /// <see cref="FileVerificationResult"/>, preserving both the signature and
+    /// checksum dimensions independently.
+    /// </summary>
+    /// <param name="file">The S-57 per-file result.</param>
+    /// <returns>The equivalent S-100 per-file result.</returns>
+    public static FileVerificationResult MapFile(S57FileVerificationResult file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        return new FileVerificationResult
+        {
+            FileName = file.FileName,
+            Outcome = MapOutcome(file.SignatureOutcome),
+            ChecksumOutcome = MapOutcome(file.ChecksumOutcome),
+            Detail = ComposeDetail(file),
+        };
+    }
+
+    /// <summary>
+    /// Maps an <see cref="S57Outcome"/> onto the S-100
+    /// <see cref="VerificationOutcome"/> by name. The two enumerations are kept
+    /// byte-identical so the cross-repo bridge can drive both uniformly.
+    /// </summary>
+    /// <param name="outcome">The S-57 outcome.</param>
+    /// <returns>The equivalent S-100 outcome.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The S-57 outcome has no S-100 counterpart (indicates the two
+    /// enumerations have diverged).
+    /// </exception>
+    public static VerificationOutcome MapOutcome(S57Outcome outcome) => outcome switch
+    {
+        S57Outcome.Ok => VerificationOutcome.Ok,
+        S57Outcome.NotSigned => VerificationOutcome.NotSigned,
+        S57Outcome.SignatureInvalid => VerificationOutcome.SignatureInvalid,
+        S57Outcome.CertificateUntrusted => VerificationOutcome.CertificateUntrusted,
+        S57Outcome.CertificateExpired => VerificationOutcome.CertificateExpired,
+        S57Outcome.CertificateNotFound => VerificationOutcome.CertificateNotFound,
+        S57Outcome.FileMissing => VerificationOutcome.FileMissing,
+        S57Outcome.Error => VerificationOutcome.Error,
+        S57Outcome.NoChecksum => VerificationOutcome.NoChecksum,
+        S57Outcome.ChecksumMismatch => VerificationOutcome.ChecksumMismatch,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(outcome), outcome,
+            "S-57 verification outcome has no S-100 counterpart; the outcome enumerations have diverged."),
+    };
+
+    /// <summary>
+    /// Builds a human-readable detail string carrying the S-57 CRC values (which
+    /// the S-100 SHA-256 model has no field for) plus any upstream detail.
+    /// </summary>
+    private static string? ComposeDetail(S57FileVerificationResult file)
+    {
+        string? crc = (file.ExpectedCrc, file.ActualCrc) switch
+        {
+            (null or "", null or "") => null,
+            var (expected, actual) => $"CRC expected={Display(expected)} actual={Display(actual)}",
+        };
+
+        if (string.IsNullOrEmpty(file.Detail))
+            return crc;
+        return crc is null ? file.Detail : $"{file.Detail}; {crc}";
+
+        static string Display(string? value) => string.IsNullOrEmpty(value) ? "—" : value;
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/CatalogueDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/CatalogueDiscoveryMetadata.cs
@@ -42,6 +42,14 @@ public sealed class CatalogueDiscoveryMetadata
     /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
     public DigitalSignatureValue? DigitalSignatureValue { get; init; }
 
+    /// <summary>
+    /// The declared cryptographic hash for this catalogue file, if the
+    /// catalogue carries one. Used to integrity-check the file independently
+    /// of any digital signature.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10, Table 15-12.</remarks>
+    public CryptographicHash? ExpectedHash { get; init; }
+
     public bool CompressionFlag { get; init; }
 
     public string? DefaultLocaleLanguage { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/CryptographicHash.cs
+++ b/src/EncDotNet.S100.ExchangeSets/CryptographicHash.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace EncDotNet.S100.ExchangeSets;
+
+/// <summary>
+/// Represents a parsed S-100 cryptographic hash MRN of the form
+/// <c>urn:mrn:iho:s100:hash:&lt;algorithm&gt;:&lt;hex&gt;</c>, used to declare
+/// the expected digest of an exchange-set resource so its content integrity
+/// can be verified independently of any digital signature.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-8.10, Table 15-12. The MRN namespace is
+/// defined by the specification, but a fixed catalogue slot for it is not;
+/// <see cref="ExchangeCatalogueReader"/> therefore discovers it best-effort.
+/// All fields are case-insensitive per the specification.
+/// </remarks>
+public sealed class CryptographicHash
+{
+    /// <summary>The MRN prefix shared by every S-100 cryptographic hash MRN.</summary>
+    public const string MrnPrefix = "urn:mrn:iho:s100:hash:";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CryptographicHash"/> class.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The hash algorithm token (e.g. <c>sha256</c>), normalized to lower case.
+    /// </param>
+    /// <param name="hexValue">
+    /// The computed hash expressed as a lower-case hexadecimal string.
+    /// </param>
+    public CryptographicHash(string algorithm, string hexValue)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(algorithm);
+        ArgumentException.ThrowIfNullOrEmpty(hexValue);
+
+        Algorithm = algorithm.ToLowerInvariant();
+        HexValue = hexValue.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The hash algorithm token (e.g. <c>sha256</c>), in lower case.
+    /// </summary>
+    public string Algorithm { get; }
+
+    /// <summary>
+    /// The expected hash expressed as a lower-case hexadecimal string.
+    /// </summary>
+    public string HexValue { get; }
+
+    /// <summary>
+    /// Attempts to parse an S-100 cryptographic hash MRN
+    /// (<c>urn:mrn:iho:s100:hash:&lt;algorithm&gt;:&lt;hex&gt;</c>).
+    /// </summary>
+    /// <param name="value">The candidate MRN string (may be <see langword="null"/>).</param>
+    /// <param name="hash">The parsed hash on success; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is a well-formed hash MRN.</returns>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10, Table 15-12.</remarks>
+    public static bool TryParse(string? value, [NotNullWhen(true)] out CryptographicHash? hash)
+    {
+        hash = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var trimmed = value.Trim();
+        if (!trimmed.StartsWith(MrnPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var remainder = trimmed[MrnPrefix.Length..];
+        var separator = remainder.IndexOf(':');
+        if (separator <= 0 || separator >= remainder.Length - 1)
+            return false;
+
+        var algorithm = remainder[..separator];
+        var hex = remainder[(separator + 1)..];
+
+        if (!IsHex(hex))
+            return false;
+
+        hash = new CryptographicHash(algorithm, hex);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="candidate"/> matches
+    /// this declared hash, comparing the hexadecimal value case-insensitively.
+    /// </summary>
+    /// <param name="candidate">A computed hash expressed as a hexadecimal string.</param>
+    public bool Matches(string? candidate) =>
+        candidate is not null &&
+        string.Equals(HexValue, candidate.Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsHex(string value)
+    {
+        if (value.Length == 0 || (value.Length % 2) != 0)
+            return false;
+
+        foreach (var c in value)
+        {
+            var isHexDigit = c is >= '0' and <= '9'
+                or >= 'a' and <= 'f'
+                or >= 'A' and <= 'F';
+            if (!isHexDigit)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{MrnPrefix}{Algorithm}:{HexValue}";
+}

--- a/src/EncDotNet.S100.ExchangeSets/DatasetDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/DatasetDiscoveryMetadata.cs
@@ -40,6 +40,14 @@ public sealed class DatasetDiscoveryMetadata
     /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
     public DigitalSignatureValue? DigitalSignatureValue { get; init; }
 
+    /// <summary>
+    /// The declared cryptographic hash for this dataset file, if the catalogue
+    /// carries one. Used to integrity-check the file independently of any
+    /// digital signature.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10, Table 15-12.</remarks>
+    public CryptographicHash? ExpectedHash { get; init; }
+
     public bool Copyright { get; init; }
 
     public string? Classification { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -123,6 +123,7 @@ public static class ExchangeCatalogueReader
             DigitalSignatureReference = (string?)element.Element(xc + "digitalSignatureReference"),
             DigitalSignatureAlgorithm = ParseSignatureAlgorithm(element, xc),
             DigitalSignatureValue = ReadDigitalSignatureValue(element.Element(xc + "digitalSignatureValue")),
+            ExpectedHash = ReadExpectedHash(element),
             Copyright = ParseBool(element, "copyright", xc),
             Classification = ReadCodeListValue(element.Element(xc + "classification")),
             Purpose = (string?)element.Element(xc + "purpose"),
@@ -164,6 +165,7 @@ public static class ExchangeCatalogueReader
             DigitalSignatureReference = (string?)element.Element(xc + "digitalSignatureReference"),
             DigitalSignatureAlgorithm = ParseSignatureAlgorithm(element, xc),
             DigitalSignatureValue = ReadDigitalSignatureValue(element.Element(xc + "digitalSignatureValue")),
+            ExpectedHash = ReadExpectedHash(element),
             SupportedResources = element
                 .Elements(xc + "supportedResource")
                 .Select(e => e.Value.Trim())
@@ -189,6 +191,7 @@ public static class ExchangeCatalogueReader
             DigitalSignatureReference = (string?)element.Element(xc + "digitalSignatureReference"),
             DigitalSignatureAlgorithm = ParseSignatureAlgorithm(element, xc),
             DigitalSignatureValue = ReadDigitalSignatureValue(element.Element(xc + "digitalSignatureValue")),
+            ExpectedHash = ReadExpectedHash(element),
             CompressionFlag = ParseBool(element, "compressionFlag", xc),
             DefaultLocaleLanguage = ReadLocaleLanguage(defaultLocaleEl, lan),
             DefaultLocaleCharacterEncoding = ReadLocaleCharacterEncoding(defaultLocaleEl, lan),
@@ -348,6 +351,31 @@ public static class ExchangeCatalogueReader
             CertificateRef = certRef,
             Value = Convert.FromBase64String(base64),
         };
+    }
+
+    /// <summary>
+    /// Discovers an S-100 cryptographic hash MRN
+    /// (<c>urn:mrn:iho:s100:hash:&lt;algorithm&gt;:&lt;hex&gt;</c>) declared
+    /// within a discovery-metadata element. The specification defines the MRN
+    /// namespace but not a fixed catalogue slot, so this scans the element's
+    /// descendant values best-effort and returns the first that parses.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10, Table 15-12.</remarks>
+    private static CryptographicHash? ReadExpectedHash(XElement element)
+    {
+        foreach (var node in element.DescendantNodesAndSelf().OfType<XText>())
+        {
+            if (CryptographicHash.TryParse(node.Value, out var hash))
+                return hash;
+        }
+
+        foreach (var attribute in element.Descendants().Attributes())
+        {
+            if (CryptographicHash.TryParse(attribute.Value, out var hash))
+                return hash;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerificationResult.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerificationResult.cs
@@ -10,8 +10,25 @@ public sealed class ExchangeSetVerificationResult
 
     /// <summary>
     /// Returns <c>true</c> when every file in the exchange set has
-    /// <see cref="VerificationOutcome.Ok"/> as its outcome.
+    /// <see cref="VerificationOutcome.Ok"/> as its <em>signature</em> outcome.
     /// </summary>
+    /// <remarks>
+    /// This is intentionally a strict <em>signature-only</em> predicate: it is
+    /// <c>false</c> for an unsigned set (every file <see cref="VerificationOutcome.NotSigned"/>),
+    /// and it does not consider the checksum dimension at all. It is paired with
+    /// <see cref="IsUnsigned"/> by callers (e.g. the viewer) that distinguish
+    /// "signed and all valid" from "unsigned".
+    /// <para>
+    /// It is deliberately <em>not</em> the overall integrity verdict. Because
+    /// S-100 mandates no per-resource checksum (integrity is via Part 15
+    /// signatures), a "no checksum present" case must not count as a failure;
+    /// that non-failing semantic lives in <see cref="IntegrityVerified"/> (and in
+    /// the <c>s100 validate</c> exit code). This matches the sibling S-57
+    /// implementation, whose <c>AllValid</c> treats a missing CRC
+    /// (<see cref="VerificationOutcome.NoChecksum"/>) as non-failing and fails
+    /// only on mismatch, missing file, error, or invalid signature.
+    /// </para>
+    /// </remarks>
     public bool AllValid => FileResults.All(r => r.Outcome == VerificationOutcome.Ok);
 
     /// <summary>
@@ -25,4 +42,31 @@ public sealed class ExchangeSetVerificationResult
     /// (all are <see cref="VerificationOutcome.NotSigned"/>).
     /// </summary>
     public bool IsUnsigned => FileResults.All(r => r.Outcome == VerificationOutcome.NotSigned);
+
+    /// <summary>
+    /// Returns <c>true</c> when at least one file's computed digest did not
+    /// match its declared cryptographic hash
+    /// (<see cref="VerificationOutcome.ChecksumMismatch"/>).
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10.</remarks>
+    public bool HasChecksumMismatches =>
+        FileResults.Any(r => r.ChecksumOutcome == VerificationOutcome.ChecksumMismatch);
+
+    /// <summary>
+    /// Returns <c>true</c> when at least one referenced file was missing from
+    /// the asset source (an incomplete exchange set), reported in either the
+    /// signature or the checksum dimension.
+    /// </summary>
+    public bool HasMissingFiles =>
+        FileResults.Any(r => r.Outcome == VerificationOutcome.FileMissing
+            || r.ChecksumOutcome == VerificationOutcome.FileMissing);
+
+    /// <summary>
+    /// Returns <c>true</c> when the exchange set is structurally intact: no
+    /// referenced file is missing and no declared checksum failed. Files with
+    /// no declared checksum (<see cref="VerificationOutcome.NoChecksum"/>) do
+    /// not by themselves invalidate integrity, since the specification does not
+    /// mandate per-resource hashes.
+    /// </summary>
+    public bool IntegrityVerified => !HasMissingFiles && !HasChecksumMismatches;
 }

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerifier.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSetVerifier.cs
@@ -11,9 +11,14 @@ namespace EncDotNet.S100.ExchangeSets;
 /// <remarks>
 /// S-100 Edition 5.2.1 Part 15. Signatures are computed over the raw bytes of
 /// each referenced file and verified against the certificate identified by
-/// <see cref="DigitalSignatureValue.CertificateRef"/>.
+/// <see cref="DigitalSignatureValue.CertificateRef"/>. Each file is also
+/// integrity-checked: its SHA-256 digest is computed and, when the catalogue
+/// declares a cryptographic hash (Part 15 §15-8.10), compared against it. This
+/// integrity dimension is reported independently of the signature dimension
+/// (see <see cref="FileVerificationResult.ChecksumOutcome"/>), so even an
+/// unsigned exchange set can be checked for missing or corrupt files.
 /// </remarks>
-public sealed class ExchangeSetVerifier : IExchangeSetVerifier
+public class ExchangeSetVerifier : IExchangeSetVerifier
 {
     /// <summary>Buffer size used when streaming file content for hashing.</summary>
     private const int StreamBufferSize = 81920;
@@ -41,7 +46,7 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         {
             var result = await VerifyFileAsync(
                 source, ds.RelativePath, ds.DigitalSignatureValue, ds.DigitalSignatureAlgorithm,
-                certLookup, trustAnchors, cancellationToken);
+                ds.ExpectedHash, certLookup, trustAnchors, cancellationToken);
             results.Add(result);
         }
 
@@ -50,7 +55,7 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         {
             var result = await VerifyFileAsync(
                 source, sf.RelativePath, sf.DigitalSignatureValue, sf.DigitalSignatureAlgorithm,
-                certLookup, trustAnchors, cancellationToken);
+                sf.ExpectedHash, certLookup, trustAnchors, cancellationToken);
             results.Add(result);
         }
 
@@ -59,7 +64,7 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         {
             var result = await VerifyFileAsync(
                 source, cf.RelativePath, cf.DigitalSignatureValue, cf.DigitalSignatureAlgorithm,
-                certLookup, trustAnchors, cancellationToken);
+                cf.ExpectedHash, certLookup, trustAnchors, cancellationToken);
             results.Add(result);
         }
 
@@ -70,33 +75,122 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         return new ExchangeSetVerificationResult { FileResults = results };
     }
 
-    private static async Task<FileVerificationResult> VerifyFileAsync(
+    private async Task<FileVerificationResult> VerifyFileAsync(
         IAssetSource source,
         string fileName,
         DigitalSignatureValue? signatureValue,
         DigitalSignatureAlgorithm algorithm,
+        CryptographicHash? expectedHash,
         Dictionary<string, CertificateEntry> certLookup,
         TrustAnchorOptions trustAnchors,
         CancellationToken cancellationToken)
     {
-        if (signatureValue is null)
+        // Hash the file content once, regardless of whether it is signed, so
+        // that an unsigned exchange set can still be integrity-checked. The
+        // same SHA-256 digest feeds both the checksum dimension and (when a
+        // signature is present) the signature verification below.
+        byte[] fileHash;
+        try
+        {
+            var normalizedPath = ExchangeSet.NormalizeFileName(fileName);
+            await using var stream = await OpenContentForHashingAsync(
+                source, normalizedPath, signatureValue, cancellationToken);
+            fileHash = await ComputeSha256HashAsync(stream, cancellationToken);
+        }
+        catch (FileNotFoundException)
         {
             return new FileVerificationResult
             {
                 FileName = fileName,
-                Outcome = VerificationOutcome.NotSigned,
+                Outcome = VerificationOutcome.FileMissing,
+                ChecksumOutcome = VerificationOutcome.FileMissing,
             };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return new FileVerificationResult
+            {
+                FileName = fileName,
+                Outcome = VerificationOutcome.Error,
+                ChecksumOutcome = VerificationOutcome.Error,
+                Detail = $"Failed to read file: {ex.Message}",
+            };
+        }
+
+        var computedHex = Convert.ToHexString(fileHash).ToLowerInvariant();
+
+        // Checksum dimension: compare against the declared cryptographic hash
+        // when one is present (S-100 Edition 5.2.1 Part 15 §15-8.10), otherwise
+        // report that there is nothing to validate against.
+        var checksumOutcome = expectedHash is null
+            ? VerificationOutcome.NoChecksum
+            : expectedHash.Matches(computedHex)
+                ? VerificationOutcome.Ok
+                : VerificationOutcome.ChecksumMismatch;
+
+        // Signature dimension: independent of the checksum result.
+        var (signatureOutcome, detail) = EvaluateSignature(
+            signatureValue, algorithm, fileHash, certLookup, trustAnchors);
+
+        return new FileVerificationResult
+        {
+            FileName = fileName,
+            Outcome = signatureOutcome,
+            ChecksumOutcome = checksumOutcome,
+            ComputedSha256 = computedHex,
+            Detail = detail,
+        };
+    }
+
+    /// <summary>
+    /// Opens the file content that should be hashed for verification.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation returns the raw bytes from the asset source.
+    /// This is the seam where Part 15 decryption would slot in: a future
+    /// override (or injected decrypted-content provider) could return the
+    /// decrypted, decompressed bytes for a <c>dataStatus="encrypted"</c>
+    /// signature (S-100 Edition 5.2.1 Part 15 §15-8.8, Table 15-10) so that the
+    /// computed digest matches the signature, which is produced over the
+    /// unencrypted resource. The <paramref name="signatureValue"/> is supplied
+    /// so an override can decide whether decryption is required.
+    /// </remarks>
+    /// <param name="source">The asset source containing the file.</param>
+    /// <param name="normalizedPath">The normalized, source-relative file path.</param>
+    /// <param name="signatureValue">The file's signature value, if any.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A readable stream over the bytes to hash.</returns>
+    protected virtual Task<Stream> OpenContentForHashingAsync(
+        IAssetSource source,
+        string normalizedPath,
+        DigitalSignatureValue? signatureValue,
+        CancellationToken cancellationToken)
+    {
+        return source.OpenAsync(normalizedPath, cancellationToken);
+    }
+
+    /// <summary>
+    /// Evaluates the digital-signature dimension for a file whose content has
+    /// already been hashed. Returns <see cref="VerificationOutcome.NotSigned"/>
+    /// when the file carries no signature.
+    /// </summary>
+    private static (VerificationOutcome Outcome, string? Detail) EvaluateSignature(
+        DigitalSignatureValue? signatureValue,
+        DigitalSignatureAlgorithm algorithm,
+        byte[] fileHash,
+        Dictionary<string, CertificateEntry> certLookup,
+        TrustAnchorOptions trustAnchors)
+    {
+        if (signatureValue is null)
+        {
+            return (VerificationOutcome.NotSigned, null);
         }
 
         // Resolve the certificate
         if (!certLookup.TryGetValue(signatureValue.CertificateRef, out var certEntry))
         {
-            return new FileVerificationResult
-            {
-                FileName = fileName,
-                Outcome = VerificationOutcome.CertificateNotFound,
-                Detail = $"Certificate '{signatureValue.CertificateRef}' not found in catalogue.",
-            };
+            return (VerificationOutcome.CertificateNotFound,
+                $"Certificate '{signatureValue.CertificateRef}' not found in catalogue.");
         }
 
         X509Certificate2 cert;
@@ -110,12 +204,8 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
         }
         catch (CryptographicException ex)
         {
-            return new FileVerificationResult
-            {
-                FileName = fileName,
-                Outcome = VerificationOutcome.Error,
-                Detail = $"Failed to parse certificate '{signatureValue.CertificateRef}': {ex.Message}",
-            };
+            return (VerificationOutcome.Error,
+                $"Failed to parse certificate '{signatureValue.CertificateRef}': {ex.Message}");
         }
 
         using (cert)
@@ -124,63 +214,22 @@ public sealed class ExchangeSetVerifier : IExchangeSetVerifier
             var trustOutcome = ValidateCertificateTrust(cert, trustAnchors);
             if (trustOutcome is not null)
             {
-                return new FileVerificationResult
-                {
-                    FileName = fileName,
-                    Outcome = trustOutcome.Value,
-                    Detail = trustOutcome.Value == VerificationOutcome.CertificateExpired
-                        ? $"Certificate '{signatureValue.CertificateRef}' expired on {cert.NotAfter:O}."
-                        : $"Certificate '{signatureValue.CertificateRef}' is not trusted.",
-                };
-            }
-
-            // Hash the file content
-            byte[] fileHash;
-            try
-            {
-                var normalizedPath = ExchangeSet.NormalizeFileName(fileName);
-                await using var stream = await source.OpenAsync(normalizedPath, cancellationToken);
-                fileHash = await ComputeSha256HashAsync(stream, cancellationToken);
-            }
-            catch (FileNotFoundException)
-            {
-                return new FileVerificationResult
-                {
-                    FileName = fileName,
-                    Outcome = VerificationOutcome.FileMissing,
-                };
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                return new FileVerificationResult
-                {
-                    FileName = fileName,
-                    Outcome = VerificationOutcome.Error,
-                    Detail = $"Failed to read file: {ex.Message}",
-                };
+                var detail = trustOutcome.Value == VerificationOutcome.CertificateExpired
+                    ? $"Certificate '{signatureValue.CertificateRef}' expired on {cert.NotAfter:O}."
+                    : $"Certificate '{signatureValue.CertificateRef}' is not trusted.";
+                return (trustOutcome.Value, detail);
             }
 
             // Verify the signature
-            bool valid;
             try
             {
-                valid = VerifySignature(cert, algorithm, fileHash, signatureValue.Value);
+                var valid = VerifySignature(cert, algorithm, fileHash, signatureValue.Value);
+                return (valid ? VerificationOutcome.Ok : VerificationOutcome.SignatureInvalid, null);
             }
             catch (CryptographicException ex)
             {
-                return new FileVerificationResult
-                {
-                    FileName = fileName,
-                    Outcome = VerificationOutcome.Error,
-                    Detail = $"Signature verification error: {ex.Message}",
-                };
+                return (VerificationOutcome.Error, $"Signature verification error: {ex.Message}");
             }
-
-            return new FileVerificationResult
-            {
-                FileName = fileName,
-                Outcome = valid ? VerificationOutcome.Ok : VerificationOutcome.SignatureInvalid,
-            };
         }
     }
 

--- a/src/EncDotNet.S100.ExchangeSets/FileVerificationResult.cs
+++ b/src/EncDotNet.S100.ExchangeSets/FileVerificationResult.cs
@@ -1,15 +1,42 @@
 namespace EncDotNet.S100.ExchangeSets;
 
 /// <summary>
-/// The verification result for a single file in an exchange set.
+/// The verification result for a single file in an exchange set, carrying two
+/// independent dimensions: the digital-signature outcome
+/// (<see cref="Outcome"/>) and the checksum/integrity outcome
+/// (<see cref="ChecksumOutcome"/>).
 /// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15. A file may, for example, report a valid
+/// checksum while being unsigned, so the two dimensions are reported
+/// separately rather than collapsed into a single value.
+/// </remarks>
 public sealed class FileVerificationResult
 {
     /// <summary>The file name as declared in the catalogue discovery metadata.</summary>
     public required string FileName { get; init; }
 
-    /// <summary>The verification outcome for this file.</summary>
+    /// <summary>
+    /// The digital-signature verification outcome for this file
+    /// (S-100 Edition 5.2.1 Part 15 §15-8.9).
+    /// </summary>
     public required VerificationOutcome Outcome { get; init; }
+
+    /// <summary>
+    /// The checksum/integrity outcome for this file, independent of
+    /// <see cref="Outcome"/>. Defaults to <see cref="VerificationOutcome.NoChecksum"/>
+    /// when the file carries no declared cryptographic hash to compare against.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10.</remarks>
+    public VerificationOutcome ChecksumOutcome { get; init; } = VerificationOutcome.NoChecksum;
+
+    /// <summary>
+    /// The SHA-256 digest computed over the file content, expressed as a
+    /// lower-case hexadecimal string; <see langword="null"/> when the file
+    /// was missing or could not be read. Surfaced so an unsigned exchange set
+    /// can still be integrity-checked against an externally supplied digest.
+    /// </summary>
+    public string? ComputedSha256 { get; init; }
 
     /// <summary>Optional detail message (e.g. exception message on <see cref="VerificationOutcome.Error"/>).</summary>
     public string? Detail { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/README.md
+++ b/src/EncDotNet.S100.ExchangeSets/README.md
@@ -41,7 +41,7 @@ not just the generic `S100_DatasetDiscoveryMetadata`.
 
 ## Digital Signature Verification
 
-The library implements the S-100 Part 15 Data Protection Scheme for **signature verification**. Exchange sets may include per-file digital signatures (DSA or ECDSA P-256 over SHA-256) embedded in `CATALOG.XML`, along with a certificate block referencing the signing data provider.
+The library implements the S-100 Part 15 Data Protection Scheme for **signature verification** and a complementary **checksum/integrity** dimension. Exchange sets may include per-file digital signatures (DSA or ECDSA P-256 over SHA-256) embedded in `CATALOG.XML`, along with a certificate block referencing the signing data provider. Independently of any signature, each file's SHA-256 digest is computed and its presence/readability confirmed, so even an **unsigned** exchange set can be checked for missing or corrupt files.
 
 ### Model types
 
@@ -51,8 +51,9 @@ The library implements the S-100 Part 15 Data Protection Scheme for **signature 
 | `DigitalSignatureValue` | Parsed `S100_SE_DigitalSignature` (id, certificateRef, raw signature bytes) | §15-4.2 |
 | `CertificateBlock` | Certificate collection from the catalogue (scheme administrator ID + certificate entries) | §15-5 |
 | `CertificateEntry` | Individual X.509 certificate (id, issuer, DER-encoded bytes) | §15-5.2 |
+| `CryptographicHash` | Parsed hash MRN `urn:mrn:iho:s100:hash:<alg>:<hex>` used to integrity-check a resource | §15-8.10, Table 15-12 |
 
-These are surfaced as properties on `DatasetDiscoveryMetadata`, `SupportFileDiscoveryMetadata`, `CatalogueDiscoveryMetadata` (via `DigitalSignatureAlgorithm` and `DigitalSignatureValue?`), and on `ExchangeCatalogue` (via `CertificateBlock?`).
+These are surfaced as properties on `DatasetDiscoveryMetadata`, `SupportFileDiscoveryMetadata`, `CatalogueDiscoveryMetadata` (via `DigitalSignatureAlgorithm`, `DigitalSignatureValue?`, and `ExpectedHash?`), and on `ExchangeCatalogue` (via `CertificateBlock?`).
 
 ### Verification API
 
@@ -98,15 +99,64 @@ else if (result.HasInvalidSignatures)
 
 ### Verification outcomes
 
-| `VerificationOutcome` | Meaning |
-|---|---|
-| `Ok` | Signature is valid and certificate is trusted (or trust check skipped) |
-| `NotSigned` | No digital signature present for this file |
-| `SignatureInvalid` | Signature does not match the file contents |
-| `CertificateUntrusted` | Signature is valid but the certificate is not trusted |
-| `CertificateExpired` | Certificate has expired |
-| `FileMissing` | Referenced file not found in the asset source |
-| `Error` | Unexpected error during verification |
+Each `FileVerificationResult` reports **two independent dimensions**: the digital-signature outcome (`Outcome`) and the checksum/integrity outcome (`ChecksumOutcome`). A file may, for example, report a valid checksum while being unsigned. `ComputedSha256` carries the file's SHA-256 digest (lower-case hex) — useful for the unsigned case. Both dimensions use the same `VerificationOutcome` enum:
+
+| `VerificationOutcome` | Dimension | Meaning |
+|---|---|---|
+| `Ok` | both | Signature valid (and certificate trusted), or computed digest matched the declared hash |
+| `NotSigned` | signature | No digital signature present for this file |
+| `SignatureInvalid` | signature | Signature does not match the file contents |
+| `CertificateUntrusted` | signature | Signature is valid but the certificate is not trusted |
+| `CertificateExpired` | signature | Certificate has expired |
+| `CertificateNotFound` | signature | Referenced certificate not found in the catalogue |
+| `FileMissing` | both | Referenced file not found in the asset source (incomplete set) |
+| `Error` | both | Unexpected error during verification |
+| `NoChecksum` | checksum | File present and readable, but no declared hash to compare against |
+| `ChecksumMismatch` | checksum | Computed digest does not match the declared cryptographic hash |
+
+> The `VerificationOutcome` members are append-only: their names and ordinals are stable so downstream consumers (including the S-57 exchange-set bridge) can mirror them.
+
+`ExchangeSetVerificationResult` exposes aggregate helpers across both dimensions: `AllValid`, `HasInvalidSignatures`, `IsUnsigned` (signature side) and `HasChecksumMismatches`, `HasMissingFiles`, `IntegrityVerified` (checksum side).
+
+#### How a missing checksum is treated
+
+S-100 integrity is delivered by Part 15 signatures, and the specification mandates **no** per-resource checksum element, so a "no checksum present" case (`NoChecksum`) must **not** count as a failure. This is a deliberate, documented decision:
+
+- `AllValid` is a strict **signature-only** predicate — it requires every file's signature to be `Ok`, ignores the checksum dimension, and is therefore `false` for an unsigned set. Callers pair it with `IsUnsigned` to tell "signed and all valid" apart from "unsigned". It is **not** the overall integrity verdict.
+- `IntegrityVerified` is the integrity verdict: `true` unless a file is missing or a *declared* checksum mismatched. `NoChecksum` does **not** fail it.
+- The `s100 validate` exit code follows the same rule — a file fails only on `ChecksumMismatch` / `FileMissing` / `Error` / invalid signature (and, under `--strict`, also `NotSigned` / `NoChecksum`).
+
+This mirrors the sibling S-57 implementation (`EncDotNet` #6), whose `AllValid` likewise treats a missing CRC as non-failing (the CATALOG.031 self-reference legitimately has none) and fails only on mismatch, missing file, error, or invalid signature — keeping the two repos' semantics consistent for any future shared/bridge abstraction.
+
+### Checksum / integrity verification
+
+S-100 has **no per-resource CRC element** like S-57's CATALOG.031; the digital signature itself "serves the dual purpose of a checksum against the unencrypted data file" (Part 15 §15-8.9). The only standalone digest construct is the optional cryptographic hash MRN `urn:mrn:iho:s100:hash:<alg>:<hex>` (§15-8.10, Table 15-12), which real catalogues rarely carry and for which the specification defines no fixed catalogue slot. Accordingly:
+
+- Every file is hashed (streaming SHA-256) and checked for presence/readability, so an unsigned set can still be checked for **missing or corrupt** files.
+- When the catalogue declares a hash MRN for a resource (discovered best-effort by `ExchangeCatalogueReader` and surfaced as `ExpectedHash`), the computed digest is compared against it (`Ok` / `ChecksumMismatch`); otherwise the file reports `NoChecksum`.
+
+### Part 15 decryption seam
+
+Encryption/decryption is **not** implemented. The seam for it is `ExchangeSetVerifier.OpenContentForHashingAsync(...)`, a `protected virtual` hook that today returns the raw bytes from the asset source. A future override (or injected decrypted-content provider) would return the decrypted, decompressed bytes for a `dataStatus="encrypted"` signature (§15-8.8, Table 15-10) so the computed digest matches the signature, which is produced over the unencrypted resource. The newer `S100_SE_SignatureOnData` / `S100_SE_SignatureOnSignature` forms and the `dataStatus` attribute are not yet parsed.
+
+### CLI
+
+The `s100 validate` command verifies an exchange set when given a `CATALOG.XML`, a directory containing one, or a `.zip` whose root holds one:
+
+```sh
+s100 validate exchangeset/CATALOG.XML
+s100 validate ./exchangeset            # folder
+s100 validate exchangeset.zip --format json
+```
+
+It prints a per-file signature/checksum table (or JSON), exits `0` when no file fails, and `6` (the shared findings exit code) on any failure. `--strict` additionally fails unsigned files and files with no declared checksum.
+
+The same command also verifies **S-57 / S-63 exchange sets** (a folder containing a `CATALOG.031`, or the `CATALOG.031` file itself) by routing through `EncDotNet.S100.Datasets.S57.S57ExchangeSetVerification`, which checks each file's CRC-32 and maps the upstream `EncDotNet.S57` result onto this same `ExchangeSetVerificationResult` model and exit-code semantics (`NoChecksum` / `NotSigned` non-failing). See the [S-57 bridge README](../EncDotNet.S100.Datasets.S57/README.md#exchange-set-integrity-verification).
+
+```sh
+s100 validate s57set/CATALOG.031
+s100 validate ./s57set --format json   # folder containing CATALOG.031
+```
 
 ### Trust anchor model
 
@@ -120,7 +170,8 @@ The IHO publishes test SA certificates for interoperability testing. For product
 ### Scope and limitations
 
 - **Verification only** — signing/authoring of exchange sets is not yet implemented.
-- **Encryption is out of scope** — Part 15 §3 Confidentiality (ENC permits, cell-level decryption) is not supported.
+- **Encryption is out of scope** — Part 15 §3 Confidentiality (ENC permits, cell-level decryption) is not supported; see the decryption seam above.
+- **Checksum reference is opportunistic** — S-100 mandates no per-resource hash, so `NoChecksum` is the common (and non-failing) result for unsigned sets; hash-MRN placement is discovered best-effort.
 - File hashing uses streaming SHA-256 to avoid loading large HDF5 files into memory.
 
 ## Installation

--- a/src/EncDotNet.S100.ExchangeSets/SupportFileDiscoveryMetadata.cs
+++ b/src/EncDotNet.S100.ExchangeSets/SupportFileDiscoveryMetadata.cs
@@ -42,6 +42,14 @@ public sealed class SupportFileDiscoveryMetadata
     /// <remarks>S-100 Edition 5.2.1 Part 15 §15-4.2.</remarks>
     public DigitalSignatureValue? DigitalSignatureValue { get; init; }
 
+    /// <summary>
+    /// The declared cryptographic hash for this support file, if the catalogue
+    /// carries one. Used to integrity-check the file independently of any
+    /// digital signature.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10, Table 15-12.</remarks>
+    public CryptographicHash? ExpectedHash { get; init; }
+
     public IReadOnlyList<string> SupportedResources { get; init; } = [];
 
     public string? ResourcePurpose { get; init; }

--- a/src/EncDotNet.S100.ExchangeSets/VerificationOutcome.cs
+++ b/src/EncDotNet.S100.ExchangeSets/VerificationOutcome.cs
@@ -3,10 +3,21 @@ namespace EncDotNet.S100.ExchangeSets;
 /// <summary>
 /// The outcome of verifying a single file or the catalogue as a whole.
 /// </summary>
-/// <remarks>S-100 Edition 5.2.1 Part 15.</remarks>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15. The same enumeration is used for two
+/// independent dimensions on <see cref="FileVerificationResult"/>: the
+/// digital-signature dimension (<see cref="FileVerificationResult.Outcome"/>)
+/// and the checksum/integrity dimension
+/// (<see cref="FileVerificationResult.ChecksumOutcome"/>). Members are
+/// append-only so downstream consumers (including the S-57 exchange-set
+/// bridge) can mirror the names and ordinals.
+/// </remarks>
 public enum VerificationOutcome
 {
-    /// <summary>The signature was verified successfully.</summary>
+    /// <summary>
+    /// The signature was verified successfully, or (in the checksum
+    /// dimension) the computed digest matched the declared digest.
+    /// </summary>
     Ok,
 
     /// <summary>The file or catalogue carries no digital signature.</summary>
@@ -29,4 +40,19 @@ public enum VerificationOutcome
 
     /// <summary>An unexpected error occurred during verification.</summary>
     Error,
+
+    /// <summary>
+    /// Checksum dimension only: the file is present and readable but the
+    /// catalogue declares no cryptographic hash (<c>urn:mrn:iho:s100:hash:…</c>,
+    /// S-100 Edition 5.2.1 Part 15 §15-8.10) to compare against, so its
+    /// content integrity could not be independently verified.
+    /// </summary>
+    NoChecksum,
+
+    /// <summary>
+    /// Checksum dimension only: the computed digest of the file does not
+    /// match the cryptographic hash declared in the catalogue.
+    /// </summary>
+    /// <remarks>S-100 Edition 5.2.1 Part 15 §15-8.10.</remarks>
+    ChecksumMismatch,
 }

--- a/tests/EncDotNet.S100.Cli.Tests/ConsoleCollection.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/ConsoleCollection.cs
@@ -1,0 +1,14 @@
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Serializes test classes that redirect <see cref="System.Console"/> output
+/// via <c>Console.SetOut</c> / <c>Console.SetError</c>. The console streams are
+/// process-global, so these classes must not run in parallel with one another or
+/// captured output bleeds across tests (e.g. corrupting JSON assertions).
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ConsoleCollection
+{
+    /// <summary>Collection name shared by all console-capturing CLI test classes.</summary>
+    public const string Name = "Console (serialized)";
+}

--- a/tests/EncDotNet.S100.Cli.Tests/DiagnosticTraceScopeTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/DiagnosticTraceScopeTests.cs
@@ -8,8 +8,7 @@ namespace EncDotNet.S100.Cli.Tests;
 /// portrayal diagnostics on stderr when <c>s100 render … --debug</c> is used
 /// while keeping them silent by default (issue #241).
 /// </summary>
-[Collection(nameof(DiagnosticTraceScopeTests))]
-[CollectionDefinition(nameof(DiagnosticTraceScopeTests), DisableParallelization = true)]
+[Collection(ConsoleCollection.Name)]
 public sealed class DiagnosticTraceScopeTests
 {
     [Fact]

--- a/tests/EncDotNet.S100.Cli.Tests/S57ExchangeSetInputTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/S57ExchangeSetInputTests.cs
@@ -1,0 +1,69 @@
+using EncDotNet.S100.Cli.Infrastructure;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Unit tests for the S-57 exchange-set detection helpers on
+/// <see cref="ExchangeSetInput"/>, which let <c>s100 validate</c> recognise an
+/// S-57 / S-63 <c>CATALOG.031</c> input and branch into S-57 verification.
+/// Synthetic temp directories only — no real ENC data.
+/// </summary>
+public sealed class S57ExchangeSetInputTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("s57-input-").FullName;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    [Fact]
+    public void Directory_with_catalog031_is_detected()
+    {
+        File.WriteAllBytes(Path.Combine(_root, "CATALOG.031"), []);
+
+        Assert.True(ExchangeSetInput.LooksLikeS57ExchangeSet(_root));
+        Assert.Equal(Path.GetFullPath(_root), ExchangeSetInput.ResolveS57Root(_root));
+    }
+
+    [Fact]
+    public void Catalog031_file_path_is_detected_and_resolves_to_parent()
+    {
+        string catalogue = Path.Combine(_root, "CATALOG.031");
+        File.WriteAllBytes(catalogue, []);
+
+        Assert.True(ExchangeSetInput.LooksLikeS57ExchangeSet(catalogue));
+        Assert.Equal(Path.GetFullPath(_root), ExchangeSetInput.ResolveS57Root(catalogue));
+    }
+
+    [Fact]
+    public void Detection_is_case_insensitive()
+    {
+        File.WriteAllBytes(Path.Combine(_root, "catalog.031"), []);
+
+        Assert.True(ExchangeSetInput.LooksLikeS57ExchangeSet(_root));
+    }
+
+    [Fact]
+    public void S100_exchange_set_is_not_an_s57_exchange_set()
+    {
+        File.WriteAllText(Path.Combine(_root, "CATALOG.XML"), "<x/>");
+
+        Assert.False(ExchangeSetInput.LooksLikeS57ExchangeSet(_root));
+        Assert.True(ExchangeSetInput.LooksLikeExchangeSet(_root));
+    }
+
+    [Fact]
+    public void Empty_directory_is_not_detected()
+    {
+        Assert.False(ExchangeSetInput.LooksLikeS57ExchangeSet(_root));
+    }
+
+    [Fact]
+    public void ResolveS57Root_without_catalogue_throws()
+    {
+        Assert.Throws<FileNotFoundException>(() => ExchangeSetInput.ResolveS57Root(_root));
+    }
+}

--- a/tests/EncDotNet.S100.Cli.Tests/SpecVersionWarningCliTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/SpecVersionWarningCliTests.cs
@@ -7,6 +7,7 @@ namespace EncDotNet.S100.Cli.Tests;
 /// dataset's declared edition genuinely diverges from the build-implemented
 /// edition — and stays silent otherwise (no false positives).
 /// </summary>
+[Collection(ConsoleCollection.Name)]
 public sealed class SpecVersionWarningCliTests
 {
     private const string WarningFragment = "rendering may be incomplete or incorrect";

--- a/tests/EncDotNet.S100.Cli.Tests/ValidateCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/ValidateCommandTests.cs
@@ -7,6 +7,7 @@ namespace EncDotNet.S100.Cli.Tests;
 /// End-to-end smoke tests that run the <c>s100 validate</c> command in-process
 /// against a committed synthetic dataset fixture.
 /// </summary>
+[Collection(ConsoleCollection.Name)]
 public sealed class ValidateCommandTests
 {
     private static string FixturePath(string fileName) =>

--- a/tests/EncDotNet.S100.Cli.Tests/ValidateExchangeSetCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/ValidateExchangeSetCommandTests.cs
@@ -1,0 +1,172 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using EncDotNet.S100.Cli.Infrastructure;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// End-to-end tests for <c>s100 validate &lt;exchange-set&gt;</c>, which
+/// integrity-verifies an exchange set (S-100 Edition 5.2.1 Part 15) rather than
+/// running a single-dataset rule pack. Synthetic exchange sets are built in a
+/// temp directory — no real ENC data is committed.
+/// </summary>
+[Collection(ConsoleCollection.Name)]
+public sealed class ValidateExchangeSetCommandTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("s100-xs-validate-").FullName;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    [Fact]
+    public void Validate_unsigned_intact_exchange_set_returns_success()
+    {
+        WriteFile("data.000", "hello"u8.ToArray());
+        WriteCatalogue(DatasetEntry("data.000"));
+
+        int exit = CliApp.Build().Run(["validate", _root]);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public void Validate_exchange_set_via_catalogue_path_returns_success()
+    {
+        WriteFile("data.000", "hello"u8.ToArray());
+        WriteCatalogue(DatasetEntry("data.000"));
+
+        int exit = CliApp.Build().Run(["validate", Path.Combine(_root, "CATALOG.XML")]);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public void Validate_missing_file_fails_with_findings_exit_code()
+    {
+        // Catalogue references a file that is not present on disk.
+        WriteCatalogue(DatasetEntry("missing.000"));
+
+        var (exit, stdout) = RunCapturingStdout(["validate", _root, "--format", "json"]);
+
+        Assert.Equal(6, exit);
+        using var doc = JsonDocument.Parse(stdout);
+        var root = doc.RootElement;
+        Assert.Equal("exchange-set", root.GetProperty("kind").GetString());
+        Assert.False(root.GetProperty("valid").GetBoolean());
+        Assert.True(root.GetProperty("hasMissingFiles").GetBoolean());
+        var file = root.GetProperty("files")[0];
+        Assert.Equal("FileMissing", file.GetProperty("checksumOutcome").GetString());
+    }
+
+    [Fact]
+    public void Validate_checksum_mismatch_fails_with_findings_exit_code()
+    {
+        WriteFile("data.000", "actual content"u8.ToArray());
+        var wrongHash = "urn:mrn:iho:s100:hash:sha256:" + Sha256Hex("different content"u8.ToArray());
+        WriteCatalogue(DatasetEntry("data.000", wrongHash));
+
+        var (exit, stdout) = RunCapturingStdout(["validate", _root, "--format", "json"]);
+
+        Assert.Equal(6, exit);
+        using var doc = JsonDocument.Parse(stdout);
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("hasChecksumMismatches").GetBoolean());
+        var file = root.GetProperty("files")[0];
+        Assert.Equal("ChecksumMismatch", file.GetProperty("checksumOutcome").GetString());
+        Assert.Equal(Sha256Hex("actual content"u8.ToArray()), file.GetProperty("computedSha256").GetString());
+    }
+
+    [Fact]
+    public void Validate_matching_checksum_returns_success()
+    {
+        var content = "verified content"u8.ToArray();
+        WriteFile("data.000", content);
+        WriteCatalogue(DatasetEntry("data.000", "urn:mrn:iho:s100:hash:sha256:" + Sha256Hex(content)));
+
+        var (exit, stdout) = RunCapturingStdout(["validate", _root, "--format", "json"]);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(stdout);
+        Assert.True(doc.RootElement.GetProperty("integrityVerified").GetBoolean());
+        Assert.Equal("Ok", doc.RootElement.GetProperty("files")[0].GetProperty("checksumOutcome").GetString());
+    }
+
+    [Fact]
+    public void Validate_unsigned_set_in_strict_mode_fails()
+    {
+        WriteFile("data.000", "hello"u8.ToArray());
+        WriteCatalogue(DatasetEntry("data.000"));
+
+        // Strict treats unsigned / no-checksum files as failures.
+        int exit = CliApp.Build().Run(["validate", _root, "--strict"]);
+
+        Assert.Equal(6, exit);
+    }
+
+    [Fact]
+    public void ExchangeSetInput_does_not_flag_a_plain_dataset_file()
+    {
+        var dataset = Path.Combine(_root, "data.000");
+        File.WriteAllText(dataset, "not a catalogue");
+
+        Assert.False(ExchangeSetInput.LooksLikeExchangeSet(dataset));
+    }
+
+    private static string Sha256Hex(byte[] content) =>
+        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+
+    private void WriteFile(string name, byte[] content) =>
+        File.WriteAllBytes(Path.Combine(_root, name), content);
+
+    private static string DatasetEntry(string fileName, string? hashMrn = null)
+    {
+        var hashElement = hashMrn is null
+            ? string.Empty
+            : $"\n            <S100XC:resourceHash>{hashMrn}</S100XC:resourceHash>";
+
+        return $"""
+                    <S100XC:S100_DatasetDiscoveryMetadata>
+                        <S100XC:fileName>{fileName}</S100XC:fileName>{hashElement}
+                    </S100XC:S100_DatasetDiscoveryMetadata>
+            """;
+    }
+
+    private void WriteCatalogue(string datasetEntries)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
+                <S100XC:identifier>
+                    <S100XC:identifier>TEST</S100XC:identifier>
+                    <S100XC:dateTime>2024-01-01</S100XC:dateTime>
+                </S100XC:identifier>
+                <S100XC:datasetDiscoveryMetadata>
+            {datasetEntries}
+                </S100XC:datasetDiscoveryMetadata>
+            </S100XC:S100_ExchangeCatalogue>
+            """;
+
+        File.WriteAllText(Path.Combine(_root, "CATALOG.XML"), xml, Encoding.UTF8);
+    }
+
+    private static (int Exit, string Stdout) RunCapturingStdout(string[] args)
+    {
+        var original = Console.Out;
+        var buffer = new StringWriter();
+        Console.SetOut(buffer);
+        try
+        {
+            int exit = CliApp.Build().Run(args);
+            return (exit, buffer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S57.Tests/EncDotNet.S100.Datasets.S57.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S57\EncDotNet.S100.Datasets.S57.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.ExchangeSets\EncDotNet.S100.ExchangeSets.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Datasets.S57.Tests/S57ExchangeSetVerificationTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S57.Tests/S57ExchangeSetVerificationTests.cs
@@ -1,0 +1,178 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S57;
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S57.ExchangeSets;
+using S57Outcome = EncDotNet.S57.ExchangeSets.S57VerificationOutcome;
+
+namespace EncDotNet.S100.Datasets.S57.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S57ExchangeSetVerification"/>, which maps the
+/// upstream S-57 verification result onto this repository's S-100 result model.
+/// Uses synthetic S-57 results (the S-57 result types expose <c>init</c>
+/// setters) so no real ENC data is required.
+/// </summary>
+public sealed class S57ExchangeSetVerificationTests
+{
+    [Fact]
+    public void MapOutcome_MapsEveryMemberByName()
+    {
+        foreach (S57Outcome value in Enum.GetValues<S57Outcome>())
+        {
+            VerificationOutcome mapped = S57ExchangeSetVerification.MapOutcome(value);
+            Assert.Equal(value.ToString(), mapped.ToString());
+        }
+    }
+
+    [Fact]
+    public void MapOutcome_CoversEntireS100Enum()
+    {
+        // Every S-100 outcome must be reachable from an S-57 outcome of the same
+        // name, otherwise the two enumerations have silently diverged.
+        var s57Names = Enum.GetNames<S57Outcome>().ToHashSet();
+        foreach (string name in Enum.GetNames<VerificationOutcome>())
+            Assert.Contains(name, s57Names);
+    }
+
+    [Fact]
+    public void MapFile_PreservesBothDimensionsIndependently()
+    {
+        var s57 = new S57FileVerificationResult
+        {
+            FileName = "US5WA70M\\US5WA70M.000",
+            SignatureOutcome = S57Outcome.NotSigned,
+            ChecksumOutcome = S57Outcome.Ok,
+            ExpectedCrc = "A8292AA7",
+            ActualCrc = "A8292AA7",
+        };
+
+        FileVerificationResult mapped = S57ExchangeSetVerification.MapFile(s57);
+
+        Assert.Equal("US5WA70M\\US5WA70M.000", mapped.FileName);
+        Assert.Equal(VerificationOutcome.NotSigned, mapped.Outcome);
+        Assert.Equal(VerificationOutcome.Ok, mapped.ChecksumOutcome);
+        Assert.Null(mapped.ComputedSha256);
+        Assert.Contains("CRC expected=A8292AA7 actual=A8292AA7", mapped.Detail);
+    }
+
+    [Fact]
+    public void MapFile_SurfacesCrcMismatchInDetail()
+    {
+        var s57 = new S57FileVerificationResult
+        {
+            FileName = "BADCELL.000",
+            SignatureOutcome = S57Outcome.NotSigned,
+            ChecksumOutcome = S57Outcome.ChecksumMismatch,
+            ExpectedCrc = "AAAAAAAA",
+            ActualCrc = "BBBBBBBB",
+        };
+
+        FileVerificationResult mapped = S57ExchangeSetVerification.MapFile(s57);
+
+        Assert.Equal(VerificationOutcome.ChecksumMismatch, mapped.ChecksumOutcome);
+        Assert.Contains("expected=AAAAAAAA", mapped.Detail);
+        Assert.Contains("actual=BBBBBBBB", mapped.Detail);
+    }
+
+    [Fact]
+    public void MapFile_NoCrc_LeavesDetailNull()
+    {
+        var s57 = new S57FileVerificationResult
+        {
+            FileName = "CATALOG.031",
+            SignatureOutcome = S57Outcome.NotSigned,
+            ChecksumOutcome = S57Outcome.NoChecksum,
+        };
+
+        FileVerificationResult mapped = S57ExchangeSetVerification.MapFile(s57);
+
+        Assert.Equal(VerificationOutcome.NoChecksum, mapped.ChecksumOutcome);
+        Assert.Null(mapped.Detail);
+    }
+
+    [Fact]
+    public void Map_ProjectsAllFileResults()
+    {
+        var s57 = new S57ExchangeSetVerificationResult
+        {
+            FileResults = ImmutableArray.Create(
+                new S57FileVerificationResult
+                {
+                    FileName = "CATALOG.031",
+                    SignatureOutcome = S57Outcome.NotSigned,
+                    ChecksumOutcome = S57Outcome.NoChecksum,
+                },
+                new S57FileVerificationResult
+                {
+                    FileName = "CELL.000",
+                    SignatureOutcome = S57Outcome.NotSigned,
+                    ChecksumOutcome = S57Outcome.Ok,
+                    ExpectedCrc = "1234ABCD",
+                    ActualCrc = "1234ABCD",
+                }),
+        };
+
+        ExchangeSetVerificationResult mapped = S57ExchangeSetVerification.Map(s57);
+
+        Assert.Equal(2, mapped.FileResults.Count);
+        // An unsigned but intact S-57 set: not AllValid (unsigned) yet integrity
+        // is verified (no mismatches / missing files) — matches the documented
+        // S-100 semantics and S-57's own AllValid.
+        Assert.False(mapped.AllValid);
+        Assert.True(mapped.IntegrityVerified);
+        Assert.False(mapped.HasChecksumMismatches);
+        Assert.False(mapped.HasMissingFiles);
+    }
+
+    [Fact]
+    public void Map_ChecksumMismatch_FailsIntegrity()
+    {
+        var s57 = new S57ExchangeSetVerificationResult
+        {
+            FileResults = ImmutableArray.Create(
+                new S57FileVerificationResult
+                {
+                    FileName = "CELL.000",
+                    SignatureOutcome = S57Outcome.NotSigned,
+                    ChecksumOutcome = S57Outcome.ChecksumMismatch,
+                    ExpectedCrc = "AAAA",
+                    ActualCrc = "BBBB",
+                }),
+        };
+
+        ExchangeSetVerificationResult mapped = S57ExchangeSetVerification.Map(s57);
+
+        Assert.True(mapped.HasChecksumMismatches);
+        Assert.False(mapped.IntegrityVerified);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_NullOrEmptyRoot_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => S57ExchangeSetVerification.VerifyAsync(string.Empty));
+    }
+
+    /// <summary>
+    /// End-to-end verification against a real S-57 exchange set, when one is
+    /// available via the <c>ENCDOTNET_S57_EXCHANGE_SET</c> environment variable
+    /// (pointing at the folder containing <c>CATALOG.031</c>). Skipped otherwise
+    /// so CI never depends on (or commits) real ENC data.
+    /// </summary>
+    [SkippableFact]
+    public async Task VerifyAsync_RealExchangeSet_VerifiesIntegrity()
+    {
+        string? root = Environment.GetEnvironmentVariable("ENCDOTNET_S57_EXCHANGE_SET");
+        Skip.If(string.IsNullOrEmpty(root), "ENCDOTNET_S57_EXCHANGE_SET not set.");
+        Skip.IfNot(
+            File.Exists(Path.Combine(root!, "CATALOG.031")),
+            $"No CATALOG.031 in {root}.");
+
+        ExchangeSetVerificationResult result =
+            await S57ExchangeSetVerification.VerifyAsync(root!);
+
+        Assert.NotEmpty(result.FileResults);
+        // A pristine, freshly-downloaded set should have no corrupt files.
+        Assert.True(result.IntegrityVerified);
+    }
+}

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ChecksumVerificationTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ChecksumVerificationTests.cs
@@ -1,0 +1,218 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+/// <summary>
+/// Tests for the checksum/integrity dimension of
+/// <see cref="ExchangeSetVerifier"/>, exercised against synthetic catalogues
+/// so an unsigned exchange set can be integrity-checked
+/// (S-100 Edition 5.2.1 Part 15 §15-8.10).
+/// </summary>
+public class ChecksumVerificationTests
+{
+    private static string Sha256Hex(byte[] content) =>
+        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+
+    private static string HashMrn(byte[] content) =>
+        $"urn:mrn:iho:s100:hash:sha256:{Sha256Hex(content)}";
+
+    [Fact]
+    public async Task Unsigned_NoDeclaredHash_ReportsNoChecksum_WithComputedDigest()
+    {
+        var content = "hello"u8.ToArray();
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata { FileName = "test.000" },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", content);
+
+        var result = await new ExchangeSetVerifier().VerifyAsync(
+            source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        var file = Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.NotSigned, file.Outcome);
+        Assert.Equal(VerificationOutcome.NoChecksum, file.ChecksumOutcome);
+        Assert.Equal(Sha256Hex(content), file.ComputedSha256);
+        Assert.True(result.IntegrityVerified);
+        Assert.False(result.HasChecksumMismatches);
+        Assert.False(result.HasMissingFiles);
+    }
+
+    [Fact]
+    public async Task Unsigned_MatchingDeclaredHash_ReportsChecksumOk()
+    {
+        var content = "integrity"u8.ToArray();
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    ExpectedHash = Parse(HashMrn(content)),
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", content);
+
+        var result = await new ExchangeSetVerifier().VerifyAsync(
+            source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        var file = Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.Ok, file.ChecksumOutcome);
+        Assert.True(result.IntegrityVerified);
+    }
+
+    [Fact]
+    public async Task Unsigned_DeclaredHashMismatch_ReportsChecksumMismatch()
+    {
+        var content = "actual content"u8.ToArray();
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    ExpectedHash = Parse(HashMrn("different content"u8.ToArray())),
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", content);
+
+        var result = await new ExchangeSetVerifier().VerifyAsync(
+            source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        var file = Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.ChecksumMismatch, file.ChecksumOutcome);
+        Assert.Equal(Sha256Hex(content), file.ComputedSha256);
+        Assert.True(result.HasChecksumMismatches);
+        Assert.False(result.IntegrityVerified);
+    }
+
+    [Fact]
+    public async Task MissingFile_ReportsFileMissing_InBothDimensions()
+    {
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata { FileName = "missing.000" },
+            ],
+        };
+
+        var result = await new ExchangeSetVerifier().VerifyAsync(
+            new InMemoryAssetSource(), catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        var file = Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.FileMissing, file.Outcome);
+        Assert.Equal(VerificationOutcome.FileMissing, file.ChecksumOutcome);
+        Assert.Null(file.ComputedSha256);
+        Assert.True(result.HasMissingFiles);
+        Assert.False(result.IntegrityVerified);
+    }
+
+    [Fact]
+    public async Task SignedUnencryptedFile_HasIndependentSignatureAndChecksumOutcomes()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certReq = new CertificateRequest("CN=TestSA", ecdsa, HashAlgorithmName.SHA256);
+        using var cert = certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+
+        var content = "signed content"u8.ToArray();
+        var signature = ecdsa.SignHash(SHA256.HashData(content));
+        const string certId = "urn:test:cert1";
+
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            Certificates = new CertificateBlock
+            {
+                Certificates = [new CertificateEntry { Id = certId, Issuer = "TestSA", Value = cert.RawData }],
+            },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata
+                {
+                    FileName = "test.000",
+                    DigitalSignatureReference = "ECDSA",
+                    DigitalSignatureAlgorithm = DigitalSignatureAlgorithm.ECDSA,
+                    DigitalSignatureValue = new DigitalSignatureValue
+                    {
+                        Id = "SIG1",
+                        CertificateRef = certId,
+                        Value = signature,
+                    },
+                    // No declared hash: signature is valid, checksum dimension
+                    // has nothing to compare against.
+                },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("test.000", content);
+
+        var result = await new ExchangeSetVerifier().VerifyAsync(
+            source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        var file = Assert.Single(result.FileResults);
+        Assert.Equal(VerificationOutcome.Ok, file.Outcome);
+        Assert.Equal(VerificationOutcome.NoChecksum, file.ChecksumOutcome);
+        Assert.Equal(Sha256Hex(content), file.ComputedSha256);
+        Assert.False(result.IsUnsigned);
+        Assert.True(result.IntegrityVerified);
+    }
+
+    [Fact]
+    public async Task Unsigned_IntactSet_AllValidIsFalse_ButIntegrityVerifiedIsTrue()
+    {
+        // Documents the deliberate decision (aligned with the S-57 sibling):
+        // a missing checksum is NOT a failure. AllValid is a strict
+        // signature-only predicate (false when unsigned); IntegrityVerified is
+        // the integrity verdict and treats NoChecksum as non-failing.
+        var catalogue = new ExchangeCatalogue
+        {
+            Identifier = new ExchangeCatalogueIdentifier { Identifier = "TEST", DateTime = "2024-01-01" },
+            DatasetDiscoveryMetadata =
+            [
+                new DatasetDiscoveryMetadata { FileName = "a.000" },
+                new DatasetDiscoveryMetadata { FileName = "b.000" },
+            ],
+        };
+
+        var source = new InMemoryAssetSource();
+        source.AddFile("a.000", "alpha"u8.ToArray());
+        source.AddFile("b.000", "bravo"u8.ToArray());
+
+        var result = await new ExchangeSetVerifier().VerifyAsync(
+            source, catalogue, new TrustAnchorOptions { AllowUntrustedCertificates = true });
+
+        Assert.All(result.FileResults, f => Assert.Equal(VerificationOutcome.NoChecksum, f.ChecksumOutcome));
+        Assert.True(result.IsUnsigned);
+        Assert.False(result.AllValid);
+        Assert.True(result.IntegrityVerified);
+    }
+
+    private static CryptographicHash Parse(string mrn)
+    {
+        Assert.True(CryptographicHash.TryParse(mrn, out var hash));
+        return hash;
+    }
+}

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/CryptographicHashTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/CryptographicHashTests.cs
@@ -1,0 +1,59 @@
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+public class CryptographicHashTests
+{
+    [Fact]
+    public void TryParse_ValidSha256Mrn_Succeeds()
+    {
+        var mrn = "urn:mrn:iho:s100:hash:sha256:a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447";
+
+        Assert.True(CryptographicHash.TryParse(mrn, out var hash));
+        Assert.Equal("sha256", hash.Algorithm);
+        Assert.Equal("a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447", hash.HexValue);
+    }
+
+    [Fact]
+    public void TryParse_IsCaseInsensitive_AndNormalizesToLower()
+    {
+        var mrn = "URN:MRN:IHO:S100:HASH:SHA256:ABCD";
+
+        Assert.True(CryptographicHash.TryParse(mrn, out var hash));
+        Assert.Equal("sha256", hash.Algorithm);
+        Assert.Equal("abcd", hash.HexValue);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("urn:mrn:iho:s100:dsig:ecdsa:MGUC")]      // signature MRN, not hash
+    [InlineData("urn:mrn:iho:s100:hash:sha256:")]          // missing value
+    [InlineData("urn:mrn:iho:s100:hash:sha256")]           // missing value separator
+    [InlineData("urn:mrn:iho:s100:hash:sha256:xyz")]       // non-hex value
+    [InlineData("urn:mrn:iho:s100:hash:sha256:abc")]       // odd-length hex
+    public void TryParse_InvalidInput_Fails(string? value)
+    {
+        Assert.False(CryptographicHash.TryParse(value, out var hash));
+        Assert.Null(hash);
+    }
+
+    [Fact]
+    public void Matches_ComparesHexCaseInsensitively()
+    {
+        Assert.True(CryptographicHash.TryParse("urn:mrn:iho:s100:hash:sha256:abcd", out var hash));
+
+        Assert.True(hash.Matches("ABCD"));
+        Assert.True(hash.Matches("abcd"));
+        Assert.False(hash.Matches("ef01"));
+        Assert.False(hash.Matches(null));
+    }
+
+    [Fact]
+    public void ToString_RoundTripsThroughTryParse()
+    {
+        var original = "urn:mrn:iho:s100:hash:sha256:abcd";
+        Assert.True(CryptographicHash.TryParse(original, out var hash));
+
+        Assert.Equal(original, hash.ToString());
+    }
+}

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
@@ -70,6 +70,43 @@ public class ExchangeCatalogueReaderTests
     }
 
     [Fact]
+    public void Dataset_ExpectedHash_IsParsedFromHashMrn()
+    {
+        const string xml = """
+            <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
+                <S100XC:identifier>
+                    <S100XC:identifier>TEST</S100XC:identifier>
+                    <S100XC:dateTime>2024-01-01</S100XC:dateTime>
+                </S100XC:identifier>
+                <S100XC:datasetDiscoveryMetadata>
+                    <S100XC:S100_DatasetDiscoveryMetadata>
+                        <S100XC:fileName>test.000</S100XC:fileName>
+                        <S100XC:resourceHash>urn:mrn:iho:s100:hash:sha256:a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447</S100XC:resourceHash>
+                    </S100XC:S100_DatasetDiscoveryMetadata>
+                </S100XC:datasetDiscoveryMetadata>
+            </S100XC:S100_ExchangeCatalogue>
+            """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        var catalogue = ExchangeCatalogueReader.Read(stream);
+
+        var dataset = Assert.Single(catalogue.DatasetDiscoveryMetadata);
+        Assert.NotNull(dataset.ExpectedHash);
+        Assert.Equal("sha256", dataset.ExpectedHash.Algorithm);
+        Assert.Equal(
+            "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447",
+            dataset.ExpectedHash.HexValue);
+    }
+
+    [Fact]
+    public void Dataset_ExpectedHash_IsNullWhenAbsent()
+    {
+        var catalogue = ReadTestCatalogue();
+
+        Assert.All(catalogue.DatasetDiscoveryMetadata, ds => Assert.Null(ds.ExpectedHash));
+    }
+
+    [Fact]
     public void Datasets_HasExpectedCount()
     {
         var catalogue = ReadTestCatalogue();

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/InMemoryAssetSource.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/InMemoryAssetSource.cs
@@ -1,0 +1,28 @@
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+/// <summary>
+/// A simple in-memory <see cref="IAssetSource"/> for exchange-set
+/// verification tests. Paths are matched case-insensitively; opening an
+/// unknown path throws <see cref="FileNotFoundException"/> to mimic an
+/// incomplete exchange set.
+/// </summary>
+internal sealed class InMemoryAssetSource : IAssetSource
+{
+    private readonly Dictionary<string, byte[]> _files = new(StringComparer.OrdinalIgnoreCase);
+
+    public void AddFile(string path, byte[] content) => _files[path] = content;
+
+    public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        if (_files.TryGetValue(relativePath, out var content))
+        {
+            return Task.FromResult<Stream>(new MemoryStream(content));
+        }
+
+        throw new FileNotFoundException($"File not found: {relativePath}", relativePath);
+    }
+
+    public void Dispose() { }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/ValidateCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/ValidateCommand.cs
@@ -6,6 +6,8 @@ using System.Text.RegularExpressions;
 using EncDotNet.S100.Cli.Infrastructure;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S57;
+using EncDotNet.S100.ExchangeSets;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Validation;
 using Spectre.Console;
@@ -54,9 +56,13 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
 
         public override ValidationResult Validate()
         {
-            var baseResult = base.Validate();
-            if (!baseResult.Successful)
-                return baseResult;
+            if (string.IsNullOrWhiteSpace(DatasetPath))
+                return ValidationResult.Error("A dataset or exchange set path is required.");
+
+            // Accept a single dataset file, or an exchange set expressed as a
+            // directory / CATALOG.XML / .zip (resolved later in Execute).
+            if (!File.Exists(DatasetPath) && !Directory.Exists(DatasetPath))
+                return ValidationResult.Error($"Path not found: {DatasetPath}");
 
             if (!TryParseFormat(Format, out _))
                 return ValidationResult.Error($"Unknown format '{Format}'. Use text or json.");
@@ -73,6 +79,21 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
     {
         using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
         TryParseFormat(settings.Format, out var format);
+
+        // An exchange set (folder / CATALOG.XML / .zip) is integrity-verified
+        // rather than run through a single-dataset rule pack.
+        if (ExchangeSetInput.LooksLikeExchangeSet(settings.DatasetPath))
+        {
+            return VerifyExchangeSet(settings, format);
+        }
+
+        // An S-57 / S-63 exchange set (CATALOG.031) is integrity-verified via the
+        // S-57 verifier (CRC + signature), mapped onto the same result model.
+        if (ExchangeSetInput.LooksLikeS57ExchangeSet(settings.DatasetPath))
+        {
+            return VerifyS57ExchangeSet(settings, format);
+        }
+
         var (factory, catalogueManager) = ProcessorFactoryBuilder.Build();
         try
         {
@@ -126,6 +147,201 @@ internal sealed class ValidateCommand : Command<ValidateCommand.Settings>
         {
             catalogueManager.Dispose();
         }
+    }
+
+    // ── Exchange set integrity / signature verification ──────────────
+
+    /// <summary>
+    /// Verifies an exchange set's per-file digital signatures and checksums,
+    /// reporting the outcomes and mapping failures to the shared findings exit
+    /// code. S-100 Edition 5.2.1 Part 15.
+    /// </summary>
+    private static int VerifyExchangeSet(Settings settings, OutputFormat format)
+    {
+        IAssetSource? source = null;
+        try
+        {
+            string cataloguePath;
+            string kind;
+            (source, cataloguePath, kind) = ExchangeSetInput.Open(settings.DatasetPath);
+
+            using var exchangeSet = ExchangeSet.OpenAsync(source, cataloguePath).GetAwaiter().GetResult();
+            source = null; // ownership transferred to ExchangeSet; disposed below.
+
+            var verifier = new ExchangeSetVerifier();
+            var result = verifier
+                .VerifyAsync(
+                    exchangeSet.Source,
+                    exchangeSet.Catalogue,
+                    new TrustAnchorOptions { AllowUntrustedCertificates = true })
+                .GetAwaiter()
+                .GetResult();
+
+            return format == OutputFormat.Json
+                ? EmitVerifyJson(result, settings.Strict)
+                : EmitVerifyText(result, kind, settings.Strict);
+        }
+        catch (Exception ex)
+        {
+            ReportException("Error", ex, format, settings.Debug);
+            return 1;
+        }
+        finally
+        {
+            source?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Integrity-verifies an S-57 / S-63 exchange set (<c>CATALOG.031</c>) using
+    /// the upstream S-57 verifier, mapped onto the same result model and
+    /// exit-code semantics as the S-100 path so both products surface uniformly.
+    /// </summary>
+    private static int VerifyS57ExchangeSet(Settings settings, OutputFormat format)
+    {
+        try
+        {
+            var root = ExchangeSetInput.ResolveS57Root(settings.DatasetPath);
+
+            var result = S57ExchangeSetVerification
+                .VerifyAsync(root, allowUntrustedCertificates: true)
+                .GetAwaiter()
+                .GetResult();
+
+            return format == OutputFormat.Json
+                ? EmitVerifyJson(result, settings.Strict, product: "S-57")
+                : EmitVerifyText(result, "S-57 folder", settings.Strict);
+        }
+        catch (Exception ex)
+        {
+            ReportException("Error", ex, format, settings.Debug);
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// A file fails verification when its signature is invalid/untrusted or its
+    /// checksum mismatches / the file is missing. With <paramref name="strict"/>,
+    /// an unsigned file or a file with no declared checksum also fails.
+    /// </summary>
+    private static bool FileFailed(FileVerificationResult file, bool strict)
+    {
+        var signatureFailed = file.Outcome switch
+        {
+            VerificationOutcome.SignatureInvalid => true,
+            VerificationOutcome.CertificateUntrusted => true,
+            VerificationOutcome.CertificateExpired => true,
+            VerificationOutcome.CertificateNotFound => true,
+            VerificationOutcome.FileMissing => true,
+            VerificationOutcome.Error => true,
+            VerificationOutcome.NotSigned => strict,
+            _ => false,
+        };
+
+        var checksumFailed = file.ChecksumOutcome switch
+        {
+            VerificationOutcome.ChecksumMismatch => true,
+            VerificationOutcome.FileMissing => true,
+            VerificationOutcome.Error => true,
+            VerificationOutcome.NoChecksum => strict,
+            _ => false,
+        };
+
+        return signatureFailed || checksumFailed;
+    }
+
+    private static int EmitVerifyText(ExchangeSetVerificationResult result, string kind, bool strict)
+    {
+        if (result.FileResults.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]Exchange set declares no files to verify.[/]");
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("File");
+        table.AddColumn("Signature");
+        table.AddColumn("Checksum");
+        table.AddColumn("SHA-256");
+        table.AddColumn("Detail");
+
+        foreach (var file in result.FileResults)
+        {
+            table.AddRow(
+                Markup.Escape(file.FileName),
+                OutcomeMarkup(file.Outcome, FileFailed(file, strict)),
+                OutcomeMarkup(file.ChecksumOutcome, FileFailed(file, strict)),
+                Markup.Escape(ShortDigest(file.ComputedSha256)),
+                Markup.Escape(file.Detail ?? string.Empty));
+        }
+
+        AnsiConsole.Write(table);
+
+        int failed = result.FileResults.Count(f => FileFailed(f, strict));
+        AnsiConsole.MarkupLineInterpolated(
+            $"[grey]{result.FileResults.Count} file(s) in {kind}; integrity {(result.IntegrityVerified ? "intact" : "compromised")}; signatures {SignatureSummary(result)}.[/]");
+
+        if (failed == 0)
+        {
+            AnsiConsole.MarkupLine("[green]Verified[/] — no verification failures.");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLineInterpolated($"[red]{failed} file(s) failed verification.[/]");
+        return FindingsExitCode;
+    }
+
+    private static int EmitVerifyJson(ExchangeSetVerificationResult result, bool strict, string product = "S-100")
+    {
+        int failed = result.FileResults.Count(f => FileFailed(f, strict));
+
+        var payload = new
+        {
+            kind = "exchange-set",
+            product,
+            fileCount = result.FileResults.Count,
+            integrityVerified = result.IntegrityVerified,
+            hasChecksumMismatches = result.HasChecksumMismatches,
+            hasMissingFiles = result.HasMissingFiles,
+            isUnsigned = result.FileResults.Count > 0 && result.IsUnsigned,
+            valid = failed == 0,
+            failedCount = failed,
+            files = result.FileResults
+                .Select(f => new
+                {
+                    fileName = f.FileName,
+                    signatureOutcome = f.Outcome.ToString(),
+                    checksumOutcome = f.ChecksumOutcome.ToString(),
+                    computedSha256 = f.ComputedSha256,
+                    detail = f.Detail,
+                    failed = FileFailed(f, strict),
+                })
+                .ToArray(),
+        };
+
+        Console.Out.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
+        return failed == 0 ? 0 : FindingsExitCode;
+    }
+
+    private static string SignatureSummary(ExchangeSetVerificationResult result)
+    {
+        if (result.FileResults.Count > 0 && result.IsUnsigned)
+            return "unsigned";
+        return result.AllValid ? "all valid" : "see table";
+    }
+
+    private static string ShortDigest(string? hex) =>
+        string.IsNullOrEmpty(hex) ? "—" : hex[..Math.Min(12, hex.Length)];
+
+    private static string OutcomeMarkup(VerificationOutcome outcome, bool failed)
+    {
+        var colour = outcome switch
+        {
+            VerificationOutcome.Ok => "green",
+            VerificationOutcome.NotSigned or VerificationOutcome.NoChecksum => failed ? "yellow" : "grey",
+            _ => "red",
+        };
+        return $"[{colour}]{outcome}[/]";
     }
 
     private static int EmitText(SpecRef spec, ValidationReport? report, bool strict, IReadOnlyList<string> suppressPatterns)

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -23,11 +23,14 @@ internal static class CliApp
                 .WithExample("render", "currents.h5", "out.png", "--time-step", "2", "--palette", "night");
 
             config.AddCommand<ValidateCommand>("validate")
-                .WithDescription("Validate an S-100 dataset against its product specification's normative rule pack.")
+                .WithDescription("Validate an S-100 dataset against its product specification's normative rule pack, or verify an exchange set's integrity (S-100 Part 15 signatures, or S-57 / S-63 CATALOG.031 CRCs).")
                 .WithExample("validate", "warnings.gml")
                 .WithExample("validate", "route.gml", "--strict")
                 .WithExample("validate", "chart.000", "--suppress", "S101-R-1.2,S101-R-3.2")
-                .WithExample("validate", "currents.h5", "--format", "json");
+                .WithExample("validate", "currents.h5", "--format", "json")
+                .WithExample("validate", "exchangeset/CATALOG.XML")
+                .WithExample("validate", "exchangeset.zip", "--format", "json")
+                .WithExample("validate", "s57set/CATALOG.031");
 
             config.AddCommand<InfoCommand>("info")
                 .WithDescription("Show the detected spec, edition, and available time steps for a dataset.")

--- a/tools/EncDotNet.S100.Cli/Infrastructure/ExchangeSetInput.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/ExchangeSetInput.cs
@@ -1,0 +1,177 @@
+using System.IO.Compression;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Classifies a CLI path argument as an S-100 exchange set — a directory
+/// containing a top-level <c>CATALOG.XML</c>, a <c>CATALOG.XML</c> file, or a
+/// <c>.zip</c> archive whose root holds a <c>CATALOG.XML</c> — and opens the
+/// appropriate <see cref="IAssetSource"/> for verification.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 17. Mirrors the viewer's exchange-set detection so
+/// the <c>s100 validate</c> command can integrity-check whole exchange sets in
+/// addition to single datasets.
+/// </remarks>
+internal static class ExchangeSetInput
+{
+    /// <summary>The catalogue filename, matched case-insensitively.</summary>
+    private const string CatalogueFileName = "CATALOG.XML";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="path"/> looks like an
+    /// exchange set (without opening it), so a caller can route it away from the
+    /// single-dataset path.
+    /// </summary>
+    public static bool LooksLikeExchangeSet(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        if (Directory.Exists(path))
+            return FindCatalogueInDirectory(path) is not null;
+
+        if (IsCatalogueFileName(Path.GetFileName(path)) && File.Exists(path))
+            return true;
+
+        return IsZipPath(path) && File.Exists(path) && ZipContainsRootCatalogue(path);
+    }
+
+    /// <summary>
+    /// Opens the exchange set at <paramref name="path"/>.
+    /// </summary>
+    /// <param name="path">A directory, <c>CATALOG.XML</c> file, or <c>.zip</c> archive.</param>
+    /// <returns>
+    /// The opened <see cref="IAssetSource"/>, the source-relative catalogue path,
+    /// and a short human-readable kind (<c>folder</c>, <c>catalogue</c>, or
+    /// <c>zip</c>). The caller owns disposing the returned source.
+    /// </returns>
+    /// <exception cref="FileNotFoundException">No catalogue was found.</exception>
+    public static (IAssetSource Source, string CataloguePath, string Kind) Open(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            var catalogue = FindCatalogueInDirectory(path)
+                ?? throw new FileNotFoundException(
+                    $"No {CatalogueFileName} found in folder: {path}");
+            return (FileSystemAssetSource.Create(path), Path.GetFileName(catalogue), "folder");
+        }
+
+        if (IsCatalogueFileName(Path.GetFileName(path)) && File.Exists(path))
+        {
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path))!;
+            return (FileSystemAssetSource.Create(directory), Path.GetFileName(path), "catalogue");
+        }
+
+        if (IsZipPath(path) && File.Exists(path))
+        {
+            var entryName = FindRootCatalogueEntry(path)
+                ?? throw new FileNotFoundException(
+                    $"No root {CatalogueFileName} found in archive: {path}");
+            return (ZipAssetSource.Create(path), entryName, "zip");
+        }
+
+        throw new FileNotFoundException($"Not an S-100 exchange set: {path}");
+    }
+
+    private static bool IsCatalogueFileName(string? name) =>
+        string.Equals(name, CatalogueFileName, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsZipPath(string path) =>
+        string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase);
+
+    private static string? FindCatalogueInDirectory(string folderPath)
+    {
+        try
+        {
+            return Directory
+                .EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(f => IsCatalogueFileName(Path.GetFileName(f)));
+        }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
+    }
+
+    private static bool ZipContainsRootCatalogue(string zipPath) =>
+        FindRootCatalogueEntry(zipPath) is not null;
+
+    private static string? FindRootCatalogueEntry(string zipPath)
+    {
+        try
+        {
+            using var archive = ZipFile.OpenRead(zipPath);
+            return archive.Entries.FirstOrDefault(IsRootCatalogueEntry)?.FullName;
+        }
+        catch (InvalidDataException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
+    }
+
+    private static bool IsRootCatalogueEntry(ZipArchiveEntry entry)
+    {
+        var name = entry.FullName;
+        if (name.Contains('/') || name.Contains('\\'))
+            return false;
+        return IsCatalogueFileName(name);
+    }
+
+    /// <summary>The S-57 / S-63 exchange-set catalogue filename, matched case-insensitively.</summary>
+    private const string S57CatalogueFileName = "CATALOG.031";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="path"/> looks like an
+    /// <em>S-57</em> exchange set — a directory containing a top-level
+    /// <c>CATALOG.031</c>, or a <c>CATALOG.031</c> file itself. The S-57 verifier
+    /// is directory-rooted, so (unlike the S-100 path) ZIP archives are not
+    /// accepted here.
+    /// </summary>
+    public static bool LooksLikeS57ExchangeSet(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        if (Directory.Exists(path))
+            return FindS57CatalogueInDirectory(path) is not null;
+
+        return IsS57CatalogueFileName(Path.GetFileName(path)) && File.Exists(path);
+    }
+
+    /// <summary>
+    /// Resolves the root directory of the S-57 exchange set at
+    /// <paramref name="path"/> (the folder that contains <c>CATALOG.031</c>),
+    /// which is what <see cref="EncDotNet.S100.Datasets.S57.S57ExchangeSetVerification"/>
+    /// expects.
+    /// </summary>
+    /// <exception cref="FileNotFoundException">No <c>CATALOG.031</c> was found.</exception>
+    public static string ResolveS57Root(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            if (FindS57CatalogueInDirectory(path) is null)
+                throw new FileNotFoundException(
+                    $"No {S57CatalogueFileName} found in folder: {path}");
+            return Path.GetFullPath(path);
+        }
+
+        if (IsS57CatalogueFileName(Path.GetFileName(path)) && File.Exists(path))
+            return Path.GetDirectoryName(Path.GetFullPath(path))!;
+
+        throw new FileNotFoundException($"Not an S-57 exchange set: {path}");
+    }
+
+    private static bool IsS57CatalogueFileName(string? name) =>
+        string.Equals(name, S57CatalogueFileName, StringComparison.OrdinalIgnoreCase);
+
+    private static string? FindS57CatalogueInDirectory(string folderPath)
+    {
+        try
+        {
+            return Directory
+                .EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(f => IsS57CatalogueFileName(Path.GetFileName(f)));
+        }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
+    }
+}


### PR DESCRIPTION
Closes #264.

Adds exchange-set integrity verification and surfaces it through the `s100 validate` CLI, for both **S-100** (Part 15 signatures + a checksum dimension) and **S-57 / S-63** (`CATALOG.031` CRC-32) exchange sets, with a consistent result model and exit-code semantics.

## S-100 (issue #264 core)
- `VerificationOutcome`: append-only `NoChecksum` / `ChecksumMismatch` members (names + ordinals stable so the S-57 repo can mirror them).
- `FileVerificationResult`: independent `ChecksumOutcome` + `ComputedSha256` dimensions, so a file can report checksum OK while signature `NotSigned`, etc.
- `CryptographicHash`: hash-MRN parsing (`urn:mrn:iho:s100:hash:<alg>:<hex>`, Part 15 §15-8.10).
- SHA-256 is computed for every file (signed or not), so an **unsigned** set can still be integrity-checked. Documented Part 15 decryption seam in `VerifyFileAsync`.
- `ExchangeSetVerificationResult`: `HasChecksumMismatches` / `HasMissingFiles` / `IntegrityVerified`.
- `s100 validate` verifies `CATALOG.XML`, a folder, or a `.zip` exchange set.

### `AllValid` vs `IntegrityVerified` (deliberate decision)
S-100 has **no per-resource CRC element** like S-57; integrity is via Part 15 signatures. So a missing checksum (`NoChecksum`) must **not** be a failure. `AllValid` stays the strict, signature-only predicate (preserves existing Viewer behaviour); the new `IntegrityVerified` is the relaxed predicate that treats `NoChecksum` / `NotSigned` as non-failing and fails only on `ChecksumMismatch` / `FileMissing` / `Error` / invalid signature. This matches the sibling S-57 repo's `AllValid` semantics. Pinned by `Unsigned_IntactSet_AllValidIsFalse_ButIntegrityVerifiedIsTrue`.

## S-57 bridge (EncDotNet.S57 0.5.0)
- Bump `EncDotNet.S57` 0.4.0→0.5.0 and `EncDotNet.Iso8211` 0.4.3→0.5.0 (transitively required).
- New `S57ExchangeSetVerification` adapter (in `EncDotNet.S100.Datasets.S57`) maps the upstream S-57 result onto this repo's S-100 `ExchangeSetVerificationResult`. A deliberately **thin result-mapper, not a shared interface**: the S-57 verifier is rootPath/directory-based whereas the S-100 verifier is `IAssetSource`-based. Outcomes mapped **by name** (the two enums are byte-identical, so divergence fails loudly); CRC-32 surfaced via `Detail` (`ComputedSha256` left null since S-57 uses CRC, not SHA-256); `NoChecksum` / `NotSigned` non-failing — matching our `IntegrityVerified` and S-57's own `AllValid`.
- `s100 validate` detects an S-57 `CATALOG.031` input (folder or file) and verifies it, reusing the exact table/JSON output and exit codes (added a `product` label to JSON).

## Tests & docs
- +S-100 checksum/integrity tests, +8 S-57 adapter mapping/verdict tests, +6 CLI detection tests, and a `SkippableFact` against a real set (`ENCDOTNET_S57_EXCHANGE_SET`). Synthetic fixtures only — no real ENC data committed.
- All green: 85 ExchangeSets, 74 CLI, 89 S-57-bridge; full Release build clean.
- Smoke-tested against real S-57 sets (16,847 files) — CRCs validate, integrity intact, exit 0.
- Docs: S-57 bridge README, ExchangeSets README, CLI help/examples.

## Out of scope (follow-up)
**Viewer S-57 exchange-set load/render is intentionally out of scope.** S-57 exchange sets aren't loadable through the Viewer today (its detection matches `CATALOG.XML` only; only single `.000` cells render). CLI `s100 validate` is the verification surface for now; closing the Viewer gap is tracked as a dedicated follow-up that will stack on this branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>