### PR TITLE
Use toggle switches for immediate-effect viewer settings

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml
+++ b/src/EncDotNet.S100.Viewer/App.axaml
@@ -119,5 +119,33 @@
             <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
         </Style>
+
+        <!--
+          Shared layout for settings whose change takes immediate effect:
+          a label on the left and a caption-less ToggleSwitch flush to the
+          right (the conventional settings-row layout). Used by the Settings
+          and ECDIS Display Controls panels. Apply Classes="settingRow" to a
+          two-column Grid (ColumnDefinitions="*,Auto") holding a TextBlock
+          label and a ToggleSwitch with Classes="setting".
+        -->
+        <Style Selector="ToggleSwitch.setting">
+            <Setter Property="OnContent" Value="" />
+            <Setter Property="OffContent" Value="" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+        </Style>
+        <!--
+          ShadUI's ToggleSwitch fills its "on" track with PrimaryColor; point
+          it at the application AccentBrush instead so toggled settings adopt
+          the app accent colour. (Targets the ShadUI template's SwitchBackground
+          part — see ShadUI Controls/Switch/Switch.axaml.)
+        -->
+        <Style Selector="ToggleSwitch.setting /template/ Border#SwitchBackground">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="Grid.settingRow > TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
     </Application.Styles>
 </Application>

--- a/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/EcdisDisplayPanelView.axaml
@@ -48,14 +48,16 @@
                                FontWeight="SemiBold"
                                LetterSpacing="0.5"
                                Opacity="0.7" />
-                    <CheckBox IsChecked="{Binding IsUnderRadarVisible}"
-                              ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayPlane_UnderRadar}">
-                        <TextBlock Text="{x:Static loc:Strings.DisplayPlane_UnderRadar}" />
-                    </CheckBox>
-                    <CheckBox IsChecked="{Binding IsOverRadarVisible}"
-                              ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayPlane_OverRadar}">
-                        <TextBlock Text="{x:Static loc:Strings.DisplayPlane_OverRadar}" />
-                    </CheckBox>
+                    <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                          ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayPlane_UnderRadar}">
+                        <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.DisplayPlane_UnderRadar}" />
+                        <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding IsUnderRadarVisible}" />
+                    </Grid>
+                    <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                          ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayPlane_OverRadar}">
+                        <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.DisplayPlane_OverRadar}" />
+                        <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding IsOverRadarVisible}" />
+                    </Grid>
                 </StackPanel>
 
                 <!-- Global reset -->
@@ -99,7 +101,7 @@
                                     <ItemsControl ItemsSource="{Binding Sections}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate x:DataType="vm:EcdisViewingGroupSectionViewModel">
-                                                <StackPanel Spacing="2" Margin="0,4,0,0">
+                                                <StackPanel Spacing="2" Margin="0,12,0,0">
                                                     <TextBlock Text="{Binding Title}"
                                                                IsVisible="{Binding HasTitle}"
                                                                FontSize="11"
@@ -110,12 +112,19 @@
                                                     <ItemsControl ItemsSource="{Binding ViewingGroups}">
                                                         <ItemsControl.ItemTemplate>
                                                             <DataTemplate x:DataType="vm:EcdisViewingGroupViewModel">
-                                                                <CheckBox IsChecked="{Binding IsVisible}"
-                                                                          ToolTip.Tip="{Binding Tooltip}"
-                                                                          Margin="0,1">
-                                                                    <TextBlock Text="{Binding DisplayLabel}"
+                                                                <!-- Left margin indents sub-section rows; right margin
+                                                                     keeps the right-aligned switch clear of the panel edge. -->
+                                                                <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                                                                      Margin="12,1,12,1"
+                                                                      ToolTip.Tip="{Binding Tooltip}">
+                                                                    <TextBlock Grid.Column="0"
+                                                                               Text="{Binding DisplayLabel}"
+                                                                               TextWrapping="NoWrap"
                                                                                TextTrimming="CharacterEllipsis" />
