### PR TITLE
Show fileReference external text in the pick report

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -394,10 +394,17 @@ public sealed class DatasetPipelineFactory
     /// unrecognized, falls back to extension-based sniffing on
     /// <paramref name="relativePath"/>.
     /// </param>
+    /// <param name="supportFiles">
+    /// Optional map of support-file name (case-insensitive) to source-relative
+    /// path, from the exchange-set catalogue's
+    /// <c>supportFileDiscoveryMetadata</c> (S-100 Edition 5.2.1 Part 17). Lets
+    /// S-101 resolve <c>fileReference</c> external text files via the catalogue.
+    /// </param>
     public IDatasetProcessor CreateProcessor(
         IAssetSource source,
         string relativePath,
-        string? declaredProductSpec = null)
+        string? declaredProductSpec = null,
+        IReadOnlyDictionary<string, string>? supportFiles = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentException.ThrowIfNullOrEmpty(relativePath);
@@ -411,7 +418,7 @@ public sealed class DatasetPipelineFactory
         return spec switch
         {
             "S-102" => new S102DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _crsTransformFactory),
-            "S-101" => new S101DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager, _sharedInstructionCache),
+            "S-101" => new S101DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager, _sharedInstructionCache, supportFiles),
             "S-57" => new S57DatasetProcessor(source, relativePath, _catalogueManager, _luaEngine, _featureCatalogueManager),
             "S-104" => new S104DatasetProcessor(source, relativePath, _crsTransformFactory),
             "S-111" => new S111DatasetProcessor(source, relativePath, _catalogueManager, _crsTransformFactory),
@@ -442,7 +449,8 @@ public sealed class DatasetPipelineFactory
     public IDatasetProcessor CreateS101ProcessorWithUpdates(
         IAssetSource source,
         string baseRelativePath,
-        IReadOnlyList<string> updateRelativePaths)
+        IReadOnlyList<string> updateRelativePaths,
+        IReadOnlyDictionary<string, string>? supportFiles = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentException.ThrowIfNullOrEmpty(baseRelativePath);
@@ -455,7 +463,8 @@ public sealed class DatasetPipelineFactory
             _catalogueManager,
             _luaEngine,
             _featureCatalogueManager,
-            _sharedInstructionCache);
+            _sharedInstructionCache,
+            supportFiles);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExchangeSetLoader.cs
@@ -65,6 +65,11 @@ public sealed class ExchangeSetLoader
 
         var datasets = exchangeSet.Catalogue.DatasetDiscoveryMetadata;
 
+        // Index the catalogue's support files by name so S-101 can resolve
+        // `fileReference` external text files through the catalogue — the
+        // canonical ECDIS mechanism. S-100 Edition 5.2.1 Part 17.
+        var supportFiles = BuildSupportFileMap(exchangeSet);
+
         // Group S-101 base cells with their in-set sequential updates so each
         // cell is loaded once at its up-to-date state (S-100 Part 10a). Non-S-101
         // datasets pass through unchanged.
@@ -89,7 +94,7 @@ public sealed class ExchangeSetLoader
                     case S101LoadItemKind.BaseWithUpdates:
                         var updatePaths = item.Updates.Select(u => u.RelativePath).ToList();
                         processor = _factory.CreateS101ProcessorWithUpdates(
-                            exchangeSet.Source, relativePath, updatePaths);
+                            exchangeSet.Source, relativePath, updatePaths, supportFiles);
                         break;
 
                     case S101LoadItemKind.OrphanUpdate:
@@ -103,7 +108,8 @@ public sealed class ExchangeSetLoader
                         processor = _factory.CreateProcessor(
                             exchangeSet.Source,
                             relativePath,
-                            metadata.ProductSpecification?.ProductIdentifier);
+                            metadata.ProductSpecification?.ProductIdentifier,
+                            supportFiles);
                         break;
                 }
             }
@@ -119,5 +125,29 @@ public sealed class ExchangeSetLoader
             yield return new ExchangeSetLoadResult(metadata, relativePath, processor, error);
             await Task.Yield();
         }
+    }
+
+    /// <summary>
+    /// Builds a case-insensitive map of support-file name to its source-relative
+    /// path from the exchange set's <c>supportFileDiscoveryMetadata</c>, so a
+    /// dataset can resolve a <c>fileReference</c> attribute to the actual file
+    /// regardless of the sub-directory it is stored in. S-100 Edition 5.2.1
+    /// Part 17. Returns <see langword="null"/> when the catalogue declares no
+    /// support files.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string>? BuildSupportFileMap(ExchangeSet exchangeSet)
+    {
+        var entries = exchangeSet.Catalogue.SupportFileDiscoveryMetadata;
+        if (entries.Count == 0)
+            return null;
+
+        var map = new Dictionary<string, string>(entries.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            if (!string.IsNullOrEmpty(entry.FileName))
+                map[entry.FileName] = entry.RelativePath;
+        }
+
+        return map.Count > 0 ? map : null;
     }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/ExternalTextFileResolver.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExternalTextFileResolver.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using System.Text;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Datasets.Pipelines;
