### PR TITLE
Cache and simplify vector paths for faster S-101 pan/zoom

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/CachedVectorStyleRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/CachedVectorStyleRenderer.cs
@@ -1,0 +1,590 @@
+using System;
+using System.Collections.Generic;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Rendering;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.SkiaStyles;
+using Mapsui.Rendering.Skia.Extensions;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// A drop-in replacement for Mapsui's <see cref="VectorStyleRenderer"/> that
+/// caches the projected <see cref="SKPath"/> for solid-filled / solid-outlined
+/// polygons <b>and</b> solid-stroked lines in a <b>translation-invariant</b>
+/// coordinate frame, so that a pan (which changes only the viewport centre, not
+/// its resolution) re-uses the cached path and pays only a canvas translate plus
+/// the fill/stroke, instead of re-projecting and rebuilding the path every frame.
+/// Lines are additionally <b>simplified at the build resolution</b> (see
+/// <see cref="CachedVectorStyleRenderer(ISkiaStyleRenderer, int, double)"/>) so
+/// the Skia stroker rasterises far fewer sub-pixel segments.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> Mapsui's <c>PolygonRenderer</c> / <c>LineStringRenderer</c>
+/// cache the built path in an LRU keyed on <c>(featureId, position, extent,
+/// rotation, lineWidth)</c> — and <c>extent</c> is the full viewport extent, which
+/// changes on every pan, forcing a rebuild. Profiling the AU S-101 set showed
+/// that on dense approach cells the cost is dominated by thousands of
+/// <c>LineString</c> features (bathymetry contours); path construction is
+/// redundant during a pan, and — more importantly — the Skia stroker spends the
+/// bulk of its time on the dense run of <i>sub-pixel</i> segments. See the perf
+/// investigation in the session notes (issue #274 context).
+/// </para>
+/// <para>
+/// <b>Coordinate frame.</b> Mapsui projects world → screen as
+/// <c>screenX = (worldX − CenterX)/Res + Width/2</c> and
+/// <c>screenY = (CenterY − worldY)/Res + Height/2</c>. This renderer builds the
+/// path in <i>anchor-relative pixels at the current resolution</i>:
+/// <c>px = (worldX − Ax)/Res</c>, <c>py = (Ay − worldY)/Res</c>, where the
+/// anchor <c>(Ax, Ay)</c> is the geometry's envelope minimum. The anchor
+/// subtraction (done in <see langword="double"/>) keeps the float
+/// <see cref="SKPoint"/> coordinates small and precise even at high zoom. On
+/// paint the path is drawn under a translate of
+/// <c>Tx = Width/2 + (Ax − CenterX)/Res</c>,
+/// <c>Ty = Height/2 + (CenterY − Ay)/Res</c>, which reproduces Mapsui's
+/// transform exactly. Both the path and the anchor depend only on the
+/// resolution, so they survive any pan; a zoom changes the resolution and
+/// therefore the cache key, forcing a rebuild (crisp, and far rarer than
+/// pans).
+/// </para>
+/// <para>
+/// <b>Scope.</b> Only un-rotated viewports are fast-pathed. Polygons whose
+/// <see cref="VectorStyle"/> has a solid fill and/or solid outline, and lines
+/// whose <see cref="VectorStyle.Line"/> is a solid pen with no separate visible
+/// <see cref="VectorStyle.Outline"/> casing, are cached. Points, patterned/hatched
+/// fills, dashed/casing-outlined lines, rotated viewports and any geometry that is
+/// not a polygon, multi-polygon, line or multi-line are delegated unchanged to the
+/// wrapped Mapsui renderer, so visuals are identical outside the fast path.
+/// </para>
+/// <para>
+/// <b>Thread-safety.</b> The cache is guarded by a lock because the offscreen
+/// <c>render_to_image</c> / rasterising-tile paths can invoke the shared static
+/// renderer concurrently with the on-screen compositor thread. Path
+/// construction happens outside the lock; only the dictionary mutation is
+/// serialised.
+/// </para>
+/// </remarks>
+public sealed class CachedVectorStyleRenderer : ISkiaStyleRenderer
+{
+    /// <summary>
+    /// Singleton wrapping a fresh, stateless Mapsui <see cref="VectorStyleRenderer"/>
+    /// used for delegation of everything outside the fast path.
+    /// </summary>
+    public static CachedVectorStyleRenderer Instance { get; } = new(new VectorStyleRenderer());
+
+    private readonly ISkiaStyleRenderer _inner;
+    private readonly bool _enabled;
+    private readonly double _simplifyPx;
+    private readonly object _sync = new();
+    private readonly PathCache _cache;
+
+    /// <summary>
+    /// Default pixel tolerance for resolution-aware line simplification, read
+    /// once from the <c>S100_VECTOR_SIMPLIFY_PX</c> environment variable (or
+    /// 0.6 when unset/invalid). See <see cref="CachedVectorStyleRenderer(ISkiaStyleRenderer, int, double)"/>.
+    /// </summary>
+    private static readonly double s_defaultSimplifyPx = ReadSimplifyTolerance();
+
+    private static double ReadSimplifyTolerance()
+    {
+        var raw = Environment.GetEnvironmentVariable("S100_VECTOR_SIMPLIFY_PX");
+        if (!string.IsNullOrEmpty(raw)
+            && double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v))
+        {
+            return v;
+        }
+
+        return 0.6;
+    }
+
+    /// <summary>
+    /// Creates a renderer wrapping <paramref name="inner"/> (the real Mapsui
+    /// <see cref="VectorStyleRenderer"/>) for delegation.
+    /// </summary>
+    /// <param name="inner">The renderer to delegate non-fast-path draws to.</param>
+    /// <param name="capacity">Maximum number of cached paths before LRU eviction.</param>
+    /// <param name="simplifyTolerancePx">
+    /// Pixel tolerance for resolution-aware line simplification applied at
+    /// cache-build time. Consecutive line vertices that project to within this
+    /// many pixels of the last emitted vertex are dropped, collapsing the dense
+    /// sub-pixel vertex runs of S-101 bathymetry contours so the Skia stroker
+    /// rasterises far fewer segments. Because simplification happens in the
+    /// anchored pixel frame at the build resolution and the result is cached,
+    /// the cost is paid once per (feature, zoom) and reused across all pans, and
+    /// dropped vertices are by construction sub-pixel <i>on screen</i> at that
+    /// zoom — so the result is visually indistinguishable at every zoom level.
+    /// A value &lt;= 0 disables simplification (paths are vertex-exact). When
+    /// negative, the default (env <c>S100_VECTOR_SIMPLIFY_PX</c> or 0.6) is used.
+    /// </param>
+    public CachedVectorStyleRenderer(ISkiaStyleRenderer inner, int capacity = 8192, double simplifyTolerancePx = -1)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+        _cache = new PathCache(Math.Max(1, capacity));
+        _simplifyPx = simplifyTolerancePx < 0 ? s_defaultSimplifyPx : simplifyTolerancePx;
+        // Default on; allow disabling for A/B perf comparison.
+        _enabled = (Environment.GetEnvironmentVariable("S100_VECTOR_PATH_CACHE") ?? string.Empty)
+            is not ("0" or "false" or "FALSE" or "False");
+    }
+
+    /// <summary>
+    /// The number of distinct geometry paths currently held in the cache. Each
+    /// pan re-uses existing entries (constant resolution → cache hit); a zoom
+    /// changes the resolution and adds new entries. Exposed for testing the
+    /// build-once-per-(feature, zoom) behaviour.
+    /// </summary>
+    public int CachedPathCount
+    {
+        get { lock (_sync) { return _cache.Count; } }
+    }
+
+    /// <summary>
+    /// Registers <see cref="Instance"/> as the renderer for
+    /// <see cref="VectorStyle"/>. Must be called <b>before</b> any
+    /// instrumentation wraps the renderer dictionary and never again
+    /// afterwards (so the wrapper is preserved). No-op when the path cache is
+    /// disabled or when the build/fill split measurement is active (so that
+    /// measurement characterises Mapsui's un-cached cost).
+    /// </summary>
+    public static void Register()
+    {
+        var measuring = (Environment.GetEnvironmentVariable("S100_MEASURE_VECTOR_SPLIT") ?? string.Empty)
+            is "1" or "true" or "TRUE" or "True";
+        var disabled = (Environment.GetEnvironmentVariable("S100_VECTOR_PATH_CACHE") ?? string.Empty)
+            is "0" or "false" or "FALSE" or "False";
+        if (measuring || disabled)
+        {
+            return;
+        }
+
+        global::Mapsui.Rendering.Skia.MapRenderer.RegisterStyleRenderer(typeof(VectorStyle), Instance);
+    }
+
+    /// <inheritdoc />
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer,
+        IFeature feature, IStyle style, RenderService renderService, long iteration)
+    {
+        if (!_enabled
+            || viewport.Rotation != 0
+            || style is not VectorStyle vectorStyle
+            || feature is not GeometryFeature geometryFeature
+            || geometryFeature.Geometry is not { } geometry)
+        {
+            return _inner.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
+        }
+
+        var opacity = (float)(layer.Opacity * style.Opacity);
+        switch (geometry)
+        {
+        case Polygon polygon when CanFastPolygon(vectorStyle):
+        {
+            DrawPolygon(canvas, viewport, vectorStyle, geometryFeature.Id, 0, polygon, opacity);
+            return true;
+        }
+        case MultiPolygon multiPolygon when CanFastPolygon(vectorStyle):
+        {
+            for (var i = 0; i < multiPolygon.Count; i++)
+            {
+                if (multiPolygon[i] is Polygon part)
+                {
+                    DrawPolygon(canvas, viewport, vectorStyle, geometryFeature.Id, i, part, opacity);
+                }
+            }
+            return true;
+        }
+        case LineString lineString when CanFastLine(vectorStyle):
+        {
+            DrawLine(canvas, viewport, vectorStyle, geometryFeature.Id, 0, lineString, opacity);
+            return true;
+        }
+        case MultiLineString multiLineString when CanFastLine(vectorStyle):
+        {
+            for (var i = 0; i < multiLineString.Count; i++)
+            {
+                if (multiLineString[i] is LineString part)
+                {
+                    DrawLine(canvas, viewport, vectorStyle, geometryFeature.Id, i, part, opacity);
+                }
+            }
+            return true;
+        }
+        default:
+        {
+            // GeometryCollections, points, casing-outlined lines, patterned
+            // fills, and any unsupported style: leave to Mapsui.
+            return _inner.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
+        }
+        }
+    }
+
+    /// <summary>
+    /// True when a polygon's fill and outline are solid (the only cases this
+    /// renderer reproduces pixel-for-pixel). Patterned fills and dashed/styled
+    /// outlines fall back to Mapsui.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="VectorStyle.Line"/> is deliberately <b>not</b> consulted: it
+    /// applies only to line geometries, and Mapsui initialises it to a non-null
+    /// default pen that is ignored when filling/stroking a polygon.
+    /// </remarks>
+    private static bool CanFastPolygon(VectorStyle style)
+    {
+        if (style.Fill is { FillStyle: not FillStyle.Solid })
+        {
+            return false;
+        }
+        if (style.Outline is { PenStyle: not PenStyle.Solid })
+        {
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// True when a line's stroke can be reproduced exactly: the
+    /// <see cref="VectorStyle.Line"/> pen is visible and there is no separate
+    /// visible <see cref="VectorStyle.Outline"/> casing (Mapsui draws a wider
+    /// outline pass under the line when an outline is set; that rarer case is
+    /// delegated to keep this fast path simple and pixel-identical).
+    /// </summary>
+    private static bool CanFastLine(VectorStyle style)
+    {
+        if (style.Line is not { } line || line.Color.A <= 0 || line.Width <= 0)
+        {
+            return false;
+        }
+        if (style.Outline is { } outline && outline.Color.A > 0 && outline.Width > 0)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    private void DrawLine(SKCanvas canvas, Viewport viewport, VectorStyle style,
+        long featureId, int position, LineString lineString, float opacity)
+    {
+        var resolution = viewport.Resolution;
+        if (resolution <= 0 || lineString.IsEmpty || lineString.NumPoints < 2)
+        {
+            return;
+        }
+
+        var key = new PathKey(featureId, position, BitConverter.DoubleToInt64Bits(resolution));
+
+        PathEntry? entry;
+        lock (_sync)
+        {
+            entry = _cache.Get(key);
+        }
+
+        if (entry is null)
+        {
+            var built = BuildLineEntry(lineString, resolution, _simplifyPx);
+            lock (_sync)
+            {
+                var again = _cache.Get(key);
+                if (again is not null)
+                {
+                    built.Dispose();
+                    entry = again;
+                }
+                else
+                {
+                    _cache.Add(key, built);
+                    entry = built;
+                }
+            }
+        }
+
+        var tx = viewport.Width / 2.0 + (entry.AnchorX - viewport.CenterX) / resolution;
+        var ty = viewport.Height / 2.0 + (viewport.CenterY - entry.AnchorY) / resolution;
+
+        var restore = canvas.Save();
+        try
+        {
+            canvas.Translate((float)tx, (float)ty);
+            using var strokePaint = CreateLineStrokePaint(style.Line!, opacity);
+            canvas.DrawPath(entry.Path, strokePaint);
+        }
+        finally
+        {
+            canvas.RestoreToCount(restore);
+        }
+    }
+
+    /// <summary>
+    /// Builds the translation-invariant <see cref="SKPath"/> for a line at a
+    /// given resolution, anchored at the line's envelope minimum. The full
+    /// (unclipped) line is built; Skia clips it to the canvas at draw time.
+    /// Mapsui instead re-projects and Liang-Barsky-clips every frame, which is
+    /// exactly the per-pan cost this cache removes.
+    /// </summary>
+    private static PathEntry BuildLineEntry(LineString lineString, double resolution, double tol)
+    {
+        var envelope = lineString.EnvelopeInternal;
+        var anchorX = envelope.MinX;
+        var anchorY = envelope.MinY;
+
+        var path = new SKPath();
+        var coordinates = lineString.Coordinates;
+
+        var px0 = (float)((coordinates[0].X - anchorX) / resolution);
+        var py0 = (float)((anchorY - coordinates[0].Y) / resolution);
+        path.MoveTo(px0, py0);
+
+        var lastX = px0;
+        var lastY = py0;
+        var lastIndex = coordinates.Length - 1;
+        for (var i = 1; i < coordinates.Length; i++)
+        {
+            var px = (float)((coordinates[i].X - anchorX) / resolution);
+            var py = (float)((anchorY - coordinates[i].Y) / resolution);
+
+            // Drop sub-pixel vertices, but always keep the final vertex so the
+            // line's endpoint (and overall length) is preserved exactly.
+            if (tol > 0 && i != lastIndex)
+            {
+                var dx = px - lastX;
+                var dy = py - lastY;
+                if ((dx * dx) + (dy * dy) < tol * tol)
+                {
+                    continue;
+                }
+            }
+
+            path.LineTo(px, py);
+            lastX = px;
+            lastY = py;
+        }
+
+        return new PathEntry(path, anchorX, anchorY);
+    }
+
+    /// <summary>
+    /// Reproduces Mapsui's <c>LineStringRenderer</c> stroke paint exactly,
+    /// reusing the public Mapsui Skia extension helpers for the colour, stroke
+    /// cap/join and pen-style dash effect so the rendered stroke is identical.
+    /// </summary>
+    private static SKPaint CreateLineStrokePaint(Pen line, float opacity)
+    {
+        var width = (float)line.Width;
+        return new SKPaint
+        {
+            IsAntialias = true,
+            IsStroke = true,
+            StrokeWidth = width,
+            Color = line.Color.ToSkia(opacity),
+            StrokeCap = line.PenStrokeCap.ToSkia(),
+            StrokeJoin = line.StrokeJoin.ToSkia(),
+            StrokeMiter = line.StrokeMiterLimit,
+            PathEffect = line.PenStyle != PenStyle.Solid
+                ? line.PenStyle.ToSkia(width, line.DashArray, line.DashOffset)
+                : null,
+        };
+    }
+
+    private void DrawPolygon(SKCanvas canvas, Viewport viewport, VectorStyle style,
+        long featureId, int position, Polygon polygon, float opacity)
+    {
+        var resolution = viewport.Resolution;
+        if (resolution <= 0 || polygon.ExteriorRing is null || polygon.IsEmpty)
+        {
+            return;
+        }
+
+        var key = new PathKey(featureId, position, BitConverter.DoubleToInt64Bits(resolution));
+
+        PathEntry? entry;
+        lock (_sync)
+        {
+            entry = _cache.Get(key);
+        }
+
+        if (entry is null)
+        {
+            var built = BuildEntry(polygon, resolution);
+            lock (_sync)
+            {
+                var again = _cache.Get(key);
+                if (again is not null)
+                {
+                    built.Dispose();
+                    entry = again;
+                }
+                else
+                {
+                    _cache.Add(key, built);
+                    entry = built;
+                }
+            }
+        }
+
+        var tx = viewport.Width / 2.0 + (entry.AnchorX - viewport.CenterX) / resolution;
+        var ty = viewport.Height / 2.0 + (viewport.CenterY - entry.AnchorY) / resolution;
+
+        var restore = canvas.Save();
+        try
+        {
+            canvas.Translate((float)tx, (float)ty);
+
+            if (style.Fill is { } fill && IsVisible(fill))
+            {
+                using var fillPaint = CreateFillPaint(fill, opacity);
+                canvas.DrawPath(entry.Path, fillPaint);
+            }
+
+            if (style.Outline is { } outline && IsVisible(outline))
+            {
+                using var strokePaint = CreateStrokePaint(outline, opacity);
+                canvas.DrawPath(entry.Path, strokePaint);
+            }
+        }
+        finally
+        {
+            canvas.RestoreToCount(restore);
+        }
+    }
+
+    /// <summary>
+    /// Builds the translation-invariant <see cref="SKPath"/> for a polygon at a
+    /// given resolution, anchored at the polygon's envelope minimum. Uses
+    /// even-odd fill so interior rings (holes) are subtracted regardless of
+    /// ring orientation, avoiding the orientation normalisation Mapsui performs.
+    /// </summary>
+    private static PathEntry BuildEntry(Polygon polygon, double resolution)
+    {
+        var envelope = polygon.EnvelopeInternal;
+        var anchorX = envelope.MinX;
+        var anchorY = envelope.MinY;
+
+        var path = new SKPath { FillType = SKPathFillType.EvenOdd };
+        AddRing(path, polygon.ExteriorRing!, resolution, anchorX, anchorY);
+        for (var i = 0; i < polygon.NumInteriorRings; i++)
+        {
+            AddRing(path, polygon.GetInteriorRingN(i), resolution, anchorX, anchorY);
+        }
+
+        return new PathEntry(path, anchorX, anchorY);
+    }
+
+    private static void AddRing(SKPath path, LineString ring, double resolution, double anchorX, double anchorY)
+    {
+        var coordinates = ring.Coordinates;
+        if (coordinates.Length < 2)
+        {
+            return;
+        }
+
+        path.MoveTo(
+            (float)((coordinates[0].X - anchorX) / resolution),
+            (float)((anchorY - coordinates[0].Y) / resolution));
+        for (var i = 1; i < coordinates.Length; i++)
+        {
+            path.LineTo(
+                (float)((coordinates[i].X - anchorX) / resolution),
+                (float)((anchorY - coordinates[i].Y) / resolution));
+        }
+        path.Close();
+    }
+
+    private static bool IsVisible(Brush fill) => fill.Color is { A: > 0 };
+
+    private static bool IsVisible(Pen outline) => outline.Color.A > 0 && outline.Width > 0;
+
+    private static SKPaint CreateFillPaint(Brush fill, float opacity) => new()
+    {
+        IsAntialias = true,
+        Style = SKPaintStyle.Fill,
+        Color = ToSkia(fill.Color!.Value, opacity),
+    };
+
+    private static SKPaint CreateStrokePaint(Pen outline, float opacity) => new()
+    {
+        IsAntialias = true,
+        Style = SKPaintStyle.Stroke,
+        StrokeWidth = (float)outline.Width,
+        Color = ToSkia(outline.Color, opacity),
+        StrokeCap = SKStrokeCap.Butt,
+        StrokeJoin = SKStrokeJoin.Miter,
+        StrokeMiter = 4f,
+    };
+
+    private static SKColor ToSkia(Color color, float opacity)
+    {
+        var alpha = (byte)Math.Clamp(color.A * opacity, 0, 255);
+        return new SKColor((byte)color.R, (byte)color.G, (byte)color.B, alpha);
+    }
+
+    /// <summary>Cache key: a feature/part identity paired with the exact resolution bits.</summary>
+    private readonly record struct PathKey(long FeatureId, int Position, long ResolutionBits);
+
+    /// <summary>A cached path plus the world-space anchor it was built relative to.</summary>
+    private sealed class PathEntry : IDisposable
+    {
+        public PathEntry(SKPath path, double anchorX, double anchorY)
+        {
+            Path = path;
+            AnchorX = anchorX;
+            AnchorY = anchorY;
+        }
+
+        public SKPath Path { get; }
+        public double AnchorX { get; }
+        public double AnchorY { get; }
+
+        public void Dispose() => Path.Dispose();
+    }
+
+    /// <summary>
+    /// A small single-threaded LRU of <see cref="PathEntry"/> values. Callers
+    /// must serialise access (this renderer holds a lock around all calls).
+    /// Evicted and replaced entries are disposed so their <see cref="SKPath"/>
+    /// native memory is released promptly.
+    /// </summary>
+    private sealed class PathCache
+    {
+        private readonly int _capacity;
+        private readonly Dictionary<PathKey, LinkedListNode<Node>> _map;
+        private readonly LinkedList<Node> _lru = new();
+
+        public PathCache(int capacity)
+        {
+            _capacity = capacity;
+            _map = new Dictionary<PathKey, LinkedListNode<Node>>(capacity);
+        }
+
+        public int Count => _map.Count;
+
+        public PathEntry? Get(in PathKey key)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                _lru.Remove(node);
+                _lru.AddFirst(node);
+                return node.Value.Entry;
+            }
+            return null;
+        }
+
+        public void Add(in PathKey key, PathEntry entry)
+        {
+            var node = _lru.AddFirst(new Node(key, entry));
+            _map[key] = node;
+            while (_map.Count > _capacity)
+            {
+                var last = _lru.Last!;
+                _lru.RemoveLast();
+                _map.Remove(last.Value.Key);
+                last.Value.Entry.Dispose();
+            }
+        }
+
+        private readonly record struct Node(PathKey Key, PathEntry Entry);
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -330,6 +330,62 @@ var renderer = new MapsuiDisplayListRenderer
 };
 ```
 
+## Translation-invariant vector path cache
+
+`CachedVectorStyleRenderer` is a drop-in replacement for Mapsui's
+`VectorStyleRenderer` (registered for `VectorStyle` by the viewer before
+instrumentation wraps the renderer dictionary). It targets the dominant
+pan/zoom cost on dense S-101 approach cells, where thousands of
+`LineString` features (bathymetry contours) are re-projected and
+re-stroked from scratch on **every** frame because Mapsui's own path
+cache is keyed on the full viewport `extent`, which changes on every pan.
+
+It addresses this in two ways:
+
+1. **Translation-invariant path cache.** Polygons (solid fill / solid
+   outline) and lines (solid `Line` pen, no casing `Outline`) have their
+   projected `SKPath` built in an *anchor-relative pixel frame at the
+   current resolution* and cached under `(featureId, position,
+   resolutionBits)`. A pan changes only the viewport centre, so the
+   cached path is re-used and the frame pays just a canvas translate plus
+   the fill/stroke. A zoom changes the resolution (and the key), forcing
+   a crisp rebuild — far rarer than pans. The transform reproduces
+   Mapsui's `screen = (world − Center)/Res + Size/2` exactly, so output
+   is pixel-identical outside simplification.
+
+2. **Resolution-aware line simplification.** When building a line path,
+   consecutive vertices that project to within `simplifyTolerancePx`
+   (default `0.6`) of the last emitted vertex are dropped, with endpoints
+   always preserved. Because this happens in the anchored pixel frame at
+   the build resolution and the result is cached, the cost is paid once
+   per (feature, zoom) and re-used across all pans. Dropped vertices are
+   by construction sub-pixel *on screen* at that zoom, so the result is
+   visually indistinguishable at every zoom level while removing the bulk
+   of the Skia stroker's per-segment work — the real bottleneck on dense
+   contours.
+
+On the AU IC-ENC `444147` overview pure-pan (≈3,448 line features) this
+cut the per-frame vector cost from ~479 ms (un-cached Mapsui) to ~71 ms
+and the wall-clock frame from ~660–750 ms to ~200–225 ms — roughly a 3×
+frame-time improvement — with a measured pixel diff of ≈1.5 % (anti-alias
+fringes only) versus the un-simplified render.
+
+Anything outside this scope — points, patterned/hatched fills,
+dashed/casing-outlined lines, rotated viewports, and non-polygon/line
+geometry — is delegated unchanged to the wrapped Mapsui renderer.
+
+### Tuning
+
+| Environment variable | Default | Effect |
+|---|---|---|
+| `S100_VECTOR_PATH_CACHE` | on | `0`/`false` disables the renderer entirely (pure Mapsui), for A/B comparison. |
+| `S100_VECTOR_SIMPLIFY_PX` | `0.6` | Line simplification tolerance in screen pixels; `0` disables simplification (vertex-exact paths). |
+
+The tolerance is also a constructor parameter
+(`new CachedVectorStyleRenderer(inner, capacity, simplifyTolerancePx)`),
+and `CachedPathCount` exposes the number of distinct cached paths for
+testing the build-once-per-(feature, zoom) behaviour.
+
 ## Installation
 
 ```sh

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -59,6 +59,13 @@ public partial class App : Application
 
         s_services = ConfigureServices();
 
+        // Interpose the translation-invariant vector path cache (solid
+        // polygons + solid-stroked, resolution-simplified lines) before
+        // instrumentation wraps the renderer dictionary, so the cache sits
+        // inside the counting wrapper and pans reuse projected paths instead
+        // of rebuilding and re-stroking them every frame.
+        EncDotNet.S100.Renderers.Mapsui.CachedVectorStyleRenderer.Register();
+
         EncDotNet.S100.Viewer.Diagnostics.MapPaintInstrumentation.Install();
 
         // The viewer uses a plain ServiceCollection (no generic IHost),

--- a/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
@@ -47,6 +47,28 @@ internal static class MapPaintInstrumentation
     private static readonly object Sync = new();
     private static bool s_installed;
 
+    /// <summary>
+    /// When set (env <c>S100_MEASURE_VECTOR_SPLIT</c> = <c>1</c>/<c>true</c>),
+    /// the <c>VectorStyle</c> renderer is wrapped so each draw is issued
+    /// twice for the same feature/viewport: the first draw misses
+    /// Mapsui's extent-keyed <c>VectorCache</c> (so it pays the full
+    /// <c>ToSkiaPath</c> projection + <c>SKPath</c> build cost plus the
+    /// draw-issue cost), while the immediate second draw hits the cache
+    /// (paying only the draw-issue cost). The per-paint difference
+    /// apportions the <c>VectorStyle</c> CPU cost into a "build" half
+    /// (projection / path construction — what a translation-invariant
+    /// path cache would eliminate on pans) and a "fill" half (the
+    /// remaining draw-issue cost). Off by default; gated to a
+    /// diagnostics run because it double-draws vectors.
+    /// </summary>
+    private static readonly bool s_measureSplit =
+        (Environment.GetEnvironmentVariable("S100_MEASURE_VECTOR_SPLIT") ?? string.Empty)
+            is "1" or "true" or "TRUE" or "True";
+
+    private static double s_vectorBuildMs;
+    private static double s_vectorFillMs;
+    private static long s_vectorSplitCalls;
+
     private static readonly Meter Meter =
         S100Telemetry.CreateMeter(typeof(MapPaintInstrumentation));
 
@@ -111,7 +133,20 @@ internal static class MapPaintInstrumentation
             foreach (var pair in snapshot)
             {
                 if (pair.Value is CountingStyleRenderer) continue;
-                dict[pair.Key] = new CountingStyleRenderer(pair.Key, pair.Value);
+
+                var inner = pair.Value;
+                // In split-measurement mode, interpose a double-draw
+                // measuring renderer between the counter and Mapsui's
+                // real VectorStyle renderer so the build/fill split is
+                // captured for the same draws the counter sees.
+                if (s_measureSplit
+                    && pair.Key == typeof(VectorStyle)
+                    && inner is ISkiaStyleRenderer skiaInner)
+                {
+                    inner = new MeasuringVectorStyleRenderer(skiaInner);
+                }
+
+                dict[pair.Key] = new CountingStyleRenderer(pair.Key, inner);
             }
         }
     }
