### PR TITLE
Eliminate build warnings and enforce a no-warnings policy

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,11 +6,12 @@
     <Nullable>enable</Nullable>
     <!-- Keep the build warning-free: any compiler/analyzer warning fails the
          build so they cannot quietly accumulate again. NuGet audit advisories
-         (NU19xx) are kept as warnings rather than errors because they depend on
-         an external, changing advisory feed (and on transitive packages we do
-         not control), so they must not turn a clean checkout's build red. -->
+         (NU190x) are deliberately NOT excluded — a newly-published CVE against a
+         direct or transitive package SHOULD stop the line until it is triaged.
+         NuGetAudit runs against transitive packages too (audit mode 'all'). -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>NU1900;NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,13 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Keep the build warning-free: any compiler/analyzer warning fails the
+         build so they cannot quietly accumulate again. NuGet audit advisories
+         (NU19xx) are kept as warnings rather than errors because they depend on
+         an external, changing advisory feed (and on transitive packages we do
+         not control), so they must not turn a clean checkout's build red. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>NU1900;NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -483,7 +483,7 @@ public sealed class DatasetPipelineFactory
         var source = FileSystemAssetSource.Create(directory);
 
         var baseRelative = Path.GetFileName(fullBase);
-        var updateRelatives = updateFilePaths.Select(Path.GetFileName).ToList();
+        var updateRelatives = updateFilePaths.Select(p => Path.GetFileName(p)).ToList();
 
         return new S101DatasetProcessor(
             source,

--- a/src/EncDotNet.S100.Renderers.Mapsui/AnchoredPatternFillRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/AnchoredPatternFillRenderer.cs
@@ -140,7 +140,7 @@ public sealed class AnchoredPatternFillRenderer : ISkiaStyleRenderer
                 float tx = (float)anchorScreenX + col * tileStepW;
                 float ty = (float)anchorScreenY + row * tileStepH;
                 var tileMatrix = SKMatrix.Concat(SKMatrix.CreateTranslation(tx, ty), tileScale);
-                canvas.DrawPicture(patternStyle.Tile, ref tileMatrix);
+                canvas.DrawPicture(patternStyle.Tile, in tileMatrix);
             }
         }
 

--- a/src/EncDotNet.S100.Viewer/Behaviors/SplitterPersistence.cs
+++ b/src/EncDotNet.S100.Viewer/Behaviors/SplitterPersistence.cs
@@ -160,9 +160,9 @@ internal static class SplitterPersistence
         {
             if (i < grid.RowDefinitions.Count) { prev = grid.RowDefinitions[i]; break; }
         }
-        for (int i = splitterRow + 1; i < grid.RowDefinitions.Count; i++)
+        if (splitterRow + 1 < grid.RowDefinitions.Count)
         {
-            next = grid.RowDefinitions[i]; break;
+            next = grid.RowDefinitions[splitterRow + 1];
         }
         return (prev, next);
     }
@@ -176,9 +176,9 @@ internal static class SplitterPersistence
         {
             if (i < grid.ColumnDefinitions.Count) { prev = grid.ColumnDefinitions[i]; break; }
         }
-        for (int i = splitterCol + 1; i < grid.ColumnDefinitions.Count; i++)
+        if (splitterCol + 1 < grid.ColumnDefinitions.Count)
         {
-            next = grid.ColumnDefinitions[i]; break;
+            next = grid.ColumnDefinitions[splitterCol + 1];
         }
         return (prev, next);
     }

--- a/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
+++ b/src/EncDotNet.S100.Viewer/Diagnostics/MapPaintInstrumentation.cs
@@ -285,7 +285,7 @@ internal static class MapPaintInstrumentation
             var pointCount = (feature is GeometryFeature gf && gf.Geometry is not null)
                 ? gf.Geometry.NumPoints
                 : -1;
-            var stats = GetStats(_styleName, layer?.Name ?? "(unnamed)", BucketPoints(pointCount));
+            var stats = GetStats(_styleName, layer.Name ?? "(unnamed)", BucketPoints(pointCount));
             var startTimestamp = Stopwatch.GetTimestamp();
             try
             {

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111ArrowRenderingTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111ArrowRenderingTests.cs
@@ -152,15 +152,15 @@ public sealed class S111ArrowRenderingTests : IDisposable
     }
 
     [Fact]
-    public void Day_and_Night_palettes_produce_different_resolved_SVG()
+    public async Task Day_and_Night_palettes_produce_different_resolved_SVG()
     {
         var renderer = CreateRenderer();
 
-        _catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await _catalogue.SwitchPaletteAsync(PaletteType.Day);
         renderer.Palette = _catalogue.ActivePalette;
         var daySvg = renderer.GetResolvedSvg("SCAROW01");
 
-        _catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await _catalogue.SwitchPaletteAsync(PaletteType.Night);
         renderer.Palette = _catalogue.ActivePalette;
         var nightSvg = renderer.GetResolvedSvg("SCAROW01");
 

--- a/tests/EncDotNet.S100.Datasets.S111.Tests/S111CoverageSourceTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S111.Tests/S111CoverageSourceTests.cs
@@ -107,13 +107,13 @@ public class S111CoverageSourceTests : IDisposable
     }
 
     [Fact]
