### PR TITLE
Confine map overlays to the map panel

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -355,7 +355,14 @@
                                    bh:CollapsibleRow.MinHeightWhenVisible="100"
                                    bh:CollapsibleRow.SavedHeight="{Binding BottomDockSavedHeight, Mode=TwoWay}" />
                 </Grid.RowDefinitions>
-                <Grid Grid.Row="0" DragDrop.AllowDrop="True">
+                <!--
+                    ClipToBounds keeps the map overlays (scale bar, pick/
+                    measure/zoom buttons, compass rose) confined to the map
+                    row. Without it, the top-anchored overlay stack overflows
+                    downward into the timeline / bottom dock when the map row
+                    shrinks.
+                -->
+                <Grid Grid.Row="0" DragDrop.AllowDrop="True" ClipToBounds="True">
                 <diag:InstrumentedMapControl x:Name="MapControl" />
                 <diag:GpuAccelerationProbe />
                 <views:ScaleBarView x:Name="ScaleBar"


### PR DESCRIPTION
## Summary

Map overlay controls (the scale bar, pick/measure/zoom buttons, and compass rose) could paint on top of the timeline / bottom dock panel when the timeline was expanded large enough to shrink the map row. This was visually confusing because controls that belong to the map were bleeding into an unrelated panel.

The overlay controls live in a top-anchored `StackPanel` inside the map row (`Grid.Row="0"`). An Avalonia `Grid` does not clip its children, so as the bottom dock grew and the map row shrank, the overlay stack overflowed downward past the map bounds and rendered over the timeline.

The fix sets `ClipToBounds="True"` on the inner map `Grid` so the overlays are clipped to the map panel and never spill into the timeline. One-line, layout-only change.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

Layout-only XAML change with no testable public API surface; verified manually by running the viewer and expanding the timeline panel.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

N/A — no API or documented behaviour change.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.