### PR TITLE
Fix S-101 2.0.0 datasets flagged as unsupported (#322)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/SupportedSpecEditions.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/SupportedSpecEditions.cs
@@ -25,7 +25,12 @@ public static class SupportedSpecEditions
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<SpecVersion>> _byName =
         new Dictionary<string, IReadOnlyList<SpecVersion>>(StringComparer.Ordinal)
         {
-            ["S-101"] = [new SpecVersion(1, 2, 0)],
+            // The bundled S-101 Feature and Portrayal Catalogues are Edition
+            // 2.0.0; legacy 1.x datasets are still read (their pre-2.0.0
+            // feature class names are mapped to 2.0.0 equivalents — see
+            // S101LegacyFeatureNames), so both editions are declared supported
+            // to avoid a spurious version warning on either.
+            ["S-101"] = [new SpecVersion(1, 2, 0), new SpecVersion(2, 0, 0)],
             ["S-102"] = [new SpecVersion(2, 1, 0), new SpecVersion(3, 0, 0)],
             ["S-104"] = [new SpecVersion(2, 0, 0)],
             ["S-111"] = [new SpecVersion(2, 0, 0)],

--- a/tests/EncDotNet.S100.Pipelines.Tests/SupportedSpecEditionsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SupportedSpecEditionsTests.cs
@@ -49,6 +49,43 @@ public class SupportedSpecEditionsTests
     }
 
     [Fact]
+    public void S101_ImplementsBothEditions()
+    {
+        var editions = SupportedSpecEditions.For("S-101");
+
+        Assert.Contains(new SpecVersion(1, 2, 0), editions);
+        Assert.Contains(new SpecVersion(2, 0, 0), editions);
+    }
+
+    [Fact]
+    public void Assess_DoesNotWarn_ForS101Edition200()
+    {
+        // Latest UKHO test datasets (e.g. S-101_GB_Apr26) declare edition
+        // 2.0.0, which the bundled 2.0.0 catalogues implement. Issue #322.
+        var declared = new SpecRef("S-101", new SpecVersion(2, 0, 0));
+
+        var assessment = SupportedSpecEditions.Assess(declared);
+
+        Assert.NotNull(assessment);
+        Assert.Equal(SpecMatchKind.Exact, assessment!.Kind);
+        Assert.False(assessment.IsWarning);
+    }
+
+    [Fact]
+    public void Assess_DoesNotWarn_ForLegacyS101Edition1x()
+    {
+        // Legacy 1.x datasets remain readable via legacy feature-name mapping,
+        // so they must not raise a version warning either.
+        var declared = new SpecRef("S-101", new SpecVersion(1, 2, 0));
+
+        var assessment = SupportedSpecEditions.Assess(declared);
+
+        Assert.NotNull(assessment);
+        Assert.Equal(SpecMatchKind.Exact, assessment!.Kind);
+        Assert.False(assessment.IsWarning);
+    }
+
+    [Fact]
     public void Assess_Warns_WhenDeclaredOlderMajorThanImplemented()
     {
         // S-111 fixture declares 1.0.0 but the build implements 2.0.0.


### PR DESCRIPTION
## Summary

Fixes #322. The latest UKHO S-101 test datasets (e.g. `S-101_GB_Apr26`) declare product-specification **Edition 2.0.0** and were incorrectly flagged with a version warning ("supports version 1.2.0") in the datasets pane.

## Root cause

The bundled S-101 Feature Catalogue and Portrayal Catalogue are both **Edition 2.0.0**, and `S101LegacyFeatureNames` maps legacy 1.x feature class names into their 2.0.0 equivalents — so this build genuinely targets S-101 2.0.0. However `SupportedSpecEditions` still declared only `1.2.0` for S-101.

When a dataset declared edition `2.0.0`, `SpecVersionAssessment` found no supported edition sharing major version `2`, classified the relationship as `MajorDivergence`, and surfaced a (spurious) warning.

## Change

`SupportedSpecEditions` now declares both `1.2.0` and `2.0.0` for S-101:

```csharp
["S-101"] = [new SpecVersion(1, 2, 0), new SpecVersion(2, 0, 0)],
```

- A declared `2.0.0` dataset → exact match → no warning.
- Legacy `1.x` datasets remain readable via the legacy feature-name mapper and stay benign (no warning).

## Tests

Added three cases to `SupportedSpecEditionsTests`:
- `S101_ImplementsBothEditions`
- `Assess_DoesNotWarn_ForS101Edition200` (the issue's case)
- `Assess_DoesNotWarn_ForLegacyS101Edition1x`

All 23 tests in `EncDotNet.S100.Pipelines.Tests` pass. Also verified end-to-end with the CLI `info` command against real S-101 GB data.

## Follow-up

This is a targeted fix. The underlying fragility — supported editions are asserted in code (`SupportedSpecEditions`) rather than derived from the FC/PC, which don't declare the product-spec edition they target — is tracked in a separate follow-up issue.