-                                                                </CheckBox>
+                                                                    <ToggleSwitch Grid.Column="1"
+                                                                                  Classes="setting"
+                                                                                  IsChecked="{Binding IsVisible}" />
+                                                                </Grid>
                                                             </DataTemplate>
                                                         </ItemsControl.ItemTemplate>
                                                     </ItemsControl>

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -171,9 +171,11 @@
                        FontSize="11"
                        Opacity="0.6"
                        TextWrapping="Wrap" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_BasemapEnabled}"
-                      IsChecked="{Binding BasemapEnabled}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_BasemapEnabled}" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_BasemapEnabled}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_BasemapEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding BasemapEnabled}" />
+            </Grid>
 
             <!-- Rendering optimizations (Settings → Map) -->
             <TextBlock Text="{x:Static loc:Strings.Settings_MapOptimizationsSubsection}"
@@ -184,22 +186,30 @@
                        FontSize="11"
                        Opacity="0.6"
                        TextWrapping="Wrap" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_VectorSnapshotEnabled}"
-                      IsChecked="{Binding VectorSnapshotEnabled}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_VectorSnapshotEnabled}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_VectorSnapshotPrebuildEnabled}"
-                      IsChecked="{Binding VectorSnapshotPrebuildEnabled}"
-                      IsEnabled="{Binding VectorSnapshotEnabled}"
-                      Margin="16,0,0,0"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_VectorSnapshotPrebuildEnabled}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_VectorPathCacheEnabled}"
-                      IsChecked="{Binding VectorPathCacheEnabled}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_VectorPathCacheEnabled}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_GeometrySimplificationEnabled}"
-                      IsChecked="{Binding GeometrySimplificationEnabled}"
-                      IsEnabled="{Binding VectorPathCacheEnabled}"
-                      Margin="16,0,0,0"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_GeometrySimplificationEnabled}" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_VectorSnapshotEnabled}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_VectorSnapshotEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding VectorSnapshotEnabled}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  Margin="16,0,0,0"
+                  IsEnabled="{Binding VectorSnapshotEnabled}"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_VectorSnapshotPrebuildEnabled}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_VectorSnapshotPrebuildEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding VectorSnapshotPrebuildEnabled}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_VectorPathCacheEnabled}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_VectorPathCacheEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding VectorPathCacheEnabled}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  Margin="16,0,0,0"
+                  IsEnabled="{Binding VectorPathCacheEnabled}"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_GeometrySimplificationEnabled}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_GeometrySimplificationEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding GeometrySimplificationEnabled}" />
+            </Grid>
 
             <!-- Mariner Settings (S-100 Part 9 §4.2) -->
             <Separator Margin="0,8,0,0" />
@@ -279,27 +289,41 @@
             </StackPanel>
 
             <!-- S-101 toggles -->
-            <CheckBox Content="{x:Static loc:Strings.Settings_FourShades}"
-                      IsChecked="{Binding FourShades}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_FourShades}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_ShallowWaterDangers}"
-                      IsChecked="{Binding ShallowWaterDangers}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShallowWaterDangers}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_PlainBoundaries}"
-                      IsChecked="{Binding PlainBoundaries}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_PlainBoundaries}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_SimplifiedSymbols}"
-                      IsChecked="{Binding SimplifiedSymbols}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_SimplifiedSymbols}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_FullLightLines}"
-                      IsChecked="{Binding FullLightLines}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_FullLightLines}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_RadarOverlay}"
-                      IsChecked="{Binding RadarOverlay}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_RadarOverlay}" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_IgnoreScaleMinimum}"
-                      IsChecked="{Binding IgnoreScaleMinimum}"
-                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_IgnoreScaleMinimum}" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_FourShades}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_FourShades}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding FourShades}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShallowWaterDangers}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_ShallowWaterDangers}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding ShallowWaterDangers}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_PlainBoundaries}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_PlainBoundaries}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding PlainBoundaries}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_SimplifiedSymbols}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_SimplifiedSymbols}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding SimplifiedSymbols}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_FullLightLines}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_FullLightLines}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding FullLightLines}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_RadarOverlay}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_RadarOverlay}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding RadarOverlay}" />
+            </Grid>
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_IgnoreScaleMinimum}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_IgnoreScaleMinimum}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding IgnoreScaleMinimum}" />
+            </Grid>
 
             <!-- National Language -->
             <StackPanel Spacing="6">
