### PR TITLE
Add S-57 exchange-set (CATALOG.031) support to the Viewer

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -494,6 +494,36 @@ public sealed class DatasetPipelineFactory
     }
 
     /// <summary>
+    /// Creates an S-57 dataset processor for the base cell at
+    /// <paramref name="baseRelativePath"/> with the in-set sequential update
+    /// files at <paramref name="updateRelativePaths"/> applied before
+    /// translation. Used by exchange-set bulk loading to collapse an S-57 cell
+    /// and its updates into a single up-to-date dataset. The updates are folded
+    /// into the S-57 document <em>before</em> the S-57 → S-101 translation runs.
+    /// S-57 Part 3 (dataset updating).
+    /// </summary>
+    /// <param name="source">The asset source backing the exchange set.</param>
+    /// <param name="baseRelativePath">Source-relative path of the base cell (<c>….000</c>).</param>
+    /// <param name="updateRelativePaths">Source-relative paths of the update files, in ascending update-number order.</param>
+    public IDatasetProcessor CreateS57ProcessorWithUpdates(
+        IAssetSource source,
+        string baseRelativePath,
+        IReadOnlyList<string> updateRelativePaths)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(baseRelativePath);
+        ArgumentNullException.ThrowIfNull(updateRelativePaths);
+
+        return new S57DatasetProcessor(
+            source,
+            baseRelativePath,
+            updateRelativePaths,
+            _catalogueManager,
+            _luaEngine,
+            _featureCatalogueManager);
+    }
+
+    /// <summary>
     /// Normalizes an exchange-set product identifier (e.g. <c>"S-101"</c>,
     /// <c>"S101"</c>, <c>"s-101"</c>) to the canonical spec strings used
     /// by <see cref="CreateProcessor(string)"/>'s switch (<c>"S-101"</c>, etc.).

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -50,7 +50,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueManager)
+        : this(OpenFromFile(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueManager)
     {
     }
 
@@ -66,7 +66,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager)
         : this(
-            AssetSourceHelpers.OpenSeekable(source, relativePath),
+            OpenFromSource(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
             catalogueManager,
             luaEngine,
@@ -74,25 +74,50 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
     {
     }
 
+    /// <summary>
+    /// Initializes a new <see cref="S57DatasetProcessor"/> by reading the base
+    /// cell <paramref name="baseRelativePath"/> from <paramref name="source"/>
+    /// and applying the in-set sequential update files at
+    /// <paramref name="updateRelativePaths"/> (in ascending update-number order)
+    /// before translation. Used by exchange-set bulk loading to collapse a cell
+    /// and its updates into a single up-to-date dataset (S-57 Part 3, dataset
+    /// updating).
+    /// </summary>
+    /// <remarks>
+    /// Updates are folded into the <see cref="EncDotNet.S57.S57Document"/>
+    /// <em>before</em> the S-57 → S-101 translation runs; the translator and
+    /// portrayal pipeline only ever see the fully-updated document.
+    /// </remarks>
+    public S57DatasetProcessor(
+        IAssetSource source,
+        string baseRelativePath,
+        IReadOnlyList<string> updateRelativePaths,
+        PortrayalCatalogueManager catalogueManager,
+        ILuaEngine luaEngine,
+        FeatureCatalogueManager featureCatalogueManager)
+        : this(
+            OpenFromSource(source, baseRelativePath, updateRelativePaths),
+            AssetSourceHelpers.GetFileName(baseRelativePath),
+            catalogueManager,
+            luaEngine,
+            featureCatalogueManager)
+    {
+    }
+
     private S57DatasetProcessor(
-        Stream datasetStream,
+        S57Dataset s57,
         string fileName,
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager)
     {
-        ArgumentNullException.ThrowIfNull(datasetStream);
+        ArgumentNullException.ThrowIfNull(s57);
         _fileName = fileName;
         _luaEngine = luaEngine;
         _provider = catalogueManager.GetProvider("S-101");
         _catalogue = new S101PortrayalCatalogue(_provider, _luaEngine);
         _featureCatalogueManager = featureCatalogueManager;
 
-        S57Dataset s57;
-        using (datasetStream)
-        {
-            s57 = S57Dataset.Open(datasetStream);
-        }
         // Retain the raw S-57 document so the pre-translation
         // validation pack (S57PreTranslationRules) can run against
         // fields that do not survive translation — see
@@ -104,6 +129,43 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
 
         // S-57 datasets render through the S-101 portrayal catalogue.
         Diagnostics.CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", default), _catalogue.CatalogueRef, "portrayal");
+    }
+
+    private static S57Dataset OpenFromFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        using var stream = File.OpenRead(path);
+        return S57Dataset.Open(stream);
+    }
+
+    private static S57Dataset OpenFromSource(IAssetSource source, string relativePath)
+    {
+        using var stream = AssetSourceHelpers.OpenSeekable(source, relativePath);
+        return S57Dataset.Open(stream);
+    }
+
+    private static S57Dataset OpenFromSource(
+        IAssetSource source,
+        string baseRelativePath,
+        IReadOnlyList<string> updateRelativePaths)
+    {
+        ArgumentNullException.ThrowIfNull(updateRelativePaths);
+
+        var updateStreams = new List<Stream>(updateRelativePaths.Count);
+        var baseStream = AssetSourceHelpers.OpenSeekable(source, baseRelativePath);
+        try
+        {
+            foreach (var updatePath in updateRelativePaths)
+                updateStreams.Add(AssetSourceHelpers.OpenSeekable(source, updatePath));
+
+            return S57Dataset.Open(baseStream, updateStreams);
+        }
+        finally
+        {
+            baseStream.Dispose();
+            foreach (var stream in updateStreams)
+                stream.Dispose();
+        }
     }
 
     public async Task<VectorPortrayalResult> BuildVectorPortrayalAsync(RenderContext? context = null, CancellationToken cancellationToken = default)

--- a/src/EncDotNet.S100.Datasets.S57/README.md
+++ b/src/EncDotNet.S100.Datasets.S57/README.md
@@ -121,6 +121,43 @@ Mapping notes:
 - Today the upstream S-57 verifier reports every file as `NotSigned`
   (S-63 signature verification is a seam); CRC checking is fully wired.
 
+## Exchange-set cell enumeration
+
+`S57ExchangeSetCatalog` is the loading-side companion to the verification
+adapter above. It reads a `CATALOG.031` (via `EncDotNet.S57`'s
+`S57CatalogReader`) and groups the catalogued `CATD` files into renderable
+**base cells**, each with its in-set sequential updates and (optionally) its
+extent:
+
+```csharp
+using EncDotNet.S100.Datasets.S57;
+
+IReadOnlyList<S57ExchangeSetCell> cells =
+    S57ExchangeSetCatalog.ReadBaseCells("/path/to/s57set");
+
+foreach (S57ExchangeSetCell cell in cells)
+{
+    // cell.RelativePath          → "…/US5MA1BO.000" (platform-normalised)
+    // cell.UpdateRelativePaths   → ["…/US5MA1BO.001", "…/US5MA1BO.002"]
+    // cell.BoundingBox           → EPSG:4326 extent, or null
+}
+
+BoundingBox? union = S57ExchangeSetCatalog.UnionBoundingBox(cells);
+```
+
+Files are grouped by their 8-character cell name; the `.000` file is the base
+and `.001`, `.002`, … are its updates in application order. Non-dataset
+entries (`.TXT`, certificates, the catalogue itself) are ignored, and update
+files with no matching base are skipped. The pure grouping logic is exposed as
+`SelectBaseCells(S57Catalog)` for unit testing without a real catalogue on
+disk. The viewer pairs this enumeration with a `FileSystemAssetSource` rooted
+at the exchange-set directory so each cell flows through the same
+`S57DatasetProcessor` code path as a single dropped `.000` file (with its
+in-set updates folded in via `S57Document.ApplyChanges` before translation to
+S-101).
+
+Like the verification adapter, this is a deliberately thin adapter over the
+directory-rooted S-57 model rather than a shared interface.
 ## Usage
 
 ```csharp

--- a/src/EncDotNet.S100.Datasets.S57/S57Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S57/S57Dataset.cs
@@ -42,6 +42,37 @@ public sealed class S57Dataset
     }
 
     /// <summary>
+    /// Opens an S-57 base cell from <paramref name="baseStream"/> and applies the
+    /// sequential update datasets in <paramref name="updateStreams"/>, returning
+    /// the fully-updated dataset.
+    /// </summary>
+    /// <remarks>
+    /// The base (<c>.000</c>) and each update (<c>.001</c>, <c>.002</c>, …) are
+    /// read into <see cref="EncDotNet.S57.S57Document"/>s and folded with
+    /// <see cref="EncDotNet.S57.S57Document.ApplyChanges"/> in the order supplied
+    /// — which must be ascending update-number order (S-57 Part 3, dataset
+    /// updating). The merged document is what callers translate to S-101; the
+    /// base and intermediate records are never surfaced.
+    /// </remarks>
+    /// <param name="baseStream">The base cell (<c>.000</c>) stream.</param>
+    /// <param name="updateStreams">The update streams, in ascending update-number order.</param>
+    public static S57Dataset Open(Stream baseStream, IReadOnlyList<Stream> updateStreams)
+    {
+        ArgumentNullException.ThrowIfNull(baseStream);
+        ArgumentNullException.ThrowIfNull(updateStreams);
+
+        var doc = EncDotNet.S57.S57DocumentReader.Read(baseStream);
+        foreach (var updateStream in updateStreams)
+        {
+            ArgumentNullException.ThrowIfNull(updateStream);
+            var update = EncDotNet.S57.S57DocumentReader.Read(updateStream);
+            doc = doc.ApplyChanges(update);
+        }
+
+        return new S57Dataset(doc);
+    }
+
+    /// <summary>
     /// Returns <c>true</c> when the file at <paramref name="path"/> appears to
     /// be an S-57 dataset (heuristic: the ISO 8211 DDR contains a <c>DSPM</c>
     /// field, which is unique to S-57 and not present in S-101). Returns

--- a/src/EncDotNet.S100.Datasets.S57/S57ExchangeSetCatalog.cs
+++ b/src/EncDotNet.S100.Datasets.S57/S57ExchangeSetCatalog.cs
@@ -1,0 +1,275 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S57.ExchangeSets;
+
+namespace EncDotNet.S100.Datasets.S57;
+
+/// <summary>
+/// One base cell discovered in an S-57 / S-63 exchange-set catalogue
+/// (<c>CATALOG.031</c>), together with its in-set sequential update files and
+/// (optionally) its geographic extent.
+/// </summary>
+/// <remarks>
+/// A cell is identified by an 8-character cell name (S-57 Appendix B.1 §B.1
+/// "Dataset names"). The base cell carries the <c>.000</c> file extension; its
+/// updates carry <c>.001</c>, <c>.002</c>, … in application order (S-57 Part 3,
+/// dataset updating). Both <see cref="RelativePath"/> and
+/// <see cref="UpdateRelativePaths"/> are normalised to the current platform's
+/// directory separator so they can be opened directly from a
+/// <c>FileSystemAssetSource</c> rooted at the exchange-set directory.
+/// </remarks>
+public sealed class S57ExchangeSetCell
+{
+    /// <summary>The 8-character cell name (e.g. <c>US5MA1BO</c>).</summary>
+    public required string CellName { get; init; }
+
+    /// <summary>
+    /// Source-relative path of the base cell (<c>….000</c>), normalised to the
+    /// current platform's directory separator.
+    /// </summary>
+    public required string RelativePath { get; init; }
+
+    /// <summary>
+    /// Source-relative paths of the in-set sequential update files
+    /// (<c>….001</c>, <c>….002</c>, …) in ascending update-number order,
+    /// normalised to the current platform's directory separator. Empty when the
+    /// cell has no updates in this exchange set.
+    /// </summary>
+    public required ImmutableArray<string> UpdateRelativePaths { get; init; }
+
+    /// <summary>
+    /// The cell's geographic extent (EPSG:4326) from the catalogue's
+    /// <c>CATD</c> bounding-box fields, or <see langword="null"/> when the
+    /// catalogue did not declare one for the base cell.
+    /// </summary>
+    public BoundingBox? BoundingBox { get; init; }
+}
+
+/// <summary>
+/// Enumerates the renderable base cells of an S-57 / S-63 exchange set by
+/// reading its <c>CATALOG.031</c> via the upstream <c>EncDotNet.S57</c>
+/// catalogue reader and grouping the catalogued files into base-cell + update
+/// sets.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the loading-side companion to <see cref="S57ExchangeSetVerification"/>
+/// (which is verification-only): both are deliberately thin adapters over the
+/// directory-rooted S-57 model rather than a shared interface. The viewer pairs
+/// this enumeration with a <c>FileSystemAssetSource</c> rooted at the
+/// exchange-set directory so each cell flows through the same
+/// <see cref="S57DatasetProcessor"/> code path as a single dropped <c>.000</c>
+/// file.
+/// </para>
+/// <para>
+/// The catalogue's <c>CATD</c> records reference files by an exchange-set
+/// relative path that conventionally uses backslashes (S-57 Appendix B.1); these
+/// are normalised to the running platform's separator here. Non-cell entries
+/// (text files, the catalogue itself, certificates, README files) are ignored.
+/// </para>
+/// </remarks>
+public static class S57ExchangeSetCatalog
+{
+    /// <summary>The S-57 / S-63 exchange-set catalogue filename, matched case-insensitively.</summary>
+    public const string CatalogueFileName = "CATALOG.031";
+
+    /// <summary>
+    /// Reads the <c>CATALOG.031</c> at <paramref name="rootPath"/> (a directory
+    /// containing it, or the catalogue file itself) and returns its base cells.
+    /// </summary>
+    /// <param name="rootPath">
+    /// The exchange-set root directory (the folder that contains
+    /// <c>CATALOG.031</c>), or the path to the <c>CATALOG.031</c> file.
+    /// </param>
+    /// <returns>The base cells discovered in the catalogue.</returns>
+    /// <exception cref="ArgumentException"><paramref name="rootPath"/> is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">No <c>CATALOG.031</c> was found.</exception>
+    public static IReadOnlyList<S57ExchangeSetCell> ReadBaseCells(string rootPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootPath);
+
+        var cataloguePath = ResolveCataloguePath(rootPath);
+        var catalogue = S57CatalogReader.ReadFromFile(cataloguePath, logger: null);
+        return SelectBaseCells(catalogue);
+    }
+
+    /// <summary>
+    /// Resolves the absolute path to the <c>CATALOG.031</c> file given either
+    /// the exchange-set root directory or the catalogue file path itself.
+    /// </summary>
+    /// <param name="rootPath">A directory containing <c>CATALOG.031</c>, or the file itself.</param>
+    /// <returns>The absolute path to the catalogue file.</returns>
+    /// <exception cref="FileNotFoundException">No <c>CATALOG.031</c> was found.</exception>
+    public static string ResolveCataloguePath(string rootPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootPath);
+
+        if (File.Exists(rootPath) &&
+            string.Equals(Path.GetFileName(rootPath), CatalogueFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return Path.GetFullPath(rootPath);
+        }
+
+        if (Directory.Exists(rootPath))
+        {
+            var match = Directory
+                .EnumerateFiles(rootPath, "*", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(f => string.Equals(
+                    Path.GetFileName(f), CatalogueFileName, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+                return Path.GetFullPath(match);
+        }
+
+        throw new FileNotFoundException(
+            $"No {CatalogueFileName} found at: {rootPath}", rootPath);
+    }
+
+    /// <summary>
+    /// Groups the catalogue's <c>CATD</c> entries into base cells and their
+    /// ordered updates. Exposed (rather than private) so the grouping/normalising
+    /// logic can be unit-tested directly against an in-memory
+    /// <see cref="S57Catalog"/> without a real <c>CATALOG.031</c> on disk.
+    /// </summary>
+    /// <param name="catalogue">The parsed catalogue.</param>
+    /// <returns>
+    /// The base cells, in ascending cell-name order, each with its updates in
+    /// ascending update-number order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="catalogue"/> is null.</exception>
+    public static IReadOnlyList<S57ExchangeSetCell> SelectBaseCells(S57Catalog catalogue)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+
+        // Group every ENC dataset file (….000/.001/…) by its cell name (the
+        // filename without extension), so a base cell and its sequential updates
+        // collapse into one group. Non-numeric extensions (.TXT, certificates,
+        // README files, the catalogue itself) are skipped.
+        var groups = new Dictionary<string, List<(int Update, S57CatalogEntry Entry)>>(
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in catalogue.Entries)
+        {
+            var fileName = entry.FileName;
+            if (string.IsNullOrEmpty(fileName))
+                continue;
+
+            var leaf = LeafName(fileName);
+            var dot = leaf.LastIndexOf('.');
+            if (dot < 0 || dot == leaf.Length - 1)
+                continue;
+
+            var extension = leaf[(dot + 1)..];
+            if (extension.Length != 3 ||
+                !int.TryParse(extension, System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture, out var updateNumber))
+            {
+                continue;
+            }
+
+            var cellName = leaf[..dot];
+            if (!groups.TryGetValue(cellName, out var list))
+            {
+                list = new List<(int, S57CatalogEntry)>();
+                groups[cellName] = list;
+            }
+            list.Add((updateNumber, entry));
+        }
+
+        var cells = new List<S57ExchangeSetCell>(groups.Count);
+        foreach (var (cellName, entries) in groups)
+        {
+            entries.Sort((a, b) => a.Update.CompareTo(b.Update));
+
+            // A group with no .000 base cell cannot be rendered on its own
+            // (an orphaned update); skip it rather than fail the whole set.
+            var baseEntry = entries.FirstOrDefault(e => e.Update == 0);
+            if (baseEntry.Entry is null)
+                continue;
+
+            var updates = entries
+                .Where(e => e.Update > 0)
+                .Select(e => Normalise(e.Entry.FileName))
+                .ToImmutableArray();
+
+            cells.Add(new S57ExchangeSetCell
+            {
+                CellName = cellName,
+                RelativePath = Normalise(baseEntry.Entry.FileName),
+                UpdateRelativePaths = updates,
+                BoundingBox = ToBoundingBox(baseEntry.Entry),
+            });
+        }
+
+        cells.Sort((a, b) => string.CompareOrdinal(a.CellName, b.CellName));
+        return cells;
+    }
+
+    /// <summary>
+    /// Returns the EPSG:4326 union of every cell's
+    /// <see cref="S57ExchangeSetCell.BoundingBox"/>, ignoring cells that lack
+    /// one. Returns <see langword="null"/> when no cell declared an extent.
+    /// </summary>
+    /// <param name="cells">The cells to union.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="cells"/> is null.</exception>
+    public static BoundingBox? UnionBoundingBox(IEnumerable<S57ExchangeSetCell> cells)
+    {
+        ArgumentNullException.ThrowIfNull(cells);
+
+        double? west = null, east = null, south = null, north = null;
+        foreach (var cell in cells)
+        {
+            if (cell.BoundingBox is not { } b)
+                continue;
+            west = west is null ? b.WestBoundLongitude : Math.Min(west.Value, b.WestBoundLongitude);
+            east = east is null ? b.EastBoundLongitude : Math.Max(east.Value, b.EastBoundLongitude);
+            south = south is null ? b.SouthBoundLatitude : Math.Min(south.Value, b.SouthBoundLatitude);
+            north = north is null ? b.NorthBoundLatitude : Math.Max(north.Value, b.NorthBoundLatitude);
+        }
+
+        if (west is null)
+            return null;
+
+        return new BoundingBox
+        {
+            WestBoundLongitude = west.Value,
+            EastBoundLongitude = east!.Value,
+            SouthBoundLatitude = south!.Value,
+            NorthBoundLatitude = north!.Value,
+        };
+    }
+
+    private static BoundingBox? ToBoundingBox(S57CatalogEntry entry)
+    {
+        if (entry.WesternmostLongitude is not { } west ||
+            entry.EasternmostLongitude is not { } east ||
+            entry.SouthernmostLatitude is not { } south ||
+            entry.NorthernmostLatitude is not { } north)
+        {
+            return null;
+        }
+
+        return new BoundingBox
+        {
+            WestBoundLongitude = west,
+            EastBoundLongitude = east,
+            SouthBoundLatitude = south,
+            NorthBoundLatitude = north,
+        };
+    }
+
+    /// <summary>
+    /// Normalises a catalogue-relative path (which conventionally uses
+    /// backslashes per S-57 Appendix B.1) to the running platform's directory
+    /// separator so it can be opened from a <c>FileSystemAssetSource</c>.
+    /// </summary>
+    private static string Normalise(string path) =>
+        path.Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar);
+
+    private static string LeafName(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        var idx = normalized.LastIndexOf('/');
+        return idx < 0 ? normalized : normalized[(idx + 1)..];
+    }
+}

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -77,6 +77,7 @@
     <ProjectReference Include="..\EncDotNet.S100.Diagnostics.Export\EncDotNet.S100.Diagnostics.Export.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S102\EncDotNet.S100.Datasets.S102.csproj" />
+    <ProjectReference Include="..\EncDotNet.S100.Datasets.S57\EncDotNet.S100.Datasets.S57.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S104\EncDotNet.S100.Datasets.S104.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S111\EncDotNet.S100.Datasets.S111.csproj" />
     <ProjectReference Include="..\EncDotNet.S100.Datasets.S122\EncDotNet.S100.Datasets.S122.csproj" />

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -980,11 +980,12 @@ public partial class MainWindow : ShadUI.Window
                 continue;
 
             // Folder drop: treat as an exchange set when CATALOG.XML
-            // is at the root, otherwise ignore (the dataset loader is
-            // single-file).
+            // (S-100) or CATALOG.031 (S-57) is at the root, otherwise
+            // ignore (the dataset loader is single-file).
             if (Directory.Exists(path))
             {
-                if (ExchangeSetDetection.LooksLikeExchangeSetFolder(path))
+                if (ExchangeSetDetection.LooksLikeExchangeSetFolder(path)
+                    || ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(path))
                 {
                     await RunExchangeSetAsync(path);
                 }
@@ -995,10 +996,17 @@ public partial class MainWindow : ShadUI.Window
                 continue;
 
             // File drop: a .zip with a root-level CATALOG.XML is an
-            // exchange-set ZIP; everything else falls through to the
+            // exchange-set ZIP, and a dropped CATALOG.031 is an S-57
+            // exchange set; everything else falls through to the
             // single-dataset loader.
             if (ExchangeSetDetection.IsZipPath(path) &&
                 ExchangeSetDetection.LooksLikeExchangeSetZip(path))
+            {
+                await RunExchangeSetAsync(path);
+                continue;
+            }
+
+            if (ExchangeSetDetection.IsS57CataloguePath(path))
             {
                 await RunExchangeSetAsync(path);
                 continue;

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -85,6 +85,15 @@ The viewer accepts:
 - **S-100 Exchange Sets** — point it at a directory containing a
   `CATALOG.XML` or at a `.zip` exchange-set archive, and it will
   load every dataset entry the catalogue lists.
+- **S-57 / S-63 Exchange Sets** — point it at a directory containing a
+  `CATALOG.031` (or drop the `CATALOG.031` file itself) and it will
+  enumerate every base cell the catalogue lists, apply each cell's
+  in-set sequential updates (`.001`, `.002`, …), and render them
+  through the same S-101 translation path used for loose `.000` cells.
+  The exchange-set header surfaces the same signature/integrity badge
+  as S-100 sets, driven by the S-57 verifier. (Directory/`CATALOG.031`
+  only — zipped S-57 sets are not supported, matching the
+  directory-rooted S-57 verifier used by the `s100 validate` CLI.)
 - **Loose datasets** — drop an individual `.h5` (S-102 / S-104 /
   S-111), `.gml` (any of the GML-encoded products), `.000` S-101
   ENC cell, or `.000` S-57 ENC cell onto the window.

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -313,6 +313,7 @@ internal static class Strings
     public static string Status_ExchangeSetLoadedWithErrors => Get(nameof(Status_ExchangeSetLoadedWithErrors));
     public static string Status_ExchangeSetFailed => Get(nameof(Status_ExchangeSetFailed));
     public static string Status_ExchangeSetCatalogNotFound => Get(nameof(Status_ExchangeSetCatalogNotFound));
+    public static string Status_S57ExchangeSetNoCells => Get(nameof(Status_S57ExchangeSetNoCells));
     public static string Status_ExchangeSetUnsupportedSpec => Get(nameof(Status_ExchangeSetUnsupportedSpec));
     public static string Status_ExchangeSetCancelled => Get(nameof(Status_ExchangeSetCancelled));
     public static string Status_ExchangeSetOrphanUpdate => Get(nameof(Status_ExchangeSetOrphanUpdate));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -839,6 +839,9 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Status_ExchangeSetCatalogNotFound" xml:space="preserve">
     <value>No CATALOG.XML found in {0}.</value>
   </data>
+  <data name="Status_S57ExchangeSetNoCells" xml:space="preserve">
+    <value>No renderable cells found in the S-57 exchange set {0}.</value>
+  </data>
   <data name="Status_ExchangeSetUnsupportedSpec" xml:space="preserve">
     <value>Skipped {0}: unsupported product specification '{1}'.</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoadGateway.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoadGateway.cs
@@ -60,12 +60,18 @@ internal sealed class DatasetLoadGateway : IDatasetLoadGateway
         if (System.IO.Directory.Exists(path))
         {
             return ExchangeSetDetection.LooksLikeExchangeSetFolder(path)
+                    || ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(path)
                 ? DatasetPathKind.ExchangeSet
                 : DatasetPathKind.File;
         }
 
         if (ExchangeSetDetection.IsZipPath(path)
             && ExchangeSetDetection.LooksLikeExchangeSetZip(path))
+        {
+            return DatasetPathKind.ExchangeSet;
+        }
+
+        if (ExchangeSetDetection.IsS57CataloguePath(path))
         {
             return DatasetPathKind.ExchangeSet;
         }

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -337,13 +337,20 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 if (!fromExchangeSet)
                     return _pipelineFactory.CreateProcessor(entry.FilePath);
 
-                // Collapse an S-101 base cell and its in-set sequential
-                // updates into a single up-to-date dataset. S-101 / S-100
-                // Part 10a.
-                return entry.HasUpdates
-                    ? _pipelineFactory.CreateS101ProcessorWithUpdates(
-                        entry.Source!, entry.RelativePath!, entry.UpdateRelativePaths)
-                    : _pipelineFactory.CreateProcessor(entry.Source!, entry.RelativePath!, spec);
+                // Collapse a base cell and its in-set sequential updates into a
+                // single up-to-date dataset. S-101 / S-57 / S-100 Part 10a;
+                // S-57 Part 3. The update-application path differs per product,
+                // so dispatch on the declared spec.
+                if (!entry.HasUpdates)
+                    return _pipelineFactory.CreateProcessor(entry.Source!, entry.RelativePath!, spec);
+
+                return spec switch
+                {
+                    "S-57" => _pipelineFactory.CreateS57ProcessorWithUpdates(
+                        entry.Source!, entry.RelativePath!, entry.UpdateRelativePaths),
+                    _ => _pipelineFactory.CreateS101ProcessorWithUpdates(
+                        entry.Source!, entry.RelativePath!, entry.UpdateRelativePaths),
+                };
             }, token);
             _processors[entry] = processor;
 

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
@@ -23,6 +23,10 @@ internal static class ExchangeSetDetection
     /// <summary>The catalogue filename, matched case-insensitively.</summary>
     private const string CatalogueFileName = "CATALOG.XML";
 
+    /// <summary>The S-57 / S-63 exchange-set catalogue filename, matched
+    /// case-insensitively.</summary>
+    private const string S57CatalogueFileName = "CATALOG.031";
+
     /// <summary>True when <paramref name="path"/> ends with
     /// <c>.zip</c> (case-insensitive).</summary>
     public static bool IsZipPath(string path) =>
@@ -75,5 +79,66 @@ internal static class ExchangeSetDetection
         if (name.Contains('/') || name.Contains('\\')) return false;
         return string.Equals(
             name, CatalogueFileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>True when <paramref name="path"/> is an S-57 / S-63 exchange set
+    /// — a directory containing a top-level <c>CATALOG.031</c>, or a
+    /// <c>CATALOG.031</c> file itself. The S-57 verifier is directory-rooted, so
+    /// (unlike the S-100 path) ZIP archives are not recognised here.</summary>
+    public static bool LooksLikeS57ExchangeSet(string path) =>
+        LooksLikeS57ExchangeSetFolder(path) || IsS57CataloguePath(path);
+
+    /// <summary>True when <paramref name="folderPath"/> exists and contains a
+    /// <c>CATALOG.031</c> at its top level (case-insensitive). Returns
+    /// <c>false</c> for any I/O or permission failure.</summary>
+    public static bool LooksLikeS57ExchangeSetFolder(string folderPath)
+    {
+        if (string.IsNullOrEmpty(folderPath)) return false;
+        try
+        {
+            if (!Directory.Exists(folderPath)) return false;
+            return Directory.EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
+                .Any(f => string.Equals(
+                    Path.GetFileName(f), S57CatalogueFileName,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (IOException) { return false; }
+    }
+
+    /// <summary>True when <paramref name="path"/> is an existing file named
+    /// <c>CATALOG.031</c> (case-insensitive) — i.e. the user dropped the S-57
+    /// catalogue file directly.</summary>
+    public static bool IsS57CataloguePath(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return false;
+        return string.Equals(
+                   Path.GetFileName(path), S57CatalogueFileName,
+                   StringComparison.OrdinalIgnoreCase)
+               && File.Exists(path);
+    }
+
+    /// <summary>
+    /// Resolves the root directory of the S-57 exchange set at
+    /// <paramref name="path"/> (the folder that contains <c>CATALOG.031</c>),
+    /// which is what the S-57 reader / verifier expect.
+    /// </summary>
+    /// <exception cref="FileNotFoundException">No <c>CATALOG.031</c> was found.</exception>
+    public static string ResolveS57Root(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        if (Directory.Exists(path))
+        {
+            if (!LooksLikeS57ExchangeSetFolder(path))
+                throw new FileNotFoundException(
+                    $"No {S57CatalogueFileName} found in folder: {path}");
+            return Path.GetFullPath(path);
+        }
+
+        if (IsS57CataloguePath(path))
+            return Path.GetDirectoryName(Path.GetFullPath(path))!;
+
+        throw new FileNotFoundException($"Not an S-57 exchange set: {path}");
     }
 }

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.S57;
 using EncDotNet.S100.ExchangeSets;
 using EncDotNet.S100.Viewer.Diagnostics;
 using EncDotNet.S100.Viewer.Resources;
@@ -60,6 +61,15 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         EnsureCollectionSubscription();
+
+        // An S-57 / S-63 exchange set (CATALOG.031) is structurally different
+        // from an S-100 one (CATALOG.XML) and is directory-rooted, so it has its
+        // own loader. S-100 sets fall through to the logic below.
+        if (ExchangeSetDetection.LooksLikeS57ExchangeSet(folderOrZipPath))
+        {
+            return await OpenS57Async(folderOrZipPath, progress, cancellationToken)
+                .ConfigureAwait(true);
+        }
 
         // s100.exchangeset.open child span sits under whatever
         // s100.viewer.command span the caller (MainWindow) opened.
@@ -131,12 +141,21 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
             progress?.Report(new ExchangeSetProgress(folderOrZipPath, plan.Count, 0, 0, null));
 
-            var tracked = new TrackedExchangeSet(folderOrZipPath, exchangeSet);
+            var assetSource = exchangeSet.Source;
+            var catalogue = exchangeSet.Catalogue;
+            var tracked = new TrackedExchangeSet(
+                folderOrZipPath,
+                assetSource,
+                owner: exchangeSet,
+                verifier: ct => new ExchangeSetVerifier().VerifyAsync(
+                    assetSource,
+                    catalogue,
+                    new TrustAnchorOptions { AllowUntrustedCertificates = true },
+                    ct));
             _tracked.Add(tracked);
             // From this point on, lifetime ownership transfers to the tracked
             // entry — do not dispose `exchangeSet` / `source` directly below.
-            var assetSource = tracked.ExchangeSet.Source;
-            var producer = tracked.ExchangeSet.Catalogue.Contact?.Organization;
+            var producer = catalogue.Contact?.Organization;
             var issueDate = ResolveLatestIssueDate(datasets);
 
             tracked.Header = _datasets.RegisterExchangeSetHeader(
@@ -202,7 +221,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     : item.Updates.Select(u => u.RelativePath).ToList();
 
                 var entry = _datasets.AddFromExchangeSet(
-                    tracked.ExchangeSet.Source,
+                    tracked.Source,
                     relativePath,
                     spec,
                     displayName: Path.GetFileName(relativePath),
@@ -265,7 +284,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     _datasets.RemoveExchangeSetHeader(orphanHeader);
                     tracked.Header = null;
                 }
-                tracked.ExchangeSet.Dispose();
+                tracked.Owner.Dispose();
                 _tracked.Remove(tracked);
             }
             else
@@ -309,6 +328,168 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             return new ExchangeSetOpenResult
             {
                 SourcePath = folderOrZipPath,
+                FailureMessage = ex.Message,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Opens an S-57 / S-63 exchange set (<c>CATALOG.031</c>). Unlike the S-100
+    /// path, the S-57 model is directory-rooted: cells are enumerated from the
+    /// catalogue via <see cref="S57ExchangeSetCatalog"/>, a
+    /// <see cref="FileSystemAssetSource"/> is rooted at the exchange-set
+    /// directory, and each base cell (with its in-set sequential updates) is
+    /// dispatched as an <c>"S-57"</c> entry — flowing through the same
+    /// <c>S57DatasetProcessor</c> as a single dropped <c>.000</c> file.
+    /// Integrity/signature status reuses the shared header badge, driven by the
+    /// PR #265 <see cref="S57ExchangeSetVerification"/> adapter.
+    /// </summary>
+    private async Task<ExchangeSetOpenResult> OpenS57Async(
+        string folderOrCataloguePath,
+        IProgress<ExchangeSetProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        using var activity = Telemetry.ActivitySource.StartActivity(
+            "s57.exchangeset.open", System.Diagnostics.ActivityKind.Internal);
+        activity?.SetTag("s57.exchangeset.source.path", folderOrCataloguePath);
+
+        IAssetSource? source = null;
+        try
+        {
+            string root;
+            IReadOnlyList<S57ExchangeSetCell> cells;
+            try
+            {
+                root = ExchangeSetDetection.ResolveS57Root(folderOrCataloguePath);
+                cells = S57ExchangeSetCatalog.ReadBaseCells(root);
+            }
+            catch (FileNotFoundException)
+            {
+                var msg = string.Format(
+                    Strings.Status_ExchangeSetCatalogNotFound, folderOrCataloguePath);
+                _status.StatusText = msg;
+                _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, msg);
+                activity?.SetStatus(ActivityStatusCode.Error, "catalogue not found");
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderOrCataloguePath,
+                    CatalogueNotFound = true,
+                    FailureMessage = msg,
+                };
+            }
+
+            activity?.SetTag("s57.exchangeset.cell.count", cells.Count);
+
+            if (cells.Count == 0)
+            {
+                var emptyMsg = string.Format(
+                    Strings.Status_S57ExchangeSetNoCells, folderOrCataloguePath);
+                _status.StatusText = emptyMsg;
+                _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, emptyMsg);
+                activity?.SetStatus(ActivityStatusCode.Error, "no cells");
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderOrCataloguePath,
+                    CatalogueNotFound = true,
+                    FailureMessage = emptyMsg,
+                };
+            }
+
+            progress?.Report(new ExchangeSetProgress(folderOrCataloguePath, cells.Count, 0, 0, null));
+
+            source = FileSystemAssetSource.Create(root);
+            var tracked = new TrackedExchangeSet(
+                folderOrCataloguePath,
+                source,
+                owner: source,
+                verifier: ct => S57ExchangeSetVerification.VerifyAsync(
+                    root, allowUntrustedCertificates: true, ct));
+            _tracked.Add(tracked);
+            // Lifetime ownership has transferred to the tracked entry; do not
+            // dispose `source` directly below.
+            source = null;
+
+            tracked.Header = _datasets.RegisterExchangeSetHeader(
+                tracked.Source,
+                // Use the resolved root directory (not a dropped CATALOG.031
+                // file path) so the header's display name is the set folder.
+                root,
+                producer: null,
+                issueDate: null,
+                cells.Count,
+                closeAction: CloseExchangeSetFromHeader);
+
+            var dispatched = 0;
+            foreach (var cell in cells)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                IReadOnlyList<string> updateRelativePaths = cell.UpdateRelativePaths.IsDefaultOrEmpty
+                    ? Array.Empty<string>()
+                    : cell.UpdateRelativePaths;
+
+                var entry = _datasets.AddFromExchangeSet(
+                    tracked.Source,
+                    cell.RelativePath,
+                    "S-57",
+                    displayName: cell.CellName,
+                    updateRelativePaths: updateRelativePaths);
+                tracked.Entries.Add(entry);
+                _datasets.RequestLoad(entry);
+                dispatched++;
+                progress?.Report(new ExchangeSetProgress(
+                    folderOrCataloguePath, cells.Count, dispatched, 0, cell.RelativePath));
+            }
+
+            var loadedMsg = string.Format(
+                Strings.Status_ExchangeSetLoaded, dispatched, folderOrCataloguePath);
+            _status.StatusText = loadedMsg;
+            _toasts.ShowSuccess(Strings.Toast_ExchangeSetLoaded, loadedMsg);
+
+            activity?.SetTag("s57.exchangeset.dataset.loaded", dispatched);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+
+            if (tracked.Header is { } trackedHeader)
+            {
+                trackedHeader.LoadedCount = dispatched;
+                trackedHeader.UnsupportedCount = 0;
+            }
+
+            // Fire-and-forget integrity/signature verification — surfaced as a
+            // non-blocking header badge; we never refuse to load unsigned data.
+            _ = VerifySignaturesAsync(tracked);
+
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderOrCataloguePath,
+                Total = cells.Count,
+                Loaded = dispatched,
+                SkippedUnsupported = 0,
+                Cancelled = false,
+                SkipMessages = Array.Empty<string>(),
+                UnionBoundingBox = S57ExchangeSetCatalog.UnionBoundingBox(cells),
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            source?.Dispose();
+            activity?.SetStatus(ActivityStatusCode.Error, "cancelled");
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderOrCataloguePath,
+                Cancelled = true,
+            };
+        }
+        catch (Exception ex)
+        {
+            var failedMsg = string.Format(Strings.Status_ExchangeSetFailed, folderOrCataloguePath, ex.Message);
+            _status.StatusText = failedMsg;
+            _toasts.ShowError(Strings.Toast_ExchangeSetFailed, failedMsg);
+            source?.Dispose();
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderOrCataloguePath,
                 FailureMessage = ex.Message,
             };
         }
@@ -411,7 +592,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     _datasets.RemoveExchangeSetHeader(header);
                     tracked.Header = null;
                 }
-                tracked.ExchangeSet.Dispose();
+                tracked.Owner.Dispose();
                 _tracked.RemoveAt(i);
             }
         }
@@ -466,45 +647,50 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
     private async Task VerifySignaturesAsync(TrackedExchangeSet tracked)
     {
         if (tracked.Header is null) return;
+        if (tracked.Verifier is null) return;
 
         tracked.Header.SignatureStatus = SignatureStatus.Checking;
         tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureChecking;
 
         try
         {
-            var verifier = new ExchangeSetVerifier();
-            var result = await verifier.VerifyAsync(
-                tracked.ExchangeSet.Source,
-                tracked.ExchangeSet.Catalogue,
-                new TrustAnchorOptions { AllowUntrustedCertificates = true },
-                CancellationToken.None).ConfigureAwait(true);
-
-            if (result.IsUnsigned)
-            {
-                tracked.Header.SignatureStatus = SignatureStatus.Unsigned;
-                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureUnsigned;
-            }
-            else if (result.AllValid)
-            {
-                tracked.Header.SignatureStatus = SignatureStatus.Verified;
-                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureVerified;
-            }
-            else if (result.HasInvalidSignatures)
-            {
-                tracked.Header.SignatureStatus = SignatureStatus.Invalid;
-                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureInvalid;
-            }
-            else
-            {
-                // Some files ok, some not — e.g. certificate issues
-                tracked.Header.SignatureStatus = SignatureStatus.Mixed;
-                tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureMixed;
-            }
+            var result = await tracked.Verifier(CancellationToken.None).ConfigureAwait(true);
+            ApplySignatureResult(tracked.Header, result);
         }
         catch (Exception)
         {
             tracked.Header.SignatureStatus = SignatureStatus.Error;
             tracked.Header.SignatureTooltip = Strings.Tooltip_SignatureError;
+        }
+    }
+
+    /// <summary>
+    /// Maps an <see cref="ExchangeSetVerificationResult"/> onto the header's
+    /// signature badge. Shared by the S-100 and S-57 exchange-set paths so both
+    /// surface identical integrity/signature semantics.
+    /// </summary>
+    private static void ApplySignatureResult(ExchangeSetHeader header, ExchangeSetVerificationResult result)
+    {
+        if (result.IsUnsigned)
+        {
+            header.SignatureStatus = SignatureStatus.Unsigned;
+            header.SignatureTooltip = Strings.Tooltip_SignatureUnsigned;
+        }
+        else if (result.AllValid)
+        {
+            header.SignatureStatus = SignatureStatus.Verified;
+            header.SignatureTooltip = Strings.Tooltip_SignatureVerified;
+        }
+        else if (result.HasInvalidSignatures)
+        {
+            header.SignatureStatus = SignatureStatus.Invalid;
+            header.SignatureTooltip = Strings.Tooltip_SignatureInvalid;
+        }
+        else
+        {
+            // Some files ok, some not — e.g. certificate issues
+            header.SignatureStatus = SignatureStatus.Mixed;
+            header.SignatureTooltip = Strings.Tooltip_SignatureMixed;
         }
     }
 
@@ -521,7 +707,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
         foreach (var tracked in _tracked)
         {
-            try { tracked.ExchangeSet.Dispose(); } catch { /* swallow on shutdown */ }
+            try { tracked.Owner.Dispose(); } catch { /* swallow on shutdown */ }
         }
         _tracked.Clear();
     }
@@ -529,14 +715,33 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
     private sealed class TrackedExchangeSet
     {
         public string SourcePath { get; }
-        public ExchangeSet ExchangeSet { get; }
+
+        /// <summary>The asset source backing the set; matched against
+        /// <see cref="DatasetEntry.Source"/> for lifetime tracking.</summary>
+        public IAssetSource Source { get; }
+
+        /// <summary>The object whose disposal releases the set's underlying
+        /// resources — the S-100 <see cref="ExchangeSet"/> for S-100 sets, or the
+        /// <see cref="IAssetSource"/> itself for S-57 sets.</summary>
+        public IDisposable Owner { get; }
+
+        /// <summary>Produces the integrity/signature verification result for the
+        /// header badge, or <c>null</c> when verification is not applicable.</summary>
+        public Func<CancellationToken, Task<ExchangeSetVerificationResult>>? Verifier { get; }
+
         public List<DatasetEntry> Entries { get; } = new();
         public ExchangeSetHeader? Header { get; set; }
 
-        public TrackedExchangeSet(string sourcePath, ExchangeSet exchangeSet)
+        public TrackedExchangeSet(
+            string sourcePath,
+            IAssetSource source,
+            IDisposable owner,
+            Func<CancellationToken, Task<ExchangeSetVerificationResult>>? verifier)
         {
             SourcePath = sourcePath;
-            ExchangeSet = exchangeSet;
+            Source = source;
+            Owner = owner;
+            Verifier = verifier;
         }
     }
 }

--- a/tests/EncDotNet.S100.Datasets.S57.Tests/S57ExchangeSetCatalogTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S57.Tests/S57ExchangeSetCatalogTests.cs
@@ -1,0 +1,200 @@
+using EncDotNet.S100.Datasets.S57;
+using EncDotNet.S57.ExchangeSets;
+
+namespace EncDotNet.S100.Datasets.S57.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S57ExchangeSetCatalog"/>, which groups a parsed
+/// <c>CATALOG.031</c>'s <c>CATD</c> entries into renderable base cells plus their
+/// ordered sequential updates. Builds <see cref="S57Catalog"/> /
+/// <see cref="S57CatalogEntry"/> in memory (both expose settable properties) so
+/// no real ENC data or on-disk catalogue is required.
+/// </summary>
+public sealed class S57ExchangeSetCatalogTests
+{
+    private static char Sep => Path.DirectorySeparatorChar;
+
+    private static S57Catalog Catalogue(params S57CatalogEntry[] entries) =>
+        new() { Entries = entries };
+
+    private static S57CatalogEntry Cell(
+        string fileName,
+        double? west = null,
+        double? east = null,
+        double? south = null,
+        double? north = null) =>
+        new()
+        {
+            FileName = fileName,
+            WesternmostLongitude = west,
+            EasternmostLongitude = east,
+            SouthernmostLatitude = south,
+            NorthernmostLatitude = north,
+        };
+
+    [Fact]
+    public void SelectBaseCells_GroupsBaseAndOrdersUpdates()
+    {
+        var catalogue = Catalogue(
+            Cell(@"ENC_ROOT\US5MA1BO\US5MA1BO.002"),
+            Cell(@"ENC_ROOT\US5MA1BO\US5MA1BO.000"),
+            Cell(@"ENC_ROOT\US5MA1BO\US5MA1BO.001"));
+
+        var cells = S57ExchangeSetCatalog.SelectBaseCells(catalogue);
+
+        var cell = Assert.Single(cells);
+        Assert.Equal("US5MA1BO", cell.CellName);
+        Assert.Equal($"ENC_ROOT{Sep}US5MA1BO{Sep}US5MA1BO.000", cell.RelativePath);
+        Assert.Equal(
+            new[]
+            {
+                $"ENC_ROOT{Sep}US5MA1BO{Sep}US5MA1BO.001",
+                $"ENC_ROOT{Sep}US5MA1BO{Sep}US5MA1BO.002",
+            },
+            cell.UpdateRelativePaths);
+    }
+
+    [Fact]
+    public void SelectBaseCells_SkipsNonDatasetEntries()
+    {
+        var catalogue = Catalogue(
+            Cell("CATALOG.031"),
+            Cell(@"ENC_ROOT\README.TXT"),
+            Cell(@"ENC_ROOT\US5MA1BO\US5MA1BO.000"),
+            Cell(@"ENC_ROOT\US5MA1BO\CERT.CRT"));
+
+        var cells = S57ExchangeSetCatalog.SelectBaseCells(catalogue);
+
+        var cell = Assert.Single(cells);
+        Assert.Equal("US5MA1BO", cell.CellName);
+        Assert.Empty(cell.UpdateRelativePaths);
+    }
+
+    [Fact]
+    public void SelectBaseCells_SkipsOrphanUpdatesWithoutBase()
+    {
+        var catalogue = Catalogue(
+            Cell(@"US5MA1BO\US5MA1BO.001"),
+            Cell(@"US5MA1BO\US5MA1BO.002"));
+
+        var cells = S57ExchangeSetCatalog.SelectBaseCells(catalogue);
+
+        Assert.Empty(cells);
+    }
+
+    [Fact]
+    public void SelectBaseCells_OrdersCellsByName()
+    {
+        var catalogue = Catalogue(
+            Cell("ZZ5AAAAA.000"),
+            Cell("AA5BBBBB.000"),
+            Cell("MM5CCCCC.000"));
+
+        var cells = S57ExchangeSetCatalog.SelectBaseCells(catalogue);
+
+        Assert.Equal(
+            new[] { "AA5BBBBB", "MM5CCCCC", "ZZ5AAAAA" },
+            cells.Select(c => c.CellName).ToArray());
+    }
+
+    [Fact]
+    public void SelectBaseCells_MapsBoundingBoxFromBaseEntry()
+    {
+        var catalogue = Catalogue(
+            Cell("US5MA1BO.000", west: -71.0, east: -70.0, south: 42.0, north: 43.0));
+
+        var cell = Assert.Single(S57ExchangeSetCatalog.SelectBaseCells(catalogue));
+
+        Assert.NotNull(cell.BoundingBox);
+        Assert.Equal(-71.0, cell.BoundingBox!.WestBoundLongitude);
+        Assert.Equal(-70.0, cell.BoundingBox.EastBoundLongitude);
+        Assert.Equal(42.0, cell.BoundingBox.SouthBoundLatitude);
+        Assert.Equal(43.0, cell.BoundingBox.NorthBoundLatitude);
+    }
+
+    [Fact]
+    public void SelectBaseCells_PartialBoundingBox_IsNull()
+    {
+        var catalogue = Catalogue(
+            Cell("US5MA1BO.000", west: -71.0, east: -70.0, south: 42.0, north: null));
+
+        var cell = Assert.Single(S57ExchangeSetCatalog.SelectBaseCells(catalogue));
+
+        Assert.Null(cell.BoundingBox);
+    }
+
+    [Fact]
+    public void UnionBoundingBox_UnionsCellExtents()
+    {
+        var catalogue = Catalogue(
+            Cell("AA5AAAAA.000", west: -71.0, east: -70.0, south: 42.0, north: 43.0),
+            Cell("BB5BBBBB.000", west: -72.0, east: -69.0, south: 41.0, north: 44.0));
+
+        var union = S57ExchangeSetCatalog.UnionBoundingBox(
+            S57ExchangeSetCatalog.SelectBaseCells(catalogue));
+
+        Assert.NotNull(union);
+        Assert.Equal(-72.0, union!.WestBoundLongitude);
+        Assert.Equal(-69.0, union.EastBoundLongitude);
+        Assert.Equal(41.0, union.SouthBoundLatitude);
+        Assert.Equal(44.0, union.NorthBoundLatitude);
+    }
+
+    [Fact]
+    public void UnionBoundingBox_NoExtents_ReturnsNull()
+    {
+        var catalogue = Catalogue(Cell("US5MA1BO.000"));
+
+        var union = S57ExchangeSetCatalog.UnionBoundingBox(
+            S57ExchangeSetCatalog.SelectBaseCells(catalogue));
+
+        Assert.Null(union);
+    }
+
+    [Fact]
+    public void SelectBaseCells_NullCatalogue_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => S57ExchangeSetCatalog.SelectBaseCells(null!));
+
+    [Fact]
+    public void ReadBaseCells_NullOrEmptyRoot_Throws() =>
+        Assert.Throws<ArgumentException>(
+            () => S57ExchangeSetCatalog.ReadBaseCells(string.Empty));
+
+    [Fact]
+    public void ResolveCataloguePath_MissingCatalogue_Throws()
+    {
+        var dir = Directory.CreateTempSubdirectory("s57cat");
+        try
+        {
+            Assert.Throws<FileNotFoundException>(
+                () => S57ExchangeSetCatalog.ResolveCataloguePath(dir.FullName));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveCataloguePath_FindsCatalogueInFolder()
+    {
+        var dir = Directory.CreateTempSubdirectory("s57cat");
+        try
+        {
+            var catalogue = Path.Combine(dir.FullName, "CATALOG.031");
+            File.WriteAllText(catalogue, "placeholder");
+
+            Assert.Equal(
+                Path.GetFullPath(catalogue),
+                S57ExchangeSetCatalog.ResolveCataloguePath(dir.FullName));
+            Assert.Equal(
+                Path.GetFullPath(catalogue),
+                S57ExchangeSetCatalog.ResolveCataloguePath(catalogue));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
@@ -142,4 +142,85 @@ public sealed class ExchangeSetDetectionTests : IDisposable
             Path.Combine(_tempRoot, "ghost.zip")));
         Assert.False(ExchangeSetDetection.LooksLikeExchangeSetZip(""));
     }
+
+    [Fact]
+    public void LooksLikeS57ExchangeSetFolder_TrueWhenCatalog031Present()
+    {
+        var folder = Path.Combine(_tempRoot, "s57set");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "CATALOG.031"), "binary");
+
+        Assert.True(ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(folder));
+        Assert.True(ExchangeSetDetection.LooksLikeS57ExchangeSet(folder));
+    }
+
+    [Fact]
+    public void LooksLikeS57ExchangeSetFolder_CaseInsensitive()
+    {
+        var folder = Path.Combine(_tempRoot, "s57ci");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "catalog.031"), "binary");
+
+        Assert.True(ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void IsS57CataloguePath_TrueForDroppedCatalogue031()
+    {
+        var folder = Path.Combine(_tempRoot, "s57drop");
+        Directory.CreateDirectory(folder);
+        var catalogue = Path.Combine(folder, "CATALOG.031");
+        File.WriteAllText(catalogue, "binary");
+
+        Assert.True(ExchangeSetDetection.IsS57CataloguePath(catalogue));
+        Assert.True(ExchangeSetDetection.LooksLikeS57ExchangeSet(catalogue));
+    }
+
+    [Fact]
+    public void S57Detection_FalseForS100Set()
+    {
+        var folder = Path.Combine(_tempRoot, "s100set");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "CATALOG.XML"), "<root/>");
+
+        Assert.False(ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(folder));
+        Assert.False(ExchangeSetDetection.LooksLikeS57ExchangeSet(folder));
+        // The S-100 detector must still recognise it (regression guard).
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void S57Detection_FalseForEmptyOrMissing()
+    {
+        var folder = Path.Combine(_tempRoot, "s57empty");
+        Directory.CreateDirectory(folder);
+        Assert.False(ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(folder));
+        Assert.False(ExchangeSetDetection.LooksLikeS57ExchangeSet(
+            Path.Combine(_tempRoot, "missing")));
+        Assert.False(ExchangeSetDetection.IsS57CataloguePath(""));
+    }
+
+    [Fact]
+    public void ResolveS57Root_ResolvesFolderAndFile()
+    {
+        var folder = Path.Combine(_tempRoot, "s57resolve");
+        Directory.CreateDirectory(folder);
+        var catalogue = Path.Combine(folder, "CATALOG.031");
+        File.WriteAllText(catalogue, "binary");
+
+        Assert.Equal(
+            Path.GetFullPath(folder),
+            ExchangeSetDetection.ResolveS57Root(folder));
+        Assert.Equal(
+            Path.GetFullPath(folder),
+            ExchangeSetDetection.ResolveS57Root(catalogue));
+    }
+
+    [Fact]
+    public void ResolveS57Root_ThrowsWhenNotAnS57Set()
+    {
+        Assert.Throws<FileNotFoundException>(
+            () => ExchangeSetDetection.ResolveS57Root(
+                Path.Combine(_tempRoot, "nope.000")));
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -260,4 +260,34 @@ public class ExchangeSetServiceLoaderTests
         Assert.Empty(datasets.Entries);
         Assert.Empty(datasets.ExchangeSetHeaders);
     }
+
+    /// <summary>
+    /// End-to-end S-57 exchange-set load against a real <c>CATALOG.031</c>
+    /// when one is available via the <c>ENCDOTNET_S57_EXCHANGE_SET</c>
+    /// environment variable (the folder containing <c>CATALOG.031</c>).
+    /// Skipped otherwise so CI never depends on (or commits) real ENC data.
+    /// </summary>
+    [SkippableFact]
+    public async Task OpenAsync_RealS57ExchangeSet_DispatchesCellsAsS57Entries()
+    {
+        var root = Environment.GetEnvironmentVariable("ENCDOTNET_S57_EXCHANGE_SET");
+        Skip.If(string.IsNullOrEmpty(root), "ENCDOTNET_S57_EXCHANGE_SET not set.");
+        Skip.IfNot(
+            File.Exists(Path.Combine(root!, "CATALOG.031")),
+            $"No CATALOG.031 in {root}.");
+
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(root!);
+
+        Assert.True(result.Loaded > 0);
+        Assert.Equal(result.Total, result.Loaded);
+        Assert.Equal(0, result.SkippedUnsupported);
+        Assert.All(datasets.Entries, e => Assert.Equal("S-57", e.ProductSpec));
+
+        var header = Assert.Single(datasets.ExchangeSetHeaders);
+        Assert.Equal(ExchangeSetDetection.ResolveS57Root(root!), header.SourcePath);
+        Assert.Equal(result.Loaded, header.LoadedCount);
+    }
 }


### PR DESCRIPTION
## Summary

Adds S-57 / S-63 exchange-set (`CATALOG.031`) support to the Avalonia Viewer. Builds on #264/#265 (S-57 exchange-set integrity verification for the `s100 validate` CLI + the `S57ExchangeSetVerification` result-mapping adapter), which deliberately left the Viewer out of scope. This PR closes that gap and **reuses** the #265 adapter rather than re-implementing S-57 verification.

A user can now open an S-57 exchange set and (1) see its cells loaded/rendered (each translated to S-101 via the existing `S57DatasetProcessor`), and (2) see the same signature/integrity header badge that S-100 exchange sets show.

## What changed

**Detection** (`Services/ExchangeSetDetection.cs`)
- New `CATALOG.031` helpers (`LooksLikeS57ExchangeSet*`, `IsS57CataloguePath`, `ResolveS57Root`), kept separate from the existing `CATALOG.XML` helpers so S-100 detection is untouched. Wired into `DatasetLoadGateway.Classify` and `MainWindow.OnDrop` (dropped folder containing `CATALOG.031`, or the `CATALOG.031` file itself).

**Loading / rendering**
- New `Datasets.S57/S57ExchangeSetCatalog.cs`: reads `CATALOG.031` via `EncDotNet.S57`'s `S57CatalogReader` and groups CATD entries into base cells (`.000`) + ordered updates (`.001+`) + bbox. Pure `SelectBaseCells(S57Catalog)` is unit-tested. A thin adapter (sibling to `S57ExchangeSetVerification`), not a forced shared interface.
- `ExchangeSetService.OpenS57Async` roots a `FileSystemAssetSource` at the set directory and dispatches each cell as an `"S-57"` entry, so cells flow through the same `S57DatasetProcessor` path as a single dropped `.000`.
- In-set updates are applied **before** S-101 translation: `S57Dataset.Open(base, updates)` folds via `S57Document.ApplyChanges`; new `S57DatasetProcessor` ctor + `DatasetPipelineFactory.CreateS57ProcessorWithUpdates`.
- Fixes a latent bug: `DatasetLoaderService`'s update-application branch was hardcoded to the S-101 path; it's now spec-aware (S-57 vs S-101).

**Verification surfacing**
- `TrackedExchangeSet` generalised to `Source` / `Owner` / `Verifier`; extracted a shared `ApplySignatureResult(header, ExchangeSetVerificationResult)` so S-100 and S-57 surface identical Unsigned/Verified/Invalid/Mixed badges, tooltips, and the `IntegrityVerified` / NoChecksum-non-failing semantics. S-57 verification is driven by `S57ExchangeSetVerification.VerifyAsync(root, …)` (fire-and-forget, like S-100). S-100 behaviour is unchanged.

**UI / strings**
- One new string (`Status_S57ExchangeSetNoCells`) in `Strings.resx` + `Strings.cs`, referenced via `Strings.Key`. Everything else reuses existing `Status_ExchangeSet*` / `Tooltip_Signature*` / `Toast_ExchangeSet*`. No hardcoded user-facing strings; no new buttons.

**Tests / docs**
- `S57ExchangeSetCatalogTests` (pure grouping/ordering/normalise/bbox + union, in-memory `S57Catalog`, no real data), S-57 cases in `ExchangeSetDetectionTests`, and a `SkippableFact` integration test in `ExchangeSetServiceLoaderTests` (gated on `ENCDOTNET_S57_EXCHANGE_SET`).
- Updated `Viewer/README.md` and `Datasets.S57/README.md`.

## Decisions / scope

- **Zipped S-57 sets are intentionally unsupported** — the S-57 verifier is directory-rooted, matching the CLI's `ExchangeSetInput`. Directory or dropped `CATALOG.031` only.
- S-57 header shows `null` producer/issue date (no equivalent metadata in `CATALOG.031`).

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.