### PR TITLE
Fix rotated compound symbol pivot placement in Skia renderer (#335)

### DIFF
--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -270,20 +270,30 @@ public sealed class SkiaDisplayListRenderer
                 // CullRect). Applying a further mm→px factor here would oversize
                 // every symbol by ~3.78×.
                 float scale = (float)symbol.Scale;
-                float w = bounds.Width * scale;
-                float h = bounds.Height * scale;
 
-                // Place the bbox centre on the anchor, then shift by the pivot
-                // fraction so the pivot — not the bbox centre — lands on it.
-                float pivotShiftX = (float)(symbol.PivotRelativeX * w);
-                float pivotShiftY = (float)(symbol.PivotRelativeY * h);
+                // The symbol's pivot point (S-100 Part 9 §11.5) must coincide
+                // with the feature anchor, and any rotation/scale must be about
+                // that pivot — not the bounding-box centre. Working entirely in
+                // picture coordinates, the pivot is the bbox centre shifted by
+                // the pivot fraction (PivotRelative = (centre − pivot) / size):
+                //   pivot = bboxCentre − PivotRelative × bounds
+                // Composing translate(anchor) → rotate → scale → translate(−pivot)
+                // rotates and scales the glyph about its pivot while keeping the
+                // pivot pinned to the anchor for *every* rotation. (Pre-rotation
+                // pivot shifts in screen space only land correctly at 0°, which
+                // left oriented secondary symbols — e.g. a buoy's light flare or
+                // an offset colour symbol — drifting off the anchor; see #335.)
+                float pivotPicX = bounds.Left + bounds.Width / 2f
+                    - (float)(symbol.PivotRelativeX * bounds.Width);
+                float pivotPicY = bounds.Top + bounds.Height / 2f
+                    - (float)(symbol.PivotRelativeY * bounds.Height);
 
                 canvas.Save();
-                canvas.Translate(cx + pivotShiftX, cy + pivotShiftY);
+                canvas.Translate(cx, cy);
                 if (op.Rotation is { } rot)
                     canvas.RotateDegrees((float)rot);
                 canvas.Scale(scale);
-                canvas.Translate(-(bounds.Left + bounds.Width / 2f), -(bounds.Top + bounds.Height / 2f));
+                canvas.Translate(-pivotPicX, -pivotPicY);
                 canvas.DrawPicture(picture);
                 canvas.Restore();
                 return;

--- a/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
@@ -214,6 +214,68 @@ public sealed class SkiaDisplayListRendererTests
         Assert.True(centre.Blue > centre.Red && centre.Blue > centre.Green);
     }
 