@@ -327,9 +351,11 @@
             <TextBlock Text="{x:Static loc:Strings.Settings_OwnVesselSection_Help}"
                        TextWrapping="Wrap"
                        Opacity="0.75" />
-            <CheckBox IsChecked="{Binding OwnShipOverlayEnabled}"
-                      Content="{x:Static loc:Strings.Settings_OwnVessel_OverlayEnabled}"
-                      ToolTip.Tip="{x:Static loc:Strings.Settings_OwnVessel_OverlayEnabled_Tooltip}" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Settings_OwnVessel_OverlayEnabled_Tooltip}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_OwnVessel_OverlayEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding OwnShipOverlayEnabled}" />
+            </Grid>
             <StackPanel Spacing="6">
                 <TextBlock Text="{x:Static loc:Strings.Settings_OwnVessel_Length}"
                            FontSize="12" />
@@ -377,9 +403,11 @@
                        FontSize="12"
                        FontWeight="SemiBold"
                        Margin="0,12,0,0" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_McpEnabled}"
-                      IsChecked="{Binding McpEnabled}"
-                      ToolTip.Tip="{x:Static loc:Strings.Settings_McpEnabledTooltip}" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Settings_McpEnabledTooltip}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_McpEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding McpEnabled}" />
+            </Grid>
             <StackPanel Spacing="6">
                 <TextBlock Text="{x:Static loc:Strings.Settings_McpPort}"
                            FontSize="12"
@@ -409,9 +437,11 @@
                        FontSize="11"
                        Opacity="0.6"
                        TextWrapping="Wrap" />
-            <CheckBox Content="{x:Static loc:Strings.Settings_AisEnabled}"
-                      IsChecked="{Binding AisEnabled}"
-                      ToolTip.Tip="{x:Static loc:Strings.Settings_AisEnabledTooltip}" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Settings_AisEnabledTooltip}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_AisEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding AisEnabled}" />
+            </Grid>
             <StackPanel Spacing="6">
                 <TextBlock Text="{x:Static loc:Strings.Settings_AisApiKey}"
                            FontSize="12"


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

Checkboxes are an awkward affordance for settings that take effect the
instant you change them. This PR converts the immediate-effect controls in
the viewer's **Settings** and **ECDIS Display Controls** panels to toggle
switches, which read more clearly as "on/off, live" and match common
desktop conventions.

Approach:
- Each setting becomes a settings row: a label on the left and a
  caption-less `ToggleSwitch` flush to the right, driven by shared
  `ToggleSwitch.setting` / `Grid.settingRow` styles promoted to
  `App.axaml` so both panels stay consistent.
- The nested S-101 viewing-group rows get a left indent (to read as a
  sub-section) plus a right gutter so the switch's rounded edge is no
  longer clipped at the panel edge, and subsection spacing is increased
  for legibility.
- The switches now use the application accent colour. The non-obvious
  part: this app themes controls with **ShadUI**, whose `ToggleSwitch`
  fills its "on" track (`SwitchBackground` template part) with
  `PrimaryColor`, not Avalonia Fluent's `ToggleSwitchFillOn`. So the
  fix targets ShadUI's template part directly and points it at
  `AccentBrush`.

Scope notes: mutually-exclusive Display Category options remain
RadioButtons, and non-immediate or non-settings checkboxes (layer
visibility, text-group filters, feedback dialog) are intentionally left
as checkboxes.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a viewer UI/UX change only; no spec semantics are touched.

**Spec section references cited in code/docs:**

N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

UI-only XAML/styling change with no testable library logic; verified
visually in the viewer against an S-101 cell (both panels, on/off
states, accent colour, indentation, and clipping).

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour
      changed
- [ ] New public APIs have XML doc comments

No public API changes; no doc updates required.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to
      `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.