### PR TITLE
Add generic ApplicationPanel control for viewer docks

### DIFF
--- a/.github/instructions/viewer.instructions.md
+++ b/.github/instructions/viewer.instructions.md
@@ -65,8 +65,26 @@ When modifying viewer code:
   `bh:HoverDelay.DelayMilliseconds="500"` — do not introduce a
   per-splitter style block.
 
-## Pick mode button
+## Application panels
 
+- The generic `Views.ApplicationPanel` control provides the standard
+  panel chrome: a title bar with an **upper-cased** `Title` and an
+  optional close button, above a content area that fills the remaining
+  space. It derives from `ContentControl`, so its `Content` is the panel
+  body; the title bar comes from the control template in
+  `Views/ApplicationPanel.axaml` (registered app-wide via a
+  `StyleInclude` in `App.axaml`).
+- Use it for any docked/standalone panel rather than hand-rolling a
+  header `Border` + `TextBlock` + close `Button`. The left/right/bottom
+  docks in `MainWindow.axaml` are built from it.
+- Set `Title` (natural-cased is fine — the control upper-cases it via
+  `ToUpperConverter`). For a dismissable panel set `ShowCloseButton`,
+  `CloseCommand`, `CloseCommandParameter`, and a localized
+  `CloseButtonToolTip` (`Tooltip_*`). Panels that swap content another
+  way (e.g. the left activity pane) leave `ShowCloseButton` at its
+  `false` default.
+
+## Pick mode button
 - The toggled pick-mode button uses `.pickActive` class plus a child
   selector `Button#PickModeButton.pickActive ic|FluentIcon` to push
   `Foreground=White` down to the icon (FluentIcon does not inherit

--- a/src/EncDotNet.S100.Viewer/App.axaml
+++ b/src/EncDotNet.S100.Viewer/App.axaml
@@ -88,6 +88,9 @@
     <Application.Styles>
         <themes:ShadTheme />
 
+        <!-- Generic ApplicationPanel control template (title bar + content). -->
+        <StyleInclude Source="avares://EncDotNet.S100.Viewer/Views/ApplicationPanel.axaml" />
+
         <!--
           App-wide Slider accent colour. ShadUI's Slider template sets
           PART_DecreaseButton.Background and Thumb.Background as local

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -315,26 +315,12 @@
                                   bh:CollapsibleColumn.SavedWidth="{Binding RightDockSavedWidth, Mode=TwoWay}" />
             </Grid.ColumnDefinitions>
 
-            <!-- Left dock pane (activity tabs: Datasets, FCs, PCs, etc.) -->
-            <Border Grid.Column="0"
-                    Background="{DynamicResource BackgroundColor}"
-                    IsVisible="{Binding IsLeftDockOpen}">
-                <DockPanel>
-                    <!-- Pane header -->
-                    <Border DockPanel.Dock="Top"
-                            Padding="12,8">
-                        <TextBlock Text="{Binding LeftDockTitle}"
-                                   FontSize="11"
-                                   FontWeight="Normal"
-                                   LetterSpacing="1" />
-                    </Border>
-
-                    <!-- Pane content: resolved by ActivityTabViewTemplate from the selected tab. -->
-                    <ContentControl Content="{Binding SelectedLeftTab}"
-                                    HorizontalContentAlignment="Stretch"
-                                    VerticalContentAlignment="Stretch" />
-                </DockPanel>
-            </Border>
+            <!-- Left dock pane (activity tabs: Datasets, FCs, PCs, etc.).
+                 No close button — content swaps via the activity bar. -->
+            <views:ApplicationPanel Grid.Column="0"
+                                    Title="{Binding LeftDockTitle}"
+                                    Content="{Binding SelectedLeftTab}"
+                                    IsVisible="{Binding IsLeftDockOpen}" />
 
             <!-- Resize grip between pane and map -->
             <GridSplitter Grid.Column="1"
@@ -656,44 +642,18 @@
                 <!--
                     Bottom dock (PR-M4). Hosts whichever activity tab is
                     registered with Dock=Bottom (currently Timeline only).
-                    The chrome bar owns the title + close button; the
-                    ContentControl resolves to the tab's View via
-                    ActivityTabViewTemplate.
+                    ApplicationPanel owns the title + close button; its content
+                    resolves to the tab's View via ActivityTabViewTemplate.
                 -->
-                <Border Grid.Row="2"
-                        x:Name="TimelinePanel"
-                        Background="{DynamicResource BackgroundColor}"
-                        IsVisible="{Binding IsBottomDockOpen}">
-                    <DockPanel>
-                        <Border DockPanel.Dock="Top"
-                                Padding="12,3,8,3">
-                            <Grid ColumnDefinitions="*,Auto">
-                                <TextBlock Grid.Column="0"
-                                           Text="{Binding BottomDockTitle}"
-                                           FontSize="11"
-                                           FontWeight="Normal"
-                                           LetterSpacing="1"
-                                           VerticalAlignment="Center" />
-                                <Button Grid.Column="1"
-                                        Classes="Icon"
-                                        Width="20"
-                                        Height="20"
-                                        MinWidth="0"
-                                        MinHeight="0"
-                                        Padding="0"
-                                        VerticalAlignment="Center"
-                                        Command="{Binding CloseDockCommand}"
-                                        CommandParameter="Bottom"
-                                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseTimelinePanel}">
-                                    <ic:FluentIcon Icon="Dismiss" IconVariant="Regular" FontSize="14" />
-                                </Button>
-                            </Grid>
-                        </Border>
-                        <ContentControl Content="{Binding SelectedBottomTab}"
-                                        HorizontalContentAlignment="Stretch"
-                                        VerticalContentAlignment="Stretch" />
-                    </DockPanel>
-                </Border>
+                <views:ApplicationPanel Grid.Row="2"
+                                        x:Name="TimelinePanel"
+                                        Title="{Binding BottomDockTitle}"
+                                        Content="{Binding SelectedBottomTab}"
+                                        ShowCloseButton="True"
+                                        CloseCommand="{Binding CloseDockCommand}"
+                                        CloseCommandParameter="Bottom"
+                                        CloseButtonToolTip="{x:Static loc:Strings.Tooltip_CloseTimelinePanel}"
+                                        IsVisible="{Binding IsBottomDockOpen}" />
             </Grid>
             <GridSplitter Grid.Column="3"
                           Classes="PaneSplitter"
