### PR TITLE
Fix win-arm64 signing: cross-publish on x64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,14 @@ jobs:
           - os: windows-latest
             rid: win-x64
             artifact: Viewer-win-x64
-          - os: windows-11-arm
+          # win-arm64 is cross-published on the x64 runner (not windows-11-arm)
+          # because azure/trusted-signing-action does not support ARM64 runners
+          # — its x64 signing dlib fails under emulation with "SignTool failed
+          # with exit code 3" (Azure/trusted-signing-action#92). signtool on x64
+          # signs arm64 PE binaries fine, and a RID-targeted dotnet publish
+          # produces identical win-arm64 output regardless of host arch. Native
+          # arm64 build/test coverage is retained by the separate test-arm64 job.
+          - os: windows-latest
             rid: win-arm64
             artifact: Viewer-win-arm64
           - os: ubuntu-latest


### PR DESCRIPTION
## What

Makes the `win-arm64` viewer/CLI build on the x64 runner (`windows-latest`) instead of `windows-11-arm`, so the Azure Trusted Signing step can sign it.

## Why

After #300/#301, the `win-x64` signing job succeeds but `win-arm64` fails with:

```
Signing SignTool file batch 1 of 1.
	Executing signtool.exe: ...\bin\x64\signtool.exe sign ... /dlib ...\bin\x64\Azure.CodeSigning.Dlib.dll ...
Exception: SignTool failed with exit code 3
```

`azure/trusted-signing-action` **does not support ARM64 runners** — its x64 signing dlib fails under emulation on `windows-11-arm`. This is maintainer-confirmed in [Azure/trusted-signing-action#92](https://github.com/Azure/trusted-signing-action/issues/92) (blocked on [dotnet/sign#852](https://github.com/dotnet/sign/issues/852)).

## How

`signtool` running on x64 signs **arm64** PE binaries without issue — Authenticode signing is target-architecture-agnostic — and a RID-targeted `dotnet publish -r win-arm64` produces byte-identical output regardless of host architecture. So building win-arm64 on `windows-latest` lets the existing signing step cover it.

Native arm64 build + test coverage is unaffected: it's provided by the separate `build`/`test-arm64` jobs, not the packaging `publish` job.

Refs #299