### PR TITLE
Renderer B: cull off-view layers and fix mixed-dimension pattern-clip crash

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/LayerExtentCulling.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/LayerExtentCulling.cs
@@ -1,0 +1,93 @@
+using Mapsui;
+using Mapsui.Extensions;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// Viewport-extent culling for the TiledScene ("B") custom layer renderers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mapsui's render loop invokes a layer's custom renderer for <i>every</i>
+/// enabled, resolution-visible layer each frame — it never extent-culls a
+/// custom-renderer layer (only the default per-feature path filters by extent,
+/// inside <c>GetFeatures</c>). With an exchange set of many S-101 cells loaded
+/// together that means the renderer's <c>Render</c> runs once per cell per
+/// frame, including cells whose data lies entirely outside the viewport. For
+/// the tiled arm each such off-view call still schedules (empty) tile workers,
+/// reconciles GPU residency, composites, and re-draws its live symbol overlay —
+/// and every off-view worker publish fires a full-map repaint — so multi-cell
+/// pan/zoom becomes laggier than the snapshot arm, which only blits one cached
+/// image per layer.
+/// </para>
+/// <para>
+/// This helper lets each B renderer skip a layer whose data extent does not
+/// intersect the current viewport (grown by an over-render margin), so off-view
+/// cells contribute zero render-thread and worker work.
+/// </para>
+/// </remarks>
+internal static class LayerExtentCulling
+{
+    /// <summary>
+    /// Pure axis-aligned box-intersection test in EPSG:3857 metres. The layer
+    /// box is treated as enlarged by <paramref name="marginWorld"/> on every
+    /// edge so data whose geometry sits just outside the viewport — but whose
+    /// symbols / over-render reach in — is not culled.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the (margin-grown) layer box overlaps the
+    /// viewport box.
+    /// </returns>
+    internal static bool Intersects(
+        double layerMinX, double layerMinY, double layerMaxX, double layerMaxY,
+        double vpMinX, double vpMinY, double vpMaxX, double vpMaxY,
+        double marginWorld)
+    {
+        return layerMaxX + marginWorld >= vpMinX
+            && layerMinX - marginWorld <= vpMaxX
+            && layerMaxY + marginWorld >= vpMinY
+            && layerMinY - marginWorld <= vpMaxY;
+    }
+
+    /// <summary>
+    /// Decides whether <paramref name="layer"/> may contribute to the current
+    /// frame and therefore warrants the renderer's per-frame work. A layer with
+    /// no known extent (<see cref="ILayer.Extent"/> <see langword="null"/>, e.g.
+    /// a geometry-less container) is never culled. Both the layer extent and the
+    /// viewport are in EPSG:3857 (the viewer's map CRS), so no projection is
+    /// needed.
+    /// </summary>
+    /// <param name="layer">The Mapsui layer being rendered.</param>
+    /// <param name="viewport">The live viewport.</param>
+    /// <param name="resolution">The viewport resolution (metres / DIP).</param>
+    /// <param name="marginPx">
+    /// Over-render halo, in screen pixels, added around the viewport before the
+    /// intersection test (converted to world metres via
+    /// <paramref name="resolution"/>).
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the layer should be rendered this frame;
+    /// <see langword="false"/> when it can be skipped entirely.
+    /// </returns>
+    internal static bool ShouldRender(ILayer layer, Viewport viewport, double resolution, double marginPx)
+    {
+        var extent = layer.Extent;
+        if (extent is null)
+        {
+            return true;
+        }
+
+        var vp = viewport.ToExtent();
+        if (vp is null)
+        {
+            return true;
+        }
+
+        var marginWorld = marginPx * resolution;
+        return Intersects(
+            extent.MinX, extent.MinY, extent.MaxX, extent.MaxY,
+            vp.MinX, vp.MinY, vp.MaxX, vp.MaxY,
+            marginWorld);
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -1145,11 +1145,17 @@ public sealed class MapsuiDisplayListRenderer
                 Geometry nonPatterned = nonPatternedColorFills.Count == 1
                     ? nonPatternedColorFills[0]
                     : new MultiPolygon(nonPatternedColorFills.ToArray());
-                excludeAreas = SimplifyForClip(OverlayNGRobust.Union(nonPatterned));
+                // Reduce to polygonal-only so this never becomes a mixed-dimension
+                // overlay clip (see ExtractPolygonal): OverlayNG rejects such inputs.
+                excludeAreas = ExtractPolygonal(SimplifyForClip(OverlayNGRobust.Union(nonPatterned)));
             }
             catch (TopologyException)
             {
                 // If union fails, skip land clipping
+            }
+            catch (ArgumentException)
+            {
+                // Mixed-dimension union input rejected by OverlayNG; skip land clipping.
             }
         }
 
