### PR TITLE
Stop "B" label plane from dropping labels under point symbols

### DIFF
--- a/src/EncDotNet.S100.Renderers.Skia/Scene/LabelDeclutterer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/LabelDeclutterer.cs
@@ -13,12 +13,22 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Point symbols always draw and act as fixed obstacles; labels (feature-name
-/// text and soundings, both <see cref="TextPaintOp"/>) yield to symbols and to
-/// higher-priority labels. The op list is already ordered by ascending S-100
-/// Part 9 drawing priority (later = drawn on top = more important), so labels
-/// are placed highest-priority first; a label whose on-screen footprint
-/// overlaps an already-placed footprint is suppressed.
+/// Point symbols always draw and are <b>never</b> suppressed. Matching the
+/// Mapsui "A" arm (the fidelity baseline for issue&#160;#347), they do
+/// <i>not</i> displace labels either: decluttering operates among labels only.
+/// Labels (feature-name text and soundings, both <see cref="TextPaintOp"/>)
+/// yield only to higher-priority labels. The op list is already ordered by
+/// ascending S-100 Part 9 drawing priority (later = drawn on top = more
+/// important), so labels are placed highest-priority first; a label whose
+/// on-screen footprint overlaps an already-placed <i>label</i> footprint is
+/// suppressed.
+/// </para>
+/// <para>
+/// Letting a point symbol suppress an overlapping label would drop annotation
+/// text the "A" arm always draws — e.g. S-421 route action-point / leg labels
+/// anchored on (or beside) a co-located waypoint symbol, which the coarse
+/// perceptual gate does not catch. Point symbols are therefore obstacles to
+/// nothing; only label-vs-label overlap is resolved here.
 /// </para>
 /// <para>
 /// All footprints are computed in <i>final</i> on-screen space — each anchor is
@@ -52,8 +62,9 @@ public sealed class LabelDeclutterer : IDisposable
     /// <summary>
     /// Returns the set of <see cref="TextPaintOp"/>s to <b>suppress</b> this
     /// frame (by reference identity) so the live overlay draws a decluttered
-    /// label plane. Point symbols are never suppressed; they reserve their
-    /// footprint first as obstacles. Ops that are scale-culled or fall outside
+    /// label plane. Point symbols are never suppressed and never displace a
+    /// label (parity with the Mapsui arm) — only label-vs-label overlap is
+    /// resolved. Ops that are scale-culled or fall outside
     /// <paramref name="cullBounds"/> are ignored (they are not drawn, so they
     /// neither occupy space nor need suppressing).
     /// </summary>
@@ -89,28 +100,11 @@ public sealed class LabelDeclutterer : IDisposable
         double denom = viewport.ScaleDenominator;
         var index = _index;
 
-        // Pass 1 — point symbols reserve their footprints as obstacles.
-        foreach (var op in scene.Ops)
-        {
-            if (op is not PointPaintOp point)
-                continue;
-            if (honorScaleVisibility && !ScaleVisibility.IsVisibleAtScale(point, denom))
-                continue;
-
-            var (px, py) = transform.Project(point.World);
-            px += (float)point.OffsetXpx;
-            py += (float)point.OffsetYpx;
-            (px, py) = SkiaDisplayListRenderer.RotateAbout(px, py, centerX, centerY, anchorRotationDegrees);
-            if (!cullBounds.Contains(px, py))
-                continue;
-
-            index.Add(SkiaDisplayListRenderer.PointScreenBounds(point, px, py));
-        }
-
-        // Pass 2 — labels, highest drawing priority first (reverse op order).
-        // A label that collides with an already-placed footprint is suppressed;
-        // otherwise it claims its footprint and becomes an obstacle for
-        // lower-priority labels.
+        // Labels, highest drawing priority first (reverse op order). A label that
+        // collides with an already-placed label footprint is suppressed; otherwise
+        // it claims its footprint and becomes an obstacle for lower-priority
+        // labels. Point symbols are intentionally not indexed: they always draw
+        // and never displace a label, matching the Mapsui "A" arm (issue #347).
         var scratch = _scratch;
         for (int i = scene.Ops.Count - 1; i >= 0; i--)
         {
@@ -145,8 +139,8 @@ public sealed class LabelDeclutterer : IDisposable
     public void Dispose() => _scratch.Dispose();
 
     /// <summary>
-    /// A uniform screen-space grid of occupied rectangles giving near-O(1)
-    /// overlap queries, so decluttering thousands of overlay ops per frame stays
+    /// A uniform screen-space grid of occupied label rectangles giving near-O(1)
+    /// overlap queries, so decluttering thousands of label ops per frame stays
     /// linear. Rectangles are bucketed by the fixed-size cells they touch.
     /// </summary>
     /// <remarks>

--- a/tests/EncDotNet.S100.Pipelines.Tests/LabelDeclutterTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/LabelDeclutterTests.cs
@@ -89,18 +89,36 @@ public class LabelDeclutterTests
     }
 
     [Fact]
-    public void Declutter_LabelOverlappingSymbol_SuppressesLabel()
+    public void Declutter_LabelOverlappingSymbol_KeepsLabel()
     {
-        // A point symbol always draws and reserves its footprint; a label at the
-        // same anchor yields to it (even though the label is later/higher in the
-        // op list, symbols are obstacles that never lose).
+        // A point symbol always draws but never displaces a label (parity with
+        // the Mapsui "A" arm; issue #347). A label co-located with a symbol is
+        // therefore kept — dropping it would lose annotation text "A" renders,
+        // e.g. S-421 route action-point labels anchored on a waypoint symbol.
         var point = Point("sym", 10.0, 0.0);
         var label = Text("name", 10.0, 0.0);
         var scene = new VectorScene(new List<PaintOp> { point, label });
 
         var suppressed = Declutter(scene, Centred(10.0, 0.0, 0.4));
 
-        Assert.Contains(label, suppressed);
+        Assert.DoesNotContain(label, suppressed);
+        Assert.Empty(suppressed);
+    }
+
+    [Fact]
+    public void Declutter_LabelOverlappingUnrelatedSymbol_KeepsLabel()
+    {
+        // Regression for the S-421 finding: a label anchored to one feature
+        // (a waypoint leg / action point) overlapping a *different* feature's
+        // point symbol (a co-located waypoint circle) must still draw. Point
+        // symbols are obstacles to nothing.
+        var waypointSymbol = Point("RTE.WPT.2", 10.0, 0.0);
+        var legLabel = Text("RTE.WPT.LEG.2", 10.0, 0.0, "Shallow water");
+        var scene = new VectorScene(new List<PaintOp> { waypointSymbol, legLabel });
+
+        var suppressed = Declutter(scene, Centred(10.0, 0.0, 0.4));
+
+        Assert.Empty(suppressed);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.VisualRegression.Tests/LabelOverlayCompositionTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/LabelOverlayCompositionTests.cs
@@ -132,10 +132,12 @@ public sealed class LabelOverlayCompositionTests
     }
 
     [Fact]
-    public void Overlay_LabelOverSymbol_SymbolSurvivesLabelSuppressed()
+    public void Overlay_LabelOverSymbol_BothRendered()
     {
-        // A label sharing the symbol's anchor yields to the symbol footprint, so
-        // the symbol's red pixels are present and the label's black ink is gone.
+        // A label sharing the symbol's anchor is NOT suppressed: point symbols
+        // always draw but never displace a label (parity with the Mapsui "A"
+        // arm; issue #347). Both the symbol's red pixels and the label's black
+        // ink are present.
         var scene = new VectorScene(new List<PaintOp>
         {
             Symbol("sym", 10.0, 0.0),
@@ -146,6 +148,6 @@ public sealed class LabelOverlayCompositionTests
         var (black, red) = RenderOverlay(scene, viewport, declutter: true);
 
         Assert.True(red > 0, "symbol did not render");
-        Assert.True(black == 0, $"label over symbol should be suppressed, but {black} label pixels remain");
+        Assert.True(black > 0, $"label over symbol should survive, but {black} label pixels remain");
     }
 }


### PR DESCRIPTION
## Summary

Multi-product A/B golden-image parity validation of the tiled async "B" render subsystem (`RenderSubsystemKind.TiledScene` / `S100VectorTileRenderer`, issue #347) surfaced an **S-421 (route plans) fidelity regression**: "B" rendered only **1 of 4** RouteActionPoint/leg text labels that the Mapsui "A" arm draws. The coarse perceptual gate missed it because labels are a tiny pixel fraction.

**Root cause:** `LabelDeclutterer` treated every point symbol as a hard obstacle (Pass 1) and suppressed any label whose footprint overlapped one (Pass 2). S-421 route labels are anchored on/beside co-located waypoint circles, so 3 of 4 collided with an *unrelated* waypoint symbol and were dropped. The "A" arm has no such rule.

**Fix:** point symbols always draw but no longer displace labels; decluttering now resolves **label-vs-label** overlap only, matching the "A" arm (the #347 fidelity baseline). This restores all four S-421 labels (verified via the headless A/B harness) and keeps the pooled, zero-steady-state-allocation index intact.

Relates to #347 (one sub-item of multi-product parity validation; does **not** close it).

## Spec alignment

- [x] N/A — change is purely infrastructural (renderer declutter logic, no spec-semantic change)

**Spec section references cited in code/docs:** N/A — renderer behaviour only.

## Tests

- [x] Added/updated xunit tests under `tests/`
  - `LabelDeclutterTests`: flipped the pinned `Declutter_LabelOverlappingSymbol` test to assert the label is **kept**; added `Declutter_LabelOverlappingUnrelatedSymbol_KeepsLabel` regression test (the exact S-421 case).
  - `LabelOverlayCompositionTests`: `Overlay_LabelOverSymbol_*` now assert both symbol **and** label render.
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally
  - Pipelines: 765 passed, 1 skipped
  - VisualRegression: 69 passed, 5 skipped
  - S-421: 73 passed

Build: `dotnet build -c Release` → **0 Warning(s), 0 Error(s)** (no-warnings policy, #354).

## Documentation

- [x] Updated XML doc comments on the changed declutter logic

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None.