@@ -706,44 +666,19 @@
             <!--
                 Right dock (PR-M4). Hosts whichever activity tab is
                 registered with Dock=Right (currently Pick Report only).
-                The chrome bar owns the title + close button; the
-                ContentControl resolves to the tab's View via
-                ActivityTabViewTemplate. Pick Report stays open with an
-                empty-state watermark when there is no active pick.
+                ApplicationPanel owns the title + close button; its content
+                resolves to the tab's View via ActivityTabViewTemplate. Pick
+                Report stays open with an empty-state watermark when there is
+                no active pick.
             -->
-            <Border Grid.Column="4"
-                    Background="{DynamicResource BackgroundColor}"
-                    IsVisible="{Binding IsRightDockOpen}">
-                <DockPanel>
-                    <Border DockPanel.Dock="Top"
-                            Padding="12,3,8,3">
-                        <Grid ColumnDefinitions="*,Auto">
-                            <TextBlock Grid.Column="0"
-                                       Text="{Binding RightDockTitle}"
-                                       FontSize="11"
-                                       FontWeight="Normal"
-                                       LetterSpacing="1"
-                                       VerticalAlignment="Center" />
-                            <Button Grid.Column="1"
-                                    Classes="Icon"
-                                    Width="20"
-                                    Height="20"
-                                    MinWidth="0"
-                                    MinHeight="0"
-                                    Padding="0"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding CloseDockCommand}"
-                                    CommandParameter="Right"
-                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ClosePickPanel}">
-                                <ic:FluentIcon Icon="Dismiss" IconVariant="Regular" FontSize="14" />
-                            </Button>
-                        </Grid>
-                    </Border>
-                    <ContentControl Content="{Binding SelectedRightTab}"
-                                    HorizontalContentAlignment="Stretch"
-                                    VerticalContentAlignment="Stretch" />
-                </DockPanel>
-            </Border>
+            <views:ApplicationPanel Grid.Column="4"
+                                    Title="{Binding RightDockTitle}"
+                                    Content="{Binding SelectedRightTab}"
+                                    ShowCloseButton="True"
+                                    CloseCommand="{Binding CloseDockCommand}"
+                                    CloseCommandParameter="Right"
+                                    CloseButtonToolTip="{x:Static loc:Strings.Tooltip_ClosePickPanel}"
+                                    IsVisible="{Binding IsRightDockOpen}" />
         </Grid>
     </DockPanel>
     <shadui:ToastHost x:Name="ToastHost"

