### PR TITLE
Migrate viewer to Avalonia 12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,11 +6,13 @@
 
   <ItemGroup>
     <!-- Avalonia -->
-    <PackageVersion Include="Avalonia" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
+    <PackageVersion Include="Avalonia" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <!-- DevTools support; Avalonia 12 replaced the old Avalonia.Diagnostics package. -->
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
     <!-- MVVM / DI -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
@@ -30,23 +32,23 @@
     <PackageVersion Include="EncDotNet.Iso8211" Version="0.5.0" />
     <PackageVersion Include="EncDotNet.S57" Version="0.5.0" />
     <!-- Mapping / rendering -->
-    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.323" />
-    <PackageVersion Include="Mapsui" Version="5.0.2" />
-    <PackageVersion Include="Mapsui.Avalonia" Version="5.0.2" />
-    <PackageVersion Include="Mapsui.Nts" Version="5.0.2" />
-    <PackageVersion Include="Mapsui.Rendering.Skia" Version="5.0.2" />
-    <PackageVersion Include="Mapsui.Tiling" Version="5.0.2" />
+    <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.328" />
+    <PackageVersion Include="Mapsui" Version="5.1.0" />
+    <PackageVersion Include="Mapsui.Avalonia12" Version="5.1.0" />
+    <PackageVersion Include="Mapsui.Nts" Version="5.1.0" />
+    <PackageVersion Include="Mapsui.Rendering.Skia" Version="5.1.0" />
+    <PackageVersion Include="Mapsui.Tiling" Version="5.1.0" />
     <PackageVersion Include="MoonSharp" Version="2.0.0" />
     <PackageVersion Include="ProjNet" Version="2.0.0" />
     <PackageVersion Include="PureHDF" Version="2.1.2" />
-    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.4" />
-    <PackageVersion Include="ShadUI" Version="0.1.6" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-798" />
+    <PackageVersion Include="ShadUI" Version="0.2.3" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageVersion Include="Svg.Skia" Version="3.2.1" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
     <!-- Test -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -15,7 +15,7 @@ using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
 using EncDotNet.S100.Viewer.ViewModels.Activities;
 using EncDotNet.S100.Viewer.Views;
-using FluentIcons.Avalonia.Fluent;
+using FluentIcons.Avalonia;
 using FluentIcons.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -59,13 +59,13 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <PackageReference Include="Avalonia.Diagnostics">
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentIcons.Avalonia.Fluent" />
+    <PackageReference Include="FluentIcons.Avalonia" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" />
-    <PackageReference Include="Mapsui.Avalonia" />
+    <PackageReference Include="Mapsui.Avalonia12" />
     <PackageReference Include="ShadUI" />
     <PackageReference Include="Spectre.Console.Cli" />
     <PackageReference Include="Tmds.DBus.Protocol" />

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
         xmlns:mapsui="clr-namespace:Mapsui.UI.Avalonia;assembly=Mapsui.UI.Avalonia"
-        xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+        xmlns:ic="using:FluentIcons.Avalonia"
         xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
         xmlns:activities="using:EncDotNet.S100.Viewer.ViewModels.Activities"
         xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -1,7 +1,7 @@
 # EncDotNet.S100.Viewer
 
 Cross-platform desktop viewer for IHO S-100 nautical chart data,
-built on Avalonia 11 + Mapsui 5. Runs on macOS (Apple Silicon),
+built on Avalonia 12 + Mapsui 5. Runs on macOS (Apple Silicon),
 Windows, and Linux out of the box, with no native HDF5 dependencies
 and no commercial S-52 assets.
 

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Input.Platform;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.S101;

--- a/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
@@ -126,8 +126,8 @@ internal sealed class MapInteractionController
         _mapControl = mapControl;
 
         // Trackpad magnify / rotate gestures, double-tap zoom, single-tap pick.
-        mapControl.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, OnMapMagnify);
-        mapControl.AddHandler(Gestures.PointerTouchPadGestureRotateEvent, OnMapRotateGesture);
+        mapControl.AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, OnMapMagnify);
+        mapControl.AddHandler(InputElement.PointerTouchPadGestureRotateEvent, OnMapRotateGesture);
         mapControl.DoubleTapped += OnMapDoubleTapped;
         mapControl.MapTapped += OnMapTapped;
 

