### PR TITLE
Viewer UX polish: pick report redesign, shared accent lists, display settings overlay

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml
+++ b/src/EncDotNet.S100.Viewer/App.axaml
@@ -147,5 +147,156 @@
             <Setter Property="VerticalAlignment" Value="Center" />
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
+
+        <!--
+          Shared activity-panel list selection language. Every selectable
+          list in the side panels (Datasets, Feature Search, Catalogues,
+          Vessels, and the Pick Report hit list) adopts the same subtle
+          look instead of a solid accent fill with white text: a 3px accent
+          left bar plus a low-opacity accent tint on hover/selection, and
+          the row's primary text adopting the accent colour when selected.
+          The tint keeps secondary text and inline icons legible without
+          per-row white overrides — important for the muted S-100 dusk and
+          night chrome variants where a bright fill dominates the panel.
+
+          Usage: apply Classes="accentList" to a ListBox, and mark each
+          row's primary/title TextBlock with Classes="accentListTitle" so
+          it picks up the accent colour on selection. Per-row padding can be
+          tuned by overriding ListBoxItem Padding in a list-scoped style.
+        -->
+        <Style Selector="ListBox.accentList ListBoxItem">
+            <Setter Property="Padding" Value="8,5" />
+            <Setter Property="Margin" Value="0,1" />
+            <!-- MinHeight matches the effective height of the datasets list rows
+                 (a 36px ShadUI Icon button + 2x5px vertical padding) so every
+                 accent list shares the same vertical rhythm regardless of whether
+                 a row carries action buttons or text only. -->
+            <Setter Property="MinHeight" Value="46" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Grid ColumnDefinitions="3,*">
+                        <Border Name="PART_Bar"
+                                Grid.Column="0"
+                                Width="3"
+                                CornerRadius="1.5"
+                                Background="Transparent" />
+                        <Panel Grid.Column="1">
+                            <Border Name="PART_Tint"
+                                    Background="{DynamicResource AccentBrush}"
+                                    Opacity="0"
+                                    CornerRadius="4" />
+                            <ContentPresenter Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              Padding="{TemplateBinding Padding}"
+                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              HorizontalContentAlignment="Stretch" />
+                        </Panel>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="ListBox.accentList ListBoxItem:pointerover /template/ Border#PART_Tint">
+            <Setter Property="Opacity" Value="0.06" />
+        </Style>
+        <Style Selector="ListBox.accentList ListBoxItem:selected /template/ Border#PART_Tint">
+            <Setter Property="Opacity" Value="0.12" />
+        </Style>
+        <Style Selector="ListBox.accentList ListBoxItem:selected /template/ Border#PART_Bar">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="ListBox.accentList ListBoxItem:selected TextBlock.accentListTitle">
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+        </Style>
+
+        <!--
+          Segmented control (iOS-style pill group) used by the map Display
+          Settings overlay. A rounded track (Border.segmentTrack) holds an
+          equal-width row of segments; the active segment is lifted onto a
+          raised card. Two segment flavours share one look:
+            * RadioButton.segment  — single-select groups (display category,
+              palette). Exactly one segment is checked at a time.
+            * ToggleButton.segment — independent multi-toggle groups (text
+              viewing groups), where each segment can be on/off on its own.
+          Theme-aware: the track uses SecondaryColor and the raised card uses
+          CardBackgroundColor, so the control adapts to the S-100 dusk/night
+          chrome variants alongside the rest of the app.
+        -->
+        <Style Selector="Border.segmentTrack">
+            <Setter Property="Background" Value="{DynamicResource SecondaryColor}" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="3" />
+        </Style>
+        <Style Selector="RadioButton.segment">
+            <Setter Property="Foreground" Value="{DynamicResource MutedColor}" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="MinHeight" Value="28" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Name="Seg"
+                            Background="Transparent"
+                            CornerRadius="6"
+                            Padding="12,5">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="ToggleButton.segment">
+            <Setter Property="Foreground" Value="{DynamicResource MutedColor}" />
+            <Setter Property="FontSize" Value="12" />
+            <!-- ShadUI's base ToggleButton sets MinHeight=36; pin both segment
+                 flavours to the same MinHeight so the multi-toggle Text row
+                 lines up exactly with the single-select Display/Palette rows. -->
+            <Setter Property="MinHeight" Value="28" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Name="Seg"
+                            Background="Transparent"
+                            CornerRadius="6"
+                            Padding="12,5">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <!-- Hover affordance on the resting (unchecked) segments. -->
+        <Style Selector="RadioButton.segment:pointerover /template/ Border#Seg">
+            <Setter Property="Background" Value="{DynamicResource BorderColor30}" />
+        </Style>
+        <Style Selector="ToggleButton.segment:pointerover /template/ Border#Seg">
+            <Setter Property="Background" Value="{DynamicResource BorderColor30}" />
+        </Style>
+        <!-- Active segment: raised card + stronger, bolder text. -->
+        <Style Selector="RadioButton.segment:checked /template/ Border#Seg">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundColor}" />
+            <Setter Property="BoxShadow" Value="0 1 3 0 #1F000000" />
+        </Style>
+        <Style Selector="ToggleButton.segment:checked /template/ Border#Seg">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundColor}" />
+            <Setter Property="BoxShadow" Value="0 1 3 0 #1F000000" />
+        </Style>
+        <Style Selector="RadioButton.segment:checked">
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <Style Selector="ToggleButton.segment:checked">
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <!-- Disabled track (e.g. Text group with no text layers loaded). -->
+        <Style Selector="Border.segmentTrack:disabled">
+            <Setter Property="Opacity" Value="0.5" />
+        </Style>
     </Application.Styles>
 </Application>

