### PR TITLE
Speed up S-100 symbol/sounding overlay and fix B to A render-subsystem switch crash

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -607,6 +607,21 @@ Because old tiles had symbols baked in, `TileDiskCache.FormatVersion` was bumped
 `1 → 2` so they are never reused (which would double-draw symbols). See design
 Appendix F.11.
 
+Because the overlay redraws every symbol and sounding glyph **per frame**, three
+costs are kept off the hot path. First, parsed symbol pictures are cached
+process-wide in `SkiaDisplayListRenderer` keyed by the resolved SVG content, so
+`SKSvg.CreateFromSvg` runs once per distinct symbol rather than once per op per
+frame (the set of distinct symbol SVGs is small and bounded by the symbol
+catalogue × palette). Second, `RenderOnto` culls point/text ops whose projected
+anchor falls outside the viewport (inflated by `PointCullMarginPx`) before
+parsing a symbol or measuring a label; `DrawOverlay` passes an explicit cull
+rectangle expanded to the rotated viewport's bounding box so nothing visible is
+dropped under rotation. Third, text drawing pools its `SKFont` (cached by pixel
+size) and `SKPaint` for the duration of a render instead of allocating a native
+font/paint per label, so a dense sounding overlay no longer churns thousands of
+handles per frame. None of these change what is drawn — only the work done for
+glyphs that cannot be seen or that share resources.
+
 ### Prediction / pre-warm (Phase 3)
 
 To stop a pan or zoom from transiently exposing cold tiles, the tiled renderer
@@ -751,6 +766,24 @@ residency) plus a one-line note whenever the layer draws nothing — the diagnos
 that root-caused both this and the ghosting issue. **Verified (GB Solent exchange
 set):** trackpad pinch-zoom and pinch-rotate keep the chart visible and aligned,
 corners filled, single tile scale with no ghosting.
+
+**Rotation-composite teardown (off-thread finalization, issue #332).** The rotated
+frame's off-screen composite — a GPU-backed `SKSurface` and its `SKImage` snapshot —
+is GPU-resident just like the tiles, so it carries the same thread-confinement rule:
+it must be freed on the render thread, never the GC finalizer thread. During steady
+rendering the next `Composite` frees the previous frame's pair inline (deferred-draw
+safe), but when the tiled ("B") layer is torn down with a rotated frame still set —
+notably **switching the render subsystem from "B" tiled to "A" Mapsui**, which
+re-portrays and swaps in fresh layers — that pair was reachable only from the
+weakly-held `TileState` and was finalized off-thread, racing the now-active "A" render
+thread inside the native Skia GPU backend and crashing the process. The fix mirrors
+each GPU-backed rotation pair into its layer's `GpuRegistryEntry` (the same
+strong-referenced, render-thread-disposed registry that already shields the GPU
+texture cache), in lockstep with the `TileState`, so `ReconcileGpuCaches` frees it on
+the render thread when the owning layer is collected. Only the small GPU pair is
+pinned — the far larger CPU tile cache stays on the weakly-held `TileState` and
+remains GC-collectible. (Software/CPU rotation surfaces are safe to finalize
+off-thread and are not mirrored.)
 
 **Graceful shutdown (Appendix F.10):** the rasterisation workers call into native
 Skia, so the process must not begin tearing down `libSkiaSharp` (managed-runtime

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -266,18 +266,53 @@ public static class S100VectorTileRenderer
 
     /// <summary>
     /// Process-wide registry of every live GPU-texture residency cache, keyed
-    /// weakly by its owning <see cref="ILayer"/> (Phase&#160;5). This holds a
-    /// <em>strong</em> reference to each <see cref="TileCache"/> of GPU-backed
-    /// <see cref="SKImage"/>s so the GC's finalizer thread can never reclaim
-    /// them — GPU resources must be freed on the thread that owns the
-    /// <see cref="GRContext"/>, and finalizing them off-thread crashes the
-    /// native Skia GPU backend. When a layer is torn down (dataset closed,
-    /// palette re-portrayal swapping in a fresh layer, or a silent GC of an
-    /// abandoned layer) its weak entry goes dead; <see cref="ReconcileGpuCaches"/>
-    /// then disposes the orphaned cache on the render thread under the live
-    /// context. See <c>docs/design/S100-Render-Subsystem-Design.md</c> Appendix&#160;F.
+    /// weakly by its owning <see cref="ILayer"/> (Phase&#160;5). Each entry holds
+    /// a <em>strong</em> reference to that layer's <see cref="TileCache"/> of
+    /// GPU-backed <see cref="SKImage"/> tiles <em>and</em> to its current
+    /// GPU-backed rotation composite (<see cref="GpuRegistryEntry.RotationSurface"/>
+    /// / <see cref="GpuRegistryEntry.RotationImage"/>), so the GC's finalizer
+    /// thread can never reclaim any of them. GPU resources must be freed on the
+    /// thread that owns the <see cref="GRContext"/>, and finalizing them
+    /// off-thread crashes the native Skia GPU backend (observed as a
+    /// finalizer/render-thread race when switching the render subsystem from "B"
+    /// tiled to "A" Mapsui, which re-portrays and swaps in fresh layers, leaving
+    /// the old layer's GPU rotation surface to be finalized off-thread). Only GPU
+    /// objects are pinned here — the layer's far larger CPU tile cache stays on
+    /// the weakly-held <see cref="TileState"/> so it remains GC-collectible. When
+    /// a layer is torn down (dataset closed, palette re-portrayal or subsystem
+    /// switch swapping in a fresh layer, or a silent GC of an abandoned layer)
+    /// its weak entry goes dead; <see cref="ReconcileGpuCaches"/> then disposes
+    /// the orphaned cache and rotation composite on the render thread under the
+    /// live context. See <c>docs/design/S100-Render-Subsystem-Design.md</c>
+    /// Appendix&#160;F.
     /// </summary>
-    private static readonly List<(WeakReference<ILayer> Layer, TileCache Cache, GRContext Context)> s_gpuRegistry = new();
+    private static readonly List<GpuRegistryEntry> s_gpuRegistry = new();
+
+    /// <summary>
+    /// A single layer's pinned GPU residency: its texture cache and — mirrored
+    /// from the owning <see cref="TileState"/> in lockstep — its current rotated
+    /// off-screen composite. The mirror exists purely to keep those GPU objects
+    /// strongly reachable (off the weakly-held <see cref="TileState"/>) so they
+    /// survive to be disposed on the render thread rather than the finalizer
+    /// thread. See <see cref="s_gpuRegistry"/>.
+    /// </summary>
+    internal sealed class GpuRegistryEntry
+    {
+        public required WeakReference<ILayer> Layer;
+        public required TileCache Cache;
+
+        // The owning GRContext (typed as object so the teardown lifecycle can be
+        // unit-tested with a sentinel context — a real GRContext needs a GPU and
+        // is unavailable headlessly). Compared only by reference identity.
+        public required object Context;
+
+        // Strong mirror of TileState.RotationSurface/RotationImage for GPU-backed
+        // rotated frames, kept in lockstep with the TileState (set and cleared
+        // together in Composite). Null on north-up frames.
+        public SKSurface? RotationSurface;
+        public SKImage? RotationImage;
+    }
+
 
     private static readonly object s_gpuRegistrySync = new();
 
@@ -714,11 +749,18 @@ public static class S100VectorTileRenderer
         // deferred and flushes only after Render returns, so the surface/image
         // that backed the last rotated blit had to outlive that frame; by now it
         // has flushed and can be released (mirrors the GPU tile cache's
-        // DrainPendingDisposals discipline). Harmless on north-up frames.
+        // DrainPendingDisposals discipline). Harmless on north-up frames. The
+        // GPU-registry mirror is cleared in lockstep so it never references a
+        // disposed surface (see GpuRegistryEntry).
         state.RotationImage?.Dispose();
         state.RotationImage = null;
         state.RotationSurface?.Dispose();
         state.RotationSurface = null;
+        if (state.GpuEntry is { } entryAtStart)
+        {
+            entryAtStart.RotationImage = null;
+            entryAtStart.RotationSurface = null;
+        }
 
         // Target band visible tiles, and whether the band fully covers the
         // viewport (every visible tile already cached).
@@ -908,9 +950,19 @@ public static class S100VectorTileRenderer
 
         // DrawImage is deferred until the frame flushes (after Render returns), so
         // the image and its backing surface must outlive this frame; they are freed
-        // at the start of the next composite.
+        // at the start of the next composite. Mirror GPU-backed resources into the
+        // GPU registry entry (in lockstep with the TileState) so that, if this
+        // layer is torn down before the next composite, ReconcileGpuCaches frees
+        // them on the render thread rather than the finalizer thread crashing the
+        // native backend. CPU-backed (no grContext) composites are safe to
+        // finalize off-thread and need no mirror.
         state.RotationImage = image;
         state.RotationSurface = surface;
+        if (grContext is not null && state.GpuEntry is { } entryAtEnd)
+        {
+            entryAtEnd.RotationImage = image;
+            entryAtEnd.RotationSurface = surface;
+        }
     }
 
     /// <summary>
