### PR TITLE
Sign Windows viewer/CLI via Azure Trusted Signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,10 @@ jobs:
       # attribute on unsigned PR artifacts if they need to run them. Gate it to
       # main CI runs (pushes to main and v* tags), i.e. skip on pull_request.
       MACOS_SIGNING_ENABLED: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12 != '' && github.event_name != 'pull_request' }}
+      # Windows Authenticode signing via Azure Trusted Signing. Gated the same
+      # way as macOS: only when the signing service principal secret is present
+      # and the run is not a pull_request, so PRs produce unsigned win-* zips.
+      WINDOWS_SIGNING_ENABLED: ${{ secrets.AZURE_CLIENT_ID != '' && github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -199,6 +203,48 @@ jobs:
           --self-contained true
           -p:Version=${{ steps.version.outputs.version }}
           --output src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish/cli
+
+      - name: Sign Windows binaries (Azure Trusted Signing)
+        # Authenticode-sign the published Windows executables before they are
+        # archived, so both the viewer zip and the standalone s100 CLI zip
+        # contain signed binaries. Signing the viewer publish folder recursively
+        # also covers the bundled cli/s100.exe under it. Account-specific (but
+        # non-secret) endpoint/account/profile values come from repo variables;
+        # the service principal credentials come from secrets. Must run before
+        # the "Archive ..." steps below.
+        if: startsWith(matrix.rid, 'win-') && env.WINDOWS_SIGNING_ENABLED == 'true'
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_SIGNING_PROFILE_NAME }}
+          files-folder: ${{ github.workspace }}\src\EncDotNet.S100.Viewer\bin\Release\net10.0\${{ matrix.rid }}\publish
+          files-folder-filter: exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify Windows signatures
+        if: startsWith(matrix.rid, 'win-') && env.WINDOWS_SIGNING_ENABLED == 'true'
+        shell: pwsh
+        run: |
+          $publish = "src/EncDotNet.S100.Viewer/bin/Release/net10.0/${{ matrix.rid }}/publish"
+          $targets = @(
+            "$publish/EncDotNet.S100.Viewer.exe",
+            "$publish/cli/s100.exe"
+          )
+          foreach ($exe in $targets) {
+            $sig = Get-AuthenticodeSignature $exe
+            Write-Host "$exe => $($sig.Status)"
+            if ($sig.Status -ne 'Valid') {
+              Write-Error "Signature for $exe is $($sig.Status), expected Valid."
+              exit 1
+            }
+          }
 
       - name: Archive standalone s100 CLI (Linux)
         # Package the self-contained `s100` CLI as its own per-RID release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,61 @@ group paths.
   localization and UI rules in `.github/instructions/viewer.instructions.md`
   (every user-facing string lives in `Resources/Strings.resx`).
 
