### PR TITLE
Fix tiled "B" renderer banding/seams when zooming under rotation (#330)

### DIFF
--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -758,14 +758,31 @@ Fix: support rotated viewports instead of bailing (only `resolution <= 0`
 and a sizeless viewport still bail).
 
 - **Canvas rotation, convention-free.** The composite is drawn north-up
-  as before, then the whole sequence is wrapped in
-  `canvas.RotateDegrees(θ, w/2, h/2)` about the screen centre. θ is
+  as before, then rotated `θ` about the screen centre. θ is
   **derived from Mapsui's own `WorldToScreenXY`** — the projected screen
   direction of world-north is measured and compared against north-up's
   straight-up (−90°) — so it matches Mapsui's rotation sign/convention
   exactly without hardcoding it (Mapsui 5 ships only a DLL; the other
   vector renderer, `CachedVectorStyleRenderer`, already projects
-  per-vertex through the same `WorldToScreenXY`).
+  per-vertex through the same `WorldToScreenXY`). **Seam-free rotation
+  (issue #330):** the backdrop + target tiles are first composited
+  north-up into an **off-screen surface** (`CompositeRotated`) and then
+  the *single* finished image is rotated about the screen centre — rather
+  than rotating the live canvas and blitting each tile under it. Rotating
+  per-tile turned every hard clip-to-core edge and the cross-band
+  backdrop/target boundary into an independently-rasterised rotated seam,
+  so a non-north-up zoom transition revealed banding/seams between tiles
+  and bands. Compositing north-up first keeps those joins in the clean
+  axis-aligned space (where they abut exactly) and carries no internal
+  seam through the one rotated blit. The off-screen spans the
+  `RotatedCoverSize` box at device resolution; its layout
+  (`TileGrid.RotationCompositeLayout`) is pure and unit-tested
+  (`TileGridTests.RotationCompositeLayout_*`). Because `DrawImage` is
+  deferred until the frame flushes, the surface/image are held on
+  `TileState` and freed at the next composite. If the (GPU) off-screen
+  cannot be allocated the method falls back to the old rotate-canvas
+  per-tile blit so the chart stays visible. North-up (the common case) is
+  unchanged: tiles are blitted straight onto the canvas with no off-screen.
 - **Rotated-corner coverage.** A rotated viewport's corners poke outside
   the north-up box, so tile *selection* (`VisibleTiles` /
   `PredictedTiles` / the fallback intersect test) uses

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -560,11 +560,15 @@ set (replaced every frame), and all cache access is serialised through the layer
 lock so the worker cannot dispose an image the compositor is blitting. Telemetry
 histograms `TileRasterizeDuration` (worker) and `TileCompositeDuration` (UI
 composite pass) attribute the two halves. A rotated viewport (e.g. an incidental
-trackpad-pinch spin) is composited north-up and then rotated about the screen
-centre by an angle derived from Mapsui's own `WorldToScreenXY` projection (so the
-sign matches without hardcoding); tile selection grows to the rotated viewport's
-bounding box (`TileGrid.RotatedCoverSize`) so corners stay covered. See design
-Appendix F.8.
+trackpad-pinch spin) is composited north-up into an off-screen surface and then
+that single image is rotated about the screen centre by an angle derived from
+Mapsui's own `WorldToScreenXY` projection (so the sign matches without
+hardcoding); tile selection grows to the rotated viewport's bounding box
+(`TileGrid.RotatedCoverSize`) so corners stay covered. Compositing north-up first
+(rather than rotating the live canvas and blitting each tile under it) keeps every
+clip-to-core join and the cross-band backdrop/target boundary in the clean
+axis-aligned space, so a non-north-up zoom transition no longer reveals
+banding/seams between tiles and bands (issue #330). See design Appendix F.8.
 
 **Measured (PDB01, 18-step gesture script).** On-screen `frameDurationMs` stayed
 bounded — p50 ≈ 7.7 ms, p90 ≈ 34 ms, max ≈ 37 ms (the worst frames are zoom-out
@@ -722,10 +726,13 @@ back in renders correctly with no crash and no blank frame.
 **Rotated-viewport blanking (Appendix F.8):** the tiled compositor formerly bailed
 on any non-zero `viewport.Rotation`, so an incidental trackpad-pinch spin (which
 rarely returns to exactly 0) blanked the chart until a dataset reload. It now
-composites north-up and rotates the canvas about the screen centre by an angle
-derived from Mapsui's `WorldToScreenXY` (matching its convention without
-hardcoding), enlarging tile selection to the rotated bounding box
-(`TileGrid.RotatedCoverSize`) so corners stay covered. Set
+composites north-up into an off-screen surface and rotates that single image about
+the screen centre by an angle derived from Mapsui's `WorldToScreenXY` (matching its
+convention without hardcoding), enlarging tile selection to the rotated bounding box
+(`TileGrid.RotatedCoverSize`) so corners stay covered. Compositing north-up first
+also keeps the per-tile clip-to-core joins and the cross-band backdrop/target
+boundary seam-free under rotation, so a non-north-up zoom transition no longer
+bands (issue #330). Set
 `S100_VECTOR_TILE_DIAG=1` to emit a rate-limited (~1 Hz) per-frame compositor
 summary to stderr (target-band completeness, fallback bands drawn, cache/GPU
 residency) plus a one-line note whenever the layer draws nothing — the diagnostic

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -692,6 +692,16 @@ public static class S100VectorTileRenderer
         // here (frame start, pre-draw) frees only already-flushed images.
         gpuCache?.DrainPendingDisposals();
 
+        // Free the previous frame's rotated off-screen composite. DrawImage is
+        // deferred and flushes only after Render returns, so the surface/image
+        // that backed the last rotated blit had to outlive that frame; by now it
+        // has flushed and can be released (mirrors the GPU tile cache's
+        // DrainPendingDisposals discipline). Harmless on north-up frames.
+        state.RotationImage?.Dispose();
+        state.RotationImage = null;
+        state.RotationSurface?.Dispose();
+        state.RotationSurface = null;
+
         // Target band visible tiles, and whether the band fully covers the
         // viewport (every visible tile already cached).
         var target = TileGrid.VisibleTiles(centerX, centerY, coverWidth, coverHeight, resolution, band);
@@ -741,35 +751,148 @@ public static class S100VectorTileRenderer
             }
         }
 
