### PR TITLE
Fix MCP server issues #310, #311, #312, #313

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- EncDotNet -->
-    <PackageVersion Include="EncDotNet.Iso8211" Version="0.5.0" />
+    <PackageVersion Include="EncDotNet.Iso8211" Version="0.5.1" />
     <PackageVersion Include="EncDotNet.S57" Version="0.5.0" />
     <!-- Mapping / rendering -->
     <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.328" />

--- a/src/EncDotNet.S100.Datasets.S101/S101FeatureXmlSource.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101FeatureXmlSource.cs
@@ -132,6 +132,8 @@ public sealed class S101FeatureXmlSource : IFeatureXmlSource
     {
         double cmfx = doc.StructureInfo.CoordinateMultiplicationFactorX;
         double cmfy = doc.StructureInfo.CoordinateMultiplicationFactorY;
+        // Defensive divide-by-zero guards only; valid datasets supply COMF (typically
+        // 1e7) in the DSSI record. See HostGetSpatialData in S101LuaDataProvider.
         if (cmfx == 0) cmfx = 10_000_000;
         if (cmfy == 0) cmfy = 10_000_000;
 
@@ -200,6 +202,8 @@ public sealed class S101FeatureXmlSource : IFeatureXmlSource
     {
         double cmfx = doc.StructureInfo.CoordinateMultiplicationFactorX;
         double cmfy = doc.StructureInfo.CoordinateMultiplicationFactorY;
+        // Defensive divide-by-zero guards only; valid datasets supply COMF (typically
+        // 1e7) in the DSSI record. See HostGetSpatialData in S101LuaDataProvider.
         if (cmfx == 0) cmfx = 10_000_000;
         if (cmfy == 0) cmfy = 10_000_000;
 

--- a/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101LuaDataProvider.cs
@@ -752,10 +752,15 @@ public sealed class S101LuaDataProvider : ILuaDataProvider
         double cmfx = _doc.StructureInfo.CoordinateMultiplicationFactorX;
         double cmfy = _doc.StructureInfo.CoordinateMultiplicationFactorY;
         double cmfz = _doc.StructureInfo.CoordinateMultiplicationFactorZ;
+        // Defensive divide-by-zero guards only. Valid S-101 datasets populate the
+        // coordinate multiplication factors in the DSSI record (S-100 Part 10a
+        // §10a-6.1.2.2) — typically COMF=1e7 for lat/lon and SOMF=100 for depth — so
+        // these fallbacks do not fire for well-formed data. They protect against a
+        // missing/partial DSSI yielding an Infinity coordinate. (The factors are
+        // parsed correctly as of EncDotNet.Iso8211 0.5.1, which fixed the b48
+        // 8-byte binary-control parse; the SOMF=10 default is an S-57 holdover.)
         if (cmfx == 0) cmfx = 10_000_000;
         if (cmfy == 0) cmfy = 10_000_000;
-        // CMFZ defaults to S-57 SOMF (10) when zero; S-101 datasets that encode Z
-        // explicitly should populate this via the DSSI record.
         if (cmfz == 0) cmfz = 10;
 
         if (rcnm == RcnmPoint && _doc.Points.TryGetValue(rcid, out var pt))

--- a/src/EncDotNet.S100.Datasets.S101/S101VectorSource.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101VectorSource.cs
@@ -105,6 +105,8 @@ public sealed class S101VectorSource : IVectorSource
         var results = new List<(double, double)>();
         double cmfx = doc.StructureInfo.CoordinateMultiplicationFactorX;
         double cmfy = doc.StructureInfo.CoordinateMultiplicationFactorY;
+        // Defensive divide-by-zero guards only; valid datasets supply COMF (typically
+        // 1e7) in the DSSI record. See HostGetSpatialData in S101LuaDataProvider.
         if (cmfx == 0) cmfx = 10_000_000;
         if (cmfy == 0) cmfy = 10_000_000;
 
@@ -125,6 +127,8 @@ public sealed class S101VectorSource : IVectorSource
         var results = new List<(double, double)>();
         double cmfx = doc.StructureInfo.CoordinateMultiplicationFactorX;
         double cmfy = doc.StructureInfo.CoordinateMultiplicationFactorY;
+        // Defensive divide-by-zero guards only; valid datasets supply COMF (typically
+        // 1e7) in the DSSI record. See HostGetSpatialData in S101LuaDataProvider.
         if (cmfx == 0) cmfx = 10_000_000;
         if (cmfy == 0) cmfy = 10_000_000;
 
@@ -212,6 +216,8 @@ public sealed class S101VectorSource : IVectorSource
     {
         double cmfx = doc.StructureInfo.CoordinateMultiplicationFactorX;
         double cmfy = doc.StructureInfo.CoordinateMultiplicationFactorY;
+        // Defensive divide-by-zero guards only; valid datasets supply COMF (typically
+        // 1e7) in the DSSI record. See HostGetSpatialData in S101LuaDataProvider.
         if (cmfx == 0) cmfx = 10_000_000;
         if (cmfy == 0) cmfy = 10_000_000;
 

--- a/src/EncDotNet.S100.Mcp.Tools/QueryFeaturesTool.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/QueryFeaturesTool.cs
@@ -36,7 +36,8 @@ public sealed record QueryFeaturesRequest(
     [property: Description("Optional attribute-value predicates; a feature must satisfy all of them (logical AND). Discover valid attributes and enumerated values with describe_feature_type.")] ImmutableArray<AttributePredicate> Attributes = default,
     [property: Description("When true, replaces the default bounding-box intersection test with true full-geometry intersection: point-in-polygon containment for area features (interior-ring holes honoured) and genuine segment crossing — e.g. \"which features does this route leg actually cross?\". Slightly more expensive; default false.")] bool Precise = false,
     [property: Description("Zero-based page index into the result set.")] int Page = 0,
-    [property: Description("Maximum features per page; clamped to the range 1..500.")] int PageSize = 50);
+    [property: Description("Maximum features per page; clamped to the range 1..500.")] int PageSize = 50,
+    [property: Description("Optional single-dataset filter; when supplied only the dataset with this identifier (from list_datasets) is queried. Null queries every matching dataset.")] DatasetId? Dataset = null);
 
 /// <summary>
 /// Per-feature summary returned by <see cref="QueryFeaturesTool"/>.
@@ -146,6 +147,11 @@ public sealed class QueryFeaturesTool
         foreach (var dataset in snapshot)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (request.Dataset is { } datasetId && dataset.Id != datasetId)
+            {
+                continue;
+            }
 
             if (request.Spec is { } spec && !SpecMatches(dataset.Spec, spec))
             {

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
@@ -44,6 +44,11 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
     /// Default Z (depth/height) multiplication factor used when the dataset's
     /// DSSI record leaves <c>CMFZ</c> at zero — the S-57 SOMF convention of 10
     /// (decimetre resolution), matching the S-101 portrayal data provider.
+    /// This is a defensive fallback only: well-formed S-101 datasets encode
+    /// CMFZ in the DSSI record (S-100 Part 10a §10a-6.1.2.2; typically 100 for
+    /// centimetre depth resolution), parsed correctly as of
+    /// EncDotNet.Iso8211 0.5.1 (which fixed the <c>b48</c> 8-byte binary-control
+    /// parse), so it is not expected to fire for valid data.
     /// </summary>
     private const double DefaultZMultiplicationFactor = 10.0;
 

--- a/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
+++ b/src/EncDotNet.S100.Mcp.Tools/Spec/S101FeatureDescriber.cs
@@ -37,6 +37,16 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
 {
     private const byte FeatureRecordRcnm = 100;
 
+    /// <summary>RCNM of a MultiPoint spatial record (S-100 Part 10a §3).</summary>
+    private const byte MultiPointRcnm = 115;
+
+    /// <summary>
+    /// Default Z (depth/height) multiplication factor used when the dataset's
+    /// DSSI record leaves <c>CMFZ</c> at zero — the S-57 SOMF convention of 10
+    /// (decimetre resolution), matching the S-101 portrayal data provider.
+    /// </summary>
+    private const double DefaultZMultiplicationFactor = 10.0;
+
     public string SpecName => "S-101";
 
     public ToolResult<DescribeFeatureResult> Describe(FeatureDescriberContext context)
@@ -77,7 +87,8 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
             : feature.FeatureTypeCode.ToString(CultureInfo.InvariantCulture);
 
         var geometry = ResolveGeometry(s101.Dataset, feature.RecordId);
-        var attributes = SerializeAttributes(feature, document, geometry);
+        var depths = ResolveMultiPointDepths(feature, document);
+        var attributes = SerializeAttributes(feature, document, geometry, depths);
         return ToolResult<DescribeFeatureResult>.Ok(new DescribeFeatureResult(
             context.Dataset.Spec,
             acronym,
@@ -128,8 +139,49 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
         return uint.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out rcid);
     }
 
+    /// <summary>
+    /// Resolves the per-point depth (Z ordinate) of a MultiPoint feature
+    /// such as an S-101 <c>Sounding</c>. In S-101 a sounding's charted depth
+    /// is encoded as the third ordinate of each point in its MultiPoint
+    /// spatial record (S-100 Part 10a §8), scaled by the dataset's Z
+    /// multiplication factor (DSSI <c>CMFZ</c>, defaulting to the S-57 SOMF
+    /// value of 10 when zero). Returns the depths in the same order as the
+    /// coordinates produced by <see cref="S101VectorSource"/> (spatial
+    /// associations in order, then each record's points in order), or
+    /// <see langword="null"/> when the feature references no MultiPoint
+    /// record so non-sounding geometry is unaffected.
+    /// </summary>
+    private static IReadOnlyList<double>? ResolveMultiPointDepths(
+        S101FeatureRecord feature, S101Document document)
+    {
+        if (feature.SpatialAssociations.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var cmfz = document.StructureInfo.CoordinateMultiplicationFactorZ == 0
+            ? DefaultZMultiplicationFactor
+            : document.StructureInfo.CoordinateMultiplicationFactorZ;
+
+        List<double>? depths = null;
+        foreach (var spa in feature.SpatialAssociations)
+        {
+            if (spa.RecordName != MultiPointRcnm) continue;
+            if (!document.MultiPoints.TryGetValue(spa.RecordId, out var mp)) continue;
+
+            depths ??= new List<double>(mp.Points.Length);
+            foreach (var (_, _, z) in mp.Points)
+            {
+                depths.Add(z / cmfz);
+            }
+        }
+
+        return depths;
+    }
+
     private static JsonElement SerializeAttributes(
-        S101FeatureRecord feature, S101Document document, Feature? geometry)
+        S101FeatureRecord feature, S101Document document, Feature? geometry,
+        IReadOnlyList<double>? depths)
     {
         var attributeList = new List<Dictionary<string, object?>>();
         foreach (var attr in feature.Attributes)
@@ -188,6 +240,7 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
                 ["roleAcronym"] = document.RoleCatalogue.TryGetValue(ia.RoleCode, out var rac)
                     ? rac
                     : null,
+                ["target"] = ResolveInformationTarget(ia.RecordId, document),
             });
         }
 
@@ -209,7 +262,7 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
                 ? fac0
                 : null,
             ["geometryPrimitive"] = ClassifyGeometry(feature, document),
-            ["geometry"] = BuildGeometry(geometry),
+            ["geometry"] = BuildGeometry(geometry, depths),
             ["spatialAssociations"] = spatial,
             ["attributes"] = attributeList,
             ["featureAssociations"] = featureAssoc,
@@ -221,6 +274,52 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
     }
 
     /// <summary>
+    /// Dereferences an information association's target record id against
+    /// <see cref="S101Document.InformationTypes"/> and inlines the
+    /// associated information record's type and attributes so an agent can
+    /// read the linked text (e.g. an <c>information</c> / <c>text</c>
+    /// attribute on a linked information type) directly from the
+    /// <c>describe_feature</c> payload, without a second lookup. This is a
+    /// single, non-recursive dereference — the target's own information
+    /// associations are not followed — so the payload stays bounded
+    /// (S-101, INAS field; S-100 Part 10a). Returns <see langword="null"/>
+    /// when the target record is not present in the dataset (e.g. a
+    /// dangling pointer or a record carried by a companion cell).
+    /// </summary>
+    private static Dictionary<string, object?>? ResolveInformationTarget(
+        uint targetRecordId, S101Document document)
+    {
+        if (!document.InformationTypes.TryGetValue(targetRecordId, out var info))
+        {
+            return null;
+        }
+
+        var attributeList = new List<Dictionary<string, object?>>();
+        foreach (var attr in info.Attributes)
+        {
+            attributeList.Add(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["code"] = attr.NumericCode,
+                ["acronym"] = document.AttributeTypeCatalogue.TryGetValue(attr.NumericCode, out var ac)
+                    ? ac
+                    : null,
+                ["index"] = attr.Index,
+                ["value"] = attr.Value,
+            });
+        }
+
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["recordId"] = info.RecordId,
+            ["informationTypeCode"] = info.InformationTypeCode,
+            ["informationTypeAcronym"] = document.InformationTypeCatalogue.TryGetValue(info.InformationTypeCode, out var itac)
+                ? itac
+                : null,
+            ["attributes"] = attributeList,
+        };
+    }
+
+    /// <summary>
     /// Builds the resolved-geometry block for the serialised payload from
     /// the coordinates resolved by <see cref="S101VectorSource"/>. Returns
     /// <c>null</c> when the feature has no resolvable geometry (e.g.
