### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![.NET](https://img.shields.io/badge/.NET-10-512bd4)](https://dotnet.microsoft.com/)
 [![NuGet](https://img.shields.io/nuget/v/EncDotNet.S100.Core)](https://www.nuget.org/packages?q=EncDotNet.S100)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://philliphoff.github.io/EncDotNet.S100/)
+[![Discord](https://img.shields.io/discord/1516327073663156294?label=Discord&logo=discord&logoColor=white)](https://discord.gg/kf6B9EZqqB)
 
 ## Overview
 


### PR DESCRIPTION
Adds a Discord badge to the top of the README so visitors can discover and join the project's new Discord server.

The badge sits alongside the existing CI/License/Release/NuGet/Docs badges and links to the permanent invite (`discord.gg/kf6B9EZqqB`). With the server widget enabled, shields.io also renders the live member count.

A matching badge was added to the companion `EncDotNet` repo via a separate PR.