### PR TITLE
Tidy viewer UX: AIS-gated Vessels panel, ordered activity bar, toast-only notifications

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -525,54 +525,60 @@ public partial class App : Application
         // edits to MainWindow.axaml. Ids match the legacy ActivityKind enum
         // names so existing ViewerSettings.LastSelectedActivity values
         // round-trip unchanged.
-        services.AddActivityTab<FeatureCataloguesViewModel, FeatureCataloguesView>(
-            id: "FeatureCatalogues",
-            order: 10,
-            title: Strings.Pane_FeatureCatalogues,
-            tooltip: Strings.Tooltip_FeatureCatalogues,
-            iconFactory: static () => new FluentIcon { Icon = Icon.BookOpen, IconVariant = IconVariant.Regular, FontSize = 22 });
-        services.AddActivityTab<PortrayalCataloguesViewModel, PortrayalCataloguesView>(
-            id: "PortrayalCatalogues",
-            order: 20,
-            title: Strings.Pane_PortrayalCatalogues,
-            tooltip: Strings.Tooltip_PortrayalCatalogues,
-            iconFactory: static () => new FluentIcon { Icon = Icon.PaintBrush, IconVariant = IconVariant.Regular, FontSize = 22 });
+        // Activity tabs are ordered by importance via IActivityTab.Order
+        // (ascending top-to-bottom). Data sources come first, then the
+        // display / interaction tools, then the live overlays, then the
+        // reference catalogues; Settings is pinned to the bottom
+        // (order >= 1000). Tabs that can be hidden (Vessels, Helm) are
+        // never persisted as last-selected so they can't be restored
+        // while hidden.
         services.AddActivityTab<DatasetsViewModel, DatasetsView>(
             id: "Datasets",
-            order: 30,
+            order: 10,
             title: Strings.Pane_Datasets,
             tooltip: Strings.Tooltip_Datasets,
             iconFactory: static () => new FluentIcon { Icon = Icon.Layer, IconVariant = IconVariant.Regular, FontSize = 22 });
         services.AddActivityTab<CatalogPanelViewModel, CatalogPanelView>(
             id: "Catalog",
-            order: 40,
+            order: 20,
             title: Strings.Pane_Catalog,
             tooltip: Strings.Tooltip_Catalog,
             iconFactory: static () => new FluentIcon { Icon = Icon.Library, IconVariant = IconVariant.Regular, FontSize = 22 });
+        services.AddActivityTab<EcdisDisplayPanelViewModel, EcdisDisplayPanelView>(
+            id: "EcdisDisplay",
+            order: 30,
+            title: Strings.Pane_EcdisDisplay,
+            tooltip: Strings.Tooltip_EcdisDisplay,
+            iconFactory: static () => new FluentIcon { Icon = Icon.Eye, IconVariant = IconVariant.Regular, FontSize = 22 });
         services.AddActivityTab<LayerStackViewModel, LayerStackView>(
             id: "LayerStack",
-            order: 50,
+            order: 40,
             title: Strings.Pane_LayerStack,
             tooltip: Strings.Tooltip_LayerStack,
             iconFactory: static () => new FluentIcon { Icon = Icon.Stack, IconVariant = IconVariant.Regular, FontSize = 22 });
         services.AddActivityTab<FeatureSearchViewModel, FeatureSearchView>(
             id: "Search",
-            order: 60,
+            order: 50,
             title: Strings.Pane_Search,
             tooltip: Strings.Tooltip_Search,
             iconFactory: static () => new FluentIcon { Icon = Icon.Search, IconVariant = IconVariant.Regular, FontSize = 22 });
+        // Vessels tab — shown only while the AIS overlay is enabled
+        // (its visibility source bridges SettingsViewModel.AisEnabled).
         services.AddActivityTab<VesselListViewModel, VesselListView>(
             id: "Vessels",
-            order: 65,
+            order: 60,
             title: Strings.Pane_Vessels,
             tooltip: Strings.Tooltip_Vessels,
-            iconFactory: static () => new FluentIcon { Icon = Icon.VehicleShip, IconVariant = IconVariant.Regular, FontSize = 22 });
+            iconFactory: static () => new FluentIcon { Icon = Icon.VehicleShip, IconVariant = IconVariant.Regular, FontSize = 22 },
+            persistAsLastSelected: false,
+            visibilitySourceFactory: static sp =>
+                new EncDotNet.S100.Viewer.ViewModels.Activities.AisOverlayVisibilitySource(
+                    sp.GetRequiredService<SettingsViewModel>()));
         // Helm tab — shown only while own-vessel tracking is enabled
         // (its visibility source bridges SettingsViewModel.OwnShipOverlayEnabled).
-        // Never persisted as last-selected so it can't be restored while hidden.
         services.AddActivityTab<HelmViewModel, HelmView>(
             id: "Helm",
-            order: 67,
+            order: 70,
             title: Strings.Pane_Helm,
             tooltip: Strings.Tooltip_Helm,
             iconFactory: static () => new FluentIcon { Icon = Icon.TopSpeed, IconVariant = IconVariant.Regular, FontSize = 22 },
@@ -580,12 +586,18 @@ public partial class App : Application
             visibilitySourceFactory: static sp =>
                 new EncDotNet.S100.Viewer.ViewModels.Activities.OwnShipTrackingVisibilitySource(
                     sp.GetRequiredService<SettingsViewModel>()));
