### PR TITLE
Add viewer basemap enable/disable setting and CLI flag

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -43,6 +43,7 @@ public partial class MainWindow : ShadUI.Window
     private Map? _renderActivityMap;
     private EventHandler? _renderActivityRefreshHandler;
     private EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost? _dynamicSourceOverlayHost;
+    private ILayer? _basemapLayer;
     private readonly List<IDisposable> _dynamicSourceRegistrations = new();
     private string? _screenshotPath;
     private bool _exitAfterScreenshot;
@@ -231,7 +232,16 @@ public partial class MainWindow : ShadUI.Window
             }
         };
 
-        MapControl.Map?.Layers.Add(OpenStreetMap.CreateTileLayer());
+        // Online OSM basemap (issue #295). Shown by default; the user can
+        // disable it from Settings (or via the --basemap CLI flag) for
+        // offline use or to exclude basemap tile activity from performance
+        // measurements. Keep a reference so toggling can add/remove it live.
+        if (_viewModel.Settings.BasemapEnabled)
+        {
+            _basemapLayer = OpenStreetMap.CreateTileLayer();
+            MapControl.Map?.Layers.Add(_basemapLayer);
+        }
+        _viewModel.Settings.BasemapEnabledChanged += OnBasemapEnabledChanged;
 
         // ENC water colour (S-52 / S-101 DEPDW) — used as the map control
         // background so the unrendered area outside the tile layer's
@@ -512,6 +522,32 @@ public partial class MainWindow : ShadUI.Window
         {
             source.Changed -= OnChanged;
         }
