### PR TITLE
Fix intermittent missing buoys at certain zoom levels

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
@@ -162,7 +162,14 @@ public sealed class MapsuiDatasetRenderer
                 && result.OutOfBandMinDisplayScale is int denom
                 && layer is MemoryLayer memoryLayer)
             {
-                var cap = denom * MapsuiDisplayListRenderer.DenomToResolutionMetres;
+                // Convert the cell-wide out-of-band denominator at the layer's
+                // centre latitude so the cutoff matches the cell's true scale in
+                // EPSG:3857 (web-mercator inflates ground distance by 1/cos φ).
+                var layerExtent = memoryLayer.Extent;
+                var latitudeRadians = layerExtent is null
+                    ? 0.0
+                    : MapsuiDisplayListRenderer.WebMercatorYToLatitudeRadians((layerExtent.MinY + layerExtent.MaxY) / 2.0);
+                var cap = MapsuiDisplayListRenderer.DenominatorToResolution(denom, latitudeRadians);
                 ApplyOutOfScaleBandCap(memoryLayer.Features, cap);
             }
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -438,29 +438,95 @@ public sealed class MapsuiDisplayListRenderer
     }
 
     /// <summary>
-    /// S-100 Part 9 scale denominator → Mapsui resolution (m/px in EPSG:3857)
-    /// at 96 DPI: 1 px = 0.28 mm = 0.00028 m on the nominal display surface,
-    /// so resolution ≈ scaleDenominator × 0.00028.
+    /// S-100 Part 9 scale denominator → ground metres per display pixel at
+    /// 96 DPI: 1 px = 0.28 mm = 0.00028 m on the nominal display surface, so
+    /// <i>ground</i> resolution ≈ scaleDenominator × 0.00028. To obtain the
+    /// Mapsui EPSG:3857 resolution (metres/pixel at the equator) this must be
+    /// divided by <c>cos(latitude)</c> to undo web-mercator scale distortion —
+    /// see <see cref="DenominatorToResolution"/>.
     /// </summary>
     public const double DenomToResolutionMetres = 0.00028;
+
+    /// <summary>Earth radius (m) of the EPSG:3857 web-mercator sphere, matching
+    /// <see cref="Scene.WebMercator.EarthRadius"/>.</summary>
+    private const double WebMercatorEarthRadius = 6378137.0;
+
+    /// <summary>
+    /// Converts an EPSG:3857 northing (metres) to its geodetic latitude in
+    /// radians, used to undo web-mercator scale distortion when mapping an
+    /// S-100 true-scale denominator to a Mapsui resolution.
+    /// </summary>
+    internal static double WebMercatorYToLatitudeRadians(double y)
+        => 2.0 * Math.Atan(Math.Exp(y / WebMercatorEarthRadius)) - Math.PI / 2.0;
+
+    /// <summary>
+    /// Converts an S-100 Part 9 §11.1 scale denominator (a <i>true-scale</i>
+    /// value, e.g. SCAMIN / <c>minimumDisplayScale</c>) to the equivalent Mapsui
+    /// EPSG:3857 resolution (metres/pixel at the equator) at
+    /// <paramref name="latitudeRadians"/>. Because web-mercator inflates ground
+    /// distances by <c>1/cos φ</c>, the equator-referenced resolution that
+    /// corresponds to a true-scale denominator is
+    /// <c>denom × 0.00028 / cos φ</c>. Omitting the <c>cos φ</c> term (the prior
+    /// behaviour) is only correct on the equator and biases scale-visibility
+    /// cutoffs toward hiding detail at finer zooms as latitude increases — at
+    /// φ ≈ 50.8° (≈ 1/cos φ = 1.58) a cell's detail was suppressed roughly
+    /// two-thirds of a zoom level too early. Matches the Skia headless backend,
+    /// which already applies <c>cos(midLat)</c> (see
+    /// <see cref="Scene.HeadlessVectorRenderer"/>).
+    /// </summary>
+    /// <param name="scaleDenominator">The S-100 true-scale denominator.</param>
+    /// <param name="latitudeRadians">
+    /// The representative latitude (radians) of the feature/cell the limit
+    /// applies to; <c>0</c> (the equator) yields the uncorrected conversion.
+    /// </param>
+    /// <returns>The Mapsui EPSG:3857 resolution (m/px at the equator).</returns>
+    internal static double DenominatorToResolution(double scaleDenominator, double latitudeRadians)
+    {
+        var cos = Math.Cos(latitudeRadians);
+        if (cos < 1e-6)
+        {
+            // Guard against the poles / invalid latitudes (EPSG:3857 is clamped
+            // to ±85.06°, where cos ≈ 0.087, so this only trips on bad input).
+            cos = 1e-6;
+        }
+
+        return scaleDenominator * DenomToResolutionMetres / cos;
+    }
+
+    /// <summary>
+    /// The representative latitude (radians) of a feature, taken from the centre
+    /// of its EPSG:3857 extent. Geometry-less features (no extent) fall back to
+    /// the equator, i.e. no web-mercator correction.
+    /// </summary>
+    private static double FeatureLatitudeRadians(IFeature feature)
+    {
+        var extent = feature.Extent;
+        return extent is null
+            ? 0.0
+            : WebMercatorYToLatitudeRadians((extent.MinY + extent.MaxY) / 2.0);
+    }
 
     /// <summary>
     /// Maps the S-100 Part 9 §11.1 scale denominators carried on a
     /// <see cref="Scene.PaintOp"/> onto each Mapsui style.  <c>ScaleMinimum</c>
     /// is the most zoomed-out limit (largest allowed denominator) and maps to
     /// Mapsui's <c>MaxVisible</c>; <c>ScaleMaximum</c> is the most zoomed-in
