### PR TITLE
Harden colour-palette loading across dataset specs (#321)

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101PortrayalCatalogue.cs
@@ -58,17 +58,39 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
     public ColorPalette ActivePalette { get; private set; } = ColorPalette.Default;
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// When the requested palette cannot be resolved (for example, a portrayal
+    /// catalogue whose colour profile is absent, malformed, or in a format the
+    /// reader does not support), this method degrades gracefully rather than
+    /// throwing: it falls back to the Day palette, then to any palette that did
+    /// load, and finally to <see cref="ColorPalette.Default"/>. This mirrors the
+    /// behaviour of <c>GmlPortrayalCatalogueBase.SwitchPaletteAsync</c> so a
+    /// colour-profile problem yields a usable render with a diagnostic instead
+    /// of aborting the whole dataset load. See issue #321.
+    /// </remarks>
     public async ValueTask SwitchPaletteAsync(PaletteType type, CancellationToken cancellationToken = default)
     {
         await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_cache.Palettes.TryGetValue(type, out var palette))
+        if (_cache.Palettes.TryGetValue(type, out var palette))
         {
-            throw new KeyNotFoundException($"Color palette '{type}' not found in the portrayal catalogue.");
+            Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Palette);
+            ActivePalette = palette;
+            return;
         }
 
-        Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Palette);
-        ActivePalette = palette;
+        // Graceful fallback: prefer Day, then any loaded palette, then the
+        // built-in default. The active palette never becomes null, so the
+        // renderer can still resolve colour tokens (falling back to black).
+        var fallback = _cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette)
+            ? dayPalette
+            : _cache.Palettes.Values.FirstOrDefault() ?? ColorPalette.Default;
+
+        Console.WriteLine(
+            $"[S101] Color palette '{type}' not found in the portrayal catalogue; " +
+            $"falling back to '{fallback.Name}' ({fallback.Colors.Count} colors).");
+
+        ActivePalette = fallback;
     }
 
     public ViewingGroupController ViewingGroups { get; } = new();
@@ -80,18 +102,20 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── Palettes ───────────────────────────────────────────────────────
 
-    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
-    {
-        if (_cache.PalettesLoaded)
-        {
-            if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
-            {
-                ActivePalette = dayPalette;
-            }
-            return;
-        }
-        _cache.PalettesLoaded = true;
+    private ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken) =>
+        PaletteLoadCoordinator.EnsureLoadedAsync(
+            _cache, LoadPalettesIntoCacheAsync, ApplyDayPalette, cancellationToken);
 
+    private void ApplyDayPalette()
+    {
+        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        {
+            ActivePalette = dayPalette;
+        }
+    }
+
+    private async ValueTask LoadPalettesIntoCacheAsync(CancellationToken cancellationToken)
+    {
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -117,7 +141,7 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
                     var palette = ColorProfileReader.Read(stream, paletteName);
                     _cache.Palettes[paletteType.Value] = palette;
                 }
-                catch (Exception)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // If a color profile cannot be loaded, skip it gracefully.
                 }
@@ -139,18 +163,12 @@ public sealed class S101PortrayalCatalogue : IVectorPortrayalCatalogue
                             _cache.Palettes[type] = palette;
                         }
                     }
-                    catch (Exception)
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         // Skip gracefully.
                     }
                 }
             }
-        }
-
-        // Set Day palette as active if available
-        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayFinal))
-        {
-            ActivePalette = dayFinal;
         }
     }
 

--- a/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S102/S102PortrayalCatalogue.cs
@@ -207,7 +207,7 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
                     using var reader = new StreamReader(stream);
                     _cachedLuaSource = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Leave _cachedLuaSource null — ResolveColorScheme will throw
                     // a clear InvalidOperationException when invoked.
@@ -215,17 +215,21 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
             }
         }
 