@@ -228,9 +327,13 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
     /// a bounding box (south/west/north/east), the exterior coordinates as
     /// <c>[latitude, longitude]</c> pairs, and any interior (hole) rings —
     /// enough for an agent to compute distance / bearing or drive
-    /// <c>set_viewport</c>.
+    /// <c>set_viewport</c>. For MultiPoint soundings a parallel
+    /// <c>depths</c> array (metres, positive down) is included, aligned
+    /// one-to-one with <c>coordinates</c>, so an agent can read the charted
+    /// depth at each sounding (e.g. for under-keel-clearance reasoning).
     /// </summary>
-    private static Dictionary<string, object?>? BuildGeometry(Feature? geometry)
+    private static Dictionary<string, object?>? BuildGeometry(
+        Feature? geometry, IReadOnlyList<double>? depths)
     {
         if (geometry is null || geometry.Coordinates.Count == 0)
         {
@@ -264,6 +367,14 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
             }
         }
 
+        // Only surface depths when they align one-to-one with the resolved
+        // coordinates; a mismatch means the geometry projection and the raw
+        // MultiPoint records diverged, in which case omitting the array is
+        // safer than emitting misaligned depths.
+        var alignedDepths = depths is not null && depths.Count == coordinates.Count
+            ? depths
+            : null;
+
         return new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["primitive"] = geometry.GeometryType.ToString(),