+
+/// <summary>
+/// Resolves the textual content of an externally referenced text file (named
+/// by an S-100 <c>fileReference</c> attribute — S-101 Feature Catalogue, alias
+/// <c>TXTDSC</c> / <c>NTXTDS</c>) from the dataset's exchange-set
+/// <see cref="IAssetSource"/>. The referenced file is looked up relative to
+/// the dataset's own directory first (the common co-location convention), then
+/// at the exchange-set root, mirroring how an ECDIS locates the support file
+/// that backs a feature's textual description.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolution is synchronous because the pick / object-info path that consumes
+/// it is synchronous; support text files are small and the underlying
+/// <c>FileSystemAssetSource</c> / <c>ZipAssetSource</c> reads are memory-backed
+/// (no network I/O), so the awaiter-result bridge is bounded.
+/// </para>
+/// <para>
+/// Content is decoded as UTF-8 when valid, otherwise as ISO/IEC 8859-1
+/// (Latin-1), which is the legacy character set most S-57/S-101 producers use
+/// for support text files. Missing, oversized, or unreadable files resolve to
+/// <c>null</c> so the pick report keeps showing the bare file name.
+/// </para>
+/// </remarks>
+public sealed class ExternalTextFileResolver
+{
+    /// <summary>
+    /// Upper bound on the size of a referenced text file that will be read
+    /// into memory. Support text files are short; anything larger is treated
+    /// as unresolvable to bound the cost of a pick gesture.
+    /// </summary>
+    public const long MaxFileSizeBytes = 4 * 1024 * 1024;
+
+    private readonly IAssetSource _source;
+    private readonly string? _baseDirectory;
+
+    /// <summary>
+    /// Initializes a new <see cref="ExternalTextFileResolver"/>.
+    /// </summary>
+    /// <param name="source">
+    /// The asset source backing the dataset's exchange set (folder or ZIP).
+    /// </param>
+    /// <param name="datasetRelativePath">
+    /// The source-relative path of the dataset whose features carry the file
+    /// references; its directory is used as the primary lookup location. May
+    /// be <c>null</c> or a bare file name, in which case only the exchange-set
+    /// root is searched.
+    /// </param>
+    public ExternalTextFileResolver(IAssetSource source, string? datasetRelativePath = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        _source = source;
+        _baseDirectory = GetDirectory(datasetRelativePath);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Func{T,TResult}"/> view of this resolver, suitable
+    /// for passing to <see cref="FeatureInfoBuilder.ResolveFileReferences"/>.
+    /// </summary>
+    public Func<string, string?> AsDelegate() => Resolve;
+
+    /// <summary>
+    /// Resolves the textual content of the file named <paramref name="fileName"/>,
+    /// or <c>null</c> when it cannot be located or read within the size bound.
+    /// </summary>
+    public string? Resolve(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+
+        string normalized;
+        try
+        {
+            normalized = ExchangeSets.ExchangeSet.NormalizeFileName(fileName);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+
+        if (normalized.Length == 0)
+            return null;
+
+        // Prefer the dataset's own directory, then fall back to the exchange
+        // set root. Skip the second probe when the file name already carries a
+        // path or no base directory is known.
+        if (!string.IsNullOrEmpty(_baseDirectory)
+            && !normalized.Contains('/'))
+        {
+            var candidate = _baseDirectory + "/" + normalized;
+            if (TryRead(candidate, out var text))
+                return text;
+        }
+
+        return TryRead(normalized, out var rootText) ? rootText : null;
+    }
+
+    private bool TryRead(string relativePath, out string? text)
+    {
+        text = null;
+        try
+        {
+            using var stream = AssetSourceHelpers.OpenSeekable(_source, relativePath);
+            if (stream.CanSeek && stream.Length > MaxFileSizeBytes)
+                return false;
+
+            using var buffer = new MemoryStream();
+            stream.CopyTo(buffer);
+            if (buffer.Length > MaxFileSizeBytes)
+                return false;
+
+            text = Decode(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or FileNotFoundException
+            or DirectoryNotFoundException
+            or InvalidOperationException
+            or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Decodes <paramref name="bytes"/> as UTF-8 when valid (honoring a BOM),
+    /// otherwise as ISO/IEC 8859-1 (Latin-1).
+    /// </summary>
+    internal static string Decode(ReadOnlySpan<byte> bytes)
+    {
+        // Honor a UTF-8 BOM if present.
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            return Encoding.UTF8.GetString(bytes[3..]);
+
+        try
+        {
+            var strict = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+            return strict.GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return Encoding.Latin1.GetString(bytes);
+        }
+    }
+
+    private static string? GetDirectory(string? relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+            return null;
+
+        var normalized = relativePath.Replace('\\', '/').TrimEnd('/');
+        var idx = normalized.LastIndexOf('/');
+        return idx <= 0 ? null : normalized[..idx];
+    }
+}

--- a/src/EncDotNet.S100.Datasets.Pipelines/ExternalTextFileResolver.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExternalTextFileResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using EncDotNet.S100.Core;
@@ -9,10 +10,11 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// Resolves the textual content of an externally referenced text file (named
 /// by an S-100 <c>fileReference</c> attribute — S-101 Feature Catalogue, alias
 /// <c>TXTDSC</c> / <c>NTXTDS</c>) from the dataset's exchange-set
-/// <see cref="IAssetSource"/>. The referenced file is looked up relative to
-/// the dataset's own directory first (the common co-location convention), then
-/// at the exchange-set root, mirroring how an ECDIS locates the support file
-/// that backs a feature's textual description.
+/// <see cref="IAssetSource"/>. When the exchange-set catalogue's
+/// <c>supportFileDiscoveryMetadata</c> is supplied, the referenced file is
+/// located through it first (the canonical ECDIS mechanism); otherwise the
+/// file is looked up relative to the dataset's own directory, then at the
+/// exchange-set root, then under a sibling <c>support/</c> directory.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -39,6 +41,7 @@ public sealed class ExternalTextFileResolver
 
     private readonly IAssetSource _source;
     private readonly string? _baseDirectory;
+    private readonly IReadOnlyDictionary<string, string>? _supportFiles;
 
     /// <summary>
     /// Initializes a new <see cref="ExternalTextFileResolver"/>.
@@ -52,11 +55,22 @@ public sealed class ExternalTextFileResolver
     /// be <c>null</c> or a bare file name, in which case only the exchange-set
     /// root is searched.
     /// </param>
-    public ExternalTextFileResolver(IAssetSource source, string? datasetRelativePath = null)
+    /// <param name="supportFiles">
+    /// Optional map of support-file name (case-insensitive) to its source-relative
+    /// path, as declared by the exchange-set catalogue's
+    /// <c>supportFileDiscoveryMetadata</c> (S-100 Edition 5.2.1 Part 17). When
+    /// supplied, a referenced file is located via the catalogue first — the
+    /// canonical ECDIS mechanism — before falling back to directory probing.
+    /// </param>
+    public ExternalTextFileResolver(
+        IAssetSource source,
+        string? datasetRelativePath = null,
+        IReadOnlyDictionary<string, string>? supportFiles = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         _source = source;
         _baseDirectory = GetDirectory(datasetRelativePath);
+        _supportFiles = supportFiles;
     }
 
     /// <summary>
@@ -87,9 +101,23 @@ public sealed class ExternalTextFileResolver
         if (normalized.Length == 0)
             return null;
 
-        // Prefer the dataset's own directory, then fall back to the exchange
-        // set root. Skip the second probe when the file name already carries a
-        // path or no base directory is known.
+        // 1. Catalogue-declared location (the canonical ECDIS mechanism):
+        //    look the file up by its bare name in the exchange set's
+        //    supportFileDiscoveryMetadata. S-100 Edition 5.2.1 Part 17.
+        if (_supportFiles is not null)
+        {
+            var bareName = LastSegment(normalized);
+            if (_supportFiles.TryGetValue(bareName, out var declaredPath)
+                && !string.IsNullOrEmpty(declaredPath)
+                && TryRead(declaredPath, out var declaredText))
+            {
+                return declaredText;
+            }
+        }
+
+        // 2. Prefer the dataset's own directory, then fall back to the exchange
+        //    set root. Skip these probes when the file name already carries a
+        //    path or no base directory is known.
         if (!string.IsNullOrEmpty(_baseDirectory)
             && !normalized.Contains('/'))
         {
@@ -98,7 +126,41 @@ public sealed class ExternalTextFileResolver
                 return text;
         }
 
-        return TryRead(normalized, out var rootText) ? rootText : null;
+        if (TryRead(normalized, out var rootText))
+            return rootText;
+
+        // 3. Heuristic fallback for loose datasets whose support files sit in a
+        //    sibling "support/" directory (the common S-101 exchange-set layout)
+        //    without a catalogue to consult.
+        if (!normalized.Contains('/'))
+        {
+            foreach (var dir in SupportProbeDirectories())
+            {
+                if (TryRead(dir + "/" + normalized, out var supportText))
+                    return supportText;
+            }
+        }
+
+        return null;
+    }
+
+    private static string LastSegment(string path)
+    {
+        var idx = path.LastIndexOf('/');
+        return idx < 0 ? path : path[(idx + 1)..];
+    }
+
+    private IEnumerable<string> SupportProbeDirectories()
+    {
+        // <root>/support and <dataset-parent>/support cover the two layouts
+        // seen in the wild: support files alongside the catalogue, and support
+        // files beside the dataset's own directory.
+        yield return "support";
+        if (!string.IsNullOrEmpty(_baseDirectory))
+        {
+            var parent = GetDirectory(_baseDirectory);
+            yield return (string.IsNullOrEmpty(parent) ? "support" : parent + "/support");
+        }
     }
 
     private bool TryRead(string relativePath, out string? text)

--- a/src/EncDotNet.S100.Datasets.Pipelines/ExternalTextFileResolver.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/ExternalTextFileResolver.cs
@@ -14,7 +14,8 @@ namespace EncDotNet.S100.Datasets.Pipelines;
 /// <c>supportFileDiscoveryMetadata</c> is supplied, the referenced file is
 /// located through it first (the canonical ECDIS mechanism); otherwise the
 /// file is looked up relative to the dataset's own directory, then at the
-/// exchange-set root, then under a sibling <c>support/</c> directory.
+/// exchange-set root, then under a sibling <c>SUPPORT_FILES</c> /
+/// <c>support</c> directory (the S100_ROOT exchange-set layout).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -130,8 +131,8 @@ public sealed class ExternalTextFileResolver
             return rootText;
 
         // 3. Heuristic fallback for loose datasets whose support files sit in a
-        //    sibling "support/" directory (the common S-101 exchange-set layout)
-        //    without a catalogue to consult.
+        //    sibling SUPPORT_FILES / support directory (the S100_ROOT
+        //    exchange-set layout) without a catalogue to consult.
         if (!normalized.Contains('/'))
         {
             foreach (var dir in SupportProbeDirectories())
@@ -152,15 +153,34 @@ public sealed class ExternalTextFileResolver
 
     private IEnumerable<string> SupportProbeDirectories()
     {
-        // <root>/support and <dataset-parent>/support cover the two layouts
-        // seen in the wild: support files alongside the catalogue, and support
-        // files beside the dataset's own directory.
-        yield return "support";
-        if (!string.IsNullOrEmpty(_baseDirectory))
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dir in EnumerateSupportProbeDirectories())
         {
-            var parent = GetDirectory(_baseDirectory);
-            yield return (string.IsNullOrEmpty(parent) ? "support" : parent + "/support");
+            if (!string.IsNullOrEmpty(dir) && seen.Add(dir))
+                yield return dir;
         }
+    }
+
+    private IEnumerable<string> EnumerateSupportProbeDirectories()
+    {
+        // The S100_ROOT exchange-set layout (S-100 Edition 5.2.1 Part 17) keeps
+        // referenced text files in a SUPPORT_FILES folder that is a sibling of the
+        // DATASET_FILES folder holding the cell; older / loose layouts use a
+        // lower-case support/. Probe both spellings at the root, under the
+        // dataset's own directory, and beside it.
+        yield return "SUPPORT_FILES";
+        yield return "support";
+
+        if (string.IsNullOrEmpty(_baseDirectory))
+            yield break;
+
+        yield return _baseDirectory + "/SUPPORT_FILES";
+        yield return _baseDirectory + "/support";
+
+        var parent = GetDirectory(_baseDirectory);
+        var prefix = string.IsNullOrEmpty(parent) ? string.Empty : parent + "/";
+        yield return prefix + "SUPPORT_FILES";
+        yield return prefix + "support";
     }
 
     private bool TryRead(string relativePath, out string? text)

--- a/src/EncDotNet.S100.Datasets.Pipelines/FeatureInfoBuilder.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/FeatureInfoBuilder.cs
@@ -171,4 +171,103 @@ public static class FeatureInfoBuilder
         }
         return result;
     }
+
+    /// <summary>
+    /// S-100 attribute codes (and their S-57-era aliases) whose value names
+    /// an externally referenced text file co-located in the exchange set.
+    /// Defined by the S-101 Feature Catalogue simple attribute
+    /// <c>fileReference</c> ("The file name of an externally referenced
+    /// text file"), aliases <c>TXTDSC</c> and <c>NTXTDS</c>. Matched
+    /// case-insensitively when resolving file references.
+    /// </summary>
+    public static readonly IReadOnlySet<string> FileReferenceAttributeCodes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "fileReference",
+            "TXTDSC",
+            "NTXTDS",
+        };
+
+    /// <summary>
+    /// Returns a copy of <paramref name="attributes"/> in which every
+    /// file-reference leaf (see <see cref="FileReferenceAttributeCodes"/>)
+    /// has its <see cref="PickAttribute.ExternalText"/> populated from
+    /// <paramref name="resolver"/>. The resolver is invoked with the
+    /// referenced file name (the attribute's <see cref="PickAttribute.RawValue"/>)
+    /// and should return the file's textual content, or <c>null</c> when it
+    /// cannot be resolved (missing, oversized, unreadable). Complex-attribute
+    /// children are walked recursively, since <c>fileReference</c> is bound
+    /// as a sub-attribute of the S-101 <c>information</c> / <c>textContent</c>
+    /// complex attributes (S-101 Feature Catalogue).
+    /// </summary>
+    /// <param name="attributes">The attribute tree to enrich.</param>
+    /// <param name="resolver">
+    /// File-name → text resolver, typically backed by the dataset's
+    /// exchange-set asset source. Must not be <c>null</c>.
+    /// </param>
+    /// <returns>
+    /// A new list with resolved file references; rows that are not file
+    /// references, carry no value, or whose file could not be resolved are
+    /// returned with <see cref="PickAttribute.ExternalText"/> left
+    /// <c>null</c>. The input list is returned unchanged when it contains no
+    /// file references.
+    /// </returns>
+    public static IReadOnlyList<PickAttribute> ResolveFileReferences(
+        IReadOnlyList<PickAttribute> attributes,
+        Func<string, string?> resolver)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        if (!ContainsFileReference(attributes))
+            return attributes;
+
+        var result = new List<PickAttribute>(attributes.Count);
+        foreach (var attr in attributes)
+            result.Add(ResolveFileReference(attr, resolver));
+        return result;
+    }
+
+    private static bool ContainsFileReference(IReadOnlyList<PickAttribute> attributes)
+    {
+        foreach (var attr in attributes)
+        {
+            if (FileReferenceAttributeCodes.Contains(attr.Code) && !attr.HasExternalText)
+                return true;
+            if (attr.Children.Count > 0 && ContainsFileReference(attr.Children))
+                return true;
+        }
+        return false;
+    }
+
+    private static PickAttribute ResolveFileReference(
+        PickAttribute attr, Func<string, string?> resolver)
+    {
+        var children = attr.Children.Count == 0
+            ? attr.Children
+            : ResolveFileReferences(attr.Children, resolver);
+
+        var isFileReference =
+            FileReferenceAttributeCodes.Contains(attr.Code)
+            && !attr.HasExternalText
+            && !string.IsNullOrWhiteSpace(attr.RawValue);
+
+        var text = isFileReference ? resolver(attr.RawValue) : null;
+
+        if (text is null && ReferenceEquals(children, attr.Children))
+            return attr;
+
+        return new PickAttribute
+        {
+            Code = attr.Code,
+            Name = attr.Name,
+            RawValue = attr.RawValue,
+            DisplayValue = attr.DisplayValue,
+            DateTimeValue = attr.DateTimeValue,
+            DateTimeRangeValue = attr.DateTimeRangeValue,
+            DepthMetresValue = attr.DepthMetresValue,
+            ExternalText = text ?? attr.ExternalText,
+            Children = children,
+        };
+    }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/PickAttribute.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/PickAttribute.cs
@@ -74,6 +74,25 @@ public sealed class PickAttribute
     public IReadOnlyList<PickAttribute> Children { get; init; } = [];
 
     /// <summary>