-        // Rotate the whole composite about the screen centre so the north-up tile
-        // projection aligns with Mapsui's rotated base map (no-op when 0).
-        var rotate = rotationDeg != 0;
-        if (rotate)
+        // A rotated viewport is composited north-up into an off-screen surface and
+        // then rotated as a SINGLE image about the screen centre, rather than
+        // rotating the live canvas and blitting each tile under it. Rotating
+        // per-tile turned every hard clip-to-core edge — and the cross-band
+        // backdrop/target boundary — into an independently rasterised rotated
+        // seam, so a non-north-up zoom transition revealed banding/seams between
+        // tiles and bands (issue #330). Compositing north-up first keeps those
+        // joins in the clean axis-aligned space (where they abut exactly) and
+        // carries no internal seam through the one rotated blit. North-up (the
+        // common case) is unchanged: tiles are blitted straight onto the canvas.
+        if (rotationDeg != 0)
         {
-            canvas.Save();
-            canvas.RotateDegrees((float)rotationDeg, (float)(widthDip * 0.5), (float)(heightDip * 0.5));
+            CompositeRotated(
+                canvas, state, fallback, target,
+                centerX, centerY, widthDip, heightDip, coverWidth, coverHeight,
+                resolution, rotationDeg, grContext, gpuCache);
         }
