### PR TITLE
Apply out-of-scale-band cap to TiledScene (B) point features

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
@@ -152,6 +152,14 @@ public sealed class MapsuiDatasetRenderer
                 SymbolProvider = result.SymbolProvider,
                 AreaFillProvider = result.AreaFillProvider,
                 LineStyleProvider = result.LineStyleProvider,
+                // TiledScene ("B") subsystem only: the Mapsui ("A") path enforces
+                // this cell-wide cap via per-feature MaxVisible below
+                // (ApplyOutOfScaleBandCap). Propagating it here lets the
+                // VectorScene IR honour it too, so features without their own
+                // SCAMIN are hidden out of scale band in both subsystems.
+                OutOfBandMinDisplayScale = sub.ApplyOutOfBandCap
+                    ? result.OutOfBandMinDisplayScale
+                    : null,
             };
 
             var layer = renderer.Render(sub.Instructions, result.GeometryProvider);

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -101,6 +101,19 @@ public sealed class MapsuiDisplayListRenderer
     public double TextScale { get; set; } = 1.0;
 
     /// <summary>
+    /// Optional dataset-wide out-of-scale-band cap, as an S-100 Part 9 §11.1
+    /// scale denominator (the cell's most-permissive
+    /// <c>DataCoverage.minimumDisplayScale</c>; S-101 FC §3.1.1). Applies only
+    /// to the TiledScene ("B") render subsystem: it is propagated onto the
+    /// <see cref="Scene.VectorScene"/> ops so that, like the Mapsui ("A")
+    /// feature path (<c>MapsuiDatasetRenderer.ApplyOutOfScaleBandCap</c>),
+    /// features lacking their own SCAMIN are hidden once the display is zoomed
+    /// out past the cell's compilation scale. <see langword="null"/> (the
+    /// default) applies no cap.
+    /// </summary>
+    public int? OutOfBandMinDisplayScale { get; set; }
+
+    /// <summary>
     /// Optional shared cache for processed-SVG symbol entries and rasterised
     /// pattern tiles. When set, the renderer routes its symbol/pattern
     /// lookups through this cache so re-renders of the same dataset (e.g.
@@ -414,6 +427,7 @@ public sealed class MapsuiDisplayListRenderer
                 PatternResolver = GetPatternTilePng,
                 SymbolScale = SymbolScale,
                 TextScale = TextScale,
+                OutOfBandMinDisplayScale = OutOfBandMinDisplayScale,
             };
             var builtScene = sceneBuilder.Build(instructions, geometryProvider);
             if (TiledSceneModeIsTiled)

--- a/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
@@ -74,6 +74,34 @@ public sealed class VectorSceneBuilder
     public double TextScale { get; init; } = 1.0;
 
     /// <summary>
+    /// Optional dataset-wide out-of-scale-band cap, expressed as an S-100
+    /// Part 9 §11.1 scale denominator (the cell's most-permissive
+    /// <c>DataCoverage.minimumDisplayScale</c>; S-101 FC §3.1.1). When set,
+    /// every op's effective <see cref="PaintOp.ScaleMinimum"/> is clamped to
+    /// this denominator, so features lacking their own SCAMIN — and those
+    /// whose SCAMIN is more permissive than the cell's — are hidden once the
+    /// display is zoomed out past the cell's compilation scale. This mirrors
+    /// the cap the Mapsui feature path applies via per-feature
+    /// <c>MaxVisible</c> (<c>MapsuiDatasetRenderer.ApplyOutOfScaleBandCap</c>),
+    /// keeping the <see cref="VectorScene"/> IR consumed by the TiledScene
+    /// render subsystem in agreement with the Mapsui subsystem.
+    /// </summary>
+    public double? OutOfBandMinDisplayScale { get; init; }
+
+    /// <summary>
+    /// Clamps a per-op <c>ScaleMinimum</c> (largest allowed denominator) to the
+    /// dataset-wide <see cref="OutOfBandMinDisplayScale"/> cap when one is set.
+    /// An op with no SCAMIN inherits the cap; an op with a more-permissive
+    /// SCAMIN is tightened to it. Returns the value unchanged when no cap is set.
+    /// </summary>
+    private double? CapScaleMinimum(double? scaleMinimum)
+    {
+        if (OutOfBandMinDisplayScale is not double cap)
+            return scaleMinimum;
+        return scaleMinimum.HasValue ? Math.Min(scaleMinimum.Value, cap) : cap;
+    }
+
+    /// <summary>
     /// Convenience helper that produces a <see cref="SymbolAsset"/> from raw SVG
     /// content by recovering the pivot (<see cref="SvgPivotMetrics.TryParse"/>)
     /// and processing CSS classes (<see cref="SvgProcessor.Process"/>). Returns