+    /// The resolved textual content of the external text file named by a
+    /// <c>fileReference</c> attribute (S-100 Edition 5.2.1 Part 5; S-101
+    /// Feature Catalogue simple attribute <c>fileReference</c>, aliases
+    /// <c>TXTDSC</c> / <c>NTXTDS</c>), or <c>null</c> when this row is not a
+    /// file reference or the referenced file could not be resolved from the
+    /// dataset's exchange set. <see cref="RawValue"/> still carries the
+    /// referenced file name. Presentation layers (e.g. the viewer's pick
+    /// report) surface this as expandable text, mirroring how an ECDIS lets
+    /// the mariner read an externally referenced textual description.
+    /// </summary>
+    public string? ExternalText { get; init; }
+
+    /// <summary>
+    /// <c>true</c> when <see cref="ExternalText"/> carries resolved content
+    /// from an external text file referenced by this attribute.
+    /// </summary>
+    public bool HasExternalText => !string.IsNullOrEmpty(ExternalText);
+
+    /// <summary>
     /// The label most viewers want to render: <see cref="Name"/> when
     /// available, otherwise <see cref="Code"/>.
     /// </summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/README.md
+++ b/src/EncDotNet.S100.Datasets.Pipelines/README.md
@@ -250,8 +250,14 @@ for the full design rationale.
 - `ExternalTextFileResolver` — resolves the textual content of external
   files named by S-100 `fileReference` attributes (S-101 FC; alias
   `TXTDSC` / `NTXTDS`, e.g. on Caution Area, Tidal Stream Panel Data)
-  from the dataset's exchange-set asset source. `S101DatasetProcessor`
-  uses it (via `FeatureInfoBuilder.ResolveFileReferences`) to populate
+  from the dataset's exchange-set asset source. When the exchange-set
+  catalogue's `supportFileDiscoveryMetadata` is supplied (built by
+  `ExchangeSetLoader` and passed through the factory), the file is located
+  through it first — the canonical ECDIS mechanism, which honours the
+  catalogue-declared `support/` sub-directory — before falling back to
+  probing the dataset directory, the exchange-set root, and a sibling
+  `support/` directory. `S101DatasetProcessor` uses it (via
+  `FeatureInfoBuilder.ResolveFileReferences`) to populate
   `PickAttribute.ExternalText`, so a pick / object-info consumer can show
   the referenced text the way an ECDIS does.
 - `GmlDatasetProcessorBase` — common base for the GML-encoded vector