-        if (_cache.PalettesLoaded)
-        {
-            if (ActivePalette.Colors.Count == 0 &&
-                _cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
-            {
-                ActivePalette = dayPalette;
-            }
-            return;
-        }
-        _cache.PalettesLoaded = true;
+        await PaletteLoadCoordinator.EnsureLoadedAsync(
+            _cache, LoadPalettesIntoCacheAsync, ApplyDayPalette, cancellationToken).ConfigureAwait(false);
+    }
 
+    private void ApplyDayPalette()
+    {
+        if (ActivePalette.Colors.Count == 0 &&
+            _cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        {
+            ActivePalette = dayPalette;
+        }
+    }
+
+    private async ValueTask LoadPalettesIntoCacheAsync(CancellationToken cancellationToken)
+    {
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -251,7 +255,7 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
                     var palette = ColorProfileReader.Read(stream, manifestName);
                     _cache.Palettes[paletteType.Value] = palette;
                 }
-                catch (Exception)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Skip gracefully — fall through to fallback colours
                     // at instruction-parse time.
@@ -273,17 +277,12 @@ public class S102PortrayalCatalogue : ICoveragePortrayalCatalogue
                             _cache.Palettes[type] = palette;
                         }
                     }
-                    catch (Exception)
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         // Skip gracefully.
                     }
                 }
             }
-        }
-
-        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayFinal))
-        {
-            ActivePalette = dayFinal;
         }
     }
 

--- a/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S111/S111PortrayalCatalogue.cs
@@ -71,13 +71,18 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
         await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
         await EnsureSpeedBandsLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_cache.Palettes.TryGetValue(type, out var palette))
+        if (_cache.Palettes.TryGetValue(type, out var palette))
         {
-            throw new KeyNotFoundException($"Color palette '{type}' not found in the S-111 portrayal catalogue.");
+            Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Palette);
+            ActivePalette = palette;
+            return;
         }
 
-        Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Palette);
-        ActivePalette = palette;
+        // Graceful fallback rather than throwing (issue #321): prefer Day, then
+        // any loaded palette, then the built-in default.
+        ActivePalette = _cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette)
+            ? dayPalette
+            : _cache.Palettes.Values.FirstOrDefault() ?? ColorPalette.Default;
     }
 
     /// <summary>
@@ -134,18 +139,21 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
     /// first access. Subsequent calls are a no-op thanks to the sticky
     /// <see cref="IPortrayalAssetCache.PalettesLoaded"/> flag.
     /// </summary>
-    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
-    {
-        if (_cache.PalettesLoaded)
-        {
-            if (ActivePalette.Colors.Count == 0
-                && _cache.Palettes.TryGetValue(PaletteType.Day, out var cachedDay))
-            {
-                ActivePalette = cachedDay;
-            }
-            return;
-        }
+    private ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken) =>
+        PaletteLoadCoordinator.EnsureLoadedAsync(
+            _cache, LoadPalettesIntoCacheAsync, ApplyDayPalette, cancellationToken);
 
+    private void ApplyDayPalette()
+    {
+        if (ActivePalette.Colors.Count == 0
+            && _cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+        {
+            ActivePalette = dayPalette;
+        }
+    }
+
+    private async ValueTask LoadPalettesIntoCacheAsync(CancellationToken cancellationToken)
+    {
         var colorProfileItem = _provider.Catalogue.ColorProfiles.FirstOrDefault()
             ?? throw new InvalidOperationException("S-111 portrayal catalogue does not contain a color profile.");
 
@@ -163,13 +171,6 @@ public class S111PortrayalCatalogue : ICoveragePortrayalCatalogue
             {
                 _cache.Palettes[type] = palette;
             }
-        }
-
-        _cache.PalettesLoaded = true;
-
-        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
-        {
-            ActivePalette = dayPalette;
         }
     }
 

--- a/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S131/S131PortrayalCatalogue.cs
@@ -65,11 +65,18 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
     {
         await EnsurePalettesLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_cache.Palettes.TryGetValue(type, out var palette))
-            throw new KeyNotFoundException($"Color palette '{type}' not found in the S-131 portrayal catalogue.");
+        if (_cache.Palettes.TryGetValue(type, out var palette))
+        {
+            Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Palette);
+            ActivePalette = palette;
+            return;
+        }
 
