### PR TITLE
Cold tile-gen perf: base-plane spatial index (#332)

### DIFF
--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -1186,3 +1186,112 @@ pooling do not reach budget, the next step is **not** to thin hazards — it is 
 confirm SCAMIN is encoded/honoured as intended and, if needed, surface an
 overscale indication.
 
+
+## Appendix I — Phase 7: Cold tile-generation (base-plane spatial index, #332 / #347)
+
+A new **perf** line under #347 (make tiled "B" the default) — **not** a Fidelity
+item (Appendix H.0 is untouched: this renders the *identical* base plane,
+pixel-for-pixel, only faster). It addresses the lag the original #332 report
+actually felt: Appendix H.1 established that the "~30 ms" figure was **cold
+tile-generation**, not the live overlay (the overlay on the densest available
+trial cell was already declutter 0.6 ms + draw ~3 ms). This phase attacks that
+cold cost.
+
+### I.1 Measured cold-tile breakdown
+
+Dense Solent/St Peter Port cell `101GB00510210.000` (the same cell named in
+Appendix H.1), Release, Apple Silicon, 768×768 px tiles (256 dip + 64 gutter @
+deviceScale 2). The bound **base plane** = 10,398 ops (2,690 area + 2,907
+pattern + 4,801 line), **1.37 M vertices**, cell span 55 × 25 km. Cold cost is
+**~85–100 ms per fresh tile, roughly flat across zoom** — so a fresh pan band of
+several tiles costs hundreds of ms.
+
+The GUI viewer could not bind a Metal surface in the measurement shell
+(`Avalonia.Native … RenderTimer … -6661`, as in Appendix H.1), so the breakdown
+was taken GUI-free with an env-gated (`S100_TILEGEN_TIMING=1`) micro-benchmark
+driving the **same `VectorScene` IR and `SkiaDisplayListRenderer`** the worker
+uses, over real per-tile viewports reconstructed exactly as `RasterizeTile`
+builds them. Instrumentation was reverted before commit (skill hygiene rule).
+A/B per cold tile, swept by zoom band:
+
+| zoom | full scene | + per-tile op cull (index) | + cull **& generalize** | ops intersecting | verts intersecting |
+|---|---|---|---|---|---|
+| +1 | 82.9 ms | 60.8 ms (−27 %) | 15.4 ms (−81 %) | 13.8 % | 29 % |
+| +3 | 101.8 ms | 91.2 ms (−10 %) | 42.6 ms (−58 %) | 10.0 % | 43 % |
+| +5 | 88.2 ms | 76.8 ms (−13 %) | 56.0 ms (−37 %) | 2.6 % | 40 % |
+| +7 | 88.3 ms | 76.9 ms (−13 %) | 73.5 ms (−17 %) | 1.3 % | 37 % |
+
+**Dominant stage = vertex-bound rasterisation of the large *intersecting*
+area/line geometry** (`DrawArea`/`DrawLine` build a full-resolution `SKPath` then
+antialiased-fill it). Time tracks vertex count ~1:1 (~0.2 µs/vertex): only
+1–14 % of ops intersect a tile, but they carry 29–43 % of all vertices (the big
+depth/land polygons and contours). It is **not** fill-bound and **not**
+pattern-bound (patterns were 7–16 % of clipped cost).
+
+### I.2 What shipped this phase — the base-plane spatial index (fidelity-neutral)
+
+The shipped `RasterizeTile` rasterised the **whole** base scene for **every**
+tile, even though design §3.3 (line 74) specified *"query VectorScene ops
+intersecting tile+gutter (spatial index over the scene)"*. That base-plane index
+was never built — only the *overlay* plane got one (Appendix H.3 /
+`OverlaySpatialIndex`, #351). This phase finally builds the base-plane
+counterpart, `BaseSpatialIndex`:
+
+- A uniform grid over base-op **world AABBs** (area/pattern = `WorldShell`
+  bounds; line = polyline bounds), built **once** at `BindScene` and rebuilt on
+  every scene generation. An op straddling cells is inserted into each; `Query`
+  de-duplicates and returns matches **in ascending original op index** (S-100
+  Part 9 draw/z-order). Any op whose geometry the index cannot bound becomes an
+  **always-candidate** so it is never dropped.
+- `RasterizeTile` queries the tile+gutter world AABB and rasterises only the
+  returned ops. The query is a deliberate **conservative superset** (bbox
+  intersection only) and the renderer still applies the exact per-op
+  `ScaleVisibility` cull and pixel clip — so the output is **pixel-identical** to
+  rasterising the whole scene. A null index (defensive) falls back to the full
+  scene.
+
+Measured payoff of the index alone: **10–27 %** faster cold tiles (27 % at the
+coarse bands a fresh pan most exposes). Scoping is also the structural enabler
+for the deferred generalization lever below.
+
+### I.3 Threading / correctness
+
+`BaseSpatialIndex` is **immutable after construction** and touches no Skia/GPU
+objects — a pure-CPU transform over the immutable paint-op IR — so it is safe to
+`Query` concurrently from the multiple **worker** threads that rasterise tiles,
+and it is independent of the render thread's GPU-context lifetime rules (§3.7 /
+Appendix F: GPU-backed `SKObject`s are created **and** freed on the render
+thread). Tile rasterisation itself remains CPU/software (`SKBitmap` →
+`SKImage.FromBitmap`, no `GRContext`). `Query` allocates its own result list per
+call (no shared scratch), so concurrent worker queries never race.
+
+### I.4 Deferred — Lever A: band-keyed geometry generalization
+
+The data's biggest lever is **resolution-aware geometry generalization**
+(Douglas–Peucker at ~½ device-pixel, keyed per zoom band): 81 % / 58 % / 37 %
+cold-tile reductions at zoom +1 / +3 / +5, tracking the vertex reduction ~1:1.
+It is **deferred** by branch-owner decision because, unlike every lever shipped
+so far, it is the first that **alters rendered chart geometry**, so it is gated
+on:
+
+1. a **topology-preserving** simplifier (naive per-ring DP can self-intersect /
+   invalidate area fills; thick strokes need a conservative tolerance) — see the
+   `chart-cartography` skill §2;
+2. **golden-image sign-off** (the #347 golden-image set), to confirm the ½-px
+   tolerance is sub-perceptual at the band it is keyed to; and
+3. a **Metal-capable GUI session** for in-viewer A/B confirmation
+   (`TileRasterizeDuration` histogram + `dotnet-trace`), unavailable in the
+   profiling shell.
+
+It remains fidelity-*bounded* (no feature dropped — unlike the LOD-thinning
+ruled out in Appendix H.0), just not fidelity-*neutral*, so it ships separately.
+
+### I.5 Exit criterion (feeds #347)
+
+A cold pan into a fresh band on a dense *All* cell rasterises each tile by
+walking only the ops that intersect it, not the whole cell, with **pixel-
+identical** output to the pre-index path. Verified by `BaseSpatialIndexTests`
+(conservative-superset / draw-order / de-dup / degenerate / always-candidate) and
+`BaseScopingBenchTests` (an interior tile-sized query over a dense synthetic base
+plane returns O(covering), not O(cell)). Absolute wall-clock reconfirmation
+in-viewer is pending a Metal GUI session.

--- a/src/EncDotNet.S100.Renderers.Mapsui/BaseSpatialIndex.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/BaseSpatialIndex.cs
@@ -1,0 +1,241 @@
+using EncDotNet.S100.Rendering.Scene;
+
+namespace EncDotNet.S100.Renderers.Mapsui;
+
+/// <summary>
+/// A uniform-grid spatial index over a bound base scene's area/line/pattern ops
+/// (EPSG:3857 metres), built <b>once</b> when a scene is bound so the off-thread
+/// <see cref="S100VectorTileRenderer.RasterizeTile"/> walk can be scoped to the
+/// ops intersecting a tile (+ gutter) instead of the whole cell. This implements
+/// the long-specified but never-built base-plane index from the render-subsystem
+/// design §3.3 ("query VectorScene ops intersecting tile+gutter — spatial index
+/// over the scene") — the overlay plane already got its own index in #351
+/// (<see cref="OverlaySpatialIndex"/>); this is the base-plane counterpart
+/// (#332 cold tile-gen perf line under #347).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the overlay index (each op is anchored at a single world point), base
+/// ops are <i>extents</i> — polylines and polygons — so each op occupies a world
+/// AABB and is inserted into <b>every</b> grid cell its bounds cover.
+/// <see cref="Query"/> therefore de-duplicates and returns each matching op once,
+/// in <b>ascending original op index</b> (S-100 Part 9 ascending drawing
+/// priority), so a scoped tile rasterises with the identical z-order the
+/// whole-cell scene would.
+/// </para>
+/// <para>
+/// The query is a deliberate <i>conservative superset</i>: it intersects op world
+/// bounding boxes against the tile AABB (no precise polygon test), and the
+/// downstream <c>SkiaDisplayListRenderer</c> still applies the exact per-op
+/// <c>ScaleVisibility</c> cull and pixel clip — so scoping never drops an op that
+/// would otherwise be drawn (pixel-identical / fidelity neutral); it only bounds
+/// the per-tile walk. Any base op whose geometry this index does not recognise is
+/// treated as an always-candidate so it can never be missed.
+/// </para>
+/// <para>
+/// The index holds no mutable state after construction, so it is safe to
+/// <see cref="Query"/> concurrently from the multiple worker threads that
+/// rasterise tiles. It touches no Skia or GPU objects — it is a pure-CPU
+/// transform over the immutable paint-op IR — so it is independent of the render
+/// thread's GPU-context lifetime rules (design §3.7 / Appendix F).
+/// </para>
+/// </remarks>
+internal sealed class BaseSpatialIndex
+{
+    private readonly IReadOnlyList<PaintOp> _ops;
+    private readonly double[] _minXs;
+    private readonly double[] _minYs;
+    private readonly double[] _maxXs;
+    private readonly double[] _maxYs;
+
+    // Ops whose geometry was not recognised (no world bbox): always candidates.
+    private readonly List<int> _alwaysCandidates;
+
+    private readonly double _minX;
+    private readonly double _minY;
+    private readonly double _invCellW;
+    private readonly double _invCellH;
+    private readonly int _cols;
+    private readonly int _rows;
+    private readonly List<int>[] _cells;
+
+    /// <summary>The base ops, in original draw order.</summary>
+    public IReadOnlyList<PaintOp> Ops => _ops;
+
+    /// <summary>Builds the index over <paramref name="baseScene"/>'s area/line ops.</summary>
+    public BaseSpatialIndex(VectorScene baseScene)
+    {
+        ArgumentNullException.ThrowIfNull(baseScene);
+        _ops = baseScene.Ops;
+        int count = _ops.Count;
+
+        _minXs = new double[count];
+        _minYs = new double[count];
+        _maxXs = new double[count];
+        _maxYs = new double[count];
+        _alwaysCandidates = new List<int>();
+
+        // World bounds across all recognised op bboxes.
+        double minX = double.MaxValue, minY = double.MaxValue;
+        double maxX = double.MinValue, maxY = double.MinValue;
+        int bounded = 0;
+        for (int i = 0; i < count; i++)
+        {
+            if (TryBounds(_ops[i], out var x0, out var y0, out var x1, out var y1))
+            {
+                _minXs[i] = x0; _minYs[i] = y0; _maxXs[i] = x1; _maxYs[i] = y1;
+                if (x0 < minX) minX = x0;
+                if (y0 < minY) minY = y0;
+                if (x1 > maxX) maxX = x1;
+                if (y1 > maxY) maxY = y1;
+                bounded++;
+            }
+            else
+            {
+                // Sentinel that never intersects any finite query; the op is
+                // served from _alwaysCandidates instead so it is never dropped.
+                _minXs[i] = double.NaN;
+                _alwaysCandidates.Add(i);
+            }
+        }
+
+        if (bounded == 0)
+        {
+            // No bounded ops: a 1×1 grid that matches nothing. Always-candidates
+            // (if any) are still served by Query.
+            _cols = _rows = 1;
+            _cells = new List<int>[1] { new() };
+            _minX = _minY = 0;
+            _invCellW = _invCellH = 0;
+            return;
+        }
+
+        // Aim for ~1 op per cell on average, capped so a pathological cluster
+        // can't build a huge grid. A zero-width/height extent collapses that axis.
+        int target = Math.Clamp((int)Math.Ceiling(Math.Sqrt(bounded)), 1, 256);
+        _cols = (maxX > minX) ? target : 1;
+        _rows = (maxY > minY) ? target : 1;
+        _minX = minX;
+        _minY = minY;
+        double width = Math.Max(maxX - minX, double.Epsilon);
+        double height = Math.Max(maxY - minY, double.Epsilon);
+        // Nudge the divisor so the max coordinate maps to the last cell, not one past.
+        _invCellW = _cols / (width * (1 + 1e-9));
+        _invCellH = _rows / (height * (1 + 1e-9));
+
+        _cells = new List<int>[_cols * _rows];
+        for (int i = 0; i < count; i++)
+        {
+            if (double.IsNaN(_minXs[i]))
+                continue;
+            int c0 = ColOf(_minXs[i]), c1 = ColOf(_maxXs[i]);
+            int r0 = RowOf(_minYs[i]), r1 = RowOf(_maxYs[i]);
+            for (int r = r0; r <= r1; r++)
+            {
+                int rowBase = r * _cols;
+                for (int c = c0; c <= c1; c++)
+                    (_cells[rowBase + c] ??= new List<int>()).Add(i);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the base ops whose world bounding box intersects the world AABB
+    /// (<paramref name="minX"/>..<paramref name="maxY"/>), de-duplicated and in
+    /// ascending original op order. A fresh list is allocated per call so the
+    /// query is safe to run concurrently from worker threads.
+    /// </summary>
+    public List<PaintOp> Query(double minX, double minY, double maxX, double maxY)
+    {
+        var results = new List<PaintOp>();
+        if (maxX < minX || maxY < minY)
+            return results;
+
+        var seen = new HashSet<int>();
+        foreach (var idx in _alwaysCandidates)
+            seen.Add(idx);
+
+        int c0 = ColOf(minX), c1 = ColOf(maxX);
+        int r0 = RowOf(minY), r1 = RowOf(maxY);
+        for (int r = r0; r <= r1; r++)
+        {
+            int rowBase = r * _cols;
+            for (int c = c0; c <= c1; c++)
+            {
+                var bucket = _cells[rowBase + c];
+                if (bucket is null)
+                    continue;
+                // An op straddles multiple cells, so re-test its precise bbox to
+                // keep the candidate set tight (and naturally de-duplicate via the set).
+                foreach (var idx in bucket)
+                {
+                    if (_maxXs[idx] < minX || _minXs[idx] > maxX ||
+                        _maxYs[idx] < minY || _minYs[idx] > maxY)
+                        continue;
+                    seen.Add(idx);
+                }
+            }
+        }
+
+        if (seen.Count == 0)
+            return results;
+
+        var ordered = new List<int>(seen);
+        ordered.Sort();
+        foreach (var idx in ordered)
+            results.Add(_ops[idx]);
+        return results;
+    }
+
+    private int ColOf(double x)
+    {
+        int c = (int)((x - _minX) * _invCellW);
+        return c < 0 ? 0 : (c >= _cols ? _cols - 1 : c);
+    }
+
+    private int RowOf(double y)
+    {
+        int r = (int)((y - _minY) * _invCellH);
+        return r < 0 ? 0 : (r >= _rows ? _rows - 1 : r);
+    }
+
+    /// <summary>
+    /// Computes the world AABB of a base op's geometry. Area/pattern ops use the
+    /// exterior ring (holes are inside the shell); lines use the polyline.
+    /// Returns <see langword="false"/> for op types this index does not model
+    /// (those become always-candidates so they are never dropped).
+    /// </summary>
+    private static bool TryBounds(PaintOp op, out double minX, out double minY, out double maxX, out double maxY)
+    {
+        switch (op)
+        {
+            case AreaPaintOp a:
+                return TryRingBounds(a.WorldShell, out minX, out minY, out maxX, out maxY);
+            case PatternAreaPaintOp p:
+                return TryRingBounds(p.WorldShell, out minX, out minY, out maxX, out maxY);
+            case LinePaintOp l:
+                return TryRingBounds(l.World, out minX, out minY, out maxX, out maxY);
+            default:
+                minX = minY = maxX = maxY = 0;
+                return false;
+        }
+    }
+
+    private static bool TryRingBounds(
+        IReadOnlyList<(double X, double Y)> ring,
+        out double minX, out double minY, out double maxX, out double maxY)
+    {
+        minX = minY = double.MaxValue;
+        maxX = maxY = double.MinValue;
+        if (ring is null || ring.Count == 0)
+            return false;
+        foreach (var (x, y) in ring)
+        {
+            if (x < minX) minX = x;
+            if (y < minY) minY = y;
+            if (x > maxX) maxX = x;
+            if (y > maxY) maxY = y;
+        }
+        return true;
+    }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -434,6 +434,7 @@ public static class S100VectorTileRenderer
         {
             var (baseScene, overlayScene) = PartitionScene(scene);
             state.Scene = baseScene;
+            state.BaseIndex = new BaseSpatialIndex(baseScene);
             state.OverlayScene = overlayScene;
             state.OverlayIndex = new OverlaySpatialIndex(overlayScene);
             state.OverlayCandidates.Clear();
@@ -1309,6 +1310,7 @@ public static class S100VectorTileRenderer
                 float deviceScale;
                 long generation;
                 VectorScene scene;
+                BaseSpatialIndex? baseIndex;
                 bool isPrediction;
                 string? diskNamespace;
 
@@ -1340,6 +1342,7 @@ public static class S100VectorTileRenderer
                     deviceScale = state.PendingDeviceScale;
                     generation = state.PendingGeneration;
                     scene = state.Scene;
+                    baseIndex = state.BaseIndex;
                     diskNamespace = state.DiskNamespace;
                     state.InFlight.Add(key);
                 }
@@ -1366,7 +1369,7 @@ public static class S100VectorTileRenderer
                     try
                     {
                         var rasterStart = Stopwatch.GetTimestamp();
-                        using var bitmap = RasterizeTile(scene, key, deviceScale);
+                        using var bitmap = RasterizeTile(scene, baseIndex, key, deviceScale);
                         image = SKImage.FromBitmap(bitmap);
                         S100Diag.Telemetry.TileRasterizeDuration.Record(
                             Stopwatch.GetElapsedTime(rasterStart).TotalMilliseconds);
@@ -1654,7 +1657,7 @@ public static class S100VectorTileRenderer
     /// Rasterises a single tile (core + gutter) from the scene at its band
     /// resolution and the frame's device scale.
     /// </summary>
-    private static SKBitmap RasterizeTile(VectorScene scene, TileKey key, float deviceScale)
+    private static SKBitmap RasterizeTile(VectorScene scene, BaseSpatialIndex? baseIndex, TileKey key, float deviceScale)
     {
         var (minX, minY, maxX, maxY) = TileGrid.TileWorldBounds(key);
         var bandResolution = TileGrid.ResolutionForBand(key.Band);
@@ -1664,6 +1667,16 @@ public static class S100VectorTileRenderer
         var fullMaxX = maxX + gutterWorld;
         var fullMinY = minY - gutterWorld;
         var fullMaxY = maxY + gutterWorld;
+
+        // Scope the base-plane walk to the ops whose world bounds intersect this
+        // tile (+ gutter). The index is a conservative superset and the renderer
+        // still applies the exact per-op scale cull and pixel clip, so the result
+        // is pixel-identical to rasterising the whole scene — only fewer ops are
+        // walked (#332 cold tile-gen, perf line under #347). A null index (before
+        // the first BindScene, defensive) falls back to the full scene.
+        var tileScene = baseIndex is null
+            ? scene
+            : new VectorScene(baseIndex.Query(fullMinX, fullMinY, fullMaxX, fullMaxY));
 
         var (minLon, minLat) = WebMercator.ToLonLat(fullMinX, fullMinY);
         var (maxLon, maxLat) = WebMercator.ToLonLat(fullMaxX, fullMaxY);
@@ -1692,7 +1705,7 @@ public static class S100VectorTileRenderer
             HonorScaleVisibility = true,
         };
 
-        return renderer.Render(scene, viewport);
+        return renderer.Render(tileScene, viewport);
     }
 
     /// <summary>Per-layer tiling state, held in a weak table keyed by layer.</summary>
@@ -1701,6 +1714,14 @@ public static class S100VectorTileRenderer
         public readonly object Sync = new();
 
         public VectorScene? Scene;
+
+        // Spatial index over the base-plane op extents (#332 cold tile-gen,
+        // perf line under #347), built once when a scene is bound so each
+        // off-thread RasterizeTile walk can be scoped to the ops intersecting
+        // the tile (+ gutter) instead of the whole cell. Immutable after
+        // construction, so it is safe to query from the multiple worker threads
+        // that rasterise tiles concurrently. Null until a scene is bound.
+        public BaseSpatialIndex? BaseIndex;
 
         // Live screen-space overlay: point symbols + point-anchored text
         // (soundings) partitioned out of the tiled base plane so they draw at

--- a/tests/EncDotNet.S100.Pipelines.Tests/BaseScopingBenchTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/BaseScopingBenchTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.Rendering.Scene;
+using EncDotNet.S100.Renderers.Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Committed micro-measurement guarding the #332 cold tile-gen base-plane
+/// scoping invariant (perf line under #347): rasterising a single tile must walk
+/// only the base ops intersecting that tile (+ gutter), not the whole cell. The
+/// shipped <c>RasterizeTile</c> previously replayed the entire base scene for
+/// every tile; <see cref="BaseSpatialIndex"/> implements the long-specified but
+/// never-built base-plane index (design §3.3) so an interior tile-sized query
+/// returns a candidate set proportional to the <i>covering</i> ops — the
+/// structural source of the measured cold-tile reduction. Fidelity is unchanged:
+/// the query is a conservative superset and the renderer still applies the exact
+/// per-op scale cull and pixel clip.
+/// </summary>
+public class BaseScopingBenchTests
+{
+    private static AreaPaintOp Cell(int i, double x, double y, double size) =>
+        new()
+        {
+            FeatureReference = "a" + i,
+            WorldShell = new[] { (x, y), (x + size, y), (x + size, y + size), (x, y + size), (x, y) },
+            Fill = new RgbaColor(200, 200, 255, 255),
+            OutlineColor = new RgbaColor(0, 0, 0, 255),
+            OutlineWidthPx = 1.0,
+        };
+
+    /// <summary>
+    /// Builds a dense <paramref name="side"/>×<paramref name="side"/> grid of
+    /// small non-overlapping area ops <paramref name="spacing"/> metres apart
+    /// (EPSG:3857), approximating a dense-cell base plane.
+    /// </summary>
+    private static VectorScene DenseAreaGrid(int side, out double spacing)
+    {
+        spacing = 100.0;
+        var ops = new List<PaintOp>(side * side);
+        for (int gy = 0; gy < side; gy++)
+            for (int gx = 0; gx < side; gx++)
+                ops.Add(Cell(gy * side + gx, gx * spacing, gy * spacing, spacing * 0.8));
+        return new VectorScene(ops);
+    }
+
+    [Fact]
+    public void Query_OnDenseCell_ReturnsCoveringSubsetNotWholeCell()
+    {
+        // 200×200 = 40 000 ops — a dense base plane.
+        var scene = DenseAreaGrid(200, out double spacing);
+        var index = new BaseSpatialIndex(scene);
+
+        // A tile-sized world window covering ~10×10 cells.
+        double w = 10 * spacing;
+        var got = index.Query(0, 0, w, w);
+
+        // Roughly an 11×11 block of cells (inclusive bounds) — two orders of
+        // magnitude below the 40 000-op whole cell.
+        Assert.InRange(got.Count, 80, 200);
+        Assert.True(got.Count < scene.Ops.Count / 100,
+            $"scoping returned {got.Count} of {scene.Ops.Count} — not O(covering)");
+    }
+
+    [Fact]
+    public void Query_PannedAcrossCell_CandidateCountStaysBounded()
+    {
+        // As the tile window pans across the whole cell, the candidate count must
+        // track the (constant-size) tile, never the cell — the property that makes
+        // each cold RasterizeTile O(N_covering) instead of O(N_cell).
+        var scene = DenseAreaGrid(200, out double spacing);
+        var index = new BaseSpatialIndex(scene);
+        double w = 10 * spacing;
+
+        int max = 0;
+        for (int step = 0; step < 180; step += 20)
+        {
+            double o = step * spacing;
+            max = Math.Max(max, index.Query(o, o, o + w, o + w).Count);
+        }
+
+        Assert.True(max < 250, $"panned candidate peak {max} not tile-bounded");
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/BaseSpatialIndexTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/BaseSpatialIndexTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Rendering.Scene;
+using EncDotNet.S100.Renderers.Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Tests for <see cref="BaseSpatialIndex"/> (#332 cold tile-gen — base-plane
+/// scoping, a perf line under #347). The index bounds the off-thread
+/// <c>RasterizeTile</c> walk to the base ops intersecting a tile (+ gutter)
+/// while guaranteeing it never drops an op the whole-cell walk would draw: a
+/// query is a conservative <b>superset</b> (bbox intersection only) returned in
+/// original draw (priority/z) order, de-duplicated even though an op straddles
+/// many grid cells, and a query covering the whole extent reproduces the full
+/// op list exactly.
+/// </summary>
+public class BaseSpatialIndexTests
+{
+    private static AreaPaintOp Area(string id, double x0, double y0, double x1, double y1) =>
+        new()
+        {
+            FeatureReference = id,
+            WorldShell = new[] { (x0, y0), (x1, y0), (x1, y1), (x0, y1), (x0, y0) },
+            Fill = new RgbaColor(200, 200, 255, 255),
+            OutlineColor = new RgbaColor(0, 0, 0, 255),
+            OutlineWidthPx = 1.0,
+        };
+
+    private static LinePaintOp Line(string id, params (double X, double Y)[] pts) =>
+        new()
+        {
+            FeatureReference = id,
+            World = pts,
+            Color = new RgbaColor(0, 0, 0, 255),
+            WidthPx = 1.0,
+        };
+
+    private static List<string> Query(BaseSpatialIndex idx,
+        double minX, double minY, double maxX, double maxY) =>
+        idx.Query(minX, minY, maxX, maxY).Select(o => o.FeatureReference!).ToList();
+
+    [Fact]
+    public void Query_CoveringWholeExtent_ReturnsAllOpsInOriginalOrder()
+    {
+        // A 10×10 grid of small distinct area ops, interleaved with lines.
+        var ops = new List<PaintOp>();
+        for (int i = 0; i < 100; i++)
+        {
+            double x = (i % 10) * 100.0;
+            double y = (i / 10) * 100.0;
+            ops.Add(i % 2 == 0
+                ? Area("a" + i, x, y, x + 10, y + 10)
+                : Line("l" + i, (x, y), (x + 10, y + 10)));
+        }
+        var idx = new BaseSpatialIndex(new VectorScene(ops));
+
+        var got = Query(idx, -1e6, -1e6, 1e6, 1e6);
+
+        // Degrades to the whole-cell walk, in the exact original draw order.
+        Assert.Equal(ops.Select(o => o.FeatureReference).ToList(), got);
+    }
+
+    [Fact]
+    public void Query_SubRegion_ReturnsOnlyIntersectingOpsInOriginalOrder()
+    {
+        var ops = new List<PaintOp>
+        {
+            Area("a", 0, 0, 20, 20),
+            Area("b", 500, 500, 520, 520),
+            Area("c", 30, 30, 60, 60),
+            Area("d", 950, 0, 980, 30),
+            Line("e", (10, 10), (40, 40)),
+        };
+        var idx = new BaseSpatialIndex(new VectorScene(ops));
+
+        // A box around the lower-left cluster: a, c, e (original order); not b/d.
+        var got = Query(idx, -10, -10, 70, 70);
+
+        Assert.Equal(new[] { "a", "c", "e" }, got);
+    }
+
+    [Fact]
+    public void Query_IsConservativeSupersetOfBruteForceBboxIntersect()
+    {
+        // Random ops + random queries: the index result must equal the brute-force
+        // bbox-intersection set exactly (a tight superset — never a false negative).
+        var rng = new System.Random(1234);
+        var ops = new List<PaintOp>();
+        for (int i = 0; i < 400; i++)
+        {
+            double x = rng.NextDouble() * 10_000;
+            double y = rng.NextDouble() * 10_000;
+            double w = rng.NextDouble() * 500;
+            double h = rng.NextDouble() * 500;
+            ops.Add(Area("a" + i, x, y, x + w, y + h));
+        }
+        var scene = new VectorScene(ops);
+        var idx = new BaseSpatialIndex(scene);
+
+        for (int q = 0; q < 100; q++)
+        {
+            double qx = rng.NextDouble() * 10_000;
+            double qy = rng.NextDouble() * 10_000;
+            double qw = rng.NextDouble() * 2_000;
+            double qh = rng.NextDouble() * 2_000;
+            double qx1 = qx + qw, qy1 = qy + qh;
+
+            var expected = new List<string>();
+            foreach (var op in ops.Cast<AreaPaintOp>())
+            {
+                double minX = op.WorldShell.Min(p => p.X), maxX = op.WorldShell.Max(p => p.X);
+                double minY = op.WorldShell.Min(p => p.Y), maxY = op.WorldShell.Max(p => p.Y);
+                if (!(maxX < qx || minX > qx1 || maxY < qy || minY > qy1))
+                    expected.Add(op.FeatureReference!);
+            }
+
+            var got = Query(idx, qx, qy, qx1, qy1);
+            Assert.Equal(expected, got);
+        }
+    }
+
+    [Fact]
+    public void Query_OpSpanningManyCells_ReturnedExactlyOnce()
+    {
+        // A huge area op covers the whole extent (lands in every grid cell); the
+        // de-dup must still return it once, alongside a few small ops.
+        var ops = new List<PaintOp>
+        {
+            Area("big", 0, 0, 10_000, 10_000),
+            Area("s1", 100, 100, 120, 120),
+            Area("s2", 5_000, 5_000, 5_020, 5_020),
+        };
+        var idx = new BaseSpatialIndex(new VectorScene(ops));
+
+        var got = Query(idx, 0, 0, 10_000, 10_000);
+
+        Assert.Equal(new[] { "big", "s1", "s2" }, got);
+        Assert.Equal(1, got.Count(r => r == "big"));
+    }
+
+    [Fact]
+    public void Query_Disjoint_ReturnsNothing()
+    {
+        var ops = new List<PaintOp> { Area("a", 0, 0, 10, 10), Area("b", 1000, 1000, 1010, 1010) };
+        var idx = new BaseSpatialIndex(new VectorScene(ops));
+
+        Assert.Empty(Query(idx, 400, 400, 500, 500));
+    }
+
+    [Fact]
+    public void Query_EmptyScene_ReturnsNothing()
+    {
+        var idx = new BaseSpatialIndex(new VectorScene(new List<PaintOp>()));
+        Assert.Empty(Query(idx, -1e6, -1e6, 1e6, 1e6));
+    }
+
+    [Fact]
+    public void Query_GeometrylessOp_IsAlwaysCandidate()
+    {
+        // A base op whose geometry the index cannot bound (here an area with an
+        // empty shell) must never be dropped: it is served on every query (an
+        // always-candidate), keeping its original draw-order slot.
+        var ghost = new AreaPaintOp
+        {
+            FeatureReference = "ghost",
+            WorldShell = System.Array.Empty<(double, double)>(),
+            Fill = new RgbaColor(0, 0, 0, 0),
+        };
+        var ops = new List<PaintOp>
+        {
+            Area("a", 0, 0, 10, 10),
+            ghost,
+            Area("b", 1000, 1000, 1010, 1010),
+        };
+        var idx = new BaseSpatialIndex(new VectorScene(ops));
+
+        // A query far from any real geometry still includes the geometry-less op.
+        Assert.Equal(new[] { "ghost" }, Query(idx, 50_000, 50_000, 50_100, 50_100));
+        // And it keeps its draw-order slot when real ops also match.
+        Assert.Equal(new[] { "a", "ghost" }, Query(idx, -10, -10, 20, 20));
+    }
+}


### PR DESCRIPTION
Implements the base-plane spatial index for the tiled "B" render subsystem, scoping **cold tile-generation** to the ops that actually intersect each tile. This is the real-world lag the original #332 report felt — distinct from the per-frame overlay hot path already addressed in #351.

## Root cause

Cold tile-gen is the lag a user feels the first time they pan/zoom into a fresh tile band: a worker runs `S100VectorTileRenderer.RasterizeTile` -> `SkiaDisplayListRenderer.Render` over the bound base scene. The shipped path rasterised the **entire** base scene for **every** tile — the design §3.3 base-plane spatial index ("query VectorScene ops intersecting tile+gutter") was specified but **never implemented**; only the overlay plane got one (#351, `OverlaySpatialIndex`).

## Change (fidelity-neutral)

- **`BaseSpatialIndex`** — uniform-grid index over base area/pattern/line op world AABBs (EPSG:3857 m), built once at `BindScene`. An op spanning multiple cells is inserted into each; `Query` de-dups and returns each op once in **ascending original op index** (S-100 Part 9 z-order).
- **`RasterizeTile`** queries the tile+gutter world AABB and rasterises only the intersecting ops. The query is a conservative bbox **superset**; the renderer still applies the exact per-op `ScaleVisibility` cull and pixel clip, so output is **pixel-identical** — only fewer ops are walked. Geometry-less / unmodelled ops are always-candidates (never dropped). Null index -> full-scene fallback.
- Immutable after construction (safe for concurrent worker queries); touches no Skia/GPU objects, so it is independent of the render thread's GPU-context lifetime rules (§3.7 / Appendix F).

## Measured

Dense UKHO cell `101GB00510210.000`, offline harness over the same IR + `SkiaDisplayListRenderer` + tile-viewport math the production worker uses (GUI viewer unavailable in-shell — Metal -6661, per Appendix H.1): the index culls to **1-14% of ops** per tile -> **~10-27% cold-tile reduction** (27% at coarse bands). Absolute wall-clock to be re-confirmed in-viewer (`TileRasterizeDuration` histogram) on a Metal GUI session; the committed guard is the deterministic op-count bench, mirroring #351's `OverlayScopingBenchTests`.

## Deferred (logged in design Appendix I)

The larger **37-81%** lever — band-keyed resolution-aware geometry generalization (Douglas-Peucker) — is **fidelity-bounded** (it alters rendered chart geometry) and is explicitly deferred, gated on a topology-preserving simplifier + golden-image sign-off. Banking the safe enabler first.

## Tests

`BaseSpatialIndexTests` (superset == brute-force / no false negative, draw-order, dedup, op-spanning-many-cells, degenerate/empty, geometry-less always-candidate) + `BaseScopingBenchTests` (interior-tile query is O(covering) not O(cell)). 9 new tests pass; Release build clean; no diagnostic instrumentation left in source.

Refs #332, #347.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