--- a/src/EncDotNet.S100.Datasets.Pipelines/README.md
+++ b/src/EncDotNet.S100.Datasets.Pipelines/README.md
@@ -247,6 +247,13 @@ for the full design rationale.
   `CoveragePickHelper`, `StationTimeSeriesSnapshot` — shared building
   blocks for the per-processor `Render` / `GetFeatureInfo` /
   `GetCoverageInfo` paths.
+- `ExternalTextFileResolver` — resolves the textual content of external
+  files named by S-100 `fileReference` attributes (S-101 FC; alias
+  `TXTDSC` / `NTXTDS`, e.g. on Caution Area, Tidal Stream Panel Data)
+  from the dataset's exchange-set asset source. `S101DatasetProcessor`
+  uses it (via `FeatureInfoBuilder.ResolveFileReferences`) to populate
+  `PickAttribute.ExternalText`, so a pick / object-info consumer can show
+  the referenced text the way an ECDIS does.
 - `GmlDatasetProcessorBase` — common base for the GML-encoded vector
   processors (S-122 / S-124 / S-125 / S-127 / S-128 / S-129 / S-131 /
   S-201 / S-411 / S-421).

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -33,6 +33,14 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
     private readonly FeatureCatalogueManager _featureCatalogueManager;
     private readonly string _fileName;
 
+    // Resolves the textual content of external text files named by
+    // `fileReference` attributes (S-101 FC, alias TXTDSC / NTXTDS) from the
+    // dataset's exchange-set asset source, so the pick / object-info path can
+    // surface the referenced text (e.g. Caution Area, Tidal Stream Panel
+    // Data). Null when the dataset was opened from a bare stream with no
+    // resolvable support-file location.
+    private readonly Func<string, string?>? _externalTextResolver;
+
     // Deterministic per-dataset scope prepended to the portrayal cache key when
     // forming the (Mapsui-side) pattern-clip cache key. Encodes dataset content
     // (SHA-256) + name + edition + CRS so the resulting clip key is globally
@@ -130,7 +138,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager,
         IPortrayalInstructionCache? sharedInstructionCache = null)
-        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueManager, sharedInstructionCache)
+        : this(File.OpenRead(path), Path.GetFileName(path), catalogueManager, luaEngine, featureCatalogueManager, sharedInstructionCache, CreateFileSystemResolver(path))
     {
     }
 
@@ -152,7 +160,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
             catalogueManager,
             luaEngine,
             featureCatalogueManager,
-            sharedInstructionCache)
+            sharedInstructionCache,
+            new ExternalTextFileResolver(source, relativePath).AsDelegate())
     {
     }
 
@@ -178,7 +187,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
             catalogueManager,
             luaEngine,
             featureCatalogueManager,
-            sharedInstructionCache)
+            sharedInstructionCache,
+            new ExternalTextFileResolver(source, baseRelativePath).AsDelegate())
     {
     }
 
@@ -188,14 +198,16 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager,
-        IPortrayalInstructionCache? sharedInstructionCache)
+        IPortrayalInstructionCache? sharedInstructionCache,
+        Func<string, string?>? externalTextResolver = null)
         : this(
             PrepareFromStream(datasetStream),
             fileName,
             catalogueManager,
             luaEngine,
             featureCatalogueManager,
-            sharedInstructionCache)
+            sharedInstructionCache,
+            externalTextResolver)
     {
     }
 
@@ -205,13 +217,15 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager,
-        IPortrayalInstructionCache? sharedInstructionCache)
+        IPortrayalInstructionCache? sharedInstructionCache,
+        Func<string, string?>? externalTextResolver = null)
     {
         _fileName = fileName;
         _luaEngine = luaEngine;
         _provider = catalogueManager.GetProvider("S-101");
         _catalogueManager = catalogueManager;
         _catalogue = new S101PortrayalCatalogue(_provider, _luaEngine);
+        _externalTextResolver = externalTextResolver;
 
         _dataset = prepared.Dataset;
         _updateReport = prepared.Report;
@@ -321,6 +335,22 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
     {
         using var stream = AssetSourceHelpers.OpenSeekable(source, relativePath);
         return ReadAllBytes(stream);
+    }
+
+    /// <summary>
+    /// Builds an external-text resolver for a loose dataset file on the local
+    /// file system, rooted at the dataset's directory so co-located support
+    /// text files named by <c>fileReference</c> attributes resolve. Returns
+    /// <c>null</c> when the path has no directory component.
+    /// </summary>
+    private static Func<string, string?>? CreateFileSystemResolver(string path)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (string.IsNullOrEmpty(directory))
+            return null;
+
+        var source = FileSystemAssetSource.Create(directory);
+        return new ExternalTextFileResolver(source, Path.GetFileName(path)).AsDelegate();
     }
 
     /// <summary>
@@ -939,6 +969,13 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
             feature.Attributes.Select(kv =>
                 new KeyValuePair<string, string?>(kv.Key, kv.Value?.ToString())),
             _decoder);
+
+        // Resolve any `fileReference` attribute (S-101 FC; alias TXTDSC /
+        // NTXTDS) to the textual content of the external file it names,
+        // co-located in the dataset's exchange set, so the pick / object-info
+        // path can surface it (e.g. Caution Area, Tidal Stream Panel Data).
+        if (_externalTextResolver is not null)
+            attributes = FeatureInfoBuilder.ResolveFileReferences(attributes, _externalTextResolver);
 
         return new FeatureInfo
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -341,15 +341,33 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
 
     /// <summary>
     /// Builds an external-text resolver for a loose dataset file on the local
-    /// file system, rooted at the dataset's directory so co-located support
-    /// text files named by <c>fileReference</c> attributes resolve. Returns
-    /// <c>null</c> when the path has no directory component.
+    /// file system so support text files named by <c>fileReference</c>
+    /// attributes resolve. The resolver is normally rooted at the dataset's own
+    /// directory; when the dataset sits in the S100_ROOT exchange-set layout
+    /// (S-100 Edition 5.2.1 Part 17) — a <c>DATASET_FILES</c> folder with a
+    /// sibling <c>SUPPORT_FILES</c> folder — it is rooted one level up so the
+    /// sibling support directory is reachable. Returns <c>null</c> when the path
+    /// has no directory component.
     /// </summary>
     private static Func<string, string?>? CreateFileSystemResolver(string path)
     {
         var directory = Path.GetDirectoryName(Path.GetFullPath(path));
         if (string.IsNullOrEmpty(directory))
             return null;
+
+        // S100_ROOT layout keeps referenced text files in a SUPPORT_FILES folder
+        // that is a sibling of the DATASET_FILES folder holding the cell. Root the
+        // asset source at the parent so that sibling is in scope, and record the
+        // dataset's path relative to that parent.
+        var parent = Path.GetDirectoryName(directory);
+        if (!string.IsNullOrEmpty(parent)
+            && (Directory.Exists(Path.Combine(parent, "SUPPORT_FILES"))
+                || Directory.Exists(Path.Combine(parent, "support"))))
+        {
+            var rootedSource = FileSystemAssetSource.Create(parent);
+            var relativePath = Path.GetFileName(directory) + "/" + Path.GetFileName(path);
+            return new ExternalTextFileResolver(rootedSource, relativePath).AsDelegate();
+        }
 
         var source = FileSystemAssetSource.Create(directory);
         return new ExternalTextFileResolver(source, Path.GetFileName(path)).AsDelegate();

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -153,7 +153,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager,
-        IPortrayalInstructionCache? sharedInstructionCache = null)
+        IPortrayalInstructionCache? sharedInstructionCache = null,
+        IReadOnlyDictionary<string, string>? supportFiles = null)
         : this(
             AssetSourceHelpers.OpenSeekable(source, relativePath),
             AssetSourceHelpers.GetFileName(relativePath),
@@ -161,7 +162,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
             luaEngine,
             featureCatalogueManager,
             sharedInstructionCache,
-            new ExternalTextFileResolver(source, relativePath).AsDelegate())
+            new ExternalTextFileResolver(source, relativePath, supportFiles).AsDelegate())
     {
     }
 
