### PR TITLE
Add unclean-shutdown crash detection with next-startup feedback reporting

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -37,6 +37,17 @@ public partial class App : Application
     private static EncDotNet.S100.Viewer.Diagnostics.ILastErrorTracker? s_lastErrorTracker;
 
     /// <summary>
+    /// Previous viewer sessions that terminated without a clean shutdown
+    /// (detected via <see cref="Diagnostics.UncleanShutdownSentinel"/>),
+    /// or empty when the last run(s) exited normally. Set once during
+    /// startup; the main window reads it to surface a crash-recovery
+    /// notification. May contain more than one entry when several
+    /// instances crashed since the last clean launch.
+    /// </summary>
+    internal static IReadOnlyList<EncDotNet.S100.Viewer.Diagnostics.PreviousSession> PreviousUncleanShutdowns { get; private set; } =
+        Array.Empty<EncDotNet.S100.Viewer.Diagnostics.PreviousSession>();
+
+    /// <summary>
     /// Application-wide service container. Populated during
     /// <see cref="OnFrameworkInitializationCompleted"/>; throws if accessed
     /// before the framework is initialized.
@@ -72,6 +83,14 @@ public partial class App : Application
         // funnel through LogCrash).
         s_lastErrorTracker = s_services.GetRequiredService<
             EncDotNet.S100.Viewer.Diagnostics.ILastErrorTracker>();
+
+        // Detect an unclean shutdown from the previous run (native crash,
+        // FailFast, kill, … — none of which the managed handlers above can
+        // catch) and route it into the last-error tracker so the feedback
+        // reporter and the startup notification can surface it. Disabled
+        // for ephemeral / one-shot screenshot runs so automation never
+        // writes a marker or reports a stale one.
+        DetectPreviousUncleanShutdown();
 
         // ShadUI resolves custom dialog content by an explicit
         // view/context-view-model registration on the DialogManager (a
@@ -411,6 +430,8 @@ public partial class App : Application
         // Feedback reporting: diagnostics capture + modal dialog plumbing.
         services.AddSingleton<EncDotNet.S100.Viewer.Diagnostics.ILastErrorTracker,
             EncDotNet.S100.Viewer.Diagnostics.LastErrorTracker>();
+        services.AddSingleton<EncDotNet.S100.Viewer.Diagnostics.ICrashHistory,
+            EncDotNet.S100.Viewer.Diagnostics.CrashHistory>();
         services.AddSingleton<IAppScreenshotProvider, AppScreenshotProvider>();
         services.AddSingleton<ShadUI.DialogManager>();
         services.AddSingleton<IFeedbackService, FeedbackService>();
@@ -710,5 +731,46 @@ public partial class App : Application
         Console.Error.WriteLine($"[{label}] {message}");
         CrashLog.Append(label, message);
         s_lastErrorTracker?.Record(label, message);
+    }
+
+    /// <summary>
+    /// Configures the unclean-shutdown sentinel for this run, then begins
+    /// a session. When a previous run's marker survived (an unclean
+    /// termination), captures every detected crash — with a tail of the
+    /// crash log — into the dedicated <see cref="Diagnostics.ICrashHistory"/>
+    /// so the feedback report always carries it, and stashes the list on
+    /// <see cref="PreviousUncleanShutdowns"/> for the main window to report.
+    /// </summary>
+    /// <remarks>
+    /// Crashes are deliberately routed to the sticky crash history rather
+    /// than the single-slot <see cref="Diagnostics.ILastErrorTracker"/>: a
+    /// crash is a stronger signal than an ordinary runtime exception and must
+    /// not be evicted by a later, non-fatal error before the user sends
+    /// feedback.
+    /// </remarks>
+    private static void DetectPreviousUncleanShutdown()
+    {
+        var options = StartupOptions;
+
+        // Skip ephemeral / one-shot screenshot automation runs: they must
+        // leave no marker behind and must not surface a stale crash.
+        var enabled = !(options?.Ephemeral == true || options?.ExitAfterScreenshot == true);
+
+        var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+
+        EncDotNet.S100.Viewer.Diagnostics.UncleanShutdownSentinel.Configure(enabled);
+        var crashed =
+            EncDotNet.S100.Viewer.Diagnostics.UncleanShutdownSentinel.BeginSession(version);
+        if (crashed.Count == 0)
+            return;
+
+        PreviousUncleanShutdowns = crashed;
+
+        // Capture every detected crash (with a tail of the crash log) into the
+        // sticky crash history so the feedback report always includes it,
+        // independent of any runtime errors recorded later this session.
+        var tail = CrashLog.ReadTail(8000);
+        s_services?.GetService<EncDotNet.S100.Viewer.Diagnostics.ICrashHistory>()
+            ?.Capture(crashed, tail);
     }
 }

--- a/src/EncDotNet.S100.Viewer/CrashLog.cs
+++ b/src/EncDotNet.S100.Viewer/CrashLog.cs
@@ -64,4 +64,34 @@ internal static class CrashLog
             // Best-effort — diagnostics must never crash the process.
         }
     }
+
+    /// <summary>
+    /// Returns the trailing <paramref name="maxChars"/> characters of the
+    /// configured crash-log file, or <see langword="null"/> when the file
+    /// does not exist or cannot be read. Used to attach recent crash
+    /// context to a feedback report on the next startup. Never throws.
+    /// </summary>
+    /// <param name="maxChars">Maximum number of trailing characters to
+    /// return. Values &lt;= 0 yield <see langword="null"/>.</param>
+    public static string? ReadTail(int maxChars)
+    {
+        if (maxChars <= 0)
+            return null;
+
+        string path;
+        lock (Gate) path = s_path;
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+
+            var text = File.ReadAllText(path);
+            return text.Length <= maxChars ? text : text[^maxChars..];
+        }
+        catch
+        {
+            // Best-effort — diagnostics must never crash the process.
+            return null;
+        }
+    }
 }

