### PR TITLE
Add consistent empty-state placeholders across viewer panels

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -330,7 +330,9 @@
                     </Border>
 
                     <!-- Pane content: resolved by ActivityTabViewTemplate from the selected tab. -->
-                    <ContentControl Content="{Binding SelectedLeftTab}" />
+                    <ContentControl Content="{Binding SelectedLeftTab}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch" />
                 </DockPanel>
             </Border>
 
@@ -657,7 +659,7 @@
                         IsVisible="{Binding IsBottomDockOpen}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top"
-                                Padding="12,6,8,6">
+                                Padding="12,3,8,3">
                             <Grid ColumnDefinitions="*,Auto">
                                 <TextBlock Grid.Column="0"
                                            Text="{Binding BottomDockTitle}"
@@ -667,6 +669,12 @@
                                            VerticalAlignment="Center" />
                                 <Button Grid.Column="1"
                                         Classes="Icon"
+                                        Width="20"
+                                        Height="20"
+                                        MinWidth="0"
+                                        MinHeight="0"
+                                        Padding="0"
+                                        VerticalAlignment="Center"
                                         Command="{Binding CloseDockCommand}"
                                         CommandParameter="Bottom"
                                         ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseTimelinePanel}">
@@ -674,7 +682,9 @@
                                 </Button>
                             </Grid>
                         </Border>
-                        <ContentControl Content="{Binding SelectedBottomTab}" />
+                        <ContentControl Content="{Binding SelectedBottomTab}"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Stretch" />
                     </DockPanel>
                 </Border>
             </Grid>
@@ -699,7 +709,7 @@
                     IsVisible="{Binding IsRightDockOpen}">
                 <DockPanel>
                     <Border DockPanel.Dock="Top"
-                            Padding="12,6,8,6">
+                            Padding="12,3,8,3">
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Grid.Column="0"
                                        Text="{Binding RightDockTitle}"
@@ -709,6 +719,12 @@
                                        VerticalAlignment="Center" />
                             <Button Grid.Column="1"
                                     Classes="Icon"
+                                    Width="20"
+                                    Height="20"
+                                    MinWidth="0"
+                                    MinHeight="0"
+                                    Padding="0"
+                                    VerticalAlignment="Center"
                                     Command="{Binding CloseDockCommand}"
                                     CommandParameter="Right"
                                     ToolTip.Tip="{x:Static loc:Strings.Tooltip_ClosePickPanel}">
@@ -716,7 +732,9 @@
                             </Button>
                         </Grid>
                     </Border>
-                    <ContentControl Content="{Binding SelectedRightTab}" />
+                    <ContentControl Content="{Binding SelectedRightTab}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch" />
                 </DockPanel>
             </Border>
         </Grid>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -73,6 +73,8 @@ internal static class Strings
     public static string LayerStack_PanelTitle => Get(nameof(LayerStack_PanelTitle));
     public static string LayerStack_ShowEmptyPlanes => Get(nameof(LayerStack_ShowEmptyPlanes));
     public static string LayerStack_EmptyPlane_Placeholder => Get(nameof(LayerStack_EmptyPlane_Placeholder));
+    public static string LayerStack_EmptyTitle => Get(nameof(LayerStack_EmptyTitle));
+    public static string LayerStack_EmptyDescription => Get(nameof(LayerStack_EmptyDescription));
     public static string LayerStack_ActiveTooltip => Get(nameof(LayerStack_ActiveTooltip));
     public static string LayerStack_DynamicEntry_VisibilityTooltip => Get(nameof(LayerStack_DynamicEntry_VisibilityTooltip));
     public static string LayerStack_VisibilityVsActive_HelpText => Get(nameof(LayerStack_VisibilityVsActive_HelpText));
@@ -90,7 +92,10 @@ internal static class Strings
 
     // Search
     public static string Search_Placeholder => Get(nameof(Search_Placeholder));
-    public static string Search_NoResults => Get(nameof(Search_NoResults));
+    public static string Search_EmptyTitle => Get(nameof(Search_EmptyTitle));
+    public static string Search_EmptyDescription => Get(nameof(Search_EmptyDescription));
+    public static string Search_NoResultsTitle => Get(nameof(Search_NoResultsTitle));
+    public static string Search_NoResultsDescription => Get(nameof(Search_NoResultsDescription));
     public static string Search_ResultsFooter => Get(nameof(Search_ResultsFooter));
     public static string Search_TruncatedFooter => Get(nameof(Search_TruncatedFooter));
 
@@ -155,6 +160,9 @@ internal static class Strings
 
     // Buttons / actions
     public static string Button_OpenDataset => Get(nameof(Button_OpenDataset));
+    public static string Datasets_EmptyTitle => Get(nameof(Datasets_EmptyTitle));
+    public static string Datasets_EmptyDescription => Get(nameof(Datasets_EmptyDescription));
+    public static string Tooltip_AddDataset => Get(nameof(Tooltip_AddDataset));
     public static string Button_AddFeatureCatalogue => Get(nameof(Button_AddFeatureCatalogue));
     public static string Button_AddPortrayalCatalogue => Get(nameof(Button_AddPortrayalCatalogue));
 
@@ -185,7 +193,8 @@ internal static class Strings
     public static string Catalogue_BuiltInLabel => Get(nameof(Catalogue_BuiltInLabel));
 
     // Catalog (S-128) panel
-    public static string Catalog_EmptyMessage => Get(nameof(Catalog_EmptyMessage));
+    public static string Catalog_EmptyTitle => Get(nameof(Catalog_EmptyTitle));
+    public static string Catalog_EmptyDescription => Get(nameof(Catalog_EmptyDescription));
     public static string Catalog_SelectEntryPlaceholder => Get(nameof(Catalog_SelectEntryPlaceholder));
     public static string Catalog_NotForNavigation => Get(nameof(Catalog_NotForNavigation));
     public static string Catalog_Field_Spec => Get(nameof(Catalog_Field_Spec));