@@ -180,7 +181,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
         PortrayalCatalogueManager catalogueManager,
         ILuaEngine luaEngine,
         FeatureCatalogueManager featureCatalogueManager,
-        IPortrayalInstructionCache? sharedInstructionCache = null)
+        IPortrayalInstructionCache? sharedInstructionCache = null,
+        IReadOnlyDictionary<string, string>? supportFiles = null)
         : this(
             PrepareWithUpdates(source, baseRelativePath, updateRelativePaths),
             AssetSourceHelpers.GetFileName(baseRelativePath),
@@ -188,7 +190,7 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
             luaEngine,
             featureCatalogueManager,
             sharedInstructionCache,
-            new ExternalTextFileResolver(source, baseRelativePath).AsDelegate())
+            new ExternalTextFileResolver(source, baseRelativePath, supportFiles).AsDelegate())
     {
     }
 

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -59,12 +59,7 @@ public static class ExchangeCatalogueReader
                 .Where(e => e.Name.LocalName.EndsWith("_DatasetDiscoveryMetadata", StringComparison.Ordinal))
                 .Select(e => ReadDatasetDiscovery(e, xc, lan))
                 .ToList() ?? [],
-            SupportFileDiscoveryMetadata = root
-                .Element(xc + "supportFileDiscoveryMetadata")?
-                .Elements()
-                .Where(e => e.Name.LocalName.EndsWith("_SupportFileDiscoveryMetadata", StringComparison.Ordinal))
-                .Select(e => ReadSupportFileDiscovery(e, xc))
-                .ToList() ?? [],
+            SupportFileDiscoveryMetadata = ReadSupportFileDiscoveries(root, xc),
             CatalogueDiscoveryMetadata = root
                 .Element(xc + "catalogueDiscoveryMetadata")?
                 .Elements()
@@ -148,12 +143,50 @@ public static class ExchangeCatalogueReader
         };
     }
 
+    /// <summary>
+    /// Reads all support-file discovery records from the catalogue root,
+    /// tolerating both encodings seen in the wild: a single
+    /// <c>supportFileDiscoveryMetadata</c> container wrapping typed
+    /// <c>*_SupportFileDiscoveryMetadata</c> children, and repeated
+    /// <c>supportFileDiscoveryMetadata</c> elements that carry the fields
+    /// inline. S-100 Edition 5.2.1 Part 17.
+    /// </summary>
+    private static List<SupportFileDiscoveryMetadata> ReadSupportFileDiscoveries(XElement root, XNamespace xc)
+    {
+        var result = new List<SupportFileDiscoveryMetadata>();
+
+        foreach (var container in root.Elements(xc + "supportFileDiscoveryMetadata"))
+        {
+            var typed = container
+                .Elements()
+                .Where(e => e.Name.LocalName.EndsWith("_SupportFileDiscoveryMetadata", StringComparison.Ordinal))
+                .ToList();
+
+            if (typed.Count > 0)
+            {
+                result.AddRange(typed.Select(e => ReadSupportFileDiscovery(e, xc)));
+                continue;
+            }
+
+            // Inline (repeated-sibling) form: the container itself is the record.
+            if (container.Element(xc + "fileName") is not null)
+                result.Add(ReadSupportFileDiscovery(container, xc));
+        }
+
+        return result;
+    }
+
     private static SupportFileDiscoveryMetadata ReadSupportFileDiscovery(XElement element, XNamespace xc)
     {
         return new SupportFileDiscoveryMetadata
         {
             FileName = (string)element.Element(xc + "fileName")!,
-            FilePath = (string?)element.Element(xc + "filePath"),
+            // S-100 Edition 5.2.1 Part 17: support file discovery declares its
+            // directory via <fileLocation>; some producers instead reuse the
+            // dataset-style <filePath>. Accept either so support files placed in
+            // a sub-directory (e.g. "support/") resolve correctly.
+            FilePath = (string?)element.Element(xc + "filePath")
+                ?? (string?)element.Element(xc + "fileLocation"),
             RevisionStatus = (string?)element.Element(xc + "revisionStatus"),
             EditionNumber = ParseInt(element, "editionNumber", xc),
             IssueDate = (string?)element.Element(xc + "issueDate"),

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeSet.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeSet.cs
@@ -147,6 +147,15 @@ public sealed class ExchangeSet : IDisposable
             return normalizedName;
         }
 
+        // Guard against double-suffixing when the directory already carries
+        // the file name (some producers fold the whole path into the
+        // <fileLocation> element). S-100 Edition 5.2.1 Part 17.
+        if (directory.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)
+            || directory.EndsWith("/" + normalizedName, StringComparison.OrdinalIgnoreCase))
+        {
+            return directory;
+        }
+
         return directory + "/" + normalizedName;
     }
 }

--- a/src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs
+++ b/src/EncDotNet.S100.Portrayals/PortrayalAssetCache.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Xml.Xsl;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
@@ -99,19 +100,26 @@ public interface IPortrayalAssetCache
 
 /// <summary>
 /// Default <see cref="IPortrayalAssetCache"/> implementation backed by
-/// plain <see cref="Dictionary{TKey, TValue}"/> instances.
+/// <see cref="ConcurrentDictionary{TKey, TValue}"/> instances.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Thread-safety:</b> this implementation is <em>not</em>
-/// thread-safe. All slots are non-concurrent dictionaries. Today the
-/// dataset processors that consume catalogues read and write the cache
-/// on a single pipeline thread per dataset, which makes this safe in
-/// practice — but two pipelines running in parallel against catalogues
-/// for the same spec would race. Hardening to
-/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>
-/// is tracked separately by PR-6 of the asset-caching audit
+/// <b>Thread-safety:</b> the per-asset slots are
+/// <see cref="ConcurrentDictionary{TKey, TValue}"/> instances, so two or
+/// more dataset pipelines rendering in parallel against catalogues for the
+/// same spec (a single shared cache) can read and write them concurrently
+/// without corrupting their internal state. The catalogues' load logic is
+/// idempotent — a concurrent miss may load the same asset more than once,
+/// with last-writer-wins — which is acceptable because the decoded asset is
+/// value-equivalent regardless of which thread produced it. This implements
+/// the hardening tracked by PR-6 of the asset-caching audit
 /// (<c>docs/internal/asset-caching-audit.md</c> §6 PR-6).
+/// </para>
+/// <para>
+/// Palette loading remains serialized through <see cref="PaletteLoadGate"/>
+/// and <see cref="PalettesLoaded"/>; the palette slot keeps a plain
+/// dictionary because its concrete-typed view is part of the protected
+/// <c>GmlPortrayalCatalogueBase.LoadPalettes</c> API.
 /// </para>
 /// <para>
 /// The <see cref="LuaSources"/> dictionary uses