-        services.AddActivityTab<EcdisDisplayPanelViewModel, EcdisDisplayPanelView>(
-            id: "EcdisDisplay",
-            order: 70,
-            title: Strings.Pane_EcdisDisplay,
-            tooltip: Strings.Tooltip_EcdisDisplay,
-            iconFactory: static () => new FluentIcon { Icon = Icon.Eye, IconVariant = IconVariant.Regular, FontSize = 22 });
+        services.AddActivityTab<FeatureCataloguesViewModel, FeatureCataloguesView>(
+            id: "FeatureCatalogues",
+            order: 80,
+            title: Strings.Pane_FeatureCatalogues,
+            tooltip: Strings.Tooltip_FeatureCatalogues,
+            iconFactory: static () => new FluentIcon { Icon = Icon.BookOpen, IconVariant = IconVariant.Regular, FontSize = 22 });
+        services.AddActivityTab<PortrayalCataloguesViewModel, PortrayalCataloguesView>(
+            id: "PortrayalCatalogues",
+            order: 90,
+            title: Strings.Pane_PortrayalCatalogues,
+            tooltip: Strings.Tooltip_PortrayalCatalogues,
+            iconFactory: static () => new FluentIcon { Icon = Icon.PaintBrush, IconVariant = IconVariant.Regular, FontSize = 22 });
         services.AddActivityTab<SettingsViewModel, SettingsView>(
             id: "Settings",
             order: 1000,

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -590,35 +590,6 @@
                                            Height="{Binding Bounds.Width, ElementName=ZoomInButton}" />
                 </StackPanel>
 
-                <!-- Partial-failure / failure banner (es3-progress).
-                     Anchored to the top of the map area; dismissable via the
-                     X button. Stays out of the way of the scale bar by
-                     reserving the top edge with a small offset. -->
-                <Border HorizontalAlignment="Stretch"
-                        VerticalAlignment="Top"
-                        Margin="48,4,180,0"
-                        Padding="12,8"
-                        CornerRadius="4"
-                        Background="{DynamicResource BackgroundColor}"
-                        BorderBrush="{DynamicResource AccentBrush}"
-                        BorderThickness="1"
-                        IsVisible="{Binding IsExchangeSetBannerVisible}">
-                    <DockPanel LastChildFill="True">
-                        <Button DockPanel.Dock="Right"
-                                Command="{Binding DismissExchangeSetBannerCommand}"
-                                ToolTip.Tip="{x:Static loc:Strings.Banner_Dismiss}"
-                                Background="Transparent"
-                                BorderThickness="0"
-                                Padding="4"
-                                Margin="8,0,0,0">
-                            <ic:FluentIcon Icon="Dismiss" IconVariant="Regular" FontSize="14" />
-                        </Button>
-                        <TextBlock Text="{Binding ExchangeSetBannerMessage}"
-                                   VerticalAlignment="Center"
-                                   TextWrapping="Wrap" />
-                    </DockPanel>
-                </Border>
-
                 <!-- Exchange-set progress overlay (es3-progress).
                      Centered card; non-modal — the user can still pan the
                      map underneath but cannot start a second exchange-set

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -175,8 +175,6 @@ public partial class MainWindow : ShadUI.Window
             _dynamicSourceOverlayHost?.Dispose();
             _dynamicSourceOverlayHost = null;
         };
-        _loader.StatusChanged += text => _viewModel.StatusText = text;
-
         DataContext = _viewModel;
 
         // Build the native menu bar (File / View › Appearance) and keep its