-    /// limit (smallest allowed denominator) and maps to <c>MinVisible</c>.
+    /// limit (smallest allowed denominator) and maps to <c>MinVisible</c>. Both
+    /// denominators are converted at the feature's latitude so the web-mercator
+    /// resolution cutoffs line up with the feature's true scale.
     /// </summary>
     private static void ApplyScaleVisibility(IFeature feature, double? scaleMinimum, double? scaleMaximum)
     {
         if (!scaleMinimum.HasValue && !scaleMaximum.HasValue)
             return;
 
+        var latitudeRadians = FeatureLatitudeRadians(feature);
+
         double? maxRes = scaleMinimum.HasValue
-            ? scaleMinimum.Value * DenomToResolutionMetres
+            ? DenominatorToResolution(scaleMinimum.Value, latitudeRadians)
             : (double?)null;
         double? minRes = scaleMaximum.HasValue
-            ? scaleMaximum.Value * DenomToResolutionMetres
+            ? DenominatorToResolution(scaleMaximum.Value, latitudeRadians)
             : (double?)null;
 
         foreach (var style in feature.Styles)

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -41,6 +41,7 @@ collection / priority-clip / insert phase here.
 - `<foreground>` / `<background>` colours accept either a palette token or a literal `#RRGGBB` / `RRGGBBAA` hex value, with the optional `transparency` attribute applied as alpha attenuation.
 - Text alignment, mm offsets, and `textLine` start/end offsets (Relative or Absolute) are honoured per S-100 Part 9 §11.4.
 - `LineStyleProvider`, `SymbolProvider`, and `AreaFillProvider` callbacks let the host project plug in a portrayal catalogue without coupling the renderer to a specific dataset library.
+- **Scale-visibility limits are latitude-corrected.** S-100 Part 9 §11.1 scale denominators (per-feature `ScaleMinimum`/`ScaleMaximum`, and the cell-wide out-of-band cap derived from `DataCoverage.minimumDisplayScale`) are *true-scale* values, whereas a Mapsui `resolution` is metres/pixel at the EPSG:3857 equator. Because web-mercator inflates ground distance by `1/cos φ`, the equator-referenced resolution for a denominator is `denom × 0.00028 / cos φ` (`MapsuiDisplayListRenderer.DenominatorToResolution`). Per-feature limits convert at the feature's extent-centre latitude; the cell-wide cap converts at the layer's extent-centre latitude. Omitting the `cos φ` term (the prior behaviour) was only correct on the equator and suppressed detail roughly `1/cos φ` zoom levels too early — at φ ≈ 50.8° (≈ 1.58×) a cell's linework vanished about two-thirds of a zoom level before it should. This now matches the Skia headless backend, which already applies `cos(midLat)`.
 
 ### Sharing processed-SVG and pattern-tile work across renders
 
@@ -385,7 +386,7 @@ geometry — is delegated unchanged to the wrapped Mapsui renderer.
 | `S100_VECTOR_SNAPSHOT_PREBUILD` | on | `0`/`false` disables the off-thread pre-build (see below) and falls back to the single-image snapshot (synchronous re-record on zoom and on a pan past the margin). |
 | `S100_VECTOR_SNAPSHOT_PAN_MARGIN` | `512` | Pixels of margin used for off-thread *pan* re-records (the sustained-pan look-ahead). Larger than `…_MARGIN` so one recentred-ahead background record covers roughly a full viewport of travel. Only used when the pre-build is on. |
 | `S100_VECTOR_SNAPSHOT_PAN_REFRESH` | `0.5` | Fraction (0–1) of the active snapshot's margin at which the off-thread pan re-record is triggered (while the image still fully covers the view). Smaller = earlier/more frequent; larger = more deferred. Only used when the pre-build is on. |
-| `S100_VECTOR_SNAPSHOT_DIAG` | off | `1`/`true` logs record / replay / stale / prebuild-publish / pan-refresh decisions to stderr. |
+| `S100_VECTOR_SNAPSHOT_DIAG` | off | `1`/`true` logs record / replay / stale / live-on-scale-band / prebuild-publish / pan-refresh decisions to stderr. |
 
 ### Raster vector snapshot
 
@@ -416,7 +417,18 @@ instead of a single image, and hides the record-frame stall in four ways:
 2. **Scaled-stale blit** — on a zoom whose image is not yet built, the nearest
    existing image is blitted *scaled* (one linear resample, slightly blurry)
    for a frame or two while the exact-resolution image is built off-thread.
-   This also smooths continuous / pinch zoom.
+   This also smooths continuous / pinch zoom. **A scaled-stale blit is only
+   used when no scale-visibility boundary (`MinVisible`/`MaxVisible`, e.g. the
+   S-101 out-of-band cap derived from `DataCoverage.minimumDisplayScale`) lies
+   between the recorded image's resolution and the current one.** When a zoom
+   crosses such a boundary the two resolutions have *different* visible feature
+   sets — a buoy shown at one zoom is capped-hidden at the other — so reusing
+   the wrong-resolution raster would briefly drop (or wrongly show) those
+   features. In that case the layer is drawn **live** for that single frame
+   (feature-correct, like the rotated-viewport fallback) while the
+   exact-resolution image records off-thread. This eliminated an intermittent
+   bug where point/text features (buoys, beacons, labels) flickered or vanished
+   when zooming across the cell's display-scale cutoff.
 3. **Sustained-pan look-ahead** — the original snapshot only buys
    `…_MARGIN` (256 px) of pan before a re-record, and that re-record used to
    run *synchronously* on the render thread (~250–650 ms), so a sustained drag

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSnapshotRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSnapshotRenderer.cs
@@ -64,9 +64,14 @@ namespace EncDotNet.S100.Renderers.Mapsui;
 /// wrappers are all honoured — in the same draw order
 /// (<see cref="ILayer.SortFeatures"/> over <see cref="ILayer.GetFeatures"/>,
 /// layer style first then per-feature styles). The replayed pixels are therefore
-/// identical to a live frame (modulo a single linear resample during sub-pixel
-/// pans). Rotated viewports fall back to live per-feature drawing (no image),
-/// preserving correctness.
+/// identical to a live frame at the <i>same</i> resolution (modulo a single
+/// linear resample during sub-pixel pans). A raster recorded at one resolution
+/// is only reused (scaled) at another when no scale-visibility boundary
+/// (<c>MinVisible</c>/<c>MaxVisible</c>, e.g. the S-101 out-of-band cap) lies
+/// between the two resolutions; otherwise the layer is drawn live for that frame
+/// so a feature that is shown at one zoom but hidden at the other never blits
+/// from the wrong-resolution image. Rotated viewports likewise fall back to live
+/// per-feature drawing (no image), preserving correctness.
 /// </para>
 /// <para>
 /// <b>Lifetime.</b> Snapshot state is held per <see cref="ILayer"/> instance in
@@ -374,6 +379,7 @@ public static class S100VectorSnapshotRenderer
 
         SKImage? toBlit;
         SKRect dest;
+        var drawLive = false;
 
         lock (state.Sync)
         {
@@ -413,15 +419,41 @@ public static class S100VectorSnapshotRenderer
                 if (staleIndex >= 0)
                 {
                     var stale = state.Entries[staleIndex];
-                    stale.LastUsedTick = System.Threading.Interlocked.Increment(ref s_tick);
-                    (toBlit, dest) = BlitOf(stale, viewport, resolution);
 
-                    if (s_diag)
+                    // A scaled-stale blit reuses a raster recorded at a different
+                    // resolution. That is only sound when the set of styles passing
+                    // scale visibility cannot differ between the two resolutions;
+                    // across the S-101 out-of-band cap (or any MinVisible/MaxVisible
+                    // boundary) the recorded image would show the wrong feature set
+                    // (e.g. buoys present at one zoom but capped-hidden at the
+                    // other). When membership may differ, draw the layer live for
+                    // this frame (feature-correct, like the rotated-viewport path)
+                    // while the exact-resolution image records off-thread.
+                    if (VisibleSetMayDiffer(GetVisibilityThresholds(state, layer, featureCount), stale.Resolution, resolution))
                     {
-                        Console.Error.WriteLine($"[VecSnapshot] STALE blit res={resolution:G6} from={stale.Resolution:G6} feats={featureCount} entries={state.Entries.Count}");
-                    }
+                        toBlit = null;
+                        dest = default;
+                        drawLive = true;
 
-                    EnsureAsyncRecord(state, layer, viewport, resolution, featureCount, scale);
+                        if (s_diag)
+                        {
+                            Console.Error.WriteLine($"[VecSnapshot] LIVE (scale-band) res={resolution:G6} from={stale.Resolution:G6} feats={featureCount} entries={state.Entries.Count}");
+                        }
+
+                        EnsureAsyncRecord(state, layer, viewport, resolution, featureCount, scale);
+                    }
+                    else
+                    {
+                        stale.LastUsedTick = System.Threading.Interlocked.Increment(ref s_tick);
+                        (toBlit, dest) = BlitOf(stale, viewport, resolution);
+
+                        if (s_diag)
+                        {
+                            Console.Error.WriteLine($"[VecSnapshot] STALE blit res={resolution:G6} from={stale.Resolution:G6} feats={featureCount} entries={state.Entries.Count}");
+                        }
+
+                        EnsureAsyncRecord(state, layer, viewport, resolution, featureCount, scale);
+                    }
                 }
                 else if (FindNearestSameResolutionEntry(state, viewport, resolution, featureCount) is { } nearest)
                 {
@@ -462,7 +494,11 @@ public static class S100VectorSnapshotRenderer
             }
         }
 