@@ -995,6 +1047,7 @@ public static class S100VectorTileRenderer
                 state.GpuTextures.Dispose();
                 state.GpuTextures = null;
                 state.GpuContext = null;
+                state.GpuEntry = null;
             }
 
             return;
@@ -1009,7 +1062,7 @@ public static class S100VectorTileRenderer
             }
 
             state.GpuTextures = new TileCache(GpuBudgetBytes, deferDisposal: true);
-            RegisterGpuCache(layer, state.GpuTextures, grContext);
+            state.GpuEntry = RegisterGpuCache(layer, state.GpuTextures, grContext);
             state.GpuContext = grContext;
             state.GpuGeneration = state.Generation;
         }
@@ -1021,16 +1074,27 @@ public static class S100VectorTileRenderer
     }
 
     /// <summary>
-    /// Registers a GPU-texture cache in the process-wide registry so it is held
-    /// alive against off-thread finalization until its owning layer is collected
-    /// (Phase&#160;5). See <see cref="s_gpuRegistry"/>.
+    /// Registers a GPU-texture cache in the process-wide registry so it — and the
+    /// owning layer's GPU rotation composite, mirrored into the returned entry —
+    /// are held alive against off-thread finalization until the owning layer is
+    /// collected (Phase&#160;5). Returns the entry so the caller can mirror its
+    /// rotation resources into it. See <see cref="s_gpuRegistry"/>.
     /// </summary>
-    private static void RegisterGpuCache(ILayer layer, TileCache cache, GRContext context)
+    private static GpuRegistryEntry RegisterGpuCache(ILayer layer, TileCache cache, object context)
     {
+        var entry = new GpuRegistryEntry
+        {
+            Layer = new WeakReference<ILayer>(layer),
+            Cache = cache,
+            Context = context,
+        };
+
         lock (s_gpuRegistrySync)
         {
-            s_gpuRegistry.Add((new WeakReference<ILayer>(layer), cache, context));
+            s_gpuRegistry.Add(entry);
         }
+
+        return entry;
     }
 
     /// <summary>
@@ -1054,17 +1118,20 @@ public static class S100VectorTileRenderer
 
     /// <summary>
     /// Disposes — on the render thread, under the live <see cref="GRContext"/> —
