### PR TITLE
Make feedback screenshot drag-and-droppable into GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -24,7 +24,10 @@ body:
       label: Screenshot
       description: |
         If the viewer copied a screenshot to your clipboard, paste it here with
-        **⌘V / Ctrl+V**. You can leave this empty.
+        **⌘V / Ctrl+V**. If that paste fails with "failed to upload", the viewer
+        also revealed a `screenshot.png` file in your file manager — drag that
+        file into this field instead (file uploads are more reliable than
+        pasting). You can leave this empty.
 
   - type: textarea
     id: diagnostics

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -342,10 +342,17 @@ viewer has a built-in **Report Feedback** experience:
   you always see precisely what will be sent before submitting.
 - On submit the viewer writes a local **bundle** — a zip containing
   `diagnostics.json`, your `feedback.txt`, and (if included) the
-  `screenshot.png` — under your temp folder, reveals it in the file
-  manager, and opens a **prefilled GitHub new-issue page** in your
-  browser. Attach the bundle to the issue (the screenshot can't be
-  embedded automatically) and submit.
+  `screenshot.png` — under your temp folder. When a screenshot is
+  included it also writes a **standalone `…-screenshot.png`** next to
+  the bundle and reveals *that* file in the file manager, then opens a
+  **prefilled GitHub new-issue page** in your browser.
+- The screenshot is copied to your clipboard so you can paste it into
+  the issue with ⌘V / Ctrl+V. GitHub's clipboard paste-to-upload is
+  unreliable, though — it often reports *"failed to upload image.png"*
+  even for a valid PNG. If that happens, **drag the revealed
+  `…-screenshot.png` file into the form's Screenshot field instead**;
+  file uploads succeed where pasting fails. The prefilled form and the
+  confirmation toast both spell this out.
 
 No data leaves your machine until you choose to create the GitHub
 issue, and nothing is uploaded by the viewer itself.

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -453,10 +453,10 @@
     <value>Feedback ready</value>
   </data>
   <data name="Feedback_SubmittedBody" xml:space="preserve">
-    <value>A prefilled GitHub issue was opened in your browser. The feedback bundle was saved to {0}.</value>
+    <value>A prefilled GitHub issue was opened in your browser. Your screenshot was saved to {0} — drag it into the form's Screenshot field.</value>
   </data>
   <data name="Feedback_SubmittedBodyClipboard" xml:space="preserve">
-    <value>A prefilled GitHub issue was opened in your browser. Paste your screenshot into it with ⌘V / Ctrl+V. The feedback bundle was also saved to {0}.</value>
+    <value>A prefilled GitHub issue was opened in your browser. Paste your screenshot with ⌘V / Ctrl+V; if the upload fails, drag the file we revealed at {0} into the form instead.</value>
   </data>
   <data name="Feedback_SubmitFailedTitle" xml:space="preserve">
     <value>Could not prepare feedback</value>

--- a/src/EncDotNet.S100.Viewer/Services/FeedbackService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeedbackService.cs
@@ -192,27 +192,63 @@ internal sealed class FeedbackService : IFeedbackService
         var json = request.Report.ToJson();
         var userMessage = request.UserMessage?.Trim() ?? string.Empty;
 
-        var bundlePath = await Task.Run(
-            () => WriteBundle(json, userMessage, request.ScreenshotPng),
+        var hasScreenshot = request.ScreenshotPng is { Length: > 0 };
+
+        var (bundlePath, screenshotPath) = await Task.Run(
+            () => WriteArtifacts(json, userMessage, request.ScreenshotPng),
             cancellationToken).ConfigureAwait(false);
 
         // Place the screenshot on the clipboard so the user can paste it
         // straight into the GitHub issue (a URL cannot embed an image).
+        // Pasting is convenient but flaky: GitHub's browser paste-to-upload
+        // frequently reports "failed to upload image.png" even for a valid
+        // PNG, whereas dragging the standalone file in is reliable. The
+        // revealed screenshot.png below is the dependable fallback.
         var screenshotOnClipboard = false;
-        if (request.ScreenshotPng is { Length: > 0 })
+        if (hasScreenshot)
         {
             screenshotOnClipboard = await TryCopyImageToClipboardAsync(
-                request.ScreenshotPng, cancellationToken).ConfigureAwait(false);
+                request.ScreenshotPng!, cancellationToken).ConfigureAwait(false);
         }
 
         var issueUrl = BuildIssueUrl(
-            request.Report, userMessage, json, bundlePath,
-            request.ScreenshotPng is { Length: > 0 }, screenshotOnClipboard);
+            request.Report, userMessage, json, screenshotPath,
+            hasScreenshot, screenshotOnClipboard);
 
         OpenInBrowser(issueUrl);
