### PR TITLE
Add pick location to the Object Information panel

### DIFF
--- a/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
@@ -26,6 +26,17 @@ internal static class LatLonFormatter
     public static string Format(double latitude, double longitude) =>
         $"{FormatDegMin(latitude, 'N', 'S', 2)}  {FormatDegMin(longitude, 'E', 'W', 3)}";
 
+    /// <summary>
+    /// Formats a (latitude, longitude) pair as signed decimal degrees,
+    /// e.g. <c>"47.601234, -122.334567"</c>. This machine-friendly form is
+    /// what the pick panel places on the clipboard so the coordinate can be
+    /// pasted straight into tools and scripts during debugging.
+    /// </summary>
+    public static string FormatDecimal(double latitude, double longitude) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{latitude:0.000000}, {longitude:0.000000}");
+
     private static string FormatDegMin(double value, char positive, char negative, int degWidth)
     {
         var hemi = value >= 0 ? positive : negative;

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -151,6 +151,10 @@ Toggle **Pick Mode** (the cross-hair toolbar button or the
 the **Object Information** panel on the right. Each pick report
 shows:
 
+- The **location** (latitude/longitude, in degrees-decimal-minutes)
+  of the click point, with a copy button that places the coordinate
+  on the clipboard as signed decimal degrees — handy when capturing a
+  point for debugging.
 - A **hit list** of every overlapping feature — select a row to
   switch the attribute view.
 - The selected feature's class, identifier, source dataset, and

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -115,6 +115,7 @@ internal static class Strings
     public static string Tooltip_ClosePickPanel => Get(nameof(Tooltip_ClosePickPanel));
     public static string Tooltip_SelectHit => Get(nameof(Tooltip_SelectHit));
     public static string Tooltip_FollowReference => Get(nameof(Tooltip_FollowReference));
+    public static string Tooltip_CopyLocation => Get(nameof(Tooltip_CopyLocation));
     public static string Tooltip_Search => Get(nameof(Tooltip_Search));
     public static string Tooltip_ClearSearch => Get(nameof(Tooltip_ClearSearch));
     public static string Tooltip_OpenSearchResult => Get(nameof(Tooltip_OpenSearchResult));
@@ -240,6 +241,7 @@ internal static class Strings
     public static string Pick_HitListItemFormat => Get(nameof(Pick_HitListItemFormat));
     public static string Pick_ReferencesHeader => Get(nameof(Pick_ReferencesHeader));
     public static string Pick_ReferenceItemFormat => Get(nameof(Pick_ReferenceItemFormat));
+    public static string Pick_LocationHeader => Get(nameof(Pick_LocationHeader));
 
     // Pick panel: station time-series chart
     public static string Pick_Chart_Title_WaterLevel => Get(nameof(Pick_Chart_Title_WaterLevel));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -618,6 +618,13 @@
   <data name="Tooltip_FollowReference" xml:space="preserve">
     <value>Show the referenced feature's details</value>
   </data>
+  <data name="Pick_LocationHeader" xml:space="preserve">
+    <value>LOCATION</value>
+    <comment>Header above the pick location (lat/lon of the click point) in the Object Information panel.</comment>
+  </data>
+  <data name="Tooltip_CopyLocation" xml:space="preserve">
+    <value>Copy this location (decimal degrees) to the clipboard</value>
+  </data>
   <!-- Pick panel: station time-series chart -->
   <data name="Pick_Chart_Title_WaterLevel" xml:space="preserve">
     <value>Water Level</value>

--- a/src/EncDotNet.S100.Viewer/Services/PickService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/PickService.cs
@@ -131,7 +131,7 @@ internal sealed class PickService : IPickService
             // grid and returns a synthesised feature.
             if (TryCoveragePick(mapInfo, out var coverageHit))
             {
-                _pickReport.SetPicks(new[] { coverageHit });
+                _pickReport.SetPicks(new[] { coverageHit }, Array.Empty<DynamicPickHit>(), TryGetLocation(mapInfo));
                 _status.StatusText = string.Format(
                     Strings.Status_FeatureSummary,
                     coverageHit.FeatureTypeName ?? coverageHit.FeatureType,
@@ -146,7 +146,7 @@ internal sealed class PickService : IPickService
             return;
         }
 
-        _pickReport.SetPicks(hits, dynamic);
+        _pickReport.SetPicks(hits, dynamic, TryGetLocation(mapInfo));
 
         // Status text follows the first hit. Dataset hits take
         // precedence (their labels carry more dataset context); fall
@@ -355,6 +355,22 @@ internal sealed class PickService : IPickService
         owningEntry = null!;
         processor = null!;
         return false;
+    }
+
+    /// <summary>
+    /// Projects the pick's world position to WGS84 and wraps it as a
+    /// <see cref="PickLocation"/>. Returns <c>null</c> when the
+    /// <see cref="MapInfo"/> carries no world position (e.g. a pick that
+    /// originated outside the map surface).
+    /// </summary>
+    private static PickLocation? TryGetLocation(MapInfo mapInfo)
+    {
+        if (mapInfo.WorldPosition is not { } world)
+            return null;
+
+        // SphericalMercator → WGS84. Mapsui returns (lon, lat).
+        var (lon, lat) = SphericalMercator.ToLonLat(world.X, world.Y);
+        return new PickLocation(lat, lon);
     }
 
     private bool TryCoveragePick(MapInfo mapInfo, out PickHit hit)

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickLocation.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickLocation.cs
@@ -1,0 +1,11 @@
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Geographic location (WGS84) of the point the user clicked to produce a
+/// pick. Pick reports describe features at a location, but that location is
+/// otherwise not part of the report; capturing it here lets the Object
+/// Information panel show — and copy — the exact lat/lon for debugging.
+/// </summary>
+/// <param name="Latitude">Latitude in decimal degrees (positive north).</param>
+/// <param name="Longitude">Longitude in decimal degrees (positive east).</param>
+internal readonly record struct PickLocation(double Latitude, double Longitude);

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -33,6 +33,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     private string? _productSpec;
     private bool _hasPick;
     private PickHit? _selectedHit;
+    private PickLocation? _location;
 
     public PickReportViewModel()
         : this(timeFormat: null, marinerSettings: null)
@@ -51,6 +52,9 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         _timeFormat = timeFormat;
         _marinerSettings = marinerSettings;
         ClearCommand = new RelayCommand(Clear);
+        CopyLocationCommand = new RelayCommand(
+            () => { if (_location is { } loc) CopyLocationRequested?.Invoke(this, LatLonFormatter.FormatDecimal(loc.Latitude, loc.Longitude)); },
+            () => _location is not null);
         NavigateCommand = new RelayCommand<FeatureReference>(
             r => { if (r is not null) NavigateRequested?.Invoke(this, r); },
             r => r is not null);
@@ -228,6 +232,38 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     /// </summary>
     public bool HasDatasetPick => Hits.Count > 0;
 
+    /// <summary>
+    /// Geographic location (WGS84) of the click that produced the current
+    /// pick, or <c>null</c> when the pick carries no location (e.g. a
+    /// programmatic open via feature search). Set by the pick service from
+    /// the map's world position.
+    /// </summary>
+    public PickLocation? Location
+    {
+        get => _location;
+        private set
+        {
+            if (Nullable.Equals(_location, value))
+                return;
+            _location = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasLocation));
+            OnPropertyChanged(nameof(LocationDisplay));
+            (CopyLocationCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        }
+    }
+
+    /// <summary>True when a pick location is available to display and copy.</summary>
+    public bool HasLocation => _location is not null;
+
+    /// <summary>
+    /// Mariner-friendly degrees-decimal-minutes rendering of
+    /// <see cref="Location"/> for display in the panel, or <c>null</c> when
+    /// no location is available.
+    /// </summary>
+    public string? LocationDisplay =>
+        _location is { } loc ? LatLonFormatter.Format(loc.Latitude, loc.Longitude) : null;
+
     /// <inheritdoc />
     public event EventHandler? ContentBecameAvailable;
 
@@ -295,6 +331,21 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
 
     /// <summary>Clears the panel.</summary>
     public ICommand ClearCommand { get; }
+
+    /// <summary>
+    /// Copies <see cref="Location"/> to the clipboard as signed decimal
+    /// degrees. Enabled only when <see cref="HasLocation"/> is true; raises
+    /// <see cref="CopyLocationRequested"/> with the clipboard text so the
+    /// view owns the actual clipboard access (keeping the view-model
+    /// unit-testable without a clipboard backend).
+    /// </summary>
+    public ICommand CopyLocationCommand { get; }
+
+    /// <summary>
+    /// Raised when the user invokes <see cref="CopyLocationCommand"/>. The
+    /// payload is the clipboard-ready coordinate text.
+    /// </summary>
+    public event EventHandler<string>? CopyLocationRequested;
 
     /// <summary>
     /// "Take the helm of this vessel" (pirate mode). Parameter is the
@@ -365,9 +416,17 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     /// behaviour); when only dynamic hits are present the detail view
     /// is left empty and only the dynamic section is shown.
     /// </summary>
+    /// <param name="hits">Dataset-owned feature hits.</param>
+    /// <param name="dynamicHits">Dynamic-source hits (AIS, own-ship, …).</param>
+    /// <param name="location">
+    /// Geographic location of the click that produced the pick, or
+    /// <c>null</c> when no location is available (e.g. a programmatic
+    /// open). Surfaced in the panel and copyable to the clipboard.
+    /// </param>
     public void SetPicks(
         IReadOnlyList<PickHit> hits,
-        IReadOnlyList<DynamicPickHit> dynamicHits)
+        IReadOnlyList<DynamicPickHit> dynamicHits,
+        PickLocation? location = null)
     {
         ArgumentNullException.ThrowIfNull(hits);
         ArgumentNullException.ThrowIfNull(dynamicHits);
@@ -387,6 +446,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
             return;
         }
 