@@ -275,6 +386,7 @@ internal sealed class S101FeatureDescriber : ISpecFeatureDescriber
                 ["eastLongitude"] = east,
             },
             ["coordinates"] = coordinates,
+            ["depths"] = alignedDepths,
             ["interiorRings"] = interiorRings,
         };
     }

--- a/src/EncDotNet.S100.Mcp/README.md
+++ b/src/EncDotNet.S100.Mcp/README.md
@@ -55,7 +55,7 @@ The server exposes the read-only tools defined by
 | Tool name | Returns |
 |---|---|
 | `list_datasets` | Per-dataset summaries (id, spec, name, extent) |
-| `describe_feature` | Spec / feature type / attributes for a feature in a dataset |
+| `describe_feature` | Spec / feature type / attributes for a feature in a dataset. For S-101, each information association is dereferenced — the linked information type record's attributes (e.g. `information` / text) are inlined under a `target` block — and MultiPoint soundings carry a per-point `depths` array |
 | `sample_coverage` | Sampled value at a lat/lon for a coverage dataset (S-102 / S-104 / S-111); optional `times` JSON envelope (instant / range / series) populates a per-step `series` array for S-104 / S-111 |
 | `find_at` | Datasets whose declared bbox contains a point or intersects a `GeoQuery` envelope |
 | `query_features` | Features from loaded GML datasets that intersect a spatial query (point / box / polygon / polyline); optional `times` envelope filters out features whose `fixedDateRange`/`periodicDateRange` is disjoint from the window (features without validity metadata are always included) |
@@ -63,8 +63,9 @@ The server exposes the read-only tools defined by
 | `list_specs` | Spec catalogue with per-spec capability flags (query / describe / sample / list time-steps) |
 | `list_time_steps` | Available UTC time-step instants (+ cadence) for a time-varying coverage dataset (S-104 / S-111) |
 
-Spatial queries are passed as a JSON envelope on the `query` (or
-`polyline`) parameter:
+Spatial queries may be passed either as a structured JSON **object**
+(preferred) or, for backward compatibility, as a JSON **string**
+containing the same envelope, on the `query` (or `polyline`) parameter:
 
 ```json
 {"kind": "point",    "latitude": 47.6, "longitude": -122.3}
@@ -72,6 +73,12 @@ Spatial queries are passed as a JSON envelope on the `query` (or
 {"kind": "polygon",  "ring": [[47, -123], [48, -123], [48, -122], [47, -123]]}
 {"kind": "polyline", "vertices": [[47.6, -122.3], [47.7, -122.4]], "corridorWidthMeters": 1000}
 ```
+
+`query_features` also accepts an optional `datasetId` to scope the query
+to a single loaded cell (matching `count_features` / `search_features`).
+Malformed envelopes (missing `kind`, out-of-range coordinates, bad JSON)
+return a structured `invalid_argument` error naming the offending
+parameter rather than an opaque `internal_error`.
 
 See `src/EncDotNet.S100.Mcp.Tools/README.md` for the full tool
 contract, request/response schemas, and error codes.

--- a/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
+++ b/src/EncDotNet.S100.Mcp/S100McpServerToolFactory.cs
@@ -356,7 +356,7 @@ internal static class S100McpServerToolFactory
             "describe_feature for full attributes. The result also carries a typeBreakdown " +
             "(per-feature-type counts of the full match set). Pagination is server-side.";
 