-    /// any registered GPU-texture caches whose owning layer has been collected
-    /// (Phase&#160;5). This is the teardown path for closed datasets and
-    /// re-portrayed (layer-swapped) datasets: the layer is gone so its
-    /// <see cref="TileState"/> never renders again, but the registry kept its
-    /// GPU images alive so they are freed here on the GPU-owning thread instead
-    /// of crashing the native backend on the finalizer thread. Only caches bound
-    /// to <paramref name="grContext"/> are touched; a cache from a different
-    /// (e.g. lost) context is left for that context's own teardown rather than
-    /// freed under the wrong one. See <see cref="s_gpuRegistry"/>.
+    /// the GPU resources of any registered entry whose owning layer has been
+    /// collected (Phase&#160;5): the GPU-texture residency cache and the GPU
+    /// rotation composite (<see cref="GpuRegistryEntry.RotationSurface"/> /
+    /// <see cref="GpuRegistryEntry.RotationImage"/>). This is the teardown path
+    /// for closed datasets, re-portrayed (layer-swapped) datasets, and
+    /// render-subsystem switches: the layer is gone so its <see cref="TileState"/>
+    /// never renders again, but the registry kept its GPU objects alive so they
+    /// are freed here on the GPU-owning thread instead of crashing the native
+    /// backend on the finalizer thread. Only resources bound to
+    /// <paramref name="grContext"/> are touched; a cache from a different (e.g.
+    /// lost) context is left for that context's own teardown rather than freed
+    /// under the wrong one. See <see cref="s_gpuRegistry"/>.
     /// </summary>