@@ -200,7 +209,8 @@ internal static class Strings
 
     // Pick (Object Information) panel
     public static string Pick_PanelTitle => Get(nameof(Pick_PanelTitle));
-    public static string PickReport_EmptyState => Get(nameof(PickReport_EmptyState));
+    public static string PickReport_EmptyTitle => Get(nameof(PickReport_EmptyTitle));
+    public static string PickReport_EmptyDescription => Get(nameof(PickReport_EmptyDescription));
     public static string Pick_IdLabel => Get(nameof(Pick_IdLabel));
     public static string Pick_SpecFormat => Get(nameof(Pick_SpecFormat));
     public static string Pick_SourceFormat => Get(nameof(Pick_SourceFormat));
@@ -349,7 +359,8 @@ internal static class Strings
     public static string Tooltip_ResetOverrides => Get(nameof(Tooltip_ResetOverrides));
     public static string Button_ResetAllOverrides => Get(nameof(Button_ResetAllOverrides));
     public static string Tooltip_ResetAllOverrides => Get(nameof(Tooltip_ResetAllOverrides));
-    public static string EcdisPanel_NoSpecs => Get(nameof(EcdisPanel_NoSpecs));
+    public static string EcdisPanel_NoSpecsTitle => Get(nameof(EcdisPanel_NoSpecsTitle));
+    public static string EcdisPanel_NoSpecsDescription => Get(nameof(EcdisPanel_NoSpecsDescription));
     public static string EcdisPanel_OverrideCountFormat => Get(nameof(EcdisPanel_OverrideCountFormat));
     public static string EcdisPanel_CategoryHeader => Get(nameof(EcdisPanel_CategoryHeader));
     public static string EcdisPanel_SynthesizedLabelFormat => Get(nameof(EcdisPanel_SynthesizedLabelFormat));
@@ -473,8 +484,10 @@ internal static class Strings
     public static string Tooltip_Vessels => Get(nameof(Tooltip_Vessels));
     public static string Tooltip_VesselRow => Get(nameof(Tooltip_VesselRow));
     public static string Tooltip_OwnShipRow => Get(nameof(Tooltip_OwnShipRow));