+## Release signing
+
+The `publish` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
+code-signs the desktop viewer and the standalone `s100` CLI for macOS and
+Windows. Both are **gated to non-PR runs** (pushes to `main` and `v*` tags) and
+are skipped automatically when the required secrets are absent, so forks and
+pull requests build unsigned artifacts without failing.
+
+### macOS (Developer ID + notarization)
+
+Signing/notarization runs when `APPLE_DEVELOPER_CERTIFICATE_P12` is present.
+Required repository **secrets**: `APPLE_DEVELOPER_CERTIFICATE_P12`,
+`APPLE_DEVELOPER_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`,
+`APPLE_TEAM_ID`, `APPLE_APP_PASSWORD`.
+
+### Windows (Azure Trusted Signing)
+
+The Windows `.exe`s are Authenticode-signed with
+[Azure Trusted Signing](https://azure.microsoft.com/products/trusted-signing)
+via the [`azure/trusted-signing-action`](https://github.com/Azure/trusted-signing-action).
+Signing runs when `AZURE_CLIENT_ID` is present.
+
+One-time Azure setup:
+
+1. Create a **Trusted Signing Account** and a **Public Trust** certificate
+   profile, and complete Microsoft identity validation. ("Private Trust"
+   profiles do **not** clear SmartScreen warnings.)
+2. Register a single-tenant **App registration** (its service principal is the
+   CI identity) and add a **client secret**.
+3. On the Trusted Signing Account's **Access control (IAM)**, assign the app
+   the **Trusted Signing Certificate Profile Signer** role. Without this the
+   signing step fails with `403 Forbidden`.
+
+Required repository **secrets** (from the app registration):
+
+| Secret | Source |
+|---|---|
+| `AZURE_TENANT_ID` | App registration → Overview → Directory (tenant) ID |
+| `AZURE_CLIENT_ID` | App registration → Overview → Application (client) ID |
+| `AZURE_CLIENT_SECRET` | App registration → Certificates & secrets → secret **Value** |
+
+Required repository **variables** (non-secret, account-specific, case-sensitive):
+
+| Variable | Source |
+|---|---|
+| `AZURE_SIGNING_ENDPOINT` | Trusted Signing Account → Overview → Account URI (e.g. `https://wus2.codesigning.azure.net/`) |
+| `AZURE_SIGNING_ACCOUNT_NAME` | Trusted Signing Account name |
+| `AZURE_SIGNING_PROFILE_NAME` | Certificate profile name |
+
+The workflow signs every `.exe` under the viewer publish folder (covering both
+the viewer and the bundled `cli/s100.exe`) before archiving, then a "Verify
+Windows signatures" step asserts `Get-AuthenticodeSignature` returns `Valid`.
+The identity is OV-level, so SmartScreen reputation accrues over downloads
+rather than instantly.
+
 ## Branch & pull-request workflow
 
 1. Create a topic branch off `main` (e.g. `fix-s104-trend-flag` or

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ dotnet run --project src/EncDotNet.S100.Viewer
 
 Pre-built per-platform binaries are attached to every
 [release](https://github.com/philliphoff/EncDotNet.S100/releases).
-The macOS DMG is Developer-ID signed and Apple-notarized; Windows
+The macOS DMG is Developer-ID signed and Apple-notarized; the Windows
+`.exe` is Authenticode-signed via Azure Trusted Signing. Windows
 ships as architecture-tagged `zip` archives and Linux as
 architecture-tagged `tar.gz` archives. The standalone `s100`
 command-line tool is also attached per platform as

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,7 +38,8 @@ tar -xzf s100-<version>-<rid>.tar.gz
 
 The macOS archive is code-signed and notarized, so Gatekeeper verifies it
 online on first launch. If a copied binary is still quarantined, clear the
-attribute with `xattr -d com.apple.quarantine ./s100`.
+attribute with `xattr -d com.apple.quarantine ./s100`. The Windows `s100.exe`
+is Authenticode-signed via Azure Trusted Signing.
 
 The same `s100` executable also ships inside the S-100 Viewer application
 bundle (under `cli/`); see the project README for that layout.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ attaches a pre-built, self-contained app per platform:
 | Platform | Asset | First launch |
 |---|---|---|
 | macOS (Apple silicon) | `.dmg` | Signed and Apple-notarized — open the DMG and drag the app to Applications. |
-| Windows | `.zip` | Extract and run the `.exe`. |
+| Windows | `.zip` | Extract and run the `.exe`. The executable is Authenticode-signed via Azure Trusted Signing. |
 | Linux | `.tar.gz` | Extract and run the executable. See [Linux prerequisites](#linux-prerequisites) below. |
 
 #### Linux prerequisites


### PR DESCRIPTION
## What

Adds Authenticode signing for the Windows desktop viewer and the standalone `s100` CLI using [Azure Trusted Signing](https://azure.microsoft.com/products/trusted-signing), closing the gap with the existing macOS Developer-ID + notarization flow.

## Why

Today the `win-x64` / `win-arm64` viewer zips and the `s100` CLI zips ship **unsigned**, so users hit SmartScreen "Unknown Publisher" warnings. macOS already has a full sign + notarize + staple pipeline; this brings Windows to parity. See #299 for the investigation.

## How

In the `publish` job of `.github/workflows/ci.yml`:

- New `WINDOWS_SIGNING_ENABLED` env gate — `secrets.AZURE_CLIENT_ID != '' && github.event_name != 'pull_request'`, mirroring `MACOS_SIGNING_ENABLED`. PRs and forks build unsigned and don't fail.
- A `azure/trusted-signing-action@v0` step signs every `.exe` recursively under the viewer publish folder. It runs **after** the CLI publish but **before** the archive steps, so it covers both `EncDotNet.S100.Viewer.exe` and the bundled `cli/s100.exe` — meaning both the viewer zip and the standalone CLI zip ship signed.
- A "Verify Windows signatures" step fails the build unless `Get-AuthenticodeSignature` reports `Valid` for both exes.

Credentials come from **secrets** (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`); account-specific non-secret values from **variables** (`AZURE_SIGNING_ENDPOINT`, `AZURE_SIGNING_ACCOUNT_NAME`, `AZURE_SIGNING_PROFILE_NAME`). Uses a client-secret service principal (no OIDC), so the job's existing `contents: read` permission is unchanged.

## Docs

- `CONTRIBUTING.md`: new **Release signing** section documenting both macOS and Windows setup (service principal, role assignment, secrets, variables).
- `README.md`, `docs/getting-started.md`, `docs/cli.md`: note that Windows binaries are Authenticode-signed.

## Testing notes

Signing is intentionally **skipped on pull requests**, so this PR's CI will not exercise it. It runs on push to `main` (a safe smoke test — the verify step catches misconfigured endpoint/account/profile or a missing role assignment) and on `v*` release tags. The required secrets/variables have been configured on the repo.

Identity is OV-level, so SmartScreen reputation accrues over downloads rather than instantly.

Refs #299