-    public void PortrayalCatalogue_ResolveColorScheme_MapsSpeedToColors()
+    public async Task PortrayalCatalogue_ResolveColorScheme_MapsSpeedToColors()
     {
         const string portrayalPath = "TestData/PortrayalCatalogue";
         Skip.IfNot(Directory.Exists(portrayalPath), $"Portrayal catalogue not found at {portrayalPath}.");
 
         var source = FileSystemAssetSource.Create(portrayalPath);
-        using var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
+        using var provider = await PortrayalCatalogueProvider.OpenAsync(source);
         var catalogue = new S111PortrayalCatalogue(provider);
 
         var scheme = catalogue.ResolveColorScheme(MarinerSettings.Default);
@@ -156,15 +156,15 @@ public class S111CoverageSourceTests : IDisposable
     }
 
     [Fact]
-    public void PortrayalCatalogue_ResolveSymbolScheme_Returns9Bands()
+    public async Task PortrayalCatalogue_ResolveSymbolScheme_Returns9Bands()
     {
         const string portrayalPath = "TestData/PortrayalCatalogue";
         Skip.IfNot(Directory.Exists(portrayalPath), $"Portrayal catalogue not found at {portrayalPath}.");
 
         var source = FileSystemAssetSource.Create(portrayalPath);
-        using var provider = PortrayalCatalogueProvider.OpenAsync(source).GetAwaiter().GetResult();
+        using var provider = await PortrayalCatalogueProvider.OpenAsync(source);
         var catalogue = new S111PortrayalCatalogue(provider);
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
 
         var scheme = catalogue.ResolveSymbolScheme(MarinerSettings.Default);
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/CacheCounterTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CacheCounterTests.cs
@@ -35,9 +35,9 @@ public sealed class CacheCounterTests
             "s100.lua.source.cache.miss.count", misses);
 
         const string fileName = "S100Scripting.lua";
-        _ = catalogue.GetLuaSourceAsync(fileName).AsTask().GetAwaiter().GetResult();
-        _ = catalogue.GetLuaSourceAsync(fileName).AsTask().GetAwaiter().GetResult();
-        _ = catalogue.GetLuaSourceAsync(fileName).AsTask().GetAwaiter().GetResult();
+        _ = await catalogue.GetLuaSourceAsync(fileName);
+        _ = await catalogue.GetLuaSourceAsync(fileName);
+        _ = await catalogue.GetLuaSourceAsync(fileName);
 
         listener.Dispose();
         KeyValuePair<string, object?>[][] hitSnap;
@@ -73,8 +73,8 @@ public sealed class CacheCounterTests
 
         // Find a real symbol id to ensure we hit the cache miss/hit path.
         var symbolId = provider.Catalogue.Symbols.First().Id;
-        _ = catalogue.GetSymbolAsync(symbolId).AsTask().GetAwaiter().GetResult();
-        _ = catalogue.GetSymbolAsync(symbolId).AsTask().GetAwaiter().GetResult();
+        _ = await catalogue.GetSymbolAsync(symbolId);
+        _ = await catalogue.GetSymbolAsync(symbolId);
 
         listener.Dispose();
         KeyValuePair<string, object?>[][] hitSnap;

--- a/tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/LuaSourceCacheTests.cs
@@ -31,9 +31,9 @@ public class LuaSourceCacheTests
         // not leak in.
         var openCountBefore = counting.GetOpenCount("Rules/main.lua");
 
-        var first = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var second = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var third = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var first = await catalogue.GetLuaSourceAsync("main.lua");
+        var second = await catalogue.GetLuaSourceAsync("main.lua");
+        var third = await catalogue.GetLuaSourceAsync("main.lua");
 
         Assert.NotNull(first);
         Assert.NotEmpty(first!);
@@ -59,9 +59,9 @@ public class LuaSourceCacheTests
         const string missing = "definitely-not-a-real-rule.lua";
         var openCountBefore = counting.GetOpenCount($"Rules/{missing}");
 
-        var a = catalogue.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult();
-        var b = catalogue.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult();
-        var c = catalogue.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult();
+        var a = await catalogue.GetLuaSourceAsync(missing);
+        var b = await catalogue.GetLuaSourceAsync(missing);
+        var c = await catalogue.GetLuaSourceAsync(missing);
 
         Assert.Null(a);
         Assert.Null(b);
@@ -85,9 +85,9 @@ public class LuaSourceCacheTests
 
         var openCountBefore = counting.GetOpenCount("Rules/main.lua");
 