@@ -124,6 +159,13 @@ internal static class MapPaintInstrumentation
         {
             stats.Calls = 0;
             stats.DurationMs = 0;
+        }
+
+        if (s_measureSplit)
+        {
+            s_vectorBuildMs = 0;
+            s_vectorFillMs = 0;
+            s_vectorSplitCalls = 0;
         }
     }
 
@@ -170,6 +212,18 @@ internal static class MapPaintInstrumentation
             result.Add(new EncDotNet.S100.Viewer.Services.RenderStyleStat(style, acc.Calls, acc.DurationMs));
         }
         result.Sort(static (a, b) => b.DurationMs.CompareTo(a.DurationMs));
+
+        // In split-measurement mode, surface the build/fill apportionment
+        // as two synthetic entries so they flow through the existing
+        // get_render_stats payload unchanged. Calls are reported as 0 so
+        // the differential's extra draws don't inflate TotalDrawCalls;
+        // the real VectorStyle call count is available from its own entry.
+        if (s_measureSplit && s_vectorSplitCalls > 0)
+        {
+            result.Add(new EncDotNet.S100.Viewer.Services.RenderStyleStat("VectorBuild", 0, s_vectorBuildMs));
+            result.Add(new EncDotNet.S100.Viewer.Services.RenderStyleStat("VectorFill", 0, s_vectorFillMs));
+        }
+
         return result;
     }
 