+    // ── Rotated pivot placement (#335) ─────────────────────────────────
+
+    [Theory]
+    [InlineData(0.0, 0.0, -1.0)]    // glyph directly above the anchor
+    [InlineData(90.0, 1.0, 0.0)]    // rotated 90° CW (screen) => glyph to the right
+    [InlineData(180.0, 0.0, 1.0)]   // rotated 180° => glyph below the anchor
+    public void Render_RotatedSymbol_PivotsAboutAnchor_NotBboxCentre(
+        double rotation, double expectDirX, double expectDirY)
+    {
+        // A symbol whose pivot (S-100 Part 9 §11.5) sits at the BOTTOM-centre
+        // with its only painted content (a red square) near the TOP. When the
+        // pivot is pinned to the anchor and the glyph is rotated about it, the
+        // glyph must swing around the anchor at a fixed radius. The earlier
+        // renderer applied the pivot shift in screen space *before* rotating,
+        // so rotated secondary symbols (e.g. a buoy's oriented light flare)
+        // drifted off the anchor — the #335 compound-buoy defect.
+        const string svg =
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"4mm\" height=\"10mm\" " +
+            "viewBox=\"-2 -10 4 10\">" +
+            "<rect x=\"-1\" y=\"-10\" width=\"2\" height=\"2\" fill=\"red\"/>" +
+            "<circle class=\"pivotPoint\" cx=\"0\" cy=\"0\" r=\"0.2\" fill=\"none\"/></svg>";
+
+        var asset = VectorSceneBuilder.ResolveSymbolAsset(svg, null)!.Value;
+        var scene = new VectorScene([
+            new PointPaintOp
+            {
+                FeatureReference = "sym",
+                World = Project(0.005, 0.005),  // centre => screen (100, 100)
+                Rotation = rotation,
+                Symbol = new ResolvedSymbol(
+                    asset.ProcessedSvg, Scale: 2.0,
+                    asset.PivotRelativeX, asset.PivotRelativeY),
+            },
+        ]);
+
+        using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+
+        // Red-square centroid.
+        long sx = 0, sy = 0, n = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red > 150 && p.Green < 100 && p.Blue < 100) { sx += x; sy += y; n++; }
+        }
+        Assert.True(n > 0, "Symbol rendered nothing.");
+
+        double cx = sx / (double)n, cy = sy / (double)n;
+        const double anchorX = 100, anchorY = 100;
+        double dx = cx - anchorX, dy = cy - anchorY;
+        double radius = Math.Sqrt(dx * dx + dy * dy);
+
+        // The glyph sits ~9 mm above the pivot; at 96 DPI × Scale 2 that is a
+        // fixed ~68 px radius regardless of rotation. A wrong (pre-rotation,
+        // screen-space) pivot shift collapses or shifts this radius.
+        Assert.InRange(radius, 60.0, 76.0);
+
+        // ...and it must lie in the expected direction once rotated.
+        Assert.InRange(dx / radius, expectDirX - 0.15, expectDirX + 0.15);
+        Assert.InRange(dy / radius, expectDirY - 0.15, expectDirY + 0.15);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private static double RenderLineAndMeasureCentreWidth(double widthPx, double geoSpan)


### PR DESCRIPTION
## Summary

Compound buoy symbols (topmark, colour symbol, light flare) appeared overlapped at the anchor instead of correctly offset when rendered through the tiled/Skia subsystem ("B"). Fixes #335. The Mapsui subsystem ("A") was never affected by this bug.

`SkiaDisplayListRenderer.DrawPoint` applied the SVG pivot (S-100 Part 9 §11.5) as a pre-rotation translation in *screen* space. That only lands the pivot on the feature anchor at rotation 0 degrees, so any rotated symbol (e.g. a buoy's oriented light flare) drifted off the anchor. Unrotated parts rendered fine, which is why the defect was easy to miss and only showed up on compound buoys.

The fix rotates and scales **about the pivot**, working entirely in picture coordinates so the pivot stays pinned to the anchor at every rotation. The new transform composes `translate(anchor) -> rotate -> scale -> translate(-pivot)`. This is algebraically identical to the old path at 0 degrees, so unrotated symbols are byte-for-byte unchanged; only rotated symbols move (correctly).

A probe confirmed the behaviour: a pivot-at-bottom glyph that should sit a fixed ~68 px from the anchor previously collapsed to ~9 px at 180 degrees and shifted off-radius at 90 degrees; after the fix it holds ~67-68 px and swings to the correct quadrant. Verified end-to-end in the viewer: the Thorn Channel west-cardinal buoy now renders with topmark above the body and the light flare offset down-right.

Note: while comparing subsystems I saw "A" not draw this buoy's point symbol at certain zoom levels. That is a known, separate zoom-dependent symbol-visibility issue and is out of scope here.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)

**Spec section references cited in code/docs:** S-100 Part 9 §11.5 (symbol pivot placement), cited in the `DrawPoint` comment.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (N/A here; the new test uses a synthetic in-memory SVG)
- [x] `dotnet test --configuration Release` passes locally (VisualRegression 57 passed/5 skipped; Pipelines 689 passed/1 skipped)

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md` (N/A - no public API or documented behaviour change)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A)
- [x] New public APIs have XML doc comments (N/A - internal renderer change, no new public API)

## Dependencies

- [x] No new NuGet dependencies
- [x] `gh-advisory-database` security check run for any new dependency (N/A)

## Breaking changes

None. The transform is identical to the prior behaviour at 0 degrees rotation; only rotated symbols change, and that change is the bug fix.