### PR TITLE
Add Report Feedback experience to the viewer

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,37 @@
+name: Viewer feedback
+description: Send feedback from the S-100 Viewer (prefilled by the app's "Report Feedback" command).
+title: "[Feedback]: "
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your feedback! This form is normally opened pre-filled by
+        the viewer's **Report Feedback** command. Review what's here, paste your
+        screenshot if you captured one, and submit.
+
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Your feedback
+      description: What happened, or what could be improved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot
+      description: |
+        If the viewer copied a screenshot to your clipboard, paste it here with
+        **⌘V / Ctrl+V**. You can leave this empty.
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Technical details (auto-collected)
+      description: |
+        Collected automatically by the viewer to help diagnose the issue (app
+        version, OS, .NET runtime, current viewport, loaded datasets, and the
+        most recent error, if any). No file contents or personal data are
+        included. Edit or delete anything you don't want to share.

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -29,6 +29,14 @@ public partial class App : Application
     private static IServiceProvider? s_services;
 
     /// <summary>
+    /// Records the most recent unhandled error so the feedback reporter
+    /// can include it. Assigned once the service container is built; the
+    /// global exception handlers funnel through <see cref="LogCrash"/>
+    /// which forwards here.
+    /// </summary>
+    private static EncDotNet.S100.Viewer.Diagnostics.ILastErrorTracker? s_lastErrorTracker;
+
+    /// <summary>
     /// Application-wide service container. Populated during
     /// <see cref="OnFrameworkInitializationCompleted"/>; throws if accessed
     /// before the framework is initialized.
@@ -58,6 +66,19 @@ public partial class App : Application
         };
 
         s_services = ConfigureServices();
+
+        // Now that the container exists, route recorded crashes into the
+        // feedback reporter's last-error tracker (the global handlers above
+        // funnel through LogCrash).
+        s_lastErrorTracker = s_services.GetRequiredService<
+            EncDotNet.S100.Viewer.Diagnostics.ILastErrorTracker>();
+
+        // ShadUI resolves custom dialog content by an explicit
+        // view/context-view-model registration on the DialogManager (a
+        // DataTemplate alone is not sufficient). Register the feedback
+        // dialog now that the singleton manager exists.
+        s_services.GetRequiredService<ShadUI.DialogManager>()
+            .Register<Views.FeedbackDialogView, ViewModels.FeedbackDialogViewModel>();
 
         // Interpose the translation-invariant vector path cache (solid
         // polygons + solid-stroked, resolution-simplified lines) before
@@ -375,6 +396,17 @@ public partial class App : Application
         services.AddSingleton<IStatusPresenter, StatusPresenter>();
         services.AddSingleton<ShadUI.ToastManager>();
         services.AddSingleton<IToastService, ToastService>();
+
+        // Feedback reporting: diagnostics capture + modal dialog plumbing.
+        services.AddSingleton<EncDotNet.S100.Viewer.Diagnostics.ILastErrorTracker,
+            EncDotNet.S100.Viewer.Diagnostics.LastErrorTracker>();
+        services.AddSingleton<IAppScreenshotProvider, AppScreenshotProvider>();
+        services.AddSingleton<ShadUI.DialogManager>();
+        services.AddSingleton<IFeedbackService, FeedbackService>();
+        services.AddTransient<FeedbackDialogViewModel>();
+        services.AddSingleton<Func<FeedbackDialogViewModel>>(sp =>
+            sp.GetRequiredService<FeedbackDialogViewModel>);
+
         services.AddSingleton<IDatasetLoaderService, DatasetLoaderService>();
         services.AddSingleton<IPickService, PickService>();
         services.AddSingleton<EncDotNet.S100.Viewer.Services.DynamicSources.IDynamicSourcePickService>(sp =>
@@ -666,5 +698,6 @@ public partial class App : Application
     {
         Console.Error.WriteLine($"[{label}] {message}");
         CrashLog.Append(label, message);
+        s_lastErrorTracker?.Record(label, message);
     }
 }

--- a/src/EncDotNet.S100.Viewer/Diagnostics/ILastErrorTracker.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/ILastErrorTracker.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Captures the most recently observed unhandled error so the feedback
+/// reporter can include it automatically. Implementations are
+/// thread-safe — errors may be recorded from any thread (UI thread,
+/// task scheduler, <see cref="AppDomain"/> handler).
+/// </summary>
+internal interface ILastErrorTracker
+{
+    /// <summary>
+    /// The most recent error, or <see langword="null"/> when no error
+    /// has been recorded this session.
+    /// </summary>
+    LastErrorRecord? Current { get; }
+
+    /// <summary>
+    /// Records an error from a captured <see cref="Exception"/>.
+    /// </summary>
+    /// <param name="source">A short label for where the error came from
+    /// (e.g. <c>"UIThread.UnhandledException"</c>).</param>
+    /// <param name="exception">The exception to record.</param>
+    void Record(string source, Exception exception);
+
+    /// <summary>
+    /// Records an error from an already-formatted message (used by the
+    /// crash-log path, which may only have a string available).
+    /// </summary>
+    /// <param name="source">A short label for where the error came from.</param>
+    /// <param name="message">The error text, typically
+    /// <see cref="Exception.ToString"/>.</param>
+    void Record(string source, string message);
+}
+
+/// <summary>
+/// Immutable snapshot of a single recorded error.
+/// </summary>
+/// <param name="TimestampUtc">When the error was recorded (UTC).</param>
+/// <param name="Source">Short origin label.</param>
+/// <param name="ExceptionType">The exception's CLR type name, or
+/// <see langword="null"/> when only a message was available.</param>
+/// <param name="Message">The exception message (first line of the text
+/// when only a message was available).</param>
+/// <param name="StackTrace">The full exception text / stack trace.</param>
+internal sealed record LastErrorRecord(
+    DateTime TimestampUtc,
+    string Source,
+    string? ExceptionType,
+    string Message,
+    string? StackTrace);

--- a/src/EncDotNet.S100.Viewer/Diagnostics/LastErrorTracker.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/LastErrorTracker.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Default <see cref="ILastErrorTracker"/>: keeps only the most recent
+/// error in a single volatile field guarded by a lock. Registered as a
+/// singleton and fed by the application's global exception handlers (see
+/// <c>App.OnFrameworkInitializationCompleted</c>).
+/// </summary>
+internal sealed class LastErrorTracker : ILastErrorTracker
+{
+    private readonly object _gate = new();
+    private LastErrorRecord? _current;
+
+    /// <inheritdoc />
+    public LastErrorRecord? Current
+    {
+        get { lock (_gate) return _current; }
+    }
+
+    /// <inheritdoc />
+    public void Record(string source, Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        var record = new LastErrorRecord(
+            TimestampUtc: DateTime.UtcNow,
+            Source: string.IsNullOrWhiteSpace(source) ? "(unknown)" : source,
+            ExceptionType: exception.GetType().FullName,
+            Message: exception.Message,
+            StackTrace: exception.ToString());
+        lock (_gate) _current = record;
+    }
+
+    /// <inheritdoc />
+    public void Record(string source, string message)
+    {
+        var text = message ?? string.Empty;
+        // Use the first non-empty line as the short message; keep the
+        // whole text as the stack trace so nothing is lost.
+        var firstLine = text;
+        var newline = text.IndexOf('\n');
+        if (newline >= 0)
+            firstLine = text[..newline].TrimEnd('\r');
+
+        var record = new LastErrorRecord(
+            TimestampUtc: DateTime.UtcNow,
+            Source: string.IsNullOrWhiteSpace(source) ? "(unknown)" : source,
+            ExceptionType: null,
+            Message: firstLine,
+            StackTrace: string.IsNullOrWhiteSpace(text) ? null : text);
+        lock (_gate) _current = record;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -123,26 +123,44 @@
     </shadui:Window.Styles>
 
     <shadui:Window.RightWindowTitleBarContent>
-        <Button Command="{Binding ToggleThemeCommand}"
-                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ToggleTheme}"
-                Width="32" Height="28"
-                Padding="0"
-                HorizontalContentAlignment="Center"
-                VerticalContentAlignment="Center"
-                Background="Transparent"
-                BorderThickness="0">
-            <Panel>
-                <!-- Sun icon (shown in dark mode, click to go light) -->
-                <ic:FluentIcon Icon="WeatherSunny" IconVariant="Regular" FontSize="16"
-                               Foreground="{DynamicResource ForegroundColor}"
-                               IsVisible="{Binding IsDarkTheme}" />
-                <!-- Moon icon (shown in light mode, click to go dark) -->
-                <ic:FluentIcon Icon="WeatherMoon" IconVariant="Regular" FontSize="16"
-                               Foreground="{DynamicResource ForegroundColor}"
-                               IsVisible="{Binding !IsDarkTheme}" />
-            </Panel>
-        </Button>
+        <StackPanel Orientation="Horizontal" Spacing="0">
+            <Button Command="{Binding ShowFeedbackCommand}"
+                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ReportFeedback}"
+                    Width="32" Height="28"
+                    Padding="0"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    Background="Transparent"
+                    BorderThickness="0">
+                <ic:FluentIcon Icon="PersonFeedback" IconVariant="Regular" FontSize="16"
+                               Foreground="{DynamicResource ForegroundColor}" />
+            </Button>
+            <Button Command="{Binding ToggleThemeCommand}"
+                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ToggleTheme}"
+                    Width="32" Height="28"
+                    Padding="0"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    Background="Transparent"
+                    BorderThickness="0">
+                <Panel>
+                    <!-- Sun icon (shown in dark mode, click to go light) -->
+                    <ic:FluentIcon Icon="WeatherSunny" IconVariant="Regular" FontSize="16"
+                                   Foreground="{DynamicResource ForegroundColor}"
+                                   IsVisible="{Binding IsDarkTheme}" />
+                    <!-- Moon icon (shown in light mode, click to go dark) -->
+                    <ic:FluentIcon Icon="WeatherMoon" IconVariant="Regular" FontSize="16"
+                                   Foreground="{DynamicResource ForegroundColor}"
+                                   IsVisible="{Binding !IsDarkTheme}" />
+                </Panel>
+            </Button>
+        </StackPanel>
     </shadui:Window.RightWindowTitleBarContent>