-    public static string Vessels_Empty_Disabled => Get(nameof(Vessels_Empty_Disabled));
-    public static string Vessels_Empty_NoData => Get(nameof(Vessels_Empty_NoData));
+    public static string Vessels_Empty_DisabledTitle => Get(nameof(Vessels_Empty_DisabledTitle));
+    public static string Vessels_Empty_DisabledDescription => Get(nameof(Vessels_Empty_DisabledDescription));
+    public static string Vessels_Empty_NoDataTitle => Get(nameof(Vessels_Empty_NoDataTitle));
+    public static string Vessels_Empty_NoDataDescription => Get(nameof(Vessels_Empty_NoDataDescription));
     public static string Vessels_Unnamed => Get(nameof(Vessels_Unnamed));
     public static string Vessels_OwnShip_Name => Get(nameof(Vessels_OwnShip_Name));
     public static string Vessels_OwnShip_HelmingFormat => Get(nameof(Vessels_OwnShip_HelmingFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -56,6 +56,12 @@
   <data name="LayerStack_EmptyPlane_Placeholder" xml:space="preserve">
     <value>No datasets loaded.</value>
   </data>
+  <data name="LayerStack_EmptyTitle" xml:space="preserve">
+    <value>No datasets loaded</value>
+  </data>
+  <data name="LayerStack_EmptyDescription" xml:space="preserve">
+    <value>Open a dataset to populate the layer stack here.</value>
+  </data>
   <data name="LayerStack_ActiveTooltip" xml:space="preserve">
     <value>Active — when off, this dataset is removed from the cross-product paint stack and no longer influences S-98 interoperability rules or pick. Distinct from the per-dataset Visibility toggle on the Datasets panel.</value>
   </data>
@@ -106,8 +112,17 @@
   <data name="Search_Placeholder" xml:space="preserve">
     <value>Search features by ID, type, or dataset…</value>
   </data>
-  <data name="Search_NoResults" xml:space="preserve">
-    <value>No matching features.</value>
+  <data name="Search_EmptyTitle" xml:space="preserve">
+    <value>Search features</value>
+  </data>
+  <data name="Search_EmptyDescription" xml:space="preserve">
+    <value>Find features by ID, type, or dataset across the loaded datasets.</value>
+  </data>
+  <data name="Search_NoResultsTitle" xml:space="preserve">
+    <value>No matching features</value>
+  </data>
+  <data name="Search_NoResultsDescription" xml:space="preserve">
+    <value>Try a different ID, feature type, or dataset name.</value>
   </data>
   <data name="Search_ResultsFooter" xml:space="preserve">
     <value>{0} matching features.</value>
@@ -329,6 +344,15 @@
   <data name="Button_OpenDataset" xml:space="preserve">
     <value>Open Dataset...</value>
   </data>
+  <data name="Datasets_EmptyTitle" xml:space="preserve">
+    <value>No datasets loaded</value>
+  </data>
+  <data name="Datasets_EmptyDescription" xml:space="preserve">
+    <value>Open an S-100 dataset or exchange set, or drag one onto the window, to get started.</value>
+  </data>
+  <data name="Tooltip_AddDataset" xml:space="preserve">
+    <value>Open a dataset</value>
+  </data>
   <data name="Button_AddFeatureCatalogue" xml:space="preserve">
     <value>Add Feature Catalogue...</value>
   </data>
@@ -451,9 +475,11 @@
   </data>
 
   <!-- Catalog (S-128) panel -->
-  <data name="Catalog_EmptyMessage" xml:space="preserve">
-    <value>No catalogues found.
-Open an S-128 dataset to populate this panel.</value>
+  <data name="Catalog_EmptyTitle" xml:space="preserve">
+    <value>No catalogues found</value>
+  </data>
+  <data name="Catalog_EmptyDescription" xml:space="preserve">
+    <value>Open an S-128 dataset to populate this panel.</value>
   </data>
   <data name="Catalog_SelectEntryPlaceholder" xml:space="preserve">
     <value>Select a catalogue entry to view its properties.</value>
@@ -493,8 +519,11 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Pick_PanelTitle" xml:space="preserve">
     <value>OBJECT INFORMATION</value>
   </data>
-  <data name="PickReport_EmptyState" xml:space="preserve">
-    <value>No feature picked. Use Pick mode and click a feature on the map.</value>
+  <data name="PickReport_EmptyTitle" xml:space="preserve">
+    <value>No feature picked</value>
+  </data>
+  <data name="PickReport_EmptyDescription" xml:space="preserve">
+    <value>Use Pick mode and click a feature on the map.</value>
   </data>
   <data name="Pick_IdLabel" xml:space="preserve">
     <value>ID:</value>
@@ -884,7 +913,7 @@ Open an S-128 dataset to populate this panel.</value>
     <value>No time-varying datasets</value>
   </data>
   <data name="TimelinePanel_EmptyDescription" xml:space="preserve">
-    <value>Open an S-104 (water level), S-111 (surface currents) or S-411 (sea ice) dataset to see its timeline here.</value>
+    <value>Open an S-104, S-111 or S-411 dataset to see its timeline.</value>
   </data>
 
   <!-- Tooltips for status bar elements -->
@@ -930,9 +959,11 @@ Open an S-128 dataset to populate this panel.</value>
   <data name="Tooltip_ResetAllOverrides" xml:space="preserve">
     <value>Clear all viewing-group overrides across every spec</value>
   </data>
-  <data name="EcdisPanel_NoSpecs" xml:space="preserve">
-    <value>No vector datasets loaded.
-Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls here.</value>
+  <data name="EcdisPanel_NoSpecsTitle" xml:space="preserve">
+    <value>No vector datasets loaded</value>
+  </data>
+  <data name="EcdisPanel_NoSpecsDescription" xml:space="preserve">
+    <value>Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls here.</value>
   </data>
   <data name="EcdisPanel_OverrideCountFormat" xml:space="preserve">
     <value>{0} overrides</value>
@@ -1281,10 +1312,16 @@ Open an S-101, S-124, S-125, S-201, or S-421 dataset to see display controls her
   <data name="Tooltip_VesselRow" xml:space="preserve">
     <value>Select to centre the map on this vessel.</value>
   </data>
-  <data name="Vessels_Empty_Disabled" xml:space="preserve">
-    <value>The AIS overlay is turned off. Enable it under Settings → AIS to list nearby vessels.</value>
+  <data name="Vessels_Empty_DisabledTitle" xml:space="preserve">
+    <value>AIS overlay is off</value>
   </data>
-  <data name="Vessels_Empty_NoData" xml:space="preserve">
+  <data name="Vessels_Empty_DisabledDescription" xml:space="preserve">
+    <value>Enable it under Settings → AIS to list nearby vessels.</value>
+  </data>
+  <data name="Vessels_Empty_NoDataTitle" xml:space="preserve">
+    <value>No vessels yet</value>
+  </data>
+  <data name="Vessels_Empty_NoDataDescription" xml:space="preserve">
     <value>The AIS overlay is on but hasn't received any vessels yet. Zoom in to an area with traffic to populate the list.</value>
   </data>
   <data name="Vessels_Unnamed" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/ViewModels/CatalogPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/CatalogPanelViewModel.cs
@@ -159,8 +159,6 @@ internal sealed class CatalogPanelViewModel : ViewModelBase
 
     public bool IsEmpty => Entries.Count == 0;
 
-    public string EmptyMessage => Strings.Catalog_EmptyMessage;
-
     public CatalogPanelViewModel(IDatasetCatalogSource source)
     {
         ArgumentNullException.ThrowIfNull(source);

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -496,6 +496,13 @@ internal sealed class DatasetsViewModel : ViewModelBase
     /// of the Properties sub-panel.</summary>
     public bool HasSelection => _selectedEntry is not null;
 
+    /// <summary>
+    /// True when no datasets are loaded. Drives the Datasets panel's
+    /// empty-state placeholder and the inline "Open Dataset" prompt,
+    /// both of which are hidden once at least one dataset is present.
+    /// </summary>
+    public bool IsEmpty => Entries.Count == 0;
+
     private Action<Mapsui.MRect>? _zoomDispatcher;
     /// <summary>
     /// Routes <see cref="ValidationFindingViewModel.ZoomToFindingCommand"/>
@@ -584,6 +591,8 @@ internal sealed class DatasetsViewModel : ViewModelBase
         // for the host-side reorder logic.
         Entries.CollectionChanged += (_, e) =>
         {
+            OnPropertyChanged(nameof(IsEmpty));
+
             if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
                 _loader.SetEntryOrder(Entries.ToArray());
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/FeatureSearchViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/FeatureSearchViewModel.cs
@@ -91,6 +91,18 @@ internal sealed class FeatureSearchViewModel : ViewModelBase
 
     public ObservableCollection<FeatureSearchResultItem> Results { get; }
 
+    /// <summary>
+    /// True when the query is empty/whitespace, so the panel shows the
+    /// initial "type to search" placeholder rather than an empty list.
+    /// </summary>
+    public bool ShowEmptyPrompt => string.IsNullOrWhiteSpace(_query);
+
+    /// <summary>
+    /// True when a non-empty query returned no matches, so the panel shows
+    /// the "no matching features" placeholder.
+    /// </summary>
+    public bool ShowNoResults => !ShowEmptyPrompt && Results.Count == 0;
+
     private FeatureSearchResultItem? _selectedResult;
     /// <summary>
     /// Currently-selected row in the results list. Setter routes to
@@ -146,6 +158,8 @@ internal sealed class FeatureSearchViewModel : ViewModelBase
         {
             Summary = null;
             __cmd.SetTag("s100.viewer.search.query_length", 0);
+            OnPropertyChanged(nameof(ShowEmptyPrompt));
+            OnPropertyChanged(nameof(ShowNoResults));
             return;
         }
 
@@ -161,11 +175,16 @@ internal sealed class FeatureSearchViewModel : ViewModelBase
 
         Summary = total switch
         {
-            0 => Strings.Search_NoResults,
+            // No-results is conveyed by the centered placeholder, so the
+            // footer stays empty to avoid duplicating the message.
+            0 => null,
             _ when total > hits.Count => string.Format(
                 Strings.Search_TruncatedFooter, hits.Count, total),
             _ => string.Format(Strings.Search_ResultsFooter, total),
         };
+
+        OnPropertyChanged(nameof(ShowEmptyPrompt));
+        OnPropertyChanged(nameof(ShowNoResults));
     }
 
     private void OpenResult(FeatureSearchResultItem? item)

--- a/src/EncDotNet.S100.Viewer/ViewModels/LayerStackViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/LayerStackViewModel.cs
@@ -83,9 +83,6 @@ internal sealed class LayerStackViewModel : ViewModelBase
     /// <summary>True when no plane row is currently displayed.</summary>
     public bool IsEmpty => Planes.Count == 0;
 
-    /// <summary>Empty-state body text (S-128 PdC picker arrives in PR-L4).</summary>
-    public string EmptyMessage => Strings.LayerStack_EmptyPlane_Placeholder;
-
     /// <summary>"Active vs. Visibility" help text for the panel footer.</summary>
     public string ActiveVsVisibilityHelp => Strings.LayerStack_VisibilityVsActive_HelpText;
 

--- a/src/EncDotNet.S100.Viewer/ViewModels/VesselListViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/VesselListViewModel.cs
@@ -288,16 +288,28 @@ internal sealed class VesselListViewModel : ViewModelBase
         private set => SetProperty(ref _isEmpty, value);
     }
 
-    private string _emptyMessage = string.Empty;
+    private string _emptyTitle = string.Empty;
     /// <summary>
-    /// Placeholder text shown while <see cref="IsEmpty"/> is
-    /// <see langword="true"/>. Distinguishes the AIS overlay being
-    /// switched off from it being on but not yet populated.
+    /// Bold primary placeholder text shown while <see cref="IsEmpty"/> is
+    /// <see langword="true"/>. Distinguishes the AIS overlay being switched
+    /// off from it being on but not yet populated.
     /// </summary>
-    public string EmptyMessage
+    public string EmptyTitle
     {
-        get => _emptyMessage;
-        private set => SetProperty(ref _emptyMessage, value);
+        get => _emptyTitle;
+        private set => SetProperty(ref _emptyTitle, value);
+    }
+
+    private string _emptyDescription = string.Empty;
+    /// <summary>
+    /// Secondary descriptive placeholder text shown beneath
+    /// <see cref="EmptyTitle"/> while <see cref="IsEmpty"/> is
+    /// <see langword="true"/>.
+    /// </summary>
+    public string EmptyDescription
+    {
+        get => _emptyDescription;
+        private set => SetProperty(ref _emptyDescription, value);
     }
 
     /// <summary>
@@ -816,9 +828,12 @@ internal sealed class VesselListViewModel : ViewModelBase
         IsEmpty = empty;
         if (empty)
         {
-            EmptyMessage = IsAisActive
-                ? Strings.Vessels_Empty_NoData
-                : Strings.Vessels_Empty_Disabled;
+            EmptyTitle = IsAisActive
+                ? Strings.Vessels_Empty_NoDataTitle
+                : Strings.Vessels_Empty_DisabledTitle;
+            EmptyDescription = IsAisActive
+                ? Strings.Vessels_Empty_NoDataDescription
+                : Strings.Vessels_Empty_DisabledDescription;
         }
     }
 

--- a/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
@@ -4,6 +4,7 @@
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
              x:Class="EncDotNet.S100.Viewer.Views.CatalogPanelView"
              x:DataType="vm:CatalogPanelViewModel">
@@ -30,22 +31,10 @@
         <!-- Empty state — a completely separate tree from the populated
              state so it cannot interact with the grid star-sizing of the
              master/detail layout. -->
-        <Border IsVisible="{Binding IsEmpty}"
-                Padding="16"
-                VerticalAlignment="Center">
-            <StackPanel Spacing="8" HorizontalAlignment="Center">
-                <ic:FluentIcon Icon="Library"
-                               IconVariant="Regular"
-                               FontSize="32"
-                               Opacity="0.4"
-                               HorizontalAlignment="Center" />
-                <TextBlock Text="{Binding EmptyMessage}"
-                           TextWrapping="Wrap"
-                           TextAlignment="Center"
-                           Opacity="0.6"
-                           FontSize="12" />
-            </StackPanel>
-        </Border>
+        <views:PlaceholderView IsVisible="{Binding IsEmpty}"
+                               Icon="Library"
+                               Header="{x:Static loc:Strings.Catalog_EmptyTitle}"
+                               Description="{x:Static loc:Strings.Catalog_EmptyDescription}" />
 
         <!-- Populated state — master/detail with resizable splitter. -->
         <Grid IsVisible="{Binding !IsEmpty}">

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ic="using:FluentIcons.Avalonia"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"
@@ -164,14 +165,6 @@
     </UserControl.Styles>
 
     <DockPanel>
-        <Button DockPanel.Dock="Bottom"
-                Classes="Outline"
-                Content="{x:Static loc:Strings.Button_OpenDataset}"
-                ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenDataset}"
-                HorizontalAlignment="Stretch"
-                Margin="8"
-                x:Name="AddButton" />
-
         <!-- Exchange-set header rows: one per loaded exchange set,
              stacked above the bulk-action toolbar. Each row exposes a
              Close button that removes every dataset contributed by