+        Location = location;
         HasPick = true;
         OnPropertyChanged(nameof(HasMultipleHits));
         OnPropertyChanged(nameof(HasDynamicHits));
@@ -454,6 +514,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         ProductSpec = null;
         Attributes.Clear();
         References.Clear();
+        Location = null;
         HasPick = false;
         OnPropertyChanged(nameof(HasAttributes));
         OnPropertyChanged(nameof(HasReferences));

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:views="using:EncDotNet.S100.Viewer.Views"
+             xmlns:ic="using:FluentIcons.Avalonia"
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
@@ -34,6 +35,37 @@
         <StackPanel DockPanel.Dock="Top"
                     Spacing="10"
                     Margin="12,4,12,8">
+            <!-- Pick location (lat/lon of the click point). Pinned to the very
+                 top so it is always visible regardless of which feature
+                 sections are shown; selectable text plus a copy button make
+                 the coordinate easy to grab for debugging. -->
+            <Border BorderBrush="{DynamicResource BorderColor}"
+                    BorderThickness="0,0,0,1"
+                    Padding="0,0,0,8"
+                    IsVisible="{Binding HasLocation}">
+                <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                    <TextBlock Grid.Row="0" Grid.Column="0"
+                               Text="{x:Static loc:Strings.Pick_LocationHeader}"
+                               FontSize="10"
+                               FontWeight="Normal"
+                               LetterSpacing="1"
+                               Opacity="0.7" />
+                    <SelectableTextBlock Grid.Row="1" Grid.Column="0"
+                                         Text="{Binding LocationDisplay}"
+                                         FontSize="13"
+                                         VerticalAlignment="Center"
+                                         TextWrapping="Wrap" />
+                    <Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                            VerticalAlignment="Center"
+                            Padding="6"
+                            Background="Transparent"
+                            Command="{Binding CopyLocationCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_CopyLocation}">
+                        <ic:FluentIcon Icon="Copy" IconVariant="Regular" FontSize="16" />
+                    </Button>
+                </Grid>
+            </Border>
+
             <!-- Hit list (visible only when more than one feature is at this point) -->
             <Border BorderBrush="{DynamicResource BorderColor}"
                     BorderThickness="0,0,0,1"

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml.cs
@@ -1,4 +1,7 @@
+using System;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using EncDotNet.S100.Viewer.ViewModels;
 
 namespace EncDotNet.S100.Viewer.Views;
 