@@ -211,7 +209,6 @@ public partial class MainWindow : ShadUI.Window
         // Surface DatasetsViewModel rejection of unknown file extensions.
         _viewModel.Datasets.UnrecognizedFileEncountered += extension =>
         {
-            _viewModel.StatusText = string.Format(Strings.Status_UnrecognizedFileType, extension);
             App.Services.GetRequiredService<IToastService>().ShowWarning(
                 Strings.Toast_Warning,
                 string.Format(Strings.Status_UnrecognizedFileType, extension));

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -180,8 +180,10 @@ corresponding feature, even when producer datasets reuse `gml:id`s
 across distinct features.
 
 A **Vessels** activity-bar panel lists the live AIS targets,
-nearest to the own ship first, in a master/detail layout. Each
-compact list row shows the vessel name, a ship-type pictogram
+nearest to the own ship first, in a master/detail layout. The
+panel's activity-bar icon is shown only while the AIS overlay is
+enabled (Settings → AIS); disabling the overlay hides the icon.
+Each compact list row shows the vessel name, a ship-type pictogram
 tinted by class, its navigation state, and the range and bearing
 from the own ship. Selecting a row recentres the map on that
 vessel while preserving the current zoom and reveals a properties

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -300,15 +300,12 @@ internal static class Strings
     public static string Status_UnrecognizedFileType => Get(nameof(Status_UnrecognizedFileType));
     public static string Status_SelectPortrayalCatalogue => Get(nameof(Status_SelectPortrayalCatalogue));
     public static string Status_LoadingFile => Get(nameof(Status_LoadingFile));
-    public static string Status_Error => Get(nameof(Status_Error));
     public static string Status_RenderingTimeStep => Get(nameof(Status_RenderingTimeStep));
-    public static string Status_RenderingAtTime => Get(nameof(Status_RenderingAtTime));
     public static string Status_FeatureNoDetails => Get(nameof(Status_FeatureNoDetails));
     public static string Status_FeatureSummary => Get(nameof(Status_FeatureSummary));
     public static string Status_FeatureSummaryWithMore => Get(nameof(Status_FeatureSummaryWithMore));
     public static string Status_FeatureRefNotFound => Get(nameof(Status_FeatureRefNotFound));
     public static string Status_FileNoLongerExists => Get(nameof(Status_FileNoLongerExists));
-    public static string Status_ExchangeSetLoading => Get(nameof(Status_ExchangeSetLoading));
     public static string Status_ExchangeSetLoaded => Get(nameof(Status_ExchangeSetLoaded));
     public static string Status_ExchangeSetLoadedWithErrors => Get(nameof(Status_ExchangeSetLoadedWithErrors));
     public static string Status_ExchangeSetFailed => Get(nameof(Status_ExchangeSetFailed));
@@ -324,9 +321,6 @@ internal static class Strings
     public static string Progress_ExchangeSetTitle => Get(nameof(Progress_ExchangeSetTitle));
     public static string Progress_ExchangeSetCounter => Get(nameof(Progress_ExchangeSetCounter));
     public static string Progress_ExchangeSetCancel => Get(nameof(Progress_ExchangeSetCancel));
-    public static string Banner_ExchangeSetPartial => Get(nameof(Banner_ExchangeSetPartial));
-    public static string Banner_ExchangeSetFailed => Get(nameof(Banner_ExchangeSetFailed));
-    public static string Banner_Dismiss => Get(nameof(Banner_Dismiss));
 
     // Dataset entry
     public static string DatasetEntry_CurrentTimeFormat => Get(nameof(DatasetEntry_CurrentTimeFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -795,14 +795,8 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Status_LoadingFile" xml:space="preserve">
     <value>Loading {0}...</value>
   </data>
-  <data name="Status_Error" xml:space="preserve">
-    <value>Error: {0}</value>
-  </data>
   <data name="Status_RenderingTimeStep" xml:space="preserve">
     <value>Rendering time step {0}/{1}...</value>
-  </data>
-  <data name="Status_RenderingAtTime" xml:space="preserve">
-    <value>Rendering at {0:u}...</value>
   </data>
   <data name="Status_FeatureNoDetails" xml:space="preserve">
     <value>Feature {0} (no details available)</value>
@@ -820,10 +814,6 @@ Open an S-128 dataset to populate this panel.</value>
   </data>
   <data name="Status_FileNoLongerExists" xml:space="preserve">
     <value>File no longer exists: {0}</value>
-  </data>
-  <data name="Status_ExchangeSetLoading" xml:space="preserve">
-    <value>Loading exchange set {0}...</value>
-    <comment>Status text while reading an exchange set's CATALOG.XML and dispatching its datasets. {0} is the source path.</comment>
   </data>
   <data name="Status_ExchangeSetLoaded" xml:space="preserve">
     <value>Loaded {0} dataset(s) from {1}.</value>
@@ -870,15 +860,6 @@ Open an S-128 dataset to populate this panel.</value>
   </data>
   <data name="Progress_ExchangeSetCancel" xml:space="preserve">
     <value>Cancel</value>
-  </data>
-  <data name="Banner_ExchangeSetPartial" xml:space="preserve">
-    <value>{0} of {1} datasets in {2} could not be loaded ({3} unsupported).</value>
-  </data>
-  <data name="Banner_ExchangeSetFailed" xml:space="preserve">
-    <value>Failed to open exchange set {0}: {1}</value>
-  </data>
-  <data name="Banner_Dismiss" xml:space="preserve">
-    <value>Dismiss</value>
   </data>
 
   <!-- Dataset entry -->

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -206,19 +206,10 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
     public event Action<DatasetEntry>? DatasetLoaded;
 
-    /// <summary>
-    /// Raised whenever the loader wants to surface a status message
-    /// (loading, errors, time-step progress, etc.). The window forwards
-    /// these to <see cref="MainViewModel.StatusText"/>.
-    /// </summary>
-    public event Action<string?>? StatusChanged;
-
     public event Action<DatasetEntry>? DatasetRemoved;
 
     /// <inheritdoc />
     public bool SuppressAutoZoom { get; set; }
-
-    private void SetStatus(string? text) => StatusChanged?.Invoke(text);
 
     /// <summary>
     /// Surfaces the outcome of S-101 sequential update application as a
@@ -238,13 +229,14 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             var msg = string.Format(
                 Strings.Status_ExchangeSetUpdatesPartial,
                 appliedCount, entry.DisplayName, problem.Text);
-            SetStatus(msg);
             _toasts.ShowWarning(Strings.Toast_Warning, msg);
         }
         else if (appliedCount > 0)
         {
-            SetStatus(string.Format(
-                Strings.Status_ExchangeSetUpdatesApplied, appliedCount, entry.DisplayName));
+            _toasts.ShowInfo(
+                Strings.Toast_Info,
+                string.Format(
+                    Strings.Status_ExchangeSetUpdatesApplied, appliedCount, entry.DisplayName));
         }
     }
 
@@ -297,7 +289,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             spec = DatasetPipelineFactory.DetectProductSpec(entry.FilePath);
             if (spec is null)
             {
-                SetStatus(string.Format(Strings.Status_UnrecognizedFileType, Path.GetExtension(entry.FilePath)));
                 _toasts.ShowWarning(Strings.Toast_Warning,
                     string.Format(Strings.Status_UnrecognizedFileType, Path.GetExtension(entry.FilePath)));
                 return;
@@ -309,13 +300,10 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         var requiredCatalogue = spec == "S-57" ? "S-101" : spec;
         if (spec != "S-104" && !_catalogueManager.HasCatalogue(requiredCatalogue))
         {
-            SetStatus(string.Format(Strings.Status_SelectPortrayalCatalogue, requiredCatalogue));
             _toasts.ShowWarning(Strings.Toast_Warning,
                 string.Format(Strings.Status_SelectPortrayalCatalogue, requiredCatalogue));
             return;
         }
-
-        SetStatus(string.Format(Strings.Status_LoadingFile, entry.DisplayName));
 
         // Show a loading toast with a Cancel action for standalone
         // dataset loads. Exchange-set entries are covered by the
@@ -416,13 +404,18 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             var validation = await Task.Run(() => SafeValidate(processor), token);
             entry.SetValidationReport(validation);
 
-            // Dismiss the loading toast before showing the result.
-            // Exchange-set entries don't show per-dataset toasts.
+            // Dismiss the loading toast and surface the per-dataset
+            // load summary as a success toast. Exchange-set entries are
+            // covered by the aggregate exchange-set toast instead, so
+            // they skip the per-dataset toast to avoid churn.
             if (!fromExchangeSet)
             {
                 _toasts.DismissAll();
+                if (!string.IsNullOrWhiteSpace(result.Info))
+                {
+                    _toasts.ShowSuccess(Strings.Toast_Success, result.Info);
+                }
             }
-            SetStatus(result.Info);
 
             // Recent files only makes sense for plain file loads. An
             // exchange-set entry's FilePath is a relative path inside
@@ -449,7 +442,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
                 _toasts.DismissAll();
                 _toasts.ShowInfo(Strings.Toast_DatasetCancelled, entry.DisplayName);
             }
-            SetStatus(null);
         }
         catch (Exception ex)
         {
@@ -466,7 +458,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             // explicitly dismissed.
             var failure = LoadFailureViewModel.FromException(
                 entry.DisplayName, entry.FilePath, ex);
-            SetStatus(string.Format(Strings.Status_Error, ex.Message));
             _toasts.ShowError(
                 title: string.Format(Strings.Toast_DatasetErrorTitle, entry.DisplayName),
                 content: failure.PrimaryMessage,
@@ -523,8 +514,6 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         }
 
         if (token.IsCancellationRequested) return;
-
-        SetStatus(string.Format(Strings.Status_RenderingAtTime, t));
 
         foreach (var (entry, adapter) in _globalTime.Adapters.ToArray())
         {

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -36,19 +36,16 @@ namespace EncDotNet.S100.Viewer.Services;
 internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 {
     private readonly DatasetsViewModel _datasets;
-    private readonly IStatusPresenter _status;
     private readonly IToastService _toasts;
     private readonly List<TrackedExchangeSet> _tracked = new();
     private bool _subscribed;
     private bool _disposed;
 
-    public ExchangeSetService(DatasetsViewModel datasets, IStatusPresenter status, IToastService toasts)
+    public ExchangeSetService(DatasetsViewModel datasets, IToastService toasts)
     {
         ArgumentNullException.ThrowIfNull(datasets);
-        ArgumentNullException.ThrowIfNull(status);
         ArgumentNullException.ThrowIfNull(toasts);
         _datasets = datasets;
-        _status = status;
         _toasts = toasts;
     }
 
@@ -92,7 +89,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             catch (FileNotFoundException)
             {
                 var msg = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
-                _status.StatusText = msg;
                 _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, msg);
                 source.Dispose();
                 activity?.SetStatus(ActivityStatusCode.Error, "catalogue not found");
@@ -116,7 +112,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             if (datasets.Count == 0)
             {
                 var emptyMsg = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath);
-                _status.StatusText = emptyMsg;
                 _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, emptyMsg);
                 exchangeSet.Dispose();
                 exchangeSet = null;
@@ -128,8 +123,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     FailureMessage = string.Format(Strings.Status_ExchangeSetCatalogNotFound, folderOrZipPath),
                 };
             }
