### PR TITLE
Add S-100 Part 15 confidentiality (decryption) library support

### DIFF
--- a/src/EncDotNet.S100.ExchangeSets/Protection/Crc32.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/Crc32.cs
@@ -1,0 +1,50 @@
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// Computes the IEEE 802.3 (reflected, polynomial <c>0xEDB88320</c>) CRC-32
+/// checksum used by the S-100 Part 15 user permit.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-7.3.1.2. The checksum is computed over the
+/// 32-character ASCII hexadecimal representation of the encrypted hardware id
+/// and appended to the user permit so its integrity can be checked without the
+/// manufacturer key. This is the same CRC-32 used by ZIP/zlib.
+/// </remarks>
+internal static class Crc32
+{
+    private static readonly uint[] Table = BuildTable();
+
+    private static uint[] BuildTable()
+    {
+        const uint polynomial = 0xEDB88320u;
+        var table = new uint[256];
+        for (uint i = 0; i < 256; i++)
+        {
+            uint crc = i;
+            for (int bit = 0; bit < 8; bit++)
+            {
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ polynomial : crc >> 1;
+            }
+
+            table[i] = crc;
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// Computes the CRC-32 checksum of the supplied bytes.
+    /// </summary>
+    /// <param name="data">The bytes to checksum.</param>
+    /// <returns>The 32-bit CRC value.</returns>
+    public static uint Compute(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFFu;
+        foreach (byte b in data)
+        {
+            crc = (crc >> 8) ^ Table[(crc ^ b) & 0xFF];
+        }
+
+        return crc ^ 0xFFFFFFFFu;
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/DataPermit.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/DataPermit.cs
@@ -1,0 +1,114 @@
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// A single <c>datasetPermit</c> record from a PERMIT.XML file: the wrapped
+/// (encrypted) cell key for one product file, together with the licensing
+/// metadata that scopes it.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-7.4.4. Permits are issued only for base
+/// datasets; the same key decrypts the matching incremental updates. The
+/// encrypted key is exactly one AES block and is unwrapped with the Data
+/// Client's hardware id.
+/// </remarks>
+public sealed class DataPermit
+{
+    private readonly byte[] _encryptedKey;
+
+    /// <summary>
+    /// Creates a data permit record.
+    /// </summary>
+    /// <param name="fileName">
+    /// The dataset file name (optionally with extension) the permit applies to.
+    /// </param>
+    /// <param name="encryptedKey">The 16-byte encrypted cell key (<c>EK</c>).</param>
+    /// <param name="expiry">The licence expiry date, if present.</param>
+    /// <param name="editionNumber">The edition number the permit applies to, if present.</param>
+    /// <param name="issueDate">The dataset issue date, if present.</param>
+    public DataPermit(
+        string fileName,
+        ReadOnlySpan<byte> encryptedKey,
+        DateOnly? expiry = null,
+        int? editionNumber = null,
+        DateOnly? issueDate = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fileName);
+        if (encryptedKey.Length != S100Cipher.KeyLength)
+        {
+            throw new ArgumentException(
+                $"An encrypted cell key must be {S100Cipher.KeyLength} bytes.", nameof(encryptedKey));
+        }
+
+        FileName = fileName;
+        _encryptedKey = encryptedKey.ToArray();
+        Expiry = expiry;
+        EditionNumber = editionNumber;
+        IssueDate = issueDate;
+    }
+
+    /// <summary>
+    /// The dataset file name the permit applies to. When no file extension is
+    /// present the permit applies to all datasets with this name regardless of
+    /// extension (§15-7.4.4 NOTE).
+    /// </summary>
+    public string FileName { get; }
+
+    /// <summary>The 16-byte encrypted cell key (<c>EK</c>, §15-7.4.4).</summary>
+    public ReadOnlySpan<byte> EncryptedKey => _encryptedKey;
+
+    /// <summary>The licence expiry date, if declared (§15-7.4.4).</summary>
+    public DateOnly? Expiry { get; }
+
+    /// <summary>The edition number the permit applies to, if declared.</summary>
+    public int? EditionNumber { get; }
+
+    /// <summary>The dataset issue date, if declared.</summary>
+    public DateOnly? IssueDate { get; }
+
+    /// <summary>
+    /// Indicates whether the permit has expired as of <paramref name="asOf"/>.
+    /// A permit with no declared expiry never expires.
+    /// </summary>
+    /// <param name="asOf">The date to evaluate against.</param>
+    /// <returns><c>true</c> if the permit's expiry date is before <paramref name="asOf"/>.</returns>
+    public bool IsExpired(DateOnly asOf) => Expiry is { } expiry && expiry < asOf;
+
+    /// <summary>
+    /// Indicates whether this permit applies to the dataset with the given file
+    /// name. Matching is case-insensitive; a permit whose <see cref="FileName"/>
+    /// carries no extension applies to any dataset with that base name
+    /// regardless of extension (§15-7.4.4 NOTE).
+    /// </summary>
+    /// <param name="datasetFileName">The dataset file name (with or without extension).</param>
+    /// <returns><c>true</c> if the permit applies to the dataset.</returns>
+    public bool AppliesTo(string datasetFileName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(datasetFileName);
+
+        if (string.Equals(FileName, datasetFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // A permit file name without an extension matches by base name only.
+        if (!Path.HasExtension(FileName))
+        {
+            string requestedBase = Path.GetFileNameWithoutExtension(datasetFileName);
+            return string.Equals(FileName, requestedBase, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+
+    /// <summary>
+    /// Unwraps the cell key for this permit using the Data Client's hardware id.
+    /// </summary>
+    /// <param name="hardwareId">The system hardware id.</param>
+    /// <returns>The 16-byte decrypted cell key.</returns>
+    public byte[] DecryptCellKey(HardwareId hardwareId)
+    {
+        ArgumentNullException.ThrowIfNull(hardwareId);
+        return S100Cipher.DecryptBlock(_encryptedKey, hardwareId.Value);
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/DecryptingAssetSource.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/DecryptingAssetSource.cs
@@ -1,0 +1,131 @@
+using System.IO.Compression;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// An <see cref="IAssetSource"/> decorator that transparently decrypts (and
+/// optionally decompresses) the protected files of an S-100 Part 15 exchange
+/// set as they are read, so downstream dataset readers and the
+/// <see cref="ExchangeSetVerifier"/> can consume plaintext through the ordinary
+/// <see cref="IAssetSource"/> contract.
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-100 Edition 5.2.1 Part 15 §15-5, §15-6. A file is decrypted only when the
+/// supplied <see cref="IDatasetKeyProvider"/> yields a cell key for it; files
+/// with no key (for example the exchange catalogue or unencrypted support files)
+/// are passed through unchanged. Because the digital signature is computed over
+/// the unencrypted resource (§15-8.9), wrapping the source in this decorator
+/// lets the existing signature verifier validate an encrypted set without
+/// modification.
+/// </para>
+/// <para>
+/// When <c>decompress</c> is enabled, a decrypted file that begins with the ZIP
+/// local-file-header signature is treated as the single-file DEFLATE archive
+/// mandated by §15-5.2 and its sole entry is returned; other content is returned
+/// as-is.
+/// </para>
+/// </remarks>
+public sealed class DecryptingAssetSource : IAssetSource
+{
+    private static readonly byte[] ZipLocalFileHeader = [0x50, 0x4B, 0x03, 0x04];
+
+    private readonly IAssetSource _inner;
+    private readonly IDatasetKeyProvider _keyProvider;
+    private readonly bool _decompress;
+    private readonly bool _ownsInner;
+
+    /// <summary>
+    /// Creates a decrypting asset source.
+    /// </summary>
+    /// <param name="inner">The underlying asset source to read encrypted bytes from.</param>
+    /// <param name="keyProvider">The provider that resolves cell keys per dataset.</param>
+    /// <param name="decompress">
+    /// Whether to decompress decrypted files that are single-file ZIP archives
+    /// (set when the exchange set declares <c>compressionFlag</c>, §15-5.3).
+    /// </param>
+    /// <param name="ownsInner">
+    /// Whether disposing this instance should also dispose <paramref name="inner"/>.
+    /// Defaults to <c>true</c>.
+    /// </param>
+    public DecryptingAssetSource(
+        IAssetSource inner,
+        IDatasetKeyProvider keyProvider,
+        bool decompress = false,
+        bool ownsInner = true)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _keyProvider = keyProvider ?? throw new ArgumentNullException(nameof(keyProvider));
+        _decompress = decompress;
+        _ownsInner = ownsInner;
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        string fileName = GetFileName(relativePath);
+        if (!_keyProvider.TryGetCellKey(fileName, out byte[]? cellKey) || cellKey is null)
+        {
+            // No key for this file: it is not protected (e.g. the catalogue).
+            return await _inner.OpenAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        }
+
+        byte[] ciphertext = await ReadAllBytesAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        byte[] plaintext = S100Cipher.DecryptDataset(ciphertext, cellKey);
+        Array.Clear(cellKey);
+
+        if (_decompress && IsZipArchive(plaintext))
+        {
+            plaintext = ExtractSingleEntry(plaintext);
+        }
+
+        return new MemoryStream(plaintext, writable: false);
+    }
+
+    private async Task<byte[]> ReadAllBytesAsync(string relativePath, CancellationToken cancellationToken)
+    {
+        await using Stream stream = await _inner.OpenAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        using var buffer = new MemoryStream(
+            capacity: stream.CanSeek ? (int)Math.Min(stream.Length, int.MaxValue) : 4096);
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return buffer.ToArray();
+    }
+
+    private static bool IsZipArchive(byte[] content) =>
+        content.Length >= ZipLocalFileHeader.Length &&
+        content.AsSpan(0, ZipLocalFileHeader.Length).SequenceEqual(ZipLocalFileHeader);
+
+    private static byte[] ExtractSingleEntry(byte[] zipBytes)
+    {
+        using var zipStream = new MemoryStream(zipBytes, writable: false);
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        ZipArchiveEntry entry = archive.Entries.Count == 1
+            ? archive.Entries[0]
+            : throw new InvalidDataException(
+                $"A compressed Part 15 resource must contain exactly one entry but contained {archive.Entries.Count}.");
+
+        using Stream entryStream = entry.Open();
+        using var output = new MemoryStream(
+            capacity: entry.Length > 0 && entry.Length <= int.MaxValue ? (int)entry.Length : 4096);
+        entryStream.CopyTo(output);
+        return output.ToArray();
+    }
+
+    private static string GetFileName(string relativePath)
+    {
+        int slash = relativePath.LastIndexOfAny(['/', '\\']);
+        return slash >= 0 ? relativePath[(slash + 1)..] : relativePath;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_ownsInner)
+        {
+            _inner.Dispose();
+        }
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/HardwareId.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/HardwareId.cs
@@ -1,0 +1,77 @@
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// A 16-byte (128-bit) hardware identifier (<c>HW_ID</c>) assigned by an OEM to
+/// an end-user system. The hardware id is the key with which a Data Server wraps
+/// the per-product cell keys delivered in a <see cref="DataPermit"/>.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-7.3.1.1. The hardware id is exactly one AES
+/// block, so it is wrapped/unwrapped with a single-block encryption that needs
+/// no padding.
+/// </remarks>
+public sealed class HardwareId : IEquatable<HardwareId>
+{
+    private readonly byte[] _value;
+
+    private HardwareId(byte[] value) => _value = value;
+
+    /// <summary>The 16 raw bytes of the hardware id.</summary>
+    public ReadOnlySpan<byte> Value => _value;
+
+    /// <summary>
+    /// Creates a hardware id from 16 raw bytes.
+    /// </summary>
+    /// <param name="value">Exactly 16 bytes.</param>
+    /// <returns>The hardware id.</returns>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not 16 bytes.</exception>
+    public static HardwareId FromBytes(ReadOnlySpan<byte> value)
+    {
+        if (value.Length != S100Cipher.KeyLength)
+        {
+            throw new ArgumentException(
+                $"A hardware id must be exactly {S100Cipher.KeyLength} bytes.", nameof(value));
+        }
+
+        return new HardwareId(value.ToArray());
+    }
+
+    /// <summary>
+    /// Parses a hardware id from its 32-character hexadecimal representation.
+    /// </summary>
+    /// <param name="hex">A 32-character hexadecimal string (case-insensitive).</param>
+    /// <returns>The hardware id.</returns>
+    /// <exception cref="FormatException">The string is not 32 hexadecimal characters.</exception>
+    public static HardwareId Parse(string hex)
+    {
+        ArgumentNullException.ThrowIfNull(hex);
+        if (hex.Length != 2 * S100Cipher.KeyLength)
+        {
+            throw new FormatException(
+                $"A hardware id must be {2 * S100Cipher.KeyLength} hexadecimal characters.");
+        }
+
+        return new HardwareId(Convert.FromHexString(hex));
+    }
+
+    /// <summary>
+    /// Returns the upper-case 32-character hexadecimal representation.
+    /// </summary>
+    public override string ToString() =>
+        Convert.ToHexString(_value).ToUpperInvariant();
+
+    /// <inheritdoc />
+    public bool Equals(HardwareId? other) =>
+        other is not null && _value.AsSpan().SequenceEqual(other._value);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => Equals(obj as HardwareId);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.AddBytes(_value);
+        return hash.ToHashCode();
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/IDatasetKeyProvider.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/IDatasetKeyProvider.cs
@@ -1,0 +1,26 @@
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// Resolves the S-100 Part 15 cell (product) key needed to decrypt a given
+/// dataset file.
+/// </summary>
+/// <remarks>
+/// Implementations encapsulate where keys come from — for example a parsed
+/// PERMIT.XML unwrapped with a hardware id (<see cref="PermitKeyProvider"/>), or
+/// a fixed key in tests. This is the seam that lets
+/// <see cref="DecryptingAssetSource"/> stay independent of the licensing model.
+/// </remarks>
+public interface IDatasetKeyProvider
+{
+    /// <summary>
+    /// Attempts to resolve the 16-byte cell key for the dataset with the given
+    /// file name.
+    /// </summary>
+    /// <param name="datasetFileName">
+    /// The dataset file name (with or without extension) as it appears in the
+    /// exchange set.
+    /// </param>
+    /// <param name="cellKey">The resolved 16-byte cell key, if available.</param>
+    /// <returns><c>true</c> if a key was resolved.</returns>
+    bool TryGetCellKey(string datasetFileName, out byte[]? cellKey);
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/PermitFile.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/PermitFile.cs
@@ -1,0 +1,238 @@
+using System.Globalization;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// A parsed PERMIT.XML file: the licensing document a Data Server issues to a
+/// Data Client conveying the (encrypted) cell keys for the products it has
+/// licensed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-100 Edition 5.2.1 Part 15 §15-7.4. A permit file is a sequence of one or
+/// more header/products pairs (each pair, modelled here as a
+/// <see cref="PermitGroup"/>, may address a different end-user system). Each
+/// <c>products</c> section groups <c>datasetPermit</c> records by product
+/// specification id (for example <c>S-101</c>).
+/// </para>
+/// <para>
+/// Parsing is namespace-tolerant: it reads by local element name so both the
+/// <c>http://www.iho.int/s100/se/5.0</c> and <c>5.1</c> schema namespaces are
+/// accepted. The accompanying <c>PERMIT.SIGN</c> signature file (§15-7.4.5) is
+/// not processed by this reader.
+/// </para>
+/// </remarks>
+public sealed class PermitFile
+{
+    private PermitFile(IReadOnlyList<PermitGroup> groups) => Groups = groups;
+
+    /// <summary>The header/products groups contained in the permit file.</summary>
+    public IReadOnlyList<PermitGroup> Groups { get; }
+
+    /// <summary>
+    /// Reads and parses a permit file from a stream.
+    /// </summary>
+    /// <param name="stream">A stream positioned at the start of the PERMIT.XML content.</param>
+    /// <returns>The parsed permit file.</returns>
+    public static PermitFile Read(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        var doc = XDocument.Load(stream);
+        return Parse(doc);
+    }
+
+    /// <summary>
+    /// Reads and parses a permit file from a path on disk.
+    /// </summary>
+    /// <param name="path">The path to the PERMIT.XML file.</param>
+    /// <returns>The parsed permit file.</returns>
+    public static PermitFile Read(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        var doc = XDocument.Load(path);
+        return Parse(doc);
+    }
+
+    private static PermitFile Parse(XDocument doc)
+    {
+        XElement root = doc.Root ?? throw new XmlException("Missing root element.");
+        if (!string.Equals(root.Name.LocalName, "Permit", StringComparison.Ordinal))
+        {
+            throw new XmlException($"Unexpected permit root element '{root.Name.LocalName}'.");
+        }
+
+        var groups = new List<PermitGroup>();
+        PermitHeader? pendingHeader = null;
+
+        foreach (XElement child in root.Elements())
+        {
+            switch (child.Name.LocalName)
+            {
+                case "header":
+                    pendingHeader = ParseHeader(child);
+                    break;
+
+                case "products":
+                    var products = ParseProducts(child);
+                    groups.Add(new PermitGroup(pendingHeader ?? new PermitHeader(), products));
+                    pendingHeader = null;
+                    break;
+            }
+        }
+
+        return new PermitFile(groups);
+    }
+
+    private static PermitHeader ParseHeader(XElement header)
+    {
+        return new PermitHeader
+        {
+            IssueDate = ParseDate(ChildValue(header, "issueDate")),
+            DataServerName = ChildValue(header, "dataServerName"),
+            DataServerIdentifier = ChildValue(header, "dataServerIdentifier"),
+            Version = ChildValue(header, "version"),
+            UserPermit = ChildValue(header, "userpermit"),
+        };
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<DataPermit>> ParseProducts(XElement products)
+    {
+        var byProduct = new Dictionary<string, IReadOnlyList<DataPermit>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (XElement product in products.Elements().Where(e => e.Name.LocalName == "product"))
+        {
+            string id = (string?)product.Attribute("id") ?? string.Empty;
+            var permits = new List<DataPermit>();
+
+            foreach (XElement permit in product.Elements()
+                         .Where(e => e.Name.LocalName is "datasetPermit" or "permit"))
+            {
+                permits.Add(ParsePermit(permit));
+            }
+
+            if (byProduct.TryGetValue(id, out IReadOnlyList<DataPermit>? existing))
+            {
+                ((List<DataPermit>)existing).AddRange(permits);
+            }
+            else
+            {
+                byProduct[id] = permits;
+            }
+        }
+
+        return byProduct;
+    }
+
+    private static DataPermit ParsePermit(XElement permit)
+    {
+        string? fileName = ChildValue(permit, "filename");
+        if (string.IsNullOrEmpty(fileName))
+        {
+            throw new XmlException("A datasetPermit is missing its filename element.");
+        }
+
+        string? encryptedKeyHex = ChildValue(permit, "encryptedKey");
+        if (string.IsNullOrEmpty(encryptedKeyHex))
+        {
+            throw new XmlException($"datasetPermit for '{fileName}' is missing its encryptedKey element.");
+        }
+
+        byte[] encryptedKey;
+        try
+        {
+            encryptedKey = Convert.FromHexString(encryptedKeyHex.Trim());
+        }
+        catch (FormatException ex)
+        {
+            throw new XmlException(
+                $"datasetPermit for '{fileName}' has a non-hexadecimal encryptedKey.", ex);
+        }
+
+        int? editionNumber = null;
+        if (int.TryParse(ChildValue(permit, "editionNumber"), NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out int edition))
+        {
+            editionNumber = edition;
+        }
+
+        return new DataPermit(
+            fileName.Trim(),
+            encryptedKey,
+            ParseDate(ChildValue(permit, "expiry")),
+            editionNumber,
+            ParseDate(ChildValue(permit, "issueDate")));
+    }
+
+    private static string? ChildValue(XElement parent, string localName) =>
+        parent.Elements().FirstOrDefault(e => e.Name.LocalName == localName)?.Value?.Trim();
+
+    private static DateOnly? ParseDate(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        // Permit dates are xs:date and may carry a trailing 'Z' (e.g. 2018-03-20Z).
+        string trimmed = value.Trim().TrimEnd('Z', 'z');
+        return DateOnly.TryParse(trimmed, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly date)
+            ? date
+            : null;
+    }
+
+    /// <summary>
+    /// Finds the permit that applies to the given dataset file name, optionally
+    /// restricting the search to a single product specification id.
+    /// </summary>
+    /// <param name="datasetFileName">The dataset file name (with or without extension).</param>
+    /// <param name="permit">The matching permit, if found.</param>
+    /// <param name="productId">An optional product id (e.g. <c>S-101</c>) to restrict the search.</param>
+    /// <returns><c>true</c> if a matching permit was found.</returns>
+    public bool TryGetPermit(string datasetFileName, out DataPermit? permit, string? productId = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(datasetFileName);
+
+        foreach (PermitGroup group in Groups)
+        {
+            foreach ((string id, IReadOnlyList<DataPermit> permits) in group.Products)
+            {
+                if (productId is not null && !string.Equals(id, productId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                foreach (DataPermit candidate in permits)
+                {
+                    if (candidate.AppliesTo(datasetFileName))
+                    {
+                        permit = candidate;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        permit = null;
+        return false;
+    }
+}
+
+/// <summary>
+/// One header/products pair within a <see cref="PermitFile"/> (§15-7.4.3).
+/// </summary>
+public sealed class PermitGroup
+{
+    internal PermitGroup(PermitHeader header, IReadOnlyDictionary<string, IReadOnlyList<DataPermit>> products)
+    {
+        Header = header;
+        Products = products;
+    }
+
+    /// <summary>The header that applies to this group's permits.</summary>
+    public PermitHeader Header { get; }
+
+    /// <summary>The permits in this group, keyed by product specification id.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<DataPermit>> Products { get; }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/PermitHeader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/PermitHeader.cs
@@ -1,0 +1,29 @@
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// The <c>header</c> section of a PERMIT.XML file: provenance and addressing
+/// metadata that applies to the permits that follow it.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-7.4.2.
+/// </remarks>
+public sealed class PermitHeader
+{
+    /// <summary>The date the permit file was issued (§15-7.4.2).</summary>
+    public DateOnly? IssueDate { get; init; }
+
+    /// <summary>The name of the Data Server that generated the permit file.</summary>
+    public string? DataServerName { get; init; }
+
+    /// <summary>The short identifier of the Data Server.</summary>
+    public string? DataServerIdentifier { get; init; }
+
+    /// <summary>The S-100 version the permit file conforms to (e.g. <c>1.0.0</c>).</summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// The user permit the permits are addressed to, allowing a client to verify
+    /// the file is intended for its system.
+    /// </summary>
+    public string? UserPermit { get; init; }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/PermitKeyProvider.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/PermitKeyProvider.cs
@@ -1,0 +1,49 @@
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// An <see cref="IDatasetKeyProvider"/> backed by a parsed <see cref="PermitFile"/>
+/// and a Data Client hardware id. It locates the permit for a requested dataset
+/// and unwraps its cell key with the hardware id.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-7. The hardware id is the Data Client system
+/// identifier that data permits are bound to; the same key decrypts a base
+/// dataset and all of its incremental updates (§15-6.2).
+/// </remarks>
+public sealed class PermitKeyProvider : IDatasetKeyProvider
+{
+    private readonly PermitFile _permitFile;
+    private readonly HardwareId _hardwareId;
+    private readonly string? _productId;
+
+    /// <summary>
+    /// Creates a key provider over a permit file and hardware id.
+    /// </summary>
+    /// <param name="permitFile">The parsed permit file.</param>
+    /// <param name="hardwareId">The Data Client system hardware id.</param>
+    /// <param name="productId">
+    /// An optional product specification id (e.g. <c>S-101</c>) to restrict permit
+    /// lookups to a single product section.
+    /// </param>
+    public PermitKeyProvider(PermitFile permitFile, HardwareId hardwareId, string? productId = null)
+    {
+        _permitFile = permitFile ?? throw new ArgumentNullException(nameof(permitFile));
+        _hardwareId = hardwareId ?? throw new ArgumentNullException(nameof(hardwareId));
+        _productId = productId;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetCellKey(string datasetFileName, out byte[]? cellKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(datasetFileName);
+
+        if (_permitFile.TryGetPermit(datasetFileName, out DataPermit? permit, _productId) && permit is not null)
+        {
+            cellKey = permit.DecryptCellKey(_hardwareId);
+            return true;
+        }
+
+        cellKey = null;
+        return false;
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/S100Cipher.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/S100Cipher.cs
@@ -1,0 +1,172 @@
+using System.Security.Cryptography;
+
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// Implements the symmetric (confidentiality) cryptography of the S-100 Part 15
+/// Data Protection Scheme: AES-128 in CBC mode with the modified initialization
+/// vector handling, plus the single-block key-wrapping used for cell keys and
+/// hardware identifiers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-100 Edition 5.2.1 Part 15 §15-6. The scheme always uses a 128-bit key
+/// (§15-6.2.1) and PKCS#7 padding (§15-6.2.2). Dataset files use a modified CBC
+/// mode (§15-6.2.4): the plaintext is prepended with one random block and
+/// encrypted under a random initialization vector that is <em>not</em>
+/// transmitted; on decryption an arbitrary IV is used and the first recovered
+/// plaintext block is discarded.
+/// </para>
+/// <para>
+/// Cell keys and hardware identifiers are exactly one AES block (16 bytes) and
+/// are wrapped with a single-block encryption with no chaining or padding
+/// (§15-7.3.1.1, §15-7.4.4).
+/// </para>
+/// </remarks>
+public static class S100Cipher
+{
+    /// <summary>The AES block size in bytes (128 bits).</summary>
+    public const int BlockSize = 16;
+
+    /// <summary>The S-100 Part 15 key length in bytes (128 bits).</summary>
+    public const int KeyLength = 16;
+
+    /// <summary>
+    /// Encrypts a single 16-byte block with AES-128 (no chaining, no padding).
+    /// Used to wrap a hardware id with a manufacturer key (§15-7.3.1.1) or a
+    /// cell key with a hardware id (§15-7.4.4).
+    /// </summary>
+    /// <param name="block">The 16-byte plaintext block.</param>
+    /// <param name="key">The 16-byte key.</param>
+    /// <returns>The 16-byte ciphertext block.</returns>
+    public static byte[] EncryptBlock(ReadOnlySpan<byte> block, ReadOnlySpan<byte> key)
+    {
+        ValidateBlock(block, nameof(block));
+        ValidateKey(key);
+
+        using var aes = CreateAes(key);
+        return aes.EncryptEcb(block, PaddingMode.None);
+    }
+
+    /// <summary>
+    /// Decrypts a single 16-byte block with AES-128 (no chaining, no padding).
+    /// This is the inverse of <see cref="EncryptBlock"/> and is used to unwrap a
+    /// cell key from an encrypted key with the hardware id (§15-7.4.4) or a
+    /// hardware id from a user permit with the manufacturer key (§15-7.3.1.1).
+    /// </summary>
+    /// <param name="block">The 16-byte ciphertext block.</param>
+    /// <param name="key">The 16-byte key.</param>
+    /// <returns>The 16-byte plaintext block.</returns>
+    public static byte[] DecryptBlock(ReadOnlySpan<byte> block, ReadOnlySpan<byte> key)
+    {
+        ValidateBlock(block, nameof(block));
+        ValidateKey(key);
+
+        using var aes = CreateAes(key);
+        return aes.DecryptEcb(block, PaddingMode.None);
+    }
+
+    /// <summary>
+    /// Decrypts a dataset (or other product file) that was encrypted with the
+    /// S-100 Part 15 modified CBC mode.
+    /// </summary>
+    /// <remarks>
+    /// S-100 Edition 5.2.1 Part 15 §15-6.2.4. The ciphertext is decrypted with
+    /// AES-128-CBC under an arbitrary (zero) IV — which only corrupts the first
+    /// plaintext block — the PKCS#7 padding is removed, and the leading random
+    /// block is discarded, yielding the original (still compressed, if the
+    /// product specification applies compression) bytes.
+    /// </remarks>
+    /// <param name="ciphertext">The encrypted file content.</param>
+    /// <param name="cellKey">The 16-byte cell (product) key.</param>
+    /// <returns>The decrypted bytes with the random prefix block removed.</returns>
+    /// <exception cref="CryptographicException">
+    /// The ciphertext is not a positive multiple of the block size, is shorter
+    /// than the mandatory random block, or has invalid padding.
+    /// </exception>
+    public static byte[] DecryptDataset(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> cellKey)
+    {
+        ValidateKey(cellKey);
+
+        if (ciphertext.Length == 0 || ciphertext.Length % BlockSize != 0)
+        {
+            throw new CryptographicException(
+                "Encrypted dataset length must be a positive multiple of the AES block size.");
+        }
+
+        using var aes = CreateAes(cellKey);
+        Span<byte> iv = stackalloc byte[BlockSize];
+        byte[] plaintext = aes.DecryptCbc(ciphertext, iv, PaddingMode.PKCS7);
+
+        // The first block is the random block prepended during encryption.
+        if (plaintext.Length < BlockSize)
+        {
+            throw new CryptographicException(
+                "Decrypted dataset is shorter than the mandatory random prefix block.");
+        }
+
+        return plaintext[BlockSize..];
+    }
+
+    /// <summary>
+    /// Encrypts bytes with the S-100 Part 15 modified CBC mode. Provided to
+    /// support round-trip testing and synthetic fixture generation; production
+    /// reading only needs <see cref="DecryptDataset"/>.
+    /// </summary>
+    /// <remarks>
+    /// S-100 Edition 5.2.1 Part 15 §15-6.2.4. A cryptographically random block
+    /// is prepended to <paramref name="plaintext"/>, the result is PKCS#7-padded
+    /// and encrypted with AES-128-CBC under a random IV that is intentionally
+    /// not returned.
+    /// </remarks>
+    /// <param name="plaintext">The bytes to encrypt (already compressed, if applicable).</param>
+    /// <param name="cellKey">The 16-byte cell (product) key.</param>
+    /// <returns>The encrypted file content.</returns>
+    public static byte[] EncryptDataset(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> cellKey)
+    {
+        ValidateKey(cellKey);
+
+        byte[] prefixed = new byte[BlockSize + plaintext.Length];
+        RandomNumberGenerator.Fill(prefixed.AsSpan(0, BlockSize));
+        plaintext.CopyTo(prefixed.AsSpan(BlockSize));
+
+        Span<byte> iv = stackalloc byte[BlockSize];
+        RandomNumberGenerator.Fill(iv);
+
+        using var aes = CreateAes(cellKey);
+        try
+        {
+            return aes.EncryptCbc(prefixed, iv, PaddingMode.PKCS7);
+        }
+        finally
+        {
+            Array.Clear(prefixed);
+        }
+    }
+
+    private static Aes CreateAes(ReadOnlySpan<byte> key)
+    {
+        var aes = Aes.Create();
+        aes.KeySize = 128;
+        aes.Key = key.ToArray();
+        return aes;
+    }
+
+    private static void ValidateKey(ReadOnlySpan<byte> key)
+    {
+        if (key.Length != KeyLength)
+        {
+            throw new ArgumentException(
+                $"S-100 Part 15 keys must be {KeyLength} bytes (128 bits).", nameof(key));
+        }
+    }
+
+    private static void ValidateBlock(ReadOnlySpan<byte> block, string paramName)
+    {
+        if (block.Length != BlockSize)
+        {
+            throw new ArgumentException(
+                $"A block must be exactly {BlockSize} bytes (the AES block size).", paramName);
+        }
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/Protection/UserPermit.cs
+++ b/src/EncDotNet.S100.ExchangeSets/Protection/UserPermit.cs
@@ -1,0 +1,156 @@
+using System.Text;
+
+namespace EncDotNet.S100.ExchangeSets.Protection;
+
+/// <summary>
+/// A parsed or constructed S-100 Part 15 <em>user permit</em>: the 46-character
+/// token an OEM issues to a Data Client that conveys the system's hardware id in
+/// an encrypted form, together with a checksum and the manufacturer identifier.
+/// </summary>
+/// <remarks>
+/// S-100 Edition 5.2.1 Part 15 §15-7.3. The user permit is the concatenation of
+/// the 32-character hexadecimal encrypted hardware id, an 8-character CRC-32
+/// checksum over that hexadecimal text, and the 6-character manufacturer id
+/// (<c>M_ID</c>). Only a Data Server (or the issuing OEM) holds the manufacturer
+/// key (<c>M_KEY</c>) needed to recover the hardware id with
+/// <see cref="DecryptHardwareId"/>.
+/// </remarks>
+public sealed class UserPermit
+{
+    /// <summary>The total length, in characters, of a user permit (§15-7.3.1).</summary>
+    public const int Length = 46;
+
+    private const int EncryptedHwIdHexLength = 32;
+    private const int ChecksumHexLength = 8;
+    private const int ManufacturerIdLength = 6;
+
+    private readonly byte[] _encryptedHardwareId;
+
+    private UserPermit(byte[] encryptedHardwareId, uint checksum, string manufacturerId)
+    {
+        _encryptedHardwareId = encryptedHardwareId;
+        Checksum = checksum;
+        ManufacturerId = manufacturerId;
+    }
+
+    /// <summary>The 16-byte encrypted hardware id (the wrapped <c>HW_ID</c>).</summary>
+    public ReadOnlySpan<byte> EncryptedHardwareId => _encryptedHardwareId;
+
+    /// <summary>The CRC-32 checksum carried by the permit (§15-7.3.1.2).</summary>
+    public uint Checksum { get; }
+
+    /// <summary>The 6-character manufacturer identifier (<c>M_ID</c>, §15-7.3.1.3).</summary>
+    public string ManufacturerId { get; }
+
+    /// <summary>
+    /// Creates a user permit by encrypting <paramref name="hardwareId"/> with the
+    /// manufacturer key and appending the checksum and manufacturer id.
+    /// </summary>
+    /// <param name="hardwareId">The system hardware id to wrap.</param>
+    /// <param name="manufacturerKey">The 16-byte manufacturer key (<c>M_KEY</c>).</param>
+    /// <param name="manufacturerId">The 6-character manufacturer id (<c>M_ID</c>).</param>
+    /// <returns>The constructed user permit.</returns>
+    public static UserPermit Create(
+        HardwareId hardwareId,
+        ReadOnlySpan<byte> manufacturerKey,
+        string manufacturerId)
+    {
+        ArgumentNullException.ThrowIfNull(hardwareId);
+        ValidateManufacturerId(manufacturerId);
+
+        byte[] encrypted = S100Cipher.EncryptBlock(hardwareId.Value, manufacturerKey);
+        uint checksum = ComputeChecksum(encrypted);
+        return new UserPermit(encrypted, checksum, manufacturerId.ToUpperInvariant());
+    }
+
+    /// <summary>
+    /// Parses a user permit from its 46-character textual form and validates its
+    /// CRC-32 checksum.
+    /// </summary>
+    /// <param name="permit">The 46-character user permit.</param>
+    /// <returns>The parsed user permit.</returns>
+    /// <exception cref="FormatException">
+    /// The permit is malformed or its checksum does not match the encrypted
+    /// hardware id.
+    /// </exception>
+    public static UserPermit Parse(string permit)
+    {
+        ArgumentNullException.ThrowIfNull(permit);
+        string trimmed = permit.Trim();
+        if (trimmed.Length != Length)
+        {
+            throw new FormatException($"A user permit must be {Length} characters long.");
+        }
+
+        string encryptedHex = trimmed[..EncryptedHwIdHexLength];
+        string checksumHex = trimmed.Substring(EncryptedHwIdHexLength, ChecksumHexLength);
+        string manufacturerId = trimmed[(EncryptedHwIdHexLength + ChecksumHexLength)..];
+
+        byte[] encrypted;
+        try
+        {
+            encrypted = Convert.FromHexString(encryptedHex);
+        }
+        catch (FormatException)
+        {
+            throw new FormatException("The encrypted hardware id is not valid hexadecimal.");
+        }
+
+        if (!uint.TryParse(checksumHex, System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out uint declaredChecksum))
+        {
+            throw new FormatException("The user permit checksum is not valid hexadecimal.");
+        }
+
+        uint computedChecksum = ComputeChecksum(encrypted);
+        if (computedChecksum != declaredChecksum)
+        {
+            throw new FormatException(
+                $"User permit checksum mismatch: declared {declaredChecksum:X8}, computed {computedChecksum:X8}.");
+        }
+
+        return new UserPermit(encrypted, declaredChecksum, manufacturerId.ToUpperInvariant());
+    }
+
+    /// <summary>
+    /// Recovers the hardware id by decrypting the encrypted hardware id with the
+    /// manufacturer key.
+    /// </summary>
+    /// <param name="manufacturerKey">The 16-byte manufacturer key (<c>M_KEY</c>).</param>
+    /// <returns>The recovered hardware id.</returns>
+    public HardwareId DecryptHardwareId(ReadOnlySpan<byte> manufacturerKey)
+    {
+        byte[] hwId = S100Cipher.DecryptBlock(_encryptedHardwareId, manufacturerKey);
+        return HardwareId.FromBytes(hwId);
+    }
+
+    /// <summary>
+    /// Returns the 46-character textual form of the user permit (upper-case).
+    /// </summary>
+    public override string ToString()
+    {
+        var builder = new StringBuilder(Length);
+        builder.Append(Convert.ToHexString(_encryptedHardwareId).ToUpperInvariant());
+        builder.Append(Checksum.ToString("X8", System.Globalization.CultureInfo.InvariantCulture));
+        builder.Append(ManufacturerId);
+        return builder.ToString();
+    }
+
+    private static uint ComputeChecksum(byte[] encryptedHardwareId)
+    {
+        // The checksum is computed over the ASCII hexadecimal text of the
+        // encrypted hardware id, not over its raw bytes (§15-7.3.1.2).
+        string hex = Convert.ToHexString(encryptedHardwareId).ToUpperInvariant();
+        return Crc32.Compute(Encoding.ASCII.GetBytes(hex));
+    }
+
+    private static void ValidateManufacturerId(string manufacturerId)
+    {
+        ArgumentNullException.ThrowIfNull(manufacturerId);
+        if (manufacturerId.Length != ManufacturerIdLength)
+        {
+            throw new ArgumentException(
+                $"A manufacturer id must be {ManufacturerIdLength} characters.", nameof(manufacturerId));
+        }
+    }
+}

--- a/src/EncDotNet.S100.ExchangeSets/README.md
+++ b/src/EncDotNet.S100.ExchangeSets/README.md
@@ -135,9 +135,40 @@ S-100 has **no per-resource CRC element** like S-57's CATALOG.031; the digital s
 - Every file is hashed (streaming SHA-256) and checked for presence/readability, so an unsigned set can still be checked for **missing or corrupt** files.
 - When the catalogue declares a hash MRN for a resource (discovered best-effort by `ExchangeCatalogueReader` and surfaced as `ExpectedHash`), the computed digest is compared against it (`Ok` / `ChecksumMismatch`); otherwise the file reports `NoChecksum`.
 
-### Part 15 decryption seam
+### Part 15 confidentiality (decryption)
 
-Encryption/decryption is **not** implemented. The seam for it is `ExchangeSetVerifier.OpenContentForHashingAsync(...)`, a `protected virtual` hook that today returns the raw bytes from the asset source. A future override (or injected decrypted-content provider) would return the decrypted, decompressed bytes for a `dataStatus="encrypted"` signature (§15-8.8, Table 15-10) so the computed digest matches the signature, which is produced over the unencrypted resource. The newer `S100_SE_SignatureOnData` / `S100_SE_SignatureOnSignature` forms and the `dataStatus` attribute are not yet parsed.
+The **confidentiality** dimension of Part 15 — reading **encrypted** datasets — is implemented at the library level under the `EncDotNet.S100.ExchangeSets.Protection` namespace. Signing/authoring and viewer/CLI wiring remain out of scope.
+
+| Type | Role | S-100 Part 15 ref |
+|---|---|---|
+| `S100Cipher` | AES-128 primitives: single-block key wrap/unwrap (`EncryptBlock`/`DecryptBlock`) and dataset modified-CBC `DecryptDataset`/`EncryptDataset` | §15-6 |
+| `HardwareId` | 16-byte Data Client system id (`HW_ID`) | §15-7.3.1.1 |
+| `UserPermit` | 46-char user permit: parse/validate (CRC-32), `Create`, and `DecryptHardwareId(M_KEY)` | §15-7.3 |
+| `DataPermit` | One `datasetPermit` record (`encryptedKey`, expiry, edition); `DecryptCellKey(HardwareId)` | §15-7.4.4 |
+| `PermitFile` / `PermitGroup` / `PermitHeader` | `PERMIT.XML` parser (namespace-tolerant 5.0/5.1) with `TryGetPermit` lookup | §15-7.4 |
+| `IDatasetKeyProvider` / `PermitKeyProvider` | Resolves a cell key per dataset from a permit + hardware id | §15-7 |
+| `DecryptingAssetSource` | `IAssetSource` decorator that decrypts (and optionally decompresses) keyed files transparently | §15-5, §15-6 |
+
+**Crypto details** (all pinned to the §15 worked examples in unit tests): AES-128, PKCS#7 padding, and the §15-6.2.4 *modified CBC* mode (a random block is prepended before encryption and discarded on decryption, so no IV is transmitted). Cell keys and hardware ids are exactly one AES block and are wrapped with single-block ECB. Compression (§15-5.2) is ZIP/DEFLATE, applied *before* encryption; `DecryptingAssetSource` unzips the single-entry archive when `decompress` is set.
+
+```csharp
+using EncDotNet.S100.ExchangeSets.Protection;
+
+// Hardware id either recovered from a user permit (needs the OEM M_KEY) or held by the client.
+HardwareId hwId = UserPermit.Parse(userPermitText).DecryptHardwareId(manufacturerKey);
+
+// Parse the licence and build a per-dataset key provider.
+PermitFile permits = PermitFile.Read("PERMIT.XML");
+var keys = new PermitKeyProvider(permits, hwId);
+
+// Wrap any IAssetSource so encrypted datasets read as plaintext.
+using IAssetSource source = new DecryptingAssetSource(fileSystemOrZipSource, keys, decompress: true);
+await using Stream plaintext = await source.OpenAsync("S-101/101GB40079ABCDEF.000");
+```
+
+Because the digital signature is produced over the **unencrypted** resource (§15-8.9), an encrypted exchange set can be signature-verified simply by passing a `DecryptingAssetSource` as the `source` to `ExchangeSetVerifier.VerifyAsync(...)` — the verifier hashes the decrypted bytes through the existing `OpenContentForHashingAsync` seam, no override required.
+
+**Not yet implemented:** parsing of the `dataStatus="encrypted"` attribute and the `S100_SE_SignatureOnData` / `S100_SE_SignatureOnSignature` forms (§15-8.11), the `PERMIT.SIGN` permit-file signature (§15-7.4.5), and any viewer/CLI surface for supplying permits and keys.
 
 ### CLI
 
@@ -170,7 +201,7 @@ The IHO publishes test SA certificates for interoperability testing. For product
 ### Scope and limitations
 
 - **Verification only** — signing/authoring of exchange sets is not yet implemented.
-- **Encryption is out of scope** — Part 15 §3 Confidentiality (ENC permits, cell-level decryption) is not supported; see the decryption seam above.
+- **Decryption is implemented; encryption metadata parsing is not** — Part 15 §3 confidentiality (permits, cell-key unwrap, AES modified-CBC decryption, decompression) is supported via the `Protection` namespace (see above), but the catalogue-level `dataStatus`/`SignatureOnData` markers that flag *which* files are encrypted are not yet parsed, so encrypted files are recognised by the presence of a matching permit key.
 - **Checksum reference is opportunistic** — S-100 mandates no per-resource hash, so `NoChecksum` is the common (and non-failing) result for unsigned sets; hash-MRN placement is discovered best-effort.
 - File hashing uses streaming SHA-256 to avoid loading large HDF5 files into memory.
 

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ProtectionTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ProtectionTests.cs
@@ -1,0 +1,359 @@
+using System.IO.Compression;
+using System.Text;
+using EncDotNet.S100.ExchangeSets.Protection;
+
+namespace EncDotNet.S100.ExchangeSets.Tests;
+
+/// <summary>
+/// Tests for the S-100 Part 15 confidentiality support. Where possible these
+/// use the known-answer vectors published in S-100 Edition 5.2.1 Part 15 so the
+/// implementation is pinned to the specification.
+/// </summary>
+public class ProtectionTests
+{
+    // S-100 Part 15 §15-7.3.1.1 / Table 15-4 worked example.
+    private const string ExampleHardwareId = "40384B45B54596201114FE9904220101";
+    private const string ExampleManufacturerKey = "4D5A79677065774A7343705272664F72";
+    private const string ExampleEncryptedHardwareId = "AD1DAD797C966EC9F6A55B66ED982815";
+    private const string ExampleManufacturerId = "859868";
+    private const string ExampleUserPermit = "AD1DAD797C966EC9F6A55B66ED98281599B3C7B1859868";
+
+    private static byte[] Hex(string s) => Convert.FromHexString(s);
+
+    // --- S100Cipher: block wrapping -----------------------------------------
+
+    [Fact]
+    public void EncryptBlock_MatchesPart15HardwareIdExample()
+    {
+        byte[] encrypted = S100Cipher.EncryptBlock(Hex(ExampleHardwareId), Hex(ExampleManufacturerKey));
+
+        Assert.Equal(ExampleEncryptedHardwareId, Convert.ToHexString(encrypted));
+    }
+
+    [Fact]
+    public void DecryptBlock_IsInverseOfEncryptBlock()
+    {
+        byte[] recovered = S100Cipher.DecryptBlock(
+            Hex(ExampleEncryptedHardwareId), Hex(ExampleManufacturerKey));
+
+        Assert.Equal(ExampleHardwareId, Convert.ToHexString(recovered));
+    }
+
+    [Fact]
+    public void EncryptBlock_MatchesFipsAes128KnownAnswer()
+    {
+        // S-100 Part 15 §15-6.2.5 (FIPS single-block example).
+        byte[] cipher = S100Cipher.EncryptBlock(
+            Hex("00112233445566778899AABBCCDDEEFF"),
+            Hex("000102030405060708090A0B0C0D0E0F"));
+
+        Assert.Equal("69C4E0D86A7B0430D8CDB78070B4C55A", Convert.ToHexString(cipher));
+    }
+
+    // --- S100Cipher: dataset (modified CBC) ---------------------------------
+
+    [Fact]
+    public void DecryptDataset_MatchesPart15ModifiedCbcExample()
+    {
+        // S-100 Part 15 §15-6.2.5 modified CBC example.
+        byte[] ciphertext = Hex("ba45ee0602a629357ae3902c224dd9d5dd3b073b847f4d432871194397d9a603");
+        byte[] cellKey = Hex("123456789ABCDEF0123456789ABCDEF0");
+
+        byte[] plaintext = S100Cipher.DecryptDataset(ciphertext, cellKey);
+
+        Assert.Equal("FEDCBA9876543210", Convert.ToHexString(plaintext));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(1000)]
+    public void EncryptDataset_RoundTrips(int length)
+    {
+        byte[] cellKey = Hex(ExampleManufacturerKey);
+        byte[] payload = new byte[length];
+        new Random(length).NextBytes(payload);
+
+        byte[] ciphertext = S100Cipher.EncryptDataset(payload, cellKey);
+        byte[] recovered = S100Cipher.DecryptDataset(ciphertext, cellKey);
+
+        Assert.Equal(payload, recovered);
+    }
+
+    [Fact]
+    public void EncryptDataset_ProducesDifferentCiphertextEachTime()
+    {
+        byte[] cellKey = Hex(ExampleManufacturerKey);
+        byte[] payload = Encoding.ASCII.GetBytes("S-100 Part 15");
+
+        byte[] a = S100Cipher.EncryptDataset(payload, cellKey);
+        byte[] b = S100Cipher.EncryptDataset(payload, cellKey);
+
+        Assert.NotEqual(a, b);
+        Assert.Equal(payload, S100Cipher.DecryptDataset(a, cellKey));
+        Assert.Equal(payload, S100Cipher.DecryptDataset(b, cellKey));
+    }
+
+    [Fact]
+    public void DecryptDataset_RejectsNonBlockAlignedInput()
+    {
+        Assert.Throws<System.Security.Cryptography.CryptographicException>(
+            () => S100Cipher.DecryptDataset(new byte[20], Hex(ExampleManufacturerKey)));
+    }
+
+    [Fact]
+    public void EncryptBlock_RejectsWrongSizedKey()
+    {
+        Assert.Throws<ArgumentException>(() => S100Cipher.EncryptBlock(new byte[16], new byte[8]));
+    }
+
+    // --- UserPermit ----------------------------------------------------------
+
+    [Fact]
+    public void UserPermit_Parse_ReadsExampleAndValidatesChecksum()
+    {
+        UserPermit permit = UserPermit.Parse(ExampleUserPermit);
+
+        Assert.Equal(ExampleManufacturerId, permit.ManufacturerId);
+        Assert.Equal(0x99B3C7B1u, permit.Checksum);
+        Assert.Equal(ExampleEncryptedHardwareId, Convert.ToHexString(permit.EncryptedHardwareId));
+    }
+
+    [Fact]
+    public void UserPermit_DecryptHardwareId_RecoversHardwareId()
+    {
+        UserPermit permit = UserPermit.Parse(ExampleUserPermit);
+
+        HardwareId hwId = permit.DecryptHardwareId(Hex(ExampleManufacturerKey));
+
+        Assert.Equal(ExampleHardwareId, hwId.ToString());
+    }
+
+    [Fact]
+    public void UserPermit_Create_ProducesExamplePermit()
+    {
+        UserPermit permit = UserPermit.Create(
+            HardwareId.Parse(ExampleHardwareId),
+            Hex(ExampleManufacturerKey),
+            ExampleManufacturerId);
+
+        Assert.Equal(ExampleUserPermit, permit.ToString());
+    }
+
+    [Fact]
+    public void UserPermit_Parse_RejectsBadChecksum()
+    {
+        string tampered = "AD1DAD797C966EC9F6A55B66ED98281500000000859868";
+
+        Assert.Throws<FormatException>(() => UserPermit.Parse(tampered));
+    }
+
+    [Fact]
+    public void UserPermit_Parse_RejectsWrongLength()
+    {
+        Assert.Throws<FormatException>(() => UserPermit.Parse("TOOSHORT"));
+    }
+
+    // --- PermitFile ----------------------------------------------------------
+
+    private const string ExamplePermitXml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Permit xmlns="http://www.iho.int/s100/se/5.1">
+            <header>
+                <issueDate>2018-03-20Z</issueDate>
+                <dataServerName>Primar</dataServerName>
+                <dataServerIdentifier>PR</dataServerIdentifier>
+                <version>1.0.0</version>
+                <userpermit>267C3AD506E69B1ED18AA5ECC7FFDE6E7C330CE8859868</userpermit>
+            </header>
+            <products>
+                <product id="S-101">
+                    <datasetPermit>
+                        <filename>101GB40079ABCDEF</filename>
+                        <editionNumber>10</editionNumber>
+                        <expiry>2022-12-31</expiry>
+                        <encryptedKey>2E16E07E451FF1854156634DA3DD3FB8</encryptedKey>
+                    </datasetPermit>
+                    <datasetPermit>
+                        <filename>101NO32802411223</filename>
+                        <editionNumber>5</editionNumber>
+                        <expiry>2022-06-10</expiry>
+                        <encryptedKey>C714B5C0FBDF14BFE4B1F12E62CE5FF6</encryptedKey>
+                    </datasetPermit>
+                </product>
+                <product id="S-102">
+                    <datasetPermit>
+                        <filename>102NO329048208.h5</filename>
+                        <editionNumber>1</editionNumber>
+                        <expiry>2022-12-31</expiry>
+                        <encryptedKey>50BBC28B6793E1C3966B45FB2932E1BE</encryptedKey>
+                    </datasetPermit>
+                </product>
+            </products>
+        </Permit>
+        """;
+
+    private static PermitFile ReadExamplePermit()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(ExamplePermitXml));
+        return PermitFile.Read(stream);
+    }
+
+    [Fact]
+    public void PermitFile_Read_ParsesHeaderAndProducts()
+    {
+        PermitFile permit = ReadExamplePermit();
+
+        PermitGroup group = Assert.Single(permit.Groups);
+        Assert.Equal("Primar", group.Header.DataServerName);
+        Assert.Equal("PR", group.Header.DataServerIdentifier);
+        Assert.Equal(new DateOnly(2018, 3, 20), group.Header.IssueDate);
+        Assert.True(group.Products.ContainsKey("S-101"));
+        Assert.True(group.Products.ContainsKey("S-102"));
+        Assert.Equal(2, group.Products["S-101"].Count);
+    }
+
+    [Fact]
+    public void PermitFile_TryGetPermit_MatchesByBaseNameIgnoringExtension()
+    {
+        PermitFile permit = ReadExamplePermit();
+
+        Assert.True(permit.TryGetPermit("101GB40079ABCDEF.000", out DataPermit? found));
+        Assert.NotNull(found);
+        Assert.Equal(10, found!.EditionNumber);
+        Assert.Equal(new DateOnly(2022, 12, 31), found.Expiry);
+        Assert.Equal("2E16E07E451FF1854156634DA3DD3FB8", Convert.ToHexString(found.EncryptedKey));
+    }
+
+    [Fact]
+    public void PermitFile_TryGetPermit_MatchesExplicitExtension()
+    {
+        PermitFile permit = ReadExamplePermit();
+
+        Assert.True(permit.TryGetPermit("102NO329048208.h5", out DataPermit? found));
+        Assert.NotNull(found);
+        Assert.Equal("50BBC28B6793E1C3966B45FB2932E1BE", Convert.ToHexString(found!.EncryptedKey));
+    }
+
+    [Fact]
+    public void PermitFile_TryGetPermit_ProductIdRestrictsSearch()
+    {
+        PermitFile permit = ReadExamplePermit();
+
+        Assert.False(permit.TryGetPermit("102NO329048208.h5", out _, productId: "S-101"));
+        Assert.True(permit.TryGetPermit("102NO329048208.h5", out _, productId: "S-102"));
+    }
+
+    [Fact]
+    public void DataPermit_AppliesTo_ExtensionRules()
+    {
+        var noExt = new DataPermit("ABC123", new byte[16]);
+        Assert.True(noExt.AppliesTo("ABC123"));
+        Assert.True(noExt.AppliesTo("ABC123.000"));
+        Assert.True(noExt.AppliesTo("abc123.001"));
+        Assert.False(noExt.AppliesTo("ABC124.000"));
+
+        var withExt = new DataPermit("ABC123.h5", new byte[16]);
+        Assert.True(withExt.AppliesTo("ABC123.h5"));
+        Assert.False(withExt.AppliesTo("ABC123.000"));
+    }
+
+    // --- End to end: PermitKeyProvider + DecryptingAssetSource ---------------
+
+    [Fact]
+    public async Task DecryptingAssetSource_DecryptsKeyedFile_AndPassesThroughOthers()
+    {
+        byte[] hardwareId = Hex(ExampleHardwareId);
+        byte[] cellKey = Hex("000102030405060708090A0B0C0D0E0F");
+        byte[] payload = Encoding.ASCII.GetBytes("This is the decrypted S-101 dataset content.");
+
+        // A permit whose encryptedKey unwraps (with the HW_ID) to our cell key.
+        byte[] encryptedKey = S100Cipher.EncryptBlock(cellKey, hardwareId);
+        string permitXml = BuildPermitXml("101AA00000000001", Convert.ToHexString(encryptedKey));
+        PermitFile permitFile;
+        using (var ps = new MemoryStream(Encoding.UTF8.GetBytes(permitXml)))
+        {
+            permitFile = PermitFile.Read(ps);
+        }
+
+        var keyProvider = new PermitKeyProvider(permitFile, HardwareId.FromBytes(hardwareId));
+
+        var inner = new InMemoryAssetSource();
+        inner.AddFile("S-101/101AA00000000001.000", S100Cipher.EncryptDataset(payload, cellKey));
+        inner.AddFile("CATALOG.XML", Encoding.UTF8.GetBytes("<catalogue/>"));
+
+        using var decrypting = new DecryptingAssetSource(inner, keyProvider);
+
+        Assert.Equal(payload, await ReadAll(decrypting, "S-101/101AA00000000001.000"));
+        Assert.Equal("<catalogue/>", Encoding.UTF8.GetString(await ReadAll(decrypting, "CATALOG.XML")));
+    }
+
+    [Fact]
+    public async Task DecryptingAssetSource_DecompressesSingleEntryZip()
+    {
+        byte[] cellKey = Hex("000102030405060708090A0B0C0D0E0F");
+        byte[] hardwareId = Hex(ExampleHardwareId);
+        byte[] payload = Encoding.ASCII.GetBytes(new string('x', 500));
+
+        byte[] zipped = ZipSingleEntry("101AA00000000002.000", payload);
+        byte[] encrypted = S100Cipher.EncryptDataset(zipped, cellKey);
+
+        byte[] encryptedKey = S100Cipher.EncryptBlock(cellKey, hardwareId);
+        string permitXml = BuildPermitXml("101AA00000000002", Convert.ToHexString(encryptedKey));
+        PermitFile permitFile;
+        using (var ps = new MemoryStream(Encoding.UTF8.GetBytes(permitXml)))
+        {
+            permitFile = PermitFile.Read(ps);
+        }
+
+        var keyProvider = new PermitKeyProvider(permitFile, HardwareId.FromBytes(hardwareId));
+        var inner = new InMemoryAssetSource();
+        inner.AddFile("101AA00000000002.000", encrypted);
+
+        using var decrypting = new DecryptingAssetSource(inner, keyProvider, decompress: true);
+
+        Assert.Equal(payload, await ReadAll(decrypting, "101AA00000000002.000"));
+    }
+
+    private static string BuildPermitXml(string fileName, string encryptedKeyHex) => $"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Permit xmlns="http://www.iho.int/s100/se/5.1">
+            <header>
+                <dataServerName>Test</dataServerName>
+            </header>
+            <products>
+                <product id="S-101">
+                    <datasetPermit>
+                        <filename>{fileName}</filename>
+                        <expiry>2099-12-31</expiry>
+                        <encryptedKey>{encryptedKeyHex}</encryptedKey>
+                    </datasetPermit>
+                </product>
+            </products>
+        </Permit>
+        """;
+
+    private static byte[] ZipSingleEntry(string entryName, byte[] content)
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            ZipArchiveEntry entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using Stream entryStream = entry.Open();
+            entryStream.Write(content);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static async Task<byte[]> ReadAll(DecryptingAssetSource source, string path)
+    {
+        await using Stream stream = await source.OpenAsync(path);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        return ms.ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

Adds basic, library-level support for reading **encrypted** S-100 datasets, implementing the confidentiality dimension of the S-100 Edition 5.2.1 Part 15 Data Protection Scheme. Until now the repo had signature verification and integrity checks but explicitly treated encryption as out of scope (a documented seam only). This change closes that gap so a licensed, encrypted exchange set can actually be decrypted and read.

The work is intentionally scoped to the library. Viewer/CLI UX for supplying permits and keys is deferred to a follow-up, as is parsing of the catalogue-level `dataStatus`/`SignatureOnData` markers.

## Approach

Everything lands under a new `EncDotNet.S100.ExchangeSets.Protection` namespace, built around the existing `IAssetSource` abstraction so the decryption is transparent to every downstream reader:

- `S100Cipher` -- AES-128 primitives: single-block key wrap/unwrap (for cell keys and hardware ids) and the dataset modified-CBC mode from 15-6.2.4 (a random block is prepended before encryption and discarded on decryption, so no IV is transmitted; PKCS#7 padding).
- `HardwareId`, `UserPermit` (parse/validate CRC-32, `Create`, `DecryptHardwareId(M_KEY)`), `DataPermit`, and `PermitFile`/`PermitGroup`/`PermitHeader` -- a namespace-tolerant (5.0/5.1) `PERMIT.XML` parser with per-dataset lookup, including the spec's "no extension matches any extension" rule.
- `IDatasetKeyProvider` + `PermitKeyProvider` -- resolve a cell key for a given dataset from a permit plus a hardware id.
- `DecryptingAssetSource` -- an `IAssetSource` decorator that decrypts (and optionally decompresses the single-entry ZIP from 15-5.2) keyed files on read and passes unkeyed files (the catalogue, unencrypted support files) straight through.

The nice payoff: because the digital signature is computed over the *unencrypted* resource (15-8.9), an encrypted set can be signature-verified with no verifier changes -- just pass a `DecryptingAssetSource` as the `source` to `ExchangeSetVerifier.VerifyAsync(...)` and the existing hashing seam sees plaintext.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A -- change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** Part 15 15-5 (compression), 15-6 (AES-128, PKCS#7, modified CBC), 15-7.3 (user permit + CRC-32 + M_ID), 15-7.4 (data permit / PERMIT.XML), 15-8.9 (signature over cleartext). The unit tests pin the cipher, CRC-32, and modified-CBC behaviour to the worked examples in 15-6.2.5 and Table 15-4.

## Tests

- [x] Added/updated xunit tests under `tests/` (`ProtectionTests`, 25 cases: spec known-answer vectors plus round-trips and an end-to-end permit -> key -> decrypt -> decompress flow)
- [x] Tests requiring real data files use `SkippableFact` (N/A -- all fixtures are synthetic, no real/encrypted IHO data needed)
- [x] `dotnet test --configuration Release` passes locally (110/110 in the ExchangeSets test project; clean build on net8.0 and net10.0)

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (new Part 15 confidentiality section; reworked the old "decryption seam" and scope notes)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A -- no viewer/CLI surface yet)
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (none added; AES/CRC use the BCL and `System.IO.Compression`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A -- no new dependencies)

## Breaking changes

None. All additions are new public types; no existing APIs changed.