-        if (toBlit is not null)
+        if (drawLive)
+        {
+            DrawLayerLive(canvas, viewport, layer, viewport.ToExtent(), renderService);
+        }
+        else if (toBlit is not null)
         {
             canvas.DrawImage(toBlit, dest, s_sampling);
         }
@@ -520,6 +556,122 @@ public static class S100VectorSnapshotRenderer
         var tx = (anchor.RecordCenterX - centerX) / resolution + (width - anchor.RecordWidth) / 2.0;
         var ty = (centerY - anchor.RecordCenterY) / resolution + (height - anchor.RecordHeight) / 2.0;
         return (tx, ty);
+    }
+
+    /// <summary>
+    /// <c>true</c> when the set of styles that pass scale visibility
+    /// (<c>MinVisible &lt;= resolution &lt;= MaxVisible</c>) <i>could</i> differ
+    /// between <paramref name="resolutionA"/> and <paramref name="resolutionB"/>,
+    /// i.e. a recorded raster at one resolution must not be reused (even scaled)
+    /// at the other because a feature/style that is hidden at one is shown at the
+    /// other. This is the case exactly when one of <paramref name="thresholds"/>
+    /// (the distinct <c>MinVisible</c>/<c>MaxVisible</c> boundaries present on the
+    /// layer) lies within the closed interval spanned by the two resolutions.
+    /// Conservative: boundary-touching thresholds count as "may differ" so a
+    /// scaled-stale blit is never used across a scale-visibility transition (the
+    /// S-101 out-of-band cap being the dominant case). Pure and testable.
+    /// </summary>
+    internal static bool VisibleSetMayDiffer(IReadOnlyList<double> thresholds, double resolutionA, double resolutionB)
+    {
+        if (thresholds is null || thresholds.Count == 0 || resolutionA == resolutionB)
+        {
+            return false;
+        }
+
+        var lo = Math.Min(resolutionA, resolutionB);
+        var hi = Math.Max(resolutionA, resolutionB);
+        for (var i = 0; i < thresholds.Count; i++)
+        {
+            var t = thresholds[i];
+            if (t >= lo && t <= hi)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Collects the distinct, finite scale-visibility boundaries
+    /// (<c>MinVisible</c> and <c>MaxVisible</c>) present across the layer's style
+    /// and its features' styles. Default-unbounded limits (<c>MinVisible == 0</c>,
+    /// <c>MaxVisible == double.MaxValue</c>) are excluded because they never flip
+    /// membership. Used by <see cref="VisibleSetMayDiffer"/> to decide whether a
+    /// cross-resolution stale blit is membership-safe. Only the in-memory feature
+    /// collection is consulted (the S-101 vector layers are <see cref="MemoryLayer"/>);
+    /// for any other layer kind an empty set is returned, preserving the prior
+    /// scaled-stale-blit behaviour.
+    /// </summary>
+    private static double[] CollectVisibilityThresholds(ILayer layer)
+    {
+        var set = new SortedSet<double>();
+
+        void Collect(IStyle? style)
+        {
+            if (style is null)
+            {
+                return;
+            }
+
+            var min = style.MinVisible;
+            if (min > 0 && !double.IsInfinity(min) && min < double.MaxValue)
+            {
+                set.Add(min);
+            }
+
+            var max = style.MaxVisible;
+            if (max > 0 && !double.IsInfinity(max) && max < double.MaxValue)
+            {
+                set.Add(max);
+            }
+
+            if (style is StyleCollection collection)
+            {
+                foreach (var child in collection.Styles)
+                {
+                    Collect(child);
+                }
+            }
+        }
+
+        Collect(layer.Style);
+
+        if (layer is MemoryLayer memoryLayer && memoryLayer.Features is { } features)
+        {
+            foreach (var feature in features)
+            {
+                if (feature.Styles is null)
+                {
+                    continue;
+                }
+
+                foreach (var style in feature.Styles)
+                {
+                    Collect(style);
+                }
+            }
+        }
+
+        var array = new double[set.Count];
+        set.CopyTo(array);
+        return array;
+    }
+
+    /// <summary>
+    /// Returns the layer's cached scale-visibility thresholds, recomputing them
+    /// when absent or when the visible feature count has changed (the same guard
+    /// that forces a re-record). Caller must hold <c>state.Sync</c>.
+    /// </summary>
+    private static IReadOnlyList<double> GetVisibilityThresholds(SnapshotState state, ILayer layer, int featureCount)
+    {
+        if (state.VisibilityThresholds is null || state.ThresholdsFeatureCount != featureCount)
+        {
+            state.VisibilityThresholds = CollectVisibilityThresholds(layer);
+            state.ThresholdsFeatureCount = featureCount;
+        }
+
+        return state.VisibilityThresholds;
     }
 
     /// <summary>
@@ -1303,6 +1455,13 @@ public static class S100VectorSnapshotRenderer
         public double PrevResolution;
         public double LastResolution;
         public readonly HashSet<double> InFlight = new();
+
+        // Cached scale-visibility boundaries (distinct MinVisible/MaxVisible) for
+        // the current feature set, used to decide whether a cross-resolution stale
+        // blit could paint a feature set inconsistent with the current resolution.
+        // Recomputed when the feature count changes (same guard as a re-record).
+        public double[]? VisibilityThresholds;
+        public int ThresholdsFeatureCount = int.MinValue;
 
         // Sustained-pan look-ahead: at most one off-thread same-resolution
         // recentred re-record is in flight at a time.

--- a/tests/EncDotNet.S100.Pipelines.Tests/MapsuiScaleDenominatorConversionTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/MapsuiScaleDenominatorConversionTests.cs
@@ -1,0 +1,93 @@
+using System;
+using EncDotNet.S100.Renderers.Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies the web-mercator latitude correction applied when converting an
+/// S-100 Part 9 §11.1 true-scale denominator to a Mapsui EPSG:3857 resolution
+/// (metres/pixel at the equator). Web-mercator inflates ground distances by
+/// <c>1/cos φ</c>, so a true-scale denominator maps to a larger equator-
+/// referenced resolution as latitude increases; omitting the term (the prior
+/// behaviour) suppressed detail too early off the equator.
+/// </summary>
+public class MapsuiScaleDenominatorConversionTests
+{
+    private const double WebMercatorEarthRadius = 6378137.0;
+
+    private static double LatitudeToWebMercatorY(double latitudeRadians)
+        => WebMercatorEarthRadius * Math.Log(Math.Tan(Math.PI / 4.0 + latitudeRadians / 2.0));
+
+    [Fact]
+    public void DenominatorToResolution_AtEquator_IsUncorrected()
+    {
+        var res = MapsuiDisplayListRenderer.DenominatorToResolution(22000, 0.0);
+
+        Assert.Equal(22000 * MapsuiDisplayListRenderer.DenomToResolutionMetres, res, 6);
+    }
+
+    [Fact]
+    public void DenominatorToResolution_OffEquator_DividesByCosLatitude()
+    {
+        var latitudeRadians = 50.77 * Math.PI / 180.0;
+
+        var res = MapsuiDisplayListRenderer.DenominatorToResolution(22000, latitudeRadians);
+
+        var expected = 22000 * MapsuiDisplayListRenderer.DenomToResolutionMetres / Math.Cos(latitudeRadians);
+        Assert.Equal(expected, res, 6);
+    }
+
+    [Fact]
+    public void DenominatorToResolution_OffEquator_IsLargerThanEquator()
+    {
+        var equator = MapsuiDisplayListRenderer.DenominatorToResolution(22000, 0.0);
+        var cowes = MapsuiDisplayListRenderer.DenominatorToResolution(22000, 50.77 * Math.PI / 180.0);
+
+        Assert.True(cowes > equator);
+    }
+
+    [Fact]
+    public void DenominatorToResolution_ClampsNearPoles()
+    {
+        // cos(90°) = 0 would divide by zero; the helper clamps cos to 1e-6.
+        var res = MapsuiDisplayListRenderer.DenominatorToResolution(22000, Math.PI / 2.0);
+
+        var expected = 22000 * MapsuiDisplayListRenderer.DenomToResolutionMetres / 1e-6;
+        Assert.Equal(expected, res, 3);
+    }
+
+    [Fact]
+    public void WebMercatorYToLatitudeRadians_RoundTrips()
+    {
+        var latitudeRadians = 50.77 * Math.PI / 180.0;
+        var y = LatitudeToWebMercatorY(latitudeRadians);
+
+        var recovered = MapsuiDisplayListRenderer.WebMercatorYToLatitudeRadians(y);
+
+        Assert.Equal(latitudeRadians, recovered, 9);
+    }
+
+    [Fact]
+    public void WebMercatorYToLatitudeRadians_AtEquatorIsZero()
+    {
+        Assert.Equal(0.0, MapsuiDisplayListRenderer.WebMercatorYToLatitudeRadians(0.0), 12);
+    }
+
+    [Fact]
+    public void Cowes22000Cap_MakesZoom14Visible()
+    {
+        // 101GB00602793 (Cowes/Solent): DataCoverage.minimumDisplayScale = 22000.
+        // res(z) = 156543.03392804097 / 2^z.  Uncorrected the cap = 6.16 m/px sits
+        // between z14 (9.55) and z15 (4.78), hiding linework at z14. Corrected at
+        // φ ≈ 50.77° the cap ≈ 9.74 m/px, which now admits z14.
+        var latitudeRadians = 50.77 * Math.PI / 180.0;
+        var cap = MapsuiDisplayListRenderer.DenominatorToResolution(22000, latitudeRadians);
+
+        const double z14 = 156543.03392804097 / (1 << 14);
+        const double uncorrected = 22000 * MapsuiDisplayListRenderer.DenomToResolutionMetres;
+
+        Assert.True(uncorrected < z14, "precondition: uncorrected cap hides z14");
+        Assert.True(cap > z14, "corrected cap should admit z14 linework");
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S100VectorSnapshotRendererTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S100VectorSnapshotRendererTests.cs
@@ -421,4 +421,67 @@ public sealed class S100VectorSnapshotRendererTests
 
         Assert.False(resynced);
     }
+
+    // --- VisibleSetMayDiffer: cross-resolution scale-visibility guard -------
+
+    // The S-101 out-of-band cap (this cell: minimumDisplayScale 22000 →
+    // capRes 6.16 m/px) is a single MaxVisible boundary on the linework layer.
+    private static readonly double[] CapThreshold = { 6.16 };
+
+    [Fact]
+    public void VisibleSetMayDiffer_FalseWhenNoThresholds()
+    {
+        Assert.False(S100VectorSnapshotRenderer.VisibleSetMayDiffer(Array.Empty<double>(), 9.55, 4.78));
+    }
+
+    [Fact]
+    public void VisibleSetMayDiffer_FalseWhenResolutionsEqual()
+    {
+        Assert.False(S100VectorSnapshotRenderer.VisibleSetMayDiffer(CapThreshold, 4.78, 4.78));
+    }
+
+    [Fact]
+    public void VisibleSetMayDiffer_TrueWhenThresholdBetween_ZoomCrossesCap()
+    {
+        // z14 (9.55, capped-hidden) -> z15 (4.78, visible): the 6.16 cap lies
+        // between them, so a stale blit would paint the wrong feature set.
+        Assert.True(S100VectorSnapshotRenderer.VisibleSetMayDiffer(CapThreshold, 9.55, 4.78));
+        // Direction-independent.
+        Assert.True(S100VectorSnapshotRenderer.VisibleSetMayDiffer(CapThreshold, 4.78, 9.55));
+    }
+
+    [Fact]
+    public void VisibleSetMayDiffer_FalseWhenBothInsideVisibleBand()
+    {
+        // z15 (4.78) -> z16 (2.39): both below the 6.16 cap (linework visible at
+        // both) — a scaled-stale blit is membership-safe.
+        Assert.False(S100VectorSnapshotRenderer.VisibleSetMayDiffer(CapThreshold, 4.78, 2.39));
+    }
+
+    [Fact]
+    public void VisibleSetMayDiffer_FalseWhenBothInsideHiddenBand()
+    {
+        // z13 (19.11) -> z14 (9.55): both above the 6.16 cap (linework hidden at
+        // both) — the recorded raster is empty either way, so the blit is safe.
+        Assert.False(S100VectorSnapshotRenderer.VisibleSetMayDiffer(CapThreshold, 19.11, 9.55));
+    }
+
+    [Fact]
+    public void VisibleSetMayDiffer_TrueWhenResolutionTouchesThreshold()
+    {
+        // Conservative: a resolution sitting exactly on the boundary counts as
+        // "may differ" so the blit is never used across the transition.
+        Assert.True(S100VectorSnapshotRenderer.VisibleSetMayDiffer(CapThreshold, 6.16, 4.78));
+    }
+
+    [Fact]
+    public void VisibleSetMayDiffer_HandlesMultipleThresholds()
+    {
+        double[] thresholds = { 2.0, 6.16, 30.0 };
+
+        // Spans only the 6.16 boundary.
+        Assert.True(S100VectorSnapshotRenderer.VisibleSetMayDiffer(thresholds, 9.55, 4.78));
+        // Spans none (between 6.16 and 30.0).
+        Assert.False(S100VectorSnapshotRenderer.VisibleSetMayDiffer(thresholds, 9.55, 19.11));
+    }
 }


### PR DESCRIPTION
## Summary

Buoys, beacons, and labels intermittently vanished at certain zoom levels in Standard mode on S-101 charts: zooming in/out brought them back, panning had no effect, they flickered during zoom, and they could paradoxically reappear when zooming *out*. This was two separate defects in the Mapsui vector path.

**Bug 1 - stale-blit across the scale-visibility boundary.** `S100VectorSnapshotRenderer` (the raster vector snapshot path, on by default) caches per-resolution rasters. During zoom, before the exact-resolution record finishes building off-thread, it blits a different-resolution cached image scaled to fit. Across the S-101 out-of-band cap boundary (derived from `DataCoverage.minimumDisplayScale`) the two resolutions have *different visible feature sets*, so:
- zooming out could blit a zoomed-in raster that still contained buoys (features appear when zooming out), and
- a capped-out stale raster with no buoys could persist once settled until the async record healed.

Fix: in the cross-resolution stale branch, draw the layer live for that frame when a scale-visibility threshold lies between the stale anchor's resolution and the current resolution; otherwise keep the (membership-safe) scaled blit.

**Bug 2 - latitude-omitted scale conversion.** S-100 Part 9 scale denominators are *true-scale*, but a Mapsui `resolution` is metres/pixel at the EPSG:3857 equator. Web-mercator inflates ground distance by `1/cos(latitude)`, so converting a denominator to a resolution must divide by `cos(latitude)`. The Mapsui path omitted it (correct only on the equator), so scale-visibility cutoffs fired too early off the equator - about 0.66 zoom levels at lat 50.8N, which is what hid a cell's linework one zoom level before it should. Per-feature limits now convert at the feature's extent-centre latitude, and the cell-wide cap converts at the layer's extent-centre latitude. This brings the Mapsui path into parity with the Skia headless backend, which already applied `cos(midLat)`.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [x] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A - change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** S-100 Part 9 §11.1 (scale denominators / `minimumDisplayScale`); EPSG:3857 web-mercator `1/cos φ` scale distortion. Both are referenced in the XML doc comments on the new conversion helpers.

## Tests

- [x] Added/updated xunit tests under `tests/` (8 for the stale-blit guard `VisibleSetMayDiffer`; 7 for `DenominatorToResolution` / `WebMercatorYToLatitudeRadians`, including the lat 50.8N cap-at-z14 case)
- [x] Tests requiring real data files use `SkippableFact` (no new real-data tests needed; new tests are pure)
- [x] `dotnet test --configuration Release` passes locally (Pipelines.Tests: 600 passed / 1 skipped)

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (`Renderers.Mapsui`: stale-blit membership guard + latitude-corrected scale conversion)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [ ] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None. `ApplyOutOfScaleBandCap(IEnumerable<IFeature>, double)` keeps its signature; the latitude correction is applied at the call site.

## Verification notes

Verified visually in the viewer against the Cowes cell (`101GB00602793`, lat ~50.8N) in Standard / Day: at z14 the chart linework (depth contours, breakwater, restricted-area limits, channel symbols) now renders where the uncorrected cap previously suppressed it. Bug 1 is a transient during-zoom artifact that a settled one-shot screenshot cannot reproduce (it always lands on the always-correct live frame), so it is pinned by unit tests rather than image diffing.