--- a/src/EncDotNet.S100.Viewer/AttributeColourSwatchConverter.cs
+++ b/src/EncDotNet.S100.Viewer/AttributeColourSwatchConverter.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Renders a small colour swatch beside attribute values that name a
+/// colour (e.g. an S-101 <c>colour</c> attribute decoded to "Red"). The
+/// converter input is the <see cref="PickAttribute"/> row; with the default
+/// (or <c>"brush"</c>) parameter it returns the swatch <see cref="IBrush"/>
+/// (transparent when the row is not a recognised colour), and with the
+/// <c>"visible"</c> parameter it returns a <see cref="bool"/> for the
+/// swatch's visibility. The swatch is purely indicative — it is not a
+/// portrayal-accurate colour token.
+/// </summary>
+internal sealed class AttributeColourSwatchConverter : IValueConverter
+{
+    public static AttributeColourSwatchConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var brush = ResolveBrush(value as PickAttribute);
+        var wantVisible = string.Equals(parameter as string, "visible", StringComparison.OrdinalIgnoreCase);
+        if (wantVisible)
+            return brush is not null;
+
+        return brush ?? Brushes.Transparent;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+
+    private static IBrush? ResolveBrush(PickAttribute? attr)
+    {
+        if (attr is null)
+            return null;
+
+        // Only attempt a swatch for colour-typed attributes so non-colour
+        // values that happen to spell a colour word are left untouched.
+        if (!IsColourAttribute(attr.Code, attr.Name))
+            return null;
+
+        var text = attr.DisplayText;
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        // Colour values may be compound (e.g. "Red;White"); the swatch shows
+        // the first recognised colour.
+        foreach (var token in text.Split([';', '/', ',', '&'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (TryMapColour(token, out var color))
+                return new SolidColorBrush(color);
+        }
+
+        return null;
+    }
+
+    private static bool IsColourAttribute(string? code, string? name)
+        => Contains(code, "colour") || Contains(code, "color")
+           || Contains(name, "colour") || Contains(name, "color");
+
+    private static bool Contains(string? haystack, string needle)
+        => haystack is not null && haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryMapColour(string token, out Color color)
+    {
+        color = token.ToLowerInvariant() switch
+        {
+            "white" => Colors.White,
+            "black" => Colors.Black,
+            "red" => Color.FromRgb(0xD0, 0x21, 0x21),
+            "green" => Color.FromRgb(0x1F, 0x9D, 0x55),
+            "blue" => Color.FromRgb(0x1F, 0x6F, 0xD0),
+            "yellow" => Color.FromRgb(0xF2, 0xC4, 0x1D),
+            "grey" or "gray" => Color.FromRgb(0x80, 0x80, 0x80),
+            "brown" => Color.FromRgb(0x8B, 0x5A, 0x2B),
+            "amber" => Color.FromRgb(0xFF, 0xBF, 0x00),
+            "violet" => Color.FromRgb(0x7A, 0x3C, 0xC8),
+            "orange" => Color.FromRgb(0xE8, 0x7A, 0x17),
+            "magenta" => Color.FromRgb(0xC0, 0x37, 0x8A),
+            "pink" => Color.FromRgb(0xE8, 0x8A, 0xA8),
+            _ => default,
+        };
+
+        return color != default;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/AttributeTooltipConverter.cs
+++ b/src/EncDotNet.S100.Viewer/AttributeTooltipConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Builds a tooltip string that pairs a friendly label/value with its raw
+/// counterpart so the full text remains readable even when the table cell
+/// truncates it. The converter takes two bindings — <c>[friendly, raw]</c>
+/// — and returns <c>"friendly (raw)"</c>. The parenthesised raw form is
+/// omitted when the raw text is empty or equal (ordinal, case-insensitive)
+/// to the friendly text, avoiding redundant <c>"Foo (Foo)"</c> tooltips.
+/// </summary>
+internal sealed class AttributeTooltipConverter : IMultiValueConverter
+{
+    public static AttributeTooltipConverter Instance { get; } = new();
+
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var friendly = values.Count > 0 ? values[0] as string : null;
+        var raw = values.Count > 1 ? values[1] as string : null;
+
+        if (string.IsNullOrWhiteSpace(friendly))
+            return string.IsNullOrWhiteSpace(raw) ? null : raw;
+
+        if (string.IsNullOrWhiteSpace(raw) ||
+            string.Equals(friendly, raw, StringComparison.OrdinalIgnoreCase))
+            return friendly;
+
+        return $"{friendly} ({raw})";
+    }
+}

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -467,110 +467,160 @@
                         <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
                     </Button>
                     <!--
-                      Display category pill — compact label that opens
-                      a flyout to switch between ECDIS display categories.
+                      Consolidated display-settings button. Replaces the
+                      former Display category / Text / Palette pills with a
+                      single overlay panel that exposes all three as
+                      segmented toggles (see the segmented-control styles in
+                      App.axaml). The button adopts the accent fill while its
+                      flyout is open (:flyout-open), matching the Pick and
+                      Measure mode buttons above.
                     -->
-                    <Button Classes="MapOverlay"
-                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplayMode}"
-                            Padding="8,4"
-                            FontSize="11"
-                            HorizontalContentAlignment="Center"
-                            VerticalContentAlignment="Center"
-                            Content="{Binding DisplayToolbar.ActiveCategoryLabel}">
+                    <Button x:Name="DisplaySettingsButton"
+                            Classes="Icon MapOverlay"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_DisplaySettings}">
+                        <Button.Styles>
+                            <Style Selector="Button#DisplaySettingsButton:flyout-open">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#DisplaySettingsButton:flyout-open /template/ ContentPresenter">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                            </Style>
+                            <Style Selector="Button#DisplaySettingsButton:flyout-open ic|FluentIcon">
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#DisplaySettingsButton:flyout-open /template/ Border#HoverBackground">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Opacity" Value="1" />
+                            </Style>
+                        </Button.Styles>
+                        <ic:FluentIcon Icon="Options" IconVariant="Regular" FontSize="16" />
                         <Button.Flyout>
-                            <Flyout Placement="BottomEdgeAlignedRight">
-                                <StackPanel Spacing="4" MinWidth="160">
-                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_DisplayBase}"
-                                                 IsChecked="{Binding DisplayToolbar.IsDisplayBase, Mode=OneWay}"
-                                                 GroupName="DisplayCategoryFlyout">
-                                        <RadioButton.Command>
-                                            <Binding Path="DisplayToolbar.SetDisplayBaseCommand" />
-                                        </RadioButton.Command>
-                                    </RadioButton>
-                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_Standard}"
-                                                 IsChecked="{Binding DisplayToolbar.IsStandard, Mode=OneWay}"
-                                                 GroupName="DisplayCategoryFlyout">
-                                        <RadioButton.Command>
-                                            <Binding Path="DisplayToolbar.SetStandardCommand" />
-                                        </RadioButton.Command>
-                                    </RadioButton>
-                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_OtherInformation}"
-                                                 IsChecked="{Binding DisplayToolbar.IsOtherInformation, Mode=OneWay}"
-                                                 GroupName="DisplayCategoryFlyout">
-                                        <RadioButton.Command>
-                                            <Binding Path="DisplayToolbar.SetOtherInformationCommand" />
-                                        </RadioButton.Command>
-                                    </RadioButton>
-                                    <RadioButton Content="{x:Static loc:Strings.DisplayCategory_All}"
-                                                 IsChecked="{Binding DisplayToolbar.IsAll, Mode=OneWay}"
-                                                 GroupName="DisplayCategoryFlyout">
-                                        <RadioButton.Command>
-                                            <Binding Path="DisplayToolbar.SetAllCommand" />
-                                        </RadioButton.Command>
-                                    </RadioButton>
+                            <Flyout Placement="Left">
+                                <!-- Fixed-width content inside a padded border:
+                                     the explicit Width keeps the panel from
+                                     nudging wider when a segment's label turns
+                                     semibold on selection, and the Border gives
+                                     the card breathing room on all edges. -->
+                                <Border Padding="16,14,16,16" Background="Transparent">
+                                <StackPanel Width="340" Spacing="14">
+                                    <!-- Header -->
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{x:Static loc:Strings.DisplaySettings_Title}"
+                                                   FontSize="11"
+                                                   FontWeight="SemiBold"
+                                                   LetterSpacing="0.8"
+                                                   Opacity="0.7"
+                                                   VerticalAlignment="Center" />
+                                        <Button Grid.Column="1"
+                                                Classes="Icon"
+                                                Width="28"
+                                                Height="28"
+                                                Padding="0"
+                                                Click="OnCloseDisplaySettings"
+                                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseDisplaySettings}">
+                                            <ic:FluentIcon Icon="Dismiss"
+                                                           IconVariant="Regular"
+                                                           FontSize="16"
+                                                           Foreground="{DynamicResource ForegroundColor}" />
+                                        </Button>
+                                    </Grid>
+
+                                    <!-- Display base -->
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="{x:Static loc:Strings.DisplaySettings_DisplayBaseHeader}"
+                                                   FontSize="12"
+                                                   FontWeight="Medium"
+                                                   Opacity="0.8" />
+                                        <Border Classes="segmentTrack">
+                                            <UniformGrid Rows="1">
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsCategory"
+                                                             Content="{x:Static loc:Strings.Segment_DisplayBase}"
+                                                             IsChecked="{Binding DisplayToolbar.IsDisplayBase, Mode=OneWay}"
+                                                             Command="{Binding DisplayToolbar.SetDisplayBaseCommand}" />
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsCategory"
+                                                             Content="{x:Static loc:Strings.DisplayCategory_Standard}"
+                                                             IsChecked="{Binding DisplayToolbar.IsStandard, Mode=OneWay}"
+                                                             Command="{Binding DisplayToolbar.SetStandardCommand}" />
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsCategory"
+                                                             Content="{x:Static loc:Strings.Segment_DisplayOther}"
+                                                             IsChecked="{Binding DisplayToolbar.IsOtherInformation, Mode=OneWay}"
+                                                             Command="{Binding DisplayToolbar.SetOtherInformationCommand}" />
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsCategory"
+                                                             Content="{x:Static loc:Strings.DisplayCategory_All}"
+                                                             IsChecked="{Binding DisplayToolbar.IsAll, Mode=OneWay}"
+                                                             Command="{Binding DisplayToolbar.SetAllCommand}" />
+                                            </UniformGrid>
+                                        </Border>
+                                    </StackPanel>
+
+                                    <!-- Text viewing groups -->
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="{x:Static loc:Strings.DisplaySettings_TextHeader}"
+                                                   FontSize="12"
+                                                   FontWeight="Medium"
+                                                   Opacity="0.8" />
+                                        <Border Classes="segmentTrack"
+                                                IsEnabled="{Binding TextToolbar.IsEnabled}">
+                                            <UniformGrid Rows="1">
+                                                <ToggleButton Classes="segment"
+                                                              Content="{x:Static loc:Strings.Segment_TextImportant}"
+                                                              IsChecked="{Binding TextToolbar.IsImportantVisible, Mode=OneWay}"
+                                                              Command="{Binding TextToolbar.ToggleImportantCommand}" />
+                                                <ToggleButton Classes="segment"
+                                                              Content="{x:Static loc:Strings.Segment_TextOther}"
+                                                              IsChecked="{Binding TextToolbar.IsOtherVisible, Mode=OneWay}"
+                                                              Command="{Binding TextToolbar.ToggleOtherCommand}" />
+                                                <ToggleButton Classes="segment"
+                                                              Content="{x:Static loc:Strings.Segment_TextAll}"
+                                                              IsChecked="{Binding TextToolbar.IsAllVisible, Mode=OneWay}"
+                                                              Command="{Binding TextToolbar.ToggleAllCommand}" />
+                                            </UniformGrid>
+                                        </Border>
+                                    </StackPanel>
+
+                                    <!--
+                                      S-100 map palette (PR-N1) — Day/Dusk/Night
+                                      switch for the chart S-100 colour profile.
+                                      Bound to SettingsViewModel.SelectedPalette
+                                      which already triggers a re-render through
+                                      DatasetLoaderService.
+                                    -->
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="{x:Static loc:Strings.DisplaySettings_PaletteHeader}"
+                                                   FontSize="12"
+                                                   FontWeight="Medium"
+                                                   Opacity="0.8" />
+                                        <Border Classes="segmentTrack">
+                                            <UniformGrid Rows="1">
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsPalette"
+                                                             Content="{x:Static loc:Strings.Palette_Day}"
+                                                             IsChecked="{Binding Settings.IsPaletteDay, Mode=OneWay}"
+                                                             Command="{Binding Settings.SetPaletteDayCommand}" />
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsPalette"
+                                                             Content="{x:Static loc:Strings.Palette_Dusk}"
+                                                             IsChecked="{Binding Settings.IsPaletteDusk, Mode=OneWay}"
+                                                             Command="{Binding Settings.SetPaletteDuskCommand}" />
+                                                <RadioButton Classes="segment"
+                                                             GroupName="DisplaySettingsPalette"
+                                                             Content="{x:Static loc:Strings.Palette_Night}"
+                                                             IsChecked="{Binding Settings.IsPaletteNight, Mode=OneWay}"
+                                                             Command="{Binding Settings.SetPaletteNightCommand}" />
+                                            </UniformGrid>
+                                        </Border>
+                                    </StackPanel>
                                 </StackPanel>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
-                    <!--
-                      Text group pill — compact label that opens a flyout
-                      to toggle text viewing-group layers on/off.
-                    -->
-                    <Button Classes="MapOverlay"
-                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_TextGroupPill}"
-                            Padding="8,4"
-                            FontSize="11"
-                            HorizontalContentAlignment="Center"
-                            VerticalContentAlignment="Center"
-                            Content="{x:Static loc:Strings.Toolbar_Text}"
-                            IsEnabled="{Binding TextToolbar.IsEnabled}">
-                        <Button.Flyout>
-                            <Flyout Placement="BottomEdgeAlignedRight">
-                                <StackPanel Spacing="4" MinWidth="160">
-                                    <CheckBox Content="{x:Static loc:Strings.TextGroup_Important}"
-                                              IsChecked="{Binding TextToolbar.IsImportantVisible}"
-                                              Command="{Binding TextToolbar.ToggleImportantCommand}" />
-                                    <CheckBox Content="{x:Static loc:Strings.TextGroup_Other}"
-                                              IsChecked="{Binding TextToolbar.IsOtherVisible}"
-                                              Command="{Binding TextToolbar.ToggleOtherCommand}" />
-                                    <CheckBox Content="{x:Static loc:Strings.TextGroup_All}"
-                                              IsChecked="{Binding TextToolbar.IsAllVisible}"
-                                              Command="{Binding TextToolbar.ToggleAllCommand}" />
-                                </StackPanel>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
-                    <!--
-                      S-100 map palette pill (PR-N1) — Day/Dusk/Night
-                      switch for the chart S-100 colour profile. Bound to
-                      SettingsViewModel.SelectedPalette which already
-                      triggers a re-render through DatasetLoaderService;
-                      this is purely a more-accessible UI surface for an
-                      existing setting.
-                    -->
-                    <Button Classes="MapOverlay"
-                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_SwitchPalette}"
-                            Padding="8,4"
-                            FontSize="11"
-                            HorizontalContentAlignment="Center"
-                            VerticalContentAlignment="Center"
-                            Content="{x:Static loc:Strings.Toolbar_Palette}">
-                        <Button.Flyout>
-                            <Flyout Placement="BottomEdgeAlignedRight">
-                                <StackPanel Spacing="4" MinWidth="160">
-                                    <RadioButton Content="{x:Static loc:Strings.Palette_Day}"
-                                                 GroupName="MapPaletteFlyout"
-                                                 IsChecked="{Binding Settings.IsPaletteDay, Mode=OneWay}"
-                                                 Command="{Binding Settings.SetPaletteDayCommand}" />
-                                    <RadioButton Content="{x:Static loc:Strings.Palette_Dusk}"
-                                                 GroupName="MapPaletteFlyout"
-                                                 IsChecked="{Binding Settings.IsPaletteDusk, Mode=OneWay}"
-                                                 Command="{Binding Settings.SetPaletteDuskCommand}" />
-                                    <RadioButton Content="{x:Static loc:Strings.Palette_Night}"
-                                                 GroupName="MapPaletteFlyout"
-                                                 IsChecked="{Binding Settings.IsPaletteNight, Mode=OneWay}"
-                                                 Command="{Binding Settings.SetPaletteNightCommand}" />
-                                </StackPanel>
+                                </Border>
                             </Flyout>
                         </Button.Flyout>
                     </Button>

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -50,6 +50,7 @@ public partial class MainWindow : ShadUI.Window
     private bool _closeAfterScreenshot;
     private bool _fullWindowScreenshot;
     private ViewerCommandSettings? _startupOptions;
+    private Color _accentColor;
 
     public MainWindow() : this(null) { }
 
@@ -204,9 +205,13 @@ public partial class MainWindow : ShadUI.Window
             }
         }
 
-        // Apply persisted accent color
+        // Apply persisted accent color. Both the user's colour choice and
+        // the active chrome theme feed the effective brush, so re-apply on
+        // either change (the low-light themes mute the accent).
         ApplyAccentColor(_viewModel.Settings.AccentColor);
         _viewModel.Settings.AccentColorChanged += ApplyAccentColor;
+        if (Application.Current is { } themedApp)
+            themedApp.ActualThemeVariantChanged += (_, _) => ApplyAccentColor(_accentColor);
 
         // Apply persisted scale-bar distance unit and react to changes.
         ScaleBar.Unit = _viewModel.Settings.DistanceUnit;
@@ -524,6 +529,15 @@ public partial class MainWindow : ShadUI.Window
     }
 
     /// <summary>