-
-            _status.StatusText = string.Format(Strings.Status_ExchangeSetLoading, folderOrZipPath);
 
             // Group S-101 base cells with their in-set sequential updates
             // (….001/.002/…) so each cell loads as a single up-to-date
@@ -190,7 +183,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 if (item.Kind == S101LoadItemKind.OrphanUpdate)
                 {
                     var orphanMsg = string.Format(Strings.Status_ExchangeSetOrphanUpdate, relativePath);
-                    _status.StatusText = orphanMsg;
                     _toasts.ShowWarning(Strings.Toast_Warning, orphanMsg);
                     skipMessages.Add(orphanMsg);
                     skipped++;
@@ -209,7 +201,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                         metadata.ProductSpecification?.ProductIdentifier
                             ?? metadata.ProductSpecification?.Name
                             ?? string.Empty);
-                    _status.StatusText = msg;
                     _toasts.ShowWarning(Strings.Toast_Warning, msg);
                     skipMessages.Add(msg);
                     skipped++;
@@ -240,14 +231,12 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 var cancelledMsg = string.Format(
                     Strings.Status_ExchangeSetCancelled,
                     dispatched, plan.Count, folderOrZipPath);
-                _status.StatusText = cancelledMsg;
                 _toasts.ShowInfo(Strings.Toast_Info, cancelledMsg);
             }
             else if (skipped == 0)
             {
                 var loadedMsg = string.Format(
                     Strings.Status_ExchangeSetLoaded, dispatched, folderOrZipPath);
-                _status.StatusText = loadedMsg;
                 _toasts.ShowSuccess(Strings.Toast_ExchangeSetLoaded, loadedMsg);
             }
             else
@@ -255,7 +244,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 var partialMsg = string.Format(
                     Strings.Status_ExchangeSetLoadedWithErrors,
                     dispatched, plan.Count, folderOrZipPath, skipped);
-                _status.StatusText = partialMsg;
                 _toasts.ShowWarning(Strings.Toast_ExchangeSetLoaded, partialMsg);
             }
 
