### PR TITLE
Support non-PNG output formats in `s100 render` (#190)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # Command-line rendering (`s100`)
 
 `EncDotNet.S100.Cli` is a cross-platform .NET console tool, invoked as **`s100`**,
-that renders any supported S-100 dataset to a PNG image. It drives the same
+that renders any supported S-100 dataset to a PNG, JPEG, or WebP image. It drives the same
 portrayal pipelines as the Avalonia viewer, but rasterises through the
 Mapsui-free Skia *headless* renderers so it can run without a UI — making it
 suitable for batch scripts (e.g. generating sea-ice or surface-current
@@ -11,7 +11,7 @@ It offers three subcommands:
 
 | Command | Purpose |
 |---|---|
-| `s100 render <dataset> <output>` | Render a dataset to a PNG image. |
+| `s100 render <dataset> <output>` | Render a dataset to an image (PNG, JPEG, or WebP). |
 | `s100 info <dataset>` | Show the detected spec, edition, headless-render capability, and (for time-series datasets) the available time steps. |
 | `s100 list-specs` | List the supported product specifications and which support headless rendering. |
 
@@ -63,7 +63,8 @@ dotnet run --project tools/EncDotNet.S100.Cli -- \
 The CLI detects a dataset's product specification from the file, runs that
 spec's portrayal pipeline — the same pipeline the Avalonia viewer uses, wired to
 the feature and portrayal catalogues bundled in the tool — and encodes the
-result to PNG. Vector specs (S-101 and the GML products) and coverage specs
+result to the requested image format (PNG by default; JPEG or WebP via
+`--format` or the output extension). Vector specs (S-101 and the GML products) and coverage specs
 (S-102/104/111) each rasterise through their own headless Skia renderer; for
 S-111 the current arrows are overlaid on the coverage. No UI or map projection
 stack is involved, so it runs anywhere .NET does.
@@ -77,6 +78,8 @@ stack is involved, so it runs anywhere .NET does.
 | `--symbol-scale` / `--text-scale` | `1.0` | Symbol and text scale factors. |
 | `--time-step <index>` | `0` | Zero-based time step for time-series datasets (S-104 / S-111). |
 | `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
+| `--format <fmt>` | inferred from extension (else `png`) | Output image format: `png`, `jpeg` (`jpg`), or `webp`. |
+| `--quality <1-100>` | `90` | Encoder quality for lossy formats (`jpeg`, `webp`). Ignored for `png`. |
 | `--no-text` | off | Suppress text/label drawing instructions (shorthand for `--hide text`). |
 | `--hide <list>` | _none_ | Suppress drawing-instruction categories — any of `text`, `points`, `lines`, `areas` — useful for clean fills on label-dense products such as S-411 sea-ice. |
 
@@ -84,7 +87,9 @@ stack is involved, so it runs anywhere .NET does.
 
 - **Headless rendering** for S-101; S-102; S-104 and S-111 *gridded* coverages;
   and the GML products S-122/124/125/127/128/129/131/201/411/421.
-- **PNG output.**
+- **Output formats:** PNG, JPEG, and WebP. The format is inferred from the
+  output file extension (or set explicitly with `--format`); `--quality`
+  controls the encoder quality for the lossy formats.
 - **Text and category suppression** via `--no-text` / `--hide` for cleaner
   previews of label-dense products.
 - **Fixed-station coverage** (S-104 / S-111 data coding format 3 / 8) is not

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
@@ -72,6 +72,102 @@ public sealed class RenderCommandTests
         Assert.Equal(0, exit);
     }
 
+    [Theory]
+    [InlineData("jpg")]
+    [InlineData("webp")]
+    public void Render_infers_non_png_format_from_extension(string extension)
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.{extension}");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            // A PNG signature must NOT be present; the bytes must decode as an image.
+            var bytes = File.ReadAllBytes(output);
+            Assert.NotEqual(PngSignature, bytes[..PngSignature.Length]);
+
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+            Assert.Equal(320, bitmap!.Width);
+            Assert.Equal(240, bitmap.Height);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_honours_explicit_format_option_over_extension()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        // No extension on the output path; --format drives the encoder.
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--format", "jpeg", "--quality", "75",
+                 "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_with_unknown_format_returns_nonzero()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(["render", dataset, output, "--format", "tiff"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Render_with_format_extension_mismatch_returns_nonzero()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(["render", dataset, output, "--format", "jpeg"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Render_with_out_of_range_quality_returns_nonzero()
+    {
+        var dataset = FixturePath("marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.jpg");
+        int exit = CliApp.Build().Run(["render", dataset, output, "--quality", "0"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
     [Fact]
     public void Render_writes_a_valid_png_for_an_s57_cell()
     {

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -24,8 +24,17 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
     internal sealed class Settings : DatasetCommandSettings
     {
         [CommandArgument(1, "<output>")]
-        [Description("Path of the PNG image to write.")]
+        [Description("Path of the image to write. The format is inferred from the file extension unless --format is given.")]
         public string OutputPath { get; init; } = string.Empty;
+
+        [CommandOption("--format")]
+        [Description("Output image format: png, jpeg (jpg), or webp. Default: inferred from the output file extension, falling back to png.")]
+        public string? Format { get; init; }
+
+        [CommandOption("--quality")]
+        [Description("Encoder quality (1-100) for lossy formats such as jpeg and webp. Ignored for png. Default 90.")]
+        [DefaultValue(90)]
+        public int Quality { get; init; }
 
         [CommandOption("-w|--width")]
         [Description("Output image width in pixels (default 1024).")]
@@ -78,6 +87,12 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
 
             if (string.IsNullOrWhiteSpace(OutputPath))
                 return ValidationResult.Error("An output path is required.");
+
+            if (!TryResolveFormat(Format, OutputPath, out _, out var formatError))
+                return ValidationResult.Error(formatError);
+
+            if (Quality is < 1 or > 100)
+                return ValidationResult.Error("--quality must be between 1 and 100.");
 
             if (Width <= 0 || Height <= 0)
                 return ValidationResult.Error("--width and --height must be positive.");
@@ -156,10 +171,11 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 .RenderHeadlessAsync(settings.Width, settings.Height, renderContext, background)
                 .GetAwaiter().GetResult();
 
-            WritePng(bitmap, settings.OutputPath);
+            TryResolveFormat(settings.Format, settings.OutputPath, out var format, out _);
+            WriteImage(bitmap, settings.OutputPath, format, settings.Quality);
 
             AnsiConsole.MarkupLineInterpolated(
-                $"[green]Wrote[/] {settings.OutputPath} ([grey]{spec}, {bitmap.Width}x{bitmap.Height}[/])");
+                $"[green]Wrote[/] {settings.OutputPath} ([grey]{spec}, {format}, {bitmap.Width}x{bitmap.Height}[/])");
             return 0;
         }
         catch (NotSupportedException ex)
@@ -202,12 +218,70 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         }
     }
 
-    private static void WritePng(SKBitmap bitmap, string outputPath)
+    private static void WriteImage(SKBitmap bitmap, string outputPath, SKEncodedImageFormat format, int quality)
     {
         using var image = SKImage.FromBitmap(bitmap);
-        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var data = image.Encode(format, quality)
+            ?? throw new NotSupportedException(
+                $"SkiaSharp could not encode the image as {format} on this platform.");
         using var stream = File.Create(outputPath);
         data.SaveTo(stream);
+    }
+
+    /// <summary>
+    /// Resolves the desired <see cref="SKEncodedImageFormat"/> from an explicit
+    /// <paramref name="format"/> option when supplied, otherwise infers it from
+    /// the extension of <paramref name="outputPath"/>, falling back to PNG when
+    /// the extension is absent or unrecognised and no explicit format is given.
+    /// Returns <see langword="false"/> with a populated <paramref name="error"/>
+    /// when an explicit format is unrecognised or an explicit format conflicts
+    /// with a recognised, differing output extension.
+    /// </summary>
+    internal static bool TryResolveFormat(
+        string? format, string outputPath, out SKEncodedImageFormat resolved, out string error)
+    {
+        resolved = SKEncodedImageFormat.Png;
+        error = string.Empty;
+
+        var extKnown = TryParseFormatToken(
+            Path.GetExtension(outputPath).TrimStart('.'), out var extFormat);
+
+        if (!string.IsNullOrWhiteSpace(format))
+        {
+            if (!TryParseFormatToken(format, out resolved))
+            {
+                error = $"Unknown --format '{format}'. Use png, jpeg, or webp.";
+                return false;
+            }
+
+            if (extKnown && extFormat != resolved)
+            {
+                error =
+                    $"--format {resolved} conflicts with the output extension " +
+                    $"'{Path.GetExtension(outputPath)}' ({extFormat}). " +
+                    "Use a matching extension or omit --format.";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (extKnown)
+            resolved = extFormat;
+
+        return true;
+    }
+
+    private static bool TryParseFormatToken(string value, out SKEncodedImageFormat format)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "png": format = SKEncodedImageFormat.Png; return true;
+            case "jpg":
+            case "jpeg": format = SKEncodedImageFormat.Jpeg; return true;
+            case "webp": format = SKEncodedImageFormat.Webp; return true;
+            default: format = SKEncodedImageFormat.Png; return false;
+        }
     }
 
     internal static bool TryParsePalette(string value, out PaletteType palette)

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -1,8 +1,8 @@
 # EncDotNet.S100.Cli (`s100`)
 
 A small, cross-platform command-line tool for working with S-100 datasets. Its
-primary command renders any supported dataset to a PNG image by running the
-dataset's portrayal pipeline through the Mapsui-free Skia *headless* renderer;
+primary command renders any supported dataset to a PNG, JPEG, or WebP image by
+running the dataset's portrayal pipeline through the Mapsui-free Skia *headless*
 it can also report a dataset's product specification (`info`) and validate a
 dataset against its specification's normative rule pack (`validate`). It is
 intended as the basis for batch scripts (for example, generating previews of
@@ -89,7 +89,8 @@ same step that signs the viewer, so it runs without Gatekeeper prompts.
 ### `s100 render <dataset> <output>`
 
 Detects the product specification of `<dataset>`, runs its portrayal pipeline,
-and writes a PNG to `<output>`.
+and writes an image to `<output>`. The output format (PNG, JPEG, or WebP) is
+inferred from the file extension unless `--format` is given.
 
 | Option | Default | Description |
 |---|---|---|
@@ -100,6 +101,8 @@ and writes a PNG to `<output>`.
 | `--text-scale` | `1.0` | Text scale factor. |
 | `--time-step <index>` | `0` | Zero-based time-step index for time-series datasets (S-104 / S-111). |
 | `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
+| `--format <fmt>` | inferred from extension, else `png` | Output image format: `png`, `jpeg` (`jpg`), or `webp`. When omitted, the format is inferred from the output file extension; an unrecognised extension falls back to `png`. An explicit `--format` that conflicts with a recognised output extension is rejected. |
+| `--quality <1-100>` | `90` | Encoder quality for lossy formats (`jpeg`, `webp`). Ignored for `png`. |
 | `--no-text` | off | Suppress text/label drawing instructions. Shorthand for `--hide text`. |
 | `--hide <list>` | _none_ | Comma-separated list of drawing-instruction categories to suppress: `text`, `points`, `lines`, `areas` (e.g. `--hide text,points`). Combines additively with `--no-text`. Useful for label-dense products such as S-411 sea-ice, where the egg-code text overlaps fills at preview scales — `--no-text` yields a BSIS-style "clean fill" preview. |
 | `--no-updates` | off | Do not apply S-101 sequential updates. By default, when the dataset is an S-101 base cell (`….000`), any sibling update files (`….001`, `….002`, …) in the same directory are applied best-effort before rendering so the cell is drawn at its up-to-date state (S-100 Part 10a). |
@@ -112,6 +115,8 @@ s100 render seaice.gml seaice.png --no-text                # clean fill preview
 s100 render chart.gml chart.png --hide text,points         # hide text + symbols
 s100 render NL4NZ110.000 cell.png                          # applies .001/.002/… updates
 s100 render NL4NZ110.000 base.png --no-updates             # render the base cell only
+s100 render warnings.gml warnings.jpg --quality 85         # JPEG (format inferred from .jpg)
+s100 render warnings.gml preview.webp                      # WebP preview
 ```
 
 > **S-101 sequential updates.** When pointed at an S-101 base cell
@@ -183,7 +188,6 @@ headless render path.
 
 ## Limitations
 
-- **PNG output only.**
 - **Vector pattern area-fills are omitted** on the headless path; points,
   lines, solid-area fills, and text render.
 - **Coverage fixed-station datasets are not supported.** S-104 / S-111 datasets


### PR DESCRIPTION
Closes #190. Follow-up to #187.

## What

Adds JPEG and WebP output to `s100 render` alongside PNG.

- **`--format <png|jpeg|jpg|webp>`** — explicit format override.
- **Extension inference** — when `--format` is omitted, the format is derived from the output file extension (`.jpg` → JPEG, `.webp` → WebP), falling back to PNG for unknown/missing extensions.
- **`--quality <1-100>`** (default 90) — encoder quality for lossy formats (JPEG/WebP); ignored for PNG.
- The encoder is validated against `SKEncodedImageFormat`; a null encode result (unsupported on the platform) raises a clear `NotSupportedException`.
- The success line now reports the chosen format.

## Validation

Fails fast with clear errors for:
- unknown `--format` values,
- a `--format` that conflicts with a recognised output extension (e.g. `--format jpeg out.png`),
- `--quality` outside `1-100`.

## Acceptance (per #190)

- ✅ `s100 render dataset out.jpg` and `out.webp` produce valid images.
- ✅ Unsupported / mismatched formats fail with a clear validation error.
- ✅ Tests cover extension inference and non-PNG encodes.

## Tests

New `RenderCommandTests` cases: extension inference for `.jpg`/`.webp` (asserts no PNG signature + decodes), explicit `--format` over an extensionless path, and three failure cases (unknown format, format/extension mismatch, out-of-range quality). All 80 CLI tests pass.

## Docs

Updated `docs/cli.md` and `tools/EncDotNet.S100.Cli/README.md` (options tables, capabilities, examples; removed the "PNG output only" limitation).

## Note

A `--format` that contradicts a recognised extension is treated as a hard error rather than silently overriding. Happy to relax this if preferred.