--- a/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
@@ -131,7 +131,7 @@ internal sealed class NativeMenuBuilder
     {
         var item = new NativeMenuItem(label)
         {
-            ToggleType = NativeMenuItemToggleType.CheckBox,
+            ToggleType = MenuItemToggleType.CheckBox,
             IsChecked = initiallyChecked,
         };
         if (gesture is not null)

--- a/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"

--- a/src/EncDotNet.S100.Viewer/Views/FeatureCataloguesView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeatureCataloguesView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              x:Class="EncDotNet.S100.Viewer.Views.FeatureCataloguesView"

--- a/src/EncDotNet.S100.Viewer/Views/FeatureSearchView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeatureSearchView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              x:Class="EncDotNet.S100.Viewer.Views.FeatureSearchView"
@@ -18,7 +18,7 @@
                 <TextBox Grid.Column="0"
                          x:Name="SearchBox"
                          Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         Watermark="{x:Static loc:Strings.Search_Placeholder}"
+                         PlaceholderText="{x:Static loc:Strings.Search_Placeholder}"
                          VerticalContentAlignment="Center"
                          Padding="8,4" />
                 <Button Grid.Column="1"

--- a/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              x:Class="EncDotNet.S100.Viewer.Views.LayerStackView"

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"

--- a/src/EncDotNet.S100.Viewer/Views/PortrayalCataloguesView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PortrayalCataloguesView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              x:Class="EncDotNet.S100.Viewer.Views.PortrayalCataloguesView"

--- a/src/EncDotNet.S100.Viewer/Views/TimelineView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/TimelineView.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              x:Class="EncDotNet.S100.Viewer.Views.TimelineView"
              x:DataType="vm:TimelineViewModel">
 

--- a/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:conv="using:EncDotNet.S100.Viewer"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"

--- a/tests/EncDotNet.S100.Viewer.Tests/ActivityTabVisibilityTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ActivityTabVisibilityTests.cs
@@ -54,7 +54,7 @@ public sealed class ActivityTabVisibilityTests
     }
 
     [Fact]
-    public void VisibilityChanged_RaisesPropertyChanged()
+    public void VisibilityChanged_RaisesPropertyChanged() => HeadlessTest.Run(() =>
     {
         var source = new FakeVisibility(initial: false);
         using var tab = CreateTab(source);
@@ -69,7 +69,7 @@ public sealed class ActivityTabVisibilityTests
 
         Assert.True(tab.IsVisible);
         Assert.Equal(1, raised);
-    }
+    });
 
     [Fact]
     public void Dispose_UnsubscribesFromVisibilitySource()

--- a/tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj
+++ b/tests/EncDotNet.S100.Viewer.Tests/EncDotNet.S100.Viewer.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Avalonia.Headless" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/EncDotNet.S100.Viewer.Tests/HeadlessTest.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/HeadlessTest.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using Avalonia.Headless;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Runs a test body on the Avalonia headless dispatcher thread.
+/// <para>
+/// Avalonia 12 reworked the dispatcher so
+/// <see cref="Avalonia.Threading.Dispatcher.UIThread"/> is bound to a single
+/// thread and only pumped there. View models that marshal work via
+/// <c>Dispatcher.UIThread</c> (e.g. <c>LayerStackViewModel</c> rebuilding in
+/// response to events) therefore need a real, pumped dispatcher to observe
+/// the result synchronously. This helper dispatches the body onto the
+/// headless session's UI thread, where <c>CheckAccess()</c> is <c>true</c>.
+/// </para>
+/// <para>
+/// We use the base <c>Avalonia.Headless</c> session API rather than
+/// <c>Avalonia.Headless.XUnit</c>'s <c>[AvaloniaFact]</c> because that
+/// package targets xunit v3 while this test suite uses xunit v2.
+/// </para>
+/// </summary>
+internal static class HeadlessTest
+{
+    public static void Run(Action body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        var session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessTest).Assembly);
+        session.Dispatch(body, CancellationToken.None).GetAwaiter().GetResult();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LayerStackViewModelTests.cs
@@ -74,7 +74,7 @@ public class LayerStackViewModelTests
     }
 
     [Fact]
-    public void LayerStackChanged_TriggersRebuild()
+    public void LayerStackChanged_TriggersRebuild() => HeadlessTest.Run(() =>
     {
         var loader = new ControllableLoader();
         var vm = new LayerStackViewModel(loader);
@@ -85,10 +85,10 @@ public class LayerStackViewModelTests
 
         Assert.Single(vm.Planes);
         Assert.Equal(S98DisplayPlane.BaseChartUnder, vm.Planes[0].Plane);
-    }
+    });
 
     [Fact]
-    public void ExpansionState_PreservedAcrossRebuild()
+    public void ExpansionState_PreservedAcrossRebuild() => HeadlessTest.Run(() =>
     {
         var loader = new ControllableLoader();
         loader.SetEntries(Entry("a.000", S98DisplayPlane.BaseChartUnder, 10));
@@ -106,7 +106,7 @@ public class LayerStackViewModelTests
         var rebuilt = Assert.Single(vm.Planes);
         Assert.False(rebuilt.IsExpanded);
         Assert.Equal(2, rebuilt.Children.Count);
-    }
+    });
 
     [Fact]
     public void IsActive_TogglesViaLoader()