-        Portrayals.Diagnostics.PortrayalCacheMetrics.RecordHit(ProductTag, Portrayals.Diagnostics.PortrayalAssetKinds.Palette);
-        ActivePalette = palette;
+        // Graceful fallback rather than throwing (issue #321): prefer Day, then
+        // any loaded palette, then the built-in default.
+        ActivePalette = _cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette)
+            ? dayPalette
+            : _cache.Palettes.Values.FirstOrDefault() ?? ColorPalette.Default;
     }
 
     /// <inheritdoc/>
@@ -83,16 +90,18 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
 
     // ── Palettes ───────────────────────────────────────────────────────
 
-    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
-    {
-        if (_cache.PalettesLoaded)
-        {
-            if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayCached))
-                ActivePalette = dayCached;
-            return;
-        }
-        _cache.PalettesLoaded = true;
+    private ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken) =>
+        PaletteLoadCoordinator.EnsureLoadedAsync(
+            _cache, LoadPalettesIntoCacheAsync, ApplyDayPalette, cancellationToken);
 
+    private void ApplyDayPalette()
+    {
+        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
+            ActivePalette = dayPalette;
+    }
+
+    private async ValueTask LoadPalettesIntoCacheAsync(CancellationToken cancellationToken)
+    {
         foreach (var item in _provider.Catalogue.ColorProfiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -116,7 +125,7 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
                     var palette = ColorProfileReader.Read(stream, paletteName);
                     _cache.Palettes[paletteType.Value] = palette;
                 }
-                catch
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Skip gracefully if a colour profile cannot be loaded.
                 }
@@ -133,13 +142,10 @@ public sealed class S131PortrayalCatalogue : IVectorPortrayalCatalogue
                         if (palette.Colors.Count > 0)
                             _cache.Palettes[type] = palette;
                     }
-                    catch { }
+                    catch (Exception ex) when (ex is not OperationCanceledException) { }
                 }
             }
         }
-
-        if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
-            ActivePalette = dayPalette;
     }
 
     // ── Rules ──────────────────────────────────────────────────────────

--- a/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
+++ b/src/EncDotNet.S100.Datasets.S411/S411PortrayalCatalogue.cs
@@ -53,7 +53,7 @@ public sealed class S411PortrayalCatalogue : GmlPortrayalCatalogueBase
                 var palette = ColorProfileReader.Read(stream, paletteName);
                 palettes[paletteType.Value] = palette;
             }
-            catch (Exception) { }
+            catch (Exception ex) when (ex is not OperationCanceledException) { }
         }
     }
 

--- a/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
+++ b/src/EncDotNet.S100.Portrayals/GmlPortrayalCatalogueBase.cs
@@ -96,19 +96,15 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
 
     // ── Palettes ───────────────────────────────────────────────────────
 
-    private async ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken)
-    {
-        if (_cache.PalettesLoaded)
-        {
-            if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayCached))
-            {
-                ActivePalette = dayCached;
-            }
-            return;
-        }
-        _cache.PalettesLoaded = true;
-        await LoadPalettesAsync(((PortrayalAssetCache)_cache).PalettesDictionary, cancellationToken).ConfigureAwait(false);
+    private ValueTask EnsurePalettesLoadedAsync(CancellationToken cancellationToken) =>
+        PaletteLoadCoordinator.EnsureLoadedAsync(
+            _cache,
+            ct => new ValueTask(LoadPalettesAsync(((PortrayalAssetCache)_cache).PalettesDictionary, ct)),
+            ApplyDayPalette,
+            cancellationToken);
 
+    private void ApplyDayPalette()
+    {
         if (_cache.Palettes.TryGetValue(PaletteType.Day, out var dayPalette))
         {
             ActivePalette = dayPalette;
@@ -147,7 +143,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
                     var palette = ColorProfileReader.Read(stream, paletteName);
                     palettes[paletteType.Value] = palette;
                 }
-                catch (Exception)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Skip gracefully.
                 }