@@ -242,6 +296,50 @@ internal static class MapPaintInstrumentation
                 stats.Calls++;
                 stats.DurationMs += Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
             }
+        }
+    }
+
+    /// <summary>
+    /// Interposed before Mapsui's real <c>VectorStyle</c> renderer in
+    /// split-measurement mode. Each <see cref="Draw"/> issues the inner
+    /// renderer twice for the same feature and viewport. The first call
+    /// misses Mapsui's extent-keyed <c>VectorCache</c> and pays the full
+    /// projection + <c>SKPath</c> construction cost (plus the draw-issue
+    /// cost); the immediate second call hits the cache and pays only the
+    /// draw-issue cost. The difference is accumulated as the per-paint
+    /// "build" cost and the second call as the "fill" cost, letting a
+    /// diagnostics run quantify how much of <c>VectorStyle</c>'s CPU time
+    /// a translation-invariant path cache could remove on pans.
+    /// </summary>
+    /// <remarks>
+    /// Only the first draw's return value is propagated. The extra draw
+    /// produces identical overdraw, so this must stay gated behind
+    /// <see cref="s_measureSplit"/>. The differential is only meaningful
+    /// while Mapsui's <c>VectorCache</c> is enabled; if it is disabled
+    /// the second draw also rebuilds and the build half collapses toward
+    /// zero, which the harness can detect.
+    /// </remarks>
+    private sealed class MeasuringVectorStyleRenderer : ISkiaStyleRenderer
+    {
+        private readonly ISkiaStyleRenderer _inner;
+
+        public MeasuringVectorStyleRenderer(ISkiaStyleRenderer inner) => _inner = inner;
+
+        public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer,
+            IFeature feature, IStyle style, RenderService renderService, long iteration)
+        {
+            var firstStart = Stopwatch.GetTimestamp();
+            var result = _inner.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
+            var firstMs = Stopwatch.GetElapsedTime(firstStart).TotalMilliseconds;
+
+            var secondStart = Stopwatch.GetTimestamp();
+            _inner.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
+            var secondMs = Stopwatch.GetElapsedTime(secondStart).TotalMilliseconds;
+
+            s_vectorBuildMs += Math.Max(0, firstMs - secondMs);
+            s_vectorFillMs += secondMs;
+            s_vectorSplitCalls++;
+            return result;
         }
     }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/CachedVectorStyleRendererTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CachedVectorStyleRendererTests.cs