--- a/tests/EncDotNet.S100.Viewer.Tests/TestAppBuilder.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/TestAppBuilder.cs
@@ -3,6 +3,9 @@ using Avalonia.Headless;
 using EncDotNet.S100.Viewer.Tests;
 
 [assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+// Avalonia headless uses a process-global session that is not parallel-safe; serializing
+// the assembly avoids dispatcher/thread-pool contention that destabilizes timing-sensitive CI tests.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]
 
 namespace EncDotNet.S100.Viewer.Tests;
 

--- a/tests/EncDotNet.S100.Viewer.Tests/TestAppBuilder.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/TestAppBuilder.cs
@@ -1,0 +1,22 @@
+using Avalonia;
+using Avalonia.Headless;
+using EncDotNet.S100.Viewer.Tests;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Minimal headless Avalonia application used by <c>[AvaloniaFact]</c>
+/// tests. Avalonia 12's dispatcher rework means
+/// <see cref="Avalonia.Threading.Dispatcher.UIThread"/> is only marshaled
+/// (and pumped) on a real dispatcher thread; view-model tests that exercise
+/// the <c>Dispatcher.UIThread</c> path therefore run under the headless
+/// platform so the dispatcher is available and pumped per test.
+/// </summary>
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<Application>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewModels/LayerStackViewModelDynamicSourceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewModels/LayerStackViewModelDynamicSourceTests.cs
@@ -63,7 +63,7 @@ public class LayerStackViewModelDynamicSourceTests
     }
 
     [Fact]
-    public void SourcesChanged_TriggersRebuild_AddingNewRow()
+    public void SourcesChanged_TriggersRebuild_AddingNewRow() => HeadlessTest.Run(() =>
     {
         var loader = new ControllableLoader();
         var registry = new FakeRegistry();
@@ -75,10 +75,10 @@ public class LayerStackViewModelDynamicSourceTests
 
         var plane = vm.Planes.Single(p => p.Plane == S98DisplayPlane.DynamicArrows);
         Assert.Single(plane.Children.OfType<LayerStackDynamicEntryViewModel>());
-    }
+    });
 
     [Fact]
-    public void SourcesChanged_TriggersRebuild_RemovingRow()
+    public void SourcesChanged_TriggersRebuild_RemovingRow() => HeadlessTest.Run(() =>
     {
         var loader = new ControllableLoader();
         var registry = new FakeRegistry();
@@ -88,7 +88,7 @@ public class LayerStackViewModelDynamicSourceTests
         registry.RemoveAt(0);
 
         Assert.DoesNotContain(vm.Planes, p => p.Plane == S98DisplayPlane.DynamicArrows);
-    }
+    });
 
     [Fact]
     public void MixedPlane_DatasetAndDynamicRowsCoexist_DatasetsFirst()


### PR DESCRIPTION
Closes #17.

Mapsui 5.1.0 now ships an Avalonia 12 variant (`Mapsui.Avalonia12`), unblocking the upgrade from Avalonia 11.3.10 → 12.0.4.

## Package changes (`Directory.Packages.props`)
- **Avalonia\*** 11.3.10 → 12.0.4
- **Avalonia.Diagnostics** removed; **AvaloniaUI.DiagnosticsSupport** 2.2.2 added (debug-only) — Avalonia 12 dropped the old diagnostics package
- **Mapsui\*** 5.0.2 → 5.1.0; **Mapsui.Avalonia** → **Mapsui.Avalonia12** (the Avalonia 12 variant)
- **FluentIcons.Avalonia.Fluent** 2.0.323 → **FluentIcons.Avalonia** 2.1.328 — the non-Fluent package targets Avalonia 12 directly and drops the FluentAvalonia dependency entirely, while still exposing the same `<FluentIcon Icon= IconVariant= FontSize=>` control
- **ShadUI** 0.1.6 → 0.2.3 (Avalonia 12 line)
- **LiveChartsCore.SkiaSharpView.Avalonia** 2.0.4 → 2.1.0-dev-798 (only Avalonia 12 build available)
- **SkiaSharp\*** 3.119.1 → 3.119.4; **Tmds.DBus.Protocol** 0.21.3 → 0.92.0

## Code changes (Avalonia 12 breaking changes)
- `IClipboard.SetTextAsync` is now an extension (`Avalonia.Input.Platform`)
- Gesture routed events re-exposed on `InputElement` (`PointerTouchPadGestureMagnifyEvent`/`RotateEvent`)
- `NativeMenuItemToggleType` → `MenuItemToggleType`
- `TextBox` `Watermark` → `PlaceholderText`
- FluentIcons namespace migration across XAML + code-behind

## Tests
- Added headless test infra (`Avalonia.Headless`, `TestAppBuilder`, `HeadlessTest`) so dispatcher-marshaled view-model tests run on a pumped UI thread. Avalonia 12's dispatcher rework binds `Dispatcher.UIThread` to a single thread, so `CheckAccess()` returns false on xunit pool threads — the affected tests now dispatch their bodies onto the headless UI thread.

## Verification
- `dotnet build` clean (no AVLN/obsolete warnings introduced)
- `dotnet test --configuration Release` green across the full solution
- Headless smoke test confirms the full App (DI, OpenTelemetry, ShadUI `ShadTheme`, `MainWindow` XAML) initializes without runtime error — clearing the ShadUI 0.2.x runtime risk that a build alone can't catch