### PR TITLE
Fix unsupported product spec for catalogs without productIdentifier

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -1,6 +1,8 @@
 using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.ExchangeSets;
 using EncDotNet.S100.Features;
+using System.Globalization;
 using EncDotNet.S100.Hdf5.PureHdf;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector.Caching;
@@ -546,6 +548,28 @@ public sealed class DatasetPipelineFactory
                 or "S-129" or "S-131" or "S-201" or "S-411" or "S-421" => normalized,
             _ => null,
         };
+    }
+
+    /// <summary>
+    /// Resolves the canonical spec string (<c>"S-101"</c>, etc.) for an
+    /// exchange-set <see cref="ProductSpecification"/> entry. Tries, in order,
+    /// the <see cref="ProductSpecification.ProductIdentifier"/>, the
+    /// <see cref="ProductSpecification.Name"/>, and finally the
+    /// <see cref="ProductSpecification.Number"/> (e.g. <c>101</c> → <c>"S-101"</c>).
+    /// Many real-world S-100 catalogues (e.g. IC-ENC S-101 sets) populate only
+    /// <c>name</c>/<c>number</c> and omit <c>productIdentifier</c>; this overload
+    /// keeps such datasets from being reported as an unsupported product
+    /// specification. Returns <c>null</c> when none of the fields resolve.
+    /// </summary>
+    public static string? MapProductSpecificationToSpec(ProductSpecification? productSpecification)
+    {
+        if (productSpecification is null) return null;
+
+        return MapProductIdentifierToSpec(productSpecification.ProductIdentifier)
+            ?? MapProductIdentifierToSpec(productSpecification.Name)
+            ?? (productSpecification.Number is int number
+                ? MapProductIdentifierToSpec(string.Create(CultureInfo.InvariantCulture, $"S-{number}"))
+                : null);
     }
 
     private static string? DetectProductSpecByExtension(string relativePath)

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101ExchangeSetUpdatePlan.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101ExchangeSetUpdatePlan.cs
@@ -122,7 +122,7 @@ public static class S101ExchangeSetUpdatePlan
     }
 
     private static bool IsS101(DatasetDiscoveryMetadata metadata) =>
-        DatasetPipelineFactory.MapProductIdentifierToSpec(metadata.ProductSpecification?.ProductIdentifier) == "S-101";
+        DatasetPipelineFactory.MapProductSpecificationToSpec(metadata.ProductSpecification) == "S-101";
 
     private static string GetCellName(DatasetDiscoveryMetadata metadata) =>
         Path.GetFileNameWithoutExtension(metadata.FileName);

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -199,14 +199,16 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     continue;
                 }
 
-                var spec = DatasetPipelineFactory.MapProductIdentifierToSpec(
-                    metadata.ProductSpecification?.ProductIdentifier);
+                var spec = DatasetPipelineFactory.MapProductSpecificationToSpec(
+                    metadata.ProductSpecification);
                 if (spec is null)
                 {
                     var msg = string.Format(
                         Strings.Status_ExchangeSetUnsupportedSpec,
                         relativePath,
-                        metadata.ProductSpecification?.ProductIdentifier ?? string.Empty);
+                        metadata.ProductSpecification?.ProductIdentifier
+                            ?? metadata.ProductSpecification?.Name
+                            ?? string.Empty);
                     _status.StatusText = msg;
                     _toasts.ShowWarning(Strings.Toast_Warning, msg);
                     skipMessages.Add(msg);

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryMappingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryMappingTests.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.ExchangeSets;
 
 namespace EncDotNet.S100.Pipelines.Tests;
 
@@ -36,5 +37,40 @@ public class DatasetPipelineFactoryMappingTests
     public void MapProductIdentifierToSpec_ReturnsNullForUnknown(string? input)
     {
         Assert.Null(DatasetPipelineFactory.MapProductIdentifierToSpec(input));
+    }
+
+    [Fact]
+    public void MapProductSpecificationToSpec_ReturnsNullForNull()
+    {
+        Assert.Null(DatasetPipelineFactory.MapProductSpecificationToSpec(null));
+    }
+
+    [Fact]
+    public void MapProductSpecificationToSpec_PrefersProductIdentifier()
+    {
+        var spec = new ProductSpecification { ProductIdentifier = "S-102", Name = "S-101", Number = 101 };
+        Assert.Equal("S-102", DatasetPipelineFactory.MapProductSpecificationToSpec(spec));
+    }
+
+    [Fact]
+    public void MapProductSpecificationToSpec_FallsBackToName()
+    {
+        // IC-ENC S-101 sets carry only name/version/number and omit productIdentifier.
+        var spec = new ProductSpecification { Name = "S-101", Version = "010000", Number = 101 };
+        Assert.Equal("S-101", DatasetPipelineFactory.MapProductSpecificationToSpec(spec));
+    }
+
+    [Fact]
+    public void MapProductSpecificationToSpec_FallsBackToNumber()
+    {
+        var spec = new ProductSpecification { Number = 101 };
+        Assert.Equal("S-101", DatasetPipelineFactory.MapProductSpecificationToSpec(spec));
+    }
+
+    [Fact]
+    public void MapProductSpecificationToSpec_ReturnsNullWhenNothingResolves()
+    {
+        var spec = new ProductSpecification { Name = "garbage", Number = 999 };
+        Assert.Null(DatasetPipelineFactory.MapProductSpecificationToSpec(spec));
     }
 }


### PR DESCRIPTION
## Summary

S-100 exchange-set catalogs are allowed to declare their product specification using the `<S100XC:name>` / `<S100XC:number>` elements and omit the optional `<S100XC:productIdentifier>`. Several real-world sets do exactly this, including the GB IC-ENC S-101 sets under `~/Downloads/IC-ENC/GB`. The viewer was resolving the spec from `ProductSpecification.ProductIdentifier` alone, so every cell in those sets fell through to `null` and was skipped with the misleading message `unsupported product specification ''` (the empty quotes being the tell: the identifier was missing, not unrecognized).

The fix adds `DatasetPipelineFactory.MapProductSpecificationToSpec(ProductSpecification?)`, which resolves in order `ProductIdentifier` -> `Name` -> `Number` (e.g. `101` -> `"S-101"`). This mirrors the fallback already present in `ProductSpecificationExtensions.TryToSpecRef` (which preferred `Name`+`Version`); the loader path simply wasn't using it. Both call sites now use the new overload:

- `ExchangeSetService` (the loader) - and the "unsupported" warning now also reports `Name` when an identifier is genuinely missing.
- `S101ExchangeSetUpdatePlan.IsS101` - so base/update grouping recognizes these cells too.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [x] S-100 framework (`s100-framework`)

**Spec section references cited in code/docs:** S-100 Part 17 exchange-set discovery metadata `productSpecification` (`name`/`number`/`productIdentifier`). The XML doc on the new method explains the `name`/`number`-only catalog case.

## Tests

- [x] Added/updated xunit tests under `tests/` (5 new cases in `DatasetPipelineFactoryMappingTests` covering identifier preference, name fallback, number fallback, null, and unresolvable input)
- [ ] Tests requiring real data files use `SkippableFact` (N/A - no real data files needed)
- [x] `dotnet test` passes locally for the affected test project (27/27)

## Documentation

- [x] New public API has XML doc comments
- N/A - no README or conceptual doc changes; behaviour change is a bug fix

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None. `MapProductIdentifierToSpec` is unchanged; the new `MapProductSpecificationToSpec` is additive and strictly broadens which catalogs load.