@@ -1221,12 +1227,16 @@ public sealed class MapsuiDisplayListRenderer
             result[i] = (patternRef, priority, clipped);
 
             // Add this entry's (generalized) area to the higher-priority union
-            // for use by the next, lower-priority entries.
+            // for use by the next, lower-priority entries. The union is reduced
+            // to polygonal-only so it can never become a mixed-dimension
+            // GeometryCollection that the next iteration's Difference overlay
+            // (and OverlayNG) would reject.
             try
             {
-                higherPriorityAreas = higherPriorityAreas is null
+                Geometry accumulated = higherPriorityAreas is null
                     ? geometry
                     : OverlayNGRobust.Overlay(higherPriorityAreas, geometry, SpatialFunction.Union);
+                higherPriorityAreas = ExtractPolygonal(accumulated) ?? higherPriorityAreas;
             }
             catch (TopologyException)
             {
@@ -1289,14 +1299,63 @@ public sealed class MapsuiDisplayListRenderer
             if (!simplified.IsValid)
             {
                 var fixedGeometry = simplified.Buffer(0);
-                return fixedGeometry.IsEmpty ? geometry : fixedGeometry;
+                simplified = fixedGeometry.IsEmpty ? geometry : fixedGeometry;
             }
 
-            return simplified;
+            // Topology-preserving simplification (and the Buffer(0) repair above)
+            // can collapse thin polygons to linestrings, producing a
+            // mixed-dimension GeometryCollection. OverlayNG rejects such inputs
+            // with "Overlay input is mixed-dimension", which previously failed the
+            // entire pattern-clip for a cell. Keep only the polygonal components
+            // so the result is always a valid overlay subject/clip area.
+            var polygonal = ExtractPolygonal(simplified);
+            return polygonal is null || polygonal.IsEmpty ? geometry : polygonal;
         }
         catch (TopologyException)
         {
             return geometry;
+        }
+    }
+
+    /// <summary>
+    /// Reduces an arbitrary geometry to its polygonal components, returning a
+    /// <see cref="Polygon"/> or <see cref="MultiPolygon"/> (or <see langword="null"/>
+    /// when no polygonal component exists). This guards the pattern-clip overlays
+    /// against the mixed-dimension <see cref="GeometryCollection"/> that
+    /// topology-preserving simplification can emit, which OverlayNG rejects.
+    /// </summary>
+    /// <param name="geometry">The geometry to reduce; may be any dimension.</param>
+    /// <returns>
+    /// The polygonal-only geometry, or <see langword="null"/> when the input
+    /// contains no polygon.
+    /// </returns>
+    internal static Geometry? ExtractPolygonal(Geometry geometry)
+    {
+        if (geometry is Polygon or MultiPolygon)
+            return geometry;
+
+        var polygons = new List<Polygon>();
+        CollectPolygons(geometry, polygons);
+
+        if (polygons.Count == 0)
+            return null;
+        if (polygons.Count == 1)
+            return polygons[0];
+
+        return geometry.Factory.CreateMultiPolygon(polygons.ToArray());
+    }
+
+    private static void CollectPolygons(Geometry geometry, List<Polygon> sink)
+    {
+        switch (geometry)
+        {
+            case Polygon polygon:
+                sink.Add(polygon);
+                break;
+            case GeometryCollection collection:
+                for (int i = 0; i < collection.NumGeometries; i++)
+                    CollectPolygons(collection.GetGeometryN(i), sink);
+                break;
         }
     }
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSceneRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSceneRenderer.cs
@@ -195,6 +195,18 @@ public static class S100VectorSceneRenderer
             return;
         }
 