-        var del = ([Description("Spatial query JSON envelope. Shapes: {\"kind\":\"point\",\"latitude\":lat,\"longitude\":lon}, {\"kind\":\"box\",\"south\":s,\"west\":w,\"north\":n,\"east\":e}, {\"kind\":\"polygon\",\"ring\":[[lat,lon],...]}, {\"kind\":\"polyline\",\"vertices\":[[lat,lon],...],\"corridorWidthMeters\":w}.")] string query,
+        var del = ([Description("Spatial query envelope, supplied either as a JSON object (preferred) or a JSON string containing one. Shapes: {\"kind\":\"point\",\"latitude\":lat,\"longitude\":lon}, {\"kind\":\"box\",\"south\":s,\"west\":w,\"north\":n,\"east\":e}, {\"kind\":\"polygon\",\"ring\":[[lat,lon],...]}, {\"kind\":\"polyline\",\"vertices\":[[lat,lon],...],\"corridorWidthMeters\":w}.")] JsonElement query,
                    [Description("Optional spec filter (e.g. \"S-124/1.5.0\"); null matches every spec.")] string? spec = null,
                    [Description("Optional case-sensitive feature-type filter (the GML element local name, e.g. \"NavwarnPart\", \"BuoyLateral\"); null returns every feature type.")] string? featureType = null,
                    [Description("Optional temporal filter JSON envelope. Shapes: {\"kind\":\"instant\",\"t\":\"2024-01-01T12:00:00Z\"}, {\"kind\":\"range\",\"from\":\"...\",\"to\":\"...\"}, {\"kind\":\"series\",\"from\":\"...\",\"to\":\"...\",\"stepSeconds\":N}. Excludes features whose fixedDateRange/periodicDateRange is disjoint from the window; features without validity metadata are always included.")] string? times = null,
@@ -364,6 +364,7 @@ internal static class S100McpServerToolFactory
                    [Description("When true, replaces the default bounding-box test with true full-geometry intersection: point-in-polygon containment for areas (holes honoured) and genuine segment crossing (e.g. which features a route leg actually crosses). Default false.")] bool precise = false,
                    [Description("Zero-based page index.")] int page = 0,
                    [Description("Page size (clamped to 1..500).")] int pageSize = 50,
+                   [Description("Optional dataset identifier (typically from list_datasets); null queries across every matching dataset.")] string? datasetId = null,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(
@@ -375,7 +376,8 @@ internal static class S100McpServerToolFactory
                         ParseAttributePredicates(attributes),
                         precise,
                         page,
-                        pageSize),
+                        pageSize,
+                        string.IsNullOrWhiteSpace(datasetId) ? null : new DatasetId(datasetId)),
                     ct));
 
         return McpServerTool.Create(del, new McpServerToolCreateOptions
@@ -399,7 +401,7 @@ internal static class S100McpServerToolFactory
 
         var del = ([Description("Optional spec filter (e.g. \"S-101\" or \"S-124/1.5.0\"); null matches every spec.")] string? spec = null,
                    [Description("Optional dataset identifier (typically from list_datasets); null counts across every matching dataset.")] string? datasetId = null,
-                   [Description("Optional spatial query JSON envelope (same shapes as query_features: point / box / polygon / polyline). When supplied, only features whose bounding box intersects are counted; geometry-less features are excluded.")] string? query = null,
+                   [Description("Optional spatial query envelope, supplied as a JSON object (preferred) or a JSON string (same shapes as query_features: point / box / polygon / polyline). When supplied, only features whose bounding box intersects are counted; geometry-less features are excluded.")] JsonElement? query = null,
                    CancellationToken ct = default) =>
             DispatchAsync(() =>
                 inner.InvokeAsync(
@@ -433,7 +435,7 @@ internal static class S100McpServerToolFactory
         var del = ([Description("The text to search for in feature names (OBJNAM / NOBJNM / objectName / featureName). Required.")] string text,
                    [Description("Optional spec filter (e.g. \"S-101\" or \"S-124/1.5.0\"); null matches every spec.")] string? spec = null,
                    [Description("Optional dataset identifier (typically from list_datasets); null searches across every matching dataset.")] string? datasetId = null,
-                   [Description("Optional spatial query JSON envelope (same shapes as query_features: point / box / polygon / polyline). When supplied, only features whose bounding box intersects are searched; geometry-less features are excluded.")] string? query = null,
+                   [Description("Optional spatial query envelope, supplied as a JSON object (preferred) or a JSON string (same shapes as query_features: point / box / polygon / polyline). When supplied, only features whose bounding box intersects are searched; geometry-less features are excluded.")] JsonElement? query = null,
                    [Description("When true the match is case-sensitive; default false.")] bool caseSensitive = false,
                    [Description("When true a name must equal the search text exactly; when false (default) any name containing the text matches.")] bool exact = false,
                    [Description("Zero-based page index.")] int page = 0,
@@ -562,6 +564,35 @@ internal static class S100McpServerToolFactory
     private static GeoQuery? ParseGeoQuery(string? queryJson)
         => string.IsNullOrWhiteSpace(queryJson) ? null : GeoQueryJsonReader.Parse(queryJson);
 
+    /// <summary>
+    /// Parses a spatial query supplied either as a structured JSON object
+    /// (e.g. <c>{"kind":"box",...}</c>) — the ergonomic form an agent
+    /// intuitively reaches for — or, for backward compatibility, as a JSON
+    /// string containing that same envelope. Returns <see langword="null"/>
+    /// when the argument is absent/null, and throws
+    /// <see cref="ArgumentException"/> (mapped to a structured
+    /// <c>invalid_argument</c> error) for any other shape.
+    /// </summary>
+    private static GeoQuery? ParseGeoQuery(JsonElement? query)
+    {
+        if (query is not { } element)
+        {
+            return null;
+        }
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            JsonValueKind.String => ParseGeoQuery(element.GetString()),
+            JsonValueKind.Object => GeoQueryJsonReader.Parse(element.GetRawText()),
+            _ => throw new ArgumentException(
+                "query must be a JSON envelope object with a \"kind\" of point|box|polygon|polyline "
+                + "(e.g. {\"kind\":\"box\",\"south\":s,\"west\":w,\"north\":n,\"east\":e}), "
+                + "or a JSON string containing one.",
+                nameof(query)),
+        };
+    }
+
     private static TimeQuery? ParseTimeQuery(string? timesJson)
         => string.IsNullOrWhiteSpace(timesJson) ? null : TimeQueryJsonReader.Parse(timesJson);
 
@@ -645,10 +676,31 @@ internal static class S100McpServerToolFactory
         {
             throw;
         }
+        catch (Exception ex) when (ex is ArgumentException or FormatException or JsonException)
+        {
+            // Malformed caller input (bad query/time/attribute/spec JSON or
+            // an out-of-range value) surfaces as a structured invalid_argument
+            // error naming the offending parameter where known, rather than an
+            // opaque internal_error — see issue #312.
+            return ArgumentFailure(ex);
+        }
         catch (Exception ex)
         {
             return InternalError(ex);
         }
+    }
+
+    /// <summary>
+    /// Maps a caller-input exception (<see cref="ArgumentException"/>,
+    /// <see cref="FormatException"/>, or <see cref="JsonException"/>) to a
+    /// structured <c>invalid_argument</c> error envelope, carrying the
+    /// offending parameter name when the exception is an
+    /// <see cref="ArgumentException"/> that supplies one.
+    /// </summary>
+    private static CallToolResult ArgumentFailure(Exception ex)
+    {
+        var argument = ex is ArgumentException { ParamName: { Length: > 0 } name } ? name : null;
+        return Failure(new InvalidArgument(argument ?? string.Empty, ex.Message));
     }
 
     private static CallToolResult Success<T>(T value)

--- a/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ViewerDatasetCatalog.cs
@@ -271,10 +271,28 @@ internal sealed class ViewerDatasetCatalog : IDatasetCatalog, IDisposable
         var bounds = ComputeS101Bounds(dataset) ?? WorldBounds;
         return new LoadedDataset(
             id,
-            new SpecRef("S-101", default),
+            new SpecRef("S-101", ResolveS101Edition(dataset)),
             bounds,
             null,
             new S101DatasetData(dataset));
+    }
+
+    /// <summary>
+    /// Resolves the product-specification edition an S-101 cell declares in
+    /// its ISO 8211 dataset identification (DSID/PRED subfield; S-100
+    /// Part 10a §4.3.1) so <c>list_datasets</c> surfaces the real edition
+    /// instead of <c>0.0.0</c>. Returns the <see langword="default"/>
+    /// <see cref="SpecVersion"/> when the subfield is absent or not a
+    /// <c>major[.minor[.clarification]]</c> string.
+    /// </summary>
+    internal static SpecVersion ResolveS101Edition(S101Dataset dataset)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        var declaredEdition = dataset.Document.Identification?.ProductSpecificationEdition;
+        return !string.IsNullOrWhiteSpace(declaredEdition)
+            && SpecVersion.TryParse(declaredEdition, out var edition)
+            ? edition
+            : default;
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tests/S100McpServerRoundTripTests.cs
@@ -623,7 +623,10 @@ public class S100McpServerRoundTripTests
 
         Assert.True(result.IsError ?? false, "Expected isError=true for unknown query kind.");
         var payload = ParseSingleJson(result);
-        Assert.Equal("internal_error", payload["code"]!.GetValue<string>());
+        // Malformed query envelopes now map to a structured invalid_argument
+        // error (naming the offending parameter) rather than an opaque
+        // internal_error — see issue #312.
+        Assert.Equal("invalid_argument", payload["code"]!.GetValue<string>());
     }
 
     [Fact]