-        var first = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var second = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var third = catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var first = await catalogue.GetLuaSourceAsync("main.lua");
+        var second = await catalogue.GetLuaSourceAsync("main.lua");
+        var third = await catalogue.GetLuaSourceAsync("main.lua");
 
         Assert.NotNull(first);
         Assert.NotEmpty(first!);
@@ -116,8 +116,8 @@ public class LuaSourceCacheTests
         var providerB = await PortrayalCatalogueProvider.OpenAsync(countingB);
         var catalogueB = new S101PortrayalCatalogue(providerB);
 
-        var srcA = catalogueA.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var srcB = catalogueB.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var srcA = await catalogueA.GetLuaSourceAsync("main.lua");
+        var srcB = await catalogueB.GetLuaSourceAsync("main.lua");
 
         Assert.NotNull(srcA);
         Assert.NotNull(srcB);

--- a/tests/EncDotNet.S100.Pipelines.Tests/S102PortrayalCatalogueTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S102PortrayalCatalogueTests.cs
@@ -53,10 +53,10 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void DayPalette_LoadsAllSixDepthTokens()
+    public async Task DayPalette_LoadsAllSixDepthTokens()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
 
         foreach (var token in new[] { "DEPDW", "DEPMD", "DEPMS", "DEPVS", "DEPIT", "NODTA" })
         {
@@ -70,17 +70,17 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void DuskAndNightPalettes_Load_AndDifferFromDay()
+    public async Task DuskAndNightPalettes_Load_AndDifferFromDay()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         Assert.True(catalogue.ActivePalette.TryResolve("DEPVS", out var dayHex));
 
-        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
         Assert.True(catalogue.ActivePalette.TryResolve("DEPVS", out var duskHex));
         Assert.NotEqual(dayHex, duskHex);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         Assert.True(catalogue.ActivePalette.TryResolve("DEPVS", out var nightHex));
         Assert.Equal(NightDEPVS, nightHex, StringComparer.OrdinalIgnoreCase);
     }
@@ -139,10 +139,10 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void NightPalette_SwitchAppliesToResolvedScheme()
+    public async Task NightPalette_SwitchAppliesToResolvedScheme()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings { FourShades = false, SafetyContour = 30.0 });
 
@@ -150,10 +150,10 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void NoDataColor_IsPopulatedFromActivePaletteNODTA()
+    public async Task NoDataColor_IsPopulatedFromActivePaletteNODTA()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings { FourShades = false, SafetyContour = 30.0 });
 
@@ -163,10 +163,10 @@ public sealed class S102PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void NoDataColor_IsNull_WhenRenderNoDataFillDisabled()
+    public async Task NoDataColor_IsNull_WhenRenderNoDataFillDisabled()
     {
         var catalogue = new S102PortrayalCatalogue(_engine, _provider) { RenderNoDataFill = false };
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings { FourShades = false, SafetyContour = 30.0 });
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/S104Dcf8ProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S104Dcf8ProcessorTests.cs
@@ -64,7 +64,7 @@ public class S104Dcf8ProcessorTests
     }
 
     [Fact]
-    public void Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey()
+    public async Task Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey()
     {
         var path = WriteFixture();
         try
@@ -72,7 +72,7 @@ public class S104Dcf8ProcessorTests
             using var processor = (System.IDisposable?)null; // placeholder so analyzers don't complain about disposable processors
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
 
-            var result = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            var result = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
 
             Assert.Single(result.Layers);
             var memoryLayer = Assert.IsType<MemoryLayer>(result.Layers[0]);
@@ -95,7 +95,7 @@ public class S104Dcf8ProcessorTests
     }
 
     [Fact]
-    public void GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample()
+    public async Task GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample()
     {
         var path = WriteFixture();
         try
@@ -105,7 +105,7 @@ public class S104Dcf8ProcessorTests
             // Render at the second time-step; GetFeatureInfo should report
             // the value at the same step (height = 1.5, trend = 2 for Alpha).
             var secondStep = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p, new S104RenderContext { TimeStep = secondStep }).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p, new S104RenderContext { TimeStep = secondStep });
 
             var info = p.GetFeatureInfo("station:Alpha");
 
@@ -129,13 +129,13 @@ public class S104Dcf8ProcessorTests
     }
 
     [Fact]