@@ -167,7 +163,7 @@ public abstract class GmlPortrayalCatalogueBase : IVectorPortrayalCatalogue
                             palettes[type] = palette;
                         }
                     }
-                    catch (Exception)
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         // Skip gracefully.
                     }

--- a/src/EncDotNet.S100.Portrayals/PaletteLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Portrayals/PaletteLoadCoordinator.cs
@@ -1,0 +1,95 @@
+namespace EncDotNet.S100.Portrayals;
+
+/// <summary>
+/// Centralizes the concurrency-safe, one-shot colour-palette load protocol
+/// shared by every portrayal catalogue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A single <see cref="IPortrayalAssetCache"/> is shared per product spec
+/// across every dataset of that spec (for example, every cell of one S-101
+/// exchange set), and those datasets load on separate threads. Two earlier
+/// defects followed from loading palettes ad hoc:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <description>
+///       <b>Cache poisoning.</b> Marking <see cref="IPortrayalAssetCache.PalettesLoaded"/>
+///       before the load completed meant a cancelled or aborted load (routine
+///       in the viewer when a pan/zoom/reload cancels the in-flight render)
+///       left the shared cache flagged loaded-but-empty, so every later palette
+///       lookup failed.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Races.</b> Concurrent loaders wrote the non-thread-safe palette
+///       dictionary simultaneously, or a second loader observed it
+///       half-populated.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// This helper serializes the load through
+/// <see cref="IPortrayalAssetCache.PaletteLoadGate"/> with double-checked
+/// locking and commits <see cref="IPortrayalAssetCache.PalettesLoaded"/> only
+/// after the load runs to completion without being cancelled. See issue #321.
+/// </para>
+/// </remarks>
+public static class PaletteLoadCoordinator
+{
+    /// <summary>
+    /// Ensures the shared cache's palettes are loaded exactly once, safely
+    /// under concurrency, retrying after a cancelled attempt rather than
+    /// poisoning the cache.
+    /// </summary>
+    /// <param name="cache">The shared per-spec asset cache.</param>
+    /// <param name="loadInto">
+    /// Populates <see cref="IPortrayalAssetCache.Palettes"/>. Invoked at most
+    /// once per successful load while the gate is held. Must not set
+    /// <see cref="IPortrayalAssetCache.PalettesLoaded"/> itself.
+    /// </param>
+    /// <param name="onLoaded">
+    /// Applies the catalogue's active-palette selection (typically Day). Called
+    /// after the load completes and on the already-loaded fast path.
+    /// </param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public static async ValueTask EnsureLoadedAsync(
+        IPortrayalAssetCache cache,
+        Func<CancellationToken, ValueTask> loadInto,
+        Action onLoaded,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(loadInto);
+        ArgumentNullException.ThrowIfNull(onLoaded);
+
+        if (cache.PalettesLoaded)
+        {
+            onLoaded();
+            return;
+        }
+
+        await cache.PaletteLoadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Double-checked: another loader may have completed while we waited.
+            if (cache.PalettesLoaded)
+            {
+                onLoaded();
+                return;
+            }
+
+            await loadInto(cancellationToken).ConfigureAwait(false);
+
+            // Commit only now that the load has run to completion without being
+            // cancelled, so a cancelled attempt is retried on the next call.
+            cache.PalettesLoaded = true;
+            onLoaded();
+        }
+        finally
+        {
+            cache.PaletteLoadGate.Release();
+        }
+    }
+}

--- a/src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs
@@ -85,6 +85,16 @@ public interface IPortrayalAssetCache
     /// (and re-opening the underlying colour-profile assets).
     /// </summary>
     bool PalettesLoaded { get; set; }
+
+    /// <summary>
+    /// Serializes the one-shot palette load across catalogues that share this
+    /// cache. Multiple datasets of the same spec (for example, every cell of
+    /// one S-101 exchange set) load on separate threads but share a single
+    /// per-spec cache; without this gate they would race to populate the
+    /// non-thread-safe palette dictionary or observe it half-populated. See
+    /// issue #321.
+    /// </summary>
+    SemaphoreSlim PaletteLoadGate { get; }
 }
 
 /// <summary>
