### PR TITLE
Skip FeatureXML build when no XSLT portrayal rules apply

### DIFF
--- a/src/EncDotNet.S100.Core/Pipelines/Vector/Xslt/XsltRuleExecutor.cs
+++ b/src/EncDotNet.S100.Core/Pipelines/Vector/Xslt/XsltRuleExecutor.cs
@@ -17,12 +17,21 @@ namespace EncDotNet.S100.Pipelines.Vector.Xslt;
 /// The executor performs four sub-stages, each of which previously lived
 /// inline in <see cref="VectorPipeline"/>:
 /// <list type="number">
+///   <item>Rule selection — match dataset feature types to catalogue rules
+///     (uses only the cheap <see cref="IFeatureXmlSource.FeatureTypesPresent"/>).</item>
 ///   <item>FeatureXML acquisition from <see cref="IFeatureXmlSource"/>.</item>
-///   <item>Rule selection — match dataset feature types to catalogue rules.</item>
 ///   <item>XSLT transformation — run each applicable XSLT rule against the FeatureXML.</item>
 ///   <item>Drawing-instruction assembly — parse the XSLT output into typed
 ///     objects via <see cref="Part9DisplayListReader"/>.</item>
 /// </list>
+/// </para>
+/// <para>
+/// Rule selection deliberately precedes FeatureXML acquisition so the
+/// expensive FeatureXML materialisation can be skipped entirely when no
+/// applicable XSLT rule exists — the common case for products whose
+/// portrayal is entirely Lua-driven (e.g. S-101, S-131). This is
+/// behaviour-preserving: an XSLT pass over zero rules always yields an
+/// empty display list.
 /// </para>
 /// <para>
 /// Instances are <b>render-bound</b>: the FeatureXML source, catalogue, and
@@ -79,19 +88,17 @@ public sealed class XsltRuleExecutor : IVectorRuleExecutor
         cancellationToken.ThrowIfCancellationRequested();
         var stageTag = new KeyValuePair<string, object?>(TelemetryTags.PipelineStage, "vector");
 