@@ -322,7 +310,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         catch (Exception ex)
         {
             var failedMsg = string.Format(Strings.Status_ExchangeSetFailed, folderOrZipPath, ex.Message);
-            _status.StatusText = failedMsg;
             _toasts.ShowError(Strings.Toast_ExchangeSetFailed, failedMsg);
             exchangeSet?.Dispose();
             source?.Dispose();
@@ -369,7 +356,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             {
                 var msg = string.Format(
                     Strings.Status_ExchangeSetCatalogNotFound, folderOrCataloguePath);
-                _status.StatusText = msg;
                 _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, msg);
                 activity?.SetStatus(ActivityStatusCode.Error, "catalogue not found");
                 return new ExchangeSetOpenResult
@@ -386,7 +372,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             {
                 var emptyMsg = string.Format(
                     Strings.Status_S57ExchangeSetNoCells, folderOrCataloguePath);
-                _status.StatusText = emptyMsg;
                 _toasts.ShowWarning(Strings.Toast_ExchangeSetFailed, emptyMsg);
                 activity?.SetStatus(ActivityStatusCode.Error, "no cells");
                 return new ExchangeSetOpenResult
@@ -445,7 +430,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
             var loadedMsg = string.Format(
                 Strings.Status_ExchangeSetLoaded, dispatched, folderOrCataloguePath);
-            _status.StatusText = loadedMsg;
             _toasts.ShowSuccess(Strings.Toast_ExchangeSetLoaded, loadedMsg);
 
             activity?.SetTag("s57.exchangeset.dataset.loaded", dispatched);
@@ -485,7 +469,6 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         catch (Exception ex)
         {
             var failedMsg = string.Format(Strings.Status_ExchangeSetFailed, folderOrCataloguePath, ex.Message);
-            _status.StatusText = failedMsg;
             _toasts.ShowError(Strings.Toast_ExchangeSetFailed, failedMsg);
             source?.Dispose();
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -156,14 +156,6 @@ internal interface IDatasetLoaderService
     event Action<DatasetEntry>? DatasetLoaded;
 
     /// <summary>
-    /// Raised whenever the loader produces a user-visible status message
-    /// (load progress, errors, time-step changes, palette switches).
-    /// Subscribers (typically <see cref="MainWindow"/>) forward to
-    /// <see cref="MainViewModel.StatusText"/>.
-    /// </summary>
-    event Action<string?>? StatusChanged;
-
-    /// <summary>
     /// Raised after <see cref="RemoveEntry"/> has dropped the entry from
     /// the loader's processor cache. Consumers can use this to release
     /// any per-entry state they kept alongside the loader (e.g. an

--- a/src/EncDotNet.S100.Viewer/ViewModels/Activities/AisOverlayVisibilitySource.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/Activities/AisOverlayVisibilitySource.cs
@@ -1,0 +1,35 @@
+using System;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.ViewModels.Activities;
+
+/// <summary>
+/// <see cref="ITabVisibilitySource"/> that shows the Vessels tab only
+/// while the AIS overlay is enabled. Bridges
+/// <see cref="SettingsViewModel.AisEnabled"/> /
+/// <see cref="SettingsViewModel.AisEnabledChanged"/> to the
+/// activity-tab visibility contract, mirroring
+/// <see cref="OwnShipTrackingVisibilitySource"/> for the Helm tab.
+/// </summary>
+internal sealed class AisOverlayVisibilitySource : ITabVisibilitySource, IDisposable
+{
+    private readonly SettingsViewModel _settings;
+
+    public AisOverlayVisibilitySource(SettingsViewModel settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+        _settings.AisEnabledChanged += OnAisEnabledChanged;
+    }
+
+    /// <inheritdoc />
+    public bool IsVisible => _settings.AisEnabled;
+
+    /// <inheritdoc />
+    public event Action<bool>? VisibilityChanged;
+
+    private void OnAisEnabledChanged(bool enabled) => VisibilityChanged?.Invoke(enabled);
+
+    public void Dispose()
+        => _settings.AisEnabledChanged -= OnAisEnabledChanged;
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -685,7 +685,7 @@ internal sealed class DatasetsViewModel : ViewModelBase
 
     /// <summary>
     /// Loads the supplied entry through the dataset loader. Fire-and-forget;
-    /// errors are surfaced via <see cref="IDatasetLoaderService.StatusChanged"/>.
+    /// errors are surfaced via the toast notification service.
     /// </summary>
     public void RequestLoad(DatasetEntry entry)
     {

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -618,8 +618,6 @@ internal sealed class MainViewModel : ViewModelBase
     private string? _exchangeSetCurrentDataset;
     private string? _exchangeSetCounter;
     private string? _exchangeSetSourceLabel;
-    private bool _isExchangeSetBannerVisible;
-    private string? _exchangeSetBannerMessage;
     private System.Threading.CancellationTokenSource? _exchangeSetCts;
 
     /// <summary>
@@ -666,27 +664,10 @@ internal sealed class MainViewModel : ViewModelBase
     /// <summary>Cancels the in-flight exchange-set load. No-op if idle.</summary>
     public ICommand CancelExchangeSetCommand { get; }
 
-    /// <summary>True while a partial-failure / fatal-error banner is shown.</summary>
-    public bool IsExchangeSetBannerVisible
-    {
-        get => _isExchangeSetBannerVisible;
-        private set => SetProperty(ref _isExchangeSetBannerVisible, value);
-    }
-
-    /// <summary>Banner body text (already localised + formatted).</summary>
-    public string? ExchangeSetBannerMessage
-    {
-        get => _exchangeSetBannerMessage;
-        private set => SetProperty(ref _exchangeSetBannerMessage, value);
-    }
-
-    /// <summary>Hides the partial-failure banner.</summary>
-    public ICommand DismissExchangeSetBannerCommand { get; }
-
     /// <summary>
     /// Called by <see cref="MainWindow"/> when an exchange-set load is
-    /// about to start. Captures the cancellation source, resets progress
-    /// state, and clears any leftover banner.
+    /// about to start. Captures the cancellation source and resets
+    /// progress state.
     /// </summary>
     internal System.Threading.CancellationToken BeginExchangeSetLoad(string sourcePath)
     {
@@ -694,8 +675,6 @@ internal sealed class MainViewModel : ViewModelBase
         _exchangeSetCts?.Dispose();
         _exchangeSetCts = new System.Threading.CancellationTokenSource();
 
-        IsExchangeSetBannerVisible = false;
-        ExchangeSetBannerMessage = null;
         ExchangeSetSourceLabel = sourcePath;
         ExchangeSetCurrentDataset = null;
         ExchangeSetCounter = null;
@@ -718,28 +697,16 @@ internal sealed class MainViewModel : ViewModelBase
 
     /// <summary>
     /// Called by <see cref="MainWindow"/> when an exchange-set load
-    /// completes (or is cancelled / fatally fails). Hides the overlay
-    /// and surfaces a banner if there is anything worth flagging.
+    /// completes (or is cancelled / fatally fails). Hides the progress
+    /// overlay. Outcome notifications (success / partial / failure) are
+    /// surfaced by <see cref="Services.IExchangeSetService"/> through the
+    /// toast notification service.
     /// </summary>
     internal void EndExchangeSetLoad(ExchangeSetOpenResult result)
     {
         ArgumentNullException.ThrowIfNull(result);
         IsExchangeSetLoading = false;
         ExchangeSetCurrentDataset = null;
-
-        if (result.FailureMessage is { } message && !result.CatalogueNotFound)
-        {
-            ExchangeSetBannerMessage = string.Format(
-                Strings.Banner_ExchangeSetFailed, result.SourcePath, message);
-            IsExchangeSetBannerVisible = true;
-        }
-        else if (result.SkippedUnsupported > 0)
-        {
-            ExchangeSetBannerMessage = string.Format(
-                Strings.Banner_ExchangeSetPartial,
-                result.SkippedUnsupported, result.Total, result.SourcePath, result.SkippedUnsupported);
-            IsExchangeSetBannerVisible = true;
-        }
     }
 
     /// <summary>
@@ -1076,8 +1043,6 @@ internal sealed class MainViewModel : ViewModelBase
         CancelExchangeSetCommand = new RelayCommand(
             () => _exchangeSetCts?.Cancel(),
             () => IsExchangeSetLoading);
-        DismissExchangeSetBannerCommand = new RelayCommand(
-            () => IsExchangeSetBannerVisible = false);
 
         // Re-evaluate Cancel command when the loading flag changes so the
         // overlay button enables/disables correctly.
@@ -1199,9 +1164,9 @@ internal sealed class MainViewModel : ViewModelBase
 
         if (!File.Exists(path))
         {
-            var msg = string.Format(Strings.Status_FileNoLongerExists, path);
-            StatusText = msg;
-            _toasts.ShowWarning(Strings.Toast_Warning, msg);
+            _toasts.ShowWarning(
+                Strings.Toast_Warning,
+                string.Format(Strings.Status_FileNoLongerExists, path));
             // Drop the missing entry so the menu reflects reality.
             _recentFiles.Remove(path);
             return;

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -758,6 +758,14 @@ internal sealed class SettingsViewModel : ViewModelBase
         _settings.AisOverlay ??= new AisOverlaySettings();
     }
 
+    /// <summary>
+    /// Raised when <see cref="AisEnabled"/> changes. The activity bar
+    /// wires this (via <see cref="Activities.AisOverlayVisibilitySource"/>)
+    /// so the Vessels tab appears / disappears live with the overlay
+    /// opt-in.
+    /// </summary>
+    public event Action<bool>? AisEnabledChanged;
+
     private bool _aisEnabled;
     /// <summary>
     /// User opt-in for the AIS overlay. Persisted to
@@ -774,6 +782,7 @@ internal sealed class SettingsViewModel : ViewModelBase
                 EnsureAisOverlaySettings();
                 _settings.AisOverlay!.Enabled = value;
                 _settings.Save();
+                AisEnabledChanged?.Invoke(value);
             }
         }
     }

--- a/tests/EncDotNet.S100.Viewer.Tests/ActivityTabRegistryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ActivityTabRegistryTests.cs
@@ -79,7 +79,6 @@ public sealed class ActivityTabRegistryTests : IDisposable
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public System.Threading.Tasks.Task LoadAsync(DatasetEntry entry, System.Threading.CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
         public System.Threading.Tasks.Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => System.Threading.Tasks.Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/ActivityTabVisibilityTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ActivityTabVisibilityTests.cs
@@ -116,3 +116,48 @@ public sealed class OwnShipTrackingVisibilitySourceTests
         Assert.Equal(true, last);
     }
 }
+
+public sealed class AisOverlayVisibilitySourceTests
+{
+    [Fact]
+    public void IsVisible_ReflectsAisEnabled()
+    {
+        var settings = new ViewerSettings { AisOverlay = new AisOverlaySettings { Enabled = true } };
+        var svm = new SettingsViewModel(settings);
+        using var source = new AisOverlayVisibilitySource(svm);
+
+        Assert.True(source.IsVisible);
+    }
+
+    [Fact]
+    public void VisibilityChanged_RaisedOnAisToggle()
+    {
+        var settings = new ViewerSettings { AisOverlay = new AisOverlaySettings { Enabled = false } };
+        var svm = new SettingsViewModel(settings);
+        using var source = new AisOverlayVisibilitySource(svm);
+
+        bool? last = null;
+        source.VisibilityChanged += v => last = v;
+
+        svm.AisEnabled = true;
+
+        Assert.True(source.IsVisible);
+        Assert.Equal(true, last);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromSettings()
+    {
+        var settings = new ViewerSettings { AisOverlay = new AisOverlaySettings { Enabled = false } };
+        var svm = new SettingsViewModel(settings);
+        var source = new AisOverlayVisibilitySource(svm);
+        source.Dispose();
+
+        var raised = 0;
+        source.VisibilityChanged += _ => raised++;
+
+        svm.AisEnabled = true;
+
+        Assert.Equal(0, raised);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelExchangeSetHeaderTests.cs
@@ -30,7 +30,6 @@ public class DatasetsViewModelExchangeSetHeaderTests
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
@@ -22,7 +22,6 @@ public class DatasetsViewModelTests
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default)
         {

--- a/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/EcdisDisplayPanelViewModelTests.cs
@@ -19,7 +19,6 @@ public class EcdisDisplayPanelViewModelTests
             new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event System.Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event System.Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event System.Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -44,12 +44,6 @@ public class ExchangeSetServiceLoaderTests
     private static string S101OrphanFixture() =>
         Path.Combine(FixturesRoot(), "Synthetic-S101Orphan");
 
-    private sealed class StubStatus : IStatusPresenter
-    {
-        public string? StatusText { get; set; }
-        public event PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
-    }
-
     private sealed class NoopLoader : IDatasetLoaderService
     {
         public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
@@ -58,7 +52,6 @@ public class ExchangeSetServiceLoaderTests
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
@@ -76,7 +69,7 @@ public class ExchangeSetServiceLoaderTests
     private static (DatasetsViewModel datasets, ExchangeSetService service) CreateSystem()
     {
         var datasets = new DatasetsViewModel(new NoopLoader());
-        var service = new ExchangeSetService(datasets, new StubStatus(), new StubToastService());
+        var service = new ExchangeSetService(datasets, new StubToastService());
         return (datasets, service);
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FakeDatasetLoaderService.cs
@@ -52,7 +52,6 @@ internal sealed class FakeDatasetLoaderService : IDatasetLoaderService
         new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
 
     public event Action<DatasetEntry>? DatasetLoaded;
-    public event Action<string?>? StatusChanged;
     public event Action<DatasetEntry>? DatasetRemoved;
     public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
     public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureSearchServiceTests.cs
@@ -39,7 +39,6 @@ public class FeatureSearchServiceTests
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
@@ -162,7 +162,6 @@ public class LayerStackViewModelTests
 
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
 
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/LayoutPersistenceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LayoutPersistenceTests.cs
@@ -77,7 +77,6 @@ public sealed class LayoutPersistenceTests : IDisposable
         public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; } = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public System.Threading.Tasks.Task LoadAsync(DatasetEntry entry, System.Threading.CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
         public System.Threading.Tasks.Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => System.Threading.Tasks.Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelExchangeSetProgressTests.cs
@@ -50,7 +50,6 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
@@ -139,7 +138,7 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
     }
 
     [Fact]
-    public void EndExchangeSetLoad_FullSuccess_ClearsBanner()
+    public void EndExchangeSetLoad_FullSuccess_ClearsLoadingState()
     {
         var vm = CreateViewModel();
         vm.BeginExchangeSetLoad("/some/folder");
@@ -152,11 +151,11 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
         });
 
         Assert.False(vm.IsExchangeSetLoading);
-        Assert.False(vm.IsExchangeSetBannerVisible);
+        Assert.Null(vm.ExchangeSetCurrentDataset);
     }
 
     [Fact]
-    public void EndExchangeSetLoad_PartialFailure_ShowsBanner()
+    public void EndExchangeSetLoad_PartialFailure_ClearsLoadingState()
     {
         var vm = CreateViewModel();
         vm.BeginExchangeSetLoad("/some/folder");
@@ -170,12 +169,11 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
         });
 
         Assert.False(vm.IsExchangeSetLoading);
-        Assert.True(vm.IsExchangeSetBannerVisible);
-        Assert.False(string.IsNullOrEmpty(vm.ExchangeSetBannerMessage));
+        Assert.Null(vm.ExchangeSetCurrentDataset);
     }
 
     [Fact]
-    public void EndExchangeSetLoad_FatalFailure_ShowsBanner()
+    public void EndExchangeSetLoad_FatalFailure_ClearsLoadingState()
     {
         var vm = CreateViewModel();
         vm.BeginExchangeSetLoad("/missing");
@@ -186,24 +184,7 @@ public class MainViewModelExchangeSetProgressTests : IDisposable
             FailureMessage = "boom",
         });
 
-        Assert.True(vm.IsExchangeSetBannerVisible);
-        Assert.Contains("boom", vm.ExchangeSetBannerMessage);
-    }
-
-    [Fact]
-    public void DismissBannerCommand_HidesBanner()
-    {
-        var vm = CreateViewModel();
-        vm.BeginExchangeSetLoad("/some/folder");
-        vm.EndExchangeSetLoad(new ExchangeSetOpenResult
-        {
-            SourcePath = "/some/folder",
-            Total = 2, Loaded = 1, SkippedUnsupported = 1,
-        });
-        Assert.True(vm.IsExchangeSetBannerVisible);
-
-        vm.DismissExchangeSetBannerCommand.Execute(null);
-
-        Assert.False(vm.IsExchangeSetBannerVisible);
+        Assert.False(vm.IsExchangeSetLoading);
+        Assert.Null(vm.ExchangeSetCurrentDataset);
     }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelOpenRecentTests.cs