+
+    <shadui:Window.Hosts>
+        <!-- Hosts ShadUI modal dialogs (e.g. Report Feedback). -->
+        <shadui:DialogHost Manager="{Binding DialogManager}" x:Name="PART_DialogHost" />
+    </shadui:Window.Hosts>
 
     <Panel>
     <DockPanel>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -129,6 +129,8 @@ public partial class MainWindow : ShadUI.Window
         // loader subscribes to its own settings dependencies internally.
         var mapHost = new MapsuiMapHost(MapControl);
         App.Services.GetRequiredService<IMapHostAccessor>().Current = mapHost;
+        // Let the feedback reporter capture the whole application window.
+        App.Services.GetRequiredService<IAppScreenshotProvider>().Target = this;
         // Render-state controller bridges MCP / scripted callers to the
         // viewer's palette and ECDIS display category without exposing
         // SettingsViewModel / EcdisDisplayState directly.

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -322,7 +322,34 @@ from the second pass are rebadged `S101-as-S57/<rule-id>` so the
 user can tell whether a problem originated in the raw S-57 input or
 in the translated projection.
 
-## Own-ship and dynamic overlays
+## Reporting feedback
+
+To make it easy to file consistent, well-formed bug reports, the
+viewer has a built-in **Report Feedback** experience:
+
+- A feedback button sits in the application title bar next to the
+  theme toggle; there is also a **Help → Report Feedback…** menu entry.
+- Both open a modal dialog that explains exactly what is collected,
+  lets you type a free-form description, and previews an optional
+  screenshot of the application window (falling back to a render of
+  the current map view). Untick the screenshot checkbox to exclude it.
+- Automatically-collected diagnostics include app/build and runtime
+  info, the current viewport (centre, zoom, CRS, rotation), per-dataset
+  stats (product, visibility, validation error/warning counts), and the
+  most recently encountered error (type, message, stack trace) captured
+  by the global exception handlers.
+- An **expandable raw-data section** shows the full JSON payload, so
+  you always see precisely what will be sent before submitting.
+- On submit the viewer writes a local **bundle** — a zip containing
+  `diagnostics.json`, your `feedback.txt`, and (if included) the
+  `screenshot.png` — under your temp folder, reveals it in the file
+  manager, and opens a **prefilled GitHub new-issue page** in your
+  browser. Attach the bundle to the issue (the screenshot can't be
+  embedded automatically) and submit.
+
+No data leaves your machine until you choose to create the GitHub
+issue, and nothing is uploaded by the viewer itself.
+
 
 A live "own ship" overlay sits alongside the static datasets,
 publishing a single moving point through the

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -101,6 +101,7 @@ internal static class Strings
 
     // Tooltips
     public static string Tooltip_ToggleTheme => Get(nameof(Tooltip_ToggleTheme));
+    public static string Tooltip_ReportFeedback => Get(nameof(Tooltip_ReportFeedback));
     public static string Tooltip_Settings => Get(nameof(Tooltip_Settings));
     public static string Tooltip_FeatureCatalogues => Get(nameof(Tooltip_FeatureCatalogues));
     public static string Tooltip_PortrayalCatalogues => Get(nameof(Tooltip_PortrayalCatalogues));
@@ -181,6 +182,25 @@ internal static class Strings
     public static string Menu_Timeline => Get(nameof(Menu_Timeline));
     public static string Menu_PickReport => Get(nameof(Menu_PickReport));
     public static string Menu_PickMode => Get(nameof(Menu_PickMode));
+    public static string Menu_Help => Get(nameof(Menu_Help));
+    public static string Menu_ReportFeedback => Get(nameof(Menu_ReportFeedback));
+
+    // Feedback dialog
+    public static string Feedback_DialogTitle => Get(nameof(Feedback_DialogTitle));
+    public static string Feedback_DataDescription => Get(nameof(Feedback_DataDescription));
+    public static string Feedback_YourFeedbackLabel => Get(nameof(Feedback_YourFeedbackLabel));
+    public static string Feedback_FeedbackWatermark => Get(nameof(Feedback_FeedbackWatermark));
+    public static string Feedback_IncludeScreenshot => Get(nameof(Feedback_IncludeScreenshot));
+    public static string Feedback_ScreenshotPreviewTooltip => Get(nameof(Feedback_ScreenshotPreviewTooltip));
+    public static string Feedback_RawDataHeader => Get(nameof(Feedback_RawDataHeader));
+    public static string Feedback_Cancel => Get(nameof(Feedback_Cancel));
+    public static string Feedback_CancelTooltip => Get(nameof(Feedback_CancelTooltip));
+    public static string Feedback_Submit => Get(nameof(Feedback_Submit));
+    public static string Feedback_SubmitTooltip => Get(nameof(Feedback_SubmitTooltip));
+    public static string Feedback_SubmittedTitle => Get(nameof(Feedback_SubmittedTitle));
+    public static string Feedback_SubmittedBody => Get(nameof(Feedback_SubmittedBody));
+    public static string Feedback_SubmittedBodyClipboard => Get(nameof(Feedback_SubmittedBodyClipboard));
+    public static string Feedback_SubmitFailedTitle => Get(nameof(Feedback_SubmitFailedTitle));
 
     // File picker
     public static string FilePicker_OpenDatasetTitle => Get(nameof(FilePicker_OpenDatasetTitle));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -135,6 +135,9 @@
   <data name="Tooltip_ToggleTheme" xml:space="preserve">
     <value>Toggle Light/Dark Theme</value>
   </data>
+  <data name="Tooltip_ReportFeedback" xml:space="preserve">
+    <value>Report Feedback</value>
+  </data>
   <data name="Tooltip_Settings" xml:space="preserve">
     <value>Settings</value>
   </data>
@@ -404,6 +407,59 @@
   </data>
   <data name="Menu_PickMode" xml:space="preserve">
     <value>Pick Mode</value>
