### PR TITLE
Skip synthetic "_simple_" line style in catalogue pre-warm (#286)

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/Vector/DrawingInstruction.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/DrawingInstruction.cs
@@ -134,6 +134,21 @@ public sealed class PointInstruction : DrawingInstruction
 /// </summary>
 public sealed class LineInstruction : DrawingInstruction
 {
+    /// <summary>
+    /// Sentinel <see cref="LineStyleReference"/> (and
+    /// <see cref="AreaInstruction.OutlineStyleReference"/>) value emitted by
+    /// the S-100 Part 9A Lua portrayal model (<c>PortrayalModel.lua</c>'s
+    /// <c>SimpleLineStyle</c>) to denote an inline "simple" line style whose
+    /// colour, width, and dash pattern are carried directly on the
+    /// instruction (<see cref="LineColor"/> / <see cref="LineWidth"/> /
+    /// <see cref="Dashes"/>) rather than by a named complex line style in the
+    /// portrayal catalogue. Renderers and the catalogue pre-warm must treat
+    /// this value as "no catalogue lookup" — attempting to resolve it would
+    /// always miss (and historically threw a <see cref="KeyNotFoundException"/>
+    /// on every dataset load).
+    /// </summary>
+    public const string SimpleLineStyleReference = "_simple_";
+
     /// <summary>Reference (by name) to a line style in the portrayal catalogue.</summary>
     public string? LineStyleReference { get; init; }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/CataloguePreWarm.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/CataloguePreWarm.cs
@@ -41,12 +41,14 @@ internal static class CataloguePreWarm
                     symbolNames.Add(p.SymbolReference);
                     break;
                 case LineInstruction l when !string.IsNullOrEmpty(l.LineStyleReference):
-                    lineNames.Add(l.LineStyleReference);
+                    if (!IsSimpleLineStyle(l.LineStyleReference))
+                        lineNames.Add(l.LineStyleReference);
                     break;
                 case AreaInstruction a:
                     if (!string.IsNullOrEmpty(a.AreaFillReference))
                         areaNames.Add(a.AreaFillReference);
-                    if (!string.IsNullOrEmpty(a.OutlineStyleReference))
+                    if (!string.IsNullOrEmpty(a.OutlineStyleReference) &&
+                        !IsSimpleLineStyle(a.OutlineStyleReference))
                         lineNames.Add(a.OutlineStyleReference);
                     break;
             }
@@ -95,6 +97,15 @@ internal static class CataloguePreWarm
 
         return new PreWarmResult(symbols, lineStyles, areaFills);
     }