@@ -260,7 +253,13 @@
         <StackPanel DockPanel.Dock="Top"
                     Orientation="Horizontal"
                     Spacing="4"
-                    Margin="8,4,8,0">
+                    Margin="8,4,8,0"
+                    IsVisible="{Binding !IsEmpty}">
+            <Button Classes="Icon"
+                    x:Name="ToolbarAddButton"
+                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_AddDataset}">
+                <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="14" />
+            </Button>
             <Button Classes="Icon"
                     Command="{Binding ShowAllCommand}"
                     ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShowAllDatasets}">
@@ -673,6 +672,29 @@
                     </TabControl>
                 </Panel>
             </Border>
+
+            <!-- Empty-state placeholder: shown in the master (list) row
+                 when no datasets are loaded, centered within that area so
+                 it doesn't drift over the Properties sub-panel below.
+                 Declared after the list so it sits above the (otherwise
+                 transparent) ListBox, keeping the inline "Open Dataset"
+                 button hit-testable. The button sits directly below the
+                 placeholder and disappears once a dataset is present (the
+                 menu, the toolbar "+" and drag-and-drop remain available). -->
+            <StackPanel Grid.Row="0"
+                        IsVisible="{Binding IsEmpty}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Spacing="8">
+                <views:PlaceholderView Icon="Layer"
+                                       Header="{x:Static loc:Strings.Datasets_EmptyTitle}"
+                                       Description="{x:Static loc:Strings.Datasets_EmptyDescription}" />
+                <Button x:Name="EmptyAddButton"
+                        Classes="Outline"
+                        Content="{x:Static loc:Strings.Button_OpenDataset}"
+                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenDataset}"
+                        HorizontalAlignment="Center" />
+            </StackPanel>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
@@ -14,7 +14,8 @@ public partial class DatasetsView : UserControl
     public DatasetsView()
     {
         InitializeComponent();
-        AddButton.Click += OnAddClick;
+        EmptyAddButton.Click += OnAddClick;
+        ToolbarAddButton.Click += OnAddClick;
     }
 
     private async void OnAddClick(object? sender, RoutedEventArgs e)