@@ -56,7 +56,6 @@ public class MainViewModelOpenRecentTests : IDisposable
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) { Loaded.Add(entry); return Task.CompletedTask; }
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
@@ -71,14 +70,32 @@ public class MainViewModelOpenRecentTests : IDisposable
         public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
+    private sealed class RecordingToastService : IToastService
+    {
+        public int WarningCount { get; private set; }
+        public void ShowInfo(string title, string? content = null) { }
+        public void ShowSuccess(string title, string? content = null) { }
+        public void ShowWarning(string title, string? content = null) => WarningCount++;
+        public void ShowError(string title, string? content = null, string? actionLabel = null, Action? action = null, bool sticky = false) { }
+        public void ShowLoading(string title, string? content = null, string? actionLabel = null, Action? action = null) { }
+        public void DismissAll() { }
+    }
+
     private MainViewModel CreateViewModel(
         out RecordingLoaderService loader,
         out StubRecentFilesService recent)
+        => CreateViewModel(out loader, out recent, out _);
+
+    private MainViewModel CreateViewModel(
+        out RecordingLoaderService loader,
+        out StubRecentFilesService recent,
+        out RecordingToastService toasts)
     {
         var settings = new ViewerSettings { SettingsFilePath = _tempSettingsPath };
         var catalogues = new PortrayalCatalogueManager();
         loader = new RecordingLoaderService();
         recent = new StubRecentFilesService();
+        toasts = new RecordingToastService();
         var datasets = new DatasetsViewModel(loader);
         return new MainViewModel(
             settings,
@@ -97,20 +114,20 @@ public class MainViewModelOpenRecentTests : IDisposable
             themeService: new StubThemeService(),
             recentFiles: recent,
             measureAppearance: new StubMeasureOverlayAppearanceProvider(),
-            toasts: new StubToastService());
+            toasts: toasts);
     }
 
     [Fact]