+    /// Closes the consolidated display-settings overlay when its in-panel
+    /// close (✕) button is clicked. The flyout otherwise dismisses on
+    /// light-dismiss (click-away) or Escape; this button gives the panel
+    /// an explicit affordance matching the mockup.
+    /// </summary>
+    private void OnCloseDisplaySettings(object? sender, RoutedEventArgs e)
+        => DisplaySettingsButton.Flyout?.Hide();
+
+    /// <summary>
     /// Adds or removes the online basemap tile layer in response to the
     /// Settings toggle (issue #295). The basemap always sits at the
     /// bottom of the layer stack (index 0) beneath every dataset and
@@ -790,7 +804,10 @@ public partial class MainWindow : ShadUI.Window
 
     private void ApplyAccentColor(Color color)
     {
-        Resources["AccentBrush"] = new SolidColorBrush(color);
+        _accentColor = color;
+        var variant = Application.Current?.ActualThemeVariant;
+        var theme = ChromeThemes.FromVariant(variant) ?? ChromeTheme.Light;
+        Resources["AccentBrush"] = new SolidColorBrush(AccentColors.ForTheme(color, theme));
     }
 
     private void CaptureScreenshot(string outputPath)

--- a/src/EncDotNet.S100.Viewer/ProportionalWidthConverter.cs
+++ b/src/EncDotNet.S100.Viewer/ProportionalWidthConverter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Multiplies a bound width by a fraction (passed as <c>ConverterParameter</c>),
+/// clamping the result to a non-negative value. Used by the pick report's
+/// attribute table to cap the auto-sized label column to a fraction of the
+/// panel width, so a long attribute name grows to fit when there is room but
+/// can never crowd out the value column on a narrow panel.
+/// </summary>
+internal sealed class ProportionalWidthConverter : IValueConverter
+{
+    public static ProportionalWidthConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not double width || double.IsNaN(width) || double.IsInfinity(width))
+            return double.NaN;
+
+        var fraction = parameter switch
+        {
+            double d => d,
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => 1d,
+        };
+
+        return Math.Max(0d, width * fraction);
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -116,6 +116,7 @@ internal static class Strings
     public static string Tooltip_SelectHit => Get(nameof(Tooltip_SelectHit));
     public static string Tooltip_FollowReference => Get(nameof(Tooltip_FollowReference));
     public static string Tooltip_CopyLocation => Get(nameof(Tooltip_CopyLocation));
+    public static string Tooltip_CopyIdentity => Get(nameof(Tooltip_CopyIdentity));
     public static string Tooltip_Search => Get(nameof(Tooltip_Search));
     public static string Tooltip_ClearSearch => Get(nameof(Tooltip_ClearSearch));
     public static string Tooltip_OpenSearchResult => Get(nameof(Tooltip_OpenSearchResult));
@@ -233,6 +234,7 @@ internal static class Strings
     public static string PickReport_EmptyTitle => Get(nameof(PickReport_EmptyTitle));
     public static string PickReport_EmptyDescription => Get(nameof(PickReport_EmptyDescription));
     public static string Pick_IdLabel => Get(nameof(Pick_IdLabel));
+    public static string Pick_IdCaption => Get(nameof(Pick_IdCaption));
     public static string Pick_SpecFormat => Get(nameof(Pick_SpecFormat));
     public static string Pick_SourceFormat => Get(nameof(Pick_SourceFormat));
     public static string Pick_AttributesHeading => Get(nameof(Pick_AttributesHeading));
@@ -420,6 +422,19 @@ internal static class Strings
     // Map palette toolbar pill (PR-N1)
     public static string Toolbar_Palette => Get(nameof(Toolbar_Palette));
     public static string Tooltip_SwitchPalette => Get(nameof(Tooltip_SwitchPalette));
+
+    // Display settings overlay (consolidated map command-bar settings)
+    public static string DisplaySettings_Title => Get(nameof(DisplaySettings_Title));
+    public static string Tooltip_DisplaySettings => Get(nameof(Tooltip_DisplaySettings));
+    public static string Tooltip_CloseDisplaySettings => Get(nameof(Tooltip_CloseDisplaySettings));
+    public static string DisplaySettings_DisplayBaseHeader => Get(nameof(DisplaySettings_DisplayBaseHeader));
+    public static string DisplaySettings_TextHeader => Get(nameof(DisplaySettings_TextHeader));
+    public static string DisplaySettings_PaletteHeader => Get(nameof(DisplaySettings_PaletteHeader));
+    public static string Segment_DisplayBase => Get(nameof(Segment_DisplayBase));
+    public static string Segment_DisplayOther => Get(nameof(Segment_DisplayOther));
+    public static string Segment_TextImportant => Get(nameof(Segment_TextImportant));
+    public static string Segment_TextOther => Get(nameof(Segment_TextOther));
+    public static string Segment_TextAll => Get(nameof(Segment_TextAll));
 
     // Toast notification titles
     public static string Toast_Error => Get(nameof(Toast_Error));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -625,6 +625,13 @@
   <data name="Tooltip_CopyLocation" xml:space="preserve">
     <value>Copy this location (decimal degrees) to the clipboard</value>
   </data>
+  <data name="Pick_IdCaption" xml:space="preserve">
+    <value>ID {0}</value>
+    <comment>Leading segment of the demoted identity caption in the Object Information panel; {0} is the feature identifier.</comment>
+  </data>
+  <data name="Tooltip_CopyIdentity" xml:space="preserve">
+    <value>Copy this feature's name and identity to the clipboard</value>
+  </data>
   <!-- Pick panel: station time-series chart -->
   <data name="Pick_Chart_Title_WaterLevel" xml:space="preserve">
     <value>Water Level</value>
@@ -1134,6 +1141,46 @@
   </data>
   <data name="Tooltip_SwitchPalette" xml:space="preserve">
     <value>Switch S-100 map palette (Day / Dusk / Night)</value>
+  </data>
+
+  <!-- Display settings overlay (consolidated map command-bar settings) -->
+  <data name="DisplaySettings_Title" xml:space="preserve">
+    <value>Display Settings</value>
+  </data>
+  <data name="Tooltip_DisplaySettings" xml:space="preserve">
+    <value>Display settings (category, text, palette)</value>
+  </data>
+  <data name="Tooltip_CloseDisplaySettings" xml:space="preserve">
+    <value>Close display settings</value>
+  </data>
+  <data name="DisplaySettings_DisplayBaseHeader" xml:space="preserve">
+    <value>Display base</value>
+  </data>
+  <data name="DisplaySettings_TextHeader" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="DisplaySettings_PaletteHeader" xml:space="preserve">
+    <value>Palette</value>
+  </data>
+  <data name="Segment_DisplayBase" xml:space="preserve">
+    <value>Base</value>
+    <comment>Compact segment label for the Display Base category in the display-settings overlay.</comment>
+  </data>
+  <data name="Segment_DisplayOther" xml:space="preserve">
+    <value>Other</value>
+    <comment>Compact segment label for the Other Information category in the display-settings overlay.</comment>
+  </data>
+  <data name="Segment_TextImportant" xml:space="preserve">
+    <value>Important</value>
+    <comment>Compact segment label for the Important text viewing group.</comment>
+  </data>
+  <data name="Segment_TextOther" xml:space="preserve">
+    <value>Other</value>
+    <comment>Compact segment label for the Other text viewing group.</comment>
+  </data>
+  <data name="Segment_TextAll" xml:space="preserve">
+    <value>All</value>
+    <comment>Compact segment label for the All text viewing group.</comment>
   </data>
 
   <!-- Toast notification titles -->

--- a/src/EncDotNet.S100.Viewer/Services/AccentColors.cs
+++ b/src/EncDotNet.S100.Viewer/Services/AccentColors.cs
@@ -1,0 +1,66 @@
+using System;
+using Avalonia.Media;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Derives the effective chrome accent brush colour for a given
+/// <see cref="ChromeTheme"/>. The user picks a single accent colour
+/// (<c>ViewerSettings.AccentColor</c>); on the low-light S-100 chrome
+/// themes that vivid colour would otherwise become the brightest,
+/// most saturated element on screen and pull the eye away from the
+/// chart. These themes therefore receive a muted variant — desaturated
+/// and dimmed so the accent reads as an accent, not a beacon — while
+/// the stock Light / Dark themes use the user's colour unchanged.
+/// </summary>
+internal static class AccentColors
+{
+    /// <summary>
+    /// Returns the accent colour to assign to the <c>AccentBrush</c>
+    /// resource for the supplied chrome <paramref name="theme"/>.
+    /// Light and Dark return <paramref name="accent"/> untouched;
+    /// S-100 Dusk and Night return a desaturated, dimmed variant.
+    /// </summary>
+    /// <param name="accent">The user-selected accent colour.</param>
+    /// <param name="theme">The active chrome theme.</param>
+    /// <returns>The muted (or original) accent colour.</returns>
+    public static Color ForTheme(Color accent, ChromeTheme theme) => theme switch
+    {
+        // Night sits on a near-black background; a vivid accent dominates
+        // dark-adapted vision, so desaturate hard and dim well below the
+        // surrounding text brightness.
+        ChromeTheme.S100Night => Mute(accent, saturationScale: 0.55, brightnessScale: 0.60),
+
+        // Dusk is a warm-dim light palette; soften the accent's vibrancy
+        // and pull it down slightly so it harmonises with the muted chrome.
+        ChromeTheme.S100Dusk => Mute(accent, saturationScale: 0.65, brightnessScale: 0.80),
+
+        _ => accent,
+    };
+
+    /// <summary>
+    /// Desaturates <paramref name="color"/> toward its perceptual luma
+    /// by <paramref name="saturationScale"/> (1 = unchanged, 0 = grey),
+    /// then scales overall brightness by <paramref name="brightnessScale"/>.
+    /// The alpha channel is preserved.
+    /// </summary>
+    private static Color Mute(Color color, double saturationScale, double brightnessScale)
+    {
+        double r = color.R;
+        double g = color.G;
+        double b = color.B;
+
+        // Rec. 601 luma; matches the eye's sensitivity well enough for
+        // a desaturation pivot without dragging in a colour-space lib.
+        double luma = (0.299 * r) + (0.587 * g) + (0.114 * b);
+
+        r = (luma + ((r - luma) * saturationScale)) * brightnessScale;
+        g = (luma + ((g - luma) * saturationScale)) * brightnessScale;
+        b = (luma + ((b - luma) * saturationScale)) * brightnessScale;
+
+        return Color.FromArgb(color.A, Clamp(r), Clamp(g), Clamp(b));
+    }
+
+    private static byte Clamp(double value) =>
+        (byte)Math.Clamp(Math.Round(value), 0, 255);
+}