@@ -817,6 +820,112 @@ public class S100McpServerRoundTripTests
         Assert.Single(datasets);
         Assert.Equal("warn-here", datasets[0]!["id"]!.GetValue<string>());
     }
+
+    [Fact]
+    public async Task QueryFeatures_round_trip_accepts_structured_object_query()
+    {
+        var feature = MakeNavwarn("feat-struct", 5.0, 5.0);
+        var dataset = S124Synth.Dataset(feature);
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S124("synth-warn-struct", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10), model: dataset));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        // Pass the query envelope as a structured JSON object (the ergonomic
+        // form an agent intuitively reaches for) rather than a stringified
+        // JSON envelope — see issue #312.
+        var result = await client.CallToolAsync("query_features", new Dictionary<string, object?>
+        {
+            ["query"] = new JsonObject
+            {
+                ["kind"] = "box",
+                ["south"] = -5,
+                ["west"] = -5,
+                ["north"] = 15,
+                ["east"] = 15,
+            },
+        });
+
+        Assert.False(result.IsError ?? false, $"query_features returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var features = payload["features"]!.AsArray();
+        Assert.Single(features);
+        Assert.Equal("feat-struct", features[0]!["featureId"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task QueryFeatures_round_trip_scopes_to_datasetId()
+    {
+        var a = S124Synth.Dataset(MakeNavwarn("in-a", 5.0, 5.0));
+        var b = S124Synth.Dataset(MakeNavwarn("in-b", 6.0, 6.0));
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S124("ds-a", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10), model: a),
+            LoadedDatasetFactory.S124("ds-b", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10), model: b));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        var result = await client.CallToolAsync("query_features", new Dictionary<string, object?>
+        {
+            ["query"] = """{"kind":"box","south":-5,"west":-5,"north":15,"east":15}""",
+            ["datasetId"] = "ds-b",
+        });
+
+        Assert.False(result.IsError ?? false, $"query_features returned an error: {DumpText(result)}");
+        var payload = ParseSingleJson(result);
+        var features = payload["features"]!.AsArray();
+        var feature = Assert.Single(features);
+        Assert.Equal("in-b", feature!["featureId"]!.GetValue<string>());
+        Assert.Equal("ds-b", feature["datasetId"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task QueryFeatures_round_trip_malformed_query_returns_invalid_argument()
+    {
+        var catalog = McpTestHelpers.NewCatalog(
+            LoadedDatasetFactory.S124("ds", bounds: LoadedDatasetFactory.Box(0, 0, 10, 10),
+                model: S124Synth.Dataset(MakeNavwarn("f", 5.0, 5.0))));
+
+        await using var server = await McpTestHelpers.StartServerAsync(catalog);
+        await using var client = await McpTestClient.ConnectAsync(server);
+
+        // A query object missing the required "kind" discriminator should
+        // surface a structured invalid_argument error, not an opaque
+        // internal_error — see issue #312.
+        var result = await client.CallToolAsync("query_features", new Dictionary<string, object?>
+        {
+            ["query"] = new JsonObject
+            {
+                ["boundingBox"] = new JsonObject
+                {
+                    ["south"] = -5,
+                    ["west"] = -5,
+                    ["north"] = 15,
+                    ["east"] = 15,
+                },
+            },
+        });
+
+        Assert.True(result.IsError ?? false, "expected an error for a malformed query.");
+        var payload = ParseSingleJson(result);
+        Assert.Equal("invalid_argument", payload["code"]!.GetValue<string>());
+    }
+
+    private static S124Feature MakeNavwarn(string id, double lat, double lon) =>
+        new()
+        {
+            Id = id,
+            FeatureType = "NavwarnPart",
+            GeometryType = S100GeometryType.Point,
+            Points = ImmutableArray.Create((lat, lon)),
+            Curves = default,
+            ExteriorRing = default,
+            InteriorRings = default,
+            Attributes = ImmutableDictionary<string, string>.Empty,
+            ComplexAttributes = ImmutableArray<S124ComplexAttribute>.Empty,
+            References = ImmutableArray<GmlReference>.Empty,
+        };
 
     private static JsonObject ParseSingleJson(CallToolResult result)
     {

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS101Tests.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/DescribeFeatureToolS101Tests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using EncDotNet.S100.Mcp.Tools.Catalog;
+using EncDotNet.S100.Mcp.Tools.Tests.Fakes;
+
+namespace EncDotNet.S100.Mcp.Tools.Tests;
+
+/// <summary>
+/// Tests for the S-101 <c>describe_feature</c> describer's surfacing of
+/// MultiPoint sounding depths (issue #311): the Z ordinate of each point in
+/// a <c>Sounding</c> feature must be read, scaled by the dataset's Z
+/// multiplication factor, and returned as a <c>depths</c> array aligned
+/// one-to-one with the geometry coordinates.
+/// </summary>
+public class DescribeFeatureToolS101Tests
+{
+    [Fact]
+    public async Task Sounding_surfaces_per_point_depths_aligned_with_coordinates()
+    {
+        var dataset = S101Synth.DatasetWithSounding(
+            "enc-with-soundings",
+            new (double Lat, double Lon, double Depth)[]
+            {
+                (50.7699, -1.1396, 11.0),
+                (50.7709, -1.1367, 6.4),
+                (50.7720, -1.1340, 18.3),
+            });
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("enc"), "808"));
+
+        Assert.True(result.TryGetValue(out var value));
+        Assert.Equal("Sounding", value.FeatureTypeName);
+
+        var geometry = value.Attributes.GetProperty("geometry");
+        var coordinates = geometry.GetProperty("coordinates");
+        Assert.Equal(3, coordinates.GetArrayLength());
+
+        var depths = geometry.GetProperty("depths");
+        Assert.Equal(JsonValueKind.Array, depths.ValueKind);
+        Assert.Equal(3, depths.GetArrayLength());
+        Assert.Equal(11.0, depths[0].GetDouble(), 6);
+        Assert.Equal(6.4, depths[1].GetDouble(), 6);
+        Assert.Equal(18.3, depths[2].GetDouble(), 6);
+    }
+
+    [Fact]
+    public async Task Non_multipoint_feature_omits_depths()
+    {
+        var dataset = S101Synth.DatasetWithPointFeatures(
+            "enc-points",
+            new (uint, ushort, double, double)[] { (1u, 7, 50.0, -1.0) });
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("enc"), "1"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var depths = value.Attributes.GetProperty("geometry").GetProperty("depths");
+        Assert.Equal(JsonValueKind.Null, depths.ValueKind);
+    }
+
+    [Fact]
+    public async Task Information_association_inlines_target_record_text()
+    {
+        var dataset = S101Synth.DatasetWithAssociatedInformation(
+            "enc-with-info",
+            text: "Caution: strong tidal streams.");
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("enc"), "700"));
+
+        Assert.True(result.TryGetValue(out var value));
+
+        var infoAssociations = value.Attributes.GetProperty("informationAssociations");
+        Assert.Equal(1, infoAssociations.GetArrayLength());
+
+        var association = infoAssociations[0];
+        Assert.Equal("AdditionalInformation", association.GetProperty("acronym").GetString());
+
+        var target = association.GetProperty("target");
+        Assert.Equal(JsonValueKind.Object, target.ValueKind);
+        Assert.Equal("NauticalInformation", target.GetProperty("informationTypeAcronym").GetString());
+
+        var targetAttributes = target.GetProperty("attributes");
+        Assert.Equal(1, targetAttributes.GetArrayLength());
+        Assert.Equal("information", targetAttributes[0].GetProperty("acronym").GetString());
+        Assert.Equal("Caution: strong tidal streams.", targetAttributes[0].GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public async Task Information_association_target_is_null_when_record_absent()
+    {
+        // Feature has no information associations at all → none to dereference;
+        // the array is present and empty.
+        var dataset = S101Synth.DatasetWithPointFeatures(
+            "enc-points",
+            new (uint, ushort, double, double)[] { (1u, 7, 50.0, -1.0) });
+
+        var catalog = new FakeDatasetCatalog();
+        catalog.Add(LoadedDatasetFactory.S101("enc", dataset));
+        var tool = new DescribeFeatureTool(catalog);
+
+        var result = await tool.InvokeAsync(
+            new DescribeFeatureRequest(new DatasetId("enc"), "1"));
+
+        Assert.True(result.TryGetValue(out var value));
+        var infoAssociations = value.Attributes.GetProperty("informationAssociations");
+        Assert.Equal(JsonValueKind.Array, infoAssociations.ValueKind);
+        Assert.Equal(0, infoAssociations.GetArrayLength());
+    }
+}

--- a/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S101Synth.cs
+++ b/tests/EncDotNet.S100.Mcp.Tools.Tests/Fakes/S101Synth.cs
@@ -20,7 +20,12 @@ internal static class S101Synth
         ImmutableArray<S101FeatureRecord> features,
         ImmutableDictionary<ushort, string>? featureTypes = null,
         ImmutableDictionary<ushort, string>? attributeTypes = null,
-        ImmutableDictionary<uint, S101PointRecord>? points = null)
+        ImmutableDictionary<uint, S101PointRecord>? points = null,
+        ImmutableDictionary<uint, S101MultiPointRecord>? multiPoints = null,
+        ImmutableDictionary<uint, S101InformationRecord>? informationTypes = null,
+        ImmutableDictionary<ushort, string>? informationTypeCatalogue = null,
+        ImmutableDictionary<ushort, string>? informationAssociationCatalogue = null,
+        ImmutableDictionary<ushort, string>? roleCatalogue = null)
     {
         var document = new S101Document
         {
@@ -37,15 +42,16 @@ internal static class S101Synth
             FeatureTypeCatalogue = featureTypes ?? ImmutableDictionary<ushort, string>.Empty,
             AttributeTypeCatalogue = attributeTypes ?? ImmutableDictionary<ushort, string>.Empty,
             Points = points ?? ImmutableDictionary<uint, S101PointRecord>.Empty,
+            MultiPoints = multiPoints ?? ImmutableDictionary<uint, S101MultiPointRecord>.Empty,
             CurveSegments = ImmutableDictionary<uint, S101CurveSegmentRecord>.Empty,
             CompositeCurves = ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
             Surfaces = ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
             Features = features,
-            InformationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty,
-            InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
-            InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            InformationTypes = informationTypes ?? ImmutableDictionary<uint, S101InformationRecord>.Empty,
+            InformationTypeCatalogue = informationTypeCatalogue ?? ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = informationAssociationCatalogue ?? ImmutableDictionary<ushort, string>.Empty,
             FeatureAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
-            RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = roleCatalogue ?? ImmutableDictionary<ushort, string>.Empty,
         };
         return S101Dataset.FromDocument(document);
     }