-    public async Task OpenRecent_MissingFile_RemovesFromRecentAndSetsStatus()
+    public async Task OpenRecent_MissingFile_RemovesFromRecentAndNotifies()
     {
-        var vm = CreateViewModel(out var loader, out var recent);
+        var vm = CreateViewModel(out var loader, out var recent, out var toasts);
         var ghost = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}");
         recent.Add(ghost);
 
         await vm.OpenRecentCommand.ExecuteAsync(ghost);
 
         Assert.DoesNotContain(ghost, recent.Items);
-        Assert.False(string.IsNullOrEmpty(vm.StatusText));
+        Assert.Equal(1, toasts.WarningCount);
         Assert.Empty(loader.Loaded);
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickEmptyStateTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickEmptyStateTests.cs
@@ -72,7 +72,6 @@ public sealed class MainViewModelPickEmptyStateTests : IDisposable
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public System.Threading.Tasks.Task LoadAsync(DatasetEntry entry, System.Threading.CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
         public System.Threading.Tasks.Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => System.Threading.Tasks.Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -38,7 +38,6 @@ public class MainViewModelPickModeTests
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/MultiDockActivityTabTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MultiDockActivityTabTests.cs
@@ -183,7 +183,6 @@ public sealed class MultiDockActivityTabTests : IDisposable
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public System.Threading.Tasks.Task LoadAsync(DatasetEntry entry, System.Threading.CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
         public System.Threading.Tasks.Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => System.Threading.Tasks.Task.CompletedTask;

--- a/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickServiceTests.cs
@@ -54,7 +54,6 @@ public class PickServiceTests
             = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
@@ -165,7 +164,6 @@ public class PickServiceTests
         public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
@@ -421,7 +419,6 @@ public class PickServiceTests
         public IReadOnlyList<ILayer> CurrentStackedLayers { get; }
         public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
         public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
-        public event Action<string?>? StatusChanged { add { } remove { } }
         public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
         public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

Readies the viewer UX for real users by consolidating how transient feedback is shown and tightening the activity bar. Four cleanups:

- **Vessels panel gated on AIS.** The Vessels activity-bar tab now appears only while the AIS overlay is enabled. A new `AisOverlayVisibilitySource` bridges `SettingsViewModel.AisEnabled` / `AisEnabledChanged` to the existing `ITabVisibilitySource` contract (mirroring the Helm tab's own-ship pattern), and the tab is registered with `persistAsLastSelected: false` so it isn't restored while hidden.
- **Activity icons ordered by importance.** Left-dock tabs are reordered via the existing `IActivityTab.Order` field: Datasets(10), Catalog(20), EcdisDisplay(30), LayerStack(40), Search(50), Vessels(60), Helm(70), FeatureCatalogues(80), PortrayalCatalogues(90); Settings stays pinned at the bottom (1000). No new "priority" field was needed since `Order` already serves that role.
- **No load/error text in the status bar.** Removed all `StatusText` writes from the load lifecycle: `ExchangeSetService` drops its `IStatusPresenter` dependency, `DatasetLoaderService` loses its `StatusChanged` event and scrub feedback, and the corresponding wiring in `MainWindow.axaml.cs` / `MainViewModel` is gone. The status bar is now reserved for pick results, tool summaries, and MCP status.
- **All notifications via toasts.** Removed the exchange-set map overlay banner (XAML + VM members + dismiss command); load outcomes (success / partial / error) now surface exclusively through the ShadUI toast service.

The bespoke centered exchange-set **progress overlay** (determinate bar + per-cell counter + Cancel) was deliberately kept: it's an active-operation indicator with cancellation, not an after-the-fact notification. Whether ShadUI toasts could host it is captured for later in #269 (deferred until after this PR).

Also dropped 6 now-orphaned localization strings and cleaned up test doubles for the removed APIs.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a viewer/UX change only; no S-100 product-spec semantics are touched.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added `AisOverlayVisibilitySourceTests` (visibility seeding, live toggle, dispose-unsubscribe), rewrote the exchange-set banner tests around the new clear-state behavior, and converted the OpenRecent missing-file test to assert a warning toast instead of status text. Viewer test suite: 833 passed, 1 skipped.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Updated `src/EncDotNet.S100.Viewer/README.md` to note the Vessels panel is shown only while the AIS overlay is enabled.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No dependency changes.

## Breaking changes

None for end users. Internal-only API removals: `IDatasetLoaderService.StatusChanged` event and `MainViewModel` exchange-set banner members (`IsExchangeSetBannerVisible`, `ExchangeSetBannerMessage`, `DismissExchangeSetBannerCommand`).