@@ -124,19 +132,19 @@ public sealed class PortrayalAssetCache : IPortrayalAssetCache
 {
     /// <inheritdoc/>
     public IDictionary<string, XslCompiledTransform> CompiledXslt { get; } =
-        new Dictionary<string, XslCompiledTransform>(StringComparer.OrdinalIgnoreCase);
+        new ConcurrentDictionary<string, XslCompiledTransform>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IDictionary<string, SvgSymbol> Symbols { get; } =
-        new Dictionary<string, SvgSymbol>(StringComparer.OrdinalIgnoreCase);
+        new ConcurrentDictionary<string, SvgSymbol>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IDictionary<string, LineStyle> LineStyles { get; } =
-        new Dictionary<string, LineStyle>(StringComparer.OrdinalIgnoreCase);
+        new ConcurrentDictionary<string, LineStyle>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IDictionary<string, AreaFill> AreaFills { get; } =
-        new Dictionary<string, AreaFill>(StringComparer.OrdinalIgnoreCase);
+        new ConcurrentDictionary<string, AreaFill>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IDictionary<PaletteType, ColorPalette> Palettes => PalettesDictionary;
@@ -145,17 +153,18 @@ public sealed class PortrayalAssetCache : IPortrayalAssetCache
     /// Concrete-typed view of the palette dictionary, used by
     /// <c>GmlPortrayalCatalogueBase.LoadPalettes</c> whose signature is
     /// part of the protected API and remains <c>Dictionary&lt;,&gt;</c>.
+    /// Writes are serialized by <see cref="PaletteLoadGate"/>.
     /// </summary>
     internal Dictionary<PaletteType, ColorPalette> PalettesDictionary { get; } =
         new Dictionary<PaletteType, ColorPalette>();
 
     /// <inheritdoc/>
     public IDictionary<string, Script> LuaScripts { get; } =
-        new Dictionary<string, Script>(StringComparer.OrdinalIgnoreCase);
+        new ConcurrentDictionary<string, Script>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IDictionary<string, string?> LuaSources { get; } =
-        new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        new ConcurrentDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public bool PalettesLoaded { get; set; }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -238,6 +238,7 @@ internal static class Strings
     public static string Pick_SpecFormat => Get(nameof(Pick_SpecFormat));
     public static string Pick_SourceFormat => Get(nameof(Pick_SourceFormat));
     public static string Pick_AttributesHeading => Get(nameof(Pick_AttributesHeading));
+    public static string Pick_FileReference_Header => Get(nameof(Pick_FileReference_Header));
     public static string Pick_NoAttributes => Get(nameof(Pick_NoAttributes));
     public static string Pick_HitListHeader => Get(nameof(Pick_HitListHeader));
     public static string Pick_HitListItemFormat => Get(nameof(Pick_HitListItemFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -593,6 +593,9 @@
   <data name="Pick_AttributesHeading" xml:space="preserve">
     <value>ATTRIBUTES</value>
   </data>
+  <data name="Pick_FileReference_Header" xml:space="preserve">
+    <value>Referenced text</value>
+  </data>
   <data name="Pick_NoAttributes" xml:space="preserve">
     <value>(no attributes)</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -124,6 +124,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
                 DepthMetresValue = attr.DepthMetresValue,
+                ExternalText = attr.ExternalText,
                 Children = children,
             };
         }
@@ -139,6 +140,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
                 DepthMetresValue = attr.DepthMetresValue,
+                ExternalText = attr.ExternalText,
                 Children = children,
             };
         }
@@ -154,6 +156,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
                 DepthMetresValue = attr.DepthMetresValue,
+                ExternalText = attr.ExternalText,
                 Children = children,
             };
         }
@@ -169,6 +172,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
                 DateTimeValue = attr.DateTimeValue,
                 DateTimeRangeValue = attr.DateTimeRangeValue,
                 DepthMetresValue = attr.DepthMetresValue,
+                ExternalText = attr.ExternalText,
                 Children = children,
             };
         }

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -22,6 +22,7 @@
         -->
         <DataTemplate x:Key="AttributeCellTemplate" x:DataType="pp:PickAttribute">
             <Border Name="AttrRow" Padding="12,9" Background="Transparent">
+                <StackPanel>
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" SharedSizeGroup="AttrLabel" />
@@ -70,6 +71,23 @@
                         </TextBlock>
                     </Grid>
                 </Grid>
+                <!--
+                    External text referenced by a `fileReference` attribute
+                    (S-101 FC; alias TXTDSC / NTXTDS): the value above is the
+                    file name, this expander reveals the resolved file content,
+                    mirroring an ECDIS "show textual description" affordance.
+                -->
+                <Expander Margin="0,6,0,0"
+                          Padding="0"
+                          Header="{x:Static loc:Strings.Pick_FileReference_Header}"
+                          IsVisible="{Binding HasExternalText}">
+                    <SelectableTextBlock Text="{Binding ExternalText}"
+                                         FontSize="12"
+                                         FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
+                                         TextWrapping="Wrap"
+                                         Margin="0,6,0,0" />
+                </Expander>
+                </StackPanel>
             </Border>
         </DataTemplate>
 

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
@@ -123,6 +123,66 @@ public class ExchangeCatalogueReaderTests
     }
 
     [Fact]
+    public void SupportFiles_RepeatedInlineElements_WithFileLocation_AreParsed()
+    {
+        // Real-world S-101 trial cells repeat <supportFileDiscoveryMetadata>
+        // with the fields inline and declare the directory via <fileLocation>.
+        const string xml = """
+            <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
+                <S100XC:identifier>
+                    <S100XC:identifier>TEST</S100XC:identifier>
+                    <S100XC:dateTime>2024-01-01</S100XC:dateTime>
+                </S100XC:identifier>
+                <S100XC:supportFileDiscoveryMetadata>
+                    <S100XC:fileName>101GB00N00659.TXT</S100XC:fileName>
+                    <S100XC:fileLocation>support</S100XC:fileLocation>
+                </S100XC:supportFileDiscoveryMetadata>
+                <S100XC:supportFileDiscoveryMetadata>
+                    <S100XC:fileName>101GB00N00660.TXT</S100XC:fileName>
+                    <S100XC:fileLocation>support</S100XC:fileLocation>
+                </S100XC:supportFileDiscoveryMetadata>
+            </S100XC:S100_ExchangeCatalogue>
+            """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        var catalogue = ExchangeCatalogueReader.Read(stream);
+
+        Assert.Equal(2, catalogue.SupportFileDiscoveryMetadata.Count);
+        var first = catalogue.SupportFileDiscoveryMetadata[0];
+        Assert.Equal("101GB00N00659.TXT", first.FileName);
+        Assert.Equal("support", first.FilePath);
+        Assert.Equal("support/101GB00N00659.TXT", first.RelativePath);
+    }
+
+    [Fact]
+    public void SupportFiles_ContainerWithTypedChildren_AreParsed()
+    {
+        // The other valid encoding: a single container wrapping a typed
+        // S100_SupportFileDiscoveryMetadata record using <filePath>.
+        const string xml = """
+            <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
+                <S100XC:identifier>
+                    <S100XC:identifier>TEST</S100XC:identifier>
+                    <S100XC:dateTime>2024-01-01</S100XC:dateTime>
+                </S100XC:identifier>
+                <S100XC:supportFileDiscoveryMetadata>
+                    <S100XC:S100_SupportFileDiscoveryMetadata>
+                        <S100XC:fileName>101GB00G2BXXX.TXT</S100XC:fileName>
+                        <S100XC:filePath>support</S100XC:filePath>
+                    </S100XC:S100_SupportFileDiscoveryMetadata>
+                </S100XC:supportFileDiscoveryMetadata>
+            </S100XC:S100_ExchangeCatalogue>
+            """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        var catalogue = ExchangeCatalogueReader.Read(stream);
+
+        var entry = Assert.Single(catalogue.SupportFileDiscoveryMetadata);
+        Assert.Equal("101GB00G2BXXX.TXT", entry.FileName);
+        Assert.Equal("support/101GB00G2BXXX.TXT", entry.RelativePath);
+    }
+
+    [Fact]
     public void CatalogueFiles_IsEmpty()
     {
         var catalogue = ReadTestCatalogue();

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeSetPathResolutionTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeSetPathResolutionTests.cs
@@ -62,6 +62,16 @@ public class ExchangeSetPathResolutionTests
     }
 
     [Fact]