--- a/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
@@ -3,17 +3,16 @@
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              x:Class="EncDotNet.S100.Viewer.Views.EcdisDisplayPanelView"
              x:DataType="vm:EcdisDisplayPanelViewModel">
 
-    <DockPanel>
-        <!-- Empty state message -->
-        <TextBlock DockPanel.Dock="Top"
-                   Text="{x:Static loc:Strings.EcdisPanel_NoSpecs}"
-                   IsVisible="{Binding IsEmpty}"
-                   Opacity="0.5"
-                   TextWrapping="Wrap"
-                   Margin="12,8" />
+    <Grid>
+        <!-- Empty state -->
+        <views:PlaceholderView IsVisible="{Binding IsEmpty}"
+                               Icon="Eye"
+                               Header="{x:Static loc:Strings.EcdisPanel_NoSpecsTitle}"
+                               Description="{x:Static loc:Strings.EcdisPanel_NoSpecsDescription}" />
 
         <ScrollViewer IsVisible="{Binding !IsEmpty}">
             <StackPanel Spacing="12" Margin="12,4,12,12">
@@ -116,5 +115,5 @@
                 </ItemsControl>
             </StackPanel>
         </ScrollViewer>
-    </DockPanel>
+    </Grid>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/FeatureSearchView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeatureSearchView.axaml
@@ -3,6 +3,7 @@
              xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              x:Class="EncDotNet.S100.Viewer.Views.FeatureSearchView"
              x:DataType="vm:FeatureSearchViewModel">
 
@@ -42,8 +43,23 @@
                        TextWrapping="Wrap" />
         </Border>
 
-        <!-- Results list -->
-        <ListBox ItemsSource="{Binding Results}"
+        <!-- Results list (with empty-state placeholders sharing the fill
+             slot so they centre in the available space). -->
+        <Grid>
+            <!-- Initial prompt: no query entered yet. -->
+            <views:PlaceholderView IsVisible="{Binding ShowEmptyPrompt}"
+                                   Icon="Search"
+                                   Header="{x:Static loc:Strings.Search_EmptyTitle}"
+                                   Description="{x:Static loc:Strings.Search_EmptyDescription}" />
+
+            <!-- No matches for a non-empty query. -->
+            <views:PlaceholderView IsVisible="{Binding ShowNoResults}"
+                                   Icon="SearchInfo"
+                                   Header="{x:Static loc:Strings.Search_NoResultsTitle}"
+                                   Description="{x:Static loc:Strings.Search_NoResultsDescription}" />
+
+            <!-- Results list -->
+            <ListBox ItemsSource="{Binding Results}"
                  SelectedItem="{Binding SelectedResult, Mode=TwoWay}"
                  SelectionMode="Single"
                  BorderThickness="0"
@@ -115,6 +131,7 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
+        </Grid>
     </DockPanel>
 
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/LayerStackView.axaml
@@ -1,8 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              x:Class="EncDotNet.S100.Viewer.Views.LayerStackView"
              x:DataType="vm:LayerStackViewModel">
 