--- a/src/EncDotNet.S100.Viewer/Services/FeatureGlyphs.cs
+++ b/src/EncDotNet.S100.Viewer/Services/FeatureGlyphs.cs
@@ -1,0 +1,62 @@
+using System;
+using Icon = FluentIcons.Common.Icon;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Maps an S-100 feature-type code (e.g. <c>"BeaconLateral"</c>,
+/// <c>"DepthArea"</c>) to a representative <see cref="FluentIcons.Common.Icon"/>
+/// glyph for the Pick Report hit list and identity block. The mapping is
+/// deliberately coarse — keyed off substrings of the class code so it works
+/// across products without a per-feature lookup table — and falls back to a
+/// generic shape glyph for unrecognised classes. It is a scanning aid, not a
+/// portrayal-accurate symbol.
+/// </summary>
+internal static class FeatureGlyphs
+{
+    /// <summary>Generic glyph used when no category keyword matches.</summary>
+    public const Icon Fallback = Icon.Shapes;
+
+    /// <summary>
+    /// Returns the glyph for the supplied feature-type code. Matching is
+    /// case-insensitive and substring-based; the first matching category in
+    /// priority order wins. Returns <see cref="Fallback"/> for null, empty,
+    /// or unrecognised codes.
+    /// </summary>
+    /// <param name="featureType">The feature class/type code.</param>
+    public static Icon ForFeatureType(string? featureType)
+    {
+        if (string.IsNullOrWhiteSpace(featureType))
+            return Fallback;
+
+        var t = featureType.ToLowerInvariant();
+
+        // Order matters: check more specific keywords before broader ones
+        // (e.g. "lighthouse" before "light", "landmark" before "land").
+        if (Has(t, "lighthouse")) return Icon.BuildingLighthouse;
+        if (Has(t, "light")) return Icon.WeatherSunny;
+        if (Has(t, "beacon")) return Icon.Flag;
+        if (Has(t, "buoy")) return Icon.MyLocation;
+        if (Has(t, "depth", "sounding", "dredge")) return Icon.Water;
+        if (Has(t, "seaarea", "sea area", "water", "lake", "river", "canal")) return Icon.Water;
+        if (Has(t, "fairway", "route", "channel", "recommendedtrack", "navigationline")) return Icon.Channel;
+        if (Has(t, "coastline", "shoreline", "landarea", "landregion", "land")) return Icon.Map;
+        if (Has(t, "rock", "wreck", "obstruction", "obstacle", "hazard")) return Icon.Diamond;
+        if (Has(t, "vessel", "ship", "ais")) return Icon.VehicleShip;
+        if (Has(t, "area", "zone", "restricted", "anchorage", "region")) return Icon.LayerDiagonal;
+        if (Has(t, "navigation", "navline", "navaid")) return Icon.Navigation;
+
+        return Fallback;
+    }
+
+    private static bool Has(string text, params string[] keywords)
+    {
+        foreach (var keyword in keywords)
+        {
+            if (text.Contains(keyword, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/FeatureName.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/FeatureName.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Derives a single mariner-facing "human name" for a picked feature from
+/// its decoded attributes. S-100 products carry an instance name in a small
+/// set of well-known attributes (e.g. S-101 <c>featureName/name</c>, the
+/// simple <c>name</c>, S-57 <c>OBJNAM</c>); this helper looks for the first
+/// such value so the Pick Report can lead with "Number 10" rather than the
+/// feature class. Returns <see langword="null"/> when no name-bearing
+/// attribute is present, in which case callers fall back to the feature
+/// class name.
+/// </summary>
+internal static class FeatureName
+{
+    // Codes that carry an instance name, in preference order. Compared
+    // case-insensitively against PickAttribute.Code. "featureName" is the
+    // S-100 complex attribute whose value lives in a child "name"; the rest
+    // are simple string attributes used across products / S-57.
+    private static readonly string[] NameCodes =
+    [
+        "featureName",
+        "name",
+        "objectName",
+        "stationName",
+        "OBJNAM",
+    ];
+
+    /// <summary>
+    /// Returns the best human name found in <paramref name="attributes"/>,
+    /// or <see langword="null"/> when none of the recognised name-bearing
+    /// attributes are present or all are blank.
+    /// </summary>
+    /// <param name="attributes">The feature's decoded attribute rows.</param>
+    public static string? Derive(IReadOnlyList<PickAttribute>? attributes)
+    {
+        if (attributes is null || attributes.Count == 0)
+            return null;
+
+        foreach (var code in NameCodes)
+        {
+            foreach (var attr in attributes)
+            {
+                if (!string.Equals(attr.Code, code, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var value = ValueOf(attr);
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value.Trim();
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the display value of a (possibly complex) name attribute.
+    /// Complex attributes such as S-101 <c>featureName</c> hold their text
+    /// in a child <c>name</c> row, so prefer that child when the parent has
+    /// no direct value.
+    /// </summary>
+    private static string? ValueOf(PickAttribute attr)
+    {
+        var direct = attr.DisplayText;
+        if (!string.IsNullOrWhiteSpace(direct))
+            return direct;
+
+        foreach (var child in attr.Children)
+        {
+            if (string.Equals(child.Code, "name", StringComparison.OrdinalIgnoreCase))
+            {
+                var childValue = child.DisplayText;
+                if (!string.IsNullOrWhiteSpace(childValue))
+                    return childValue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickHit.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickHit.cs
@@ -66,4 +66,33 @@ internal sealed class PickHit
     /// back to the raw feature-type code when the FC could not decode it.
     /// </summary>
     public string DisplayLabel => FeatureTypeName ?? FeatureType;
+
+    /// <summary>
+    /// Mariner-facing instance name derived from the feature's attributes
+    /// (e.g. "Number 10" from an S-101 <c>featureName</c>), or
+    /// <see langword="null"/> when the feature carries no name attribute.
+    /// </summary>
+    public string? FeatureName => ViewModels.FeatureName.Derive(Attributes);
+
+    /// <summary>
+    /// Primary line for the hit-list row and identity block: the instance
+    /// name when present, otherwise the feature class name.
+    /// </summary>
+    public string PrimaryLabel => FeatureName ?? DisplayLabel;
+
+    /// <summary>
+    /// Secondary line beneath <see cref="PrimaryLabel"/>: the feature class
+    /// name when an instance name is leading, otherwise <see langword="null"/>
+    /// (the class is already the primary line, so no subtitle is shown).
+    /// </summary>
+    public string? SecondaryLabel => FeatureName is not null ? DisplayLabel : null;
+
+    /// <summary>True when <see cref="SecondaryLabel"/> has a value to show.</summary>
+    public bool HasSecondaryLabel => SecondaryLabel is not null;
+
+    /// <summary>
+    /// Category glyph for the feature class, used as a fast visual scanning
+    /// aid in the hit list and identity block.
+    /// </summary>
+    public FluentIcons.Common.Icon Glyph => Services.FeatureGlyphs.ForFeatureType(FeatureType);
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Viewer.Resources;
 using EncDotNet.S100.Viewer.Services;
 
 namespace EncDotNet.S100.Viewer.ViewModels;
@@ -55,6 +56,9 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         CopyLocationCommand = new RelayCommand(
             () => { if (_location is { } loc) CopyLocationRequested?.Invoke(this, LatLonFormatter.FormatDecimal(loc.Latitude, loc.Longitude)); },
             () => _location is not null);
+        CopyIdentityCommand = new RelayCommand(
+            () => { var text = IdentityClipboardText; if (!string.IsNullOrEmpty(text)) CopyIdentityRequested?.Invoke(this, text); },
+            () => _selectedHit is not null);
         NavigateCommand = new RelayCommand<FeatureReference>(
             r => { if (r is not null) NavigateRequested?.Invoke(this, r); },
             r => r is not null);
@@ -207,6 +211,65 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         private set => SetProperty(ref _productSpec, value);
     }
 
+    /// <summary>
+    /// Primary heading for the identity block: the picked feature's instance
+    /// name when one is present, otherwise the feature class name. Mirrors
+    /// <see cref="PickHit.PrimaryLabel"/> for the selected hit.
+    /// </summary>
+    public string? PrimaryLabel => _selectedHit?.PrimaryLabel;
+
+    /// <summary>
+    /// Class-name pill shown beside <see cref="PrimaryLabel"/> when an
+    /// instance name is leading; <see langword="null"/> otherwise.
+    /// </summary>
+    public string? SecondaryLabel => _selectedHit?.SecondaryLabel;
+
+    /// <summary>True when <see cref="SecondaryLabel"/> has a value to show.</summary>
+    public bool HasSecondaryLabel => !string.IsNullOrEmpty(SecondaryLabel);
+
+    /// <summary>Category glyph for the selected hit's feature class.</summary>
+    public FluentIcons.Common.Icon Glyph =>
+        _selectedHit?.Glyph ?? Services.FeatureGlyphs.Fallback;
+
+    /// <summary>
+    /// Single-line caption demoting the technical identity (ID, product
+    /// spec, source file) beneath the heading, e.g.
+    /// <c>"ID 555 · S-101 · 101GB00502793.000"</c>. Segments that are
+    /// absent are omitted. Rendered in a monospace caption style.
+    /// </summary>
+    public string? IdentityCaption
+    {
+        get
+        {
+            if (_selectedHit is null)
+                return null;
+
+            var segments = new List<string>(3);
+            if (!string.IsNullOrEmpty(FeatureRef))
+                segments.Add(string.Format(CultureInfo.CurrentCulture, Strings.Pick_IdCaption, FeatureRef));
+            if (!string.IsNullOrEmpty(ProductSpec))
+                segments.Add(ProductSpec!);
+            if (!string.IsNullOrEmpty(DatasetFileName))
+                segments.Add(DatasetFileName!);
+
+            return segments.Count > 0 ? string.Join(" · ", segments) : null;
+        }
+    }
+
+    /// <summary>Clipboard text for the copy-identity action: heading plus caption.</summary>
+    private string? IdentityClipboardText
+    {
+        get
+        {
+            if (_selectedHit is null)
+                return null;
+            var caption = IdentityCaption;
+            return string.IsNullOrEmpty(caption)
+                ? PrimaryLabel
+                : $"{PrimaryLabel}\n{caption}";
+        }
+    }
+
     /// <summary>True when a feature is currently displayed in the panel.</summary>
     public bool HasPick
     {
@@ -342,10 +405,24 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     public ICommand CopyLocationCommand { get; }
 
     /// <summary>
+    /// Copies the selected hit's identity (heading + technical caption) to
+    /// the clipboard. Enabled only when a hit is selected; raises
+    /// <see cref="CopyIdentityRequested"/> with the text so the view owns
+    /// the actual clipboard access.
+    /// </summary>
+    public ICommand CopyIdentityCommand { get; }
+
+    /// <summary>
     /// Raised when the user invokes <see cref="CopyLocationCommand"/>. The
     /// payload is the clipboard-ready coordinate text.
     /// </summary>
     public event EventHandler<string>? CopyLocationRequested;
+
+    /// <summary>
+    /// Raised when the user invokes <see cref="CopyIdentityCommand"/>. The
+    /// payload is the clipboard-ready identity text.
+    /// </summary>
+    public event EventHandler<string>? CopyIdentityRequested;
 
     /// <summary>
     /// "Take the helm of this vessel" (pirate mode). Parameter is the
@@ -538,6 +615,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
             OnPropertyChanged(nameof(HasReferences));
             OnPropertyChanged(nameof(SelectedStationSeries));
             OnPropertyChanged(nameof(HasStationSeries));
+            RaiseIdentityChanged();
             return;
         }
 
@@ -559,6 +637,22 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
 
         OnPropertyChanged(nameof(SelectedStationSeries));
         OnPropertyChanged(nameof(HasStationSeries));
+        RaiseIdentityChanged();
+    }
+
+    /// <summary>
+    /// Raises change notifications for the identity-block properties derived
+    /// from <see cref="SelectedHit"/> and refreshes the copy-identity
+    /// command's executability.
+    /// </summary>
+    private void RaiseIdentityChanged()
+    {
+        OnPropertyChanged(nameof(PrimaryLabel));
+        OnPropertyChanged(nameof(SecondaryLabel));
+        OnPropertyChanged(nameof(HasSecondaryLabel));
+        OnPropertyChanged(nameof(Glyph));
+        OnPropertyChanged(nameof(IdentityCaption));
+        (CopyIdentityCommand as RelayCommand)?.NotifyCanExecuteChanged();
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/CatalogPanelView.axaml
@@ -52,44 +52,11 @@
                  x:Name="EntryList"
                  ItemsSource="{Binding Entries}"
                  SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                 Classes="accentList"
                  Background="Transparent"
                  BorderThickness="0"
                  Padding="0"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <ListBox.Styles>
-                <!-- Suppress the default ShadUI ListBoxItem chrome (including the
-                     selection check icon) and use our own minimal selection look. -->
-                <Style Selector="ListBoxItem">
-                    <Setter Property="Padding" Value="8,6" />
-                    <Setter Property="Margin" Value="0" />
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                    <!-- Transparent (not null) background so the entire row hit-tests,
-                         not just the text glyph runs. -->
-                    <Setter Property="Background" Value="Transparent" />
-                    <Setter Property="Template">
-                        <ControlTemplate>
-                            <Border Name="PART_Container"
-                                    Background="{TemplateBinding Background}"
-                                    CornerRadius="4"
-                                    Padding="{TemplateBinding Padding}">
-                                <ContentPresenter Content="{TemplateBinding Content}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  HorizontalAlignment="Stretch"
-                                                  HorizontalContentAlignment="Stretch" />
-                            </Border>
-                        </ControlTemplate>
-                    </Setter>
-                </Style>
-                <Style Selector="ListBoxItem:pointerover /template/ Border#PART_Container">
-                    <Setter Property="Background" Value="{DynamicResource MutedBackgroundColor}" />
-                </Style>
-                <Style Selector="ListBoxItem:selected /template/ Border#PART_Container">
-                    <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                </Style>
-                <Style Selector="ListBoxItem:selected TextBlock">
-                    <Setter Property="Foreground" Value="White" />
-                </Style>
-            </ListBox.Styles>
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="vm:CatalogEntryViewModel">
                     <!-- Background=Transparent makes the entire row (including
@@ -100,6 +67,7 @@
                           Background="Transparent">
                         <StackPanel Grid.Column="0" Spacing="2">
                             <TextBlock Text="{Binding Title}"
+                                       Classes="accentListTitle"
                                        FontWeight="SemiBold"
                                        FontSize="13"
                                        TextTrimming="CharacterEllipsis" />

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -296,44 +296,13 @@
                      x:Name="DatasetList"
                      ItemsSource="{Binding Entries}"
                      SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                     Classes="accentList"
                      Background="Transparent"
                      BorderThickness="0"
                      Padding="0"
                      Margin="8,4,8,0"
                      DoubleTapped="OnDatasetDoubleTapped"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                <ListBox.Styles>
-                    <!-- Suppress the default ShadUI ListBoxItem chrome and
-                         use a minimal hover/selection look. -->
-                    <Style Selector="ListBoxItem">
-                        <Setter Property="Padding" Value="6,4" />
-                        <Setter Property="Margin" Value="0,1" />
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                        <Setter Property="Background" Value="Transparent" />
-                        <Setter Property="Template">
-                            <ControlTemplate>
-                                <Border Name="PART_Container"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="4"
-                                        Padding="{TemplateBinding Padding}">
-                                    <ContentPresenter Content="{TemplateBinding Content}"
-                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                      HorizontalAlignment="Stretch"
-                                                      HorizontalContentAlignment="Stretch" />
-                                </Border>
-                            </ControlTemplate>
-                        </Setter>
-                    </Style>
-                    <Style Selector="ListBoxItem:pointerover /template/ Border#PART_Container">
-                        <Setter Property="Background" Value="{DynamicResource MutedBackgroundColor}" />
-                    </Style>
-                    <Style Selector="ListBoxItem:selected /template/ Border#PART_Container">
-                        <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                    </Style>
-                    <Style Selector="ListBoxItem:selected TextBlock">
-                        <Setter Property="Foreground" Value="White" />
-                    </Style>
-                </ListBox.Styles>
                 <ListBox.ItemTemplate>
                     <DataTemplate x:DataType="vm:DatasetEntry">
                         <Border Background="Transparent" Focusable="True">
@@ -387,6 +356,7 @@
                                             VerticalAlignment="Center"
                                             Opacity="{Binding RowOpacity}">
                                     <TextBlock Text="{Binding DisplayName}"
+                                               Classes="accentListTitle"
                                                TextTrimming="CharacterEllipsis" />
                                     <TextBlock Text="{Binding ProductSpec}"
                                                FontSize="11"

--- a/src/EncDotNet.S100.Viewer/Views/FeatureSearchView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeatureSearchView.axaml
@@ -62,47 +62,10 @@
             <ListBox ItemsSource="{Binding Results}"
                  SelectedItem="{Binding SelectedResult, Mode=TwoWay}"
                  SelectionMode="Single"
+                 Classes="accentList"
                  BorderThickness="0"
                  Background="Transparent"
                  Padding="0">
-            <ListBox.Styles>
-                <!--
-                    Suppress the default ShadUI ListBoxItem chrome
-                    (BaseBackground/HoverBackground/SelectionBackground
-                    layers + check icon) by replacing the template with
-                    a minimal Border#PART_Container, then mirror the
-                    DatasetsView hover/selection look so search rows
-                    match the rest of the side panel.
-                -->
-                <Style Selector="ListBoxItem">
-                    <Setter Property="Padding" Value="12,6" />
-                    <Setter Property="Margin" Value="0,1" />
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                    <Setter Property="Background" Value="Transparent" />
-                    <Setter Property="Template">
-                        <ControlTemplate>
-                            <Border Name="PART_Container"
-                                    Background="{TemplateBinding Background}"
-                                    CornerRadius="4"
-                                    Padding="{TemplateBinding Padding}">
-                                <ContentPresenter Content="{TemplateBinding Content}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  HorizontalAlignment="Stretch"
-                                                  HorizontalContentAlignment="Stretch" />
-                            </Border>
-                        </ControlTemplate>
-                    </Setter>
-                </Style>
-                <Style Selector="ListBoxItem:pointerover /template/ Border#PART_Container">
-                    <Setter Property="Background" Value="{DynamicResource MutedBackgroundColor}" />
-                </Style>
-                <Style Selector="ListBoxItem:selected /template/ Border#PART_Container">
-                    <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                </Style>
-                <Style Selector="ListBoxItem:selected TextBlock">
-                    <Setter Property="Foreground" Value="White" />
-                </Style>
-            </ListBox.Styles>
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="vm:FeatureSearchResultItem">
                     <!--
@@ -115,7 +78,7 @@
                     <Border Background="Transparent"
                             ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenSearchResult}">
                         <StackPanel Orientation="Vertical" Spacing="2">
-                            <TextBlock Text="{Binding DisplayType}" FontWeight="SemiBold" />
+                            <TextBlock Text="{Binding DisplayType}" Classes="accentListTitle" FontWeight="SemiBold" />
                             <TextBlock Text="{Binding FeatureRef}"
                                        FontSize="11"
                                        Opacity="0.75" />

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -5,10 +5,98 @@
              xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
              xmlns:pp="using:EncDotNet.S100.Datasets.Pipelines"
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:conv="using:EncDotNet.S100.Viewer"
              xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
              x:Class="EncDotNet.S100.Viewer.Views.PickReportView"
              x:Name="PickRoot"
              x:DataType="vm:PickReportViewModel">
+
+    <UserControl.Resources>
+        <!--
+            Attribute table cell: one label/value row. Attributes are at most
+            two levels deep (simple rows, plus complex rows that carry a single
+            level of leaf children — see FeatureInfoBuilder), so no recursive
+            tree is needed. The label column is a fixed width so values align
+            into a tidy second column; the value column is star-sized and
+            truncates with an ellipsis (full text remains in the tooltip).
+        -->
+        <DataTemplate x:Key="AttributeCellTemplate" x:DataType="pp:PickAttribute">
+            <Border Name="AttrRow" Padding="12,9" Background="Transparent">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="AttrLabel" />
+                        <ColumnDefinition Width="14" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding DisplayName}"
+                               FontSize="12"
+                               Opacity="0.7"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxWidth="{Binding $parent[views:PickReportView].Bounds.Width, Converter={x:Static conv:ProportionalWidthConverter.Instance}, ConverterParameter=0.55}"
+                               VerticalAlignment="Center">
+                        <ToolTip.Tip>
+                            <MultiBinding Converter="{x:Static conv:AttributeTooltipConverter.Instance}">
+                                <Binding Path="DisplayName" />
+                                <Binding Path="Code" />
+                            </MultiBinding>
+                        </ToolTip.Tip>
+                    </TextBlock>
+                    <Grid Grid.Column="2"
+                          ColumnDefinitions="Auto,*"
+                          VerticalAlignment="Center">
+                        <Border Grid.Column="0"
+                                Width="12" Height="12"
+                                CornerRadius="2"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                BorderBrush="{DynamicResource BorderColor}"
+                                BorderThickness="1"
+                                Background="{Binding Converter={x:Static conv:AttributeColourSwatchConverter.Instance}}"
+                                IsVisible="{Binding Converter={x:Static conv:AttributeColourSwatchConverter.Instance}, ConverterParameter=visible}" />
+                        <TextBlock Grid.Column="1"
+                                   Text="{Binding DisplayText}"
+                                   FontSize="12"
+                                   FontWeight="Medium"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis">
+                            <ToolTip.Tip>
+                                <MultiBinding Converter="{x:Static conv:AttributeTooltipConverter.Instance}">
+                                    <Binding Path="DisplayText" />
+                                    <Binding Path="RawValue" />
+                                </MultiBinding>
+                            </ToolTip.Tip>
+                        </TextBlock>
+                    </Grid>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <!--
+            Row template for the attribute table: the attribute's own cell,
+            followed (for complex attributes) by its leaf children indented
+            one level. Children never carry further children, so a single
+            nested ItemsControl is sufficient — no recursion.
+        -->
+        <DataTemplate x:Key="AttributeRowTemplate" x:DataType="pp:PickAttribute">
+            <StackPanel>
+                <ContentControl Content="{Binding}"
+                                ContentTemplate="{StaticResource AttributeCellTemplate}" />
+                <ItemsControl ItemsSource="{Binding Children}"
+                              Margin="20,0,0,0"
+                              ItemTemplate="{StaticResource AttributeCellTemplate}" />
+            </StackPanel>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <!-- Zebra-stripe alternate top-level attribute rows for scanability.
+             Targets the row Border inside each even item container. -->
+        <Style Selector="ItemsControl.attrTable ContentPresenter:nth-child(even) Border#AttrRow">
+            <Setter Property="Background" Value="{DynamicResource MutedBackgroundColor}" />
+        </Style>
+    </UserControl.Styles>
 
     <!--
         Pick Report (Object Information) panel content. PR-M4: the chrome
@@ -79,19 +167,53 @@
                                Text="{Binding Hits.Count, StringFormat={x:Static loc:Strings.Pick_HitListHeader}}" />
                     <ListBox ItemsSource="{Binding Hits}"
                              SelectedItem="{Binding SelectedHit, Mode=TwoWay}"
+                             Classes="accentList"
                              Background="Transparent"
                              BorderThickness="0"
                              Padding="0"
-                             MaxHeight="180">
+                             MaxHeight="200"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                         <ListBox.ItemTemplate>
                             <DataTemplate x:DataType="vm:PickHit">
-                                <TextBlock FontSize="12"
-                                           TextTrimming="CharacterEllipsis"
-                                           ToolTip.Tip="{x:Static loc:Strings.Tooltip_SelectHit}">
-                                    <Run Text="{Binding DisplayLabel}" />
-                                    <Run Text=" — " FontWeight="Light" />
-                                    <Run Text="{Binding FeatureRef}" FontStyle="Italic" />
-                                </TextBlock>
+                                <Grid ColumnDefinitions="Auto,*,Auto"
+                                      ToolTip.Tip="{x:Static loc:Strings.Tooltip_SelectHit}">
+                                    <!-- Feature category glyph -->
+                                    <Border Grid.Column="0"
+                                            Width="26" Height="26"
+                                            CornerRadius="5"
+                                            Margin="0,0,8,0"
+                                            VerticalAlignment="Center"
+                                            Background="{DynamicResource MutedBackgroundColor}">
+                                        <ic:FluentIcon Icon="{Binding Glyph}"
+                                                       IconVariant="Regular"
+                                                       FontSize="16"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center" />
+                                    </Border>
+                                    <!-- Name (primary) + class (subtitle) -->
+                                    <StackPanel Grid.Column="1"
+                                                VerticalAlignment="Center"
+                                                Spacing="0">
+                                        <TextBlock Classes="accentListTitle"
+                                                   Text="{Binding PrimaryLabel}"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Text="{Binding SecondaryLabel}"
+                                                   FontSize="11"
+                                                   Opacity="0.7"
+                                                   IsVisible="{Binding HasSecondaryLabel}"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                    <!-- Identifier, demoted to the trailing edge -->
+                                    <TextBlock Grid.Column="2"
+                                               Text="{Binding FeatureRef}"
+                                               FontSize="11"
+                                               Opacity="0.55"
+                                               VerticalAlignment="Center"
+                                               Margin="8,0,0,0"
+                                               TextTrimming="CharacterEllipsis" />
+                                </Grid>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>
@@ -169,22 +291,55 @@
                 </StackPanel>
             </Border>
 
-            <!-- Header block: feature type + identity -->
-            <StackPanel Spacing="2"
-                        IsVisible="{Binding HasDatasetPick}">
-                <TextBlock Text="{Binding FeatureType}"
-                           FontSize="14"
-                           FontWeight="SemiBold" />
-                <TextBlock FontSize="11" Opacity="0.7">
-                    <Run Text="{x:Static loc:Strings.Pick_IdLabel}" />
-                    <Run Text="{Binding FeatureRef}" />
-                </TextBlock>
-                <TextBlock FontSize="11" Opacity="0.7"
-                           Text="{Binding ProductSpec, StringFormat={x:Static loc:Strings.Pick_SpecFormat}}" />
-                <TextBlock FontSize="11" Opacity="0.7"
-                           Text="{Binding DatasetFileName, StringFormat={x:Static loc:Strings.Pick_SourceFormat}}"
-                           TextWrapping="Wrap" />
-            </StackPanel>
+            <!-- Identity block: glyph + human name + class pill, with the
+                 technical identity (ID / spec / source) demoted to a single
+                 monospace caption line and a copy action. -->
+            <Grid ColumnDefinitions="Auto,*,Auto"
+                  IsVisible="{Binding HasDatasetPick}">
+                <Border Grid.Column="0"
+                        Width="36" Height="36"
+                        CornerRadius="7"
+                        Margin="0,0,10,0"
+                        VerticalAlignment="Top"
+                        Background="{DynamicResource MutedBackgroundColor}">
+                    <ic:FluentIcon Icon="{Binding Glyph}"
+                                   IconVariant="Regular"
+                                   FontSize="22"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                </Border>
+                <StackPanel Grid.Column="1" Spacing="3" VerticalAlignment="Center">
+                    <WrapPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding PrimaryLabel}"
+                                   FontSize="15"
+                                   FontWeight="SemiBold"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0" />
+                        <Border IsVisible="{Binding HasSecondaryLabel}"
+                                VerticalAlignment="Center"
+                                CornerRadius="4"
+                                Padding="6,1"
+                                Background="{DynamicResource MutedBackgroundColor}">
+                            <TextBlock Text="{Binding SecondaryLabel}"
+                                       FontSize="11"
+                                       Opacity="0.8" />
+                        </Border>
+                    </WrapPanel>
+                    <SelectableTextBlock Text="{Binding IdentityCaption}"
+                                         FontSize="11"
+                                         FontFamily="Menlo,Consolas,Courier New,monospace"
+                                         Opacity="0.6"
+                                         TextWrapping="Wrap" />
+                </StackPanel>
+                <Button Grid.Column="2"
+                        VerticalAlignment="Top"
+                        Padding="6"
+                        Background="Transparent"
+                        Command="{Binding CopyIdentityCommand}"
+                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_CopyIdentity}">
+                    <ic:FluentIcon Icon="Copy" IconVariant="Regular" FontSize="16" />
+                </Button>
+            </Grid>
 
             <!-- References list (xlink:href targets) -->
             <Border BorderBrush="{DynamicResource BorderColor}"
@@ -221,12 +376,24 @@
             </Border>
         </StackPanel>
 
-        <!-- Scrolling region: station chart (when present) + attributes -->
-        <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+        <!-- Scrolling region: station chart (when present) + attributes.
+             The content's width is capped to the panel's own rendered width
+             (PickRoot.Bounds.Width) minus the 24px horizontal scroll padding,
+             so the attribute table (which contains NoWrap cells) can never
+             extend horizontally past the panel. PickRoot's width is sized by
+             the host column and is independent of the content, so the cap
+             always resolves and never feeds back into layout — unlike the
+             themed ScrollViewer's Viewport.Width, which some control themes do
+             not surface to bindings. The cells are vertical-only (no
+             wrapping), so capping width cannot loop with the vertical bar. -->
+        <ScrollViewer x:Name="AttrScroll"
+                      HorizontalScrollBarVisibility="Disabled"
                       VerticalScrollBarVisibility="Auto"
                       Padding="12,0,12,12"
                       IsVisible="{Binding HasDatasetPick}">
-            <StackPanel Spacing="8">
+            <StackPanel Spacing="8"
+                        MaxWidth="{Binding #PickRoot.Bounds.Width, Converter={x:Static conv:WidthInsetConverter.Instance}, ConverterParameter=24}"
+                        HorizontalAlignment="Stretch">
                 <!--
                     Station time-series chart, shown only when the
                     selected hit carries a StationTimeSeriesViewModel
@@ -306,42 +473,16 @@
                                    FontWeight="Normal"
                                    LetterSpacing="1"
                                    Opacity="0.7" />
-                        <TreeView ItemsSource="{Binding Attributes}"
-                                  Background="Transparent"
-                                  BorderThickness="0"
-                                  Padding="0">
-                            <TreeView.Styles>
-                                <Style Selector="TreeViewItem">
-                                    <Setter Property="IsExpanded" Value="True" />
-                                </Style>
-                            </TreeView.Styles>
-                            <TreeView.ItemTemplate>
-                                <TreeDataTemplate x:DataType="pp:PickAttribute"
-                                                  ItemsSource="{Binding Children}">
-                                    <Grid Margin="0,2">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="8" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Grid.Column="0"
-                                                   Text="{Binding DisplayName}"
-                                                   FontSize="12"
-                                                   Opacity="0.7"
-                                                   TextWrapping="NoWrap"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip.Tip="{Binding Code}" />
-                                        <TextBlock Grid.Column="2"
-                                                   Text="{Binding DisplayText}"
-                                                   FontSize="12"
-                                                   TextWrapping="NoWrap"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   MaxWidth="220"
-                                                   ToolTip.Tip="{Binding RawValue}" />
-                                    </Grid>
-                                </TreeDataTemplate>
-                            </TreeView.ItemTemplate>
-                        </TreeView>
+                        <Border BorderBrush="{DynamicResource BorderColor}"
+                                BorderThickness="1"
+                                CornerRadius="6"
+                                ClipToBounds="True"
+                                Grid.IsSharedSizeScope="True"
+                                IsVisible="{Binding HasAttributes}">
+                            <ItemsControl ItemsSource="{Binding Attributes}"
+                                          Classes="attrTable"
+                                          ItemTemplate="{StaticResource AttributeRowTemplate}" />
+                        </Border>
                         <TextBlock Text="{x:Static loc:Strings.Pick_NoAttributes}"
                                    FontSize="12"
                                    FontStyle="Italic"
@@ -355,42 +496,16 @@
                           IsExpanded="False"
                           HorizontalAlignment="Stretch">
                     <StackPanel Spacing="4">
-                        <TreeView ItemsSource="{Binding Attributes}"
-                                  Background="Transparent"
-                                  BorderThickness="0"
-                                  Padding="0">
-                            <TreeView.Styles>
-                                <Style Selector="TreeViewItem">
-                                    <Setter Property="IsExpanded" Value="True" />
-                                </Style>
-                            </TreeView.Styles>
-                            <TreeView.ItemTemplate>
-                                <TreeDataTemplate x:DataType="pp:PickAttribute"
-                                                  ItemsSource="{Binding Children}">
-                                    <Grid Margin="0,2">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="8" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Grid.Column="0"
-                                                   Text="{Binding DisplayName}"
-                                                   FontSize="12"
-                                                   Opacity="0.7"
-                                                   TextWrapping="NoWrap"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip.Tip="{Binding Code}" />
-                                        <TextBlock Grid.Column="2"
-                                                   Text="{Binding DisplayText}"
-                                                   FontSize="12"
-                                                   TextWrapping="NoWrap"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   MaxWidth="220"
-                                                   ToolTip.Tip="{Binding RawValue}" />
-                                    </Grid>
-                                </TreeDataTemplate>
-                            </TreeView.ItemTemplate>
-                        </TreeView>
+                        <Border BorderBrush="{DynamicResource BorderColor}"
+                                BorderThickness="1"
+                                CornerRadius="6"
+                                ClipToBounds="True"
+                                Grid.IsSharedSizeScope="True"
+                                IsVisible="{Binding HasAttributes}">
+                            <ItemsControl ItemsSource="{Binding Attributes}"
+                                          Classes="attrTable"
+                                          ItemTemplate="{StaticResource AttributeRowTemplate}" />
+                        </Border>
                         <TextBlock Text="{x:Static loc:Strings.Pick_NoAttributes}"
                                    FontSize="12"
                                    FontStyle="Italic"

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml.cs
@@ -39,15 +39,21 @@ public partial class PickReportView : UserControl
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
         if (_subscribed is not null)
-            _subscribed.CopyLocationRequested -= OnCopyLocationRequested;
+        {
+            _subscribed.CopyLocationRequested -= OnCopyTextRequested;
+            _subscribed.CopyIdentityRequested -= OnCopyTextRequested;
+        }
 
         _subscribed = DataContext as PickReportViewModel;
 
         if (_subscribed is not null)
-            _subscribed.CopyLocationRequested += OnCopyLocationRequested;
+        {
+            _subscribed.CopyLocationRequested += OnCopyTextRequested;
+            _subscribed.CopyIdentityRequested += OnCopyTextRequested;
+        }
     }
 
-    private void OnCopyLocationRequested(object? sender, string text)
+    private void OnCopyTextRequested(object? sender, string text)
     {
         try
         {

--- a/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/VesselListView.axaml
@@ -56,40 +56,11 @@
                          ItemsSource="{Binding Vessels}"
                          SelectedItem="{Binding SelectedVessel, Mode=TwoWay}"
                          SelectionMode="Single"
+                         Classes="accentList"
                          BorderThickness="0"
                          Background="Transparent"
                          Padding="0"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                    <ListBox.Styles>
-                        <Style Selector="ListBoxItem">
-                            <Setter Property="Padding" Value="12,6" />
-                            <Setter Property="Margin" Value="0,1" />
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            <Setter Property="Background" Value="Transparent" />
-                            <Setter Property="Template">
-                                <ControlTemplate>
-                                    <Border Name="PART_Container"
-                                            Background="{TemplateBinding Background}"
-                                            CornerRadius="4"
-                                            Padding="{TemplateBinding Padding}">
-                                        <ContentPresenter Content="{TemplateBinding Content}"
-                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                          HorizontalAlignment="Stretch"
-                                                          HorizontalContentAlignment="Stretch" />
-                                    </Border>
-                                </ControlTemplate>
-                            </Setter>
-                        </Style>
-                        <Style Selector="ListBoxItem:pointerover /template/ Border#PART_Container">
-                            <Setter Property="Background" Value="{DynamicResource MutedBackgroundColor}" />
-                        </Style>
-                        <Style Selector="ListBoxItem:selected /template/ Border#PART_Container">
-                            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                        </Style>
-                        <Style Selector="ListBoxItem:selected TextBlock">
-                            <Setter Property="Foreground" Value="White" />
-                        </Style>
-                    </ListBox.Styles>
                     <ListBox.ItemTemplate>
                         <DataTemplate x:DataType="vm:VesselListItem">
                             <Border Background="Transparent"
@@ -117,6 +88,7 @@
 
                                     <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="2">
                                         <TextBlock Text="{Binding Name}"
+                                                   Classes="accentListTitle"
                                                    FontWeight="SemiBold"
                                                    TextTrimming="CharacterEllipsis" />
                                         <TextBlock Text="{Binding StateText}"

--- a/src/EncDotNet.S100.Viewer/WidthInsetConverter.cs
+++ b/src/EncDotNet.S100.Viewer/WidthInsetConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Subtracts a fixed inset (passed as <c>ConverterParameter</c>) from a bound
+/// width, clamping the result to a non-negative value. Used by the pick
+/// report's scrolling region to cap its content width to the panel's own
+/// rendered width minus the scroll padding — a width that is independent of
+/// the content (so it never feeds back into layout) and always resolves,
+/// unlike a themed <c>ScrollViewer.Viewport.Width</c> which some control
+/// themes do not surface to bindings.
+/// </summary>
+internal sealed class WidthInsetConverter : IValueConverter
+{
+    public static WidthInsetConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not double width || double.IsNaN(width) || double.IsInfinity(width))
+            return double.NaN;
+
+        var inset = parameter switch
+        {
+            double d => d,
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => 0d,
+        };
+
+        return Math.Max(0d, width - inset);
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/AccentColorsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/AccentColorsTests.cs
@@ -1,0 +1,51 @@
+using Avalonia.Media;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class AccentColorsTests
+{
+    private static readonly Color Accent = Color.Parse("#007ACC");
+
+    [Theory]
+    [InlineData(ChromeTheme.Light)]
+    [InlineData(ChromeTheme.Dark)]
+    public void ForTheme_StockThemes_ReturnsAccentUnchanged(ChromeTheme theme)
+    {
+        Assert.Equal(Accent, AccentColors.ForTheme(Accent, theme));
+    }
+
+    [Theory]
+    [InlineData(ChromeTheme.S100Night)]
+    [InlineData(ChromeTheme.S100Dusk)]
+    public void ForTheme_LowLightThemes_DimsAndDesaturates(ChromeTheme theme)
+    {
+        var muted = AccentColors.ForTheme(Accent, theme);
+
+        double originalLuma = Luma(Accent);
+        double mutedLuma = Luma(muted);
+        Assert.True(mutedLuma < originalLuma, "Muted accent should be dimmer.");
+
+        double originalSpread = ChannelSpread(Accent);
+        double mutedSpread = ChannelSpread(muted);
+        Assert.True(mutedSpread < originalSpread, "Muted accent should be less saturated.");
+    }
+
+    [Fact]
+    public void ForTheme_PreservesAlpha()
+    {
+        var translucent = Color.FromArgb(0x80, 0x00, 0x7A, 0xCC);
+        var muted = AccentColors.ForTheme(translucent, ChromeTheme.S100Night);
+        Assert.Equal(0x80, muted.A);
+    }
+
+    private static double Luma(Color c) => (0.299 * c.R) + (0.587 * c.G) + (0.114 * c.B);
+
+    private static double ChannelSpread(Color c)
+    {
+        int max = System.Math.Max(c.R, System.Math.Max(c.G, c.B));
+        int min = System.Math.Min(c.R, System.Math.Min(c.G, c.B));
+        return max - min;
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/AttributeColourSwatchConverterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/AttributeColourSwatchConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using Avalonia.Media;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class AttributeColourSwatchConverterTests
+{
+    private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
+
+    private static PickAttribute Attr(string code, string value, string? name = null) =>
+        new() { Code = code, Name = name, RawValue = value, DisplayValue = null, Children = [] };
+
+    private static object? Brush(PickAttribute a) =>
+        AttributeColourSwatchConverter.Instance.Convert(a, typeof(IBrush), null, Culture);
+
+    private static object? Visible(PickAttribute a) =>
+        AttributeColourSwatchConverter.Instance.Convert(a, typeof(bool), "visible", Culture);
+
+    [Fact]
+    public void ColourAttribute_KnownColour_ProducesBrushAndVisible()
+    {
+        var attr = Attr("colour", "Red");
+        var brush = Assert.IsType<SolidColorBrush>(Brush(attr));
+        Assert.Equal(Color.FromRgb(0xD0, 0x21, 0x21), brush.Color);
+        Assert.True((bool)Visible(attr)!);
+    }
+
+    [Fact]
+    public void ColourAttribute_CompoundValue_UsesFirstRecognisedColour()
+    {
+        var attr = Attr("colour", "Red;White");
+        var brush = Assert.IsType<SolidColorBrush>(Brush(attr));
+        Assert.Equal(Color.FromRgb(0xD0, 0x21, 0x21), brush.Color);
+    }
+
+    [Fact]
+    public void NonColourAttribute_EvenIfValueIsColourWord_IsNotSwatched()
+    {
+        var attr = Attr("category", "Red");
+        Assert.Same(Brushes.Transparent, Brush(attr));
+        Assert.False((bool)Visible(attr)!);
+    }
+
+    [Fact]
+    public void ColourAttribute_UnknownColourWord_IsNotVisible()
+    {
+        var attr = Attr("colour", "Mauve");
+        Assert.False((bool)Visible(attr)!);
+    }
+
+    [Fact]
+    public void ColourDetected_ViaName_WhenCodeIsOpaque()
+    {
+        var attr = Attr("COLOUR", "Green", name: "Colour");
+        Assert.True((bool)Visible(attr)!);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/AttributeTableLayoutReproTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/AttributeTableLayoutReproTests.cs
@@ -1,0 +1,117 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Layout guard for the pick-report attribute table. Mirrors the wrapper
+/// chain used by <c>PickReportView.axaml</c> (named ScrollViewer → content
+/// StackPanel whose <see cref="Layoutable.MaxWidth"/> is bound to the
+/// scroller's <see cref="ScrollViewer.Viewport"/> width → bordered
+/// ItemsControl of fixed-label / star-value rows) and asserts a very long
+/// value stays within the panel width — even when the ScrollViewer is allowed
+/// to scroll horizontally (which is how a misbehaving theme template could
+/// otherwise let the NoWrap value cells over-extend and overflow to the
+/// right). The <c>Viewport.Width</c> cap is the defence under test.
+/// </summary>
+public class AttributeTableLayoutReproTests
+{
+    private const double HostWidth = 300;
+
+    private static (Border host, TextBlock value) BuildChain(
+        string value,
+        ScrollBarVisibility horizontal)
+    {
+        var value1 = new TextBlock
+        {
+            Text = value,
+            TextWrapping = TextWrapping.NoWrap,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+
+        var rowGrid = new Grid { ColumnDefinitions = new ColumnDefinitions("140,14,*") };
+        var label = new TextBlock
+        {
+            Text = "Water Level Effect",
+            TextWrapping = TextWrapping.NoWrap,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+        Grid.SetColumn(label, 0);
+        rowGrid.Children.Add(label);
+
+        var valueOuter = new Grid { ColumnDefinitions = new ColumnDefinitions("Auto,*") };
+        Grid.SetColumn(value1, 1);
+        valueOuter.Children.Add(value1);
+        Grid.SetColumn(valueOuter, 2);
+        rowGrid.Children.Add(valueOuter);
+
+        var rowBorder = new Border { Name = "AttrRow", Padding = new Thickness(12, 9), Child = rowGrid };
+        var items = new ItemsControl { ItemsSource = new[] { rowBorder } };
+        var tableBorder = new Border
+        {
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            ClipToBounds = true,
+            Child = items,
+        };
+
+        var content = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Children = { tableBorder },
+        };
+
+        var scroller = new ScrollViewer
+        {
+            Name = "AttrScroll",
+            HorizontalScrollBarVisibility = horizontal,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Padding = new Thickness(12, 0, 12, 12),
+            Content = content,
+        };
+
+        // Mirror the real fix: cap the content to the scroller's viewport width.
+        content.Bind(Layoutable.MaxWidthProperty, new Binding
+        {
+            Source = scroller,
+            Path = "Viewport.Width",
+        });
+
+        var host = new Border { Width = HostWidth, Child = scroller };
+        return (host, value1);
+    }
+
+    private static void AssertWithinHost(ScrollBarVisibility horizontal)
+    {
+        var (host, value) = BuildChain(
+            "Always Under Water/Submerged at all states of the tide and an extremely long tail that would overflow",
+            horizontal);
+
+        // Two passes so the Viewport.Width binding settles before the cap is read.
+        for (var i = 0; i < 2; i++)
+        {
+            host.Measure(new Size(HostWidth, 1000));
+            host.Arrange(new Rect(0, 0, HostWidth, 1000));
+        }
+
+        var topLeft = value.TranslatePoint(new Point(0, 0), host) ?? new Point();
+        var right = topLeft.X + value.Bounds.Width;
+        Assert.True(
+            right <= HostWidth + 0.5,
+            $"value right edge {right:F1} exceeds host width {HostWidth} (h={horizontal}, value width {value.Bounds.Width:F1}, x {topLeft.X:F1})");
+    }
+
+    [Fact]
+    public void LongValue_HorizontalDisabled_StaysWithinHost()
+        => HeadlessTest.Run(() => AssertWithinHost(ScrollBarVisibility.Disabled));
+
+    [Fact]
+    public void LongValue_HorizontalScrollAllowed_ViewportCapStillContains()
+        => HeadlessTest.Run(() => AssertWithinHost(ScrollBarVisibility.Auto));
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/AttributeTooltipConverterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/AttributeTooltipConverterTests.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+using EncDotNet.S100.Viewer;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class AttributeTooltipConverterTests
+{
+    private static object? Convert(string? friendly, string? raw) =>
+        AttributeTooltipConverter.Instance.Convert(
+            new object?[] { friendly, raw }, typeof(string), null, CultureInfo.InvariantCulture);
+
+    [Fact]
+    public void FriendlyAndRawDiffer_PairsThem()
+    {
+        Assert.Equal("Covers and Uncovers (1)", Convert("Covers and Uncovers", "1"));
+    }
+
+    [Fact]
+    public void RawEqualsFriendly_OmitsParens()
+    {
+        Assert.Equal("20071231", Convert("20071231", "20071231"));
+    }
+
+    [Fact]
+    public void RawEqualsFriendly_CaseInsensitive_OmitsParens()
+    {
+        Assert.Equal("OBJNAM", Convert("OBJNAM", "objnam"));
+    }
+
+    [Fact]
+    public void RawEmpty_ReturnsFriendlyOnly()
+    {
+        Assert.Equal("Reported Date", Convert("Reported Date", ""));
+        Assert.Equal("Reported Date", Convert("Reported Date", null));
+    }
+
+    [Fact]
+    public void FriendlyEmpty_FallsBackToRaw()
+    {
+        Assert.Equal("CATOBS", Convert(null, "CATOBS"));
+        Assert.Equal("CATOBS", Convert("", "CATOBS"));
+    }
+
+    [Fact]
+    public void BothEmpty_ReturnsNull()
+    {
+        Assert.Null(Convert(null, null));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DisplaySettingsStringsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DisplaySettingsStringsTests.cs
@@ -1,0 +1,36 @@
+using EncDotNet.S100.Viewer.Resources;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Guards the localized strings introduced for the consolidated map
+/// Display Settings overlay (the segmented Display base / Text / Palette
+/// control). A missing or misnamed <c>.resx</c> entry would silently fall
+/// back to the key name; these assertions fail fast instead.
+/// </summary>
+public class DisplaySettingsStringsTests
+{
+    public static IEnumerable<object[]> DisplaySettingsKeys()
+    {
+        yield return new object[] { Strings.DisplaySettings_Title, nameof(Strings.DisplaySettings_Title) };
+        yield return new object[] { Strings.Tooltip_DisplaySettings, nameof(Strings.Tooltip_DisplaySettings) };
+        yield return new object[] { Strings.Tooltip_CloseDisplaySettings, nameof(Strings.Tooltip_CloseDisplaySettings) };
+        yield return new object[] { Strings.DisplaySettings_DisplayBaseHeader, nameof(Strings.DisplaySettings_DisplayBaseHeader) };
+        yield return new object[] { Strings.DisplaySettings_TextHeader, nameof(Strings.DisplaySettings_TextHeader) };
+        yield return new object[] { Strings.DisplaySettings_PaletteHeader, nameof(Strings.DisplaySettings_PaletteHeader) };
+        yield return new object[] { Strings.Segment_DisplayBase, nameof(Strings.Segment_DisplayBase) };
+        yield return new object[] { Strings.Segment_DisplayOther, nameof(Strings.Segment_DisplayOther) };
+        yield return new object[] { Strings.Segment_TextImportant, nameof(Strings.Segment_TextImportant) };
+        yield return new object[] { Strings.Segment_TextOther, nameof(Strings.Segment_TextOther) };
+        yield return new object[] { Strings.Segment_TextAll, nameof(Strings.Segment_TextAll) };
+    }
+
+    [Theory]
+    [MemberData(nameof(DisplaySettingsKeys))]
+    public void DisplaySettingsString_ResolvesToNonEmptyValue(string value, string key)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(value), $"String '{key}' did not resolve to a value.");
+        // A resx miss returns the key name itself; ensure we got a real value.
+        Assert.NotEqual(key, value);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureGlyphsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureGlyphsTests.cs
@@ -1,0 +1,44 @@
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+using Icon = FluentIcons.Common.Icon;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class FeatureGlyphsTests
+{
+    [Theory]
+    [InlineData("BeaconLateral", Icon.Flag)]
+    [InlineData("LightAllAround", Icon.WeatherSunny)]
+    [InlineData("Lighthouse", Icon.BuildingLighthouse)]
+    [InlineData("BuoyLateral", Icon.MyLocation)]
+    [InlineData("DepthArea", Icon.Water)]
+    [InlineData("Soundings", Icon.Water)]
+    [InlineData("Fairway", Icon.Channel)]
+    [InlineData("VehicleShip", Icon.VehicleShip)]
+    public void ForFeatureType_KnownCategories_MapToExpectedGlyph(string code, Icon expected)
+    {
+        Assert.Equal(expected, FeatureGlyphs.ForFeatureType(code));
+    }
+
+    [Fact]
+    public void ForFeatureType_LighthouseWinsOverLight()
+    {
+        // "Lighthouse" contains "light"; the more specific keyword must win.
+        Assert.Equal(Icon.BuildingLighthouse, FeatureGlyphs.ForFeatureType("Lighthouse"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("SomethingUnmapped")]
+    public void ForFeatureType_UnknownOrEmpty_ReturnsFallback(string? code)
+    {
+        Assert.Equal(FeatureGlyphs.Fallback, FeatureGlyphs.ForFeatureType(code));
+    }
+
+    [Fact]
+    public void ForFeatureType_IsCaseInsensitive()
+    {
+        Assert.Equal(Icon.Flag, FeatureGlyphs.ForFeatureType("beaconlateral"));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureNameTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureNameTests.cs
@@ -1,0 +1,69 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class FeatureNameTests
+{
+    private static PickAttribute Leaf(string code, string value, string? name = null) =>
+        new() { Code = code, Name = name, RawValue = value, DisplayValue = null, Children = [] };
+
+    [Fact]
+    public void Derive_SimpleName_ReturnsValue()
+    {
+        var name = FeatureName.Derive([Leaf("name", "Number 10")]);
+        Assert.Equal("Number 10", name);
+    }
+
+    [Fact]
+    public void Derive_ComplexFeatureName_ReadsChildName()
+    {
+        var complex = new PickAttribute
+        {
+            Code = "featureName",
+            Name = "Feature Name",
+            RawValue = "",
+            DisplayValue = null,
+            Children = [Leaf("name", "Number 10"), Leaf("language", "eng")],
+        };
+
+        Assert.Equal("Number 10", FeatureName.Derive([complex]));
+    }
+
+    [Fact]
+    public void Derive_PrefersFeatureNameOverSimpleName()
+    {
+        var attrs = new[]
+        {
+            Leaf("name", "Fallback"),
+            new PickAttribute
+            {
+                Code = "featureName",
+                RawValue = "",
+                Children = [Leaf("name", "Preferred")],
+            },
+        };
+
+        Assert.Equal("Preferred", FeatureName.Derive(attrs));
+    }
+
+    [Fact]
+    public void Derive_NoNameAttribute_ReturnsNull()
+    {
+        Assert.Null(FeatureName.Derive([Leaf("DRVAL1", "10.0")]));
+    }
+
+    [Fact]
+    public void Derive_EmptyOrNull_ReturnsNull()
+    {
+        Assert.Null(FeatureName.Derive([]));
+        Assert.Null(FeatureName.Derive(null));
+    }
+
+    [Fact]
+    public void Derive_BlankValue_IsIgnored()
+    {
+        Assert.Null(FeatureName.Derive([Leaf("name", "   ")]));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -617,4 +617,69 @@ public class PickReportViewModelTests
         Assert.True(Hit("ais:42").IsAisTarget);
         Assert.False(Hit("ownship").IsAisTarget);
     }
+
+    [Fact]
+    public void Identity_WithNamedFeature_LeadsWithNameAndClassPill()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPick("BeaconLateral", "Beacon, Lateral", "555", "101GB00502793.000", "S-101",
+            new[] { Leaf("name", "Number 10"), Leaf("colour", "3", "Colour") });
+
+        Assert.Equal("Number 10", vm.PrimaryLabel);
+        Assert.Equal("Beacon, Lateral", vm.SecondaryLabel);
+        Assert.True(vm.HasSecondaryLabel);
+        Assert.Equal("ID 555 · S-101 · 101GB00502793.000", vm.IdentityCaption);
+    }
+
+    [Fact]
+    public void Identity_WithoutName_LeadsWithClassAndNoPill()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPick("DepthArea", "Depth Area", "300", "test.000", "S-101",
+            new[] { Leaf("DRVAL1", "10.0") });
+
+        Assert.Equal("Depth Area", vm.PrimaryLabel);
+        Assert.Null(vm.SecondaryLabel);
+        Assert.False(vm.HasSecondaryLabel);
+        Assert.Equal("ID 300 · S-101 · test.000", vm.IdentityCaption);
+    }
+
+    [Fact]
+    public void IdentityCaption_OmitsMissingSegments()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPick("Authority", null, "auth.1", null, null, System.Array.Empty<PickAttribute>());
+
+        Assert.Equal("ID auth.1", vm.IdentityCaption);
+    }
+
+    [Fact]
+    public void CopyIdentityCommand_RaisesRequestWithNameAndCaption()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPick("BeaconLateral", "Beacon, Lateral", "555", "f.000", "S-101",
+            new[] { Leaf("name", "Number 10") });
+
+        string? captured = null;
+        vm.CopyIdentityRequested += (_, text) => captured = text;
+
+        Assert.True(vm.CopyIdentityCommand.CanExecute(null));
+        vm.CopyIdentityCommand.Execute(null);
+
+        Assert.Equal("Number 10\nID 555 · S-101 · f.000", captured);
+    }
+
+    [Fact]
+    public void Identity_ClearedAfterClear()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPick("BeaconLateral", "Beacon, Lateral", "555", "f.000", "S-101",
+            new[] { Leaf("name", "Number 10") });
+
+        vm.Clear();
+
+        Assert.Null(vm.PrimaryLabel);
+        Assert.Null(vm.IdentityCaption);
+        Assert.False(vm.CopyIdentityCommand.CanExecute(null));
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/WidthConverterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/WidthConverterTests.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+using EncDotNet.S100.Viewer;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class WidthConverterTests
+{
+    private static object? Inset(object? value, object? parameter) =>
+        WidthInsetConverter.Instance.Convert(value, typeof(double), parameter, CultureInfo.InvariantCulture);
+
+    private static object? Proportional(object? value, object? parameter) =>
+        ProportionalWidthConverter.Instance.Convert(value, typeof(double), parameter, CultureInfo.InvariantCulture);
+
+    [Fact]
+    public void Inset_SubtractsParameter()
+    {
+        Assert.Equal(336d, Inset(360d, "24"));
+    }
+
+    [Fact]
+    public void Inset_ClampsToZero()
+    {
+        Assert.Equal(0d, Inset(10d, "24"));
+    }
+
+    [Fact]
+    public void Inset_NaNWidth_ReturnsNaN()
+    {
+        Assert.Equal(double.NaN, Inset(double.NaN, "24"));
+    }
+
+    [Fact]
+    public void Inset_NonWidth_ReturnsNaN()
+    {
+        Assert.Equal(double.NaN, Inset(null, "24"));
+    }
+
+    [Fact]
+    public void Proportional_MultipliesByFraction()
+    {
+        Assert.Equal(200d, Proportional(400d, "0.5"));
+    }
+
+    [Fact]
+    public void Proportional_InfinityWidth_ReturnsNaN()
+    {
+        Assert.Equal(double.NaN, Proportional(double.PositiveInfinity, "0.55"));
+    }
+}


### PR DESCRIPTION
## Summary

A round of viewer UX polish to make the side panels and map command bar feel consistent and uncluttered.

- **Object Information (pick) panel** redesigned with per-feature glyphs, accent-coloured rows, and a per-attribute table that no longer overflows the panel. A width-inset converter caps the scroll content to the panel width, and a proportional-width converter (plus a shared-size group) keeps the attribute label column aligned without truncating when space is available.
- **Activity-panel lists** now share one look. A global `ListBox.accentList` style (accent left bar, low-opacity tint, accent-coloured title, shared `8,5` padding and a `46px` row min-height matched to the datasets list) replaces the old solid-fill + white-text selection across the Datasets, Feature Search, Catalogues, Vessels, and pick hit lists. The subtle tint keeps secondary text and inline icons legible under the muted S-100 dusk/night chrome where a bright fill dominated.
- **Map command bar** consolidates the three separate Display category / Text / Palette flyout pills into a single Display Settings button. Its overlay exposes all three as segmented toggles: single-select for Display base and Palette, independent multi-toggle for Text (preserving the existing S-101 viewing-group semantics). A new global segmented-control style adapts to the dusk/night chrome variants.

Notable details for reviewers:
- The Text group's "All" reflecting on when "Other" is toggled is expected: the S-101 portrayal catalogue defines "All other chart text" as a superset layer sharing viewing groups with "Other". This matches the old Text pill behavior and was kept intentionally.
- The settings overlay uses a fixed content width so a segment turning semibold on selection does not nudge the panel wider. ShadUI's `ToggleButton` defaults to `MinHeight=36` while `RadioButton` has none, so both segment flavours are pinned to a shared min-height to line up.
- The overlay supports light-dismiss (click-away / Esc) plus an explicit close (x) button for discoverability.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is viewer UI only; no spec encoding, feature catalogue, or portrayal semantics changed.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

1015 passed, 1 skipped. New coverage for the width/proportional converters, feature glyphs and names, accent colours, pick report view model, and the display-settings localized strings.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

No README/docs changes: this is presentational polish to existing viewer surfaces with no new user-facing concepts to document.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None.