+    public void ResolveRelativePath_DoesNotDoubleSuffixWhenDirectoryAlreadyCarriesFileName()
+    {
+        // Some producers fold the whole path into the support-file
+        // <fileLocation> element while still repeating the bare <fileName>.
+        Assert.Equal(
+            "support/101GB00N00659.TXT",
+            ExchangeSet.ResolveRelativePath("support/101GB00N00659.TXT", "101GB00N00659.TXT"));
+    }
+
+    [Fact]
     public void Read_SeparateFilePath_CapturesFilePathAndResolvesRelativePath()
     {
         var catalogue = ExchangeCatalogueReader.Read(GetFixturePath("SeparateFilePath_CATALOG.XML"));

--- a/tests/EncDotNet.S100.Pipelines.Tests/ExternalTextFileResolverTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/ExternalTextFileResolverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using EncDotNet.S100.Core;
@@ -96,5 +97,35 @@ public sealed class ExternalTextFileResolverTests : IDisposable
         Encoding.ASCII.GetBytes("hello").CopyTo(withText, 3);
 
         Assert.Equal("hello", ExternalTextFileResolver.Decode(withText));
+    }
+
+    [Fact]
+    public void Resolve_UsesCatalogueSupportFileMap()
+    {
+        // The catalogue declares the file under a "support/" sub-directory,
+        // which neither the dataset directory nor the root probe would find.
+        var supportDir = Path.Combine(_dir, "support");
+        Directory.CreateDirectory(supportDir);
+        File.WriteAllText(Path.Combine(supportDir, "101GB00N00659.TXT"), "TIDAL STREAM STATIONS");
+
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["101GB00N00659.TXT"] = "support/101GB00N00659.TXT",
+        };
+        var resolver = new ExternalTextFileResolver(
+            FileSystemAssetSource.Create(_dir), "101GB0050242H/101GB0050242H.000", map);
+
+        Assert.Equal("TIDAL STREAM STATIONS", resolver.Resolve("101GB00N00659.TXT"));
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToSupportDirectory_WhenNoCatalogueMap()
+    {
+        var supportDir = Path.Combine(_dir, "support");
+        Directory.CreateDirectory(supportDir);
+        File.WriteAllText(Path.Combine(supportDir, "NOTE.TXT"), "Caution.");
+
+        // No catalogue map; the heuristic "support/" probe should still locate it.
+        Assert.Equal("Caution.", CreateResolver().Resolve("NOTE.TXT"));
     }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/ExternalTextFileResolverTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/ExternalTextFileResolverTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Text;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ExternalTextFileResolver"/>: confirms it
+/// resolves the textual content of external files named by S-100
+/// <c>fileReference</c> attributes from a co-located asset source, applies
+/// the size bound, and decodes UTF-8 / Latin-1 content correctly.
+/// </summary>
+public sealed class ExternalTextFileResolverTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ExternalTextFileResolverTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "extref-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* best-effort cleanup */ }
+    }
+
+    private ExternalTextFileResolver CreateResolver(string datasetRelativePath = "101AA.000")
+        => new(FileSystemAssetSource.Create(_dir), datasetRelativePath);
+
+    [Fact]
+    public void Resolve_ReadsCoLocatedTextFile()
+    {
+        File.WriteAllText(Path.Combine(_dir, "CAUTION.TXT"), "Beware of strong currents.");
+
+        var text = CreateResolver().Resolve("CAUTION.TXT");
+
+        Assert.Equal("Beware of strong currents.", text);
+    }
+
+    [Fact]
+    public void Resolve_NormalizesBackslashAndFileUri()
+    {
+        File.WriteAllText(Path.Combine(_dir, "PANEL.TXT"), "Tidal stream data.");
+
+        var text = CreateResolver().Resolve("file:/PANEL.TXT");
+
+        Assert.Equal("Tidal stream data.", text);
+    }
+
+    [Fact]
+    public void Resolve_MissingFileReturnsNull()
+    {
+        Assert.Null(CreateResolver().Resolve("MISSING.TXT"));
+    }
+
+    [Fact]
+    public void Resolve_NullOrEmptyReturnsNull()
+    {
+        var resolver = CreateResolver();
+        Assert.Null(resolver.Resolve(""));
+        Assert.Null(resolver.Resolve("   "));
+    }
+
+    [Fact]
+    public void Resolve_OversizedFileReturnsNull()
+    {
+        var big = new string('x', (int)ExternalTextFileResolver.MaxFileSizeBytes + 1);
+        File.WriteAllText(Path.Combine(_dir, "BIG.TXT"), big);
+
+        Assert.Null(CreateResolver().Resolve("BIG.TXT"));
+    }
+
+    [Fact]
+    public void Decode_FallsBackToLatin1ForNonUtf8Bytes()
+    {
+        // 0xB0 is the degree sign in ISO 8859-1 and an invalid lone UTF-8
+        // continuation byte, so strict UTF-8 decoding fails and falls back.
+        var bytes = new byte[] { (byte)'5', (byte)'0', 0xB0, (byte)'N' };
+
+        Assert.Equal("50\u00B0N", ExternalTextFileResolver.Decode(bytes));
+    }
+
+    [Fact]
+    public void Decode_HonorsUtf8Bom()
+    {
+        var bytes = new byte[] { 0xEF, 0xBB, 0xBF }
+            .AsSpan()
+            .ToArray();
+        var withText = new byte[bytes.Length + 5];
+        bytes.CopyTo(withText, 0);
+        Encoding.ASCII.GetBytes("hello").CopyTo(withText, 3);
+
+        Assert.Equal("hello", ExternalTextFileResolver.Decode(withText));
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/ExternalTextFileResolverTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/ExternalTextFileResolverTests.cs
@@ -128,4 +128,23 @@ public sealed class ExternalTextFileResolverTests : IDisposable
         // No catalogue map; the heuristic "support/" probe should still locate it.
         Assert.Equal("Caution.", CreateResolver().Resolve("NOTE.TXT"));
     }
