### PR TITLE
Refresh NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,41 +6,41 @@
 
   <ItemGroup>
     <!-- Avalonia -->
-    <PackageVersion Include="Avalonia" Version="12.0.4" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.4" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.4" />
-    <PackageVersion Include="Avalonia.Skia" Version="12.0.4" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageVersion Include="Avalonia" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
     <!-- DevTools support; Avalonia 12 replaced the old Avalonia.Diagnostics package. -->
-    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <!-- MVVM / DI -->
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <!-- Logging / observability -->
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <!-- Model Context Protocol SDK (.NET) -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <!-- EncDotNet -->
     <PackageVersion Include="EncDotNet.Iso8211" Version="0.5.1" />
-    <PackageVersion Include="EncDotNet.S57" Version="0.5.0" />
+    <PackageVersion Include="EncDotNet.S57" Version="0.5.1" />
     <!-- Mapping / rendering -->
-    <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.328" />
+    <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.330" />
     <PackageVersion Include="Mapsui" Version="5.1.0" />
     <PackageVersion Include="Mapsui.Avalonia12" Version="5.1.0" />
     <PackageVersion Include="Mapsui.Nts" Version="5.1.0" />
     <PackageVersion Include="Mapsui.Rendering.Skia" Version="5.1.0" />
     <PackageVersion Include="Mapsui.Tiling" Version="5.1.0" />
     <PackageVersion Include="MoonSharp" Version="2.0.0" />
-    <PackageVersion Include="ProjNet" Version="2.0.0" />
+    <PackageVersion Include="ProjNet" Version="2.1.0" />
     <PackageVersion Include="PureHDF" Version="2.1.2" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-798" />
     <PackageVersion Include="ShadUI" Version="0.2.3" />
@@ -49,7 +49,7 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageVersion Include="Svg.Skia" Version="3.2.1" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.2" />
     <!-- Test -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -57,7 +57,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj
+++ b/src/EncDotNet.S100.AppHost/EncDotNet.S100.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refreshes NuGet dependencies to more recent versions.

## Updated packages

Centrally managed (`Directory.Packages.props`):
- Avalonia + related: `12.0.4` → `12.0.5`
- AvaloniaUI.DiagnosticsSupport: `2.2.2` → `2.2.3`
- CommunityToolkit.Mvvm: `8.4.0` → `8.4.2`
- Microsoft.Extensions.DependencyInjection(.Abstractions): `10.0.0` → `10.0.9`
- Microsoft.Extensions.Logging(.Abstractions): `9.0.0`/`10.0.0` → `10.0.9`
- OpenTelemetry (+ exporters/hosting): `1.15.3` → `1.16.0`
- ModelContextProtocol(.AspNetCore): `1.3.0` → `1.4.0`
- EncDotNet.S57: `0.5.0` → `0.5.1`
- FluentIcons.Avalonia: `2.1.328` → `2.1.330`
- ProjNet: `2.0.0` → `2.1.0`
- Tmds.DBus.Protocol: `0.92.0` → `0.94.2`
- Microsoft.Extensions.TimeProvider.Testing: `10.0.0` → `10.0.9`

AppHost project:
- Aspire (SDK + Aspire.Hosting.AppHost): `9.5.2` → `13.4.6`

## Notes

Major-version jumps that would introduce breaking changes were intentionally left in place this pass: SkiaSharp (3.x), Svg.Skia (3.x), and Spectre.Console.Cli (0.50.0).

## Validation

- `dotnet build` succeeds with no `NU1903` warnings.
- Full test suite passes (`dotnet test --configuration Release`).