-
-        foreach (var key in fallback)
+        else
         {
-            BlitTile(canvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
-        }
+            foreach (var key in fallback)
+            {
+                BlitTile(canvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
+            }
 
-        // Exact target band on top (crisp where present).
-        foreach (var key in target)
-        {
-            BlitTile(canvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
-        }
-
-        if (rotate)
-        {
-            canvas.Restore();
+            // Exact target band on top (crisp where present).
+            foreach (var key in target)
+            {
+                BlitTile(canvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
+            }
         }
 
         if (DiagEnabled)
         {
             DiagComposite(state, band, centerX, centerY, coverWidth, coverHeight, resolution, fallback);
         }
+    }
+
+    /// <summary>
+    /// Composites the backdrop + target tiles north-up into an off-screen surface
+    /// sized to the rotated viewport's cover box, then draws that single image
+    /// rotated about the screen centre. Doing the join work (per-tile clip-to-core
+    /// and the cross-band backdrop/target boundary) in the unrotated space — where
+    /// adjacent tiles abut exactly — and rotating only the finished composite
+    /// removes the per-tile rotated seams/banding that a non-north-up zoom
+    /// transition otherwise revealed (issue #330, design Appendix&#160;F.8).
+    /// </summary>
+    /// <remarks>
+    /// The off-screen is allocated at device resolution (the canvas matrix's
+    /// device scale) so the rotated blit stays crisp on HiDPI, and spans
+    /// <paramref name="coverWidth"/>&#160;&#215;&#160;<paramref name="coverHeight"/>
+    /// — the rotated bounding box — so the screen corners are filled once rotated.
+    /// The surface/image are held on <paramref name="state"/> and freed at the next
+    /// frame's composite because <c>DrawImage</c> is deferred and flushes only
+    /// after <c>Render</c> returns. If the (GPU) off-screen cannot be allocated the
+    /// method falls back to rotating the live canvas and blitting per-tile, so the
+    /// chart stays visible rather than dropping the frame.
+    /// </remarks>
+    private static void CompositeRotated(
+        SKCanvas canvas, TileState state,
+        IReadOnlyList<TileKey> fallback, IReadOnlyList<TileKey> target,
+        double centerX, double centerY, double widthDip, double heightDip,
+        double coverWidth, double coverHeight, double resolution, double rotationDeg,
+        GRContext? grContext, TileCache? gpuCache)
+    {
+        // Device scale baked into the live canvas matrix (DIP -> device px).
+        var deviceScale = canvas.TotalMatrix.ScaleX;
+        if (deviceScale <= 0 || float.IsNaN(deviceScale))
+        {
+            deviceScale = 1f;
+        }
+
+        // The north-up composite must cover the rotated viewport's bounding box,
+        // centred on the screen centre, so the screen corners are filled once the
+        // image is rotated back. Layout is a pure function (unit-tested on
+        // TileGrid) so the off-screen sizing stays verifiable without a canvas.
+        var (originX, originY, pxW, pxH) = TileGrid.RotationCompositeLayout(
+            widthDip, heightDip, coverWidth, coverHeight, deviceScale);
+
+        SKSurface? surface = null;
+        if (pxW > 0 && pxH > 0)
+        {
+            var info = new SKImageInfo(pxW, pxH, SKColorType.Rgba8888, SKAlphaType.Premul);
+            surface = grContext is not null
+                ? SKSurface.Create(grContext, budgeted: false, info)
+                : SKSurface.Create(info);
+        }
+
+        // Off-screen allocation can fail (zero size, GPU context loss/budget):
+        // fall back to rotating the live canvas and blitting per-tile so the base
+        // plane stays visible. Any hairline rotated seams beat a blank chart.
+        if (surface is null)
+        {
+            canvas.Save();
+            canvas.RotateDegrees((float)rotationDeg, (float)(widthDip * 0.5), (float)(heightDip * 0.5));
+            foreach (var key in fallback)
+            {
+                BlitTile(canvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
+            }
+
+            foreach (var key in target)
+            {
+                BlitTile(canvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
+            }
+
+            canvas.Restore();
+            return;
+        }
+
+        // Map screen DIP -> off-screen pixels: translate the cover box to the
+        // surface origin, then scale to device pixels. BlitTile keeps using live
+        // screen DIP coordinates, so the composite lands identically to north-up.
+        var offCanvas = surface.Canvas;
+        offCanvas.Clear(SKColors.Transparent);
+        offCanvas.Scale(deviceScale);
+        offCanvas.Translate((float)-originX, (float)-originY);
+
+        foreach (var key in fallback)
+        {
+            BlitTile(offCanvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
+        }
+
+        // Exact target band on top (crisp where present).
+        foreach (var key in target)
+        {
+            BlitTile(offCanvas, state, key, centerX, centerY, widthDip, heightDip, resolution, grContext, gpuCache);
+        }
+
+        var image = surface.Snapshot();
+
+        canvas.Save();
+        canvas.RotateDegrees((float)rotationDeg, (float)(widthDip * 0.5), (float)(heightDip * 0.5));
+        var dest = new SKRect(
+            (float)originX, (float)originY,
+            (float)(originX + coverWidth), (float)(originY + coverHeight));
+        canvas.DrawImage(image, dest, s_sampling);
+        canvas.Restore();
+
+        // DrawImage is deferred until the frame flushes (after Render returns), so
+        // the image and its backing surface must outlive this frame; they are freed
+        // at the start of the next composite.
+        state.RotationImage = image;
+        state.RotationSurface = surface;
     }
 
     /// <summary>
@@ -1357,5 +1480,11 @@ public static class S100VectorTileRenderer
         public bool Rendering;
         public float PendingDeviceScale = 1f;
         public long PendingGeneration;
+
+        // Off-screen north-up composite for the current rotated frame (null on
+        // north-up frames). DrawImage is deferred, so these must outlive the frame
+        // that placed them; the next composite frees them once it has flushed.
+        public SKSurface? RotationSurface;
+        public SKImage? RotationImage;
     }
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
@@ -367,6 +367,37 @@ internal static class TileGrid
         return (widthDip * c + heightDip * s, widthDip * s + heightDip * c);
     }
 
+    /// <summary>
+    /// Computes the off-screen layout for compositing a rotated viewport's tiles
+    /// north-up before rotating the finished image as a unit (issue&#160;#330). The
+    /// north-up composite must span the rotated cover box
+    /// (<paramref name="coverWidth"/> × <paramref name="coverHeight"/> DIP, from
+    /// <see cref="RotatedCoverSize"/>) centred on the screen centre so the corners
+    /// are filled once rotated, and is rasterised at device resolution
+    /// (<paramref name="deviceScale"/>) to stay crisp on HiDPI.
+    /// </summary>
+    /// <param name="widthDip">Live viewport width in DIP.</param>
+    /// <param name="heightDip">Live viewport height in DIP.</param>
+    /// <param name="coverWidth">Rotated cover-box width in DIP.</param>
+    /// <param name="coverHeight">Rotated cover-box height in DIP.</param>
+    /// <param name="deviceScale">DIP→device-pixel scale from the canvas matrix.</param>
+    /// <returns>
+    /// The cover box's top-left in screen DIP coordinates
+    /// (<c>OriginX</c>, <c>OriginY</c>) — also the rotated blit's destination
+    /// origin — and the off-screen surface size in device pixels
+    /// (<c>PixelWidth</c>, <c>PixelHeight</c>).
+    /// </returns>
+    public static (double OriginX, double OriginY, int PixelWidth, int PixelHeight) RotationCompositeLayout(
+        double widthDip, double heightDip, double coverWidth, double coverHeight, double deviceScale)
+    {
+        var scale = deviceScale > 0 && !double.IsNaN(deviceScale) ? deviceScale : 1.0;
+        var originX = widthDip * 0.5 - coverWidth * 0.5;
+        var originY = heightDip * 0.5 - coverHeight * 0.5;
+        var pixelWidth = (int)Math.Ceiling(coverWidth * scale);
+        var pixelHeight = (int)Math.Ceiling(coverHeight * scale);
+        return (originX, originY, pixelWidth, pixelHeight);
+    }
+
     /// <summary>The DIP screen rect of a tile's core (gutter excluded).</summary>
     public static ScreenRect TileCoreScreenRect(
         TileKey key, double centerX, double centerY, double widthDip, double heightDip, double resolution)

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileGridTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileGridTests.cs
@@ -246,4 +246,60 @@ public class TileGridTests
         Assert.Equal(srcW * c + srcH * s, w, 6);
         Assert.Equal(srcW * s + srcH * c, h, 6);
     }
+
+    [Fact]
+    public void RotationCompositeLayout_NorthUp_MatchesViewportAtDeviceScale()
+    {
+        // At north-up the cover box equals the viewport, so the off-screen origin
+        // is (0,0) and the pixel size is the DIP size scaled by the device scale.
+        var (originX, originY, pxW, pxH) =
+            TileGrid.RotationCompositeLayout(800, 600, 800, 600, 2.0);
+
+        Assert.Equal(0, originX, 6);
+        Assert.Equal(0, originY, 6);
+        Assert.Equal(1600, pxW);
+        Assert.Equal(1200, pxH);
+    }
+
+    [Fact]
+    public void RotationCompositeLayout_CentresCoverBoxOnScreenCentre()
+    {
+        // A cover box larger than the viewport (rotated corners poke out) is
+        // centred on the screen centre, so the origin is negative and symmetric.
+        var (originX, originY, pxW, pxH) =
+            TileGrid.RotationCompositeLayout(800, 600, 990, 990, 1.0);
+
+        Assert.Equal((800 - 990) / 2.0, originX, 6);
+        Assert.Equal((600 - 990) / 2.0, originY, 6);
+        Assert.Equal(990, pxW);
+        Assert.Equal(990, pxH);
+
+        // The cover box's centre coincides with the screen centre.
+        Assert.Equal(400, originX + 990 / 2.0, 6);
+        Assert.Equal(300, originY + 990 / 2.0, 6);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    public void RotationCompositeLayout_NonPositiveDeviceScale_FallsBackToOnePixelPerDip(double deviceScale)
+    {
+        var (_, _, pxW, pxH) =
+            TileGrid.RotationCompositeLayout(800, 600, 800, 600, deviceScale);
+
+        Assert.Equal(800, pxW);
+        Assert.Equal(600, pxH);
+    }
+
+    [Fact]
+    public void RotationCompositeLayout_RoundsPixelSizeUp()
+    {
+        // Fractional device pixels round up so the surface never clips the cover box.
+        var (_, _, pxW, pxH) =
+            TileGrid.RotationCompositeLayout(800, 600, 100.2, 100.6, 1.5);
+
+        Assert.Equal((int)System.Math.Ceiling(100.2 * 1.5), pxW);
+        Assert.Equal((int)System.Math.Ceiling(100.6 * 1.5), pxH);
+    }
 }


### PR DESCRIPTION
## Summary

In the tiled "B" render subsystem (`S100_RENDER_SUBSYSTEM=tiledscene`), zooming in/out showed banding/seam artifacts whenever the viewport was rotated away from north-up. North-up was clean; intermediate rotations revealed visible seams between tiles and bands during a zoom transition.

Root cause: the compositor rotated the **live canvas** and then blitted each tile under it. That made every per-tile hard clip-to-core edge, and the cross-band backdrop to target-band boundary, an independently rasterised rotated seam. At north-up those joins abut exactly (axis-aligned, integer pixels), so the composite is clean; under rotation the clip edges no longer line up and the coarser fallback backdrop shows through the hairline gaps.

Fix: composite north-up **first, then rotate the finished image as a unit**. The new `CompositeRotated` draws the backdrop + target tiles into an off-screen `SKSurface` sized to the `RotatedCoverSize` box at device resolution (using the same screen-DIP coordinates as north-up), then rotates that single image about the screen centre. All join work stays in the clean unrotated space, so the one rotated blit carries no internal seam.

Notable details for reviewers:
- North-up (the common case) is untouched: tiles blit straight onto the canvas with no off-screen surface.
- `DrawImage` is deferred until the frame flushes (after `Render` returns), so the surface/image are held on `TileState` and freed at the start of the next composite, mirroring the existing GPU `DrainPendingDisposals` discipline (freeing happens on the render thread).
- If the (GPU) off-screen cannot be allocated (context loss/budget/zero size), it falls back to the old rotate-canvas per-tile blit so the chart stays visible rather than dropping a frame.
- Off-screen layout (origin + device-pixel size) is extracted into the pure, unit-tested `TileGrid.RotationCompositeLayout` so the sizing stays verifiable without a live canvas.

Verified interactively in the viewer (tiled subsystem, Metal GPU, S-101 cell `101GB00302045`): rotate off north-up, then zoom in/out, no banding.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [x] N/A — change is purely infrastructural (rendering subsystem; no spec semantics)

This is a renderer-internal change to the TiledScene compositor; it touches no S-100 encoding, attribute, or portrayal-catalogue semantics.

**Spec section references cited in code/docs:** N/A (references design doc Appendix F.8, not a spec section).

## Tests

- [x] Added/updated xunit tests under `tests/` (`TileGridTests.RotationCompositeLayout_*`, 5 cases)
- [x] Tests requiring real data files use `SkippableFact` (N/A — new tests are pure geometry)
- [x] `dotnet test --configuration Release` passes locally (Pipelines suite: 695 passed, 1 skipped)

The compositor itself needs a live Skia canvas and so is not directly unit-testable; the new off-screen geometry was extracted into a pure helper and pinned with tests, and the behaviour was confirmed visually in the viewer.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (`EncDotNet.S100.Renderers.Mapsui`)
- [x] Updated conceptual docs under `docs/` (design doc Appendix F.8)
- [x] New public APIs have XML doc comments (`TileGrid.RotationCompositeLayout`)

## Dependencies

- [x] No new NuGet dependencies
- [x] `gh-advisory-database` security check run for any new dependency (N/A — none added)

## Breaking changes

None. North-up rendering is unchanged; the new behaviour only applies on rotated frames.

Closes #330