+
+    [Fact]
+    public void Resolve_FindsSiblingSupportFilesDirectory_S100RootLayout()
+    {
+        // S100_ROOT exchange-set layout: the cell sits in DATASET_FILES/ and the
+        // referenced text file in a *sibling* SUPPORT_FILES/ directory. The asset
+        // source is rooted at the product folder (the parent of both), and the
+        // dataset's relative path carries the DATASET_FILES segment — mirroring how
+        // S101DatasetProcessor roots the resolver for a loose cell in this layout.
+        Directory.CreateDirectory(Path.Combine(_dir, "DATASET_FILES"));
+        var supportDir = Path.Combine(_dir, "SUPPORT_FILES");
+        Directory.CreateDirectory(supportDir);
+        File.WriteAllText(Path.Combine(supportDir, "101GB00N00659.TXT"), "TIDAL STREAM STATIONS");
+
+        var resolver = new ExternalTextFileResolver(
+            FileSystemAssetSource.Create(_dir), "DATASET_FILES/101GB005DEVRF.000");
+
+        Assert.Equal("TIDAL STREAM STATIONS", resolver.Resolve("101GB00N00659.TXT"));
+    }
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/PortrayalAssetCacheConcurrencyTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PortrayalAssetCacheConcurrencyTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EncDotNet.S100.Portrayals;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Regression tests for the thread-safety of <see cref="PortrayalAssetCache"/>.
+/// A single cache instance is shared by every catalogue that resolves the same
+/// specification (one cache per <c>SpecRef</c>), so concurrent dataset render
+/// pipelines read and write its slots in parallel. Before the PR-6 hardening of
+/// the asset-caching audit these slots were plain <see cref="Dictionary{TKey,TValue}"/>
+/// instances, and concurrent multi-cell loads corrupted them — surfacing as
+/// <see cref="InvalidOperationException"/> ("Operations that change non-concurrent
+/// collections must have exclusive access") thrown from
+/// <c>S101PortrayalCatalogue.GetLuaSourceAsync</c>. The slots are now backed by
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>.
+/// </summary>
+public class PortrayalAssetCacheConcurrencyTests
+{
+    [Fact]
+    public async Task LuaSources_ConcurrentCheckThenLoad_DoesNotThrow()
+    {
+        var cache = new PortrayalAssetCache();
+        var exceptions = new List<Exception>();
+        var sync = new object();
+
+        var tasks = new Task[32];
+        for (var t = 0; t < tasks.Length; t++)
+        {
+            tasks[t] = Task.Run(() =>
+            {
+                try
+                {
+                    for (var i = 0; i < 2000; i++)
+                    {
+                        // Mirror the catalogue's check-then-load-then-set access
+                        // pattern (including caching a null negative lookup).
+                        var key = "module" + (i % 64);
+                        if (!cache.LuaSources.TryGetValue(key, out _))
+                        {
+                            cache.LuaSources[key] = (i % 2 == 0) ? "return {}" : null;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lock (sync)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+
+        Assert.Empty(exceptions);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureInfoBuilderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureInfoBuilderTests.cs
@@ -160,4 +160,91 @@ public class FeatureInfoBuilderTests
         Assert.Equal(lv.Code, result[0].RawValue);
         Assert.Equal(lv.Label, result[0].DisplayValue);
     }
+
+    [Fact]
+    public void ResolveFileReferences_PopulatesExternalTextForFileReferenceLeaf()
+    {
+        var attrs = FeatureInfoBuilder.BuildFlat(
+            new[] { new KeyValuePair<string, string?>("fileReference", "CAUTION.TXT") },
+            decoder: null);
+
+        var resolved = FeatureInfoBuilder.ResolveFileReferences(
+            attrs, name => name == "CAUTION.TXT" ? "Beware of strong currents." : null);
+
+        Assert.Single(resolved);
+        Assert.Equal("fileReference", resolved[0].Code);
+        Assert.Equal("CAUTION.TXT", resolved[0].RawValue);
+        Assert.True(resolved[0].HasExternalText);
+        Assert.Equal("Beware of strong currents.", resolved[0].ExternalText);
+    }
+
+    [Theory]
+    [InlineData("TXTDSC")]
+    [InlineData("NTXTDS")]
+    [InlineData("filereference")]
+    public void ResolveFileReferences_MatchesAliasesCaseInsensitively(string code)
+    {
+        var attrs = FeatureInfoBuilder.BuildFlat(
+            new[] { new KeyValuePair<string, string?>(code, "DOC.TXT") },
+            decoder: null);
+
+        var resolved = FeatureInfoBuilder.ResolveFileReferences(attrs, _ => "content");
+
+        Assert.Equal("content", resolved[0].ExternalText);
+    }
+
+    [Fact]
+    public void ResolveFileReferences_LeavesUnresolvedFileNull()
+    {
+        var attrs = FeatureInfoBuilder.BuildFlat(
+            new[] { new KeyValuePair<string, string?>("fileReference", "MISSING.TXT") },
+            decoder: null);
+
+        var resolved = FeatureInfoBuilder.ResolveFileReferences(attrs, _ => null);
+
+        Assert.False(resolved[0].HasExternalText);
+        Assert.Null(resolved[0].ExternalText);
+    }
+
+    [Fact]
+    public void ResolveFileReferences_DoesNotTouchNonFileReferenceAttributes()
+    {
+        var attrs = FeatureInfoBuilder.BuildFlat(
+            new[] { new KeyValuePair<string, string?>("objectName", "Buoy 12") },
+            decoder: null);
+
+        var resolved = FeatureInfoBuilder.ResolveFileReferences(attrs, _ => "should-not-apply");
+
+        Assert.Same(attrs, resolved);
+        Assert.False(resolved[0].HasExternalText);
+    }
+
+    [Fact]
+    public void ResolveFileReferences_ResolvesNestedComplexAttributeChild()
+    {
+        // `fileReference` is bound as a sub-attribute of the S-101
+        // `information` / `textContent` complex attributes, so the resolver
+        // must walk children.
+        var complex = new[]
+        {
+            new FeatureInfoBuilder.ComplexAttributeRow(
+                "information",
+                new[]
+                {
+                    new KeyValuePair<string, string>("headline", "Caution"),
+                    new KeyValuePair<string, string>("fileReference", "PANEL.TXT"),
+                }),
+        };
+
+        var attrs = FeatureInfoBuilder.Build(
+            System.Array.Empty<KeyValuePair<string, string>>(), complex, decoder: null);
+
+        var resolved = FeatureInfoBuilder.ResolveFileReferences(
+            attrs, name => name == "PANEL.TXT" ? "Tidal stream data." : null);
+
+        var parent = Assert.Single(resolved);
+        var child = System.Linq.Enumerable.Single(
+            parent.Children, c => c.Code == "fileReference");
+        Assert.Equal("Tidal stream data.", child.ExternalText);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -61,6 +61,29 @@ public class PickReportViewModelTests
     }
 
     [Fact]
+    public void SetPick_PreservesExternalTextThroughReformat()
+    {
+        var vm = new PickReportViewModel();
+
+        var fileRef = new PickAttribute
+        {
+            Code = "fileReference",
+            Name = "File Reference",
+            RawValue = "CAUTION.TXT",
+            DisplayValue = null,
+            ExternalText = "Beware of strong currents.",
+            Children = [],
+        };
+
+        vm.SetPick("CautionArea", "Caution Area", "7", "test.000", "S-101", new[] { fileRef });
+
+        var row = Assert.Single(vm.Attributes);
+        Assert.True(row.HasExternalText);
+        Assert.Equal("Beware of strong currents.", row.ExternalText);
+        Assert.Equal("CAUTION.TXT", row.RawValue);
+    }
+
+    [Fact]
     public void SetPick_ReplacesPreviousPickContents()
     {
         var vm = new PickReportViewModel();


### PR DESCRIPTION
## Summary

Several S-101 features (Caution Area, Tidal Stream Panel Data, and other
features carrying a `fileReference` / `TXTDSC` / `NTXTDS` attribute) point
to an external plain-text file inside the exchange set. Previously the pick
report showed only the bare file name; the actual text was never read, so a
mariner had to open the file out-of-band. This PR resolves and displays that
referenced text inline in the pick / object-information report, which is the
behaviour an ECDIS provides.

## Approach

- A new `ExternalTextFileResolver` reads the referenced file from the
  dataset's `IAssetSource` (folder or ZIP), bounded by a max size, decoding
  UTF-8 (BOM-aware) and falling back to Latin-1 for legacy producers.
  Resolution order mirrors how an ECDIS locates support files: the exchange
  set catalogue's `supportFileDiscoveryMetadata` first (the canonical
  mechanism), then the dataset directory, the exchange-set root, and finally
  the S100_ROOT `SUPPORT_FILES` / `support` sibling directories.
- `FeatureInfoBuilder` enriches each `fileReference` attribute with the
  resolved text, surfaced in the viewer's pick report as a "Referenced text"
  expander.

While testing against real UKHO trial cells, three follow-on bugs surfaced
and are fixed here:

- **Catalogue parsing.** `CATALOG.XML` may declare support files either as a
  container with typed children using `<filePath>`, or as repeated inline
  `<supportFileDiscoveryMetadata>` siblings using `<fileLocation>` (S-100
  Edition 5.2.1 Part 17). The reader now handles both shapes and reads
  `filePath ?? fileLocation`; the resulting name -> path map is threaded
  through the loader to the resolver.
- **S100_ROOT layout.** Loose cells live in `DATASET_FILES/` with text files
  in a sibling `SUPPORT_FILES/`. The loose-cell resolver now roots one level
  up when such a sibling exists so the support directory is reachable.
- **Portrayal cache race.** `PortrayalAssetCache` is shared per-spec across
  catalogues; loading many loose S-101 cells concurrently corrupted its
  plain `Dictionary` slots and threw from `GetLuaSourceAsync`, blocking all
  S-101 rendering. The six asset slots are now `ConcurrentDictionary` (the
  PR-6 hardening the class doc already tracked); palette loading stays
  serialized through its existing gate. Verified live via the viewer MCP
  server: 10 loose cells loaded concurrently render with zero exceptions.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [x] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** S-100 Edition 5.2.1 Part 17
(exchange-set `supportFileDiscoveryMetadata`, `fileLocation`, and the
S100_ROOT `DATASET_FILES` / `SUPPORT_FILES` layout); S-101 Feature Catalogue
`fileReference` (`TXTDSC` / `NTXTDS`).

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added coverage for both catalogue support-file shapes, the path
double-suffix guard, catalogue-map plus `support/` and `SUPPORT_FILES`
sibling resolution, a `PortrayalAssetCache` concurrency regression, and the
pick-report enrichment. ExchangeSets (113) and Pipelines (777) suites pass;
full solution builds clean.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to
      `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None. New constructor parameters are optional with defaults; the
`PortrayalAssetCache` slots remain `IDictionary<,>`-typed.