@@ -35,24 +35,10 @@
         <Grid>
 
         <!-- Empty state -->
-        <Border IsVisible="{Binding IsEmpty}"
-                Padding="16"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center">
-            <StackPanel Spacing="8" HorizontalAlignment="Center">
-                <ic:FluentIcon Icon="Stack"
-                               IconVariant="Regular"
-                               FontSize="32"
-                               Opacity="0.4"
-                               HorizontalAlignment="Center" />
-                <TextBlock Text="{Binding EmptyMessage}"
-                           TextWrapping="Wrap"
-                           TextAlignment="Center"
-                           Opacity="0.6"
-                           FontSize="12" />
-                <!-- TODO PR-L4 (TBD-7): PdC picker UX -->
-            </StackPanel>
-        </Border>
+        <views:PlaceholderView IsVisible="{Binding IsEmpty}"
+                               Icon="Stack"
+                               Header="{x:Static loc:Strings.LayerStack_EmptyTitle}"
+                               Description="{x:Static loc:Strings.LayerStack_EmptyDescription}" />
 
         <!-- Populated state: tree of planes, each with a list of entries. -->
         <ScrollViewer IsVisible="{Binding !IsEmpty}"

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ic="using:FluentIcons.Avalonia"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
@@ -18,24 +18,10 @@
     -->
     <Grid>
         <!-- Empty-state watermark, visible when no feature is picked. -->
-        <Border IsVisible="{Binding !HasPick}"
-                Padding="24">
-            <StackPanel HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Spacing="12">
-                <ic:FluentIcon Icon="Cursor"
-                               IconVariant="Regular"
-                               FontSize="40"
-                               Opacity="0.4"
-                               HorizontalAlignment="Center" />
-                <TextBlock Text="{x:Static loc:Strings.PickReport_EmptyState}"
-                           TextWrapping="Wrap"
-                           TextAlignment="Center"
-                           FontSize="12"
-                           Opacity="0.65"
-                           MaxWidth="240" />
-            </StackPanel>
-        </Border>
+        <views:PlaceholderView IsVisible="{Binding !HasPick}"
+                               Icon="Cursor"
+                               Header="{x:Static loc:Strings.PickReport_EmptyTitle}"
+                               Description="{x:Static loc:Strings.PickReport_EmptyDescription}" />
 
         <DockPanel IsVisible="{Binding HasPick}">
         <!--

