### PR TITLE
Fix flaky VectorPipeline_emits_xslt_transform_span telemetry test

### DIFF
--- a/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TelemetrySmokeTests.cs
@@ -146,10 +146,20 @@ public sealed class TelemetrySmokeTests
     [Fact]
     public async Task VectorPipeline_emits_xslt_transform_span()
     {
+        // Use a dedicated test ActivitySource so we can start a root activity
+        // whose TraceId scopes the spans captured by the listener. Under
+        // parallel execution, a sibling test's XSLT span can be emitted into
+        // the same process during this test's window; filtering by our own
+        // root's TraceId ensures we only assert on spans produced by this
+        // test's pipeline invocation.
+        using var testSource = new ActivitySource(
+            "EncDotNet.S100.Tests.VectorPipeline_emits_xslt_transform_span");
+
         var observed = new ConcurrentBag<Activity>();
         using var listener = new ActivityListener
         {
-            ShouldListenTo = src => src.Name == "EncDotNet.S100.Core",
+            ShouldListenTo = src =>
+                src.Name == "EncDotNet.S100.Core" || src.Name == testSource.Name,
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
             ActivityStopped = activity => observed.Add(activity),
         };
@@ -169,9 +179,15 @@ public sealed class TelemetrySmokeTests
             [new PortrayalRule { Name = "TestRule", Type = PortrayalRuleType.Xslt, ExecutionOrder = 1, AppliesTo = ["Buoy"] }],
             xsltRules: new() { ["TestRule"] = xslt });
 
+        using var root = testSource.StartActivity("test-root");
+        Assert.NotNull(root);
+
         await new VectorPipeline().ProcessAsync(source, catalogue);
 
-        var transformSpan = observed.First(a => a.OperationName == "s100.xslt.transform");
+        // Only consider the XSLT transform span belonging to this test's own
+        // activity tree (same TraceId as the root we started above).
+        var transformSpan = observed.First(a =>
+            a.OperationName == "s100.xslt.transform" && a.TraceId == root.TraceId);
         Assert.Equal("TestRule", transformSpan.GetTagItem("s100.xslt.rule"));
     }
 


### PR DESCRIPTION
## Summary

Fixes the flaky `EncDotNet.S100.Pipelines.Tests.TelemetrySmokeTests.VectorPipeline_emits_xslt_transform_span` test, which intermittently failed under parallel execution with `Expected: TestRule, Actual: All` on the `s100.xslt.rule` tag.

**Root cause:** the test captured XSLT transform spans via a process-global `ActivityListener` and asserted on `observed.First(a => a.OperationName == "s100.xslt.transform")`. When a sibling pipeline test ran concurrently in the same process, its XSLT span (`s100.xslt.rule == All`) could be captured instead of this test's own span.

**Fix:** the test now creates a dedicated test `ActivitySource`, starts a root `Activity` before invoking the pipeline, and has the listener subscribe to both `EncDotNet.S100.Core` and the test source. The pipeline's spans inherit the root's `TraceId`, so the assertion filters by `a.TraceId == root.TraceId` and only considers the `s100.xslt.transform` span produced by this test's own `ProcessAsync` invocation. No `[Collection]` serialization or parallelism changes; the assertion intent (`s100.xslt.rule == "TestRule"`) is preserved.

Closes #346

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — test-only isolation fix.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (N/A — no real data)
- [x] `dotnet test --configuration Release` passes locally

Verified the single test passes and ran the full `tests/EncDotNet.S100.Pipelines.Tests` suite 3x consecutively (718 passed, 1 skipped each run) to exercise the concurrency race.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (N/A — test-only change)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A)
- [x] New public APIs have XML doc comments (N/A — no public API changes)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependencies)

## Breaking changes

None.