+    }
+
+    /// <summary>
+    /// Adds or removes the online basemap tile layer in response to the
+    /// Settings toggle (issue #295). The basemap always sits at the
+    /// bottom of the layer stack (index 0) beneath every dataset and
+    /// overlay layer; re-enabling re-inserts a fresh tile layer there.
+    /// </summary>
+    private void OnBasemapEnabledChanged(bool enabled)
+    {
+        if (MapControl.Map is not { } map) return;
+
+        if (enabled)
+        {
+            if (_basemapLayer is not null) return;
+            _basemapLayer = OpenStreetMap.CreateTileLayer();
+            map.Layers.Insert(0, _basemapLayer);
+        }
+        else
+        {
+            if (_basemapLayer is null) return;
+            map.Layers.Remove(_basemapLayer);
+            _basemapLayer = null;
+        }
+
+        MapControl.RefreshGraphics();
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -575,6 +575,13 @@ zoom-to-extent so the framing is reproducible.
 capture before a screenshot. These override the persisted values for
 the run only.
 
+**Basemap.** `--basemap true|false` shows or hides the online
+OpenStreetMap basemap for the run, overriding the persisted setting
+(which is also exposed as a toggle in **Settings → Map**; default on).
+Disable it for offline operation, or for performance runs that want to
+measure only dataset rendering without basemap tile fetch / raster
+activity (issue #295).
+
 **Own-ship.** `--own-ship-pos <LAT,LON>` places the simulated
 own-ship at a WGS-84 position, `--own-ship-cog <DEG>` sets its course
 over ground (degrees true `[0, 360)`), and `--own-ship-sog <MS>` sets

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -311,6 +311,10 @@ internal static class Strings
     public static string Tooltip_EnableVectorRasterization => Get(nameof(Tooltip_EnableVectorRasterization));
     public static string Settings_EnableGeometrySimplification => Get(nameof(Settings_EnableGeometrySimplification));
     public static string Tooltip_EnableGeometrySimplification => Get(nameof(Tooltip_EnableGeometrySimplification));
+    public static string Settings_MapSection => Get(nameof(Settings_MapSection));
+    public static string Settings_MapSection_Help => Get(nameof(Settings_MapSection_Help));
+    public static string Settings_BasemapEnabled => Get(nameof(Settings_BasemapEnabled));
+    public static string Tooltip_BasemapEnabled => Get(nameof(Tooltip_BasemapEnabled));
     public static string Settings_NationalLanguage => Get(nameof(Settings_NationalLanguage));
     public static string Tooltip_NationalLanguage => Get(nameof(Tooltip_NationalLanguage));
     public static string Settings_NationalLanguage_Default => Get(nameof(Settings_NationalLanguage_Default));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -834,6 +834,18 @@
   <data name="Tooltip_EnableGeometrySimplification" xml:space="preserve">
     <value>Apply resolution-aware Douglas-Peucker simplification to S-100 line features at render time, with a per-zoom cache (issue #164). Speeds up paint on dense ENC line data; polygons and short lines are unaffected.</value>
   </data>
+  <data name="Settings_MapSection" xml:space="preserve">
+    <value>Map</value>
+  </data>
+  <data name="Settings_MapSection_Help" xml:space="preserve">
+    <value>Background map shown beneath the chart data.</value>
+  </data>
+  <data name="Settings_BasemapEnabled" xml:space="preserve">
+    <value>Show online basemap</value>
+  </data>
+  <data name="Tooltip_BasemapEnabled" xml:space="preserve">
+    <value>Show the online OpenStreetMap basemap beneath the chart data. Disable for offline use or to exclude basemap tile activity from performance measurements.</value>
+  </data>
   <data name="Settings_NationalLanguage" xml:space="preserve">
     <value>National Language</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/StartupSettingsFactory.cs
+++ b/src/EncDotNet.S100.Viewer/StartupSettingsFactory.cs
@@ -69,6 +69,9 @@ internal static class StartupSettingsFactory
         if (options.DisplayCategory is { } category && !string.IsNullOrWhiteSpace(category))
             settings.EcdisDisplayCategory =
                 NormalizeEnum<EncDotNet.S100.Datasets.Pipelines.EcdisDisplayCategory>(category, settings.EcdisDisplayCategory);
+
+        if (options.Basemap is { } basemapEnabled)
+            settings.BasemapEnabled = basemapEnabled;
     }
 
     private static string NormalizeEnum<TEnum>(string value, string fallback) where TEnum : struct, Enum =>

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -464,6 +464,34 @@ internal sealed class SettingsViewModel : ViewModelBase
         set { if (SetProperty(ref _enableGeometrySimplification, value)) { _settings.EnableGeometrySimplification = value; RaiseMarinerChanged(); } }
     }
 
+    /// <summary>
+    /// Raised when <see cref="BasemapEnabled"/> changes so the host can
+    /// add or remove the basemap tile layer live without a restart.
+    /// </summary>
+    public event Action<bool>? BasemapEnabledChanged;
+
+    private bool _basemapEnabled;
+    /// <summary>
+    /// Whether the online OpenStreetMap basemap is shown beneath the
+    /// chart data (issue #295). Persisted to
+    /// <see cref="ViewerSettings.BasemapEnabled"/>; toggling raises
+    /// <see cref="BasemapEnabledChanged"/> so the map host adds/removes
+    /// the tile layer without a relaunch.
+    /// </summary>
+    public bool BasemapEnabled
+    {
+        get => _basemapEnabled;
+        set
+        {
+            if (SetProperty(ref _basemapEnabled, value))
+            {
+                _settings.BasemapEnabled = value;
+                _settings.Save();
+                BasemapEnabledChanged?.Invoke(value);
+            }
+        }
+    }
+
     private string _nationalLanguage = "";
     public string NationalLanguage
     {
@@ -549,6 +577,7 @@ internal sealed class SettingsViewModel : ViewModelBase
         _ignoreScaleMinimum = settings.IgnoreScaleMinimum ?? def.IgnoreScaleMinimum;
         _enableVectorRasterization = settings.EnableVectorRasterization ?? false;
         _enableGeometrySimplification = settings.EnableGeometrySimplification ?? false;
+        _basemapEnabled = settings.BasemapEnabled;
         _nationalLanguage = settings.NationalLanguage ?? def.NationalLanguage;
 
         _mcpEnabled = settings.McpEnabled;

--- a/src/EncDotNet.S100.Viewer/ViewerCommand.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerCommand.cs
@@ -92,6 +92,10 @@ internal sealed class ViewerCommandSettings : CommandSettings
     [Description("ECDIS display category: DisplayBase, Standard, OtherInformation, or All. Overrides the persisted category for this run.")]
     public string? DisplayCategory { get; set; }
 
+    [CommandOption("--basemap <ENABLED>")]
+    [Description("Show the online basemap: true or false. Overrides the persisted setting for this run; disable it for offline use or to exclude basemap tile activity from performance measurements.")]
+    public bool? Basemap { get; set; }
+
     [CommandOption("--time-step <STEP>")]
     [Description("For time-varying data, jump to this time step after loading — a zero-based index or an ISO-8601 UTC timestamp.")]
     public string? TimeStep { get; set; }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -208,6 +208,17 @@ internal sealed class ViewerSettings
     public bool IsStatusBarVisible { get; set; } = true;
 
     /// <summary>
+    /// Whether the online OpenStreetMap basemap tile layer is shown
+    /// beneath the chart data. Enabled by default. Disabling it removes
+    /// the remote tile fetch entirely — useful for offline operation
+    /// and for agent-driven performance runs that want to measure only
+    /// dataset-related rendering without basemap tile activity (issue
+    /// #295). Can be overridden per-run with the <c>--basemap</c>
+    /// command-line flag.
+    /// </summary>
+    public bool BasemapEnabled { get; set; } = true;
+
+    /// <summary>
     /// Whether the own-ship overlay (PR-D2) is visible. The synthetic
     /// driver is always running; this flag controls whether the
     /// source publishes the glyph to the dynamic-source overlay tier.

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -161,6 +161,20 @@
                 </ComboBox>
             </StackPanel>
 
+            <!-- Map (issue #295) -->
+            <Separator Margin="0,8,0,0" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_MapSection}"
+                       FontSize="14"
+                       FontWeight="SemiBold"
+                       Opacity="0.7" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_MapSection_Help}"
+                       FontSize="11"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+            <CheckBox Content="{x:Static loc:Strings.Settings_BasemapEnabled}"
+                      IsChecked="{Binding BasemapEnabled}"
+                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_BasemapEnabled}" />
+
             <!-- Mariner Settings (S-100 Part 9 §4.2) -->
             <Separator Margin="0,8,0,0" />
             <TextBlock Text="{x:Static loc:Strings.Settings_MarinerSection}"