--- a/src/EncDotNet.S100.Viewer/Diagnostics/CrashHistory.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/CrashHistory.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Sticky record of unclean shutdowns detected from previous runs.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="ILastErrorTracker"/>, which keeps only the most recent
+/// runtime error in a single slot that later (non-fatal) errors overwrite,
+/// this history is captured once at startup and never evicted. A crash is a
+/// far stronger signal than an exception the app recovered from, so the
+/// feedback bundle must always carry every detected crash regardless of any
+/// errors that occur afterwards. Implementations are thread-safe.
+/// </remarks>
+internal interface ICrashHistory
+{
+    /// <summary>
+    /// Previous sessions that terminated without a clean shutdown, oldest
+    /// first. Empty when the previous run(s) exited cleanly.
+    /// </summary>
+    IReadOnlyList<PreviousSession> Crashes { get; }
+
+    /// <summary>
+    /// Best-effort tail of the shared crash log captured when the crashes
+    /// were detected, or <see langword="null"/> when none was available.
+    /// </summary>
+    string? CrashLogTail { get; }
+
+    /// <summary>Whether any unclean shutdown was detected.</summary>
+    bool HasCrashes { get; }
+
+    /// <summary>
+    /// Records the crashes detected at startup. Intended to be called once;
+    /// a later call replaces the previous capture.
+    /// </summary>
+    /// <param name="crashes">Detected crashed sessions (oldest first).</param>
+    /// <param name="crashLogTail">Optional tail of the crash log.</param>
+    void Capture(IReadOnlyList<PreviousSession> crashes, string? crashLogTail);
+}
+
+/// <summary>
+/// Default <see cref="ICrashHistory"/>: holds the startup crash capture in
+/// lock-guarded fields. Registered as a singleton and populated by
+/// <c>App.DetectPreviousUncleanShutdown</c>.
+/// </summary>
+internal sealed class CrashHistory : ICrashHistory
+{
+    private readonly object _gate = new();
+    private IReadOnlyList<PreviousSession> _crashes = Array.Empty<PreviousSession>();
+    private string? _crashLogTail;
+
+    /// <inheritdoc />
+    public IReadOnlyList<PreviousSession> Crashes
+    {
+        get { lock (_gate) return _crashes; }
+    }
+
+    /// <inheritdoc />
+    public string? CrashLogTail
+    {
+        get { lock (_gate) return _crashLogTail; }
+    }
+
+    /// <inheritdoc />
+    public bool HasCrashes
+    {
+        get { lock (_gate) return _crashes.Count > 0; }
+    }
+
+    /// <inheritdoc />
+    public void Capture(IReadOnlyList<PreviousSession> crashes, string? crashLogTail)
+    {
+        ArgumentNullException.ThrowIfNull(crashes);
+        lock (_gate)
+        {
+            _crashes = crashes;
+            _crashLogTail = crashLogTail;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Diagnostics/UncleanShutdownSentinel.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/UncleanShutdownSentinel.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EncDotNet.S100.Viewer.Diagnostics;
+
+/// <summary>
+/// Detects abnormal viewer terminations that the managed exception
+/// handlers cannot catch — native crashes (SkiaSharp / GPU),
+/// <see cref="Environment.FailFast(string)"/>, stack-overflow, an
+/// out-of-memory kill, or an external <c>kill -9</c> — by leaving a
+/// small <em>per-process session marker</em> file on disk for the
+/// lifetime of each run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each instance writes its own marker, named
+/// <c>viewer-session-{pid}.lock</c>, in a shared marker directory on
+/// startup (<see cref="BeginSession"/>) and deletes <em>only its own</em>
+/// marker on a clean shutdown (<see cref="MarkCleanExit"/>). This makes
+/// the sentinel correct when several viewers run side by side (e.g.
+/// charts compared in two windows): a live instance's marker is left
+/// untouched by others, and a clean exit never erases another instance's
+/// crash evidence.
+/// </para>
+/// <para>
+/// On startup, any marker whose owning process is no longer alive
+/// indicates a previous session that terminated without running its
+/// clean-shutdown path — i.e. it crashed. <see cref="BeginSession"/>
+/// returns every such session and removes their stale markers.
+/// </para>
+/// <para>
+/// Liveness is decided cross-platform (Windows, macOS, Linux) by process
+/// id <em>plus the OS process start time</em>: a recycled PID assigned to
+/// a different process has a different start time, so a reused PID is
+/// correctly treated as a dead session rather than a live one. The
+/// process name is a secondary guard used only when a start time cannot
+/// be read.
+/// </para>
+/// <para>
+/// Every operation is best-effort: a failure to read or write a marker
+/// (read-only volume, missing directory, …) is swallowed so crash
+/// detection can never itself take the process down.
+/// </para>
+/// </remarks>
+internal static class UncleanShutdownSentinel
+{
+    private static readonly object Gate = new();
+
+    private const string MarkerPrefix = "viewer-session-";
+    private const string MarkerExtension = ".lock";
+
+    /// <summary>
+    /// Tolerance when comparing a recorded process start time to the live
+    /// process's start time. Generous enough to absorb clock-resolution
+    /// and serialization rounding, tight enough to distinguish a reused
+    /// PID (whose start time differs by seconds or more).
+    /// </summary>
+    private static readonly TimeSpan StartTimeTolerance = TimeSpan.FromSeconds(2);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Default marker directory: a <c>crash-markers</c> folder under the
+    /// viewer's per-user application-data directory (alongside the
+    /// persisted settings), so markers survive temp-directory cleanup
+    /// between runs.
+    /// </summary>
+    public static string DefaultDirectory { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "EncDotNet.S100.Viewer",
+        "crash-markers");
+
+    private static string s_directory = DefaultDirectory;
+    private static bool s_enabled = true;
+
+    /// <summary>The active marker directory.</summary>
+    public static string Directory
+    {
+        get { lock (Gate) return s_directory; }
+    }
+
+    /// <summary>
+    /// Configures the sentinel. When <paramref name="enabled"/> is
+    /// <see langword="false"/> (e.g. <c>--ephemeral</c> or one-shot
+    /// screenshot runs) <see cref="BeginSession"/> and
+    /// <see cref="MarkCleanExit"/> become no-ops so automation runs never
+    /// write a marker or report a stale one.
+    /// </summary>
+    /// <param name="enabled">Whether crash detection is active this run.</param>
+    /// <param name="directory">Marker directory override; <see langword="null"/>
+    /// or whitespace resets to <see cref="DefaultDirectory"/>.</param>
+    public static void Configure(bool enabled, string? directory = null)
+    {
+        lock (Gate)
+        {
+            s_enabled = enabled;
+            s_directory = string.IsNullOrWhiteSpace(directory) ? DefaultDirectory : directory;
+        }
+    }
+
+    /// <summary>
+    /// Starts a session: scans the marker directory for sessions from
+    /// previous runs whose process is no longer alive (crashes), removes
+    /// their stale markers, then writes a fresh marker for the current
+    /// process.
+    /// </summary>
+    /// <param name="version">The current application version string,
+    /// recorded in the marker for diagnostics.</param>
+    /// <returns>
+    /// Every previous session that ended without a clean shutdown, ordered
+    /// oldest-first. Empty when there was no prior crash, when the only
+    /// other markers belong to still-running instances, or when the
+    /// sentinel is disabled.
+    /// </returns>
+    public static IReadOnlyList<PreviousSession> BeginSession(string version)
+    {
+        bool enabled;
+        string directory;
+        lock (Gate)
+        {
+            enabled = s_enabled;
+            directory = s_directory;
+        }
+
+        if (!enabled)
+            return Array.Empty<PreviousSession>();
+
+        var crashed = ScanForCrashedSessions(directory);
+        WriteMarker(directory, version);
+        return crashed;
+    }
+
+    /// <summary>
+    /// Records a clean shutdown by deleting <em>this process's</em> marker
+    /// only. After this call a subsequent startup will not report this
+    /// (graceful) exit as a crash. No-op when disabled.
+    /// </summary>
+    public static void MarkCleanExit()
+    {
+        bool enabled;
+        string directory;
+        lock (Gate)
+        {
+            enabled = s_enabled;
+            directory = s_directory;
+        }
+
+        if (!enabled)
+            return;
+
+        TryDelete(MarkerPathFor(directory, SafeCurrentPid()));
+    }
+
+    private static List<PreviousSession> ScanForCrashedSessions(string directory)
+    {
+        var results = new List<PreviousSession>();
+        try
+        {
+            if (!System.IO.Directory.Exists(directory))
+                return results;
+
+            foreach (var file in System.IO.Directory.EnumerateFiles(
+                         directory, MarkerPrefix + "*" + MarkerExtension))
+            {
+                try
+                {
+                    var marker = JsonSerializer.Deserialize<SessionMarker>(
+                        File.ReadAllText(file), JsonOptions);
+                    if (marker is null)
+                    {
+                        // Malformed marker — clean it up so it never lingers.
+                        TryDelete(file);
+                        continue;
+                    }
+
+                    // A marker whose writer is still alive belongs to a
+                    // concurrent side-by-side instance (or to this very
+                    // process on a re-scan) — leave it be.
+                    if (IsProcessAlive(marker.Pid, marker.ProcessStartUtc, marker.ProcessName))
+                        continue;
+
+                    results.Add(new PreviousSession(
+                        StartedUtc: marker.StartedUtc,
+                        Pid: marker.Pid,
+                        Version: marker.Version ?? "(unknown)"));
+
+                    // The owning process is gone — remove the stale marker so
+                    // the crash is reported exactly once.
+                    TryDelete(file);
+                }
+                catch
+                {
+                    // Skip an unreadable individual marker; keep scanning.
+                }
+            }
+        }
+        catch
+        {
+            // Directory enumeration failed — report nothing.
+        }
+
+        results.Sort(static (a, b) => a.StartedUtc.CompareTo(b.StartedUtc));
+        return results;
+    }
+
+    private static void WriteMarker(string directory, string version)
+    {
+        try
+        {
+            System.IO.Directory.CreateDirectory(directory);
+
+            var pid = SafeCurrentPid();
+            var marker = new SessionMarker
+            {
+                Pid = pid,
+                ProcessName = SafeCurrentProcessName(),
+                ProcessStartUtc = SafeCurrentProcessStartUtc(),
+                StartedUtc = DateTime.UtcNow,
+                Version = string.IsNullOrWhiteSpace(version) ? null : version,
+            };
+
+            File.WriteAllText(
+                MarkerPathFor(directory, pid),
+                JsonSerializer.Serialize(marker, JsonOptions));
+        }
+        catch
+        {
+            // Best-effort — a missing marker just means no crash detection
+            // for the next run, never a fault for this one.
+        }
+    }
+
+    private static string MarkerPathFor(string directory, int pid) =>
+        Path.Combine(directory, $"{MarkerPrefix}{pid}{MarkerExtension}");
+
+    /// <summary>
+    /// Determines whether the process that wrote a marker is still the
+    /// live process it claims to be — cross-platform. Returns
+    /// <see langword="false"/> when no process with that id exists, when
+    /// it has exited, or when its start time no longer matches (the PID
+    /// was reused by a different process).
+    /// </summary>
+    private static bool IsProcessAlive(int pid, DateTime? processStartUtc, string? processName)
+    {
+        if (pid <= 0)
+            return false;
+
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            if (process.HasExited)
+                return false;
+
+            // Primary, OS-agnostic disambiguation: the OS process start
+            // time. A recycled PID belongs to a process that started at a
+            // different time, so a mismatch means the original session is
+            // dead. Defeats PID reuse identically on Windows/macOS/Linux.
+            if (processStartUtc is { } recorded)
+            {
+                try
+                {
+                    var actual = process.StartTime.ToUniversalTime();
+                    return Math.Abs((actual - recorded).TotalSeconds) <= StartTimeTolerance.TotalSeconds;
+                }
+                catch
+                {
+                    // StartTime unreadable (access denied / exited mid-check)
+                    // — fall through to the process-name guard.
+                }
+            }
+
+            // Secondary guard when no start time is available: only treat
+            // the PID as a live viewer when the process name also matches.
+            return string.IsNullOrEmpty(processName)
+                || string.Equals(process.ProcessName, processName, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (ArgumentException)
+        {
+            // No process with that id is running.
+            return false;
+        }
+        catch
+        {
+            // Access denied or platform quirk — assume not our process so
+            // we err towards reporting rather than silently swallowing.
+            return false;
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Best-effort — never crash on cleanup.
+        }
+    }
+
+    private static int SafeCurrentPid()
+    {
+        try { return Environment.ProcessId; }
+        catch { return -1; }
+    }
+
+    private static string? SafeCurrentProcessName()
+    {
+        try { return Process.GetCurrentProcess().ProcessName; }
+        catch { return null; }
+    }
+
+    private static DateTime? SafeCurrentProcessStartUtc()
+    {
+        try { return Process.GetCurrentProcess().StartTime.ToUniversalTime(); }
+        catch { return null; }
+    }
+
+    private sealed class SessionMarker
+    {
+        public int Pid { get; set; }
+        public string? ProcessName { get; set; }
+        public DateTime? ProcessStartUtc { get; set; }
+        public DateTime StartedUtc { get; set; }
+        public string? Version { get; set; }
+    }
+}
+
+/// <summary>
+/// Immutable details of a previous viewer session that terminated without
+/// a clean shutdown.
+/// </summary>
+/// <param name="StartedUtc">When the previous session started (UTC).</param>
+/// <param name="Pid">Process id of the previous session.</param>
+/// <param name="Version">Application version of the previous session.</param>
+internal sealed record PreviousSession(
+    DateTime StartedUtc,
+    int Pid,
+    string Version);

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -169,6 +169,9 @@ public partial class MainWindow : ShadUI.Window
             // PR-M3: flush any pending debounced size writes so the last
             // splitter drag isn't lost on shutdown.
             _viewModel.OnShutdown();
+            // Record a clean shutdown so the next launch does not report
+            // this (graceful) exit as a crash.
+            EncDotNet.S100.Viewer.Diagnostics.UncleanShutdownSentinel.MarkCleanExit();
             foreach (var reg in _dynamicSourceRegistrations) reg.Dispose();
             _dynamicSourceRegistrations.Clear();
             App.Services.GetRequiredService<
@@ -436,6 +439,44 @@ public partial class MainWindow : ShadUI.Window
             // rather than leaving it at the whole-world default.
             Opened += async (_, _) => await FrameOnOwnShipAtStartupAsync();
         }
+
+        // Surface a recovery notification when the previous run terminated
+        // without a clean shutdown (a native crash, FailFast, kill, …).
+        Opened += (_, _) => ReportPreviousUncleanShutdown();
+    }
+
+    private bool _previousCrashReported;
+
+    /// <summary>
+    /// Shows a sticky warning toast when one or more previous sessions
+    /// ended unexpectedly (detected by
+    /// <see cref="App.PreviousUncleanShutdowns"/>), offering a one-click
+    /// action to open the feedback reporter — which already carries the
+    /// captured crash context via the last-error tracker. Shown at most
+    /// once per window.
+    /// </summary>
+    private void ReportPreviousUncleanShutdown()
+    {
+        if (_previousCrashReported)
+            return;
+        _previousCrashReported = true;
+
+        var crashed = App.PreviousUncleanShutdowns;
+        if (crashed.Count == 0)
+            return;
+
+        var mostRecent = crashed[^1];
+        var body = crashed.Count > 1
+            ? string.Format(Strings.Toast_PreviousCrashBodyMultiple, crashed.Count)
+            : string.Format(Strings.Toast_PreviousCrashBody, mostRecent.StartedUtc.ToLocalTime());
+
+        var toasts = App.Services.GetRequiredService<IToastService>();
+        toasts.ShowError(
+            title: Strings.Toast_PreviousCrashTitle,
+            content: body,
+            actionLabel: Strings.Toast_PreviousCrashAction,
+            action: () => _viewModel.ShowFeedbackCommand.Execute(null),
+            sticky: true);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -365,6 +365,42 @@ viewer has a built-in **Report Feedback** experience:
 No data leaves your machine until you choose to create the GitHub
 issue, and nothing is uploaded by the viewer itself.
 
+### Crash recovery (next-startup reporting)
+
+Some crashes — a native fault in the GPU/SkiaSharp stack, an
+`Environment.FailFast`, a stack overflow, an out-of-memory kill, or an
+external `kill -9` — terminate the process *before* the managed global
+exception handlers can run, so they leave no toast and no obvious trace.
+To catch these, the viewer drops a small **per-process session marker**
+file (`viewer-session-{pid}.lock`, in a `crash-markers` folder next to
+your settings) on startup and deletes its own marker on a clean
+shutdown. On the next launch, any marker whose owning process is no
+longer alive means that session terminated abnormally:
+
+- A **"Viewer recovered from an unexpected shutdown"** notification
+  appears, with a one-click **Send feedback** action.
+- The crash context — every detected session's start time, PID, and
+  version plus a tail of the `viewer-crash.log` — is attached to the
+  feedback report automatically in a dedicated **`PreviousCrashes`**
+  channel. This is deliberately separate from the single-slot
+  last-error tracker: a crash is a far stronger signal than an
+  exception the app recovered from, so it is captured once at startup
+  and **never evicted** by a later, non-fatal runtime error before you
+  send feedback. **All** detected crashes are reported, not just the
+  most recent.
+
+Because markers are **per process**, this is correct when several
+viewers run **side by side** (e.g. comparing charts in two windows): a
+live instance's marker is left untouched by the others, and one
+instance's clean exit never erases another's crash evidence. Liveness
+is decided the same way on **Windows, macOS, and Linux** — by process
+id *plus the OS process start time*, so a recycled PID is never
+mistaken for a still-running session.
+
+The markers are per-user and are **not** written for `--ephemeral` or
+one-shot `--exit-after-screenshot` automation runs, so agent harnesses
+never pollute them or surface a stale crash.
+
 
 A live "own ship" overlay sits alongside the static datasets,
 publishing a single moving point through the

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -422,6 +422,10 @@ internal static class Strings
     public static string Toast_Cancel => Get(nameof(Toast_Cancel));
     public static string Toast_ExchangeSetLoading => Get(nameof(Toast_ExchangeSetLoading));
     public static string Toast_SettingsApplied => Get(nameof(Toast_SettingsApplied));
+    public static string Toast_PreviousCrashTitle => Get(nameof(Toast_PreviousCrashTitle));
+    public static string Toast_PreviousCrashBody => Get(nameof(Toast_PreviousCrashBody));
+    public static string Toast_PreviousCrashBodyMultiple => Get(nameof(Toast_PreviousCrashBodyMultiple));
+    public static string Toast_PreviousCrashAction => Get(nameof(Toast_PreviousCrashAction));
 
     // MCP server
     public static string Status_McpRunning => Get(nameof(Status_McpRunning));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1136,6 +1136,20 @@
   <data name="Toast_SettingsApplied" xml:space="preserve">
     <value>Settings applied.</value>
   </data>
+  <data name="Toast_PreviousCrashTitle" xml:space="preserve">
+    <value>Viewer recovered from an unexpected shutdown</value>
+  </data>
+  <data name="Toast_PreviousCrashBody" xml:space="preserve">
+    <value>The previous session (started {0:g}) closed unexpectedly. Send a feedback report to help diagnose it.</value>
+    <comment>Crash-recovery toast body. {0} = local start time of the previous (crashed) session.</comment>
+  </data>
+  <data name="Toast_PreviousCrashBodyMultiple" xml:space="preserve">
+    <value>{0} previous sessions closed unexpectedly. Send a feedback report to help diagnose them.</value>
+    <comment>Crash-recovery toast body when multiple instances crashed. {0} = count of crashed sessions.</comment>
+  </data>
+  <data name="Toast_PreviousCrashAction" xml:space="preserve">
+    <value>Send feedback</value>
+  </data>
 
   <!-- MCP server -->
   <data name="Status_McpRunning" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/Services/FeedbackReport.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeedbackReport.cs
@@ -38,6 +38,23 @@ internal sealed record FeedbackReport
     /// <see langword="null"/> when none was recorded.</summary>
     public FeedbackErrorInfo? LastError { get; init; }
 
+    /// <summary>
+    /// Unclean shutdowns detected from previous runs (oldest first), or an
+    /// empty list when the previous run(s) exited cleanly. A crash is a far
+    /// stronger signal than a recovered-from runtime error, so this channel
+    /// is captured once at startup and never evicted — it is always carried
+    /// in the bundle when present, independent of <see cref="LastError"/>.
+    /// </summary>
+    public IReadOnlyList<FeedbackCrashInfo> PreviousCrashes { get; init; } =
+        Array.Empty<FeedbackCrashInfo>();
+
+    /// <summary>
+    /// Best-effort tail of the shared crash log captured when the crashes in
+    /// <see cref="PreviousCrashes"/> were detected, or <see langword="null"/>
+    /// when none was available or no crash was detected.
+    /// </summary>
+    public string? CrashLogTail { get; init; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
@@ -109,3 +126,12 @@ internal sealed record FeedbackErrorInfo(
     string? ExceptionType,
     string Message,
     string? StackTrace);
+
+/// <summary>A previous session that terminated without a clean shutdown.</summary>
+/// <param name="StartedUtc">When the crashed session started (UTC).</param>
+/// <param name="Pid">Process id of the crashed session.</param>
+/// <param name="Version">Application version string of the crashed session.</param>
+internal sealed record FeedbackCrashInfo(
+    DateTimeOffset StartedUtc,
+    int Pid,
+    string? Version);

--- a/src/EncDotNet.S100.Viewer/Services/FeedbackService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeedbackService.cs
@@ -38,6 +38,7 @@ internal sealed class FeedbackService : IFeedbackService
     private readonly DatasetsViewModel _datasets;
     private readonly IMapViewportNotifier _viewport;
     private readonly ILastErrorTracker _errors;
+    private readonly ICrashHistory _crashes;
     private readonly IThemeService _theme;
     private readonly SettingsViewModel _settings;
     private readonly IAppScreenshotProvider _screenshot;
@@ -47,6 +48,7 @@ internal sealed class FeedbackService : IFeedbackService
         DatasetsViewModel datasets,
         IMapViewportNotifier viewport,
         ILastErrorTracker errors,
+        ICrashHistory crashes,
         IThemeService theme,
         SettingsViewModel settings,
         IAppScreenshotProvider screenshot,
@@ -55,6 +57,7 @@ internal sealed class FeedbackService : IFeedbackService
         ArgumentNullException.ThrowIfNull(datasets);
         ArgumentNullException.ThrowIfNull(viewport);
         ArgumentNullException.ThrowIfNull(errors);
+        ArgumentNullException.ThrowIfNull(crashes);
         ArgumentNullException.ThrowIfNull(theme);
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(screenshot);
@@ -63,6 +66,7 @@ internal sealed class FeedbackService : IFeedbackService
         _datasets = datasets;
         _viewport = viewport;
         _errors = errors;
+        _crashes = crashes;
         _theme = theme;
         _settings = settings;
         _screenshot = screenshot;
@@ -134,6 +138,16 @@ internal sealed class FeedbackService : IFeedbackService
                 StackTrace: e.StackTrace);
         }
 
+        var previousCrashes = new List<FeedbackCrashInfo>();
+        foreach (var crash in _crashes.Crashes)
+        {
+            previousCrashes.Add(new FeedbackCrashInfo(
+                StartedUtc: new DateTimeOffset(
+                    DateTime.SpecifyKind(crash.StartedUtc, DateTimeKind.Utc)),
+                Pid: crash.Pid,
+                Version: crash.Version));
+        }
+
         return new FeedbackReport
         {
             GeneratedUtc = DateTimeOffset.UtcNow,
@@ -142,6 +156,8 @@ internal sealed class FeedbackService : IFeedbackService
             Viewport = viewport,
             Datasets = datasets,
             LastError = lastError,
+            PreviousCrashes = previousCrashes,
+            CrashLogTail = _crashes.HasCrashes ? _crashes.CrashLogTail : null,
         };
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/CrashHistoryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/CrashHistoryTests.cs
@@ -1,0 +1,85 @@
+using System;
+using EncDotNet.S100.Viewer.Diagnostics;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers the sticky crash-history store that carries detected unclean
+/// shutdowns into the feedback report. Crashes must be retained verbatim and
+/// never be evicted the way the single-slot <see cref="ILastErrorTracker"/> is.
+/// </summary>
+public class CrashHistoryTests
+{
+    private static PreviousSession Session(int pid, string version, DateTime startedUtc) =>
+        new(startedUtc, pid, version);
+
+    [Fact]
+    public void Default_IsEmpty()
+    {
+        var history = new CrashHistory();
+
+        Assert.False(history.HasCrashes);
+        Assert.Empty(history.Crashes);
+        Assert.Null(history.CrashLogTail);
+    }
+
+    [Fact]
+    public void Capture_RetainsAllCrashesAndTail()
+    {
+        var history = new CrashHistory();
+        var crashes = new[]
+        {
+            Session(1, "1.0.0", new DateTime(2026, 6, 14, 10, 0, 0, DateTimeKind.Utc)),
+            Session(2, "1.0.1", new DateTime(2026, 6, 14, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        history.Capture(crashes, "tail-text");
+
+        Assert.True(history.HasCrashes);
+        Assert.Equal(2, history.Crashes.Count);
+        Assert.Equal(1, history.Crashes[0].Pid);
+        Assert.Equal(2, history.Crashes[1].Pid);
+        Assert.Equal("tail-text", history.CrashLogTail);
+    }
+
+    [Fact]
+    public void Capture_WithNullTail_IsAllowed()
+    {
+        var history = new CrashHistory();
+
+        history.Capture(
+            new[] { Session(7, "9.9.9", new DateTime(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc)) },
+            crashLogTail: null);
+
+        Assert.True(history.HasCrashes);
+        Assert.Null(history.CrashLogTail);
+    }
+
+    [Fact]
+    public void Capture_NullCrashes_Throws()
+    {
+        var history = new CrashHistory();
+
+        Assert.Throws<ArgumentNullException>(() => history.Capture(null!, "x"));
+    }
+
+    [Fact]
+    public void Capture_IsStickyAcrossLaterErrors()
+    {
+        // The crash capture is independent of any runtime error tracking;
+        // once captured it remains until explicitly replaced.
+        var history = new CrashHistory();
+        var crashes = new[]
+        {
+            Session(42, "1.2.3", new DateTime(2026, 6, 14, 9, 0, 0, DateTimeKind.Utc)),
+        };
+
+        history.Capture(crashes, "boom");
+
+        // A subsequent (empty) capture replaces it; nothing else can evict it.
+        Assert.True(history.HasCrashes);
+        Assert.Single(history.Crashes);
+        Assert.Equal(42, history.Crashes[0].Pid);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/CrashLogTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/CrashLogTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Viewer;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers <see cref="CrashLog.ReadTail"/>: returning the trailing portion
+/// of the crash log for attachment to a next-startup feedback report.
+/// </summary>
+public sealed class CrashLogTests : IDisposable
+{
+    private readonly string _path;
+
+    public CrashLogTests()
+    {
+        _path = Path.Combine(Path.GetTempPath(), $"viewer-crash-{Guid.NewGuid():N}.log");
+        CrashLog.ConfigurePath(_path);
+    }
+
+    public void Dispose()
+    {
+        CrashLog.ConfigurePath(null);
+        try { if (File.Exists(_path)) File.Delete(_path); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void ReadTail_MissingFile_ReturnsNull()
+    {
+        Assert.Null(CrashLog.ReadTail(100));
+    }
+
+    [Fact]
+    public void ReadTail_NonPositiveMax_ReturnsNull()
+    {
+        CrashLog.Append("FATAL", "boom");
+        Assert.Null(CrashLog.ReadTail(0));
+        Assert.Null(CrashLog.ReadTail(-5));
+    }
+
+    [Fact]
+    public void ReadTail_ShorterThanMax_ReturnsWholeFile()
+    {
+        CrashLog.Append("FATAL", "boom");
+
+        var tail = CrashLog.ReadTail(10_000);
+
+        Assert.NotNull(tail);
+        Assert.Contains("FATAL", tail);
+        Assert.Contains("boom", tail);
+    }
+
+    [Fact]
+    public void ReadTail_LongerThanMax_ReturnsTrailingCharacters()
+    {
+        File.WriteAllText(_path, new string('a', 100) + "TAILMARKER");
+
+        var tail = CrashLog.ReadTail(10);
+
+        Assert.Equal("TAILMARKER", tail);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeedbackReportingTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeedbackReportingTests.cs
@@ -49,6 +49,39 @@ public class FeedbackReportingTests
     }
 
     [Fact]
+    public void ToJson_IncludesPreviousCrashes()
+    {
+        var report = SampleReport() with
+        {
+            PreviousCrashes = new[]
+            {
+                new FeedbackCrashInfo(
+                    new DateTimeOffset(2026, 6, 14, 10, 0, 0, TimeSpan.Zero), 4242, "1.2.2"),
+                new FeedbackCrashInfo(
+                    new DateTimeOffset(2026, 6, 14, 11, 0, 0, TimeSpan.Zero), 4343, "1.2.3"),
+            },
+            CrashLogTail = "[UIThread.UnhandledException] kaboom",
+        };
+
+        var json = report.ToJson();
+
+        Assert.Contains("PreviousCrashes", json);
+        Assert.Contains("\"Pid\": 4242", json);
+        Assert.Contains("\"Pid\": 4343", json);
+        Assert.Contains("CrashLogTail", json);
+        Assert.Contains("kaboom", json);
+    }
+
+    [Fact]
+    public void ToJson_OmitsCrashLogTailWhenNoCrash()
+    {
+        // Default report has an empty crash list and a null tail.
+        var json = SampleReport().ToJson();
+
+        Assert.DoesNotContain("CrashLogTail", json);
+    }
+
+    [Fact]
     public void ToJson_OmitsNullSections()
     {
         var json = SampleReport(withViewport: false, withError: false).ToJson();

--- a/tests/EncDotNet.S100.Viewer.Tests/UncleanShutdownSentinelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/UncleanShutdownSentinelTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using EncDotNet.S100.Viewer.Diagnostics;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers <see cref="UncleanShutdownSentinel"/>: per-process marker
+/// write/clear lifecycle, disabled no-ops, multi-instance behaviour
+/// (a live side-by-side instance is not reported and its marker is
+/// retained), and cross-platform PID-reuse robustness (a recycled PID
+/// with a different start time is treated as a crashed session).
+/// </summary>
+/// <remarks>
+/// The sentinel keeps process-wide static state, so every test configures
+/// its own temp marker directory and the class runs its methods
+/// sequentially.
+/// </remarks>
+public sealed class UncleanShutdownSentinelTests : IDisposable
+{
+    private readonly string _dir;
+
+    public UncleanShutdownSentinelTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"viewer-sentinel-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        UncleanShutdownSentinel.Configure(enabled: false);
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    private int MarkerCount() =>
+        Directory.EnumerateFiles(_dir, "viewer-session-*.lock").Count();
+
+    private void WriteMarker(
+        int pid,
+        string processName,
+        DateTime? processStartUtc,
+        DateTime startedUtc,
+        string version)
+    {
+        var startUtcJson = processStartUtc is { } s ? $"\"{s:O}\"" : "null";
+        var json =
+            $$"""
+            {"Pid":{{pid}},"ProcessName":"{{processName}}","ProcessStartUtc":{{startUtcJson}},"StartedUtc":"{{startedUtc:O}}","Version":"{{version}}"}
+            """;
+        File.WriteAllText(Path.Combine(_dir, $"viewer-session-{pid}.lock"), json);
+    }
+
+    [Fact]
+    public void BeginSession_NoMarkers_ReturnsEmptyAndWritesOwnMarker()
+    {
+        UncleanShutdownSentinel.Configure(enabled: true, _dir);
+
+        var crashed = UncleanShutdownSentinel.BeginSession("1.2.3");
+
+        Assert.Empty(crashed);
+        // This process's own marker now exists.
+        Assert.True(File.Exists(Path.Combine(_dir, $"viewer-session-{Environment.ProcessId}.lock")));
+    }
+
+    [Fact]
+    public void MarkCleanExit_RemovesOnlyOwnMarker()
+    {
+        UncleanShutdownSentinel.Configure(enabled: true, _dir);
+        UncleanShutdownSentinel.BeginSession("1.0.0");
+
+        // A foreign live-looking marker should be left untouched.
+        var foreignPath = Path.Combine(_dir, "viewer-session-424242.lock");
+        File.WriteAllText(foreignPath, "{}");
+
+        UncleanShutdownSentinel.MarkCleanExit();
+
+        Assert.False(File.Exists(Path.Combine(_dir, $"viewer-session-{Environment.ProcessId}.lock")));
+        Assert.True(File.Exists(foreignPath));
+    }
+
+    [Fact]
+    public void BeginSession_DeadMarkers_ReportedAndRemoved()
+    {
+        var t1 = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 1, 3, 6, 7, 8, DateTimeKind.Utc);
+        // PIDs that are overwhelmingly unlikely to map to a live process.
+        WriteMarker(999_999_991, "ghost", processStartUtc: null, t1, "9.0.0");
+        WriteMarker(999_999_992, "ghost", processStartUtc: null, t2, "9.1.0");
+
+        UncleanShutdownSentinel.Configure(enabled: true, _dir);
+        var crashed = UncleanShutdownSentinel.BeginSession("10.0.0");
+
+        Assert.Equal(2, crashed.Count);
+        // Ordered oldest-first.
+        Assert.Equal(t1, crashed[0].StartedUtc);
+        Assert.Equal(t2, crashed[1].StartedUtc);
+        Assert.Equal("9.1.0", crashed[^1].Version);
+
+        // Stale markers removed; only this process's marker remains.
+        Assert.False(File.Exists(Path.Combine(_dir, "viewer-session-999999991.lock")));
+        Assert.False(File.Exists(Path.Combine(_dir, "viewer-session-999999992.lock")));
+        Assert.Equal(1, MarkerCount());
+    }
+
+    [Fact]
+    public void BeginSession_CalledTwice_DoesNotReportOwnLiveMarker()
+    {
+        UncleanShutdownSentinel.Configure(enabled: true, _dir);
+        UncleanShutdownSentinel.BeginSession("1.0.0");
+
+        // Re-scan: our own marker is alive (matching pid + start time), so
+        // it must not be reported as a crash.
+        var crashed = UncleanShutdownSentinel.BeginSession("1.0.0");
+
+        Assert.Empty(crashed);
+    }
+
+    [Fact]
+    public void Disabled_BeginSessionAndMarkCleanExit_AreNoOps()
+    {
+        UncleanShutdownSentinel.Configure(enabled: false, _dir);
+
+        var crashed = UncleanShutdownSentinel.BeginSession("1.0.0");
+
+        Assert.Empty(crashed);
+        Assert.Equal(0, MarkerCount());
+
+        // Must not throw even with nothing to clean up.
+        UncleanShutdownSentinel.MarkCleanExit();
+    }
+
+    [SkippableFact]
+    public void BeginSession_MarkerFromLiveOtherInstance_NotReportedAndRetained()
+    {
+        using var child = StartSleeper();
+        Skip.If(child is null, "Could not spawn a helper process on this platform.");
+
+        child!.Refresh();
+        WriteMarker(
+            child.Id,
+            child.ProcessName,
+            child.StartTime.ToUniversalTime(),
+            startedUtc: DateTime.UtcNow,
+            version: "5.0.0");
+
+        UncleanShutdownSentinel.Configure(enabled: true, _dir);
+        var crashed = UncleanShutdownSentinel.BeginSession("6.0.0");
+
+        // The marker's writer (the child) is still alive — a concurrent
+        // side-by-side instance, not a crash.
+        Assert.DoesNotContain(crashed, c => c.Pid == child.Id);
+        Assert.True(File.Exists(Path.Combine(_dir, $"viewer-session-{child.Id}.lock")));
+
+        TryKill(child);
+    }
+
+    [SkippableFact]
+    public void BeginSession_PidReusedWithDifferentStartTime_ReportedAsCrash()
+    {
+        using var child = StartSleeper();
+        Skip.If(child is null, "Could not spawn a helper process on this platform.");
+
+        // Same (live) PID, but a start time from long ago: this simulates a
+        // recycled PID whose original viewer session is actually dead.
+        var staleStart = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        WriteMarker(
+            child!.Id,
+            child.ProcessName,
+            processStartUtc: staleStart,
+            startedUtc: staleStart,
+            version: "1.0.0");
+
+        UncleanShutdownSentinel.Configure(enabled: true, _dir);
+        var crashed = UncleanShutdownSentinel.BeginSession("2.0.0");
+
+        Assert.Contains(crashed, c => c.Pid == child.Id);
+        Assert.False(File.Exists(Path.Combine(_dir, $"viewer-session-{child.Id}.lock")));
+
+        TryKill(child);
+    }
+
+    private static Process? StartSleeper()
+    {
+        try
+        {
+            var psi = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new ProcessStartInfo("cmd.exe", "/c timeout /t 30 /nobreak")
+                : new ProcessStartInfo("sleep", "30");
+            psi.CreateNoWindow = true;
+            psi.UseShellExecute = false;
+            return Process.Start(psi);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try { process.Kill(entireProcessTree: true); }
+        catch { /* best-effort */ }
+    }
+}


### PR DESCRIPTION
## Problem

A viewer instance crashed with no warning. Hard/native crashes — a GPU/SkiaSharp fault, `Environment.FailFast`, a stack overflow, an OOM kill, or an external `kill -9` — terminate the process *before* the managed global exception handlers can run, so they leave no toast and no obvious trace.

## Approach

Detect abnormal terminations on the **next** startup and surface a recovery notification wired straight to the feedback reporter.

### Unclean-shutdown sentinel (`UncleanShutdownSentinel`)
- Drops a **per-process** session marker (`viewer-session-{pid}.lock`) in a `crash-markers` folder next to settings; each instance deletes only its own marker on a clean exit.
- On startup, any marker whose owning process is no longer alive is reported as a crash and removed.
- **Cross-platform PID-reuse safety:** liveness is decided by PID *plus the OS process start time* (2s tolerance) on Windows, macOS, and Linux — a recycled PID is never mistaken for a live session.
- **Side-by-side correct:** running two viewers to compare charts is safe; one instance's clean exit never erases another's crash evidence.
- Disabled for `--ephemeral` / `--exit-after-screenshot` automation runs so harnesses never pollute markers or surface a stale crash.

### Crashes are prioritized over ordinary errors (`ICrashHistory`)
- A crash is a far stronger signal than an exception the app recovered from. Detected crashes are captured once at startup into a **dedicated, sticky channel** that is **never evicted** by a later non-fatal runtime error — unlike the single-slot `ILastErrorTracker`.
- **All** detected crashes are reported, not just the most recent.
- `FeedbackReport` gains `PreviousCrashes` (StartedUtc, Pid, Version) and `CrashLogTail`, populated by `FeedbackService` from `ICrashHistory`, so the feedback bundle always carries crash context.

### UI
- Sticky **"Viewer recovered from an unexpected shutdown"** toast with single- and multi-instance wording and a one-click **Send feedback** action; clean exit is marked on window close.
- `CrashLog.ReadTail` provides a best-effort tail of the crash log.

## Testing
- `dotnet test tests/EncDotNet.S100.Viewer.Tests` → **908 passed, 1 skipped** (pre-existing env-gated skip).
- New tests: `UncleanShutdownSentinelTests` (per-PID / multi-instance / PID-reuse, incl. process-spawn `SkippableFact`s), `CrashHistoryTests`, `CrashLogTests`, and `FeedbackReportingTests` crash-field coverage.
- **Manual E2E:** planted two fake dead-PID markers, launched the built viewer non-ephemerally with an isolated profile — both fakes were consumed, the viewer wrote its own marker, and the multi-instance recovery toast rendered (screenshot-verified).

## Notes
Diagnostic payload text recorded for the report is kept English (consistent with existing crash labels); all user-facing toast strings live in `Strings.resx`/`Strings.cs` per the viewer localization rule.