+
+    // The S-100 Part 9A Lua portrayal model emits LineInstruction /
+    // AreaInstruction outline references with the inline "simple" line-style
+    // sentinel (see LineInstruction.SimpleLineStyleReference). It is never a
+    // named catalogue line style — its colour, width, and dash pattern travel
+    // on the instruction itself — so resolving it always missed and threw a
+    // KeyNotFoundException on every dataset load (#286). Skip it up front.
+    private static bool IsSimpleLineStyle(string reference) =>
+        string.Equals(reference, LineInstruction.SimpleLineStyleReference, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// The outcome of a pre-warm pass: lookup-by-name dicts for symbols,

--- a/tests/EncDotNet.S100.Pipelines.Tests/CataloguePreWarmTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CataloguePreWarmTests.cs
@@ -1,0 +1,76 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies <see cref="CataloguePreWarm"/> behaviour around the S-100 Part 9A
+/// inline "simple" line-style sentinel
+/// (<see cref="LineInstruction.SimpleLineStyleReference"/>). Regression cover
+/// for issue #286: each S-101 dataset load drove three
+/// <see cref="KeyNotFoundException"/> throws because the synthetic
+/// <c>_simple_</c> line style was looked up against (and missing from) the
+/// portrayal catalogue on every pre-warm pass.
+/// </summary>
+public sealed class CataloguePreWarmTests
+{
+    [Fact]
+    public async Task ForInstructions_DoesNotResolveSimpleLineStyleSentinel()
+    {
+        var catalogue = new CountingPortrayalAssetSource();
+        var instructions = new DrawingInstruction[]
+        {
+            new LineInstruction
+            {
+                FeatureReference = "f1",
+                LineStyleReference = LineInstruction.SimpleLineStyleReference,
+                LineColor = "CHGRD",
+                LineWidth = 0.32,
+            },
+            new AreaInstruction
+            {
+                FeatureReference = "f2",
+                OutlineStyleReference = LineInstruction.SimpleLineStyleReference,
+            },
+        };
+
+        var result = await CataloguePreWarm.ForInstructionsAsync(
+            catalogue, instructions, CancellationToken.None);
+
+        Assert.Equal(0, catalogue.LineStyleLookups);
+        Assert.False(result.LineStyles.ContainsKey(LineInstruction.SimpleLineStyleReference));
+    }
+
+    [Fact]
+    public async Task ForInstructions_StillResolvesNamedLineStyles()
+    {
+        var catalogue = new CountingPortrayalAssetSource();
+        var instructions = new DrawingInstruction[]
+        {
+            new LineInstruction { FeatureReference = "f1", LineStyleReference = "ACHARE51" },
+        };
+
+        var result = await CataloguePreWarm.ForInstructionsAsync(
+            catalogue, instructions, CancellationToken.None);
+
+        Assert.Equal(1, catalogue.LineStyleLookups);
+        Assert.NotNull(result.ResolveLineStyle("ACHARE51"));
+    }
+
+    private sealed class CountingPortrayalAssetSource : IPortrayalAssetSource
+    {
+        public int LineStyleLookups { get; private set; }
+
+        public ValueTask<SvgSymbol> GetSymbolAsync(string symbolName, CancellationToken cancellationToken = default) =>
+            new(new SvgSymbol { Name = symbolName, SvgContent = $"<svg id=\"{symbolName}\"/>" });
+
+        public ValueTask<LineStyle> GetLineStyleAsync(string name, CancellationToken cancellationToken = default)
+        {
+            LineStyleLookups++;
+            return new(new LineStyle { Name = name, Width = 1.0f, Color = "#000000" });
+        }
+
+        public ValueTask<AreaFill> GetAreaFillAsync(string name, CancellationToken cancellationToken = default) =>
+            new(new AreaFill { Name = name, Color = "#C8C8C8" });
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101SimpleLineStyleRegressionTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101SimpleLineStyleRegressionTests.cs
@@ -1,0 +1,96 @@
+using System.Runtime.ExceptionServices;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Crs.ProjNet;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Real-data regression cover for issue #286: building the vector portrayal of
+/// an S-101 cell used to throw three <see cref="KeyNotFoundException"/>s per
+/// load because the catalogue pre-warm tried to resolve the synthetic
+/// <c>_simple_</c> line-style sentinel (emitted by the Part 9A
+/// <c>SimpleLineStyle</c> portrayal model) against the portrayal catalogue,
+/// which never contains it. Skipped when no S-101 cell is installed so CI stays
+/// green.
+/// </summary>
+public class S101SimpleLineStyleRegressionTests
+{
+    private static string? FindCell()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var candidateDirs = new[]
+        {
+            Path.Combine(home, "Downloads", "IC-ENC"),
+            Path.Combine(home, "Downloads", "Complete S10X datasets", "S-101 Trial Cells"),
+        };
+
+        foreach (var dir in candidateDirs)
+        {
+            if (!Directory.Exists(dir))
+                continue;
+
+            var cell = Directory.EnumerateFiles(dir, "101*.000", SearchOption.AllDirectories)
+                .OrderBy(static p => p, StringComparer.Ordinal)
+                .FirstOrDefault();
+            if (cell is not null)
+                return cell;
+        }
+
+        return null;
+    }
+
+    private static DatasetPipelineFactory CreateFactory()
+    {
+        var catalogueManager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                catalogueManager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+
+        return new DatasetPipelineFactory(
+            catalogueManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            new FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue),
+            new EncDotNet.S100.Datasets.Pipelines.Interoperability.DisplayPlaneAuthorityProvider());
+    }
+
+    [SkippableFact]
+    public async Task BuildVectorPortrayal_DoesNotThrowForSimpleLineStyle()
+    {
+        var cell = FindCell();
+        Skip.If(cell is null, "No S-101 cell present.");
+
+        var keyNotFound = new List<string>();
+        EventHandler<FirstChanceExceptionEventArgs> handler = (_, e) =>
+        {
+            if (e.Exception is KeyNotFoundException knf)
+            {
+                lock (keyNotFound)
+                    keyNotFound.Add(knf.Message);
+            }
+        };
+
+        AppDomain.CurrentDomain.FirstChanceException += handler;
+        try
+        {
+            var factory = CreateFactory();
+            var processor = (S101DatasetProcessor)factory.CreateProcessor(cell!);
+            await processor.BuildVectorPortrayalAsync();
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= handler;
+        }
+
+        Assert.True(
+            keyNotFound.Count == 0,
+            $"Building the S-101 vector portrayal raised {keyNotFound.Count} " +
+            $"KeyNotFoundException(s): {string.Join("; ", keyNotFound)}");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the three `KeyNotFoundException` throws on every S-101 dataset load reported in #286.

The S-100 Part 9A Lua portrayal model emits `LineInstruction` / `AreaInstruction` outline references using the inline `_simple_` line-style sentinel (from `PortrayalModel.lua`'s `SimpleLineStyle`). Its colour, width, and dash pattern travel **on the instruction itself** — it is never a named complex line style in the portrayal catalogue.

`CataloguePreWarm` resolved it like any other line style, so each load threw:

> `Line style '_simple_' not found in the portrayal catalogue.`

…three times. The exceptions were caught and discarded but **never cached**, so they were re-thrown on every subsequent load.

## Change

- New `LineInstruction.SimpleLineStyleReference` constant (`"_simple_"`) documenting the Part 9A sentinel.
- `CataloguePreWarm` now skips it for both `LineInstruction.LineStyleReference` and `AreaInstruction.OutlineStyleReference`. Rendering already drew these as plain inline lines (colour token present ⇒ no catalogue lookup), so portrayal output is unchanged — minus the exceptions.

## Tests

- `CataloguePreWarmTests` — unit cover: the sentinel is not resolved against the catalogue; named line styles still are.
- `S101SimpleLineStyleRegressionTests` — skippable real-data regression: building an S-101 vector portrayal raises **zero** `KeyNotFoundException`s. Verified against UKHO/IC-ENC trial cells; reverting the fix reproduces exactly the 3 throws from #286.

Full `EncDotNet.S100.Pipelines.Tests` suite: 584 passed, 1 skipped.

## Out of scope

This PR does **not** address the per-dataset memory growth (50–100 MB/cell) also noted in #286 — that stems from the render-side caches (Mapsui scene/style/pattern-clip/tile) that back smooth pan/zoom, and warrants a more careful eviction-policy design. Tracked in a separate follow-up issue.

Closes #286 (exception portion); memory portion tracked separately.