--- a/tests/EncDotNet.S100.Viewer.Tests/StartupSettingsFactoryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/StartupSettingsFactoryTests.cs
@@ -81,6 +81,27 @@ public class StartupSettingsFactoryTests
     }
 
     [Fact]
+    public void Basemap_defaults_to_enabled_when_not_overridden()
+    {
+        var settings = StartupSettingsFactory.Create(new ViewerCommandSettings { SettingsPath = TempSettingsPath() });
+        Assert.True(settings.BasemapEnabled);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Basemap_flag_overrides_persisted_setting(bool enabled)
+    {
+        var settings = StartupSettingsFactory.Create(new ViewerCommandSettings
+        {
+            SettingsPath = TempSettingsPath(),
+            Basemap = enabled,
+        });
+
+        Assert.Equal(enabled, settings.BasemapEnabled);
+    }
+
+    [Fact]
     public void Null_options_returns_default_profile()
     {
         var settings = StartupSettingsFactory.Create(null);


### PR DESCRIPTION
## Summary

The viewer's online OpenStreetMap basemap was always on, which is a problem for the offline maritime use case and adds remote tile-fetch/raster activity that muddies dataset-focused performance measurements (#295). This adds a user-facing toggle plus a CLI flag to disable it, while keeping it enabled by default.

- New `ViewerSettings.BasemapEnabled` (default `true`), surfaced as a **Settings -> Map -> "Show online basemap"** checkbox. Toggling raises `BasemapEnabledChanged` so `MainWindow` adds/removes the OSM tile layer **live** at the bottom of the layer stack, no relaunch needed.
- New `--basemap true|false` CLI flag (`ViewerCommandSettings`), applied in `StartupSettingsFactory` to override the persisted value for a single run. Intended for offline launches and for agent-driven performance runs that want to exclude basemap tile activity from the measurement.

Verified end-to-end in the viewer: at the same viewport with the same S-101 cell, `--basemap true` renders the OSM basemap beneath the chart while `--basemap false` shows only the ENC water-colour background plus the cell coverage (screenshot payload drops from ~1.3MB to ~10KB, confirming no tiles are fetched).

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — viewer UI/CLI behaviour only; no spec semantics touched.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added `StartupSettingsFactory` tests covering the default-on behaviour and the `--basemap true|false` override. Full viewer suite (911 tests) passes.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Documented `--basemap` in the viewer README automation section.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. Basemap remains enabled by default; the setting and flag are additive.

Related to #295