@@ -177,7 +205,7 @@ public sealed class VectorSceneBuilder
         return new PatternAreaPaintOp
         {
             FeatureReference = instruction.FeatureReference,
-            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMinimum = CapScaleMinimum(instruction.ScaleMinimum),
             ScaleMaximum = instruction.ScaleMaximum,
             PatternReference = patternRef,
             WorldShell = Project(geometry.Coordinates),
@@ -211,7 +239,7 @@ public sealed class VectorSceneBuilder
         return new AreaPaintOp
         {
             FeatureReference = instruction.FeatureReference,
-            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMinimum = CapScaleMinimum(instruction.ScaleMinimum),
             ScaleMaximum = instruction.ScaleMaximum,
             WorldShell = Project(geometry.Coordinates),
             WorldHoles = holes,
@@ -268,7 +296,7 @@ public sealed class VectorSceneBuilder
         return new LinePaintOp
         {
             FeatureReference = instruction.FeatureReference,
-            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMinimum = CapScaleMinimum(instruction.ScaleMinimum),
             ScaleMaximum = instruction.ScaleMaximum,
             World = Project(coords),
             Color = ResolveColor(colorToken),
@@ -308,7 +336,7 @@ public sealed class VectorSceneBuilder
         return new PointPaintOp
         {
             FeatureReference = instruction.FeatureReference,
-            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMinimum = CapScaleMinimum(instruction.ScaleMinimum),
             ScaleMaximum = instruction.ScaleMaximum,
             World = WebMercator.FromLonLat(lon, lat),
             Symbol = symbol,
@@ -366,7 +394,7 @@ public sealed class VectorSceneBuilder
         return new TextPaintOp
         {
             FeatureReference = instruction.FeatureReference,
-            ScaleMinimum = instruction.ScaleMinimum,
+            ScaleMinimum = CapScaleMinimum(instruction.ScaleMinimum),
             ScaleMaximum = instruction.ScaleMaximum,
             World = WebMercator.FromLonLat(lon, lat),
             Text = instruction.Text,

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderOutOfBandCapTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderOutOfBandCapTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Rendering.Scene;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="VectorSceneBuilder.OutOfBandMinDisplayScale"/>
+/// propagates the cell-wide out-of-scale-band cap (S-101 FC §3.1.1
+/// <c>DataCoverage.minimumDisplayScale</c>) onto the resolved
+/// <see cref="PaintOp.ScaleMinimum"/> of the VectorScene IR consumed by the
+/// TiledScene ("B") render subsystem. This is the IR-side equivalent of the
+/// Mapsui ("A") path's per-feature <c>MaxVisible</c> cap
+/// (<c>MapsuiDatasetRenderer.ApplyOutOfScaleBandCap</c>); without it, point
+/// features lacking their own SCAMIN remained drawn at every zoom level in B.
+/// </summary>
+public sealed class VectorSceneBuilderOutOfBandCapTests
+{
+    private sealed class SinglePointGeometry : IFeatureGeometryProvider
+    {
+        public FeatureGeometry? GetGeometry(string featureReference) => new FeatureGeometry
+        {
+            Type = GeometryType.Point,
+            Coordinates = new (double, double)[] { (50.72, -1.29) },
+        };
+    }
+
+    private static PointPaintOp BuildPoint(double? instructionScaleMinimum, int? cap)
+    {
+        var builder = new VectorSceneBuilder
+        {
+            ResolveColor = static _ => new RgbaColor(0, 0, 0, 255),
+            OutOfBandMinDisplayScale = cap,
+        };
+
+        var instruction = new PointInstruction
+        {
+            FeatureReference = "f1",
+            SymbolReference = "SYM01",
+            ScaleMinimum = instructionScaleMinimum,
+        };
+
+        var scene = builder.Build(new DrawingInstruction[] { instruction }, new SinglePointGeometry());
+        return Assert.IsType<PointPaintOp>(Assert.Single(scene.Ops));
+    }
+
+    [Fact]
+    public void NoCap_LeavesMissingScaleMinimumNull()
+    {
+        var op = BuildPoint(instructionScaleMinimum: null, cap: null);
+
+        Assert.Null(op.ScaleMinimum);
+    }
+
+    [Fact]
+    public void Cap_OnMissingScaleMinimum_InheritsCap()
+    {
+        var op = BuildPoint(instructionScaleMinimum: null, cap: 90000);
+
+        Assert.Equal(90000, op.ScaleMinimum);
+    }
+
+    [Fact]
+    public void Cap_LooserScaleMinimum_IsTightenedToCap()
+    {
+        // A larger denominator is more permissive (visible when more zoomed out);
+        // it must be reduced to the cell-wide cap.
+        var op = BuildPoint(instructionScaleMinimum: 180000, cap: 90000);
+
+        Assert.Equal(90000, op.ScaleMinimum);
+    }
+
+    [Fact]
+    public void Cap_TighterScaleMinimum_IsPreserved()
+    {
+        // A smaller denominator already hides the feature sooner than the cap,
+        // so it is preserved unchanged.
+        var op = BuildPoint(instructionScaleMinimum: 45000, cap: 90000);
+
+        Assert.Equal(45000, op.ScaleMinimum);
+    }
+}


### PR DESCRIPTION
## Summary

Point features were drawn at every zoom level in the experimental TiledScene ("B") render subsystem even when they should have been culled by the cell's out-of-scale-band cap. The same cell rendered correctly in the Mapsui ("A") subsystem, which is what surfaced the discrepancy.

The S-101 cell-wide out-of-scale-band cap (DataCoverage `minimumDisplayScale`, FC 3.1.1) was only being applied to the Mapsui feature path. It was never propagated into the `VectorScene` IR that the TiledScene subsystem rasterizes, so point features lacking their own SCAMIN stayed visible at all scales in B.

The fix propagates the cap onto each resolved `PaintOp.ScaleMinimum` in `VectorSceneBuilder`, clamping to `min(existing, cap)` (or inheriting the cap when a feature has no SCAMIN of its own). It is wired through `MapsuiDisplayListRenderer` into the B-branch scene builder only, and set per sub-layer in `MapsuiDatasetRenderer` under the existing `ApplyOutOfBandCap` flag. The A path is deliberately left unchanged so its behaviour is identical to before.

Verified end-to-end in the viewer: at the previously-buggy ~1:127k viewport on cell `101GB00502793`, A and B now render identically with the point clutter gone.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [ ] N/A

**Spec section references cited in code/docs:** S-101 FC 3.1.1 (DataCoverage `minimumDisplayScale` out-of-scale-band cap).

## Tests

- [x] Added/updated xunit tests under `tests/` (`VectorSceneBuilderOutOfBandCapTests`: no-cap, inherit, tighten-looser, preserve-tighter)
- [x] Tests requiring real data files use `SkippableFact` (N/A here; new tests use synthetic instructions)
- [x] `dotnet test --configuration Release` passes locally (Pipelines.Tests: 15/15 out-of-band tests pass)

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [ ] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None. Behaviour change is limited to the experimental TiledScene subsystem, bringing it into line with the Mapsui path.