-    public void GetFeatureInfo_UnknownStationRef_ReturnsNull()
+    public async Task GetFeatureInfo_UnknownStationRef_ReturnsNull()
     {
         var path = WriteFixture();
         try
         {
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
 
             Assert.Null(p.GetFeatureInfo("station:Missing"));
             Assert.Null(p.GetFeatureInfo("not-a-station-ref"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/S104PortrayalCatalogueTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S104PortrayalCatalogueTests.cs
@@ -30,10 +30,10 @@ public sealed class S104PortrayalCatalogueTests
     ];
 
     [Fact]
-    public void Day_palette_returns_existing_blue_green_diverging_scheme()
+    public async Task Day_palette_returns_existing_blue_green_diverging_scheme()
     {
         var catalogue = new S104PortrayalCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
 
         var scheme = catalogue.ResolveColorScheme(new MarinerSettings());
 
@@ -50,14 +50,14 @@ public sealed class S104PortrayalCatalogueTests
     }
 
     [Fact]
-    public void Dusk_palette_differs_from_Day_for_at_least_one_band()
+    public async Task Dusk_palette_differs_from_Day_for_at_least_one_band()
     {
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var day = catalogue.ResolveColorScheme(new MarinerSettings());
 
-        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
         var dusk = catalogue.ResolveColorScheme(new MarinerSettings());
 
         Assert.Equal(day.Bands.Count, dusk.Bands.Count);
@@ -68,14 +68,14 @@ public sealed class S104PortrayalCatalogueTests
     }
 
     [Fact]
-    public void Night_palette_differs_from_Day_for_at_least_one_band()
+    public async Task Night_palette_differs_from_Day_for_at_least_one_band()
     {
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var day = catalogue.ResolveColorScheme(new MarinerSettings());
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         var night = catalogue.ResolveColorScheme(new MarinerSettings());
 
         Assert.Equal(day.Bands.Count, night.Bands.Count);
@@ -86,20 +86,20 @@ public sealed class S104PortrayalCatalogueTests
     }
 
     [Fact]
-    public void SwitchPalette_actually_swaps_active_band_list()
+    public async Task SwitchPalette_actually_swaps_active_band_list()
     {
         // Regression guard for the pre-PR-H stub SwitchPalette that
         // updated ActivePalette but left ResolveColorScheme returning
         // the Day band table regardless.
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var dayFirst = catalogue.ResolveColorScheme(new MarinerSettings()).Bands[0].Color;
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         var nightFirst = catalogue.ResolveColorScheme(new MarinerSettings()).Bands[0].Color;
 
-        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
         var duskFirst = catalogue.ResolveColorScheme(new MarinerSettings()).Bands[0].Color;
 
         Assert.NotEqual(dayFirst, nightFirst);
@@ -108,17 +108,17 @@ public sealed class S104PortrayalCatalogueTests
     }
 
     [Fact]
-    public void NoData_color_is_populated_per_palette()
+    public async Task NoData_color_is_populated_per_palette()
     {
         var catalogue = new S104PortrayalCatalogue();
 
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var dayNoData = catalogue.ResolveColorScheme(new MarinerSettings()).NoDataColor;
 
-        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
         var duskNoData = catalogue.ResolveColorScheme(new MarinerSettings()).NoDataColor;
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         var nightNoData = catalogue.ResolveColorScheme(new MarinerSettings()).NoDataColor;
 
         Assert.False(string.IsNullOrEmpty(dayNoData));

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111Dcf8ProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111Dcf8ProcessorTests.cs
@@ -65,7 +65,7 @@ public class S111Dcf8ProcessorTests
     }
 
     [Fact]
-    public void Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey()
+    public async Task Render_Dcf8_EmitsMemoryLayer_WithFeaturePerStation_TaggedByFeatureRefKey()
     {
         var path = WriteFixture();
         try
@@ -75,7 +75,7 @@ public class S111Dcf8ProcessorTests
             using var catalogues = new PortrayalCatalogueManager();
             var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
 
-            var result = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            var result = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
 
             Assert.Single(result.Layers);
             var memoryLayer = Assert.IsType<MemoryLayer>(result.Layers[0]);
@@ -98,7 +98,7 @@ public class S111Dcf8ProcessorTests
     }
 
     [Fact]
-    public void GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample()
+    public async Task GetFeatureInfo_StationRef_AfterRender_ReturnsCurrentTimeSample()
     {
         var path = WriteFixture();
         try
@@ -108,7 +108,7 @@ public class S111Dcf8ProcessorTests
 
             // Render at the second time-step; expected S1 speed = 0.6, dir = 50.
             var secondStep = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p, new S111RenderContext { TimeStep = secondStep }).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p, new S111RenderContext { TimeStep = secondStep });
 
             var info = p.GetFeatureInfo("station:S1");
 
@@ -132,14 +132,14 @@ public class S111Dcf8ProcessorTests
     }
 
     [Fact]
-    public void GetFeatureInfo_UnknownStationRef_ReturnsNull()
+    public async Task GetFeatureInfo_UnknownStationRef_ReturnsNull()
     {
         var path = WriteFixture();
         try
         {
             using var catalogues = new PortrayalCatalogueManager();
             var p = new S111DatasetProcessor(path, catalogues, IdentityFactory.Instance);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
 
             Assert.Null(p.GetFeatureInfo("station:Nope"));
             Assert.Null(p.GetFeatureInfo("plain-ref"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111PaletteCacheTests.cs
@@ -25,7 +25,7 @@ public class S111PaletteCacheTests
     private const string S111ColorProfileRelativePath = "ColorProfiles/colorProfile.xml";
 
     [Fact]
-    public void Repeated_SwitchPalette_calls_open_color_profile_only_once()
+    public async Task Repeated_SwitchPalette_calls_open_color_profile_only_once()
     {
         using var inner = Specification.CreatePortrayalCatalogueSource("S-111");
         using var counting = new CountingAssetSource(inner);
@@ -41,16 +41,16 @@ public class S111PaletteCacheTests
         // Switch through every palette, in arbitrary order, including a
         // switch back to Day — none of these should re-open the asset
         // after the first one.
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         Assert.NotEmpty(catalogue.ActivePalette.Colors);
 
         var after = counting.GetOpenCount(S111ColorProfileRelativePath);
@@ -64,7 +64,7 @@ public class S111PaletteCacheTests
     }
 
     [Fact]
-    public void ResolveColorScheme_does_not_reopen_color_profile_after_SwitchPalette()
+    public async Task ResolveColorScheme_does_not_reopen_color_profile_after_SwitchPalette()
     {
         using var inner = Specification.CreatePortrayalCatalogueSource("S-111");
         using var counting = new CountingAssetSource(inner);
@@ -75,7 +75,7 @@ public class S111PaletteCacheTests
         var provider = manager.GetProvider("S-111");
         var catalogue = new S111PortrayalCatalogue(provider);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var afterSwitch = counting.GetOpenCount(S111ColorProfileRelativePath);
 
         // The defensive ActivePalette.Colors.Count == 0 re-load was the

--- a/tests/EncDotNet.S100.Pipelines.Tests/S111PortrayalCatalogueTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S111PortrayalCatalogueTests.cs
@@ -55,10 +55,10 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void Day_palette_loads_all_nine_speed_band_tokens()
+    public async Task Day_palette_loads_all_nine_speed_band_tokens()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
 
         for (int i = 1; i <= 9; i++)
         {
@@ -70,13 +70,13 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void Dusk_palette_loads_and_differs_from_Day_for_at_least_one_band()
+    public async Task Dusk_palette_loads_and_differs_from_Day_for_at_least_one_band()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var dayColors = ReadBandColors(catalogue);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Dusk).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Dusk);
         var duskColors = ReadBandColors(catalogue);
 
         Assert.Equal(dayColors.Count, duskColors.Count);
@@ -87,13 +87,13 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void Night_palette_loads_and_differs_from_Day_for_at_least_one_band()
+    public async Task Night_palette_loads_and_differs_from_Day_for_at_least_one_band()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         var dayColors = ReadBandColors(catalogue);
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         var nightColors = ReadBandColors(catalogue);
 
         Assert.Equal(dayColors.Count, nightColors.Count);
@@ -142,13 +142,13 @@ public sealed class S111PortrayalCatalogueTests : IDisposable
     }
 
     [Fact]
-    public void SwitchPalette_to_Night_then_ActivePalette_reflects_change()
+    public async Task SwitchPalette_to_Night_then_ActivePalette_reflects_change()
     {
         var catalogue = CreateCatalogue();
-        catalogue.SwitchPaletteAsync(PaletteType.Day).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Day);
         Assert.True(catalogue.ActivePalette.TryResolve("SCBN1", out var dayBand1));
 
-        catalogue.SwitchPaletteAsync(PaletteType.Night).AsTask().GetAwaiter().GetResult();
+        await catalogue.SwitchPaletteAsync(PaletteType.Night);
         Assert.True(catalogue.ActivePalette.TryResolve("SCBN1", out var nightBand1));
 
         Assert.NotEqual(dayBand1, nightBand1);

--- a/tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/SpecLevelAssetCacheTests.cs
@@ -41,7 +41,7 @@ namespace EncDotNet.S100.Pipelines.Tests;
 public class SpecLevelAssetCacheTests
 {
     [Fact]
-    public void S101_two_catalogues_via_manager_share_xslt_symbol_lineStyle_areaFill_and_lua_source_caches()
+    public async Task S101_two_catalogues_via_manager_share_xslt_symbol_lineStyle_areaFill_and_lua_source_caches()
     {
         using var inner = Specification.CreatePortrayalCatalogueSource("S-101");
         using var counting = new CountingAssetSource(inner);
@@ -65,8 +65,8 @@ public class SpecLevelAssetCacheTests
         // Lua source: the most representative asset, also exercises the
         // PR-2 cache that we just lifted.
         var openMainLuaBefore = counting.GetOpenCount("Rules/main.lua");
-        var srcA = catalogueA.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var srcB = catalogueB.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var srcA = await catalogueA.GetLuaSourceAsync("main.lua");
+        var srcB = await catalogueB.GetLuaSourceAsync("main.lua");
         Assert.NotNull(srcA);
         Assert.Same(srcA, srcB);
         Assert.Equal(openMainLuaBefore + 1, counting.GetOpenCount("Rules/main.lua"));
@@ -78,8 +78,8 @@ public class SpecLevelAssetCacheTests
         {
             var xsltAssetPath = $"Rules/{xsltRule.FileName}";
             var openXsltBefore = counting.GetOpenCount(xsltAssetPath);
-            var transformA = catalogueA.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
-            var transformB = catalogueB.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
+            var transformA = await catalogueA.GetCompiledRuleAsync(xsltRule.Id);
+            var transformB = await catalogueB.GetCompiledRuleAsync(xsltRule.Id);
             Assert.Same(transformA, transformB);
             Assert.Equal(openXsltBefore + 1, counting.GetOpenCount(xsltAssetPath));
         }
@@ -90,8 +90,8 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"Symbols/{symbol.FileName}";
             var openBefore = counting.GetOpenCount(assetPath);
-            var svgA = catalogueA.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
-            var svgB = catalogueB.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
+            var svgA = await catalogueA.GetSymbolAsync(symbol.Id);
+            var svgB = await catalogueB.GetSymbolAsync(symbol.Id);
             Assert.Same(svgA, svgB);
             Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
         }
@@ -102,8 +102,8 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"LineStyles/{lineStyle.FileName}";
             var openBefore = counting.GetOpenCount(assetPath);
-            var lsA = catalogueA.GetLineStyleAsync(lineStyle.Id).AsTask().GetAwaiter().GetResult();
-            var lsB = catalogueB.GetLineStyleAsync(lineStyle.Id).AsTask().GetAwaiter().GetResult();
+            var lsA = await catalogueA.GetLineStyleAsync(lineStyle.Id);
+            var lsB = await catalogueB.GetLineStyleAsync(lineStyle.Id);
             Assert.Same(lsA, lsB);
             Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
         }
@@ -114,15 +114,15 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"AreaFills/{areaFill.FileName}";
             var openBefore = counting.GetOpenCount(assetPath);
-            var afA = catalogueA.GetAreaFillAsync(areaFill.Id).AsTask().GetAwaiter().GetResult();
-            var afB = catalogueB.GetAreaFillAsync(areaFill.Id).AsTask().GetAwaiter().GetResult();
+            var afA = await catalogueA.GetAreaFillAsync(areaFill.Id);
+            var afB = await catalogueB.GetAreaFillAsync(areaFill.Id);
             Assert.Same(afA, afB);
             Assert.Equal(openBefore + 1, counting.GetOpenCount(assetPath));
         }
     }
 
     [Fact]
-    public void S101_negative_lua_lookup_is_shared_across_catalogues_via_manager()
+    public async Task S101_negative_lua_lookup_is_shared_across_catalogues_via_manager()
     {
         using var inner = Specification.CreatePortrayalCatalogueSource("S-101");
         using var counting = new CountingAssetSource(inner);
@@ -136,9 +136,9 @@ public class SpecLevelAssetCacheTests
         const string missing = "definitely-not-a-real-rule.lua";
         var openCountBefore = counting.GetOpenCount($"Rules/{missing}");
 
-        Assert.Null(catalogueA.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult());
-        Assert.Null(catalogueB.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult());
-        Assert.Null(catalogueA.GetLuaSourceAsync(missing).AsTask().GetAwaiter().GetResult());
+        Assert.Null(await catalogueA.GetLuaSourceAsync(missing));
+        Assert.Null(await catalogueB.GetLuaSourceAsync(missing));
+        Assert.Null(await catalogueA.GetLuaSourceAsync(missing));
 
         var attempts = counting.GetOpenCount($"Rules/{missing}") - openCountBefore;
         // At most one underlying open across both catalogues: PR-2's
@@ -148,7 +148,7 @@ public class SpecLevelAssetCacheTests
     }
 
     [Fact]
-    public void S124_two_GML_catalogues_via_manager_share_xslt_symbol_lineStyle_and_areaFill_caches()
+    public async Task S124_two_GML_catalogues_via_manager_share_xslt_symbol_lineStyle_and_areaFill_caches()
     {
         using var inner = Specification.CreatePortrayalCatalogueSource("S-124");
         using var counting = new CountingAssetSource(inner);
@@ -169,8 +169,8 @@ public class SpecLevelAssetCacheTests
         var xsltAssetPath = $"Rules/{xsltRule!.FileName}";
         var openBefore = counting.GetOpenCount(xsltAssetPath);
 
-        var transformA = catalogueA.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
-        var transformB = catalogueB.GetCompiledRuleAsync(xsltRule.Id).AsTask().GetAwaiter().GetResult();
+        var transformA = await catalogueA.GetCompiledRuleAsync(xsltRule.Id);
+        var transformB = await catalogueB.GetCompiledRuleAsync(xsltRule.Id);
         Assert.Same(transformA, transformB);
 
         // Exactly one underlying open of the XSLT rule across both
@@ -184,15 +184,15 @@ public class SpecLevelAssetCacheTests
         {
             var assetPath = $"Symbols/{symbol.FileName}";
             var symOpenBefore = counting.GetOpenCount(assetPath);
-            var svgA = catalogueA.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
-            var svgB = catalogueB.GetSymbolAsync(symbol.Id).AsTask().GetAwaiter().GetResult();
+            var svgA = await catalogueA.GetSymbolAsync(symbol.Id);
+            var svgB = await catalogueB.GetSymbolAsync(symbol.Id);
             Assert.Same(svgA, svgB);
             Assert.Equal(symOpenBefore + 1, counting.GetOpenCount(assetPath));
         }
     }
 
     [Fact]
-    public void S101_and_S131_specs_keep_independent_caches()
+    public async Task S101_and_S131_specs_keep_independent_caches()
     {
         using var s101Inner = Specification.CreatePortrayalCatalogueSource("S-101");
         using var s101Counting = new CountingAssetSource(s101Inner);
@@ -213,8 +213,8 @@ public class SpecLevelAssetCacheTests
         var s101OpenBefore = s101Counting.GetOpenCount("Rules/main.lua");
         var s131OpenBefore = s131Counting.GetOpenCount("Rules/main.lua");
 
-        var s101Src = s101Catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
-        var s131Src = s131Catalogue.GetLuaSourceAsync("main.lua").AsTask().GetAwaiter().GetResult();
+        var s101Src = await s101Catalogue.GetLuaSourceAsync("main.lua");
+        var s131Src = await s131Catalogue.GetLuaSourceAsync("main.lua");
 
         Assert.NotNull(s101Src);
         Assert.NotNull(s131Src);

--- a/tests/EncDotNet.S100.Pipelines.Tests/StationTimeSeriesSnapshotTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/StationTimeSeriesSnapshotTests.cs
@@ -73,13 +73,13 @@ public class StationTimeSeriesSnapshotTests
     }
 
     [Fact]
-    public void S104_StationRef_PopulatesStationSeries_WithFullHeightSeries()
+    public async Task S104_StationRef_PopulatesStationSeries_WithFullHeightSeries()
     {
         var path = WriteS104Fixture();
         try
         {
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
             var info = p.GetFeatureInfo("station:ST01");
 
             Assert.NotNull(info);
@@ -95,13 +95,13 @@ public class StationTimeSeriesSnapshotTests
     }
 
     [Fact]
-    public void S111_StationRef_PopulatesStationSeries_WithSpeedAndDirectionChannels()
+    public async Task S111_StationRef_PopulatesStationSeries_WithSpeedAndDirectionChannels()
     {
         var path = WriteS111Fixture();
         try
         {
             var p = new S111DatasetProcessor(path, new PortrayalCatalogueManager(), IdentityFactory.Instance);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
             var info = p.GetFeatureInfo("station:S1");
 
             Assert.NotNull(info);
@@ -118,13 +118,13 @@ public class StationTimeSeriesSnapshotTests
     }
 
     [Fact]
-    public void S104_NonStationRef_StationSeriesIsNull()
+    public async Task S104_NonStationRef_StationSeriesIsNull()
     {
         var path = WriteS104Fixture();
         try
         {
             var p = new S104DatasetProcessor(path, IdentityFactory.Instance);
-            _ = new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p).GetAwaiter().GetResult();
+            _ = await new MapsuiDatasetRenderer(IdentityFactory.Instance).RenderAsync(p);
             // unknown ref returns null FeatureInfo entirely
             Assert.Null(p.GetFeatureInfo("station:Missing"));
             Assert.Null(p.GetFeatureInfo("not-a-station"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileCacheTests.cs
@@ -108,6 +108,8 @@ public class TileCacheTests
         // The replacement is now resident; the prior image was disposed on replace.
         Assert.Same(second, cache.TryGet(Key(0)));
     }
+
+    [Fact]
     public void SnapshotKeys_ReturnsResidentKeysWithoutReordering()
     {
         using var cache = new TileCache(TileCache.MinBudgetBytes);

--- a/tests/EncDotNet.S100.Pipelines.Tests/WorkerDrainGateTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/WorkerDrainGateTests.cs
@@ -49,7 +49,7 @@ public class WorkerDrainGateTests
     }
 
     [Fact]
-    public void DrainAndWait_BlocksUntilRegisteredWorkerCompletes()
+    public async Task DrainAndWait_BlocksUntilRegisteredWorkerCompletes()
     {
         var gate = new WorkerDrainGate();
         Assert.True(gate.TryRegister());
@@ -65,12 +65,12 @@ public class WorkerDrainGateTests
         });
 
         Assert.True(gate.DrainAndWait(TimeSpan.FromSeconds(5)));
-        completer.Wait();
+        await completer;
         Assert.Equal(0, gate.ActiveWorkers);
     }
 
     [Fact]
-    public void DrainAndWait_AwaitsWorkerRegisteredConcurrentlyWithDrain()
+    public async Task DrainAndWait_AwaitsWorkerRegisteredConcurrentlyWithDrain()
     {
         // A worker that registers and immediately completes while the drain is
         // racing must still leave the gate idle (no leaked active count).
@@ -85,7 +85,7 @@ public class WorkerDrainGateTests
         });
 
         gate.DrainAndWait(TimeSpan.FromSeconds(5));
-        worker.Wait();
+        await worker;
 
         Assert.Equal(0, gate.ActiveWorkers);
         Assert.True(gate.IsDraining);

--- a/tests/EncDotNet.S100.Pipelines.Tests/XsltRuleExecutorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/XsltRuleExecutorTests.cs
@@ -10,7 +10,7 @@ namespace EncDotNet.S100.Pipelines.Tests;
 public class XsltRuleExecutorTests
 {
     [Fact]
-    public void Execute_XsltPointRule_ReturnsTypedInstruction()
+    public async Task Execute_XsltPointRule_ReturnsTypedInstruction()
     {
         var source = new FakeFeatureXmlSource(
             ["Buoy"],
@@ -46,14 +46,14 @@ public class XsltRuleExecutorTests
 
         // The mariner argument is ignored by the XSLT engine; pass an explicit
         // non-default value to confirm it has no effect.
-        var instructions = executor.ExecuteAsync(new MarinerSettings { FourShades = true }).GetAwaiter().GetResult();
+        var instructions = await executor.ExecuteAsync(new MarinerSettings { FourShades = true });
 
         var inst = Assert.IsType<PointInstruction>(Assert.Single(instructions));
         Assert.Equal("1", inst.FeatureReference);
     }
 
     [Fact]
-    public void Execute_ExposesFeatureTypeAndRuleCountsForTelemetry()
+    public async Task Execute_ExposesFeatureTypeAndRuleCountsForTelemetry()
     {
         var source = new FakeFeatureXmlSource(
             ["Buoy", "Light"],
@@ -73,7 +73,7 @@ public class XsltRuleExecutorTests
             xsltRules: new() { ["BuoyRule"] = xslt });
 
         var executor = new XsltRuleExecutor(source, catalogue);
-        executor.ExecuteAsync(MarinerSettings.Default).GetAwaiter().GetResult();
+        await executor.ExecuteAsync(MarinerSettings.Default);
 
         Assert.Equal(2, executor.LastFeatureTypeCount);
 

--- a/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
@@ -51,7 +51,7 @@ public class LatLonFormatterTests
     [Fact]
     public void Placeholder_IsEmpty()
     {
-        Assert.Equal(string.Empty, LatLonFormatter.Placeholder);
+        Assert.Empty(LatLonFormatter.Placeholder);
     }
 
     [Fact]


### PR DESCRIPTION
## Why

The solution had accumulated build warnings that made it hard to notice new ones. This clears them all and adds a policy so they cannot quietly creep back in.

## What changed

**Fixed every compiler and analyzer warning surfaced by a clean build:**

- `xUnit1031` (the bulk) - converted blocking task operations (`.GetAwaiter().GetResult()`, `.Wait()`) in test methods to `async Task` + `await`. Only the analyzer-flagged lines (inside test methods) were touched; fixture constructors, `Dispose`, and helpers that legitimately block were left alone.
- `xUnit1013` - added a missing `[Fact]` to `TileCacheTests.SnapshotKeys_...`.
- `xUnit2000` - used `Assert.Empty` for `LatLonFormatter.Placeholder`.
- `CS8620` - fixed `Path.GetFileName` method-group nullability in `DatasetPipelineFactory`.
- `CS9191` - used `in` instead of `ref` for the `SKMatrix` arg in `AnchoredPatternFillRenderer`.
- `CS0162` - removed unreachable single-iteration loops in `SplitterPersistence`.
- `CS8604` - dropped a spurious null-conditional that flipped flow state in `MapPaintInstrumentation`.

**Enforcement policy** (`Directory.Build.props`):

- `TreatWarningsAsErrors=true` so warnings cannot accumulate again.
- NuGet audit advisories (NU190x) are deliberately *not* excluded, and `NuGetAuditMode=all` audits transitive packages too. A newly-published CVE against any package in the graph now fails the build until triaged, rather than being an ignorable warning.

**Dependency fix** (`Directory.Packages.props`):

- Pinned `Microsoft.Extensions.TimeProvider.Testing` to `10.1.0` (it never shipped `10.0.9`, which was producing an NU1603 resolution warning).

## Notes for reviewers

- The async test conversions are mechanical and behavior-preserving; the await points replace synchronous blocking on the exact same calls.
- The stricter audit policy is an intentional trade-off: a new advisory can turn a previously-green build red with no code change on our side. That is the intended signal so a CVE stops the line.

Build is clean (0 errors, 0 warnings) and the affected test projects pass (Pipelines 758, S111 96, Viewer 1077).