@@ -78,6 +84,134 @@ internal static class S101Synth
         }
 
         return Dataset(name, featureRecords.ToImmutable(), featureTypes, points: pointRecords.ToImmutable());
+    }
+
+    /// <summary>
+    /// Builds an S-101 dataset with a single MultiPoint <c>Sounding</c>
+    /// feature whose points carry depth (Z) values. Each depth is supplied
+    /// in metres and stored as <c>metres × CMFZ</c> (CMFZ = 10) so the
+    /// describer recovers the original metres. The feature (RCID 808) and a
+    /// matching MultiPoint spatial record (RCNM 115) are created, and the
+    /// feature-type catalogue maps the feature-type code to "Sounding".
+    /// </summary>
+    public static S101Dataset DatasetWithSounding(
+        string name,
+        IEnumerable<(double Lat, double Lon, double Depth)> soundings,
+        uint featureRcid = 808,
+        ushort featureTypeCode = 5)
+    {
+        const int cmfz = 10;
+        var points = soundings
+            .Select(s => (
+                Y: (int)Math.Round(s.Lat * CoordinateMultiplicationFactor),
+                X: (int)Math.Round(s.Lon * CoordinateMultiplicationFactor),
+                Z: (int)Math.Round(s.Depth * cmfz)))
+            .ToImmutableArray();
+
+        var multiPoint = new S101MultiPointRecord
+        {
+            RecordId = featureRcid,
+            Points = points,
+        };
+
+        var feature = new S101FeatureRecord
+        {
+            RecordId = featureRcid,
+            FeatureTypeCode = featureTypeCode,
+            ProducingAgency = 540,
+            FeatureIdentificationNumber = featureRcid,
+            FeatureIdentificationSubdivision = 0,
+            Attributes = ImmutableArray<S101Attribute>.Empty,
+            SpatialAssociations = ImmutableArray.Create(
+                new S101SpatialAssociation(115, featureRcid, 1)),
+            FeatureAssociations = ImmutableArray<S101FeatureAssociation>.Empty,
+            InformationAssociations = ImmutableArray<S101InformationAssociation>.Empty,
+        };
+
+        var featureTypes = ImmutableDictionary<ushort, string>.Empty
+            .Add(featureTypeCode, "Sounding");
+        var multiPoints = ImmutableDictionary<uint, S101MultiPointRecord>.Empty
+            .Add(featureRcid, multiPoint);
+
+        return Dataset(
+            name,
+            ImmutableArray.Create(feature),
+            featureTypes,
+            multiPoints: multiPoints);
+    }
+
+    /// <summary>
+    /// Builds an S-101 dataset with a single point feature that carries an
+    /// information association (INAS) to an information type record holding
+    /// the supplied text. Exercises the describe_feature dereferencing of
+    /// associated information records (issue #313). The feature is RCID
+    /// <paramref name="featureRcid"/>; the information record is RCID
+    /// <paramref name="infoRcid"/> and carries a single attribute
+    /// (<paramref name="textAttributeCode"/> = <paramref name="text"/>).
+    /// </summary>
+    public static S101Dataset DatasetWithAssociatedInformation(
+        string name,
+        string text,
+        uint featureRcid = 700,
+        ushort featureTypeCode = 7,
+        uint infoRcid = 9001,
+        ushort infoTypeCode = 300,
+        ushort infoAssociationCode = 401,
+        ushort roleCode = 1,
+        ushort textAttributeCode = 12)
+    {
+        var infoRecord = new S101InformationRecord
+        {
+            RecordId = infoRcid,
+            InformationTypeCode = infoTypeCode,
+            Attributes = ImmutableArray.Create(new S101Attribute(textAttributeCode, 1, text)),
+        };
+
+        var feature = new S101FeatureRecord
+        {
+            RecordId = featureRcid,
+            FeatureTypeCode = featureTypeCode,
+            ProducingAgency = 540,
+            FeatureIdentificationNumber = featureRcid,
+            FeatureIdentificationSubdivision = 0,
+            Attributes = ImmutableArray<S101Attribute>.Empty,
+            SpatialAssociations = ImmutableArray.Create(new S101SpatialAssociation(110, featureRcid, 1)),
+            FeatureAssociations = ImmutableArray<S101FeatureAssociation>.Empty,
+            InformationAssociations = ImmutableArray.Create(
+                new S101InformationAssociation(infoAssociationCode, infoRcid, roleCode)),
+        };
+
+        var points = ImmutableDictionary<uint, S101PointRecord>.Empty
+            .Add(featureRcid, new S101PointRecord
+            {
+                RecordId = featureRcid,
+                Y = (int)Math.Round(47.6 * CoordinateMultiplicationFactor),
+                X = (int)Math.Round(-122.3 * CoordinateMultiplicationFactor),
+            });
+
+        var featureTypes = ImmutableDictionary<ushort, string>.Empty
+            .Add(featureTypeCode, "CautionArea");
+        var attributeTypes = ImmutableDictionary<ushort, string>.Empty
+            .Add(textAttributeCode, "information");
+        var informationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty
+            .Add(infoRcid, infoRecord);
+        var informationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty
+            .Add(infoTypeCode, "NauticalInformation");
+        var informationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty
+            .Add(infoAssociationCode, "AdditionalInformation");
+        var roleCatalogue = ImmutableDictionary<ushort, string>.Empty
+            .Add(roleCode, "the additional information");
+
+        return Dataset(
+            name,
+            ImmutableArray.Create(feature),
+            featureTypes,
+            attributeTypes,
+            points: points,
+            informationTypes: informationTypes,
+            informationTypeCatalogue: informationTypeCatalogue,
+            informationAssociationCatalogue: informationAssociationCatalogue,
+            roleCatalogue: roleCatalogue);
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ViewerDatasetCatalogTests.cs
@@ -60,6 +60,67 @@ public class ViewerDatasetCatalogTests
         AssertBoundsAreNotWorld(loaded.Bounds);
     }
 