--- a/src/EncDotNet.S100.Viewer/Views/PlaceholderView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PlaceholderView.axaml
@@ -1,0 +1,61 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ic="using:FluentIcons.Avalonia"
+             x:Class="EncDotNet.S100.Viewer.Views.PlaceholderView"
+             x:Name="Root">
+
+    <!--
+      Shared empty-state placeholder used by every panel that can be empty,
+      so the "nothing here yet" UX is identical across the viewer: a centered
+      icon, a bold primary message, and an optional descriptive secondary
+      line. Modeled on the Timeline empty state. Consumers set Icon, Header
+      and (optionally) Description; the panel decides when to show it via the
+      usual IsVisible binding.
+
+      The content is vertically centered when the host has room, and the whole
+      thing is wrapped in a ScrollViewer so it never clips: in a short host
+      (e.g. the timeline dock at its minimum height) the panel scrolls instead.
+
+      The centre-or-scroll behaviour comes from the inner Panel's MinHeight,
+      bound to the ScrollViewer's own Bounds.Height (NOT Viewport.Height, whose
+      sub-path change-notification is unreliable in Avalonia 12). The Panel is
+      therefore always at least as tall as the viewport, so the centred content
+      sits in the middle; when the content's natural height exceeds the
+      viewport the Panel grows past it and the ScrollViewer scrolls. The
+      ScrollViewer Padding is 0 so MinHeight matches the viewport exactly and no
+      phantom scrollbar appears.
+    -->
+    <ScrollViewer x:Name="Scroll"
+                  Padding="0"
+                  HorizontalScrollBarVisibility="Disabled"
+                  VerticalScrollBarVisibility="Auto">
+        <Panel MinHeight="{Binding #Scroll.Bounds.Height}">
+        <StackPanel Spacing="6"
+                    Margin="12,16"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    MaxWidth="280">
+            <ic:FluentIcon Icon="{Binding #Root.Icon}"
+                           IconVariant="Regular"
+                           FontSize="28"
+                           Opacity="0.45"
+                           HorizontalAlignment="Center" />
+            <TextBlock Text="{Binding #Root.Header}"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       Opacity="0.7"
+                       HorizontalAlignment="Center"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap" />
+            <TextBlock Text="{Binding #Root.Description}"
+                       FontSize="11"
+                       Opacity="0.55"
+                       HorizontalAlignment="Center"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap"
+                       IsVisible="{Binding #Root.Description,
+                                   Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+        </StackPanel>
+        </Panel>
+    </ScrollViewer>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/PlaceholderView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/PlaceholderView.axaml.cs
@@ -1,0 +1,75 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using IconSymbol = FluentIcons.Common.Icon;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// Reusable empty-state placeholder presenting a centered icon, a bold
+/// primary <see cref="Header"/> message, and an optional secondary
+/// <see cref="Description"/> line. Provides one consistent "nothing here
+/// yet" treatment for every panel in the viewer that can be empty (datasets,
+/// catalogues, display controls, search, timeline, vessels, layer stack,
+/// pick report). Each panel passes the same icon it shows in the activity
+/// bar so the empty state reads as that panel.
+/// </summary>
+public partial class PlaceholderView : UserControl
+{
+    /// <summary>
+    /// The Fluent icon shown above the message. Uses the same
+    /// <see cref="FluentIcons.Common.Icon"/> enum as
+    /// <see cref="FluentIcons.Avalonia.FluentIcon"/> so callers can reuse
+    /// their activity-bar icon (e.g. <c>Icon="Clock"</c>).
+    /// </summary>
+    public static readonly StyledProperty<IconSymbol> IconProperty =
+        AvaloniaProperty.Register<PlaceholderView, IconSymbol>(nameof(Icon));
+
+    /// <summary>
+    /// The bold primary message describing the empty state.
+    /// </summary>
+    public static readonly StyledProperty<string?> HeaderProperty =
+        AvaloniaProperty.Register<PlaceholderView, string?>(nameof(Header));
+
+    /// <summary>
+    /// Optional secondary descriptive text. The line is hidden when this is
+    /// null or empty.
+    /// </summary>
+    public static readonly StyledProperty<string?> DescriptionProperty =
+        AvaloniaProperty.Register<PlaceholderView, string?>(nameof(Description));
+
+    /// <summary>
+    /// The Fluent icon shown above the message.
+    /// </summary>
+    public IconSymbol Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    /// <summary>
+    /// The bold primary message describing the empty state.
+    /// </summary>
+    public string? Header
+    {
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    /// <summary>
+    /// Optional secondary descriptive text. The line is hidden when this is
+    /// null or empty.
+    /// </summary>
+    public string? Description
+    {
+        get => GetValue(DescriptionProperty);
+        set => SetValue(DescriptionProperty, value);
+    }
+
+    public PlaceholderView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}

--- a/src/EncDotNet.S100.Viewer/Views/TimelineView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/TimelineView.axaml
@@ -16,33 +16,35 @@
     </UserControl.Styles>
 
     <Border Background="{DynamicResource BackgroundColor}"
-            Padding="12,8"
+            Padding="12,2"
             VerticalAlignment="Stretch">
-        <DockPanel LastChildFill="True"
-                   VerticalAlignment="Top">
+        <Panel>
+            <!-- Active state: timeline has at least one registered dataset.
+                 The title-row readout and the slider/range body are grouped
+                 so they only reserve layout space when active. When inactive,
+                 the placeholder below fills (and centers within) the entire
+                 timeline area rather than the leftover space under a docked
+                 title row. -->
+            <DockPanel LastChildFill="True"
+                       IsVisible="{Binding IsActive}">
 
-            <!-- Title row — PR-M4: the title + close button are owned by
-                 the bottom-dock chrome bar in MainWindow. We keep the
-                 current-time readout, aligned right, when active. -->
-            <Grid DockPanel.Dock="Top"
-                  ColumnDefinitions="*,Auto"
-                  Margin="0,0,0,4">
-                <TextBlock Grid.Column="1"
-                           Text="{Binding CurrentTimeLabel}"
-                           FontSize="12"
-                           FontFamily="Menlo, Consolas, monospace"
-                           VerticalAlignment="Center"
-                           Margin="0,0,8,0"
-                           IsVisible="{Binding IsActive}" />
-            </Grid>
+                <!-- Title row — PR-M4: the title + close button are owned by
+                     the bottom-dock chrome bar in MainWindow. We keep the
+                     current-time readout, aligned right, when active. -->
+                <Grid DockPanel.Dock="Top"
+                      ColumnDefinitions="*,Auto"
+                      Margin="0,0,0,4">
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding CurrentTimeLabel}"
+                               FontSize="12"
+                               FontFamily="Menlo, Consolas, monospace"
+                               VerticalAlignment="Center"
+                               Margin="0,0,8,0" />
+                </Grid>
 
-            <!-- Body: either the slider/range (when active) or the
-                 empty-state message (when no dataset registered). -->
-            <Panel>
-                <!-- Active state: timeline has at least one registered dataset. -->
+                <!-- Body: the slider/range readout. -->
                 <DockPanel LastChildFill="False"
-                           VerticalAlignment="Top"
-                           IsVisible="{Binding IsActive}">
+                           VerticalAlignment="Top">
 
                     <!-- Slider plus prev/next step buttons grouped at the right.
                          Buttons surface only when ticks correspond to real
@@ -108,31 +110,16 @@
                                Opacity="0.6"
                                Margin="0,4,0,0" />
                 </DockPanel>
+            </DockPanel>
 
-                <!-- Empty state: timeline pane is open but no time-varying
-                     dataset is loaded. -->
-                <StackPanel HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Spacing="6"
-                            IsVisible="{Binding !IsActive}">
-                    <ic:FluentIcon Icon="Clock"
-                                   IconVariant="Regular"
-                                   FontSize="28"
-                                   Opacity="0.45"
-                                   HorizontalAlignment="Center" />
-                    <TextBlock Text="{x:Static loc:Strings.TimelinePanel_EmptyTitle}"
-                               FontSize="13"
-                               FontWeight="SemiBold"
-                               HorizontalAlignment="Center"
-                               Opacity="0.7" />
-                    <TextBlock Text="{x:Static loc:Strings.TimelinePanel_EmptyDescription}"
-                               FontSize="11"
-                               Opacity="0.55"
-                               HorizontalAlignment="Center"
-                               TextWrapping="Wrap" />
-                </StackPanel>
-            </Panel>
-        </DockPanel>
+            <!-- Empty state: timeline pane is open but no time-varying
+                 dataset is loaded. Fills the whole timeline area so its
+                 content is centered, not offset below the title row. -->
+            <views:PlaceholderView IsVisible="{Binding !IsActive}"
+                                   Icon="Clock"
+                                   Header="{x:Static loc:Strings.TimelinePanel_EmptyTitle}"
+                                   Description="{x:Static loc:Strings.TimelinePanel_EmptyDescription}" />
+        </Panel>
     </Border>
 </UserControl>
 