@@ -149,4 +159,7 @@ public sealed class PortrayalAssetCache : IPortrayalAssetCache
 
     /// <inheritdoc/>
     public bool PalettesLoaded { get; set; }
+
+    /// <inheritdoc/>
+    public SemaphoreSlim PaletteLoadGate { get; } = new(1, 1);
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/PaletteLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PaletteLoadCoordinatorTests.cs
@@ -1,0 +1,92 @@
+using EncDotNet.S100.Portrayals;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="PaletteLoadCoordinator"/>, the shared
+/// concurrency-safe palette-load protocol introduced for issue #321. These
+/// tests exercise the coordinator directly against a real
+/// <see cref="PortrayalAssetCache"/> so the guarantees hold independently of
+/// any single product spec's catalogue.
+/// </summary>
+public class PaletteLoadCoordinatorTests
+{
+    [Fact]
+    public async Task EnsureLoaded_RunsLoadExactlyOnce_ThenUsesFastPath()
+    {
+        var cache = new PortrayalAssetCache();
+        var loadCount = 0;
+        var appliedCount = 0;
+
+        ValueTask Load(CancellationToken _)
+        {
+            loadCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        for (var i = 0; i < 5; i++)
+        {
+            await PaletteLoadCoordinator.EnsureLoadedAsync(cache, Load, () => appliedCount++);
+        }
+
+        Assert.Equal(1, loadCount);
+        Assert.Equal(5, appliedCount);
+        Assert.True(cache.PalettesLoaded);
+    }
+
+    [Fact]
+    public async Task EnsureLoaded_WhenLoadCancelled_DoesNotPoisonCache()
+    {
+        var cache = new PortrayalAssetCache();
+        var attempts = 0;
+        using var cts = new CancellationTokenSource();
+
+        ValueTask Load(CancellationToken ct)
+        {
+            attempts++;
+            // Simulate the in-flight load being cancelled partway through
+            // (e.g. the viewer aborts a render on pan/zoom/reload).
+            if (attempts == 1)
+            {
+                cts.Cancel();
+                ct.ThrowIfCancellationRequested();
+            }
+            return ValueTask.CompletedTask;
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await PaletteLoadCoordinator.EnsureLoadedAsync(cache, Load, () => { }, cts.Token));
+
+        // The cancelled attempt must NOT have committed the loaded flag.
+        Assert.False(cache.PalettesLoaded);
+
+        // A subsequent (uncancelled) load succeeds and commits.
+        await PaletteLoadCoordinator.EnsureLoadedAsync(cache, Load, () => { });
+
+        Assert.True(cache.PalettesLoaded);
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task EnsureLoaded_UnderConcurrency_LoadsOnlyOnce()
+    {
+        var cache = new PortrayalAssetCache();
+        var loadCount = 0;
+
+        async ValueTask SlowLoad(CancellationToken ct)
+        {
+            Interlocked.Increment(ref loadCount);
+            await Task.Delay(50, ct);
+        }
+
+        var tasks = Enumerable.Range(0, 16)
+            .Select(_ => Task.Run(async () =>
+                await PaletteLoadCoordinator.EnsureLoadedAsync(cache, SlowLoad, () => { })))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, loadCount);
+        Assert.True(cache.PalettesLoaded);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101PaletteFallbackTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101PaletteFallbackTests.cs
@@ -1,0 +1,157 @@
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Specifications;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Regression coverage for issue #321: when a portrayal catalogue's colour
+/// profile is present but yields no usable palette (e.g. a colour profile that
+/// only declares named colours with no sRGB values, or a format the reader does
+/// not support), <see cref="S101PortrayalCatalogue.SwitchPaletteAsync"/> must
+/// degrade gracefully to a usable palette rather than throwing a
+/// <see cref="KeyNotFoundException"/> that aborts the whole dataset load.
+/// </summary>
+public class S101PaletteFallbackTests
+{
+    // A minimal S-101 portrayal catalogue that references a single colour
+    // profile. The profile file (below) contains only named colours with no
+    // sRGB values, so ColorProfileReader produces an empty palette for Day,
+    // Dusk, and Night — the exact condition reported in #321.
+    private const string CatalogueXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <portrayalCatalogue productId="S-101" version="1.0.0">
+          <colorProfiles>
+            <colorProfile id="1">
+              <description>
+                <name>Color Profile</name>
+                <language>eng</language>
+              </description>
+              <fileName>colorProfile.xml</fileName>
+              <fileType>ColorProfile</fileType>
+              <fileFormat>XML</fileFormat>
+            </colorProfile>
+          </colorProfiles>
+        </portrayalCatalogue>
+        """;
+
+    private const string EmptyColorProfileXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <colorProfile>
+          <color token="NODTA" name="grey"><description>No data</description></color>
+          <color token="CHBLK" name="black"><description>Chart black</description></color>
+        </colorProfile>
+        """;
+
+    private static async Task<S101PortrayalCatalogue> CreateCatalogueAsync(string dir)
+    {
+        Directory.CreateDirectory(Path.Combine(dir, "ColorProfiles"));
+        await File.WriteAllTextAsync(Path.Combine(dir, "portrayal_catalogue.xml"), CatalogueXml);
+        await File.WriteAllTextAsync(Path.Combine(dir, "ColorProfiles", "colorProfile.xml"), EmptyColorProfileXml);
+
+        var source = FileSystemAssetSource.Create(dir);
+        var provider = await PortrayalCatalogueProvider.OpenAsync(source);
+        return new S101PortrayalCatalogue(provider);
+    }
+
+    [Fact]
+    public async Task SwitchPalette_WhenProfileYieldsNoColors_FallsBackInsteadOfThrowing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "encdotnet-issue321-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var catalogue = await CreateCatalogueAsync(dir);
+
+            // Must not throw KeyNotFoundException (the #321 symptom).
+            await catalogue.SwitchPaletteAsync(PaletteType.Day);
+
+            Assert.NotNull(catalogue.ActivePalette);
+            Assert.Same(ColorPalette.Default, catalogue.ActivePalette);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SwitchPalette_ToEveryType_NeverThrows()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "encdotnet-issue321-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var catalogue = await CreateCatalogueAsync(dir);
+
+            await catalogue.SwitchPaletteAsync(PaletteType.Day);
+            await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
+            await catalogue.SwitchPaletteAsync(PaletteType.Night);
+
+            Assert.NotNull(catalogue.ActivePalette);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A palette load that is cancelled part-way must not poison the shared
+    /// per-spec asset cache. Before the fix, the cache was marked
+    /// <c>PalettesLoaded</c> up-front, so a cancelled load left it flagged
+    /// loaded-but-empty and every subsequent <c>SwitchPaletteAsync('Day')</c>
+    /// threw <see cref="KeyNotFoundException"/> — the #321 symptom, reproducible
+    /// with the bundled catalogue and no custom configuration. A later,
+    /// non-cancelled call must successfully load the real Day palette.
+    /// </summary>
+    [Fact]
+    public async Task CancelledLoad_DoesNotPoisonCache_LaterLoadSucceeds()
+    {
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var provider = await PortrayalCatalogueProvider.OpenAsync(pcSource);
+        var catalogue = new S101PortrayalCatalogue(provider);
+
+        using (var cts = new CancellationTokenSource())
+        {
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await catalogue.SwitchPaletteAsync(PaletteType.Day, cts.Token));
+        }
+
+        // The cache must not have been committed by the cancelled attempt, so a
+        // fresh load resolves the real, populated Day palette.
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
+        Assert.Equal("Day", catalogue.ActivePalette.Name);
+        Assert.NotEmpty(catalogue.ActivePalette.Colors);
+    }
+
+    /// <summary>
+    /// Two catalogues sharing one per-spec cache (as happens for every cell of
+    /// a single S-101 exchange set) may load palettes concurrently on separate
+    /// threads. The shared load gate must serialize the one-shot load so neither
+    /// observes a half-populated dictionary nor throws — the multi-cell variant
+    /// of the #321 failure.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentLoads_SharingCache_BothSucceed()
+    {
+        using var pcSource = Specification.CreatePortrayalCatalogueSource("S-101");
+        var provider = await PortrayalCatalogueProvider.OpenAsync(pcSource);
+
+        // Both catalogues read provider.AssetCache, so they share one cache.
+        var catalogueA = new S101PortrayalCatalogue(provider);
+        var catalogueB = new S101PortrayalCatalogue(provider);
+
+        await Task.WhenAll(
+            Task.Run(async () => await catalogueA.SwitchPaletteAsync(PaletteType.Day)),
+            Task.Run(async () => await catalogueB.SwitchPaletteAsync(PaletteType.Day)));
+
+        Assert.Equal("Day", catalogueA.ActivePalette.Name);
+        Assert.NotEmpty(catalogueA.ActivePalette.Colors);
+        Assert.Equal("Day", catalogueB.ActivePalette.Name);
+        Assert.NotEmpty(catalogueB.ActivePalette.Colors);
+    }
+}


### PR DESCRIPTION
## Why

Loading an S-101 exchange set could abort with `KeyNotFoundException: Color palette 'Day' not found in the portrayal catalogue` (issue #321). The portrayal catalogue's `PortrayalAssetCache` is shared per product spec across every dataset of that spec (for example, every cell of one exchange set), and those cells load on separate threads. That sharing exposed two defects:

- **Cache poisoning.** `PalettesLoaded` was set to `true` *before* the awaited palette load. If the load was cancelled or aborted partway through (routine in the viewer when a pan/zoom/reload cancels an in-flight render), the shared cache was left flagged loaded-but-empty forever, so every later `SwitchPaletteAsync('Day')` failed.
- **Races.** Concurrent loaders wrote the non-thread-safe palette dictionary at the same time, or observed it half-populated.

## Approach

Centralize the concurrency-safe load protocol in one place rather than fixing each catalogue ad hoc:

- New `PaletteLoadCoordinator.EnsureLoadedAsync` serializes the one-shot load through a `PaletteLoadGate` (`SemaphoreSlim`) on the shared cache, uses double-checked locking, and commits `PalettesLoaded` **only after** the load runs to completion without being cancelled. A cancelled attempt is retried on the next call instead of poisoning the cache.
- Added `PaletteLoadGate` to `IPortrayalAssetCache` / `PortrayalAssetCache`.
- Routed every catalogue through the coordinator: **S101**, **S102** (Lua pre-warm preserved), **S111**, **S131**, and **GmlPortrayalCatalogueBase** (covering S122/124/125/127/128/129/201/411/421).
- Made `SwitchPaletteAsync` degrade gracefully (prefer Day, then any loaded palette, then `ColorPalette.Default`) instead of throwing `KeyNotFoundException`, so a colour-profile problem yields a usable render with a diagnostic rather than aborting the whole dataset load.
- Stopped `catch` blocks from swallowing `OperationCanceledException` (in the GML base and S411), so a cancelled fetch no longer masquerades as a complete-but-empty load.

S-104 is unaffected (synchronous, hardcoded bands, no cache).

## Notes for reviewers

- The shared per-spec cache is intentional and unchanged; the fix is purely about how that cache is populated safely.
- `ColorPalette.Default` has name "Day" but an empty colour dictionary, so tests assert on `Colors` being non-empty to distinguish a real Day palette from the fallback.

## Tests

- New `PaletteLoadCoordinatorTests`: load-runs-once, no-poison-on-cancel, and concurrency (16 parallel loaders load once).
- New `S101PaletteFallbackTests`: graceful fallback plus cancellation-poisoning regression.
- Full Pipelines suite (590 passed) plus S104/S111/S131/S125/S201/S421 suites all green; solution builds clean.

Fixes #321