-        RevealInFileManager(bundlePath);
 
-        return new FeedbackSubmitResult(bundlePath, issueUrl, screenshotOnClipboard);
+        // Reveal the standalone screenshot so it is ready to drag into the
+        // issue; fall back to the bundle when there is no screenshot.
+        RevealInFileManager(screenshotPath ?? bundlePath);
+
+        return new FeedbackSubmitResult(bundlePath, issueUrl, screenshotOnClipboard, screenshotPath);
+    }
+
+    /// <summary>
+    /// Writes the on-disk feedback artifacts: the diagnostics/message/image
+    /// zip bundle and, when a screenshot is included, a standalone
+    /// <c>screenshot.png</c> next to it. The standalone file exists because
+    /// GitHub's clipboard paste upload is unreliable; a loose PNG can be
+    /// dragged straight into the issue form, which always succeeds.
+    /// </summary>
+    /// <returns>The bundle path and the standalone screenshot path (or
+    /// <see langword="null"/> when no screenshot was provided).</returns>
+    internal static (string BundlePath, string? ScreenshotPath) WriteArtifacts(
+        string json, string userMessage, byte[]? screenshotPng)
+    {
+        var bundlePath = WriteBundle(json, userMessage, screenshotPng);
+
+        string? screenshotPath = null;
+        if (screenshotPng is { Length: > 0 })
+        {
+            // Mirror the bundle's stamp so the two files sort together.
+            var fileName = Path.GetFileNameWithoutExtension(bundlePath);
+            screenshotPath = Path.Combine(
+                Path.GetDirectoryName(bundlePath)!, $"{fileName}-screenshot.png");
+            File.WriteAllBytes(screenshotPath, screenshotPng);
+        }
+
+        return (bundlePath, screenshotPath);
     }
 
     internal static string WriteBundle(string json, string userMessage, byte[]? screenshotPng)
@@ -258,7 +294,7 @@ internal sealed class FeedbackService : IFeedbackService
         FeedbackReport report,
         string userMessage,
         string json,