--- a/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
@@ -5,6 +5,7 @@
              xmlns:conv="using:EncDotNet.S100.Viewer"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
              xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
              x:Class="EncDotNet.S100.Viewer.Views.VesselListView"
              x:DataType="vm:VesselListViewModel">
@@ -36,23 +37,10 @@
 
             <!-- Empty state: distinguishes the AIS overlay being off from
                  it being on but not yet populated. -->
-            <Border IsVisible="{Binding IsEmpty}"
-                    Padding="16"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center">
-                <StackPanel Spacing="8" HorizontalAlignment="Center" MaxWidth="260">
-                    <ic:FluentIcon Icon="VehicleShip"
-                                   IconVariant="Regular"
-                                   FontSize="32"
-                                   Opacity="0.4"
-                                   HorizontalAlignment="Center" />
-                    <TextBlock Text="{Binding EmptyMessage}"
-                               TextWrapping="Wrap"
-                               TextAlignment="Center"
-                               Opacity="0.6"
-                               FontSize="12" />
-                </StackPanel>
-            </Border>
+            <views:PlaceholderView IsVisible="{Binding IsEmpty}"
+                                   Icon="VehicleShip"
+                                   Header="{Binding EmptyTitle}"
+                                   Description="{Binding EmptyDescription}" />
 
             <!-- Master/detail: a compact vessel list (master) over a
                  properties sub-pane (detail) for the selected vessel. -->

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
@@ -75,6 +75,29 @@ public class DatasetsViewModelTests
     }
 
     [Fact]
+    public void IsEmpty_TogglesWithEntries_AndRaisesPropertyChanged()
+    {
+        var loader = new RecordingLoader();
+        var vm = new DatasetsViewModel(loader);
+
+        Assert.True(vm.IsEmpty);
+
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        var entry = vm.Add("/tmp/sample.000", "S-101");
+
+        Assert.False(vm.IsEmpty);
+        Assert.Contains(nameof(DatasetsViewModel.IsEmpty), raised);
+
+        raised.Clear();
+        vm.Entries.Remove(entry);
+
+        Assert.True(vm.IsEmpty);
+        Assert.Contains(nameof(DatasetsViewModel.IsEmpty), raised);
+    }
+
+    [Fact]
     public void Add_InsertsAtTopOfList()
     {
         // Photoshop/QGIS convention: newest layer goes to the top of

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewModels/VesselListViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewModels/VesselListViewModelTests.cs
@@ -526,7 +526,8 @@ public class VesselListViewModelTests
         var vm = new VesselListViewModel(new IDynamicFeatureSource[] { disabled }, accessor);
 
         Assert.True(vm.IsEmpty);
-        Assert.Equal(Strings.Vessels_Empty_Disabled, vm.EmptyMessage);
+        Assert.Equal(Strings.Vessels_Empty_DisabledTitle, vm.EmptyTitle);
+        Assert.Equal(Strings.Vessels_Empty_DisabledDescription, vm.EmptyDescription);
     }
 
     [Fact]
@@ -537,7 +538,8 @@ public class VesselListViewModelTests
         var (vm, _, _, _) = Make(ownShipEnabled: false);
 
         Assert.True(vm.IsEmpty);
-        Assert.Equal(Strings.Vessels_Empty_NoData, vm.EmptyMessage);
+        Assert.Equal(Strings.Vessels_Empty_NoDataTitle, vm.EmptyTitle);
+        Assert.Equal(Strings.Vessels_Empty_NoDataDescription, vm.EmptyDescription);
     }
 
     [Fact]
@@ -552,7 +554,8 @@ public class VesselListViewModelTests
         var vm = new VesselListViewModel(new IDynamicFeatureSource[] { misc }, accessor);
 
         Assert.True(vm.IsEmpty);
-        Assert.Equal(Strings.Vessels_Empty_Disabled, vm.EmptyMessage);
+        Assert.Equal(Strings.Vessels_Empty_DisabledTitle, vm.EmptyTitle);
+        Assert.Equal(Strings.Vessels_Empty_DisabledDescription, vm.EmptyDescription);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Empty panels in the viewer previously used a mix of empty-state UX (different layouts, plain text, or nothing at all). This introduces a single reusable `PlaceholderView` control — an icon, a bold primary message, and a descriptive secondary line, modeled on the Timeline empty state — and applies it consistently to every panel that can be empty.

## Changes

- **New `PlaceholderView` control** applied to Datasets, Catalog, Layer Stack, ECDIS Display, Vessel List, Feature Search, Pick Report and Timeline. Each panel passes its activity-bar icon so the empty UX is uniform but still identifiable.
- **Center-or-scroll layout:** content centers vertically when the host has room and scrolls when it's too short. The inner container's `MinHeight` binds to the `ScrollViewer`'s own `Bounds.Height` (the `Viewport.Height` sub-path doesn't reliably change-notify in Avalonia) with zero padding, so there's no phantom scrollbar.
- **Datasets panel:** the Open Dataset button now sits directly beneath the placeholder (hidden once a dataset loads) plus a `+` toolbar button mapped to the same open command. The empty-state is scoped to the list row and declared after the list so it centers in the master area and stays clickable above the transparent list.
- **Timeline / Pick chrome:** trimmed the dock headers to match the left-dock title height (compact 20×20 close buttons, reduced padding).
- **Strings:** split the relevant resx entries into `*_EmptyTitle` / `*_EmptyDescription` pairs and kept the hand-written `Strings.cs` in sync.

## Testing

- `dotnet test tests/EncDotNet.S100.Viewer.Tests` → 866 passed, 1 skipped.
- Manually verified empty-state appearance and the Datasets Open Dataset button in the running viewer.

## Notes

Some broader panel/dock re-architecture is anticipated as a follow-up; this PR focuses on unifying the empty-state UX.