-        // Stage 1 — load FeatureXML into a navigable document
-        XDocument featureDoc;
-        using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.feature_xml"))
-        {
-            var stageStart = Stopwatch.GetTimestamp();
-            using (var reader = _source.GetFeatureXml(cancellationToken))
-            {
-                featureDoc = XDocument.Load(reader);
-            }
-            RecordStageDuration(stageStart, "feature_xml");
-        }
-
-        // Stage 2 — select applicable rules
+        // Stage 1 — select applicable rules.
+        //
+        // Rule selection is performed *before* FeatureXML acquisition because
+        // it needs only the cheap, memoised <see cref="IFeatureXmlSource.FeatureTypesPresent"/>
+        // list — never the full materialised document. This lets us gate the
+        // expensive FeatureXML build (Stage 2) on whether any applicable XSLT
+        // rule actually exists. Products whose portrayal is entirely Lua-driven
+        // (e.g. S-101, S-131) select zero XSLT rules, so an XSLT pass would
+        // produce an empty display list regardless of input; skipping the
+        // build is therefore behaviour-preserving and avoids the dominant cost
+        // of materialising large datasets as XML.
         IReadOnlyList<PortrayalRule> applicableRules;
         using (var ruleSelectActivity = Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.rule_select"))
         {
@@ -105,6 +112,26 @@ public sealed class XsltRuleExecutor : IVectorRuleExecutor
             LastRuleCount = applicableRules.Count;
             ruleSelectActivity?.SetTag("s100.pipeline.rules.count", applicableRules.Count);
             RecordStageDuration(stageStart, "rule_select");
+        }
+
+        // Gate — if no applicable rule is an XSLT rule there is nothing for the
+        // XSLT engine to do. Return early without materialising the FeatureXML,
+        // running the (empty) transform loop, or assembling instructions.
+        if (!applicableRules.Any(r => r.Type == PortrayalRuleType.Xslt))
+        {
+            return Array.Empty<DrawingInstruction>();
+        }
+
+        // Stage 2 — load FeatureXML into a navigable document
+        XDocument featureDoc;
+        using (Telemetry.ActivitySource.StartActivity("s100.pipeline.vector.stage.feature_xml"))
+        {
+            var stageStart = Stopwatch.GetTimestamp();
+            using (var reader = _source.GetFeatureXml(cancellationToken))
+            {
+                featureDoc = XDocument.Load(reader);
+            }
+            RecordStageDuration(stageStart, "feature_xml");
         }
 
         // Stage 3 — XSLT transformation

--- a/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S131DatasetProcessor.cs
@@ -156,12 +156,15 @@ public sealed class S131DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         context?.EcdisDisplay?.ApplyTo(_catalogue);
         var palette = _catalogue.ActivePalette;
 
-        // Run the Lua portrayal pipeline. S-131 is Lua-only — there are no
-        // XSLT rules — so we provide an empty FeatureXML source to satisfy
-        // the VectorPipeline contract. All drawing instructions come from the
-        // Lua executor (Stage 4).
+        // Run the Lua portrayal pipeline. S-131 is Lua-only — its portrayal
+        // catalogue contains no XSLT rules — so the VectorPipeline's XSLT stage
+        // selects zero rules and the XsltRuleExecutor short-circuits before
+        // touching the feature source. We therefore pass the real GML feature
+        // source (consistent with every other feature product); the central
+        // gate, not a bespoke empty source, is what avoids the FeatureXML cost.
+        // All drawing instructions come from the Lua executor (Stage 4).
         var executor = new S131LuaRuleExecutor(_luaEngine, _dataset, _catalogue, fc);
-        var featureSource = new EmptyFeatureXmlSource();
+        var featureSource = new GmlFeatureXmlSource<S131Feature>(_dataset.Features);
         var pipeline = new PortrayalPipeline(executor);
         var portrayalLayer = await pipeline.ProcessAsync(
                 featureSource, _catalogue, mariner: mariner, cancellationToken: cancellationToken)
@@ -328,25 +331,5 @@ public sealed class S131DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         if (lat > maxLat) maxLat = lat;
         if (lon < minLon) minLon = lon;
         if (lon > maxLon) maxLon = lon;
-    }
-}
-
-/// <summary>
-/// An <see cref="IFeatureXmlSource"/> that contains no features. Used by
-/// S-131 (and potentially other Lua-only products) where all drawing
-/// instructions come from the Part 9A Lua executor and the XSLT stage
-/// of the <see cref="VectorPipeline"/> has nothing to do.
-/// </summary>
-internal sealed class EmptyFeatureXmlSource : IFeatureXmlSource
-{
-    /// <inheritdoc/>
-    public IReadOnlyList<string> FeatureTypesPresent => [];
-
-    /// <inheritdoc/>
-    public XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        // Return a minimal well-formed XML document so XDocument.Load succeeds.
-        return XmlReader.Create(new StringReader("<Features/>"));
     }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/XsltRuleExecutorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/XsltRuleExecutorTests.cs
@@ -96,6 +96,43 @@ public class XsltRuleExecutorTests
             () => executor.ExecuteAsync(MarinerSettings.Default, cts.Token).GetAwaiter().GetResult());
     }
 