-        string bundlePath,
+        string? screenshotPath,
         bool hasScreenshot,
         bool screenshotOnClipboard)
     {
@@ -269,15 +305,28 @@ internal sealed class FeedbackService : IFeedbackService
             : json;
         var diagnostics = "```json\n" + inlineJson + "\n```";
 
-        // The "Screenshot" field is left empty when the image is on the
-        // clipboard (the form's own description prompts the paste); when the
-        // clipboard copy was unavailable, point the user at the saved bundle.
+        // GitHub's clipboard paste-to-upload is flaky ("failed to upload
+        // image.png") even for a valid PNG, so the prefilled prompt always
+        // points the user at the standalone file revealed in their file
+        // manager — dragging it in is the reliable path. When the clipboard
+        // copy succeeded we still offer paste first as the quicker option.
         var screenshot = string.Empty;
-        if (hasScreenshot && !screenshotOnClipboard)
+        if (hasScreenshot)
         {
-            screenshot =
-                $"A screenshot was saved with this report at:\n{bundlePath}\n" +
-                "Open that file and drag screenshot.png here.";
+            var fileName = screenshotPath is null
+                ? "screenshot.png"
+                : Path.GetFileName(screenshotPath);
+
+            var builder = new StringBuilder();
+            if (screenshotOnClipboard)
+                builder.Append("A screenshot is on your clipboard — try pasting it here with ⌘V / Ctrl+V. ");
+            builder.Append("If the upload fails, drag ")
+                .Append(fileName)
+                .Append(" into this field instead");
+            if (screenshotPath is not null)
+                builder.Append(" (it was just revealed in your file manager: ").Append(screenshotPath).Append(')');
+            builder.Append(" — uploading the file is more reliable than pasting.");
+            screenshot = builder.ToString();
         }
 
         var fields = new Dictionary<string, string>

--- a/src/EncDotNet.S100.Viewer/Services/IFeedbackService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IFeedbackService.cs
@@ -54,7 +54,12 @@ internal sealed record FeedbackSubmitRequest(
 /// <param name="IssueUrl">The GitHub new-issue URL that was opened.</param>
 /// <param name="ScreenshotOnClipboard">Whether the screenshot PNG was
 /// successfully placed on the system clipboard for pasting into the issue.</param>
+/// <param name="ScreenshotPath">Absolute path of the standalone
+/// <c>screenshot.png</c> written alongside the bundle and revealed in the
+/// file manager for drag-and-drop, or <see langword="null"/> when no
+/// screenshot was included.</param>
 internal sealed record FeedbackSubmitResult(
     string BundlePath,
     string IssueUrl,
-    bool ScreenshotOnClipboard);
+    bool ScreenshotOnClipboard,
+    string? ScreenshotPath);

--- a/src/EncDotNet.S100.Viewer/ViewModels/FeedbackDialogViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/FeedbackDialogViewModel.cs
@@ -152,6 +152,10 @@ internal sealed class FeedbackDialogViewModel : ViewModelBase
                 .SubmitAsync(new FeedbackSubmitRequest(_report, UserMessage, screenshot))
                 .ConfigureAwait(true);
 
+            // Surface the loose screenshot.png (the reliable drag-and-drop
+            // source) when one was written; otherwise point at the bundle.
+            var revealedPath = result.ScreenshotPath ?? result.BundlePath;
+
             _toasts.ShowSuccess(
                 Strings.Feedback_SubmittedTitle,
                 string.Format(
@@ -159,7 +163,7 @@ internal sealed class FeedbackDialogViewModel : ViewModelBase
                     result.ScreenshotOnClipboard
                         ? Strings.Feedback_SubmittedBodyClipboard
                         : Strings.Feedback_SubmittedBody,
-                    result.BundlePath));
+                    revealedPath));
 
             _dialogManager.Close(this, new CloseDialogOptions { Success = true });
         }

--- a/tests/EncDotNet.S100.Viewer.Tests/FeedbackReportingTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeedbackReportingTests.cs
@@ -63,7 +63,8 @@ public class FeedbackReportingTests
         var report = SampleReport();
         var json = report.ToJson();
         var url = FeedbackService.BuildIssueUrl(
-            report, "Depth labels overlap", json, "/tmp/S100ViewerFeedback/feedback-x.zip",
+            report, "Depth labels overlap", json,
+            "/tmp/S100ViewerFeedback/feedback-x-screenshot.png",
             hasScreenshot: true, screenshotOnClipboard: true);
 
         Assert.StartsWith("https://github.com/philliphoff/EncDotNet.S100/issues/new?", url);
@@ -80,16 +81,33 @@ public class FeedbackReportingTests
     }
 
     [Fact]
-    public void BuildIssueUrl_PointsToBundleWhenScreenshotNotOnClipboard()
+    public void BuildIssueUrl_OffersClipboardPasteAndDragFallback()
     {
         var report = SampleReport();
         var json = report.ToJson();
         var url = FeedbackService.BuildIssueUrl(
-            report, "hi", json, "/tmp/S100ViewerFeedback/feedback-y.zip",
+            report, "hi", json, "/tmp/S100ViewerFeedback/feedback-y-screenshot.png",
+            hasScreenshot: true, screenshotOnClipboard: true);
+
+        Assert.Contains("screenshot=", url);
+        // Mentions paste (clipboard succeeded) and the drag-drop fallback file.
+        Assert.Contains(Uri.EscapeDataString("pasting"), url);
+        Assert.Contains(Uri.EscapeDataString("feedback-y-screenshot.png"), url);
+    }
+
+    [Fact]
+    public void BuildIssueUrl_PointsToFileWhenScreenshotNotOnClipboard()
+    {
+        var report = SampleReport();
+        var json = report.ToJson();
+        var url = FeedbackService.BuildIssueUrl(
+            report, "hi", json, "/tmp/S100ViewerFeedback/feedback-z-screenshot.png",
             hasScreenshot: true, screenshotOnClipboard: false);
 
         Assert.Contains("screenshot=", url);
-        Assert.Contains(Uri.EscapeDataString("screenshot.png"), url);
+        Assert.Contains(Uri.EscapeDataString("feedback-z-screenshot.png"), url);
+        // Always steers the user to the reliable drag-and-drop path.
+        Assert.Contains(Uri.EscapeDataString("drag"), url);
     }
 
     [Fact]