@@ -15,13 +18,45 @@ namespace EncDotNet.S100.Viewer.Views;
 /// <c>PickReportViewModel</c> and that it is only realised when a
 /// pick exists.
 ///
+/// The view owns clipboard access for the "copy location" command:
+/// the view-model raises an event with the coordinate text and the
+/// view writes it to the top-level clipboard, keeping the view-model
+/// free of any UI-clipboard dependency.
+///
 /// TODO PR-M4: register PickReportView as an activity tab with
 /// 'pop on pick' preference.
 /// </remarks>
 public partial class PickReportView : UserControl
 {
+    private PickReportViewModel? _subscribed;
+
     public PickReportView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_subscribed is not null)
+            _subscribed.CopyLocationRequested -= OnCopyLocationRequested;
+
+        _subscribed = DataContext as PickReportViewModel;
+
+        if (_subscribed is not null)
+            _subscribed.CopyLocationRequested += OnCopyLocationRequested;
+    }
+
+    private void OnCopyLocationRequested(object? sender, string text)
+    {
+        try
+        {
+            if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+                _ = clipboard.SetTextAsync(text);
+        }
+        catch
+        {
+            // Best-effort; clipboard access can fail on some Linux WMs.
+        }
     }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
@@ -53,4 +53,18 @@ public class LatLonFormatterTests
     {
         Assert.Equal(string.Empty, LatLonFormatter.Placeholder);
     }