+  </data>
+  <data name="Menu_Help" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="Menu_ReportFeedback" xml:space="preserve">
+    <value>Report Feedback…</value>
+  </data>
+
+  <!-- Feedback dialog -->
+  <data name="Feedback_DialogTitle" xml:space="preserve">
+    <value>Report Feedback</value>
+  </data>
+  <data name="Feedback_DataDescription" xml:space="preserve">
+    <value>This report includes the technical details below plus your optional screenshot and feedback. No file contents or personal data are collected. Expand “Show data that will be sent” to review everything first.</value>
+  </data>
+  <data name="Feedback_YourFeedbackLabel" xml:space="preserve">
+    <value>Your feedback</value>
+  </data>
+  <data name="Feedback_FeedbackWatermark" xml:space="preserve">
+    <value>Describe what happened or what could be improved…</value>
+  </data>
+  <data name="Feedback_IncludeScreenshot" xml:space="preserve">
+    <value>Include this screenshot of the application</value>
+  </data>
+  <data name="Feedback_ScreenshotPreviewTooltip" xml:space="preserve">
+    <value>This is exactly the screenshot that will be included.</value>
+  </data>
+  <data name="Feedback_RawDataHeader" xml:space="preserve">
+    <value>Show data that will be sent</value>
+  </data>
+  <data name="Feedback_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Feedback_CancelTooltip" xml:space="preserve">
+    <value>Dismiss without sending feedback</value>
+  </data>
+  <data name="Feedback_Submit" xml:space="preserve">
+    <value>Submit Feedback</value>
+  </data>
+  <data name="Feedback_SubmitTooltip" xml:space="preserve">
+    <value>Save a feedback bundle and open a prefilled GitHub issue</value>
+  </data>
+  <data name="Feedback_SubmittedTitle" xml:space="preserve">
+    <value>Feedback ready</value>
+  </data>
+  <data name="Feedback_SubmittedBody" xml:space="preserve">
+    <value>A prefilled GitHub issue was opened in your browser. The feedback bundle was saved to {0}.</value>
+  </data>
+  <data name="Feedback_SubmittedBodyClipboard" xml:space="preserve">
+    <value>A prefilled GitHub issue was opened in your browser. Paste your screenshot into it with ⌘V / Ctrl+V. The feedback bundle was also saved to {0}.</value>
+  </data>
+  <data name="Feedback_SubmitFailedTitle" xml:space="preserve">
+    <value>Could not prepare feedback</value>
   </data>
 
   <!-- File picker -->

