### PR TITLE
Fix renderer A snapshot dropping SVG point symbols

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -431,6 +431,21 @@ The trade-off is the *record* frame: the first frame at each new resolution
 device scale, costing more than a single live frame (~650 ms on PDB01). The
 off-thread pre-build below hides that cost for both zoom and sustained pan.
 
+**Image-source readiness at record time.** Mapsui resolves an `ImageStyle`'s
+image (the SVG point symbols for buoys, beacons, lights) from its
+`RenderService.ImageSourceCache`, which is normally populated by an
+*asynchronous* fetch loop. The live per-frame path tolerates a cache miss
+because it simply redraws the next frame once the fetch lands, but the
+snapshot's one-shot record does not: a record taken before the fetch
+completes would bake a symbol-less raster that the (still "valid") snapshot
+never re-records, so the symbols would vanish until the next zoom. The
+recorder therefore registers the layer's image sources **synchronously**
+before drawing (`EnsureImageSourcesRegistered`), mirroring Mapsui's own
+offscreen rasteriser (`RasterizingTileSource`, which awaits
+`ImageSourceCache.FetchAllImageDataAsync` before `RenderToBitmapStream`). The
+`svg-content://` / `base64-content://` sources used here resolve in-process,
+so this adds no I/O wait.
+
 **Off-thread pre-build (`S100_VECTOR_SNAPSHOT_PREBUILD`, default on).** When
 enabled, the renderer keeps a small per-resolution LRU of recorded images
 instead of a single image, and hides the record-frame stall in four ways:

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSnapshotRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSnapshotRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -1329,6 +1330,18 @@ public static class S100VectorSnapshotRenderer
         var iteration = System.Threading.Interlocked.Increment(ref s_iteration);
         var features = layer.SortFeatures(layer.GetFeatures(queryExtent, resolution)).ToList();
 
+        // The one-shot snapshot record races Mapsui's asynchronous image-source
+        // fetch loop. ImageStyleRenderer draws nothing when the (SVG) image bytes
+        // are not yet present in the RenderService image cache, so a record taken
+        // before that fetch completes would bake out the point symbols (buoys,
+        // beacons, lights) permanently — the snapshot stays "valid" and is never
+        // re-recorded. Mirror Mapsui's own offscreen rasteriser
+        // (RasterizingTileSource, which awaits FetchAllImageDataAsync before
+        // RenderToBitmapStream) by registering this layer's image sources
+        // synchronously before drawing. svg-content:// / base64-content:// sources
+        // resolve in-process, so the fetch completes without blocking on I/O.
+        EnsureImageSourcesRegistered(features, renderService);
+
         if (layer.Style is { } layerStyle)
         {
             foreach (var style in layerStyle.GetStylesToApply(resolution))
@@ -1377,6 +1390,47 @@ public static class S100VectorSnapshotRenderer
         finally
         {
             target.RestoreToCount(restore);
+        }
+    }
+
+    internal static void EnsureImageSourcesRegistered(IReadOnlyList<IFeature> features, RenderService renderService)
+    {
+        var cache = renderService.ImageSourceCache;
+        ConcurrentDictionary<string, string>? pending = null;
+
+        foreach (var feature in features)
+        {
+            var styles = feature.Styles;
+            if (styles is null)
+            {
+                continue;
+            }
+
+            foreach (var style in styles)
+            {
+                if (style is ImageStyle { Image: { } image } && cache.Get(image) is null)
+                {
+                    pending ??= new ConcurrentDictionary<string, string>();
+                    pending[image.Source] = image.SourceId;
+                }
+            }
+        }
+
+        if (pending is null || pending.IsEmpty)
+        {
+            return;
+        }
+
+        try
+        {
+            cache.FetchAllImageDataAsync(pending).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            if (s_diag)
+            {
+                Console.Error.WriteLine($"[VecSnapshot] image source fetch failed: {ex.Message}");
+            }
         }
     }
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/S100VectorSnapshotRendererTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S100VectorSnapshotRendererTests.cs
@@ -484,4 +484,47 @@ public sealed class S100VectorSnapshotRendererTests
         // Spans none (between 6.16 and 30.0).
         Assert.False(S100VectorSnapshotRenderer.VisibleSetMayDiffer(thresholds, 9.55, 19.11));
     }