+
+    [Fact]
+    public void FormatDecimal_RendersSignedDecimalDegrees()
+    {
+        var text = LatLonFormatter.FormatDecimal(47.601234, -122.334567);
+        Assert.Equal("47.601234, -122.334567", text);
+    }
+
+    [Fact]
+    public void FormatDecimal_PadsToSixDecimalPlaces()
+    {
+        var text = LatLonFormatter.FormatDecimal(0.0, 5.5);
+        Assert.Equal("0.000000, 5.500000", text);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -108,6 +108,71 @@ public class PickReportViewModelTests
     }
 
     [Fact]
+    public void SetPicks_WithLocation_PopulatesLocationFields()
+    {
+        var vm = new PickReportViewModel();
+
+        vm.SetPicks(
+            new[]
+            {
+                new PickHit { FeatureType = "DepthArea", FeatureRef = "42" },
+            },
+            System.Array.Empty<DynamicPickHit>(),
+            new PickLocation(47.601234, -122.334567));
+
+        Assert.True(vm.HasLocation);
+        Assert.Equal(new PickLocation(47.601234, -122.334567), vm.Location);
+        Assert.False(string.IsNullOrEmpty(vm.LocationDisplay));
+        Assert.True(vm.CopyLocationCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SetPicks_WithoutLocation_LeavesLocationEmpty()
+    {
+        var vm = new PickReportViewModel();
+
+        vm.SetPicks(new[] { new PickHit { FeatureType = "DepthArea", FeatureRef = "42" } });
+
+        Assert.False(vm.HasLocation);
+        Assert.Null(vm.Location);
+        Assert.Null(vm.LocationDisplay);
+        Assert.False(vm.CopyLocationCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Clear_ResetsLocation()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPicks(
+            new[] { new PickHit { FeatureType = "DepthArea", FeatureRef = "42" } },
+            System.Array.Empty<DynamicPickHit>(),
+            new PickLocation(10.0, 20.0));
+
+        vm.Clear();
+
+        Assert.False(vm.HasLocation);
+        Assert.Null(vm.Location);
+        Assert.False(vm.CopyLocationCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void CopyLocationCommand_RaisesRequestWithDecimalDegrees()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPicks(
+            new[] { new PickHit { FeatureType = "DepthArea", FeatureRef = "42" } },
+            System.Array.Empty<DynamicPickHit>(),
+            new PickLocation(47.601234, -122.334567));
+
+        string? copied = null;
+        vm.CopyLocationRequested += (_, text) => copied = text;
+
+        vm.CopyLocationCommand.Execute(null);
+
+        Assert.Equal("47.601234, -122.334567", copied);
+    }
+
+    [Fact]
     public void HasPickPropertyChanged_FiresOnSetPickAndClear()
     {
         var vm = new PickReportViewModel();


### PR DESCRIPTION
## Summary

Pick reports describe a feature at a location, but that location was not part of the report. Capturing it previously meant picking an object, holding the cursor over the target, and screenshotting the status-bar lat/lon. This PR surfaces the click location directly in the Object Information panel and makes it easy to copy for debugging.

A pinned LOCATION row is shown at the top of the panel. The displayed value is degrees-decimal-minutes (matching the status bar) and is selectable, so it can be copied as-is. A copy button places the coordinate on the clipboard as signed decimal degrees, which is the most universally parseable form for pasting into maps, GIS tools, scripts, and the viewer's own MCP `set_viewport`.

Design notes:
- `PickService` projects the pick's Mapsui world position (Spherical Mercator to WGS84) into a new `PickLocation` record and threads it through `SetPicks` for both vector and coverage picks.
- `PickReportViewModel` exposes `Location` / `HasLocation` / `LocationDisplay` plus a `CopyLocationCommand` that raises an event with the clipboard text; the view owns the actual clipboard write so the view-model stays UI-free and unit-testable.
- Programmatic opens (feature search, reference navigation) pass no location, so the row simply hides.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a viewer UX change with no spec semantics involved.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added VM tests (location populated, hidden when absent, cleared on `Clear`, copy raises decimal-degree text, command disabled when empty) and `LatLonFormatter.FormatDecimal` tests. Full viewer suite green (914 passed, 1 pre-existing skip).

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Viewer README's "Picking and identifying features" section documents the new location row and copy behaviour. No `docs/` conceptual page needed beyond that.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None.