+        // Skip a cell whose data extent lies entirely outside the viewport.
+        // Mapsui invokes this custom renderer for every enabled, in-resolution
+        // layer each frame without extent-culling, so an exchange set of many
+        // S-101 cells would otherwise schedule an off-thread re-raster and hold a
+        // whole-viewport image for every off-view cell. Culling here makes
+        // off-view cells cost nothing; the MarginPx halo (the same over-render
+        // recorded around the viewport) keeps edge cells rendering.
+        if (!LayerExtentCulling.ShouldRender(layer, viewport, resolution, MarginPx))
+        {
+            return;
+        }
+
         var state = s_states.GetValue(layer, static _ => new SceneState());
 
         var deviceScale = canvas.TotalMatrix.ScaleX;

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -86,6 +86,16 @@ public static class S100VectorTileRenderer
     private const int MaxImageDimension = 4096;
 
     /// <summary>
+    /// Over-render halo, in screen pixels, added around the viewport before the
+    /// per-layer extent-cull test (<see cref="LayerExtentCulling.ShouldRender"/>).
+    /// A cell whose data extent — grown by this halo — does not reach the
+    /// viewport is skipped for the frame. Sized at one tile (<see
+    /// cref="TileGrid.TileSizeDip"/>) so a cell whose geometry sits just off the
+    /// edge, but whose point symbols / gutter reach in, is never wrongly culled.
+    /// </summary>
+    private const double CullMarginPx = TileGrid.TileSizeDip;
+
+    /// <summary>
     /// How many bands away from the target a cached tile may be and still be
     /// drawn as a fill-the-gap backdrop. Bounding this is both correctness and
     /// safety: it stops tiles from many zoom levels stacking up at different
@@ -463,6 +473,20 @@ public static class S100VectorTileRenderer
         if (deviceScale <= 0 || float.IsNaN(deviceScale))
         {
             deviceScale = 1f;
+        }
+
+        // Skip a cell whose data extent lies entirely outside the viewport.
+        // Mapsui invokes this custom renderer for every enabled, in-resolution
+        // layer each frame without extent-culling (VisibleFeatureIterator only
+        // filters Enabled/Min/MaxVisible), so an exchange set of many S-101 cells
+        // would otherwise run the full per-frame path — empty-tile scheduling,
+        // GPU residency, composite, live overlay, and a redraw on every off-view
+        // worker publish — once per off-view cell. Culling here makes off-view
+        // cells cost nothing. The CullMarginPx halo keeps edge cells (whose
+        // symbols/over-render reach into the view) rendering.
+        if (!LayerExtentCulling.ShouldRender(layer, viewport, resolution, CullMarginPx))
+        {
+            return;
         }
 
         var state = s_states.GetValue(layer, static _ => new TileState());