--- a/src/EncDotNet.S100.Viewer/Services/AppScreenshotProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/AppScreenshotProvider.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="IAppScreenshotProvider"/>: renders the attached
+/// <see cref="Control"/> to a PNG using Avalonia's
+/// <see cref="RenderTargetBitmap"/>. All rendering is marshalled to the
+/// UI thread.
+/// </summary>
+internal sealed class AppScreenshotProvider : IAppScreenshotProvider
+{
+    /// <inheritdoc />
+    public Control? Target { get; set; }
+
+    /// <inheritdoc />
+    public async Task<byte[]?> CapturePngAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var target = Target;
+            if (target is null)
+                return null;
+
+            var width = (int)Math.Round(target.Bounds.Width);
+            var height = (int)Math.Round(target.Bounds.Height);
+            if (width <= 0 || height <= 0)
+                return null;
+
+            using var bitmap = new RenderTargetBitmap(new PixelSize(width, height));
+            bitmap.Render(target);
+
+            using var stream = new MemoryStream();
+            bitmap.Save(stream);
+            return stream.ToArray();
+        });
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/FeedbackReport.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeedbackReport.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Immutable snapshot of the diagnostic data the feedback reporter
+/// collects automatically. Everything shown to the user in the dialog's
+/// "raw data" section, and everything written to the feedback bundle,
+/// comes from this record — there is no hidden collection.
+/// </summary>
+/// <remarks>
+/// The screenshot is deliberately <b>not</b> part of this model: it is a
+/// separate, optional PNG that the user can preview and exclude. This
+/// record contains only textual diagnostics.
+/// </remarks>
+internal sealed record FeedbackReport
+{
+    /// <summary>When the report was generated (UTC, ISO-8601).</summary>
+    public required DateTimeOffset GeneratedUtc { get; init; }
+
+    /// <summary>Application identity / build information.</summary>
+    public required FeedbackAppInfo Application { get; init; }
+
+    /// <summary>Operating-system and .NET runtime information.</summary>
+    public required FeedbackRuntimeInfo Runtime { get; init; }
+
+    /// <summary>Current map viewport, or <see langword="null"/> when the
+    /// map has no laid-out viewport yet.</summary>
+    public FeedbackViewportInfo? Viewport { get; init; }
+
+    /// <summary>Currently-loaded datasets (may be empty).</summary>
+    public required IReadOnlyList<FeedbackDatasetInfo> Datasets { get; init; }
+
+    /// <summary>The most recent unhandled error this session, or
+    /// <see langword="null"/> when none was recorded.</summary>
+    public FeedbackErrorInfo? LastError { get; init; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Serialises the report to indented JSON — exactly the text shown in
+    /// the dialog's raw-data section and written to the bundle.
+    /// </summary>
+    public string ToJson() => JsonSerializer.Serialize(this, JsonOptions);
+}
+
+/// <summary>Application identity / build information.</summary>
+/// <param name="Name">Product name.</param>
+/// <param name="Version">Informational/assembly version string.</param>
+/// <param name="Theme">Active chrome theme (e.g. <c>Dark</c>).</param>
+/// <param name="Palette">Active S-100 portrayal palette (e.g. <c>Day</c>).</param>
+internal sealed record FeedbackAppInfo(
+    string Name,
+    string Version,
+    string Theme,
+    string Palette);
+
+/// <summary>Operating-system and .NET runtime information.</summary>
+/// <param name="OperatingSystem">OS description string.</param>
+/// <param name="Architecture">Process architecture (e.g. <c>Arm64</c>).</param>
+/// <param name="FrameworkDescription">.NET runtime description.</param>
+/// <param name="Culture">Current UI culture name.</param>
+internal sealed record FeedbackRuntimeInfo(
+    string OperatingSystem,
+    string Architecture,
+    string FrameworkDescription,
+    string Culture);
+
+/// <summary>Map viewport bounds, in WGS-84 decimal degrees.</summary>
+/// <param name="MinLatitude">South edge.</param>
+/// <param name="MinLongitude">West edge.</param>
+/// <param name="MaxLatitude">North edge.</param>
+/// <param name="MaxLongitude">East edge.</param>
+internal sealed record FeedbackViewportInfo(
+    double MinLatitude,
+    double MinLongitude,
+    double MaxLatitude,
+    double MaxLongitude);
+
+/// <summary>Summary of a single loaded dataset.</summary>
+/// <param name="DisplayName">User-facing dataset name (no full path).</param>
+/// <param name="ProductSpec">S-1xx product spec code.</param>
+/// <param name="IsVisible">Whether the dataset layer is currently shown.</param>
+/// <param name="ValidationErrorCount">Validation findings of error severity.</param>
+/// <param name="ValidationWarningCount">Validation findings of warning severity.</param>
+internal sealed record FeedbackDatasetInfo(
+    string DisplayName,
+    string ProductSpec,
+    bool IsVisible,
+    int ValidationErrorCount,
+    int ValidationWarningCount);
+
+/// <summary>The most recent unhandled error.</summary>
+/// <param name="TimestampUtc">When the error occurred (UTC).</param>
+/// <param name="Source">Short origin label.</param>
+/// <param name="ExceptionType">CLR exception type, when known.</param>
+/// <param name="Message">Error message.</param>
+/// <param name="StackTrace">Full exception text / stack trace.</param>
+internal sealed record FeedbackErrorInfo(
+    DateTimeOffset TimestampUtc,
+    string Source,
+    string? ExceptionType,
+    string Message,
+    string? StackTrace);

--- a/src/EncDotNet.S100.Viewer/Services/FeedbackService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeedbackService.cs
@@ -1,0 +1,459 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.Diagnostics;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Default <see cref="IFeedbackService"/>. Gathers diagnostics from the
+/// live view-models/services, captures an application screenshot, writes
+/// a feedback bundle (zip) to a temp folder, and opens a prefilled
+/// GitHub new-issue page.
+/// </summary>
+internal sealed class FeedbackService : IFeedbackService
+{
+    /// <summary>
+    /// Target repository for feedback issues, in <c>owner/repo</c> form.
+    /// </summary>
+    private const string GitHubRepository = "philliphoff/EncDotNet.S100";
+
+    /// <summary>
+    /// Soft cap on the diagnostics JSON embedded in the issue body. URLs
+    /// over ~8 KB are rejected by some browsers/servers, so the full data
+    /// always lives in the saved bundle and only a trimmed copy is inlined.
+    /// </summary>
+    private const int MaxInlineJsonChars = 4000;
+
+    private readonly DatasetsViewModel _datasets;
+    private readonly IMapViewportNotifier _viewport;
+    private readonly ILastErrorTracker _errors;
+    private readonly IThemeService _theme;
+    private readonly SettingsViewModel _settings;
+    private readonly IAppScreenshotProvider _screenshot;
+    private readonly IMapHostAccessor _mapHostAccessor;
+
+    public FeedbackService(
+        DatasetsViewModel datasets,
+        IMapViewportNotifier viewport,
+        ILastErrorTracker errors,
+        IThemeService theme,
+        SettingsViewModel settings,
+        IAppScreenshotProvider screenshot,
+        IMapHostAccessor mapHostAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(datasets);
+        ArgumentNullException.ThrowIfNull(viewport);
+        ArgumentNullException.ThrowIfNull(errors);
+        ArgumentNullException.ThrowIfNull(theme);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(screenshot);
+        ArgumentNullException.ThrowIfNull(mapHostAccessor);
+
+        _datasets = datasets;
+        _viewport = viewport;
+        _errors = errors;
+        _theme = theme;
+        _settings = settings;
+        _screenshot = screenshot;
+        _mapHostAccessor = mapHostAccessor;
+    }
+
+    /// <inheritdoc />
+    public async Task<FeedbackCollectResult> CollectAsync(CancellationToken cancellationToken = default)
+    {
+        var report = BuildReport();
+        var screenshot = await CaptureScreenshotAsync(cancellationToken).ConfigureAwait(false);
+        return new FeedbackCollectResult(report, screenshot);
+    }
+
+    /// <summary>
+    /// Builds the textual diagnostic snapshot. Pure and synchronous so it
+    /// can be unit-tested and called on the UI thread (it only reads
+    /// view-model state).
+    /// </summary>
+    public FeedbackReport BuildReport()
+    {
+        var assembly = typeof(FeedbackService).Assembly;
+        var version =
+            assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
+
+        var app = new FeedbackAppInfo(
+            Name: Strings.Window_Title,
+            Version: version,
+            Theme: _theme.Current.ToString(),
+            Palette: _settings.SelectedPalette.ToString());
+
+        var runtime = new FeedbackRuntimeInfo(
+            OperatingSystem: RuntimeInformation.OSDescription.Trim(),
+            Architecture: RuntimeInformation.ProcessArchitecture.ToString(),
+            FrameworkDescription: RuntimeInformation.FrameworkDescription.Trim(),
+            Culture: CultureInfo.CurrentUICulture.Name);
+
+        FeedbackViewportInfo? viewport = null;
+        if (_viewport.Current is { } v)
+        {
+            viewport = new FeedbackViewportInfo(
+                MinLatitude: v.MinLatitude,
+                MinLongitude: v.MinLongitude,
+                MaxLatitude: v.MaxLatitude,
+                MaxLongitude: v.MaxLongitude);
+        }
+
+        var datasets = new List<FeedbackDatasetInfo>();
+        foreach (var entry in _datasets.Entries)
+        {
+            datasets.Add(new FeedbackDatasetInfo(
+                DisplayName: entry.DisplayName,
+                ProductSpec: entry.ProductSpec,
+                IsVisible: entry.IsVisible,
+                ValidationErrorCount: entry.ValidationErrorCount,
+                ValidationWarningCount: entry.ValidationWarningCount));
+        }
+
+        FeedbackErrorInfo? lastError = null;
+        if (_errors.Current is { } e)
+        {
+            lastError = new FeedbackErrorInfo(
+                TimestampUtc: e.TimestampUtc,
+                Source: e.Source,
+                ExceptionType: e.ExceptionType,
+                Message: e.Message,
+                StackTrace: e.StackTrace);
+        }
+
+        return new FeedbackReport
+        {
+            GeneratedUtc = DateTimeOffset.UtcNow,
+            Application = app,
+            Runtime = runtime,
+            Viewport = viewport,
+            Datasets = datasets,
+            LastError = lastError,
+        };
+    }
+
+    private async Task<byte[]?> CaptureScreenshotAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var window = await _screenshot.CapturePngAsync(cancellationToken).ConfigureAwait(false);
+            if (window is { Length: > 0 })
+                return window;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Fall through to the map-only snapshot.
+        }
+
+        // Fallback: capture just the map if the window could not be rendered.
+        var host = _mapHostAccessor.Current;
+        if (host is null)
+            return null;
+
+        try
+        {
+            return await host.RenderCurrentViewToPngAsync(1280, 800, 1.0, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeedbackSubmitResult> SubmitAsync(
+        FeedbackSubmitRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var json = request.Report.ToJson();
+        var userMessage = request.UserMessage?.Trim() ?? string.Empty;
+
+        var bundlePath = await Task.Run(
+            () => WriteBundle(json, userMessage, request.ScreenshotPng),
+            cancellationToken).ConfigureAwait(false);
+
+        // Place the screenshot on the clipboard so the user can paste it
+        // straight into the GitHub issue (a URL cannot embed an image).
+        var screenshotOnClipboard = false;
+        if (request.ScreenshotPng is { Length: > 0 })
+        {
+            screenshotOnClipboard = await TryCopyImageToClipboardAsync(
+                request.ScreenshotPng, cancellationToken).ConfigureAwait(false);
+        }
+
+        var issueUrl = BuildIssueUrl(
+            request.Report, userMessage, json, bundlePath,
+            request.ScreenshotPng is { Length: > 0 }, screenshotOnClipboard);
+
+        OpenInBrowser(issueUrl);
+        RevealInFileManager(bundlePath);
+
+        return new FeedbackSubmitResult(bundlePath, issueUrl, screenshotOnClipboard);
+    }
+
+    internal static string WriteBundle(string json, string userMessage, byte[]? screenshotPng)
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "S100ViewerFeedback");
+        Directory.CreateDirectory(folder);
+
+        var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+        var bundlePath = Path.Combine(folder, $"feedback-{stamp}.zip");
+
+        using var archive = ZipFile.Open(bundlePath, ZipArchiveMode.Create);
+
+        var jsonEntry = archive.CreateEntry("diagnostics.json", CompressionLevel.Optimal);
+        using (var writer = new StreamWriter(jsonEntry.Open(), new UTF8Encoding(false)))
+            writer.Write(json);
+
+        var messageEntry = archive.CreateEntry("feedback.txt", CompressionLevel.Optimal);
+        using (var writer = new StreamWriter(messageEntry.Open(), new UTF8Encoding(false)))
+            writer.Write(string.IsNullOrWhiteSpace(userMessage)
+                ? "(no message provided)"
+                : userMessage);
+
+        if (screenshotPng is { Length: > 0 })
+        {
+            var imageEntry = archive.CreateEntry("screenshot.png", CompressionLevel.Optimal);
+            using var imageStream = imageEntry.Open();
+            imageStream.Write(screenshotPng, 0, screenshotPng.Length);
+        }
+
+        return bundlePath;
+    }
+
+    /// <summary>
+    /// Builds a GitHub URL that opens the repository's slim, user-friendly
+    /// <c>feedback.yml</c> issue form with its fields pre-populated. Blank
+    /// issues are disabled on the repo, so targeting a form by template name
+    /// (and prefilling by field id) is the only way to land the user on a form
+    /// that already contains the details. The full technical payload rides in
+    /// the auto-collected "diagnostics" field rather than a developer-oriented
+    /// bug-report layout.
+    /// </summary>
+    internal static string BuildIssueUrl(
+        FeedbackReport report,
+        string userMessage,
+        string json,
+        string bundlePath,
+        bool hasScreenshot,
+        bool screenshotOnClipboard)
+    {
+        _ = report;
+
+        var inlineJson = json.Length > MaxInlineJsonChars
+            ? json[..MaxInlineJsonChars] + "\n… (truncated — see diagnostics.json in the bundle)"
+            : json;
+        var diagnostics = "```json\n" + inlineJson + "\n```";
+
+        // The "Screenshot" field is left empty when the image is on the
+        // clipboard (the form's own description prompts the paste); when the
+        // clipboard copy was unavailable, point the user at the saved bundle.
+        var screenshot = string.Empty;
+        if (hasScreenshot && !screenshotOnClipboard)
+        {
+            screenshot =
+                $"A screenshot was saved with this report at:\n{bundlePath}\n" +
+                "Open that file and drag screenshot.png here.";
+        }
+
+        var fields = new Dictionary<string, string>
+        {
+            ["title"] = BuildIssueTitle(userMessage),
+            ["feedback"] = string.IsNullOrWhiteSpace(userMessage) ? string.Empty : userMessage,
+            ["screenshot"] = screenshot,
+            ["diagnostics"] = diagnostics,
+        };
+
+        var query = new StringBuilder($"https://github.com/{GitHubRepository}/issues/new?template=feedback.yml");
+        foreach (var (key, value) in fields)
+        {
+            if (string.IsNullOrEmpty(value))
+                continue;
+            query.Append('&').Append(key).Append('=').Append(Uri.EscapeDataString(value));
+        }
+
+        return query.ToString();
+    }
+
+    private static string BuildIssueTitle(string userMessage)
+    {
+        const string prefix = "[Feedback]: ";
+        if (string.IsNullOrWhiteSpace(userMessage))
+            return prefix;
+
+        var firstLine = userMessage;
+        var newline = userMessage.IndexOf('\n');
+        if (newline >= 0)
+            firstLine = userMessage[..newline];
+        firstLine = firstLine.Trim();
+
+        const int maxTitle = 80;
+        if (firstLine.Length > maxTitle - prefix.Length)
+            firstLine = firstLine[..(maxTitle - prefix.Length - 1)] + "…";
+
+        return prefix + firstLine;
+    }
+
+    private static void OpenInBrowser(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch
+        {
+            // Best-effort: the bundle path is still surfaced to the user.
+        }
+    }
+
+    private static void RevealInFileManager(string path)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Process.Start("open", new[] { "-R", path });
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{path}\"")
+                {
+                    UseShellExecute = true,
+                });
+            }
+            else
+            {
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir))
+                    Process.Start(new ProcessStartInfo("xdg-open", dir) { UseShellExecute = true });
+            }
+        }
+        catch
+        {
+            // Best-effort.
+        }
+    }
+
+    /// <summary>
+    /// Best-effort copy of a PNG image onto the system clipboard using the
+    /// platform's native tool, so the user can paste the screenshot directly
+    /// into the GitHub issue. Returns <see langword="false"/> when the
+    /// platform tool is unavailable or fails.
+    /// </summary>
+    private static async Task<bool> TryCopyImageToClipboardAsync(
+        byte[] png,
+        CancellationToken cancellationToken)
+    {
+        string? tempPng = null;
+        try
+        {
+            tempPng = Path.Combine(Path.GetTempPath(), $"s100-feedback-{Guid.NewGuid():N}.png");
+            await File.WriteAllBytesAsync(tempPng, png, cancellationToken).ConfigureAwait(false);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // AppleScript reads the file as PNG data onto the pasteboard.
+                var script =
+                    $"set the clipboard to (read (POSIX file \"{tempPng}\") as «class PNGf»)";
+                return await RunAsync("osascript", new[] { "-e", script }, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var ps =
+                    "Add-Type -AssemblyName System.Windows.Forms,System.Drawing; " +
+                    $"$img = [System.Drawing.Image]::FromFile('{tempPng}'); " +
+                    "[System.Windows.Forms.Clipboard]::SetImage($img); $img.Dispose()";
+                return await RunAsync(
+                    "powershell",
+                    new[] { "-NoProfile", "-STA", "-Command", ps },
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Prefer Wayland's wl-copy, fall back to X11's xclip.
+                if (await RunAsync("wl-copy", new[] { "--type", "image/png", tempPng }, cancellationToken)
+                        .ConfigureAwait(false))
+                    return true;
+                return await RunAsync(
+                    "xclip",
+                    new[] { "-selection", "clipboard", "-t", "image/png", "-i", tempPng },
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            if (tempPng is not null)
+            {
+                try { File.Delete(tempPng); } catch { /* best-effort */ }
+            }
+        }
+    }
+
+    private static async Task<bool> RunAsync(string fileName, string[] arguments, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(fileName)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            foreach (var arg in arguments)
+                psi.ArgumentList.Add(arg);
+
+            using var process = Process.Start(psi);
+            if (process is null)
+                return false;
+
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return process.ExitCode == 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/IAppScreenshotProvider.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IAppScreenshotProvider.cs
@@ -1,0 +1,44 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Captures a PNG snapshot of the running application window (or a
+/// designated <see cref="Control"/>) for the feedback reporter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The capture target is the live <c>MainWindow</c>, which only exists
+/// after DI is built. <see cref="Target"/> is therefore late-bound by
+/// the window during its construction — mirroring the
+/// <see cref="IMapHostAccessor"/> pattern — so services resolved earlier
+/// can hold the provider and read the target at capture time.
+/// </para>
+/// <para>
+/// Capturing the whole window yields a true "application" screenshot
+/// (chart plus surrounding chrome). When no window target is available
+/// the feedback service falls back to the map-only PNG produced by
+/// <see cref="IMapHost.RenderCurrentViewToPngAsync"/>.
+/// </para>
+/// </remarks>
+internal interface IAppScreenshotProvider
+{
+    /// <summary>
+    /// The control to capture (typically the main window), or
+    /// <see langword="null"/> when not yet attached.
+    /// </summary>
+    Control? Target { get; set; }
+
+    /// <summary>
+    /// Renders <see cref="Target"/> to PNG-encoded bytes, marshalling to
+    /// the UI thread as needed.
+    /// </summary>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// PNG bytes of the current window, or <see langword="null"/> when no
+    /// target is attached or it has no on-screen size yet.
+    /// </returns>
+    Task<byte[]?> CapturePngAsync(CancellationToken cancellationToken = default);
+}

--- a/src/EncDotNet.S100.Viewer/Services/IFeedbackService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IFeedbackService.cs
@@ -1,0 +1,60 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Collects viewer diagnostics for a user feedback report and submits a
+/// completed report (local bundle + prefilled GitHub issue).
+/// </summary>
+internal interface IFeedbackService
+{
+    /// <summary>
+    /// Gathers the current diagnostic snapshot and an optional
+    /// application screenshot. Never throws for routine "data missing"
+    /// conditions — absent pieces are simply left out.
+    /// </summary>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    Task<FeedbackCollectResult> CollectAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes a feedback bundle to disk (diagnostics JSON plus the
+    /// screenshot when included) and opens a prefilled GitHub new-issue
+    /// page in the default browser.
+    /// </summary>
+    /// <param name="request">The completed report, the user's message, and
+    /// the screenshot to include (or <see langword="null"/> to exclude it).</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The saved bundle path and the opened issue URL.</returns>
+    Task<FeedbackSubmitResult> SubmitAsync(
+        FeedbackSubmitRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Result of <see cref="IFeedbackService.CollectAsync"/>.</summary>
+/// <param name="Report">The textual diagnostic snapshot.</param>
+/// <param name="ScreenshotPng">PNG bytes of the application/map, or
+/// <see langword="null"/> when no screenshot could be captured.</param>
+internal sealed record FeedbackCollectResult(
+    FeedbackReport Report,
+    byte[]? ScreenshotPng);
+
+/// <summary>Input to <see cref="IFeedbackService.SubmitAsync"/>.</summary>
+/// <param name="Report">The diagnostic snapshot to include.</param>
+/// <param name="UserMessage">The free-form text the user entered.</param>
+/// <param name="ScreenshotPng">The screenshot to include, or
+/// <see langword="null"/> to exclude it.</param>
+internal sealed record FeedbackSubmitRequest(
+    FeedbackReport Report,
+    string UserMessage,
+    byte[]? ScreenshotPng);
+
+/// <summary>Result of <see cref="IFeedbackService.SubmitAsync"/>.</summary>
+/// <param name="BundlePath">Absolute path of the saved feedback zip.</param>
+/// <param name="IssueUrl">The GitHub new-issue URL that was opened.</param>
+/// <param name="ScreenshotOnClipboard">Whether the screenshot PNG was
+/// successfully placed on the system clipboard for pasting into the issue.</param>
+internal sealed record FeedbackSubmitResult(
+    string BundlePath,
+    string IssueUrl,
+    bool ScreenshotOnClipboard);

--- a/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
@@ -114,7 +114,14 @@ internal sealed class NativeMenuBuilder
 
         var fileMenu = BuildFileMenu();
 
-        var nativeMenu = new NativeMenu { fileMenu, viewMenu };
+        var reportFeedbackItem = new NativeMenuItem(Strings.Menu_ReportFeedback);
+        reportFeedbackItem.Click += (_, _) => _viewModel.ShowFeedbackCommand.Execute(null);
+        var helpMenu = new NativeMenuItem(Strings.Menu_Help)
+        {
+            Menu = new NativeMenu { reportFeedbackItem },
+        };
+
+        var nativeMenu = new NativeMenu { fileMenu, viewMenu, helpMenu };
         NativeMenu.SetMenu(window, nativeMenu);
 
         RebuildOpenRecentMenu();

--- a/src/EncDotNet.S100.Viewer/ViewModels/FeedbackDialogViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/FeedbackDialogViewModel.cs
@@ -1,0 +1,177 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+using ShadUI;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// View-model backing the "Report Feedback" modal dialog. Collects a
+/// diagnostic snapshot plus an optional screenshot, lets the user review
+/// and amend it, and submits via <see cref="IFeedbackService"/>.
+/// </summary>
+/// <remarks>
+/// The dialog is hosted by ShadUI's <see cref="DialogManager"/>; the
+/// view-model closes itself through that manager on submit or cancel.
+/// </remarks>
+internal sealed class FeedbackDialogViewModel : ViewModelBase
+{
+    private readonly DialogManager _dialogManager;
+    private readonly IFeedbackService _feedbackService;
+    private readonly IToastService _toasts;
+
+    private FeedbackReport? _report;
+    private byte[]? _screenshotPng;
+
+    public FeedbackDialogViewModel(
+        DialogManager dialogManager,
+        IFeedbackService feedbackService,
+        IToastService toasts)
+    {
+        ArgumentNullException.ThrowIfNull(dialogManager);
+        ArgumentNullException.ThrowIfNull(feedbackService);
+        ArgumentNullException.ThrowIfNull(toasts);
+
+        _dialogManager = dialogManager;
+        _feedbackService = feedbackService;
+        _toasts = toasts;
+
+        SubmitCommand = new AsyncRelayCommand(SubmitAsync, () => !IsBusy);
+        CancelCommand = new RelayCommand(Cancel);
+    }
+
+    /// <summary>Human-readable description of exactly what is collected.</summary>
+    public string DataDescription => Strings.Feedback_DataDescription;
+
+    private string _userMessage = string.Empty;
+    /// <summary>The free-form feedback the user typed.</summary>
+    public string UserMessage
+    {
+        get => _userMessage;
+        set => SetProperty(ref _userMessage, value);
+    }
+
+    private bool _includeScreenshot = true;
+    /// <summary>Whether the captured screenshot is included on submit.</summary>
+    public bool IncludeScreenshot
+    {
+        get => _includeScreenshot;
+        set => SetProperty(ref _includeScreenshot, value);
+    }
+
+    private Bitmap? _screenshotImage;
+    /// <summary>Decoded screenshot for preview, or <see langword="null"/>
+    /// when none was captured.</summary>
+    public Bitmap? ScreenshotImage
+    {
+        get => _screenshotImage;
+        private set
+        {
+            if (SetProperty(ref _screenshotImage, value))
+                OnPropertyChanged(nameof(HasScreenshot));
+        }
+    }
+
+    /// <summary>True when a screenshot was captured and can be previewed.</summary>
+    public bool HasScreenshot => _screenshotImage is not null;
+
+    private string _rawDiagnostics = string.Empty;
+    /// <summary>The exact diagnostics JSON that will be sent.</summary>
+    public string RawDiagnostics
+    {
+        get => _rawDiagnostics;
+        private set => SetProperty(ref _rawDiagnostics, value);
+    }
+
+    private bool _isRawDataExpanded;
+    /// <summary>Whether the raw-data disclosure section is expanded.</summary>
+    public bool IsRawDataExpanded
+    {
+        get => _isRawDataExpanded;
+        set => SetProperty(ref _isRawDataExpanded, value);
+    }
+
+    private bool _isBusy;
+    /// <summary>True while a submission is in flight.</summary>
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (SetProperty(ref _isBusy, value))
+                ((AsyncRelayCommand)SubmitCommand).NotifyCanExecuteChanged();
+        }
+    }
+
+    /// <summary>Submits the feedback (saves a bundle + opens a GitHub issue).</summary>
+    public ICommand SubmitCommand { get; }
+
+    /// <summary>Dismisses the dialog without submitting.</summary>
+    public ICommand CancelCommand { get; }
+
+    /// <summary>
+    /// Gathers diagnostics and the screenshot. Call once before showing
+    /// the dialog.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        var result = await _feedbackService.CollectAsync().ConfigureAwait(true);
+        _report = result.Report;
+        _screenshotPng = result.ScreenshotPng;
+        RawDiagnostics = result.Report.ToJson();
+
+        if (_screenshotPng is { Length: > 0 })
+        {
+            try
+            {
+                using var stream = new MemoryStream(_screenshotPng);
+                ScreenshotImage = new Bitmap(stream);
+            }
+            catch
+            {
+                ScreenshotImage = null;
+            }
+        }
+    }
+
+    private async Task SubmitAsync()
+    {
+        if (_report is null)
+            return;
+
+        IsBusy = true;
+        try
+        {
+            var screenshot = IncludeScreenshot ? _screenshotPng : null;
+            var result = await _feedbackService
+                .SubmitAsync(new FeedbackSubmitRequest(_report, UserMessage, screenshot))
+                .ConfigureAwait(true);
+
+            _toasts.ShowSuccess(
+                Strings.Feedback_SubmittedTitle,
+                string.Format(
+                    System.Globalization.CultureInfo.CurrentCulture,
+                    result.ScreenshotOnClipboard
+                        ? Strings.Feedback_SubmittedBodyClipboard
+                        : Strings.Feedback_SubmittedBody,
+                    result.BundlePath));
+
+            _dialogManager.Close(this, new CloseDialogOptions { Success = true });
+        }
+        catch (Exception ex)
+        {
+            _toasts.ShowError(Strings.Feedback_SubmitFailedTitle, ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void Cancel() => _dialogManager.Close(this);
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -11,6 +11,7 @@ using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.Tools;
 using EncDotNet.S100.Viewer.ViewModels.Activities;
+using ShadUI;
 namespace EncDotNet.S100.Viewer.ViewModels;
 
 internal sealed class MainViewModel : ViewModelBase
@@ -19,6 +20,8 @@ internal sealed class MainViewModel : ViewModelBase
     private readonly IThemeService _theme;
     private readonly IRecentFilesService _recentFiles;
     private readonly IToastService _toasts;
+    private readonly ShadUI.DialogManager _dialogManager;
+    private readonly Func<FeedbackDialogViewModel>? _feedbackDialogFactory;
 
     public FeatureCataloguesViewModel FeatureCatalogues { get; }
     public PortrayalCataloguesViewModel PortrayalCatalogues { get; }
@@ -611,6 +614,19 @@ internal sealed class MainViewModel : ViewModelBase
 
     public ICommand ToggleThemeCommand { get; }
 
+    /// <summary>
+    /// ShadUI dialog manager bound by the main window's
+    /// <c>DialogHost</c>; used to present the feedback dialog and any
+    /// future modal dialogs.
+    /// </summary>
+    public ShadUI.DialogManager DialogManager { get; }
+
+    /// <summary>
+    /// Opens the "Report Feedback" modal dialog. Triggered from the
+    /// app-bar button and the Help menu.
+    /// </summary>
+    public ICommand ShowFeedbackCommand { get; }
+
     // ─── Exchange-set progress + banner (es3-progress) ────────────────────
 
     private bool _isExchangeSetLoading;
@@ -846,6 +862,8 @@ internal sealed class MainViewModel : ViewModelBase
         IRecentFilesService recentFiles,
         IMeasureOverlayAppearanceProvider measureAppearance,
         IToastService toasts,
+        ShadUI.DialogManager? dialogManager = null,
+        Func<FeedbackDialogViewModel>? feedbackDialogFactory = null,
         IEnumerable<IActivityTab>? activityTabs = null,
         McpServerHost? mcpServerHost = null,
         IStatusPresenter? statusPresenter = null)
@@ -872,6 +890,12 @@ internal sealed class MainViewModel : ViewModelBase
         _theme = themeService;
         _recentFiles = recentFiles;
         _toasts = toasts;
+        // The dialog manager is supplied by DI in the running app; tests
+        // that construct the view-model directly omit it, so fall back to
+        // an unhosted manager to keep the DialogManager property non-null.
+        _dialogManager = dialogManager ?? new ShadUI.DialogManager();
+        _feedbackDialogFactory = feedbackDialogFactory;
+        DialogManager = _dialogManager;
         _isDarkTheme = themeService.IsDarkTheme;
         _statusPresenter = statusPresenter;
         _mcpServerHost = mcpServerHost;
@@ -1035,6 +1059,8 @@ internal sealed class MainViewModel : ViewModelBase
 
         ToggleThemeCommand = new RelayCommand(() => IsDarkTheme = _theme.ToggleTheme());
 
+        ShowFeedbackCommand = new AsyncRelayCommand(ShowFeedbackAsync);
+
         // Keep IsDarkTheme in sync when the theme is changed via paths
         // other than ToggleThemeCommand (e.g. the SettingsView chrome
         // selector, which routes through IThemeService.SetTheme).
@@ -1174,5 +1200,24 @@ internal sealed class MainViewModel : ViewModelBase
 
         SelectDefaultTab();
         await Datasets.LoadFromPathAsync(path);
+    }
+
+    /// <summary>
+    /// Collects diagnostics + an optional screenshot, then presents the
+    /// feedback dialog via the ShadUI dialog manager.
+    /// </summary>
+    private async Task ShowFeedbackAsync()
+    {
+        if (_feedbackDialogFactory is null)
+        {
+            return;
+        }
+
+        var dialog = _feedbackDialogFactory();
+        await dialog.InitializeAsync();
+        _dialogManager.CreateDialog(dialog)
+            .Dismissible()
+            .WithMaxWidth(620)
+            .Show();
     }
 }

--- a/src/EncDotNet.S100.Viewer/Views/FeedbackDialogView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeedbackDialogView.axaml
@@ -1,0 +1,115 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:ic="using:FluentIcons.Avalonia"
+             x:Class="EncDotNet.S100.Viewer.Views.FeedbackDialogView"
+             x:DataType="vm:FeedbackDialogViewModel"
+             Width="560"
+             Height="600">
+
+    <Grid Margin="24" RowDefinitions="Auto,*,Auto">
+
+        <!-- Fixed header + description -->
+        <StackPanel Grid.Row="0" Spacing="16">
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <ic:FluentIcon Icon="PersonFeedback" IconVariant="Regular" FontSize="22"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundColor}" />
+                <TextBlock Text="{x:Static loc:Strings.Feedback_DialogTitle}"
+                           FontSize="18"
+                           FontWeight="SemiBold"
+                           VerticalAlignment="Center" />
+            </StackPanel>
+
+            <TextBlock Text="{x:Static loc:Strings.Feedback_DataDescription}"
+                       FontSize="12"
+                       Opacity="0.75"
+                       TextWrapping="Wrap" />
+        </StackPanel>
+
+        <!-- Scrollable content -->
+        <ScrollViewer Grid.Row="1"
+                      Margin="0,16,0,0"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto">
+            <!-- Right gutter keeps the overlay scrollbar off the content. -->
+            <StackPanel Spacing="16" Margin="0,0,14,0">
+
+                <!-- User message -->
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{x:Static loc:Strings.Feedback_YourFeedbackLabel}"
+                               FontSize="12"
+                               FontWeight="SemiBold" />
+                    <TextBox Text="{Binding UserMessage, Mode=TwoWay}"
+                             PlaceholderText="{x:Static loc:Strings.Feedback_FeedbackWatermark}"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             MinHeight="96"
+                             MaxHeight="160"
+                             VerticalContentAlignment="Top" />
+                </StackPanel>
+
+                <!-- Screenshot -->
+                <StackPanel Spacing="8" IsVisible="{Binding HasScreenshot}">
+                    <CheckBox IsChecked="{Binding IncludeScreenshot, Mode=TwoWay}"
+                              Content="{x:Static loc:Strings.Feedback_IncludeScreenshot}" />
+                    <Border BorderBrush="{DynamicResource BorderColor}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="2"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding IncludeScreenshot}">
+                        <Image Source="{Binding ScreenshotImage}"
+                               MaxHeight="200"
+                               Stretch="Uniform"
+                               ToolTip.Tip="{x:Static loc:Strings.Feedback_ScreenshotPreviewTooltip}" />
+                    </Border>
+                </StackPanel>
+
+                <!-- Raw data disclosure (custom toggle for precise alignment) -->
+                <StackPanel Spacing="0">
+                    <ToggleButton Classes="Ghost"
+                                  Padding="4,2"
+                                  HorizontalAlignment="Left"
+                                  IsChecked="{Binding IsRawDataExpanded, Mode=TwoWay}"
+                                  ToolTip.Tip="{x:Static loc:Strings.Feedback_RawDataHeader}">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <ic:FluentIcon Icon="ChevronRight" IconVariant="Regular" FontSize="14"
+                                           VerticalAlignment="Center"
+                                           IsVisible="{Binding !IsRawDataExpanded}" />
+                            <ic:FluentIcon Icon="ChevronDown" IconVariant="Regular" FontSize="14"
+                                           VerticalAlignment="Center"
+                                           IsVisible="{Binding IsRawDataExpanded}" />
+                            <TextBlock Text="{x:Static loc:Strings.Feedback_RawDataHeader}"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                    </ToggleButton>
+                    <SelectableTextBlock Text="{Binding RawDiagnostics}"
+                                         IsVisible="{Binding IsRawDataExpanded}"
+                                         Margin="2,8,0,0"
+                                         FontSize="11"
+                                         TextWrapping="Wrap"
+                                         FontFamily="Menlo,Consolas,Courier New,monospace" />
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- Fixed actions -->
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,16,0,0">
+            <Button Classes="Outline"
+                    Content="{x:Static loc:Strings.Feedback_Cancel}"
+                    Command="{Binding CancelCommand}"
+                    IsEnabled="{Binding !IsBusy}"
+                    ToolTip.Tip="{x:Static loc:Strings.Feedback_CancelTooltip}" />
+            <Button Classes="Primary"
+                    Content="{x:Static loc:Strings.Feedback_Submit}"
+                    Command="{Binding SubmitCommand}"
+                    ToolTip.Tip="{x:Static loc:Strings.Feedback_SubmitTooltip}" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/FeedbackDialogView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/FeedbackDialogView.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// Code-behind for the "Report Feedback" modal dialog content. The view
+/// is resolved from <see cref="ViewModels.FeedbackDialogViewModel"/> via
+/// a data template and hosted by ShadUI's dialog manager.
+/// </summary>
+public partial class FeedbackDialogView : UserControl
+{
+    public FeedbackDialogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeedbackReportingTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeedbackReportingTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers the feedback reporter's pure logic: the diagnostic report
+/// serialisation, the GitHub issue-URL builder, and the on-disk bundle
+/// writer. UI presentation (the dialog) is exercised manually.
+/// </summary>
+public class FeedbackReportingTests
+{
+    private static FeedbackReport SampleReport(bool withViewport = true, bool withError = true) =>
+        new()
+        {
+            GeneratedUtc = new DateTimeOffset(2026, 6, 14, 12, 0, 0, TimeSpan.Zero),
+            Application = new FeedbackAppInfo("S-100 Viewer", "1.2.3", "Dark", "Day"),
+            Runtime = new FeedbackRuntimeInfo("macOS 15", "Arm64", ".NET 10.0", "en-US"),
+            Viewport = withViewport
+                ? new FeedbackViewportInfo(50.0, -5.0, 51.0, -4.0)
+                : null,
+            Datasets = new[]
+            {
+                new FeedbackDatasetInfo("US5MA1BO", "S-101", true, 0, 2),
+            },
+            LastError = withError
+                ? new FeedbackErrorInfo(
+                    new DateTimeOffset(2026, 6, 14, 11, 59, 0, TimeSpan.Zero),
+                    "UIThread.UnhandledException", "System.InvalidOperationException",
+                    "boom", "System.InvalidOperationException: boom\n   at X()")
+                : null,
+        };
+
+    [Fact]
+    public void ToJson_IncludesKeyFields()
+    {
+        var json = SampleReport().ToJson();
+
+        Assert.Contains("\"Version\": \"1.2.3\"", json);
+        Assert.Contains("\"Palette\": \"Day\"", json);
+        Assert.Contains("US5MA1BO", json);
+        Assert.Contains("\"ProductSpec\": \"S-101\"", json);
+        Assert.Contains("boom", json);
+    }
+
+    [Fact]
+    public void ToJson_OmitsNullSections()
+    {
+        var json = SampleReport(withViewport: false, withError: false).ToJson();
+
+        Assert.DoesNotContain("Viewport", json);
+        Assert.DoesNotContain("LastError", json);
+    }
+
+    [Fact]
+    public void BuildIssueUrl_TargetsFeedbackFormAndPrefillsFields()
+    {
+        var report = SampleReport();
+        var json = report.ToJson();
+        var url = FeedbackService.BuildIssueUrl(
+            report, "Depth labels overlap", json, "/tmp/S100ViewerFeedback/feedback-x.zip",
+            hasScreenshot: true, screenshotOnClipboard: true);
+
+        Assert.StartsWith("https://github.com/philliphoff/EncDotNet.S100/issues/new?", url);
+        // Targets the slim, user-friendly feedback form (blank issues are disabled).
+        Assert.Contains("template=feedback.yml", url);
+        // The user's words land in the feedback field, URL-encoded.
+        Assert.Contains("feedback=", url);
+        Assert.Contains(Uri.EscapeDataString("Depth labels overlap"), url);
+        // Diagnostics JSON rides in the auto-collected field.
+        Assert.Contains("diagnostics=", url);
+        Assert.Contains(Uri.EscapeDataString("US5MA1BO"), url);
+        // Title uses the feedback prefix.
+        Assert.Contains(Uri.EscapeDataString("[Feedback]: Depth labels overlap"), url);
+    }
+
+    [Fact]
+    public void BuildIssueUrl_PointsToBundleWhenScreenshotNotOnClipboard()
+    {
+        var report = SampleReport();
+        var json = report.ToJson();
+        var url = FeedbackService.BuildIssueUrl(
+            report, "hi", json, "/tmp/S100ViewerFeedback/feedback-y.zip",
+            hasScreenshot: true, screenshotOnClipboard: false);
+
+        Assert.Contains("screenshot=", url);
+        Assert.Contains(Uri.EscapeDataString("screenshot.png"), url);
+    }
+
+    [Fact]
+    public void BuildIssueUrl_TruncatesLongDiagnostics()
+    {
+        var report = SampleReport();
+        var bigJson = new string('x', 20_000);
+        var url = FeedbackService.BuildIssueUrl(
+            report, "hi", bigJson, "/tmp/b.zip", hasScreenshot: false, screenshotOnClipboard: false);
+
+        Assert.Contains(Uri.EscapeDataString("truncated"), url);
+        // Even with a huge report, the URL stays within a sane bound.
+        Assert.True(url.Length < 16_000, $"URL unexpectedly long: {url.Length}");
+    }
+
+    [Fact]
+    public void WriteBundle_WritesJsonMessageAndScreenshot()
+    {
+        var json = SampleReport().ToJson();
+        var png = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+
+        var path = FeedbackService.WriteBundle(json, "please fix", png);
+        try
+        {
+            Assert.True(File.Exists(path));
+            using var archive = ZipFile.OpenRead(path);
+
+            var names = archive.Entries.Select(e => e.FullName).ToArray();
+            Assert.Contains("diagnostics.json", names);
+            Assert.Contains("feedback.txt", names);
+            Assert.Contains("screenshot.png", names);
+
+            using var reader = new StreamReader(
+                archive.GetEntry("diagnostics.json")!.Open(), Encoding.UTF8);
+            Assert.Contains("US5MA1BO", reader.ReadToEnd());
+
+            using var msg = new StreamReader(
+                archive.GetEntry("feedback.txt")!.Open(), Encoding.UTF8);
+            Assert.Equal("please fix", msg.ReadToEnd());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteBundle_OmitsScreenshotWhenNull()
+    {
+        var path = FeedbackService.WriteBundle("{}", "", screenshotPng: null);
+        try
+        {
+            using var archive = ZipFile.OpenRead(path);
+            Assert.DoesNotContain("screenshot.png", archive.Entries.Select(e => e.FullName));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/LastErrorTrackerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LastErrorTrackerTests.cs
@@ -1,0 +1,61 @@
+using System;
+using EncDotNet.S100.Viewer.Diagnostics;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers <see cref="LastErrorTracker"/>: recording from an exception and
+/// from a pre-formatted message, and latest-wins semantics.
+/// </summary>
+public class LastErrorTrackerTests
+{
+    [Fact]
+    public void Current_IsNull_BeforeAnyError()
+    {
+        var tracker = new LastErrorTracker();
+        Assert.Null(tracker.Current);
+    }
+
+    [Fact]
+    public void Record_Exception_CapturesTypeMessageAndStack()
+    {
+        var tracker = new LastErrorTracker();
+        Exception ex;
+        try { throw new InvalidOperationException("kaboom"); }
+        catch (Exception caught) { ex = caught; }
+
+        tracker.Record("UIThread.UnhandledException", ex);
+
+        var current = tracker.Current;
+        Assert.NotNull(current);
+        Assert.Equal("UIThread.UnhandledException", current!.Source);
+        Assert.Equal("System.InvalidOperationException", current.ExceptionType);
+        Assert.Equal("kaboom", current.Message);
+        Assert.Contains("kaboom", current.StackTrace);
+    }
+
+    [Fact]
+    public void Record_Message_UsesFirstLineAsMessageAndKeepsFullText()
+    {
+        var tracker = new LastErrorTracker();
+        tracker.Record("UnhandledException", "Top line\nstack frame 1\nstack frame 2");
+
+        var current = tracker.Current;
+        Assert.NotNull(current);
+        Assert.Null(current!.ExceptionType);
+        Assert.Equal("Top line", current.Message);
+        Assert.Contains("stack frame 2", current.StackTrace);
+    }
+
+    [Fact]
+    public void Record_LatestWins()
+    {
+        var tracker = new LastErrorTracker();
+        tracker.Record("first", new Exception("one"));
+        tracker.Record("second", new Exception("two"));
+
+        Assert.Equal("two", tracker.Current!.Message);
+        Assert.Equal("second", tracker.Current.Source);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a user-facing **Report Feedback** experience to the Avalonia S-100 viewer so users can file consistent, well-formed reports without hunting for details or dragging files around.

- **Entry points**: a feedback button in the app title bar (next to the theme toggle) and a **Help → Report Feedback…** menu item, both opening a ShadUI modal dialog.
- **Dialog**: explains exactly what is collected, takes free-form feedback, previews an optional **application screenshot** (excludable via checkbox), and discloses the **exact raw diagnostics JSON** in a collapsible "Show data that will be sent" section — the user always sees precisely what will be sent.
- **Auto-collected diagnostics**: app/build info, OS + .NET runtime, current map viewport, loaded-dataset stats (product, visibility, validation counts), and the most recent unhandled error. A new `ILastErrorTracker` is wired into the global exception handlers to capture that last error.
- **Submission**: writes a local bundle (`diagnostics.json` + `feedback.txt` + `screenshot.png`) to a temp folder and reveals it, copies the screenshot to the **system clipboard** so the user can paste it straight into the issue (⌘V / Ctrl+V), and opens a **prefilled GitHub issue**.
- **New slim issue form** (`.github/ISSUE_TEMPLATE/feedback.yml`): a friendly *Viewer feedback* form (Your feedback / Screenshot / Technical details), separate from the developer-oriented `bug_report.yml`. Because the repo disables blank issues, the form is targeted by template name and prefilled by field id.

## Notes / decisions

- **Dialog registration**: ShadUI resolves custom dialogs via an explicit `DialogManager.Register<TView, TContext>()` (a DataTemplate alone isn't enough); registration happens once after the DI container builds.
- **GitHub prefill limit**: textareas with a `render:` key cap URL prefill at ~400 chars, so the diagnostics field is a plain textarea and the JSON is fenced in the prefilled value instead. Inline JSON is soft-capped (full copy always in the bundle).
- **Clipboard image copy** is best-effort per platform (macOS `osascript`, Windows PowerShell, Linux `wl-copy`/`xclip`); the saved bundle is the fallback when it's unavailable.
- The new `MainViewModel` constructor params are optional so existing tests keep constructing it directly while DI still injects the real services.

## Testing

- New unit tests: `FeedbackReportingTests` (report JSON, issue-URL/form prefill, bundle writing) and `LastErrorTrackerTests`.
- Full viewer suite: **877 passed, 1 skipped**.
- The prefilled GitHub form can only be fully verified once `feedback.yml` is merged to the default branch.

## Docs

- Added a "Reporting feedback" section to the viewer `README.md`.