-    private static void ReconcileGpuCaches(GRContext grContext)
+    private static void ReconcileGpuCaches(object grContext)
     {
         lock (s_gpuRegistrySync)
         {
@@ -1079,6 +1146,14 @@ public static class S100VectorTileRenderer
                 if (ReferenceEquals(entry.Context, grContext))
                 {
                     entry.Cache.Dispose();
+
+                    // Free the dead layer's GPU rotation composite (if a rotated
+                    // frame left one set) on the render thread too; like the
+                    // texture cache, it must not be finalized off-thread.
+                    entry.RotationImage?.Dispose();
+                    entry.RotationImage = null;
+                    entry.RotationSurface?.Dispose();
+                    entry.RotationSurface = null;
                 }
 
                 s_gpuRegistry.RemoveAt(i);
@@ -1087,7 +1162,59 @@ public static class S100VectorTileRenderer
     }
 
     /// <summary>
-    /// Blits one cached tile (if resident): positions its guttered image by
+    /// Test-only seam: registers a GPU-registry entry for <paramref name="layer"/>
+    /// (with a sentinel <paramref name="context"/> and CPU-backed rotation
+    /// resources) and returns it, so the off-thread-finalization teardown
+    /// (<see cref="ReconcileGpuCaches(object)"/>) can be exercised deterministically
+    /// without a GPU <see cref="GRContext"/>. The lifecycle is identical for CPU-
+    /// and GPU-backed resources. Not for production use.
+    /// </summary>
+    internal static GpuRegistryEntry RegisterGpuEntryForTest(
+        ILayer layer, TileCache cache, object context, SKSurface? rotationSurface, SKImage? rotationImage)
+    {
+        var entry = RegisterGpuCache(layer, cache, context);
+        entry.RotationSurface = rotationSurface;
+        entry.RotationImage = rotationImage;
+        return entry;
+    }
+
+    /// <summary>
+    /// Test-only seam: runs the dead-layer GPU teardown for the given sentinel
+    /// <paramref name="context"/>. See <see cref="ReconcileGpuCaches(object)"/>.
+    /// </summary>
+    internal static void ReconcileGpuCachesForTest(object context) => ReconcileGpuCaches(context);
+
+    /// <summary>Test-only seam: the current GPU-registry entry count.</summary>
+    internal static int GpuRegistryEntryCountForTest
+    {
+        get
+        {
+            lock (s_gpuRegistrySync)
+            {
+                return s_gpuRegistry.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Test-only seam: disposes and clears every GPU-registry entry, so a test
+    /// leaves the process-wide registry clean for the next one. Not for
+    /// production use.
+    /// </summary>
+    internal static void ClearGpuRegistryForTest()
+    {
+        lock (s_gpuRegistrySync)
+        {
+            foreach (var entry in s_gpuRegistry)
+            {
+                entry.Cache.Dispose();
+                entry.RotationImage?.Dispose();
+                entry.RotationSurface?.Dispose();
+            }
+
+            s_gpuRegistry.Clear();
+        }
+    }
     /// world bounds and hard-clips to the tile core so adjacent tiles meet
     /// exactly with no seam or double-drawn gutter. When a GPU context is
     /// supplied (Phase&#160;5), the tile's raster pixels are uploaded once to a
@@ -1390,7 +1517,36 @@ public static class S100VectorTileRenderer
                 ScaleDenominator = S100VectorSceneRenderer.ScaleDenominatorFor(centerX, centerY, resolution),
             };
 
-            s_overlayRenderer.RenderOnto(canvas, overlay, viewport);
+            // Cull point/text overlay ops whose anchor cannot be visible before
+            // paying to parse a symbol SVG or measure a label. The canvas is
+            // rotated about its centre (north-up is the v1 no-op case), and
+            // RenderOnto draws in pre-rotation pixel space, so under rotation the
+            // cull rectangle must cover the rotated viewport's bounding box.
+            const float margin = SkiaDisplayListRenderer.PointCullMarginPx;
+            SKRect cullBounds;
+            if (rotate)
+            {
+                var rad = rotationDeg * Math.PI / 180.0;
+                var cosR = Math.Abs(Math.Cos(rad));
+                var sinR = Math.Abs(Math.Sin(rad));
+                var halfW = widthDip * 0.5;
+                var halfH = heightDip * 0.5;
+                var extentX = (float)(halfW * cosR + halfH * sinR);
+                var extentY = (float)(halfW * sinR + halfH * cosR);
+                var cx0 = (float)halfW;
+                var cy0 = (float)halfH;
+                cullBounds = new SKRect(
+                    cx0 - extentX - margin, cy0 - extentY - margin,
+                    cx0 + extentX + margin, cy0 + extentY + margin);
+            }
+            else
+            {
+                cullBounds = new SKRect(
+                    -margin, -margin,
+                    (float)widthDip + margin, (float)heightDip + margin);
+            }
+
+            s_overlayRenderer.RenderOnto(canvas, overlay, viewport, cullBounds);
         }
         finally
         {
@@ -1478,6 +1634,15 @@ public static class S100VectorTileRenderer
         public TileCache? GpuTextures;
         public object? GpuContext;
         public long GpuGeneration = -1;
+
+        // The process-wide GPU-registry entry for this layer's current GPU
+        // residency (Phase 5), or null on a software surface / before the first
+        // GPU-backed paint. The registry strong-references this entry, so
+        // mirroring the GPU-backed RotationSurface/RotationImage into it (in
+        // lockstep with the fields below) keeps them reachable for render-thread
+        // disposal even after the weakly-held TileState is collected. See
+        // GpuRegistryEntry / s_gpuRegistry.
+        public GpuRegistryEntry? GpuEntry;
 
         // Visible misses drain before speculative (predicted) tiles.
         public readonly HashSet<TileKey> PendingVisible = new();

--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -34,7 +34,14 @@ exactly one place:
   `VectorScene` + `Viewport` → `SKBitmap`. The
   vector analogue of `SkiaCoverageRenderer`, suitable for a tile-serving web API
   with no Mapsui/GUI dependency. It supplies the second projection half
-  (`EPSG:3857 → screen`) via a `Viewport`-derived affine.
+  (`EPSG:3857 → screen`) via a `Viewport`-derived affine. Parsed symbol pictures
+  are cached process-wide (keyed by the resolved SVG), point/text ops whose
+  anchor falls outside the viewport (plus `PointCullMarginPx`) are culled before
+  any per-op work, and text drawing pools its `SKFont`/`SKPaint` per render —
+  all three matter for the tiled subsystem's per-frame overlay, which replays
+  this renderer live every frame. `RenderOnto` takes an optional cull rectangle
+  so a caller that rotates the canvas can expand it to the rotated viewport's
+  bounding box.
 - **`WebMercator`** (in `Rendering.Scene`) — EPSG:3857 forward projection (matches
   Mapsui's `SphericalMercator.FromLonLat`; a parity test asserts agreement).
 - **`ScaleVisibility`** (in `Rendering.Scene`) — shared S-100 Part 9 §11.1 scale-visibility rule.

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Rendering.Scene;
@@ -42,6 +43,62 @@ public sealed class SkiaDisplayListRenderer
     public bool HonorScaleVisibility { get; set; } = true;
 
     /// <summary>
+    /// Process-wide cache of parsed symbol pictures keyed by the resolved SVG
+    /// content (<see cref="ResolvedSymbol.ProcessedSvg"/>). Parsing an SVG into
+    /// an <see cref="SKPicture"/> via <see cref="SKSvg.CreateFromSvg(string)"/>
+    /// is expensive, and the tiled subsystem's live overlay redraws every point
+    /// symbol and sounding glyph on <i>every</i> frame (see
+    /// <c>S100VectorTileRenderer.DrawOverlay</c>). The set of distinct symbol
+    /// SVGs is small and bounded (symbol catalogue × palette), so caching the
+    /// parsed picture across frames and tiles eliminates per-op re-parsing.
+    /// </summary>
+    /// <remarks>
+    /// The cached value is the owning <see cref="SKSvg"/>, not the bare
+    /// <see cref="SKPicture"/>: an <see cref="SKSvg"/> owns and disposes its
+    /// <see cref="SKSvg.Picture"/>, so keeping a strong reference to the
+    /// <see cref="SKSvg"/> keeps the picture's native resources alive (a GC'd
+    /// <see cref="SKSvg"/> would finalise the picture out from under us). Entries
+    /// are never evicted; the natural bound on distinct symbols keeps the cache
+    /// small. <see cref="SKPicture"/> playback (<c>DrawPicture</c>) is
+    /// thread-safe, and the cache is a <see cref="ConcurrentDictionary{TKey,TValue}"/>
+    /// because tiles rasterise on background threads while the overlay draws on
+    /// the render thread.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<string, SKSvg?> s_symbolPictureCache =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Half-extent, in display pixels, by which the point/text cull rectangle is
+    /// grown beyond the viewport so a symbol or label whose <i>anchor</i> sits
+    /// just off-screen but whose body is partly visible is still drawn. Sized to
+    /// comfortably exceed the largest compound symbol / point-anchored label.
+    /// Exposed so callers that supply an explicit cull rectangle (e.g. the live
+    /// overlay under a rotated viewport) inflate by the same margin.
+    /// </summary>
+    public const float PointCullMarginPx = 256f;
+
+    /// <summary>
+    /// Returns the parsed picture for <paramref name="processedSvg"/>, parsing
+    /// and caching it on first use. Returns <see langword="null"/> when the SVG
+    /// cannot be parsed.
+    /// </summary>
+    private static SKPicture? GetSymbolPicture(string processedSvg)
+    {
+        var svg = s_symbolPictureCache.GetOrAdd(processedSvg, static content =>
+        {
+            try
+            {
+                return SKSvg.CreateFromSvg(content);
+            }
+            catch
+            {
+                return null;
+            }
+        });
+        return svg?.Picture;
+    }
+
+    /// <summary>
     /// Renders the scene at the requested viewport, returning a new bitmap of
     /// <see cref="Viewport.WidthPixels"/> × <see cref="Viewport.HeightPixels"/>.
     /// The caller owns the returned bitmap.
@@ -76,6 +133,29 @@ public sealed class SkiaDisplayListRenderer
     /// <param name="scene">The display list to draw.</param>
     /// <param name="viewport">The live viewport whose projection places the ops.</param>
     public void RenderOnto(SKCanvas canvas, VectorScene scene, Viewport viewport)
+        => RenderOnto(canvas, scene, viewport, pointCullBounds: null);
+
+    /// <summary>
+    /// As <see cref="RenderOnto(SKCanvas, VectorScene, Viewport)"/>, but culls
+    /// point and point-anchored text ops whose projected anchor falls outside
+    /// <paramref name="pointCullBounds"/> (in viewport pixel space) before any
+    /// per-op work — avoiding the cost of parsing a symbol SVG or measuring a
+    /// label that cannot be visible. When <paramref name="pointCullBounds"/> is
+    /// <see langword="null"/>, the cull rectangle is the viewport inflated by
+    /// <see cref="PointCullMarginPx"/>. A caller that rotates the canvas (the
+    /// live overlay under a rotated viewport) must pass an explicit rectangle
+    /// expanded to the rotated viewport's bounding box, since this method draws
+    /// in pre-rotation pixel space.
+    /// </summary>
+    /// <param name="canvas">The destination canvas. Not cleared or flushed.</param>
+    /// <param name="scene">The display list to draw.</param>
+    /// <param name="viewport">The live viewport whose projection places the ops.</param>
+    /// <param name="pointCullBounds">
+    /// Pixel-space rectangle outside which point/text ops are skipped, or
+    /// <see langword="null"/> to derive it from the viewport plus the symbol
+    /// margin.
+    /// </param>
+    public void RenderOnto(SKCanvas canvas, VectorScene scene, Viewport viewport, SKRect? pointCullBounds)
     {
         ArgumentNullException.ThrowIfNull(canvas);
         ArgumentNullException.ThrowIfNull(scene);
@@ -84,11 +164,24 @@ public sealed class SkiaDisplayListRenderer
         var transform = WorldToScreen.Create(viewport);
         double denom = viewport.ScaleDenominator;
 
+        var cullBounds = pointCullBounds ?? new SKRect(
+            -PointCullMarginPx,
+            -PointCullMarginPx,
+            viewport.WidthPixels + PointCullMarginPx,
+            viewport.HeightPixels + PointCullMarginPx);
+
         // Per-render cache of decoded pattern tiles, keyed by pattern
         // reference. Real S-101 cells can have many polygons sharing a single
         // pattern (e.g. quality-of-bathymetry overlays) so decoding the PNG
         // once and reusing the SKImage across ops is a meaningful saving.
         Dictionary<string, SKImage?>? patternImages = null;
+
+        // Per-render reusable text resources. The live overlay redraws every
+        // sounding/label per frame; allocating an SKFont + SKPaint per text op
+        // (S-100 "All" scenes have thousands) churns native handles. A single
+        // scratch reuses one paint and caches fonts by pixel size (soundings
+        // share a size), disposed once when the render completes.
+        TextDrawScratch? textScratch = null;
 
         try
         {
@@ -110,10 +203,11 @@ public sealed class SkiaDisplayListRenderer
                         DrawLine(canvas, line, transform);
                         break;
                     case PointPaintOp point:
-                        DrawPoint(canvas, point, transform);
+                        DrawPoint(canvas, point, transform, cullBounds);
                         break;
                     case TextPaintOp text:
-                        DrawText(canvas, text, transform);
+                        textScratch ??= new TextDrawScratch();
+                        DrawText(canvas, text, transform, cullBounds, textScratch);
                         break;
                 }
             }
@@ -125,6 +219,7 @@ public sealed class SkiaDisplayListRenderer
                 foreach (var img in patternImages.Values)
                     img?.Dispose();
             }
+            textScratch?.Dispose();
         }
     }
 
@@ -249,16 +344,18 @@ public sealed class SkiaDisplayListRenderer
         paint.PathEffect?.Dispose();
     }
 