--- a/tests/EncDotNet.S100.Pipelines.Tests/LayerExtentCullingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/LayerExtentCullingTests.cs
@@ -1,0 +1,106 @@
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using NetTopologySuite.Geometries;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="LayerExtentCulling"/>, the per-layer viewport-extent
+/// cull that lets the TiledScene ("B") custom layer renderers skip cells whose
+/// data lies entirely outside the viewport. Mapsui invokes a custom layer
+/// renderer for every enabled, in-resolution layer each frame without
+/// extent-culling, so without this an exchange set of many S-101 cells runs the
+/// full per-frame path (and worker churn) once per off-view cell.
+/// </summary>
+public sealed class LayerExtentCullingTests
+{
+    [Fact]
+    public void Intersects_TrueWhenBoxesOverlap()
+    {
+        Assert.True(LayerExtentCulling.Intersects(
+            layerMinX: 0, layerMinY: 0, layerMaxX: 100, layerMaxY: 100,
+            vpMinX: 50, vpMinY: 50, vpMaxX: 150, vpMaxY: 150,
+            marginWorld: 0));
+    }
+
+    [Fact]
+    public void Intersects_FalseWhenLayerFarOutsideViewport()
+    {
+        // Layer sits well to the west of the viewport, no margin.
+        Assert.False(LayerExtentCulling.Intersects(
+            layerMinX: 0, layerMinY: 0, layerMaxX: 100, layerMaxY: 100,
+            vpMinX: 1000, vpMinY: 0, vpMaxX: 1100, vpMaxY: 100,
+            marginWorld: 0));
+    }
+
+    [Fact]
+    public void Intersects_MarginPullsNearbyLayerIntoView()
+    {
+        // Layer ends at x=100, viewport starts at x=150: a 50-unit gap.
+        // No margin -> culled; a 60-unit halo -> kept.
+        Assert.False(LayerExtentCulling.Intersects(
+            0, 0, 100, 100, 150, 0, 250, 100, marginWorld: 0));
+        Assert.True(LayerExtentCulling.Intersects(
+            0, 0, 100, 100, 150, 0, 250, 100, marginWorld: 60));
+    }
+
+    [Fact]
+    public void Intersects_TrueWhenTouchingAtEdge()
+    {
+        // Shared edge at x=100 counts as intersecting (inclusive bounds).
+        Assert.True(LayerExtentCulling.Intersects(
+            0, 0, 100, 100, 100, 0, 200, 100, marginWorld: 0));
+    }
+
+    [Fact]
+    public void ShouldRender_TrueForLayerWithNoExtent()
+    {
+        // A geometry-less layer reports a null Extent and must never be culled.
+        var layer = new MemoryLayer { Features = System.Array.Empty<IFeature>() };
+        Assert.Null(layer.Extent);
+
+        Assert.True(LayerExtentCulling.ShouldRender(layer, MapViewport(), resolution: 10, marginPx: 256));
+    }
+
+    [Fact]
+    public void ShouldRender_FalseForLayerOutsideViewport()
+    {
+        // Layer ~100 km east of a viewport centred on the origin (EPSG:3857 m).
+        var layer = LayerAt(minX: 100_000, minY: 0, maxX: 101_000, maxY: 1_000);
+
+        Assert.False(LayerExtentCulling.ShouldRender(
+            layer, MapViewport(centerX: 0, centerY: 0, widthDip: 800, heightDip: 600),
+            resolution: 10, marginPx: 256));
+    }
+
+    [Fact]
+    public void ShouldRender_TrueForLayerInsideViewport()
+    {
+        var layer = LayerAt(minX: -500, minY: -500, maxX: 500, maxY: 500);
+
+        Assert.True(LayerExtentCulling.ShouldRender(
+            layer, MapViewport(centerX: 0, centerY: 0, widthDip: 800, heightDip: 600),
+            resolution: 10, marginPx: 256));
+    }
+
+    private static MemoryLayer LayerAt(double minX, double minY, double maxX, double maxY)
+    {
+        var ring = new LinearRing(new[]
+        {
+            new Coordinate(minX, minY),
+            new Coordinate(maxX, minY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(minX, maxY),
+            new Coordinate(minX, minY),
+        });
+        var feature = new GeometryFeature(new Polygon(ring));
+        return new MemoryLayer { Features = new[] { feature } };
+    }
+
+    private static Mapsui.Viewport MapViewport(
+        double centerX = 0, double centerY = 0,
+        double widthDip = 800, double heightDip = 600, double resolution = 10) =>
+        new(centerX, centerY, resolution, rotation: 0, width: widthDip, height: heightDip);
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/PatternClipPolygonalTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PatternClipPolygonalTests.cs
@@ -1,0 +1,115 @@
+using EncDotNet.S100.Renderers.Mapsui;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Overlay;
+using NetTopologySuite.Operation.OverlayNG;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that pattern-clip geometry is reduced to polygonal-only components
+/// before it reaches OverlayNG. Topology-preserving simplification can collapse
+/// thin polygons into linestrings, yielding a mixed-dimension
+/// <see cref="GeometryCollection"/> that OverlayNG rejects with
+/// "Overlay input is mixed-dimension" — previously failing a whole cell's
+/// pattern-fill clip.
+/// </summary>
+public class PatternClipPolygonalTests
+{
+    private static readonly GeometryFactory Factory = new();
+
+    private static Polygon Square(double x0, double y0, double size)
+    {
+        var ring = Factory.CreateLinearRing(
+        [
+            new Coordinate(x0, y0),
+            new Coordinate(x0 + size, y0),
+            new Coordinate(x0 + size, y0 + size),
+            new Coordinate(x0, y0 + size),
+            new Coordinate(x0, y0),
+        ]);
+        return Factory.CreatePolygon(ring);
+    }
+
+    [Fact]
+    public void ExtractPolygonal_PolygonInput_ReturnedUnchanged()
+    {
+        var polygon = Square(0, 0, 10);
+        Assert.Same(polygon, MapsuiDisplayListRenderer.ExtractPolygonal(polygon));
+    }
+
+    [Fact]
+    public void ExtractPolygonal_MixedDimensionCollection_KeepsOnlyPolygons()
+    {
+        var polygon = Square(0, 0, 10);
+        var line = Factory.CreateLineString(
+        [
+            new Coordinate(20, 20),
+            new Coordinate(30, 20),
+        ]);
+        var point = Factory.CreatePoint(new Coordinate(40, 40));
+
+        var mixed = Factory.CreateGeometryCollection([polygon, line, point]);
+
+        var result = MapsuiDisplayListRenderer.ExtractPolygonal(mixed);
+
+        Assert.NotNull(result);
+        Assert.Equal(Dimension.Surface, result!.Dimension);
+        // The single polygon component is returned as-is.
+        Assert.True(result.EqualsExact(polygon));
+    }
+
+    [Fact]
+    public void ExtractPolygonal_MultiplePolygonsInCollection_ReturnsMultiPolygon()
+    {
+        var a = Square(0, 0, 10);
+        var b = Square(100, 100, 10);
+        var line = Factory.CreateLineString(
+        [
+            new Coordinate(50, 50),
+            new Coordinate(60, 50),
+        ]);
+
+        var mixed = Factory.CreateGeometryCollection([a, line, b]);
+
+        var result = MapsuiDisplayListRenderer.ExtractPolygonal(mixed);
+
+        var multi = Assert.IsType<MultiPolygon>(result);
+        Assert.Equal(2, multi.NumGeometries);
+    }
+
+    [Fact]
+    public void ExtractPolygonal_NoPolygonComponent_ReturnsNull()
+    {
+        var line = Factory.CreateLineString(
+        [
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+        ]);
+        var collection = Factory.CreateGeometryCollection([line]);
+
+        Assert.Null(MapsuiDisplayListRenderer.ExtractPolygonal(collection));
+    }
+
+    [Fact]
+    public void ExtractPolygonal_Output_IsValidOverlayInput()
+    {
+        // The mixed-dimension collection would throw inside OverlayNG; the
+        // extracted polygonal geometry must overlay cleanly.
+        var polygon = Square(0, 0, 10);
+        var line = Factory.CreateLineString(
+        [
+            new Coordinate(2, 2),
+            new Coordinate(8, 2),
+        ]);
+        var mixed = Factory.CreateGeometryCollection([polygon, line]);
+
+        var subject = MapsuiDisplayListRenderer.ExtractPolygonal(mixed)!;
+        var clip = Square(5, 0, 10);
+
+        var difference = OverlayNGRobust.Overlay(
+            subject, clip, SpatialFunction.Difference);
+
+        Assert.NotNull(difference);
+        Assert.False(difference.IsEmpty);
+    }
+}


### PR DESCRIPTION
## Summary

Two renderer B (TiledScene) fixes surfaced while investigating laggy pan/zoom on the full UKHO S-101 trial exchange set. This is an incremental improvement — **more work remains**, so the tracking issue stays open.

### 1. Pan/zoom lag — off-view layer culling
Renderer B invoked *every* loaded cell's custom Mapsui layer renderer on *every* frame, regardless of viewport overlap. With the full 27-cell exchange set this did substantial redundant per-frame work on the UI thread (worse than renderer A). Added `LayerExtentCulling` plus early-outs in `S100VectorTileRenderer` and `S100VectorSceneRenderer` to skip layers whose extent doesn't intersect the current viewport.

### 2. "Overlay input is mixed-dimension" crash on `101GB005DEVQC.000`
`ClipPatternsByPriority` fed OverlayNG geometry that `TopologyPreservingSimplifier` / `Buffer(0)` could collapse into a mixed-dimension `GeometryCollection` (polygons + linestrings), which OverlayNG rejects — failing the entire pattern-clip for the cell. It only manifested under concurrent exchange-set load (hence the `AggregateException` with two inner exceptions; the single-cell load was clean). Added `ExtractPolygonal` to reduce every overlay subject/clip input to polygonal-only geometry, applied at `SimplifyForClip` output, the `excludeAreas` union, and the accumulated `higherPriorityAreas` union, and broadened the `excludeAreas` catch to `ArgumentException`.

## Testing
- `dotnet test -c Release tests/EncDotNet.S100.Pipelines.Tests` — **713 passed, 1 skipped**.
- New tests: `LayerExtentCullingTests` (viewport-intersection culling) and `PatternClipPolygonalTests` (5 tests proving `ExtractPolygonal` yields valid uniform-dimension overlay inputs).
- Verified in the viewer against the UKHO exchange set: `101GB005DEVQC.000` no longer raises the load error.

## Not in scope (remaining work)
Pan/zoom is improved but still not as smooth as it should be — further renderer B performance work to follow under the same issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>