+
+    [Fact]
+    public void EnsureImageSourcesRegistered_FetchesSvgImageBeforeRecord()
+    {
+        // Regression for the snapshot fast-path dropping SVG point symbols
+        // (buoys, beacons, lights). The one-shot record races Mapsui's async
+        // image-source fetch loop: ImageStyleRenderer draws nothing on an
+        // ImageSourceCache miss, so a record taken before the fetch completes
+        // bakes a symbol-less raster that the (still "valid") snapshot never
+        // re-records. The renderer must register the layer's image sources
+        // synchronously before drawing — svg-content:// resolves in-process.
+        var svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"8\" height=\"8\">"
+            + $"<!-- {Guid.NewGuid()} --><rect width=\"8\" height=\"8\" fill=\"green\"/></svg>";
+        var image = new Mapsui.Styles.Image { Source = "svg-content://" + svg, RasterizeSvg = true };
+        var feature = new Mapsui.Layers.PointFeature(0, 0);
+        feature.Styles.Add(new Mapsui.Styles.ImageStyle { Image = image });
+
+        var renderService = new Mapsui.Rendering.RenderService();
+
+        // Precondition: the SVG bytes are not yet in the cache, so a record now
+        // would omit the symbol.
+        Assert.Null(renderService.ImageSourceCache.Get(image));
+
+        S100VectorSnapshotRenderer.EnsureImageSourcesRegistered([feature], renderService);
+
+        // After registration the bytes are present, so ImageStyleRenderer can
+        // resolve and draw the symbol into the recorded raster.
+        Assert.NotNull(renderService.ImageSourceCache.Get(image));
+    }
+
+    [Fact]
+    public void EnsureImageSourcesRegistered_NoopForFeaturesWithoutImageStyles()
+    {
+        // A fallback coloured-dot point (SymbolStyle, not ImageStyle) needs no
+        // image fetch; the helper must tolerate it without throwing.
+        var feature = new Mapsui.Layers.PointFeature(0, 0);
+        feature.Styles.Add(new Mapsui.Styles.SymbolStyle());
+
+        var renderService = new Mapsui.Rendering.RenderService();
+
+        // Should complete without throwing.
+        S100VectorSnapshotRenderer.EnsureImageSourcesRegistered([feature], renderService);
+    }
 }


### PR DESCRIPTION
## Summary

The "A" (Mapsui) render arm has a residual bug where S-101 point symbols (buoys, beacons, lights) disappear during certain zooms/pans. This blocks the side-by-side A/B comparison needed to close out issue #347 (making the tiled "B" subsystem the default), since A is hard to evaluate against B when its symbols intermittently vanish.

Root cause: the A arm's raster snapshot fast path (`S100VectorSnapshotRenderer`) records a settled vector layer into a single `SKImage` once per (resolution, feature-set), then blits it on subsequent pans. The one-shot record draws each point feature's `ImageStyle` through Mapsui's `ImageStyleRenderer`, which resolves the SVG symbol from `RenderService.ImageSourceCache` and draws nothing on a cache miss. That cache is normally populated by Mapsui's asynchronous image-fetch loop, which the snapshot path bypasses (it blits instead of drawing live every frame). So a record taken before the fetch landed baked a symbol-less raster, and because the snapshot stayed "valid" it was never re-recorded, making the symbols disappear persistently. The live path (snapshot disabled) was unaffected only because it redraws every frame and recovers once the async fetch completes.

The fix registers the layer's own image sources synchronously before recording (`EnsureImageSourcesRegistered`), mirroring Mapsui's own offscreen rasteriser (`RasterizingTileSource`, which awaits `ImageSourceCache.FetchAllImageDataAsync` before `RenderToBitmapStream`). The `svg-content://` / `base64-content://` sources used here resolve in-process, so this adds no I/O wait. Verified in the headless viewer: with the snapshot enabled (previously broken), the buoy symbols now render and persist across a zoom sweep.

## Spec alignment

- [ ] S-100 framework (`s100-framework`)
- [x] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — the fix is in the Mapsui rendering pipeline (image-source cache readiness), not in spec-derived encoding/portrayal semantics.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Two new tests in `S100VectorSnapshotRendererTests` (`EnsureImageSourcesRegistered_FetchesSvgImageBeforeRecord` asserts the cache is populated for an SVG `ImageStyle`; `EnsureImageSourcesRegistered_NoopForFeaturesWithoutImageStyles` covers the fallback `SymbolStyle` no-op). Full `EncDotNet.S100.Pipelines.Tests`: 731 passed, 1 skipped.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Added a "Image-source readiness at record time" note to `src/EncDotNet.S100.Renderers.Mapsui/README.md`.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.