### PR TITLE
ci: limit macOS signing and notarization to main runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,11 @@ jobs:
     permissions:
       contents: read
     env:
-      HAS_SIGNING_SECRETS: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12 != '' }}
+      # macOS signing/notarization is expensive (notary upload + polling) and is
+      # not needed for PR validation — developers can clear the quarantine
+      # attribute on unsigned PR artifacts if they need to run them. Gate it to
+      # main CI runs (pushes to main and v* tags), i.e. skip on pull_request.
+      MACOS_SIGNING_ENABLED: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12 != '' && github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -229,7 +233,7 @@ jobs:
           find "$APP" -name '*.pdb' -delete
 
       - name: Import signing certificate
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           P12_BASE64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12 }}
           P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
@@ -242,7 +246,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
 
       - name: Sign macOS .app bundle
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
@@ -274,7 +278,7 @@ jobs:
           codesign --verify --strict --verbose=2 "$APP/Contents/MacOS/cli/s100"
 
       - name: Notarize macOS .app bundle
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -301,7 +305,7 @@ jobs:
           fi
 
       - name: Staple notarization ticket
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         continue-on-error: true
         run: |
           # The notarization ticket may not be immediately available in
@@ -321,7 +325,7 @@ jobs:
         # The bundled CLI inside the .app is signed by the recursive loop above,
         # but the standalone copy at .../publish/cli is a separate set of files
         # and must be signed independently for its own release archive.
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
@@ -346,7 +350,7 @@ jobs:
           codesign --verify --strict --verbose=2 "$CLI/s100"
 
       - name: Notarize standalone macOS s100 CLI
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -426,14 +430,14 @@ jobs:
           echo "DMG_NAME=$DMG_NAME" >> "$GITHUB_ENV"
 
       - name: Sign macOS DMG
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "$DMG_NAME"
 
       - name: Notarize macOS DMG
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -457,7 +461,7 @@ jobs:
           fi
 
       - name: Staple notarization ticket to DMG
-        if: matrix.rid == 'osx-arm64' && env.HAS_SIGNING_SECRETS == 'true'
+        if: matrix.rid == 'osx-arm64' && env.MACOS_SIGNING_ENABLED == 'true'
         continue-on-error: true
         run: |
           # Same retry shape as the .app stapler step: the notarization


### PR DESCRIPTION
## Summary

PR pipelines spend a large share of their time signing and notarizing the macOS artifacts. Notarization in particular uploads to Apple's notary service and polls for a result, adding many minutes per run. We don't need signed/notarized macOS bits on PR builds — a developer who needs to run an unsigned PR artifact can clear the `com.apple.quarantine` attribute themselves.

This change gates the macOS signing/notarization/stapling steps in `.github/workflows/ci.yml` to main CI runs only (pushes to `main` and `v*` tags), skipping them on `pull_request` events.

All nine signing-related steps already keyed off a single job-level env var. Rather than touch each `if:`, this renames `HAS_SIGNING_SECRETS` to `MACOS_SIGNING_ENABLED` and folds the event guard into its expression:

```yaml
MACOS_SIGNING_ENABLED: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12 != '' && github.event_name != 'pull_request' }}
```

PR macOS jobs still compile, package the `.app`/DMG/CLI, and upload (unsigned) artifacts — those steps are gated only on `matrix.rid == 'osx-arm64'`, not on signing.

Closes #290

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

N/A — CI workflow change only. Validated `ci.yml` parses as YAML and confirmed no stale references to the old env var name remain.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

N/A — no public API or user-facing behaviour change.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None. PR builds now produce unsigned macOS artifacts (previously signed only when secrets were available); `main` and tag builds are unchanged.