--- a/src/EncDotNet.S100.Viewer/ToUpperConverter.cs
+++ b/src/EncDotNet.S100.Viewer/ToUpperConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Uppercases a string for display using the current culture. Used by the
+/// <see cref="Views.ApplicationPanel"/> title bar so panel titles render in
+/// upper case regardless of the casing of the source string.
+/// </summary>
+internal sealed class ToUpperConverter : IValueConverter
+{
+    /// <summary>Shared singleton instance for XAML <c>x:Static</c> use.</summary>
+    public static ToUpperConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is string text ? text.ToUpper(culture) : value;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Viewer/Views/ApplicationPanel.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/ApplicationPanel.axaml
@@ -1,0 +1,70 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ic="using:FluentIcons.Avalonia"
+        xmlns:views="using:EncDotNet.S100.Viewer.Views"
+        xmlns:conv="using:EncDotNet.S100.Viewer">
+
+    <!--
+      Template for the generic ApplicationPanel control. Lays out a title bar
+      (upper-cased title + optional close button) above a ContentPresenter that
+      fills the remaining area. Centralizes the chrome that the left/right/bottom
+      docks used to hand-roll inline in MainWindow.axaml.
+    -->
+    <Style Selector="views|ApplicationPanel">
+        <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}">
+                    <DockPanel LastChildFill="True">
+                        <!-- Title bar. Fixed height so panels with and without a
+                             close button line up; title and close button are
+                             vertically centered within it. -->
+                        <Border DockPanel.Dock="Top" Height="28" Padding="12,0,6,0">
+                            <Grid ColumnDefinitions="*,Auto" VerticalAlignment="Stretch">
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding Title,
+                                                  RelativeSource={RelativeSource TemplatedParent},
+                                                  Converter={x:Static conv:ToUpperConverter.Instance}}"
+                                           FontSize="11"
+                                           FontWeight="Normal"
+                                           LetterSpacing="1"
+                                           VerticalAlignment="Center" />
+                                <!-- Close button modeled on the title-bar theme
+                                     toggle: a plain Button (default ShadUI template,
+                                     so hover/pressed come for free) with Padding=0
+                                     and a transparent background, sized to a small
+                                     glyph. -->
+                                <Button Grid.Column="1"
+                                        Width="24"
+                                        Height="24"
+                                        MinWidth="0"
+                                        MinHeight="0"
+                                        Padding="0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        IsVisible="{TemplateBinding ShowCloseButton}"
+                                        Command="{TemplateBinding CloseCommand}"
+                                        CommandParameter="{TemplateBinding CloseCommandParameter}"
+                                        ToolTip.Tip="{TemplateBinding CloseButtonToolTip}">
+                                    <ic:FluentIcon Icon="Dismiss"
+                                                   IconVariant="Regular"
+                                                   FontSize="14"
+                                                   Foreground="{DynamicResource ForegroundColor}" />
+                                </Button>
+                            </Grid>
+                        </Border>
+
+                        <!-- Panel body fills the remaining area -->
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalContentAlignment="Stretch"
+                                          VerticalContentAlignment="Stretch" />
+                    </DockPanel>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/src/EncDotNet.S100.Viewer/Views/ApplicationPanel.cs
+++ b/src/EncDotNet.S100.Viewer/Views/ApplicationPanel.cs
@@ -1,0 +1,102 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// A generic application panel: a titled chrome surface with a title bar
+/// (an upper-cased <see cref="Title"/> plus an optional close button) above a
+/// content area that fills the remaining space. Provides one consistent panel
+/// treatment for the viewer's docks (left activity pane, right companion pane,
+/// bottom strip) so each dock no longer hand-rolls its own header.
+/// </summary>
+/// <remarks>
+/// The control derives from <see cref="ContentControl"/>, so its
+/// <see cref="ContentControl.Content"/> is the panel body and fills the
+/// content area by default. The title bar is supplied by the control template;
+/// callers only set <see cref="Title"/>, and—when the panel is dismissable—
+/// <see cref="ShowCloseButton"/>, <see cref="CloseCommand"/>,
+/// <see cref="CloseCommandParameter"/> and <see cref="CloseButtonToolTip"/>.
+/// </remarks>
+public class ApplicationPanel : ContentControl
+{
+    /// <summary>
+    /// The panel title. Rendered upper-cased in the title bar, so callers may
+    /// pass a natural-cased string.
+    /// </summary>
+    public static readonly StyledProperty<string?> TitleProperty =
+        AvaloniaProperty.Register<ApplicationPanel, string?>(nameof(Title));
+
+    /// <summary>
+    /// Whether the title bar shows a close button. Defaults to <c>false</c>
+    /// (e.g. the left activity pane swaps content via the activity bar rather
+    /// than being closed from its own header).
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowCloseButtonProperty =
+        AvaloniaProperty.Register<ApplicationPanel, bool>(nameof(ShowCloseButton));
+
+    /// <summary>
+    /// Command invoked when the close button is pressed.
+    /// </summary>
+    public static readonly StyledProperty<ICommand?> CloseCommandProperty =
+        AvaloniaProperty.Register<ApplicationPanel, ICommand?>(nameof(CloseCommand));
+
+    /// <summary>
+    /// Parameter passed to <see cref="CloseCommand"/> when the close button is
+    /// pressed.
+    /// </summary>
+    public static readonly StyledProperty<object?> CloseCommandParameterProperty =
+        AvaloniaProperty.Register<ApplicationPanel, object?>(nameof(CloseCommandParameter));
+
+    /// <summary>
+    /// Tooltip text for the close button. Should be a localized string.
+    /// </summary>
+    public static readonly StyledProperty<string?> CloseButtonToolTipProperty =
+        AvaloniaProperty.Register<ApplicationPanel, string?>(nameof(CloseButtonToolTip));
+
+    /// <summary>
+    /// The panel title. Rendered upper-cased in the title bar.
+    /// </summary>
+    public string? Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    /// <summary>
+    /// Whether the title bar shows a close button.
+    /// </summary>
+    public bool ShowCloseButton
+    {
+        get => GetValue(ShowCloseButtonProperty);
+        set => SetValue(ShowCloseButtonProperty, value);
+    }
+
+    /// <summary>
+    /// Command invoked when the close button is pressed.
+    /// </summary>
+    public ICommand? CloseCommand
+    {
+        get => GetValue(CloseCommandProperty);
+        set => SetValue(CloseCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Parameter passed to <see cref="CloseCommand"/>.
+    /// </summary>
+    public object? CloseCommandParameter
+    {
+        get => GetValue(CloseCommandParameterProperty);
+        set => SetValue(CloseCommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Tooltip text for the close button.
+    /// </summary>
+    public string? CloseButtonToolTip
+    {
+        get => GetValue(CloseButtonToolTipProperty);
+        set => SetValue(CloseButtonToolTipProperty, value);
+    }
+}


### PR DESCRIPTION
## Summary

The viewer's three side docks (left activity pane, right pick pane, bottom timeline strip) each hand-rolled their own header chrome in `MainWindow.axaml` with subtly different padding and close-button handling. This introduces a single reusable `ApplicationPanel` control so all panels share one consistent title bar and behaviour.

`ApplicationPanel` derives from `ContentControl` (its `Content` is the panel body and fills the content area by default). The control template provides a fixed-height title bar with an upper-cased `Title` (via a small `ToUpperConverter`, so callers can pass natural-cased strings) and an optional close button exposed through `ShowCloseButton`, `CloseCommand`, `CloseCommandParameter`, and a localized `CloseButtonToolTip`. The three docks in `MainWindow.axaml` are rewritten to use it (left without a close button since it swaps content via the activity bar; right/bottom with one), which is a net reduction in XAML.

A couple of non-obvious details worth a look:

- The title bar uses a fixed 28px height so panels with and without a close button line up, and both title and button are vertically centered.
- The close button is a plain default-template `Button` (modeled on the existing title-bar theme toggle) rather than the ShadUI `Icon` class, which bakes in padding that can't be fully removed. This keeps the standard hover/pressed visuals with `Padding=0` and a compact glyph.

The control template lives in `Views/ApplicationPanel.axaml` and is registered app-wide via a `StyleInclude` in `App.axaml`. Guidance for reusing it on future panels was added to `viewer.instructions.md`.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — viewer UI chrome only, no spec semantics touched.

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

The viewer has no test project; following existing precedent (`PlaceholderView`, `CompassRoseView`), this control-only change ships without a unit test. Verified by building and running the viewer and exercising the panel title bars and close buttons interactively.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Documentation update is in `.github/instructions/viewer.instructions.md` (the canonical place the viewer README points to for the activity-bar/panel contract). No README or `docs/` changes were needed. New public APIs on `ApplicationPanel` carry XML doc comments.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None.