+    [Fact]
+    public async Task Execute_NoApplicableXsltRules_DoesNotBuildFeatureXml()
+    {
+        // A catalogue with zero rules: the XSLT engine has nothing to do, so
+        // the expensive FeatureXML build must be skipped entirely.
+        var source = new ThrowingFeatureXmlSource(["Buoy"]);
+        var catalogue = new FakeVectorPortrayalCatalogue([]);
+        var executor = new XsltRuleExecutor(source, catalogue);
+
+        var instructions = await executor.ExecuteAsync(MarinerSettings.Default);
+
+        Assert.Empty(instructions);
+        Assert.False(source.FeatureXmlRequested);
+        Assert.Equal(1, executor.LastFeatureTypeCount);
+        Assert.Equal(0, executor.LastRuleCount);
+    }
+
+    [Fact]
+    public async Task Execute_OnlyLuaRulesApply_DoesNotBuildFeatureXml()
+    {
+        // A Lua-only product (e.g. S-101, S-131): an applicable rule exists but
+        // it is not an XSLT rule, so the FeatureXML build is still skipped.
+        var source = new ThrowingFeatureXmlSource(["Buoy"]);
+        var catalogue = new FakeVectorPortrayalCatalogue(
+            [new PortrayalRule { Name = "BuoyLua", Type = PortrayalRuleType.Lua, ExecutionOrder = 1, AppliesTo = ["Buoy"] }]);
+        var executor = new XsltRuleExecutor(source, catalogue);
+
+        var instructions = await executor.ExecuteAsync(MarinerSettings.Default);
+
+        Assert.Empty(instructions);
+        Assert.False(source.FeatureXmlRequested);
+
+        // The applicable (Lua) rule is still reflected in telemetry even though
+        // the XSLT engine performed no work.
+        Assert.Equal(1, executor.LastRuleCount);
+    }
+
     private static XslCompiledTransform CompileXslt(string xslt)
     {
         var transform = new XslCompiledTransform();
@@ -110,6 +147,20 @@ public class XsltRuleExecutorTests
 
         public XmlReader GetFeatureXml(CancellationToken cancellationToken = default) =>
             XmlReader.Create(new StringReader(featureXml));
+    }
+
+    private sealed class ThrowingFeatureXmlSource(IReadOnlyList<string> featureTypes) : IFeatureXmlSource
+    {
+        public IReadOnlyList<string> FeatureTypesPresent { get; } = featureTypes;
+
+        public bool FeatureXmlRequested { get; private set; }
+
+        public XmlReader GetFeatureXml(CancellationToken cancellationToken = default)
+        {
+            FeatureXmlRequested = true;
+            throw new InvalidOperationException(
+                "GetFeatureXml must not be called when no applicable XSLT rule exists.");
+        }
     }
 
     private sealed class FakeVectorPortrayalCatalogue(


### PR DESCRIPTION
## Summary

Loading an S-101 exchange set in the viewer was much slower than it should be on a cold cache. Profiling traced the dominant cost to wasted feature-XML generation: the XSLT rule executor always materialized the entire cell as a Part 9 FeatureXML document (~710ms/cell) *before* checking whether any XSLT rules actually applied. Products that portray entirely via Lua (S-101, S-131) select zero XSLT rules, so that document was built and never read — roughly 19s of pure waste across a 27-cell S-101 exchange set on a cold load.

This reorders `XsltRuleExecutor.ExecuteAsync` so rule selection (which needs only the cheap, memoized `FeatureTypesPresent`) runs before FeatureXML acquisition, then gates the build: if no applicable rule is an XSLT rule, it returns an empty instruction list and skips the feature-XML, transform, and assembly stages.

The change is behaviour-preserving by construction — an XSLT pass over zero rules already yields an empty display list regardless of input — and self-correcting, because rule type is derived from file extension in the portrayal catalogue, so adding an `.xslt` rule later automatically re-enables generation.

S-131 is made consistent: it drops the bespoke `EmptyFeatureXmlSource` workaround (which hardcoded "never uses XSLT") and now passes its real `GmlFeatureXmlSource<S131Feature>` like every other feature product, relying on the central gate instead.

**Verification (cold-cache, instrumented load of the trial S-101 exchange set):**
- `stage.feature_xml`: 1 call, 27.8ms (only the lone S-128 GML cell) — down from ~19s across all 27 S-101 cells.
- `stage.rule_select`: 28 calls, 33.9ms total — runs per cell but is cheap.
- Remaining cold-load cost is now MoonSharp Lua portrayal, which the existing disk portrayal cache already eliminates on subsequent loads.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [x] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

Also touches S-131 (`s131-marine-harbour`), which the template predates. Relevant behaviour is S-100 Part 9 portrayal pipeline: an XSLT transform over zero applicable rules yields an empty display list, so skipping FeatureXML materialization is equivalent.

**Spec section references cited in code/docs:** N/A — no new spec-derived constants or element names; the change is pipeline ordering within the Part 9 vector portrayal flow.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (N/A — new tests use synthetic fakes, no real data)
- [x] `dotnet test --configuration Release` passes locally

Added three `XsltRuleExecutorTests` cases asserting `GetFeatureXml` is never called when no applicable XSLT rule exists (no-rules and Lua-only-rule cases), via a spy source that throws on `GetFeatureXml`. Existing pipeline (22) and S-131 (57) tests pass.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md` (N/A — no public API surface change)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed (N/A)
- [x] New public APIs have XML doc comments (updated `XsltRuleExecutor` class remarks to reflect the new stage order and gate)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependency)

## Breaking changes

None. The executor's observable output is unchanged; `LastFeatureTypeCount` / `LastRuleCount` telemetry is preserved.