### PR TITLE
Add S-122, viewer-evaluation, and chart-cartography agent skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,6 +152,24 @@ This repository includes per-spec **skills** under `.github/skills/<spec>/SKILL.
 - When delegating exploration via `search_subagent`, prefer one subagent per affected `src/EncDotNet.S100.Datasets.Sxxx/` project so each runs with its spec context isolated.
 - Cite the relevant spec section number(s) in PR descriptions and in XML doc comments for spec-derived constants, enums, attribute names, and group paths.
 
+### Cross-cutting skills (not tied to one product)
+
+These skills carry knowledge that spans products and/or backends. Load
+them by task signal regardless of which spec you are touching:
+
+| Signal in task | Load skill |
+|---|---|
+| Verifying a rendering/portrayal change in the viewer, designing or reproducing integration/regression scenarios, capturing reference images, measuring load/render performance, deriving fixtures from real datasets — driving the viewer headlessly via its CLI + MCP server | `viewer-evaluation` |
+| Chart composition independent of a single spec: layer/draw-order & display priority, scale-dependent generalization & declutter, label placement, day/dusk/night palette & contrast, CRS/projection pitfalls, rendering-performance strategy (geometry simplification, caching, vertex-bound cost reasoning) | `chart-cartography` |
+
+- `viewer-evaluation` applies even when you are **not** editing the
+  Viewer project — renderer, Core pipeline, and `Datasets.SXXX` work
+  often needs end-to-end visual verification. The MCP tool catalogue
+  reference lives in `docs/mcp-server.md`.
+- `chart-cartography` complements the per-spec skills: load the spec
+  skill for *what to draw*, the cartography skill for *how charts
+  should be composed and made fast*.
+
 ## Viewer UI
 
 When editing `src/EncDotNet.S100.Viewer/**`, follow the rules in

--- a/.github/instructions/viewer.instructions.md
+++ b/.github/instructions/viewer.instructions.md
@@ -90,14 +90,22 @@ When modifying viewer code:
   `Foreground=White` down to the icon (FluentIcon does not inherit
   Foreground automatically).
 
-## E2E performance testing via the MCP server
+## E2E evaluation & performance testing via the MCP server
 
-The viewer hosts an MCP server that lets an agent drive it headlessly
-for **automated load/render performance testing**. Use this whenever
-profiling dataset load or render hot paths, or validating that a
-rendering optimization actually moves a real-world scenario. The full
-tool catalogue lives in `docs/mcp-server.md`; the workflow below is the
-performance-testing recipe.
+The viewer hosts an MCP server that lets an agent drive it headlessly —
+for **visual/behavioural verification of a change** *and* for
+**automated load/render performance testing**. Reach for it whenever a
+change needs *seeing* or *exercising end-to-end*, when profiling load /
+render hot paths, or when validating that a rendering optimization
+actually moves a real-world scenario.
+
+> The general, reusable procedure (both visual-eval and performance
+> loops, launch/teardown, MCP client quirks, turning a finding into a
+> test) is the **`viewer-evaluation`** skill — load it for the full
+> recipe; it applies even from renderer / Core / `Datasets.SXXX` work,
+> not only when editing the Viewer project. The full MCP tool catalogue
+> lives in `docs/mcp-server.md`. The performance-testing specifics
+> below remain here as the viewer-local quick reference.
 
 ### 1. Launch an ephemeral instance with a dynamic MCP port
 

--- a/.github/skills/chart-cartography/SKILL.md
+++ b/.github/skills/chart-cartography/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: chart-cartography
+description: |
+  Cross-cutting cartography and chart-rendering domain expertise for
+  electronic navigational displays — the principles of how marine
+  charts are composed, layered, generalized, coloured, projected, and
+  made performant. Spec- and renderer-agnostic: it explains the
+  *why/what* of good chart rendering and how those principles manifest
+  in this codebase, then defers to the per-spec skills for product
+  semantics and to the renderer READMEs for implementation. USE FOR:
+  layer/draw-order and display-priority decisions; scale-dependent
+  generalization, declutter, SCAMIN/scale-band culling; label/text
+  placement and deconfliction; day/dusk/night palette and contrast
+  design; CRS/projection choices and distortion/antimeridian/pole
+  pitfalls; rendering-performance strategy (geometry simplification,
+  path/snapshot caching, tiling, vertex-bound cost reasoning); reviewing
+  a rendering change for cartographic correctness across products.
+  DO NOT USE FOR: a specific product's encoding/attribute/portrayal
+  rules (use the sXXX skill); Mapsui/Skia API mechanics (see the
+  renderer READMEs); driving the viewer to test (use viewer-evaluation).
+---
+
+# Chart cartography & rendering principles
+
+This skill carries the **portable cartographic knowledge** that sits
+above any one S-1xx product and below any one rendering backend. The
+goal is charts that are *legible, correctly prioritized, scale-
+appropriate, and fast*. For product semantics load the matching `sXXX`
+skill; for backend mechanics read
+[`Renderers.Mapsui`](../../../src/EncDotNet.S100.Renderers.Mapsui/README.md)
+and
+[`Renderers.Skia`](../../../src/EncDotNet.S100.Renderers.Skia/README.md).
+
+## 1. Layering & draw order
+A nautical display is a stack of semi-transparent thematic layers; the
+*order* is as meaningful as the symbols.
+
+- **Type-based draw order within a display list:** solid area fills →
+  pattern area fills → lines → points/symbols → text. Text and point
+  symbols draw last so they are never occluded by fills. This codebase
+  encodes that order explicitly (see
+  `Renderers.Skia/Scene/VectorSceneBuilder` and the Mapsui renderer),
+  then sub-orders by **`drawingPriority`** within each band.
+- **Display planes / radar:** an instruction's `displayPlane`
+  (`OverRadar` vs under) decides whether content draws above an
+  underlying radar/overlay image. Honour it before per-type ordering.
+- **Viewing groups & display categories:** features carry a
+  `viewingGroup` and map to ECDIS display categories
+  (DisplayBase / Standard / OtherInformation). The mariner-selected
+  category gates *visibility*, not draw order — keep the two concerns
+  separate (`Core/Pipelines/MarinerSettings`).
+- **Overlay transparency:** coverage overlays (e.g. bathymetry over a
+  base chart) must let lower layers show through where there is no
+  data — render NODATA/fill values **transparent**, never as an opaque
+  block. A wrong fill colour reads as "sea" or "land" and is a safety
+  issue, not a cosmetic one.
+
+## 2. Scale-dependent generalization & declutter
+Showing everything at every zoom destroys legibility *and* performance.
+
+- **Scale-band culling (SCAMIN-style):** instructions carry
+  `scaleMinimum` / `scaleMaximum`; a feature is drawn only when the
+  current display scale falls in its band. Verify culling is actually
+  effective — features that *should* drop out but don't are both a
+  clutter bug and a top performance offender.
+- **Geometry generalization:** at small scales, collapse detail you
+  cannot see. Resolution-aware line simplification (Douglas–Peucker at
+  ≈ ½–1 screen pixel tolerance) reduces thousand-vertex coastlines /
+  contours 10–100× with no visible loss. Keep tolerance conservative so
+  thick strokes (depth contours, fairway limits) don't visibly kink.
+- **Quantize by zoom band, not per-paint:** cache generalized geometry
+  keyed by a coarse (e.g. half-octave) zoom bucket and evict on band
+  change — never re-simplify every frame.
+- **Polygons need care:** per-ring simplification can self-intersect or
+  invalidate a polygon; use a topology-preserving simplifier + validity
+  check, or leave polygons un-simplified, rather than risk holes/spikes.
+
+## 3. Labels & text placement
+- Text is the most expensive thing to place well and the first to
+  clutter. Deconflict overlapping labels; prefer suppressing a label to
+  overprinting two.
+- **Geometry-less text features are normal.** A `TextPlacement` /
+  text instruction may carry no geometry of its own and instead anchor
+  to a *referenced* feature. Renderers must resolve the reference and
+  must not crash or skip on a null own-geometry.
+- Anchor text to its feature with stable offsets; keep labels upright
+  and screen-aligned (don't rotate with the map unless the symbology
+  spec demands it).
+
+## 4. Colour & palettes (day / dusk / night)
+- Provide **Day, Dusk, Night** palettes; night especially must minimise
+  emitted light (dark background, low-luminance, red-safe accents) to
+  preserve the mariner's dark adaptation. Never hard-code colours in
+  render code — resolve through the active palette.
+- Maintain figure/ground contrast within *each* palette; a colour pair
+  that works in Day can vanish in Night.
+- If a product's portrayal catalogue ships only a Day palette, palette
+  switching is a no-op for it — surface that honestly (synthesise local
+  Dusk/Night only as a documented stopgap), don't silently mis-render.
+
+## 5. CRS & projection
+- Source coordinates here are **WGS-84 lat/lon (EPSG:4326)**; the live
+  map projects to **Web Mercator (EPSG:3857)** for display (ProjNet in
+  the Mapsui renderer). Keep the source→display projection at one well-
+  defined boundary; don't smear half-projected coordinates through the
+  pipeline.
+- **Mercator distortion** grows with latitude — scale bars and any
+  metric reasoning must be latitude-aware, not assumed uniform.
+- **Antimeridian & poles** are sharp edges: bboxes crossing ±180° are
+  not generally supported; great-circle paths and high-latitude data
+  need explicit handling rather than naive linear interpolation in
+  projected space.
+
+## 6. Rendering performance (the cost model in this codebase)
+A measured review (`docs/design/mapsui-performance.md`) established the
+governing facts — reason from them, don't re-derive:
+
+- Rendering is **vertex-bound**: ~90%+ of paint time is in vector
+  geometry, at ~**1 µs per vertex**. Per-call cost is explained almost
+  entirely by vertex count; layer *count* and ordering add no
+  measurable structural overhead.
+- Therefore the highest-leverage win is **reducing vertices**
+  (generalization §2) and culling (scale bands), **not** micro-
+  optimizing paints, pooling `SKPaint`, or swapping GPU backends.
+- **Caching strategies that pay off:** pre-built/simplified geometry or
+  `SKPath`s keyed by `(feature, zoom-bucket)`; **raster snapshots** of a
+  settled vector layer to make pans instant (re-rasterize on
+  zoom/rotation change, not on every pan frame); optional tile-cached
+  vector layers help *tail* latency under heavy load but can regress
+  mean cost on light loads — keep them opt-in.
+- **Watch rotation and fast-pan paths** specifically: they have
+  historically exposed disappearing fills and render hangs; validate
+  them when touching snapshot/caching code.
+- Measure with the **viewer-evaluation** loop + `get_render_stats` and
+  `dotnet-trace`; attribute by `(layer × vertex-bucket)` before
+  optimizing, and target the few highest-cost feature classes first.
+
+## Review checklist (cartographic correctness)
+1. Draw order: areas → patterns → lines → points → text, then
+   `drawingPriority`; radar plane honoured.
+2. Visibility gated by display category & scale band — separate from
+   draw order; culling demonstrably effective.
+3. NODATA / no-coverage renders transparent, not opaque.
+4. Generalization conservative, zoom-bucketed, polygon-safe; no kinks
+   on thick strokes.
+5. Geometry-less text/overlay features tolerated.
+6. Colours resolved through the active palette; contrast holds in Day,
+   Dusk, and Night.
+7. Projection applied at one boundary; latitude-aware metrics;
+   antimeridian/pole handled or explicitly out of scope.
+8. Performance change justified against the vertex-bound cost model and
+   verified with the viewer-evaluation loop.

--- a/.github/skills/s122-marine-protected-areas/SKILL.md
+++ b/.github/skills/s122-marine-protected-areas/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: s122-marine-protected-areas
+description: |
+  Expert knowledge of IHO S-122 Marine Protected Areas Product
+  Specification (Edition 2.0.0). Covers GML encoding (S-100 Part 10b)
+  over the S-100 GML base, the S-122 application schema (marine
+  protected areas, restricted areas, regulated areas, and associated
+  text placement), and the XSLT-based portrayal pipeline. USE FOR:
+  S-122 datasets, marine protected areas, restricted/regulated areas,
+  GML parsing for S-122, XSLT portrayal of S-122, vector pipeline
+  changes affecting S-122, S122DatasetReader / S-122 reader/source
+  code, S-122 tests, edits to bundled `content/S122/**` assets.
+  DO NOT USE FOR: S-127 marine resources and services (use
+  s127-marine-services), S-124 nav warnings (use s124-nav-warnings),
+  S-125 AtoN (use s125-aton), S-101 ENC (use s101-enc), generic GML /
+  framework concerns (use s100-framework).
+---
+
+# S-122 Marine Protected Areas expert
+
+## When engaged
+- Tasks touching `src/EncDotNet.S100.Datasets.S122/**` or
+  `tests/EncDotNet.S100.Datasets.S122.Tests/**`
+- Edits to bundled portrayal assets under
+  `src/EncDotNet.S100.Specifications/content/S122/**`
+- GML/XSLT portrayal changes for marine protected areas
+- Vector pipeline changes (`IVectorSource`, `VectorPipeline`)
+  affecting S-122
+
+## Spec anchors
+- Canonical: **S-122 Edition 2.0.0** Marine Protected Areas PS
+- S-100 Part 10b: GML encoding
+- S-100 Part 9: Portrayal (XSLT path)
+- S-122 Feature/Information Catalogue (FC 2.0.0) + published XSD
+- Upstream PC:
+  [iho-ohi/S-122-Product-Specification-Development](https://github.com/iho-ohi/S-122-Product-Specification-Development)
+
+## Review checklist
+1. **Product detection is identifier-driven, not namespace-driven.**
+   The official 2.0.0 sample is mis-labelled with the **S-123**
+   namespace prefix on the dataset root
+   (`xmlns:S123="http://www.iho.int/S123/gml/1.0"`). Detection must
+   key on the S-100 `<productIdentifier>S-122…</productIdentifier>`
+   element — keep that fallback in `DatasetPipelineFactory`.
+2. **Tolerate every s100gml namespace variant** seen across releases
+   (`http://www.iho.int/s100gml/1.0`,
+   `http://www.iho.int/S100/profile/s100gml/1.0`,
+   `http://www.iho.int/s100gml/5.0`) via
+   `S122DatasetReader.DetectS100Namespace` — do not hard-code one.
+3. Coordinate ordering in `<gml:pos>` / `<gml:posList>` is **lat lon**
+   for `EPSG:4326` (S-100 Part 10b §6.2).
+4. Support **both** the standard `<member>`/`<imember>` wrappers and
+   the inline `<members>`/`<imembers>` containers. Iterate descendants
+   of the dataset root and match by feature/information type code.
+5. Portrayal goes through XSLT (not Lua); inputs to the transform must
+   be the canonical GML, and transforms must stay within features
+   supported by .NET's `XslCompiledTransform`.
+6. Renderers must tolerate **geometry-less features** (e.g.
+   `TextPlacement` may attach to a referenced feature rather than carry
+   its own geometry).
+7. Public API changes have xunit tests using the official sample under
+   `tests/datasets/S122/`.
+
+## Known pitfalls in this repo (producer-bug compensation)
+`S122DatasetReader` already auto-corrects two real-world quirks; new
+geometry parsing code must preserve both:
+
+1. **lon-lat `posList` vs. lat-lon envelope.** The UKHO trial dataset
+   emits `<gml:posList>` in lon-lat order while keeping the
+   `<gml:Envelope>` corners correctly in lat-lon. The reader samples
+   parsed coords against the declared envelope and swaps every feature
+   when the as-parsed interpretation clearly falls outside but the
+   swapped one fits. Keep the heuristic conservative (≤25 % as-is fit,
+   ≥75 % swapped fit) so spec-conformant samples are untouched.
+2. **Comma-separated tuples in `posList`.** Some producers emit
+   `lon,lat lon,lat …` tokens (the `gml:coordinates` convention)
+   instead of all-whitespace. `ParsePos` / `ParsePosList` treat both
+   whitespace and commas as separators — do not regress that.
+
+## Portrayal / palette caveats
+- The bundled `content/S122/pc/` tree is intended to be
+  **byte-identical to upstream** (PC 2.0.0). Do not edit those files.
+  If the upstream `main.xsl` ever needs adapting for this codebase's
+  display-list dialect, add a small adapter XSLT alongside it (mirror
+  the S-411 `Adapter/main.xsl` pattern).
+- The v2.0.0 PC ships only a `Day` `<palette>` block in
+  `colorProfile.xml`, so palette switching to Dusk/Night is currently a
+  no-op for S-122. Do not modify the upstream `colorProfile.xml`; if
+  local Dusk/Night palettes are needed before upstream publishes them,
+  synthesise them in code and document it explicitly.
+
+## Cite your sources
+Cite the S-122 section number (or upstream catalogue path) in XML doc
+comments when adding spec-derived constants or element names.

--- a/.github/skills/viewer-evaluation/SKILL.md
+++ b/.github/skills/viewer-evaluation/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: viewer-evaluation
+description: |
+  Procedure for running an independent, automated evaluation loop
+  against the EncDotNet.S100 Avalonia viewer using its CLI flags and
+  embedded MCP server. Lets an agent launch the viewer headlessly,
+  load datasets, drive viewport / palette / display-category / time-step
+  / own-ship, capture screenshots, await render-idle, and read render
+  stats — then iterate. USE FOR: visually verifying a rendering or
+  portrayal change; designing or reproducing integration/regression
+  scenarios; measuring load/render performance; capturing reference
+  images; deriving test fixtures from real datasets; any "does it
+  actually look/behave right in the viewer?" question — INCLUDING from
+  renderer (Renderers.Mapsui / Renderers.Skia), Core pipeline, or
+  Datasets.SXXX work, not only when editing the Viewer project.
+  DO NOT USE FOR: pure library logic unit tests (write xunit directly),
+  viewer XAML/localization conventions (see viewer.instructions.md),
+  or the MCP tool catalogue reference (see docs/mcp-server.md).
+---
+
+# Viewer evaluation loop (CLI + MCP)
+
+The viewer hosts an MCP server and a rich CLI so an agent can drive it
+**headlessly** to verify behaviour, capture images, and measure
+performance — independent of the GUI and the user's settings. Reach for
+this whenever a change needs *seeing* or *exercising end-to-end*, not
+just unit-testing. The canonical tool reference is
+[`docs/mcp-server.md`](../../../docs/mcp-server.md); this skill is the
+operating procedure.
+
+> The viewer is a GUI app — there is **no fully headless windowing
+> mode**. It still needs a display server (a real desktop, or X11 /
+> XWayland / Xvfb in CI). "Headless" here means *agent-driven without a
+> human at the keyboard*.
+
+## Pick the right tool first
+- **Library logic** (parsers, geometry, coverage sampling, display-list
+  building): write an **xunit test** in the matching `tests/` project.
+  Do not spin up the viewer for something a unit test can pin.
+- **Visual / portrayal / end-to-end behaviour** (does the chart layer,
+  colour, declutter, project, pan, or re-render correctly?): use this
+  loop. Capture the finding, then **back it with a unit test or a
+  small synthetic fixture** wherever the root cause lives in a library.
+
+## Two modes
+
+### A. One-shot capture (no MCP) — cheapest
+For a single deterministic screenshot, skip MCP entirely:
+
+```bash
+src/EncDotNet.S100.Viewer/bin/Release/net10.0/<rid>/EncDotNet.S100.Viewer \
+  --ephemeral --window-size 1600x1000 \
+  --bbox <south,west,north,east> \
+  --palette Day --display-category Standard \
+  --screenshot /tmp/eval/map.png --exit-after-screenshot \
+  path/to/dataset            # a .000 cell, .h5, .gml, or exchange-set folder/zip
+```
+
+The screenshot is captured after render quiesces. `--center LAT,LON
+--zoom N` is an alternative to `--bbox` (mutually exclusive; `--center`
+requires `--zoom`, range 0–24). Use this mode for before/after image
+diffs across a code change.
+
+### B. Interactive MCP driving — for multi-step scenarios
+Use when you need to load → reframe → toggle palette/time-step → screenshot
+repeatedly within one process, or to read structured timing.
+
+## Procedure for mode B
+
+### 1. Build, then launch the binary (not `dotnet run`)
+Build `Release` first so the PID you drive/trace is the app itself, not
+a `dotnet` host:
+
+```bash
+dotnet build -c Release src/EncDotNet.S100.Viewer
+nohup src/EncDotNet.S100.Viewer/bin/Release/net10.0/<rid>/EncDotNet.S100.Viewer \
+  --ephemeral --mcp --mcp-port-file /tmp/eval/mcp.url \
+  >/tmp/eval/viewer.log 2>&1 & disown
+```
+
+- `--ephemeral` → throwaway settings (clean, reproducible baseline; never
+  touches the user's profile).
+- `--mcp` enables the server; default `--mcp-port 0` picks a free port.
+  Any MCP flag implies `--mcp`. A CLI-driven MCP run **never** persists
+  the bound port.
+- **Poll `/tmp/eval/mcp.url`** for the endpoint URI (also printed to
+  stdout as `[MCP] listening on …`). It appears only once the server is
+  listening.
+- The app ignores SIGTERM (GUI process). **Stop it with `kill -9
+  <pid>`** when done.
+
+### 2. Connect an MCP Streamable-HTTP client
+The server speaks **MCP over Streamable HTTP**. A throwaway Python
+client (initialize handshake → `tools/call`, parsing both SSE framing
+and `structuredContent`) is enough. Keep it in the session-state
+`files/` dir — **do not commit it**. For manual poking,
+`npx @modelcontextprotocol/inspector` (transport: Streamable HTTP) works.
+
+Quirks that bite:
+- A dataset id comes back as `{"value":"<id>"}`. Tools like
+  `list_time_steps` / `describe_feature` want
+  `{"datasetId":{"value":"<id>"}}`, but `close_dataset` wants the
+  **bare string** id.
+- `open_dataset` on an S-101 **exchange-set folder** may report world
+  bounds and not portray; point it at the concrete `.000` cell file and
+  supply your own viewport.
+
+### 3. Drive the evaluation loop
+Core read-only/mutating tools (full table in `docs/mcp-server.md`):
+
+| Tool | Use |
+|---|---|
+| `open_dataset {path, spec?}` | Load a cell/tile/exchange-set. Returns bbox + `loadDurationMs`. |
+| `list_datasets` | Enumerate loaded datasets + ids. |
+| `set_viewport {south,west,north,east}` *or* `{centerLat,centerLon,zoom}` | Frame the data (forms are mutually exclusive). |
+| `set_palette {palette}` | Day / Dusk / Night — full re-render. |
+| `set_display_category {category}` | DisplayBase / Standard / OtherInformation / All. |
+| `set_time_step {index|timestamp}` | S-104 / S-111 / S-411 time-aware datasets. |
+| `set_own_ship {lat,lon,cog,sog,heading,hold}` | Position/steer simulated own-ship. |
+| `await_render_idle {quietPeriodMs,timeoutMs}` | Block until the live map settles — the harness clock. |
+| `render_to_image` | Capture the framebuffer (PNG `ImageContentBlock`) for visual eval / diffing. |
+| `get_render_stats` | Last on-screen paint: `frameDurationMs`, draw calls, per-style breakdown. |
+| `close_dataset {id}` / `close_all_datasets` | Unload (retention loops without restarting). |
+
+**Canonical visual-eval loop:**
+`open_dataset` → `set_viewport` → `await_render_idle` →
+`render_to_image` → inspect the image → adjust code/params → repeat.
+Always `await_render_idle` **before** `render_to_image` or
+`get_render_stats`, or you race the paint pass.
+
+**Performance loop:** `open_dataset` (read `loadDurationMs`) →
+`set_viewport` → `await_render_idle` (cold) → `await_render_idle` (warm)
+→ toggle `set_palette`/`set_time_step` N times, timing each round-trip;
+read `get_render_stats` for per-style cost. Palette/display/time-step
+wall time is dominated by fixed settle latency — to attribute CPU,
+profile with `dotnet-trace collect -p <viewer-pid>` (default profile;
+attach the `…/<rid>/EncDotNet.S100.Viewer` PID, not a `dotnet` host).
+See the cartography skill for the rendering cost model.
+
+## Turning a finding into a test
+- Reproduce the issue in the loop, then isolate the **smallest dataset
+  and viewport** that triggers it.
+- If the cause is in a library (display-list build, geometry,
+  simplification, coverage sampling): add an **xunit** test there with a
+  synthetic fixture under `tests/datasets/…`. Gate fixtures that need
+  real ENC/HDF5 data with `Skip.If(...)` (`Xunit.SkippableFact`) so CI
+  passes without them.
+- If it is genuinely render-output behaviour, keep a documented
+  repro recipe (dataset path + flags + expected image) in the
+  session-state notes — **not** a committed binary screenshot.
+
+## Hygiene (do not commit)
+- Real-world datasets for manual runs live under
+  `~/Downloads/Complete S10X datasets` (S-101/102/104/111 trial cells).
+  **Never commit** dataset files, captured images, traces, or the
+  throwaway MCP harness.
+- If you add a temporary env-gated `Stopwatch`/timing switch (e.g.
+  `S100_*_TIMING=1`) to attribute a stage, **remove it before
+  committing** — no diagnostic env switches in shipped code.
+- Always `kill -9` the launched viewer when the loop ends; do not leave
+  orphaned GUI processes or bound MCP ports behind.


### PR DESCRIPTION
## Summary

This is an agent-configuration maintenance pass: a review of all the AGENTS / INSTRUCTIONS / SKILLS files for currency, appropriateness, and gaps. The review surfaced one broken reference and two genuinely unserved knowledge gaps, all fixed here.

What changed and why:

- **Close a dangling skill reference.** The routing table in `copilot-instructions.md` told agents to load a `s122-marine-protected-areas` skill, but S-122 was the only spec with an instructions file and **no** `SKILL.md`. Added the missing skill, mirroring the other per-spec skills (S-123 mislabel detection, lon/lat producer-bug heuristics, Day-only palette caveat).

- **Make the headless viewer evaluation loop discoverable.** The MCP/CLI testing recipe lived only in `viewer.instructions.md`, which is gated to `src/EncDotNet.S100.Viewer/**`, so agents working in renderers, Core pipelines, or `Datasets.SXXX` never had it applied, and it was framed as performance-only. Lifted it into a model-invokable **`viewer-evaluation`** skill covering both visual verification and performance loops, launch/teardown, MCP client quirks, and turning a finding into an xunit test. The viewer instructions now point at it.

- **Add a cross-cutting cartography agent.** Every prior skill was either per-spec semantics or implementation-gated UI rules; the spec- and renderer-agnostic chart-composition knowledge (draw order/display priority, scale generalization/declutter, label placement, day/dusk/night palettes, CRS/projection pitfalls, the vertex-bound performance cost model) was scattered across `docs/design/*`. The new **`chart-cartography`** skill consolidates it while deferring to the per-spec skills for *what to draw* and to the Mapsui/Skia READMEs for *how*.

Both new cross-cutting skills are wired into a new "Cross-cutting skills" table in `copilot-instructions.md`.

This is a docs/tooling-only change: no source code, build, dependencies, or runtime behaviour are affected.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A (the new S-122 skill references the existing S-122 instructions content and upstream PC; no new spec-derived constants introduced in code).

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

N/A — no code changes; only `.github/` agent-configuration Markdown.

## Documentation

- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed — N/A (no behaviour change); agent config under `.github/` updated instead
- [x] New public APIs have XML doc comments — N/A

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None.