@@ -103,6 +121,45 @@ public class FeedbackReportingTests
         Assert.Contains(Uri.EscapeDataString("truncated"), url);
         // Even with a huge report, the URL stays within a sane bound.
         Assert.True(url.Length < 16_000, $"URL unexpectedly long: {url.Length}");
+    }
+
+    [Fact]
+    public void WriteArtifacts_WritesBundleAndStandaloneScreenshot()
+    {
+        var json = SampleReport().ToJson();
+        var png = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+
+        var (bundlePath, screenshotPath) = FeedbackService.WriteArtifacts(json, "please fix", png);
+        try
+        {
+            Assert.True(File.Exists(bundlePath));
+            Assert.NotNull(screenshotPath);
+            Assert.True(File.Exists(screenshotPath));
+            // The loose PNG carries the raw bytes (the reliable drag source).
+            Assert.Equal(png, File.ReadAllBytes(screenshotPath!));
+            Assert.EndsWith("-screenshot.png", screenshotPath);
+        }
+        finally
+        {
+            File.Delete(bundlePath);
+            if (screenshotPath is not null)
+                File.Delete(screenshotPath);
+        }
+    }
+
+    [Fact]
+    public void WriteArtifacts_OmitsStandaloneScreenshotWhenNull()
+    {
+        var (bundlePath, screenshotPath) = FeedbackService.WriteArtifacts("{}", "", screenshotPng: null);
+        try
+        {
+            Assert.True(File.Exists(bundlePath));
+            Assert.Null(screenshotPath);
+        }
+        finally
+        {
+            File.Delete(bundlePath);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The viewer's new Report Feedback command copies the captured screenshot to the clipboard so users can paste it into the prefilled GitHub issue. In practice the paste frequently fails with *"failed to upload image.png"*. I reproduced this on macOS and confirmed the clipboard genuinely holds a valid `public.png` (verified via `NSPasteboard`), so the bytes are fine. The culprit is GitHub's browser paste-to-upload path, which is a well-known flaky mechanism, whereas dragging a real PNG file into the field uploads reliably.

Rather than fight a GitHub-side limitation, this PR makes the reliable drag-and-drop path first-class:

- `FeedbackService` now writes a standalone `…-screenshot.png` next to the zip bundle (new `WriteArtifacts`) and reveals *that file* in the file manager, ready to drag.
- The prefilled issue URL's Screenshot field now always names the revealed file and tells the user to drag it in if the paste upload fails. Paste is still offered first when the clipboard copy succeeded, as the quicker option when the browser cooperates.
- The issue template (`feedback.yml`), the confirmation toast strings, and the viewer README all explain the paste-may-fail / drag-the-file behavior.

Clipboard copy is kept as the convenient first option; the loose file is the dependable fallback.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — viewer UX change, no spec semantics touched.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally (Viewer.Tests `FeedbackReportingTests`: 10/10)

New coverage: `WriteArtifacts` (standalone PNG written / omitted) and the updated `BuildIssueUrl` paste+drag messaging for both clipboard-succeeded and clipboard-failed cases.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments (`WriteArtifacts`, `FeedbackSubmitResult.ScreenshotPath`)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (none added)

## Breaking changes

None. `FeedbackSubmitResult` gains a `ScreenshotPath` member and the internal `BuildIssueUrl` signature changed (internal API, callers updated).