+    [Fact]
+    public void ResolveS101Edition_parses_declared_product_specification_edition()
+    {
+        var dataset = S101Dataset.FromDocument(SyntheticDocument("1.0.2"));
+
+        var edition = ViewerDatasetCatalog.ResolveS101Edition(dataset);
+
+        Assert.Equal(new SpecVersion(1, 0, 2), edition);
+    }
+
+    [Fact]
+    public void ResolveS101Edition_defaults_when_edition_absent()
+    {
+        var dataset = S101Dataset.FromDocument(SyntheticDocument(""));
+
+        var edition = ViewerDatasetCatalog.ResolveS101Edition(dataset);
+
+        Assert.Equal(default, edition);
+    }
+
+    [SkippableFact]
+    public void S101_entry_surfaces_declared_edition()
+    {
+        var path = Path("S101", System.IO.Path.Combine("DATASET_FILES", "101AA00DS0003.000"));
+        Skip.IfNot(File.Exists(path), $"Missing fixture {path}");
+
+        var loader = new FakeDatasetLoaderService();
+        using var catalog = new ViewerDatasetCatalog(loader);
+        var entry = new DatasetEntry(path, "S-101");
+
+        loader.RaiseLoaded(entry);
+
+        var loaded = Assert.Single(catalog.Datasets);
+        Assert.NotEqual(default, loaded.Spec.Edition);
+        Assert.Equal(new SpecVersion(1, 0, 2), loaded.Spec.Edition);
+    }
+
+    private static S101Document SyntheticDocument(string productSpecificationEdition) =>
+        new()
+        {
+            Identification = new S101DatasetIdentification
+            {
+                DatasetName = "synthetic",
+                ProductSpecification = "INT.IHO.S-101.1.0",
+                ProductSpecificationEdition = productSpecificationEdition,
+            },
+            StructureInfo = new S101DatasetStructureInfo(),
+            FeatureTypeCatalogue = System.Collections.Immutable.ImmutableDictionary<ushort, string>.Empty,
+            AttributeTypeCatalogue = System.Collections.Immutable.ImmutableDictionary<ushort, string>.Empty,
+            Points = System.Collections.Immutable.ImmutableDictionary<uint, S101PointRecord>.Empty,
+            CurveSegments = System.Collections.Immutable.ImmutableDictionary<uint, S101CurveSegmentRecord>.Empty,
+            CompositeCurves = System.Collections.Immutable.ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
+            Surfaces = System.Collections.Immutable.ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
+            Features = System.Collections.Immutable.ImmutableArray<S101FeatureRecord>.Empty,
+            InformationTypes = System.Collections.Immutable.ImmutableDictionary<uint, S101InformationRecord>.Empty,
+            InformationTypeCatalogue = System.Collections.Immutable.ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = System.Collections.Immutable.ImmutableDictionary<ushort, string>.Empty,
+            FeatureAssociationCatalogue = System.Collections.Immutable.ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = System.Collections.Immutable.ImmutableDictionary<ushort, string>.Empty,
+        };
+
     [SkippableFact]
     public void S104_entry_is_projected_with_real_bounds()
     {


### PR DESCRIPTION
## Summary

Triage and resolution of the open `mcp`-labelled issues. Each fix carries a matching xunit test.

| # | Title | Outcome |
|---|-------|---------|
| #310 | list_datasets reports edition 0.0.0 for S-101 | **Fixed** |
| #311 | Sounding depth (Z) dropped from describe_feature | **Fixed** |
| #312 | query_features calling convention friction | **Fixed** |
| #313 | S-101 associated text not resolved | **Fixed** |
| #153 | render_to_image PNG/native-bitmap leak | **Already fixed** (`dbe48f3`) — recommend close |

## Details

**#310 — S-101 edition projection.** `ViewerDatasetCatalog.ProjectS101` hard-coded `new SpecRef("S-101", default)`, so the catalog always reported edition `0.0.0` even when the cell declared a parseable PRED. Added `ResolveS101Edition` which reads and normalises the dataset's declared product-specification edition.

**#311 — sounding depth.** The vector `Feature.Coordinates` contract is 2-D `(Lat, Lon)`, so the Z ordinate of MultiPoint `Sounding` points was discarded. `S101FeatureDescriber` now reads each point's Z, scales it by the dataset's Z multiplication factor (DSSI `CMFZ`, defaulting to the S-57 SOMF value of 10 when zero — matching `S101LuaDataProvider`), and emits a parallel `depths` array aligned one-to-one with `coordinates`. Non-MultiPoint geometry is unaffected (`depths` is null).

**#312 — query_features ergonomics.** The wire layer now accepts a **structured** query object directly (a JSON string is still accepted for back-compat), adds an optional `datasetId` scope for parity with `count_features` / `search_features`, and maps malformed query envelopes (missing `kind`, bad JSON, out-of-range coords) to a structured `invalid_argument` error naming the offending parameter instead of an opaque `internal_error`.

**#313 — associated text.** `describe_feature` for S-101 now dereferences each information association against the document's information type records and inlines the linked record's type and attributes (e.g. `information` / text) under a `target` block — a single, bounded, non-recursive dereference.

**#153 — render leak.** Verified already resolved by `dbe48f3`; `MapsuiMapHost.RenderCurrentViewToPngAsync` disposes the snapshot map (after detaching live layers) and both the bitmap stream and intermediate `MemoryStream`. Posted a close-out comment recommending closure.

## Tests

- `ViewerDatasetCatalogTests` — edition parse / default / declared-edition surfacing.
- `DescribeFeatureToolS101Tests` — sounding depths aligned with coordinates; non-MultiPoint omits depths; info association inlines target record text; empty associations array.
- `S100McpServerRoundTripTests` — structured-object query, `datasetId` scoping, malformed query → `invalid_argument` (existing string-query back-compat retained).

All affected projects green: Mcp.Tests (37), Mcp.Tools.Tests (304), Viewer.Tests (956).

Closes #310, #311, #312, #313. Recommends closing #153.