-    private static void DrawPoint(SKCanvas canvas, PointPaintOp op, WorldToScreen t)
+    private static void DrawPoint(SKCanvas canvas, PointPaintOp op, WorldToScreen t, SKRect cullBounds)
     {
         var (cx, cy) = t.Project(op.World);
         cx += (float)op.OffsetXpx;
         cy += (float)op.OffsetYpx;
 
+        if (!cullBounds.Contains(cx, cy))
+            return;
+
         if (op.Symbol is { } symbol)
         {
-            using var svg = SKSvg.CreateFromSvg(symbol.ProcessedSvg);
-            var picture = svg?.Picture;
+            var picture = GetSymbolPicture(symbol.ProcessedSvg);
             if (picture is not null)
             {
                 var bounds = picture.CullRect;
@@ -311,12 +408,16 @@ public sealed class SkiaDisplayListRenderer
         canvas.DrawCircle(cx, cy, radius, dot);
     }
 
-    private static void DrawText(SKCanvas canvas, TextPaintOp op, WorldToScreen t)
+    private static void DrawText(SKCanvas canvas, TextPaintOp op, WorldToScreen t, SKRect cullBounds, TextDrawScratch scratch)
     {
         var (ax, ay) = t.Project(op.World);
 
-        using var font = new SKFont(RendererFonts.Default, (float)op.FontSizePx);
-        using var paint = new SKPaint { IsAntialias = true };
+        if (!cullBounds.Contains(ax + (float)op.OffsetXpx, ay + (float)op.OffsetYpx))
+            return;
+
+        var font = scratch.FontFor((float)op.FontSizePx);
+        var paint = scratch.Paint;
+        paint.Color = SKColors.Black;
 
         font.MeasureText(op.Text, out var textBounds, paint);
         float textWidth = textBounds.Width;
@@ -341,18 +442,55 @@ public sealed class SkiaDisplayListRenderer
 
         if (op.BackColor is { } back)
         {
-            using var bg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = back.ToSkia() };
+            paint.Color = back.ToSkia();
             const float pad = 1.5f;
             var rect = new SKRect(
                 x + textBounds.Left - pad,
                 baseline + textBounds.Top - pad,
                 x + textBounds.Left + textWidth + pad,
                 baseline + textBounds.Top + textHeight + pad);
-            canvas.DrawRect(rect, bg);
+            canvas.DrawRect(rect, paint);
         }
 
         paint.Color = op.ForeColor.ToSkia();
         canvas.DrawText(op.Text, x, baseline, SKTextAlign.Left, font, paint);
+    }
+
+    /// <summary>
+    /// Per-render scratch for text drawing: a single reusable
+    /// <see cref="SKPaint"/> (its colour is reset per op) and a cache of
+    /// <see cref="SKFont"/> keyed by pixel size. Avoids allocating native font
+    /// and paint handles per text op, which matters for the live overlay that
+    /// redraws thousands of soundings/labels every frame. Not thread-safe; one
+    /// instance per <see cref="RenderOnto(SKCanvas, VectorScene, Viewport, SKRect?)"/>
+    /// call. The paint defaults to <see cref="SKPaintStyle.Fill"/>, which is
+    /// correct for both the glyph fill and the optional label background rect.
+    /// </summary>
+    private sealed class TextDrawScratch : IDisposable
+    {
+        private readonly Dictionary<float, SKFont> _fonts = new();
+
+        /// <summary>The shared antialiased fill paint; set its colour per op.</summary>
+        public SKPaint Paint { get; } = new() { IsAntialias = true };
+
+        /// <summary>Returns a cached font for <paramref name="sizePx"/>, creating it on first use.</summary>
+        public SKFont FontFor(float sizePx)
+        {
+            if (!_fonts.TryGetValue(sizePx, out var font))
+            {
+                font = new SKFont(RendererFonts.Default, sizePx);
+                _fonts[sizePx] = font;
+            }
+            return font;
+        }
+
+        public void Dispose()
+        {
+            Paint.Dispose();
+            foreach (var font in _fonts.Values)
+                font.Dispose();
+            _fonts.Clear();
+        }
     }
 
     private static void AddRing(SKPath path, IReadOnlyList<(double X, double Y)> ring, WorldToScreen t)

--- a/tests/EncDotNet.S100.Pipelines.Tests/GpuRegistryTeardownTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/GpuRegistryTeardownTests.cs
@@ -1,0 +1,140 @@
+using System.Runtime.CompilerServices;
+using EncDotNet.S100.Renderers.Mapsui;
+using Mapsui.Layers;
+using SkiaSharp;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Guards the GPU-residency registry teardown in <see cref="S100VectorTileRenderer"/>
+/// that frees a torn-down tiled ("B") layer's GPU objects — its texture cache and
+/// its rotated off-screen composite (<c>RotationSurface</c>/<c>RotationImage</c>)
+/// — on the render thread rather than letting the GC finalizer thread reclaim them
+/// off-thread. The latter races a live render thread inside the native Skia GPU
+/// backend and crashes the process (observed when switching the render subsystem
+/// from "B" tiled to "A" Mapsui, which re-portrays and swaps in fresh layers).
+///
+/// A real GPU <see cref="SKSurface"/>/<see cref="GRContext"/> is unavailable in a
+/// headless test, but the registry's lifecycle management is identical for CPU- and
+/// GPU-backed resources, so these exercise it with CPU-backed surfaces and a
+/// sentinel context. The whole class touches the process-wide registry, so each
+/// test clears it afterwards for isolation.
+/// </summary>
+public sealed class GpuRegistryTeardownTests
+{
+    // Register an entry whose owning layer is reachable ONLY from the (weak)
+    // registry once this method returns, so a GC can collect it. Kept out-of-line
+    // so the layer is not rooted by the caller's stack frame.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RegisterWithCollectableLayer(TileCache cache, object context, SKSurface surface, SKImage image)
+    {
+        var layer = new MemoryLayer("dead");
+        S100VectorTileRenderer.RegisterGpuEntryForTest(layer, cache, context, surface, image);
+    }
+
+    [Fact]
+    public void ReconcileGpuCaches_OwningLayerCollected_DisposesRotationCompositeAndRemovesEntry()
+    {
+        try
+        {
+            var context = new object();
+            var cache = new TileCache(1024 * 1024);
+            var surface = SKSurface.Create(new SKImageInfo(8, 8));
+            var image = surface.Snapshot();
+
+            RegisterWithCollectableLayer(cache, context, surface, image);
+            Assert.Equal(1, S100VectorTileRenderer.GpuRegistryEntryCountForTest);
+
+            // Drop the only (weak) path to the layer.
+            for (var i = 0; i < 4; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            S100VectorTileRenderer.ReconcileGpuCachesForTest(context);
+
+            // The dead layer's entry is gone and its GPU rotation composite was
+            // disposed on this (render) thread — never left for the finalizer.
+            Assert.Equal(0, S100VectorTileRenderer.GpuRegistryEntryCountForTest);
+            Assert.True(IsDisposed(surface));
+            Assert.True(IsDisposed(image));
+        }
+        finally
+        {
+            S100VectorTileRenderer.ClearGpuRegistryForTest();
+        }
+    }
+
+    [Fact]
+    public void ReconcileGpuCaches_LiveLayer_RetainsEntryAndDoesNotDisposeRotationComposite()
+    {
+        var layer = new MemoryLayer("live");
+        var surface = SKSurface.Create(new SKImageInfo(8, 8));
+        var image = surface.Snapshot();
+        try
+        {
+            var context = new object();
+            var cache = new TileCache(1024 * 1024);
+            S100VectorTileRenderer.RegisterGpuEntryForTest(layer, cache, context, surface, image);
+
+            for (var i = 0; i < 4; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            S100VectorTileRenderer.ReconcileGpuCachesForTest(context);
+
+            // A live layer keeps its entry and its (still-needed) GPU resources.
+            Assert.Equal(1, S100VectorTileRenderer.GpuRegistryEntryCountForTest);
+            Assert.False(IsDisposed(surface));
+            Assert.False(IsDisposed(image));
+        }
+        finally
+        {
+            GC.KeepAlive(layer);
+            S100VectorTileRenderer.ClearGpuRegistryForTest();
+        }
+    }
+
+    [Fact]
+    public void ReconcileGpuCaches_DeadLayerDifferentContext_RemovesEntryButLeavesResourcesForOwningContext()
+    {
+        var surface = SKSurface.Create(new SKImageInfo(8, 8));
+        var image = surface.Snapshot();
+        try
+        {
+            var owningContext = new object();
+            var otherContext = new object();
+            var cache = new TileCache(1024 * 1024);
+
+            RegisterWithCollectableLayer(cache, owningContext, surface, image);
+
+            for (var i = 0; i < 4; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            // Reconciling under a *different* context must not free resources bound
+            // to the owning context (freeing under the wrong GPU context crashes);
+            // the dead entry is dropped so the owning context can reclaim them.
+            S100VectorTileRenderer.ReconcileGpuCachesForTest(otherContext);
+
+            Assert.Equal(0, S100VectorTileRenderer.GpuRegistryEntryCountForTest);
+            Assert.False(IsDisposed(surface));
+            Assert.False(IsDisposed(image));
+        }
+        finally
+        {
+            surface.Dispose();
+            image.Dispose();
+            S100VectorTileRenderer.ClearGpuRegistryForTest();
+        }
+    }
+
+    // SkiaSharp surfaces the native handle as IntPtr.Zero once disposed.
+    private static bool IsDisposed(SKObject obj) => obj.Handle == nint.Zero;
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/SymbolOverlayTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SymbolOverlayTests.cs
@@ -147,6 +147,71 @@ public class SymbolOverlayTests
         Assert.Equal(zoomedOut.Height, zoomedIn.Height);
     }
 
+    [Fact]
+    public void RenderOnto_PointAnchoredFarOutsideViewport_IsCulled()
+    {
+        const double lon = 10.0;
+        const double lat = 0.0;
+        var renderer = new SkiaDisplayListRenderer
+        {
+            Background = RgbaColor.Transparent,
+            HonorScaleVisibility = false,
+        };
+
+        // A point centred in the viewport renders; the same point pushed far
+        // off-screen (many viewport widths away) is culled before it draws.
+        var inView = MeasureOpaqueBounds(renderer,
+            new VectorScene(new List<PaintOp> { Point("p", lon, lat) }),
+            Centred(lon, lat, 0.1));
+        var offView = MeasureOpaqueBounds(renderer,
+            new VectorScene(new List<PaintOp> { Point("p", lon + 5.0, lat) }),
+            Centred(lon, lat, 0.1));
+
+        Assert.True(inView.Width > 0 && inView.Height > 0, "in-view point did not render");
+        Assert.Equal((0, 0), offView);
+    }
+
+    [Fact]
+    public void RenderOnto_SvgSymbol_RendersConsistentlyAcrossRepeatedRenders()
+    {
+        const double lon = 10.0;
+        const double lat = 0.0;
+        var scene = new VectorScene(new List<PaintOp> { PointWithSvg("buoy", lon, lat) });
+        var renderer = new SkiaDisplayListRenderer
+        {
+            Background = RgbaColor.Transparent,
+            HonorScaleVisibility = false,
+        };
+
+        // The parsed symbol picture is cached process-wide and reused across
+        // renders/frames. A regression that disposed the cached picture would
+        // yield a null picture on the next render (falling back to a dot, or
+        // nothing) — so repeated renders of the same symbol must stay identical.
+        var first = MeasureOpaqueBounds(renderer, scene, Centred(lon, lat, 0.1));
+        Assert.True(first.Width > 0 && first.Height > 0, "symbol did not render");
+        for (var i = 0; i < 3; i++)
+        {
+            var again = MeasureOpaqueBounds(renderer, scene, Centred(lon, lat, 0.1));
+            Assert.Equal(first, again);
+        }
+    }
+
+    private static PointPaintOp PointWithSvg(string id, double lon, double lat) =>
+        new()
+        {
+            FeatureReference = id,
+            World = WebMercator.FromLonLat(lon, lat),
+            Symbol = new ResolvedSymbol(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"3.98mm\" " +
+                "height=\"3.98mm\" viewBox=\"-1.99 -1.99 3.98 3.98\">" +
+                "<rect x=\"-1.99\" y=\"-1.99\" width=\"3.98\" height=\"3.98\" fill=\"red\"/></svg>",
+                Scale: 1.0,
+                PivotRelativeX: 0.0,
+                PivotRelativeY: 0.0),
+            FallbackColor = new RgbaColor(220, 20, 60, 255),
+            FallbackScale = 1.0,
+        };
+
     private static Viewport Centred(double lon, double lat, double span) =>
         new()
         {

--- a/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
@@ -411,6 +411,87 @@ public sealed class SkiaDisplayListRendererTests
         return renderer.Render(scene, viewport);
     }
 
+    [Fact]
+    public void Render_TextWithBackground_PaintsBothBackgroundAndForeground()
+    {
+        // The per-render text scratch reuses one SKPaint for the label
+        // background rectangle and the glyph fill, resetting its colour between
+        // them. This guards that the background still paints (its colour is not
+        // left as the glyph colour) and the foreground glyph paints over it.
+        var background = new RgbaColor(255, 0, 0, 255);   // red box
+        var foreground = new RgbaColor(0, 0, 255, 255);   // blue text
+        var scene = new VectorScene([
+            new TextPaintOp
+            {
+                FeatureReference = "text",
+                World = Project(0.005, 0.005),
+                Text = "ABC",
+                FontSizePx = 40,
+                ForeColor = foreground,
+                BackColor = background,
+            },
+        ]);
+
+        using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+
+        int red = 0, blue = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = 0; x < bitmap.Width; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red > 200 && p.Green < 80 && p.Blue < 80) red++;
+            if (p.Blue > 200 && p.Red < 80 && p.Green < 80) blue++;
+        }
+
+        Assert.True(red > 50, $"label background did not paint (red pixels={red}).");
+        Assert.True(blue > 20, $"label foreground did not paint (blue pixels={blue}).");
+    }
+
+    [Fact]
+    public void Render_TextOpsWithDifferentFontSizes_RenderAtDistinctSizes()
+    {
+        // The text scratch caches SKFont by pixel size; a regression that keyed
+        // the cache wrongly (or shared one font) would render both labels at the
+        // same size. Two same-text labels at 12 px and 40 px must differ in
+        // painted extent, and both must paint.
+        int Extent(double fontPx)
+        {
+            var scene = new VectorScene([
+                new TextPaintOp
+                {
+                    FeatureReference = "t",
+                    World = Project(0.005, 0.005),
+                    Text = "8",
+                    FontSizePx = fontPx,
+                    ForeColor = Black,
+                },
+            ]);
+            using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+            int minX = int.MaxValue, minY = int.MaxValue, maxX = -1, maxY = -1;
+            for (int y = 0; y < bitmap.Height; y++)
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                var p = bitmap.GetPixel(x, y);
+                if (p.Red < 128 && p.Green < 128 && p.Blue < 128)
+                {
+                    if (x < minX) minX = x;
+                    if (y < minY) minY = y;
+                    if (x > maxX) maxX = x;
+                    if (y > maxY) maxY = y;
+                }
+            }
+            return maxX < 0 ? 0 : (maxY - minY + 1);
+        }
+
+        int small = Extent(12);
+        int large = Extent(40);
+
+        Assert.True(small > 0, "12 px label did not render.");
+        Assert.True(large > small * 1.5,
+            $"40 px label ({large}px tall) was not clearly larger than the 12 px label ({small}px tall).");
+    }
+
+
     private static Viewport MakeViewport(double denom) => new()
     {
         MinLongitude = 0.0,


### PR DESCRIPTION
## Summary

Addresses issue #332: the "All" display category makes pan/zoom feel laggy because the tiled ("B") render subsystem redraws the live point-symbol/sounding overlay on every frame, and the per-op work was expensive. This PR removes the three overlay hotspots and fixes a separate GPU finalization crash uncovered while testing.

**Overlay performance** (`SkiaDisplayListRenderer`):
- Cache the parsed `SKPicture` keyed by `ProcessedSvg` instead of re-parsing the SVG XML and rebuilding the picture for every point op every frame. This was the dominant cost; a micro-benchmark of an all-on-screen dense frame went from ~122 ms to ~7 ms (about 17x).
- Cull point and text ops whose projected anchor falls outside the viewport plus a margin. The cull rect is rotation-aware (bounding box of the rotated viewport) and is computed once per frame in `S100VectorTileRenderer.DrawOverlay`. With half the ops off-view that frame dropped to ~3.5 ms (about 30x).
- Pool the per-render text `SKPaint` and cache `SKFont` by pixel size so dense sounding labels stop allocating per op (3000 labels = ~3.45 ms/frame, only a handful of gen0 GCs).

These keep the #329 scale-stability guarantee intact: symbols/soundings stay constant on-screen size across zoom, so they remain partitioned out of the tiled base plane and drawn live; nothing is baked into tiles.

**Crash fix** (`S100VectorTileRenderer`): switching the render subsystem from "B" tiled to "A" Mapsui re-portrays and swaps in fresh layers, abandoning a `TileState` whose GPU-backed rotation composite (`RotationSurface`/`RotationImage`) was reachable only weakly. It was then finalized on the GC finalizer thread while "A" was actively rendering, racing the native Skia GPU backend and segfaulting. The fix mirrors the GPU rotation pair into the layer's strong-referenced `GpuRegistryEntry` (the same process-wide registry that already shields the GPU texture cache from off-thread finalization), in lockstep with the `TileState`, so `ReconcileGpuCaches` disposes it on the render thread when the owning layer is collected. Only the small GPU surface+image pair is pinned; the much larger CPU tile cache stays weakly held and GC-collectible, so there is no memory or steady-state render-cost regression.

Closes #332

## Spec alignment

- [x] N/A — change is purely infrastructural (rendering pipeline / performance; no spec semantics touched)

**Spec section references cited in code/docs:** N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

`GpuRegistryTeardownTests` deterministically exercises the registry teardown with CPU-backed `SKSurface`/`SKImage` and a sentinel context (the lifecycle is identical to GPU-backed resources, which are unavailable headlessly): a collected layer has its composite disposed on the calling thread and its entry removed; a live layer is retained; a dead layer reconciled under a different context is dropped without freeing resources bound to the owning context. Overlay regression tests cover off-view culling, repeated-render consistency, and text background/font-size rendering. Full run: 718 Pipelines + 59 VisualRegression tests pass.

The subsystem switch itself is not drivable from the MCP harness (no subsystem tool, and the UI toggle is not headlessly scriptable), so the registry-teardown unit test is the regression guard for the GPU finalizer race.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (both Renderers.Mapsui and Renderers.Skia)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed — N/A
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency — N/A, no new dependencies

## Breaking changes

None. The new symbol-picture cache holds strong `SKSvg` references for the process lifetime (small, bounded by distinct symbol count); the GPU registry change only adds two pointer writes per rotated GPU frame.