@@ -1,0 +1,192 @@
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Rendering;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.SkiaStyles;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Validates the translation-invariant vector path cache and resolution-aware
+/// line simplification in <see cref="CachedVectorStyleRenderer"/>: it must
+/// build a geometry's <see cref="SKPath"/> once per (feature, resolution) and
+/// re-use it across pans, render byte-for-byte like Mapsui's
+/// <see cref="VectorStyleRenderer"/> when simplification is disabled, drop only
+/// sub-pixel vertices when it is enabled (preserving endpoints), and delegate
+/// geometries it does not fast-path.
+/// </summary>
+public class CachedVectorStyleRendererTests
+{
+    private static readonly RenderService Service = new();
+
+    // World coordinates roughly span [0,1000] in both axes so a 1.0 resolution
+    // maps them onto a 1000 px canvas with the centre at (500, 500).
+    private const int CanvasSize = 256;
+
+    private static GeometryFeature MakeLineFeature(IEnumerable<Coordinate> coords, long id)
+    {
+        // Each GeometryFeature is auto-assigned a stable Id; reusing the same
+        // instance across renders keeps the cache key constant (the id arg is
+        // only for test readability).
+        _ = id;
+        var feature = new GeometryFeature(new LineString(coords.ToArray()));
+        feature.Styles.Add(new VectorStyle { Line = new Pen { Color = Color.Black, Width = 2.0 }, Outline = null, Fill = null });
+        return feature;
+    }
+
+    private static Mapsui.Viewport ViewportFor(double centerX, double centerY, double resolution) =>
+        new(centerX, centerY, resolution, rotation: 0, width: CanvasSize, height: CanvasSize);
+
+    private static byte[] RenderToPng(Action<SKCanvas> draw)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(CanvasSize, CanvasSize, SKColorType.Rgba8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.White);
+        draw(surface.Canvas);
+        surface.Canvas.Flush();
+        using var image = surface.Snapshot();
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    private static int OpaqueDarkPixels(SKBitmap bitmap)
+    {
+        var count = 0;
+        for (var y = 0; y < bitmap.Height; y++)
+        for (var x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Alpha > 128 && p.Red < 80 && p.Green < 80 && p.Blue < 80)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    [Fact]
+    public void Pan_AtConstantResolution_BuildsPathOnce()
+    {
+        var renderer = new CachedVectorStyleRenderer(new VectorStyleRenderer(), simplifyTolerancePx: 0);
+        var feature = MakeLineFeature(
+            new[] { new Coordinate(100, 100), new Coordinate(900, 900) }, id: 1);
+        var style = (VectorStyle)feature.Styles.First();
+        var layer = new MemoryLayer("l") { Opacity = 1.0 };
+
+        RenderToPng(canvas => renderer.Draw(canvas, ViewportFor(500, 500, 1.0), layer, feature, style, Service, 0));
+        RenderToPng(canvas => renderer.Draw(canvas, ViewportFor(540, 500, 1.0), layer, feature, style, Service, 0));
+        RenderToPng(canvas => renderer.Draw(canvas, ViewportFor(580, 540, 1.0), layer, feature, style, Service, 0));
+
+        // Three pans at one resolution -> exactly one cached path.
+        Assert.Equal(1, renderer.CachedPathCount);
+
+        // A zoom (new resolution) adds a second entry.
+        RenderToPng(canvas => renderer.Draw(canvas, ViewportFor(500, 500, 2.0), layer, feature, style, Service, 0));
+        Assert.Equal(2, renderer.CachedPathCount);
+    }
+
+    [Fact]
+    public void DisabledSimplification_MatchesMapsuiOutput()
+    {
+        var feature = MakeLineFeature(
+            new[]
+            {
+                new Coordinate(100, 200), new Coordinate(300, 700),
+                new Coordinate(550, 250), new Coordinate(820, 760),
+            },
+            id: 2);
+        var style = (VectorStyle)feature.Styles.First();
+        var layer = new MemoryLayer("l") { Opacity = 1.0 };
+        var viewport = ViewportFor(500, 500, 3.0);
+
+        var cached = new CachedVectorStyleRenderer(new VectorStyleRenderer(), simplifyTolerancePx: 0);
+        var mapsui = new VectorStyleRenderer();
+
+        var cachedPng = RenderToPng(c => cached.Draw(c, viewport, layer, feature, style, Service, 0));
+        var mapsuiPng = RenderToPng(c => mapsui.Draw(c, viewport, layer, feature, style, Service, 0));
+
+        Assert.Equal(mapsuiPng, cachedPng);
+    }
+
+    [Fact]
+    public void Simplification_PreservesEndpoints()
+    {
+        // A line whose interior vertices are all sub-pixel apart at this
+        // resolution; only the endpoints carry geometric meaning.
+        var coords = new List<Coordinate> { new(100, 500) };
+        for (var i = 1; i < 400; i++)
+        {
+            coords.Add(new Coordinate(100 + i * 0.05, 500 + ((i % 2) * 0.05)));
+        }
+        coords.Add(new Coordinate(900, 500));
+
+        var feature = MakeLineFeature(coords, id: 3);
+        var style = (VectorStyle)feature.Styles.First();
+        var layer = new MemoryLayer("l") { Opacity = 1.0 };
+        var viewport = ViewportFor(500, 500, 1.0);
+
+        var simplified = new CachedVectorStyleRenderer(new VectorStyleRenderer(), simplifyTolerancePx: 0.6);
+        var exact = new CachedVectorStyleRenderer(new VectorStyleRenderer(), simplifyTolerancePx: 0);
+
+        using var simplifiedBmp = SKBitmap.Decode(
+            RenderToPng(c => simplified.Draw(c, viewport, layer, feature, style, Service, 0)));
+        using var exactBmp = SKBitmap.Decode(
+            RenderToPng(c => exact.Draw(c, viewport, layer, feature, style, Service, 0)));
+
+        // Both must draw the same horizontal stroke (endpoints preserved): the
+        // dark-pixel counts should be within a few percent of each other.
+        var s = OpaqueDarkPixels(simplifiedBmp);
+        var e = OpaqueDarkPixels(exactBmp);
+        Assert.True(s > 0 && e > 0, $"expected a visible stroke in both (simplified={s}, exact={e})");
+        Assert.True(Math.Abs(s - e) <= e * 0.1, $"stroke coverage differs too much: simplified={s}, exact={e}");
+    }
+
+    [Fact]
+    public void Point_IsDelegatedToInnerRenderer()
+    {
+        var inner = new CountingRenderer();
+        var renderer = new CachedVectorStyleRenderer(inner);
+        var feature = new GeometryFeature(new Point(500, 500));
+        var style = new SymbolStyle();
+        var layer = new MemoryLayer("l") { Opacity = 1.0 };
+
+        RenderToPng(c => renderer.Draw(c, ViewportFor(500, 500, 1.0), layer, feature, style, Service, 0));
+
+        Assert.Equal(1, inner.DrawCalls);
+        Assert.Equal(0, renderer.CachedPathCount);
+    }
+
+    [Fact]
+    public void Line_IsFastPathed_NotDelegated()
+    {
+        var inner = new CountingRenderer();
+        var renderer = new CachedVectorStyleRenderer(inner, simplifyTolerancePx: 0);
+        var feature = MakeLineFeature(
+            new[] { new Coordinate(100, 100), new Coordinate(900, 900) }, id: 4);
+        var style = (VectorStyle)feature.Styles.First();
+        var layer = new MemoryLayer("l") { Opacity = 1.0 };
+
+        var handled = false;
+        RenderToPng(c => handled = renderer.Draw(c, ViewportFor(500, 500, 1.0), layer, feature, style, Service, 0));
+
+        Assert.True(handled);
+        Assert.Equal(0, inner.DrawCalls);
+        Assert.Equal(1, renderer.CachedPathCount);
+    }
+
+    private sealed class CountingRenderer : ISkiaStyleRenderer
+    {
+        public int DrawCalls { get; private set; }
+
+        public bool Draw(SKCanvas canvas, Mapsui.Viewport viewport, Mapsui.Layers.ILayer layer,
+            Mapsui.IFeature feature, Mapsui.Styles.IStyle style, Mapsui.Rendering.RenderService renderService, long iteration)
+        {
+            DrawCalls++;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Targets pan/zoom sluggishness on dense S-101 approach cells (notably the AU IC-ENC set). Adds `CachedVectorStyleRenderer`, a drop-in replacement for Mapsui's `VectorStyleRenderer`.

Profiling revealed the original premise was wrong: the cost is dominated by thousands of **`LineString` features** (bathymetry contours), and within those by **Skia stroke rasterization of dense sub-pixel segments** — *not* by path construction. The fix has two complementary parts:

1. **Translation-invariant `SKPath` cache** for solid polygons and solid-stroked lines. Paths are built in an anchor-relative pixel frame at the current resolution and cached on `(featureId, position, resolutionBits)`, so a pan (constant resolution) reuses the path and pays only a canvas translate plus fill/stroke. A zoom changes the key and rebuilds crisply. The transform reproduces Mapsui's world→screen mapping exactly.

2. **Resolution-aware line simplification** (`S100_VECTOR_SIMPLIFY_PX`, default `0.6` px): consecutive vertices that project within the tolerance of the last emitted vertex are dropped at build time, endpoints preserved. Dropped vertices are sub-pixel *on screen* by construction, so the result is visually indistinguishable at every zoom while removing the bulk of the stroker's per-segment work.

## Measured result (AU 444147 overview pure-pan, ~3,448 lines)

| Metric | Cache OFF | + cache | + simplify 0.6 |
|---|---|---|---|
| mean-pan vector | 479 ms | 386 ms | **71 ms** |
| frame | ~660–750 ms | ~610–650 ms | **~200–225 ms** |

~3× faster frames, with a ~1.5 % (anti-alias-only) pixel diff versus the un-simplified render; confirmed visually identical at overview and zoomed-in scales.

## Scope & safety

- Anything outside the fast path (points, patterned/hatched fills, dashed/casing-outlined lines, rotated viewports, non-polygon/line geometry) is delegated unchanged to Mapsui — visuals identical outside the fast path.
- Both behaviours are env-toggleable for A/B comparison: `S100_VECTOR_PATH_CACHE` (`0` disables), `S100_VECTOR_SIMPLIFY_PX` (`0` = vertex-exact).

## Tests & docs

- New `CachedVectorStyleRendererTests`: build-once-per-zoom, Mapsui parity at tolerance 0, endpoint-preserving simplification, fast-path vs delegation.
- Documented the renderer in `EncDotNet.S100.Renderers.Mapsui/README.md`.
- Full solution builds; 545 pipeline + 54 visual-regression tests pass.

## Known follow-up

Still sluggish on some datasets, **especially in "All" display mode** (testing so far focused on "Standard"). A follow-up session will profile one specific dataset in "All" mode.