### PR TITLE
Add interactive routes and agent MCP route tools to the viewer

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -134,6 +134,16 @@ viewer's status-bar tooltip (e.g. `http://127.0.0.1:54321/`), and click
 | `open_dataset` *(viewer only, **mutating**)* | Loads a dataset into the live viewer using its existing open code path, so agents can measure the load hot path. `path` is a single file (S-101 `.000`, HDF5 `.h5`, GML, etc.) OR an exchange set (a folder containing `CATALOG.XML`, or a `.zip` of one); the kind is auto-detected. `spec` optionally forces a product-spec hint (e.g. `S-102`) for single-file loads. Returns the resulting catalog id(s), `spec`, bounding box (`southLatitude`/`westLongitude`/`northLatitude`/`eastLongitude`), `count`, `loadDurationMs`, and `timedOut` (exchange-set quiescence). |
 | `close_dataset` *(viewer only, **mutating**)* | Unloads a currently-loaded dataset from the live viewer by its catalog `id` (as returned by `list_datasets` / `open_dataset`), using the viewer's existing close code path so agents can measure the unload hot path. An unknown / already-removed id resolves gracefully as a non-error result with `removed = false`. Returns `removed`, `count`, and `removedDatasets` (`id` + `spec`). |
 | `close_all_datasets` *(viewer only, **mutating**)* | Unloads every currently-loaded dataset from the live viewer through the same close path used by `close_dataset`. Useful for retention loops that repeatedly load → render → unload without restarting the viewer process. Returns `removed`, `count`, and `removedDatasets` (`id` + `spec`). |
+| `create_route` *(viewer only, **mutating**)* | Creates a new, empty editable route in the live viewer's route collection and makes it the active route. Optional `name` and `id` (a GUID is generated when `id` is omitted; ids must be unique). Returns the new route's full state (see `get_route`). Add waypoints with `append_waypoint`. |
+| `list_routes` *(viewer only, read-only)* | Lists every editable route with its `routeId`, `name`, `waypointCount`, `legCount`, `totalDistanceNm`, and `isActive`, plus the collection's `activeRouteId`. |
+| `get_route` *(viewer only, read-only)* | Returns the full state of one route: `routeId`, `name`, `isActive`, `info` (name/author/description/ports/validity/vessel), `waypoints` (`index`, `lat`, `lon`, optional `number`/`name`/`fixed`/`turnRadiusNm`), `legs` (`index`, `geometryType`, computed `distanceNm`/`initialBearingDegrees`, plus the S-421 navigational envelope), and `totalDistanceNm`. Omit `routeId` to read the active route. |
+| `delete_route` *(viewer only, **mutating**)* | Removes a route from the collection. Omit `routeId` to delete the active route. Returns `routeId`, `deleted`, and the new `activeRouteId`. |
+| `append_waypoint` *(viewer only, **mutating**)* | Appends a waypoint (`lat`/`lon`, WGS-84 decimal degrees) to the end of a route, with optional `number`/`name`/`fixed`/`turnRadiusNm`. Omit `routeId` to use the active route. Returns the route's full updated state. |
+| `insert_waypoint` *(viewer only, **mutating**)* | Inserts a waypoint at `index` (in `[0, waypointCount]`; `0` prepends, `waypointCount` appends), splitting the affected leg. Same optional metadata as `append_waypoint`. Omit `routeId` to use the active route. Returns the route's full updated state. |
+| `move_waypoint` *(viewer only, **mutating**)* | Moves the waypoint at `index` (in `[0, waypointCount)`) to a new `lat`/`lon`. Omit `routeId` to use the active route. Returns the route's full updated state. |
+| `delete_waypoint` *(viewer only, **mutating**)* | Removes the waypoint at `index` (in `[0, waypointCount)`), merging the adjacent legs. Omit `routeId` to use the active route. Returns the route's full updated state. |
+| `set_leg_attributes` *(viewer only, **mutating**)* | Updates one leg (`legIndex`, in `[0, legCount)`): its `geometryType` (`loxodrome`\|`geodesic`) and/or navigational envelope (cross-track / channel limits, safety contour & depth, SOG/STW min & max, draft, static & dynamic UKC, safety margin, note — all metres/knots per S-421). All attributes optional; supplied values overwrite, omitted values are unchanged. Omit `routeId` to use the active route. Returns the route's full updated state. |
+| `set_route_info` *(viewer only, **mutating**)* | Updates route metadata (`name`, `author`, `description`, `departurePortId`, `arrivalPortId`, `validityStart`/`validityEnd`) and vessel particulars (`vesselName`/`vesselMmsi`/`vesselImo`/`vesselCallsign`/`vesselLengthMeters`/`vesselBeamMeters`; supplying any vessel field creates the vessel block). All fields optional; supplied values overwrite. Omit `routeId` to use the active route. Returns the route's full updated state. |
 
 ### Read-only vs mutating tools
 
@@ -147,17 +157,20 @@ Tools fall into two groups:
   `describe_feature_type`, `sample_coverage`, `render_to_image` (which
   snapshots from a clone of the live `Map`), `pick_features` (which
   projects a pixel through the live viewport without changing it),
-  `await_render_idle`, and
+  `await_render_idle`,
   `get_render_stats` (which observe the live render loop without
-  changing it).
+  changing it), `list_routes`, and `get_route` (which snapshot the
+  editable route collection without changing it).
 * **Mutating** — modify the live viewer's state (navigator, palette,
-  time step, loaded datasets, etc.). Use only when you intend to
+  time step, loaded datasets, routes, etc.). Use only when you intend to
   drive the viewer's UI from outside. Examples: `set_viewport`,
   `set_palette`, `set_display_category`, `set_time_step`,
-  `set_own_ship`, `open_dataset`, `close_dataset`, and
+  `set_own_ship`, `open_dataset`, `close_dataset`,
   `close_all_datasets` (which
   load / unload datasets through the viewer's own open / close code
-  path).
+  path), and the route-editing family `create_route`, `delete_route`,
+  `append_waypoint`, `insert_waypoint`, `move_waypoint`,
+  `delete_waypoint`, `set_leg_attributes`, and `set_route_info`.
 
 Tool descriptions in the registered MCP catalogue identify each tool
 as one or the other; this table is the canonical reference.
@@ -211,6 +224,33 @@ to project a screen pixel back to a geographic point.
 > dataset?"
 >
 > "Describe feature `LIGHTS.123` in the loaded S-201 dataset."
+>
+> "Plan a mid-channel route from the harbour entrance to the marina:
+> create a route, then append waypoints staying clear of the charted
+> safety contour, and set each leg's safety contour and cross-track
+> limits."
+
+### Route editing workflow
+
+The route family lets an agent close the *create → inspect → refine*
+loop against loaded datasets. A typical sequence:
+
+1. `create_route` (optionally `name`/`id`) → becomes the active route.
+2. `append_waypoint` / `insert_waypoint` to lay down the geometry; reason
+   about placement with the read-only query tools (`sample_coverage`,
+   `nearest_features`, `find_at`) along each leg.
+3. `move_waypoint` / `delete_waypoint` to refine.
+4. `set_leg_attributes` (geometry type + S-421 navigational envelope) and
+   `set_route_info` (metadata + vessel particulars).
+5. `get_route` / `list_routes` to read back the result.
+
+Edits are applied to the same persistent route collection the viewer's
+**Routes** panel and route overlay display, so changes appear live in the
+GUI. Most route tools default to the **active** route when `routeId` is
+omitted. Waypoints are addressed by zero-based `index`; legs by zero-based
+`legIndex` (leg `i` joins waypoint `i` to waypoint `i+1`). The fields
+mirror the in-repo S-421 model so a route projects onto S-421 GML with a
+near-mechanical mapping.
 
 ## Security notes
 

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -607,7 +607,8 @@ public partial class App : Application
             sp.GetRequiredService<GlobalTimeService>(),
             sp.GetRequiredService<IRenderActivityMonitor>(),
             sp.GetRequiredService<IDatasetLoadGateway>(),
-            sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipHelm>()));
+            sp.GetRequiredService<EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipHelm>(),
+            sp.GetRequiredService<EncDotNet.S100.Viewer.Services.RoutesService>()));
 
         // View models
         services.AddSingleton<FeatureCataloguesViewModel>();

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -395,6 +395,7 @@ public partial class App : Application
         services.AddSingleton<PortrayalCatalogueSeeder>();
         services.AddSingleton<ScreenshotService>();
         services.AddSingleton<EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider, MeasureOverlayAppearanceProvider>();
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.RoutesService>();
 
         // Phase 3 services: dataset orchestration, pick dispatch, file dialogs
         services.AddSingleton<GlobalTimeService>();
@@ -630,6 +631,7 @@ public partial class App : Application
         services.AddSingleton<EcdisLabelOverrideProvider>();
         services.AddSingleton<EcdisDisplayPanelViewModel>();
         services.AddSingleton<HelmViewModel>();
+        services.AddSingleton<RoutesPanelViewModel>();
         services.AddSingleton<MainViewModel>();
 
         // Activity-tab registry. Adding a new tab is a single AddActivityTab
@@ -674,6 +676,13 @@ public partial class App : Application
             title: Strings.Pane_Search,
             tooltip: Strings.Tooltip_Search,
             iconFactory: static () => new FluentIcon { Icon = Icon.Search, IconVariant = IconVariant.Regular, FontSize = 22 });
+        services.AddActivityTab<RoutesPanelViewModel, RoutesView>(
+            id: "Routes",
+            order: 55,
+            title: Strings.Pane_Routes,
+            tooltip: Strings.Tooltip_RoutesPanel,
+            iconFactory: static () => new FluentIcon { Icon = Icon.Flow, IconVariant = IconVariant.Regular, FontSize = 22 },
+            persistAsLastSelected: false);
         // Vessels tab — shown only while the AIS overlay is enabled
         // (its visibility source bridges SettingsViewModel.AisEnabled).
         services.AddActivityTab<VesselListViewModel, VesselListView>(

--- a/src/EncDotNet.S100.Viewer/Geodesy/MarineGeodesy.cs
+++ b/src/EncDotNet.S100.Viewer/Geodesy/MarineGeodesy.cs
@@ -71,6 +71,106 @@ internal static class MarineGeodesy
     }
 
     /// <summary>
+    /// Computes the great-circle (orthodromic) distance, in nautical miles,
+    /// between two WGS-84 points using the haversine formula on a sphere of
+    /// mean Earth radius. This is the shorter geodesic distance and pairs
+    /// with <see cref="GreatCircleInitialBearingDegrees"/> for legs whose
+    /// geometry is geodesic rather than loxodromic.
+    /// </summary>
+    public static double GreatCircleDistanceNm(double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg)
+    {
+        var phi1 = DegToRad(lat1Deg);
+        var phi2 = DegToRad(lat2Deg);
+        var dphi = DegToRad(lat2Deg - lat1Deg);
+        var dlam = NormalizeDeltaLonRadians(DegToRad(lon2Deg - lon1Deg));
+
+        var sinDphi = Math.Sin(dphi / 2.0);
+        var sinDlam = Math.Sin(dlam / 2.0);
+        var a = sinDphi * sinDphi + Math.Cos(phi1) * Math.Cos(phi2) * sinDlam * sinDlam;
+        var c = 2.0 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1.0 - a));
+        return c * EarthRadiusNm;
+    }
+
+    /// <summary>
+    /// Computes the great-circle initial (forward) true bearing in degrees
+    /// [0°, 360°) from the first point to the second. Unlike a rhumb-line
+    /// bearing this changes continuously along the path; it is the bearing
+    /// to steer at the departure point.
+    /// </summary>
+    public static double GreatCircleInitialBearingDegrees(double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg)
+    {
+        var phi1 = DegToRad(lat1Deg);
+        var phi2 = DegToRad(lat2Deg);
+        var dlam = NormalizeDeltaLonRadians(DegToRad(lon2Deg - lon1Deg));
+
+        var y = Math.Sin(dlam) * Math.Cos(phi2);
+        var x = Math.Cos(phi1) * Math.Sin(phi2) -
+                Math.Sin(phi1) * Math.Cos(phi2) * Math.Cos(dlam);
+        var theta = Math.Atan2(y, x);
+        var deg = RadToDeg(theta);
+        return ((deg % 360.0) + 360.0) % 360.0;
+    }
+
+    /// <summary>
+    /// Returns <paramref name="segments"/>+1 points along the great-circle
+    /// arc from the first point to the second (inclusive of both ends),
+    /// using spherical interpolation. Lets a renderer draw a geodesic leg
+    /// as a curve in Mercator space rather than a straight (rhumb-looking)
+    /// line. <paramref name="segments"/> is clamped to at least 1.
+    /// </summary>
+    public static IReadOnlyList<(double Lat, double Lon)> GreatCircleIntermediatePoints(
+        double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg, int segments)
+    {
+        if (segments < 1) segments = 1;
+
+        var phi1 = DegToRad(lat1Deg);
+        var lam1 = DegToRad(lon1Deg);
+        var phi2 = DegToRad(lat2Deg);
+        var lam2 = DegToRad(lon2Deg);
+
+        // Angular distance between the two points (haversine).
+        var dphi = phi2 - phi1;
+        var dlam = NormalizeDeltaLonRadians(lam2 - lam1);
+        var sinDphi = Math.Sin(dphi / 2.0);
+        var sinDlam = Math.Sin(dlam / 2.0);
+        var a = sinDphi * sinDphi + Math.Cos(phi1) * Math.Cos(phi2) * sinDlam * sinDlam;
+        var delta = 2.0 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1.0 - a));
+
+        var result = new List<(double Lat, double Lon)>(segments + 1);
+        if (delta < 1e-12)
+        {
+            // Coincident points — nothing to interpolate.
+            result.Add((lat1Deg, lon1Deg));
+            result.Add((lat2Deg, lon2Deg));
+            return result;
+        }
+
+        // Cartesian endpoints for slerp.
+        var x1 = Math.Cos(phi1) * Math.Cos(lam1);
+        var y1 = Math.Cos(phi1) * Math.Sin(lam1);
+        var z1 = Math.Sin(phi1);
+        var x2 = Math.Cos(phi2) * Math.Cos(lam2);
+        var y2 = Math.Cos(phi2) * Math.Sin(lam2);
+        var z2 = Math.Sin(phi2);
+        var sinDelta = Math.Sin(delta);
+
+        for (var i = 0; i <= segments; i++)
+        {
+            var f = (double)i / segments;
+            var aCoef = Math.Sin((1.0 - f) * delta) / sinDelta;
+            var bCoef = Math.Sin(f * delta) / sinDelta;
+            var x = aCoef * x1 + bCoef * x2;
+            var y = aCoef * y1 + bCoef * y2;
+            var z = aCoef * z1 + bCoef * z2;
+            var lat = Math.Atan2(z, Math.Sqrt(x * x + y * y));
+            var lon = Math.Atan2(y, x);
+            result.Add((RadToDeg(lat), RadToDeg(lon)));
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Splits a sequence of waypoints into one or more sub-paths so that no
     /// segment crosses the antimeridian (±180° longitude). Each output
     /// sub-path uses unwrapped longitudes that are continuous across its

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -202,7 +202,7 @@
                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
                 <TextBlock DockPanel.Dock="Right"
                            Text="{Binding MeasureSummary}"
-                           IsVisible="{Binding IsMeasureModeActive}"
+                           IsVisible="{Binding IsToolSummaryVisible}"
                            FontSize="12"
                            FontFamily="Menlo,Consolas,Courier New,monospace"
                            Opacity="0.85"
@@ -466,6 +466,38 @@
                             </Style>
                         </Button.Styles>
                         <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
+                    </Button>
+                    <!--
+                      Route Edit Mode toggle button. Mirrors the Measure
+                      button's accent-fill pattern; the route icon
+                      distinguishes it. Clicking enters the interactive
+                      route editor (click to add waypoints, drag to move).
+                    -->
+                    <Button x:Name="RouteEditModeButton"
+                            Classes="Icon MapOverlay"
+                            Classes.routeActive="{Binding IsRouteEditModeActive}"
+                            Command="{Binding ToggleRouteEditModeCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_RouteEditMode}">
+                        <Button.Styles>
+                            <Style Selector="Button#RouteEditModeButton.routeActive">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#RouteEditModeButton.routeActive /template/ ContentPresenter">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                            </Style>
+                            <Style Selector="Button#RouteEditModeButton.routeActive ic|FluentIcon">
+                                <Setter Property="Foreground" Value="White" />
+                            </Style>
+                            <Style Selector="Button#RouteEditModeButton.routeActive /template/ Border#HoverBackground">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                <Setter Property="Opacity" Value="1" />
+                            </Style>
+                        </Button.Styles>
+                        <ic:FluentIcon Icon="Flow" IconVariant="Regular" FontSize="16" />
                     </Button>
                     <!--
                       Consolidated display-settings button. Replaces the

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -45,6 +45,9 @@ public partial class MainWindow : ShadUI.Window
     private EventHandler? _renderActivityRefreshHandler;
     private EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost? _dynamicSourceOverlayHost;
     private ILayer? _basemapLayer;
+    private Mapsui.Layers.MemoryLayer? _routeOverlayLayer;
+    private EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider? _routeAppearance;
+    private EncDotNet.S100.Viewer.Services.RoutesService? _routeStore;
     private readonly List<IDisposable> _dynamicSourceRegistrations = new();
     private string? _screenshotPath;
     private bool _exitAfterScreenshot;
@@ -935,7 +938,8 @@ public partial class MainWindow : ShadUI.Window
             removeLayer: layer => MapControl.Map?.Layers.Remove(layer),
             setStatusSummary: text => Dispatcher.UIThread.Post(() => _viewModel.MeasureSummary = text),
             refreshGraphics: () => MapControl.RefreshGraphics(),
-            screenToLatLon: ScreenToLatLon);
+            screenToLatLon: ScreenToLatLon,
+            latLonToScreen: LatLonToScreen);
 
         // Tools (pick, measure) were registered by the view-model in its
         // constructor; here we just hand them an Avalonia-aware context.
@@ -945,8 +949,58 @@ public partial class MainWindow : ShadUI.Window
         // events are offered to the active tool first.
         interactionController.SetToolController(tools);
 
+        // The route overlay is persistent (unlike the measure overlay, which
+        // only exists while its tool is active): routes stay visible whether
+        // or not the editor tool is engaged. The host owns the layer and
+        // rebuilds it whenever the route store or theme/accent changes.
+        InitializeRouteOverlay();
+
         // Tool selection is intentionally not persisted across launches —
         // entering Pick or Measure mode must be an explicit user action.
+    }
+
+    /// <summary>
+    /// Creates the persistent route overlay layer, adds it to the map, and
+    /// subscribes to the route store and appearance provider so the overlay
+    /// reflects the current routes and theme at all times.
+    /// </summary>
+    private void InitializeRouteOverlay()
+    {
+        _routeStore = _viewModel.RoutesService;
+        _routeAppearance = App.Services.GetRequiredService<
+            EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider>();
+
+        _routeOverlayLayer = EncDotNet.S100.Viewer.Tools.RouteOverlayLayer.Create();
+        MapControl.Map?.Layers.Add(_routeOverlayLayer);
+
+        _routeStore.Changed += OnRouteStoreChanged;
+        _routeAppearance.Changed += OnRouteStoreChanged;
+
+        RebuildRouteOverlay();
+    }
+
+    private void OnRouteStoreChanged(object? sender, EventArgs e) =>
+        Dispatcher.UIThread.Post(RebuildRouteOverlay);
+
+    /// <summary>
+    /// Rebuilds the persistent route overlay from the current
+    /// <see cref="EncDotNet.S100.Viewer.Services.RoutesService"/> state and
+    /// schedules a redraw. Re-adds the layer if a map rebuild dropped it.
+    /// </summary>
+    private void RebuildRouteOverlay()
+    {
+        if (_routeOverlayLayer is null || _routeStore is null || _routeAppearance is null)
+            return;
+
+        if (MapControl.Map is { } map && !map.Layers.Contains(_routeOverlayLayer))
+            map.Layers.Add(_routeOverlayLayer);
+
+        EncDotNet.S100.Viewer.Tools.RouteOverlayLayer.Update(
+            _routeOverlayLayer,
+            _routeStore.Routes,
+            _routeStore.SelectedWaypointIndex,
+            _routeAppearance.Current);
+        MapControl.RefreshGraphics();
     }
 
     /// <summary>
@@ -974,6 +1028,29 @@ public partial class MainWindow : ShadUI.Window
         // that cross the antimeridian render with consistent endpoints.
         lon = ((lon + 540.0) % 360.0) - 180.0;
         return (lat, lon);
+    }
+
+    /// <summary>
+    /// Converts a WGS-84 lat/lon to a pointer position in
+    /// <see cref="MapControl"/> client coordinates, or <c>null</c> when no
+    /// viewport is available. Inverse of <see cref="ScreenToLatLon"/>; used
+    /// by editing tools to hit-test pointer gestures against world-space
+    /// features.
+    /// </summary>
+    private Point? LatLonToScreen((double Lat, double Lon) world)
+    {
+        if (MapControl.Map?.Navigator is not { } navigator)
+            return null;
+
+        var (x, y) = SphericalMercator.FromLonLat(world.Lon, world.Lat);
+        var screen = navigator.Viewport.WorldToScreen(x, y);
+        if (double.IsNaN(screen.X) || double.IsNaN(screen.Y) ||
+            double.IsInfinity(screen.X) || double.IsInfinity(screen.Y))
+        {
+            return null;
+        }
+
+        return new Point(screen.X, screen.Y);
     }
 
     private async Task OpenDatasetAsync()

--- a/src/EncDotNet.S100.Viewer/McpTools/RouteDtos.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RouteDtos.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>One waypoint of a route, as seen over the MCP wire.</summary>
+[Description("A single route waypoint with its position and optional metadata.")]
+internal sealed record WaypointDto(
+    [property: Description("Zero-based index of the waypoint in route order.")] int Index,
+    [property: Description("WGS-84 latitude in decimal degrees.")] double Lat,
+    [property: Description("WGS-84 longitude in decimal degrees.")] double Lon,
+    [property: Description("Author-assigned ordinal (S-421 routeWaypointID), or null.")] int? Number,
+    [property: Description("Human-readable waypoint name, or null.")] string? Name,
+    [property: Description("Whether the waypoint is pinned and must not be moved, or null when unset.")] bool? Fixed,
+    [property: Description("Planned turn radius at the waypoint in nautical miles, or null.")] double? TurnRadiusNm);
+
+/// <summary>One leg of a route, including its computed geometry.</summary>
+[Description("A single route leg (the segment joining two consecutive waypoints) with its computed metrics and navigational envelope.")]
+internal sealed record LegDto(
+    [property: Description("Zero-based index of the leg; leg i joins waypoint i to waypoint i+1.")] int Index,
+    [property: Description("Leg path geometry: \"loxodrome\" (rhumb line, constant bearing) or \"geodesic\" (great circle).")] string GeometryType,
+    [property: Description("Computed leg length in nautical miles.")] double DistanceNm,
+    [property: Description("Computed initial true bearing in degrees [0, 360).")] double InitialBearingDegrees,
+    [property: Description("Starboard cross-track distance limit in metres, or null.")] double? StarboardCrossTrackDistanceLimitMeters,
+    [property: Description("Port cross-track distance limit in metres, or null.")] double? PortCrossTrackDistanceLimitMeters,
+    [property: Description("Starboard channel limit in metres, or null.")] double? StarboardChannelLimitMeters,
+    [property: Description("Port channel limit in metres, or null.")] double? PortChannelLimitMeters,
+    [property: Description("Safety contour for the leg in metres, or null.")] double? SafetyContourMeters,
+    [property: Description("Safety depth for the leg in metres, or null.")] double? SafetyDepthMeters,
+    [property: Description("Minimum speed over ground in knots, or null.")] double? SpeedOverGroundMinKnots,
+    [property: Description("Maximum speed over ground in knots, or null.")] double? SpeedOverGroundMaxKnots,
+    [property: Description("Minimum speed through water in knots, or null.")] double? SpeedThroughWaterMinKnots,
+    [property: Description("Maximum speed through water in knots, or null.")] double? SpeedThroughWaterMaxKnots,
+    [property: Description("Planned draft for the leg in metres, or null.")] double? DraftMeters,
+    [property: Description("Static under-keel clearance in metres, or null.")] double? StaticUnderKeelClearanceMeters,
+    [property: Description("Dynamic under-keel clearance in metres, or null.")] double? DynamicUnderKeelClearanceMeters,
+    [property: Description("Safety margin in metres, or null.")] double? SafetyMarginMeters,
+    [property: Description("Free-text note for the leg, or null.")] string? Note);
+
+/// <summary>Vessel metadata carried by a route's info block.</summary>
+[Description("Vessel metadata the route is planned for; all fields optional.")]
+internal sealed record VesselDto(
+    [property: Description("Vessel name, or null.")] string? Name,
+    [property: Description("Maritime Mobile Service Identity, or null.")] string? Mmsi,
+    [property: Description("IMO number, or null.")] string? Imo,
+    [property: Description("Call sign, or null.")] string? Callsign,
+    [property: Description("Overall length in metres, or null.")] double? LengthMeters,
+    [property: Description("Beam in metres, or null.")] double? BeamMeters);
+
+/// <summary>Route-level metadata.</summary>
+[Description("Route-level metadata (S-421 RouteInfo); all fields optional.")]
+internal sealed record RouteInfoDto(
+    [property: Description("Route name, or null.")] string? Name,
+    [property: Description("Route author / originator, or null.")] string? Author,
+    [property: Description("Free-text description, or null.")] string? Description,
+    [property: Description("Departure port identifier, or null.")] string? DeparturePortId,
+    [property: Description("Arrival port identifier, or null.")] string? ArrivalPortId,
+    [property: Description("Planned start of validity (UTC ISO-8601), or null.")] DateTimeOffset? ValidityStart,
+    [property: Description("Planned end of validity (UTC ISO-8601), or null.")] DateTimeOffset? ValidityEnd,
+    [property: Description("Vessel metadata, or null when no vessel has been set.")] VesselDto? Vessel);
+
+/// <summary>A compact route summary returned by list_routes.</summary>
+[Description("A compact route summary: identity plus aggregate metrics.")]
+internal sealed record RouteSummary(
+    [property: Description("Stable route identifier.")] string RouteId,
+    [property: Description("Route name, or null.")] string? Name,
+    [property: Description("Whether this is the collection's active (default-target) route.")] bool IsActive,
+    [property: Description("Number of waypoints in the route.")] int WaypointCount,
+    [property: Description("Number of legs (max(0, waypointCount - 1)).")] int LegCount,
+    [property: Description("Total route length in nautical miles.")] double TotalDistanceNm);
+
+/// <summary>The full projection of a single route.</summary>
+[Description("The full state of one route: identity, metadata, ordered waypoints and legs, and total distance.")]
+internal sealed record RouteDetail(
+    [property: Description("Stable route identifier.")] string RouteId,
+    [property: Description("Route name, or null.")] string? Name,
+    [property: Description("Whether this is the collection's active (default-target) route.")] bool IsActive,
+    [property: Description("Route-level metadata.")] RouteInfoDto Info,
+    [property: Description("Waypoints in route order.")] IReadOnlyList<WaypointDto> Waypoints,
+    [property: Description("Legs in route order; leg i joins waypoint i to waypoint i+1.")] IReadOnlyList<LegDto> Legs,
+    [property: Description("Total route length in nautical miles.")] double TotalDistanceNm);
+
+/// <summary>Result of list_routes.</summary>
+[Description("Result of list_routes: every route in the collection plus the active route id.")]
+internal sealed record ListRoutesResult(
+    [property: Description("All routes in insertion order.")] IReadOnlyList<RouteSummary> Routes,
+    [property: Description("Id of the active route, or null when the collection is empty.")] string? ActiveRouteId);
+
+/// <summary>Result of delete_route.</summary>
+[Description("Result of delete_route: which route was removed and the new active route id.")]
+internal sealed record DeleteRouteResult(
+    [property: Description("Id of the route that was requested for deletion.")] string RouteId,
+    [property: Description("Whether the route was present and removed.")] bool Deleted,
+    [property: Description("Id of the active route after deletion, or null when the collection is now empty.")] string? ActiveRouteId);
+
+/// <summary>
+/// Builds wire DTOs from the live route model. All members assume they are
+/// called on the UI thread (inside an <see cref="IRouteEditInvoker"/>
+/// callback), so they read the mutable model without locking.
+/// </summary>
+internal static class RouteProjection
+{
+    /// <summary>Maps a geometry-type enum to its wire token.</summary>
+    public static string GeometryToken(RouteLegGeometryType type)
+        => type == RouteLegGeometryType.Geodesic ? "geodesic" : "loxodrome";
+
+    /// <summary>Projects a single route to a <see cref="RouteDetail"/>.</summary>
+    public static RouteDetail Detail(Route route, RoutesService routes)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        ArgumentNullException.ThrowIfNull(routes);
+
+        var waypoints = new List<WaypointDto>(route.Waypoints.Count);
+        for (var i = 0; i < route.Waypoints.Count; i++)
+        {
+            var wp = route.Waypoints[i];
+            waypoints.Add(new WaypointDto(
+                i, wp.Position.Latitude, wp.Position.Longitude,
+                wp.Number, wp.Name, wp.Fixed, wp.TurnRadiusNm));
+        }
+
+        var legs = new List<LegDto>(route.Legs.Count);
+        for (var i = 0; i < route.Legs.Count; i++)
+        {
+            var leg = route.Legs[i];
+            var metrics = route.ComputeLegMetrics(i);
+            legs.Add(new LegDto(
+                i,
+                GeometryToken(leg.GeometryType),
+                metrics.DistanceNm,
+                metrics.InitialBearingDegrees,
+                leg.StarboardCrossTrackDistanceLimitMeters,
+                leg.PortCrossTrackDistanceLimitMeters,
+                leg.StarboardChannelLimitMeters,
+                leg.PortChannelLimitMeters,
+                leg.SafetyContourMeters,
+                leg.SafetyDepthMeters,
+                leg.SpeedOverGroundMinKnots,
+                leg.SpeedOverGroundMaxKnots,
+                leg.SpeedThroughWaterMinKnots,
+                leg.SpeedThroughWaterMaxKnots,
+                leg.DraftMeters,
+                leg.StaticUnderKeelClearanceMeters,
+                leg.DynamicUnderKeelClearanceMeters,
+                leg.SafetyMarginMeters,
+                leg.Note));
+        }
+
+        return new RouteDetail(
+            route.Id,
+            route.Name,
+            ReferenceEquals(route, routes.Routes.ActiveRoute),
+            Info(route.Info),
+            waypoints,
+            legs,
+            route.TotalDistanceNm());
+    }
+
+    /// <summary>Projects a single route to a compact <see cref="RouteSummary"/>.</summary>
+    public static RouteSummary Summary(Route route, RoutesService routes)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        ArgumentNullException.ThrowIfNull(routes);
+        return new RouteSummary(
+            route.Id,
+            route.Name,
+            ReferenceEquals(route, routes.Routes.ActiveRoute),
+            route.Waypoints.Count,
+            route.Legs.Count,
+            route.TotalDistanceNm());
+    }
+
+    private static RouteInfoDto Info(RouteInfo info)
+        => new(
+            info.Name,
+            info.Author,
+            info.Description,
+            info.DeparturePortId,
+            info.ArrivalPortId,
+            info.ValidityStart,
+            info.ValidityEnd,
+            info.Vessel is { } v
+                ? new VesselDto(v.Name, v.Mmsi, v.Imo, v.Callsign, v.LengthMeters, v.BeamMeters)
+                : null);
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/RouteEditInvoker.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RouteEditInvoker.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Marshals a route read/mutation onto the viewer's UI thread.
+/// </summary>
+/// <remarks>
+/// <para>
+/// MCP tools execute on Kestrel request threads, not the Avalonia UI
+/// thread. The route MCP tools mutate the shared
+/// <see cref="EncDotNet.S100.Viewer.Services.RoutesService"/>, whose
+/// <c>Changed</c> event is consumed directly (without marshalling) by the
+/// UI-bound <c>RoutesPanelViewModel</c> — which rebuilds
+/// <c>ObservableCollection</c>s that Avalonia requires to be touched only
+/// on the UI thread. Every route tool therefore performs its mutation and
+/// result projection inside <see cref="InvokeAsync{T}"/> so the resulting
+/// <c>Changed</c> fan-out (panel rebuild and overlay refresh) runs with UI
+/// affinity.
+/// </para>
+/// <para>
+/// Reads are marshalled too, so a tool always snapshots a consistent route
+/// state rather than racing the interactive editor.
+/// </para>
+/// </remarks>
+internal interface IRouteEditInvoker
+{
+    /// <summary>
+    /// Runs <paramref name="action"/> on the UI thread and returns its
+    /// result.
+    /// </summary>
+    /// <typeparam name="T">The action's result type.</typeparam>
+    /// <param name="action">The work to run with UI affinity.</param>
+    /// <returns>A task completing with the action's return value.</returns>
+    Task<T> InvokeAsync<T>(Func<T> action);
+}
+
+/// <summary>
+/// Production <see cref="IRouteEditInvoker"/> backed by
+/// <see cref="Dispatcher.UIThread"/>.
+/// </summary>
+internal sealed class DispatcherRouteEditInvoker : IRouteEditInvoker
+{
+    /// <inheritdoc />
+    public Task<T> InvokeAsync<T>(Func<T> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return Dispatcher.UIThread.InvokeAsync(action).GetTask();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/RouteMcpAdapters.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RouteMcpAdapters.cs
@@ -1,0 +1,488 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Shared JSON options and result-translation helpers for the route MCP
+/// adapters. Centralises the success / failure / internal-error wire shapes
+/// so every <c>Route*McpAdapter</c> emits an identical payload contract.
+/// </summary>
+internal static class RouteAdapterShared
+{
+    /// <summary>
+    /// The serializer options every route adapter uses. A configured
+    /// <c>TypeInfoResolver</c> is required so the MCP SDK can call
+    /// <see cref="JsonSerializerOptions.MakeReadOnly()"/> in the published
+    /// (reflection-disabled) viewer without throwing.
+    /// </summary>
+    public static JsonSerializerOptions Options { get; } = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
+    };
+
+    /// <summary>Runs <paramref name="resultFactory"/> and translates its outcome.</summary>
+    public static async Task<CallToolResult> DispatchAsync<T>(Func<Task<ToolResult<T>>> resultFactory)
+    {
+        try
+        {
+            var result = await resultFactory().ConfigureAwait(false);
+            return Translate(result);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return InternalError(ex);
+        }
+    }
+
+    /// <summary>Translates a completed <see cref="ToolResult{T}"/> to a wire result.</summary>
+    public static CallToolResult Translate<T>(ToolResult<T> result)
+    {
+        if (result.TryGetValue(out var value))
+            return Success(value);
+        result.TryGetError(out var err);
+        return Failure(err!);
+    }
+
+    private static CallToolResult Success<T>(T value)
+    {
+        var node = JsonSerializer.SerializeToNode(value, Options) ?? new JsonObject();
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = node.ToJsonString(Options) }],
+            IsError = false,
+        };
+    }
+
+    private static CallToolResult Failure(ToolError error)
+    {
+        var details = JsonSerializer.SerializeToNode(error, error.GetType(), Options) as JsonObject
+            ?? new JsonObject();
+        details.Remove("code");
+        details.Remove("message");
+        details.Remove("Code");
+        details.Remove("Message");
+
+        var payload = new JsonObject
+        {
+            ["code"] = error.Code,
+            ["message"] = error.Message,
+            ["details"] = details,
+        };
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = payload.ToJsonString(Options) }],
+            IsError = true,
+        };
+    }
+
+    private static CallToolResult InternalError(Exception ex)
+    {
+        var payload = new JsonObject
+        {
+            ["code"] = "internal_error",
+            ["message"] = ex.Message,
+            ["details"] = new JsonObject { ["exceptionType"] = ex.GetType().FullName },
+        };
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = payload.ToJsonString(Options) }],
+            IsError = true,
+        };
+    }
+}
+
+/// <summary>Wraps <see cref="CreateRouteTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class CreateRouteMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Creates a new, empty editable route in the live viewer and makes it the active route. " +
+        "Returns the new route's full state. Add waypoints with append_waypoint. Viewer-injected tool.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(CreateRouteTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Optional route name.")] string? name = null,
+            [System.ComponentModel.Description("Optional stable route id; a GUID is generated when omitted. Must be unique.")] string? id = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(new CreateRouteRequest(name, id), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = CreateRouteTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="ListRoutesTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class ListRoutesMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Lists every editable route in the live viewer with its id, name, waypoint/leg counts, " +
+        "total distance, and whether it is the active route. Viewer-injected tool.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(ListRoutesTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(new ListRoutesRequest(), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = ListRoutesTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<ListRoutesResult> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="GetRouteTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class GetRouteMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Returns the full state of one route in the live viewer: identity, metadata, ordered " +
+        "waypoints, and legs with computed distance/bearing. Omit routeId to read the active route. " +
+        "Viewer-injected tool.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(GetRouteTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Id of the route to return; omit to use the active route.")] string? routeId = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(new GetRouteRequest(routeId), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = GetRouteTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="DeleteRouteTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class DeleteRouteMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Removes a route from the live viewer's collection. Omit routeId to delete the active route. " +
+        "Returns the new active route id. Viewer-injected tool — mutates live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(DeleteRouteTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Id of the route to delete; omit to delete the active route.")] string? routeId = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(new DeleteRouteRequest(routeId), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = DeleteRouteTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<DeleteRouteResult> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="AppendWaypointTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class AppendWaypointMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Appends a waypoint to the end of a route in the live viewer. Omit routeId to use the active " +
+        "route. Returns the route's full updated state. Viewer-injected tool — mutates live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(AppendWaypointTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("WGS-84 latitude in decimal degrees [-90, 90].")] double lat,
+            [System.ComponentModel.Description("WGS-84 longitude in decimal degrees [-180, 180].")] double lon,
+            [System.ComponentModel.Description("Id of the route to append to; omit to use the active route.")] string? routeId = null,
+            [System.ComponentModel.Description("Optional author-assigned ordinal (S-421 routeWaypointID).")] int? number = null,
+            [System.ComponentModel.Description("Optional waypoint name.")] string? name = null,
+            [System.ComponentModel.Description("Optional flag pinning the waypoint so it must not be moved.")] bool? @fixed = null,
+            [System.ComponentModel.Description("Optional planned turn radius at the waypoint, in nautical miles.")] double? turnRadiusNm = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(
+                new AppendWaypointRequest(lat, lon, routeId, number, name, @fixed, turnRadiusNm), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = AppendWaypointTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="InsertWaypointTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class InsertWaypointMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Inserts a waypoint at a given index of a route in the live viewer, splitting the affected " +
+        "leg. Index 0 prepends; waypointCount appends. Omit routeId to use the active route. Returns " +
+        "the route's full updated state. Viewer-injected tool — mutates live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(InsertWaypointTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Insertion index in [0, waypointCount]; 0 prepends, waypointCount appends.")] int index,
+            [System.ComponentModel.Description("WGS-84 latitude in decimal degrees [-90, 90].")] double lat,
+            [System.ComponentModel.Description("WGS-84 longitude in decimal degrees [-180, 180].")] double lon,
+            [System.ComponentModel.Description("Id of the route to insert into; omit to use the active route.")] string? routeId = null,
+            [System.ComponentModel.Description("Optional author-assigned ordinal (S-421 routeWaypointID).")] int? number = null,
+            [System.ComponentModel.Description("Optional waypoint name.")] string? name = null,
+            [System.ComponentModel.Description("Optional flag pinning the waypoint so it must not be moved.")] bool? @fixed = null,
+            [System.ComponentModel.Description("Optional planned turn radius at the waypoint, in nautical miles.")] double? turnRadiusNm = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(
+                new InsertWaypointRequest(index, lat, lon, routeId, number, name, @fixed, turnRadiusNm), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = InsertWaypointTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="MoveWaypointTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class MoveWaypointMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Moves an existing waypoint of a route in the live viewer to a new position. Omit routeId to " +
+        "use the active route. Returns the route's full updated state. Viewer-injected tool — mutates " +
+        "live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(MoveWaypointTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Index of the waypoint to move in [0, waypointCount).")] int index,
+            [System.ComponentModel.Description("New WGS-84 latitude in decimal degrees [-90, 90].")] double lat,
+            [System.ComponentModel.Description("New WGS-84 longitude in decimal degrees [-180, 180].")] double lon,
+            [System.ComponentModel.Description("Id of the route to edit; omit to use the active route.")] string? routeId = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(
+                new MoveWaypointRequest(index, lat, lon, routeId), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = MoveWaypointTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="DeleteWaypointTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class DeleteWaypointMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Removes a waypoint from a route in the live viewer, merging the adjacent legs. Omit routeId " +
+        "to use the active route. Returns the route's full updated state. Viewer-injected tool — " +
+        "mutates live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(DeleteWaypointTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Index of the waypoint to remove in [0, waypointCount).")] int index,
+            [System.ComponentModel.Description("Id of the route to edit; omit to use the active route.")] string? routeId = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(
+                new DeleteWaypointRequest(index, routeId), ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = DeleteWaypointTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="SetLegAttributesTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class SetLegAttributesMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Updates one leg of a route in the live viewer: its geometry type (loxodrome|geodesic) and/or " +
+        "navigational envelope (cross-track and channel limits, safety contour/depth, speed and draft " +
+        "limits, under-keel clearances, note). All attributes optional; supplied values overwrite. " +
+        "Omit routeId to use the active route. Viewer-injected tool — mutates live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(SetLegAttributesTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Index of the leg to edit in [0, legCount); leg i joins waypoint i to waypoint i+1.")] int legIndex,
+            [System.ComponentModel.Description("Id of the route to edit; omit to use the active route.")] string? routeId = null,
+            [System.ComponentModel.Description("Leg path geometry: \"loxodrome\" (rhumb line) or \"geodesic\" (great circle).")] string? geometryType = null,
+            [System.ComponentModel.Description("Starboard cross-track distance limit in metres.")] double? starboardCrossTrackDistanceLimitMeters = null,
+            [System.ComponentModel.Description("Port cross-track distance limit in metres.")] double? portCrossTrackDistanceLimitMeters = null,
+            [System.ComponentModel.Description("Starboard channel limit in metres.")] double? starboardChannelLimitMeters = null,
+            [System.ComponentModel.Description("Port channel limit in metres.")] double? portChannelLimitMeters = null,
+            [System.ComponentModel.Description("Safety contour for the leg in metres.")] double? safetyContourMeters = null,
+            [System.ComponentModel.Description("Safety depth for the leg in metres.")] double? safetyDepthMeters = null,
+            [System.ComponentModel.Description("Minimum speed over ground in knots.")] double? speedOverGroundMinKnots = null,
+            [System.ComponentModel.Description("Maximum speed over ground in knots.")] double? speedOverGroundMaxKnots = null,
+            [System.ComponentModel.Description("Minimum speed through water in knots.")] double? speedThroughWaterMinKnots = null,
+            [System.ComponentModel.Description("Maximum speed through water in knots.")] double? speedThroughWaterMaxKnots = null,
+            [System.ComponentModel.Description("Planned draft for the leg in metres.")] double? draftMeters = null,
+            [System.ComponentModel.Description("Static under-keel clearance in metres.")] double? staticUnderKeelClearanceMeters = null,
+            [System.ComponentModel.Description("Dynamic under-keel clearance in metres.")] double? dynamicUnderKeelClearanceMeters = null,
+            [System.ComponentModel.Description("Safety margin in metres.")] double? safetyMarginMeters = null,
+            [System.ComponentModel.Description("Free-text note for the leg.")] string? note = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(
+                new SetLegAttributesRequest(
+                    legIndex, routeId, geometryType,
+                    starboardCrossTrackDistanceLimitMeters, portCrossTrackDistanceLimitMeters,
+                    starboardChannelLimitMeters, portChannelLimitMeters,
+                    safetyContourMeters, safetyDepthMeters,
+                    speedOverGroundMinKnots, speedOverGroundMaxKnots,
+                    speedThroughWaterMinKnots, speedThroughWaterMaxKnots,
+                    draftMeters, staticUnderKeelClearanceMeters, dynamicUnderKeelClearanceMeters,
+                    safetyMarginMeters, note),
+                ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SetLegAttributesTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}
+
+/// <summary>Wraps <see cref="SetRouteInfoTool"/> as an <see cref="McpServerTool"/>.</summary>
+internal static class SetRouteInfoMcpAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = RouteAdapterShared.Options;
+
+    private const string Description =
+        "Updates a route's metadata in the live viewer (name, author, description, departure/arrival " +
+        "ports, validity window) and vessel particulars (name, MMSI, IMO, call sign, length, beam). " +
+        "All fields optional; supplied values overwrite. Omit routeId to use the active route. " +
+        "Viewer-injected tool — mutates live state.";
+
+    /// <summary>Creates the <see cref="McpServerTool"/>.</summary>
+    public static McpServerTool Create(SetRouteInfoTool inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        var del = (
+            [System.ComponentModel.Description("Id of the route to edit; omit to use the active route.")] string? routeId = null,
+            [System.ComponentModel.Description("Route name.")] string? name = null,
+            [System.ComponentModel.Description("Route author / originator.")] string? author = null,
+            [System.ComponentModel.Description("Free-text route description.")] string? description = null,
+            [System.ComponentModel.Description("Departure port identifier.")] string? departurePortId = null,
+            [System.ComponentModel.Description("Arrival port identifier.")] string? arrivalPortId = null,
+            [System.ComponentModel.Description("Planned start of validity (UTC ISO-8601).")] DateTimeOffset? validityStart = null,
+            [System.ComponentModel.Description("Planned end of validity (UTC ISO-8601).")] DateTimeOffset? validityEnd = null,
+            [System.ComponentModel.Description("Vessel name (creates the vessel block when supplied).")] string? vesselName = null,
+            [System.ComponentModel.Description("Vessel MMSI (creates the vessel block when supplied).")] string? vesselMmsi = null,
+            [System.ComponentModel.Description("Vessel IMO number (creates the vessel block when supplied).")] string? vesselImo = null,
+            [System.ComponentModel.Description("Vessel call sign (creates the vessel block when supplied).")] string? vesselCallsign = null,
+            [System.ComponentModel.Description("Vessel overall length in metres (creates the vessel block when supplied).")] double? vesselLengthMeters = null,
+            [System.ComponentModel.Description("Vessel beam in metres (creates the vessel block when supplied).")] double? vesselBeamMeters = null,
+            CancellationToken ct = default) =>
+            RouteAdapterShared.DispatchAsync(() => inner.InvokeAsync(
+                new SetRouteInfoRequest(
+                    routeId, name, author, description, departurePortId, arrivalPortId,
+                    validityStart, validityEnd,
+                    vesselName, vesselMmsi, vesselImo, vesselCallsign, vesselLengthMeters, vesselBeamMeters),
+                ct));
+
+        return McpServerTool.Create(del, new McpServerToolCreateOptions
+        {
+            Name = SetRouteInfoTool.Name,
+            Description = Description,
+            SerializerOptions = JsonOptions,
+        });
+    }
+
+    /// <summary>Test seam mirroring the production translation.</summary>
+    internal static CallToolResult TranslateResult(ToolResult<RouteDetail> result)
+        => RouteAdapterShared.Translate(result);
+}

--- a/src/EncDotNet.S100.Viewer/McpTools/RouteNotFound.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RouteNotFound.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using EncDotNet.S100.Mcp.Tools;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// The supplied route identifier does not match any route in the viewer's
+/// editable route collection. Distinguished from
+/// <see cref="InvalidArgument"/> in that the value is well-formed; it simply
+/// does not resolve. Also raised when a tool defaults to the active route
+/// but the collection is empty.
+/// </summary>
+/// <param name="RouteId">The route identifier that could not be resolved,
+/// or <c>"(active)"</c> when the active route was requested but none
+/// exists.</param>
+[Description("Raised when the requested routeId does not match any route in the viewer's editable route collection (or when the active route was requested but the collection is empty).")]
+internal sealed record RouteNotFound(
+    [property: Description("The route identifier that could not be resolved, or \"(active)\" when the active route was requested but none exists.")] string RouteId)
+    : ToolError("route_not_found", $"No route with id '{RouteId}' exists in the viewer's route collection.");

--- a/src/EncDotNet.S100.Viewer/McpTools/RouteTools.cs
+++ b/src/EncDotNet.S100.Viewer/McpTools/RouteTools.cs
@@ -1,0 +1,663 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.McpTools;
+
+/// <summary>
+/// Shared base for the agent-facing route tools. Holds the
+/// <see cref="RoutesService"/> mutation surface and the
+/// <see cref="IRouteEditInvoker"/> that marshals work onto the UI thread,
+/// and provides route resolution plus coordinate validation common to the
+/// family.
+/// </summary>
+/// <remarks>
+/// Every tool resolves its target route by id, defaulting to the active
+/// route when the id is omitted, and runs all model access inside
+/// <see cref="IRouteEditInvoker.InvokeAsync{T}"/> so that the resulting
+/// <c>Changed</c> fan-out (overlay redraw, panel rebuild) executes with UI
+/// affinity.
+/// </remarks>
+internal abstract class RouteToolBase
+{
+    internal const double MinLat = -90.0;
+    internal const double MaxLat = 90.0;
+    internal const double MinLon = -180.0;
+    internal const double MaxLon = 180.0;
+
+    /// <summary>The shared route mutation surface.</summary>
+    protected RoutesService Routes { get; }
+
+    /// <summary>Marshals model access onto the UI thread.</summary>
+    protected IRouteEditInvoker Invoker { get; }
+
+    /// <summary>Creates a new <see cref="RouteToolBase"/>.</summary>
+    protected RouteToolBase(RoutesService routes, IRouteEditInvoker invoker)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        ArgumentNullException.ThrowIfNull(invoker);
+        Routes = routes;
+        Invoker = invoker;
+    }
+
+    /// <summary>
+    /// Resolves the target route. When <paramref name="routeId"/> is null or
+    /// whitespace the active route is used. Sets <paramref name="error"/> and
+    /// returns <c>null</c> when the route cannot be resolved.
+    /// </summary>
+    protected Route? Resolve(string? routeId, out ToolError? error)
+    {
+        if (string.IsNullOrWhiteSpace(routeId))
+        {
+            var active = Routes.Routes.ActiveRoute;
+            if (active is null)
+            {
+                error = new RouteNotFound("(active)");
+                return null;
+            }
+            error = null;
+            return active;
+        }
+
+        var route = Routes.Routes.FindById(routeId);
+        if (route is null)
+        {
+            error = new RouteNotFound(routeId);
+            return null;
+        }
+        error = null;
+        return route;
+    }
+
+    /// <summary>Validates a latitude/longitude pair against the WGS-84 range.</summary>
+    protected static ToolError? ValidateLatLon(double lat, double lon)
+    {
+        if (NotFinite(lat))
+            return new InvalidArgument("lat", $"value {lat} is not a finite number");
+        if (lat < MinLat || lat > MaxLat)
+            return new InvalidArgument("lat", $"value {lat} is outside the WGS-84 range [{MinLat}, {MaxLat}]");
+        if (NotFinite(lon))
+            return new InvalidArgument("lon", $"value {lon} is not a finite number");
+        if (lon < MinLon || lon > MaxLon)
+            return new InvalidArgument("lon", $"value {lon} is outside the WGS-84 range [{MinLon}, {MaxLon}]");
+        return null;
+    }
+
+    /// <summary>Applies any supplied waypoint metadata in place.</summary>
+    protected static void ApplyWaypointMetadata(
+        RouteWaypoint waypoint, int? number, string? name, bool? @fixed, double? turnRadiusNm)
+    {
+        if (number.HasValue) waypoint.Number = number;
+        if (name is not null) waypoint.Name = name;
+        if (@fixed.HasValue) waypoint.Fixed = @fixed;
+        if (turnRadiusNm.HasValue) waypoint.TurnRadiusNm = turnRadiusNm;
+    }
+
+    /// <summary>Whether any waypoint-metadata field was supplied.</summary>
+    protected static bool HasWaypointMetadata(int? number, string? name, bool? @fixed, double? turnRadiusNm)
+        => number.HasValue || name is not null || @fixed.HasValue || turnRadiusNm.HasValue;
+
+    private protected static bool NotFinite(double v) => double.IsNaN(v) || double.IsInfinity(v);
+
+    private protected static ToolResult<RouteDetail> Ok(Route route, RoutesService routes)
+        => ToolResult<RouteDetail>.Ok(RouteProjection.Detail(route, routes));
+}
+
+// ---------------------------------------------------------------------------
+// create_route
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="CreateRouteTool"/>.</summary>
+[Description("Request for create_route: create a new, empty route and make it active.")]
+internal sealed record CreateRouteRequest(
+    [property: Description("Optional route name.")] string? Name = null,
+    [property: Description("Optional stable route id; a GUID is generated when omitted. Must be unique within the collection.")] string? Id = null);
+
+/// <summary>
+/// Creates a new editable route, adds it to the viewer's route collection,
+/// and makes it the active route. The created route is empty; add waypoints
+/// with <c>append_waypoint</c>.
+/// </summary>
+internal sealed class CreateRouteTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "create_route";
+
+    /// <summary>Creates a new <see cref="CreateRouteTool"/>.</summary>
+    public CreateRouteTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        CreateRouteRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Invoker.InvokeAsync(() =>
+        {
+            Route route;
+            try
+            {
+                route = Routes.Routes.CreateRoute(request.Name, request.Id);
+            }
+            catch (ArgumentException ex)
+            {
+                return ToolResult<RouteDetail>.Err(new InvalidArgument("id", ex.Message));
+            }
+            return Ok(route, Routes);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// list_routes
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="ListRoutesTool"/> (no parameters).</summary>
+[Description("Request for list_routes: no parameters.")]
+internal sealed record ListRoutesRequest();
+
+/// <summary>Lists every route in the viewer's collection with aggregate metrics.</summary>
+internal sealed class ListRoutesTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "list_routes";
+
+    /// <summary>Creates a new <see cref="ListRoutesTool"/>.</summary>
+    public ListRoutesTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<ListRoutesResult>> InvokeAsync(
+        ListRoutesRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var summaries = new System.Collections.Generic.List<RouteSummary>(Routes.Routes.Routes.Count);
+            foreach (var route in Routes.Routes.Routes)
+                summaries.Add(RouteProjection.Summary(route, Routes));
+            return ToolResult<ListRoutesResult>.Ok(
+                new ListRoutesResult(summaries, Routes.Routes.ActiveRoute?.Id));
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// get_route
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="GetRouteTool"/>.</summary>
+[Description("Request for get_route: return the full state of one route.")]
+internal sealed record GetRouteRequest(
+    [property: Description("Id of the route to return; omit to use the active route.")] string? RouteId = null);
+
+/// <summary>Returns the full state of a single route.</summary>
+internal sealed class GetRouteTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "get_route";
+
+    /// <summary>Creates a new <see cref="GetRouteTool"/>.</summary>
+    public GetRouteTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        GetRouteRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            return route is null
+                ? ToolResult<RouteDetail>.Err(error!)
+                : Ok(route, Routes);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// delete_route
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="DeleteRouteTool"/>.</summary>
+[Description("Request for delete_route: remove a route from the collection.")]
+internal sealed record DeleteRouteRequest(
+    [property: Description("Id of the route to delete; omit to delete the active route.")] string? RouteId = null);
+
+/// <summary>Removes a route from the viewer's collection.</summary>
+internal sealed class DeleteRouteTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "delete_route";
+
+    /// <summary>Creates a new <see cref="DeleteRouteTool"/>.</summary>
+    public DeleteRouteTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<DeleteRouteResult>> InvokeAsync(
+        DeleteRouteRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<DeleteRouteResult>.Err(error!);
+
+            var removed = Routes.Routes.Remove(route);
+            return ToolResult<DeleteRouteResult>.Ok(
+                new DeleteRouteResult(route.Id, removed, Routes.Routes.ActiveRoute?.Id));
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// append_waypoint
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="AppendWaypointTool"/>.</summary>
+[Description("Request for append_waypoint: add a waypoint to the end of a route.")]
+internal sealed record AppendWaypointRequest(
+    [property: Description("WGS-84 latitude in decimal degrees [-90, 90].")] double Lat,
+    [property: Description("WGS-84 longitude in decimal degrees [-180, 180].")] double Lon,
+    [property: Description("Id of the route to append to; omit to use the active route.")] string? RouteId = null,
+    [property: Description("Optional author-assigned ordinal (S-421 routeWaypointID).")] int? Number = null,
+    [property: Description("Optional waypoint name.")] string? Name = null,
+    [property: Description("Optional flag pinning the waypoint so it must not be moved.")] bool? Fixed = null,
+    [property: Description("Optional planned turn radius at the waypoint, in nautical miles.")] double? TurnRadiusNm = null);
+
+/// <summary>Appends a waypoint to the end of a route.</summary>
+internal sealed class AppendWaypointTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "append_waypoint";
+
+    /// <summary>Creates a new <see cref="AppendWaypointTool"/>.</summary>
+    public AppendWaypointTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        AppendWaypointRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (ValidateLatLon(request.Lat, request.Lon) is { } latLonError)
+            return Task.FromResult(ToolResult<RouteDetail>.Err(latLonError));
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<RouteDetail>.Err(error!);
+
+            var waypoint = route.AppendWaypoint(new GeoPosition(request.Lat, request.Lon));
+            if (HasWaypointMetadata(request.Number, request.Name, request.Fixed, request.TurnRadiusNm))
+            {
+                ApplyWaypointMetadata(waypoint, request.Number, request.Name, request.Fixed, request.TurnRadiusNm);
+                route.NotifyChanged();
+            }
+            return Ok(route, Routes);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// insert_waypoint
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="InsertWaypointTool"/>.</summary>
+[Description("Request for insert_waypoint: insert a waypoint at a position in a route, splitting the affected leg.")]
+internal sealed record InsertWaypointRequest(
+    [property: Description("Insertion index in [0, waypointCount]; 0 prepends, waypointCount appends.")] int Index,
+    [property: Description("WGS-84 latitude in decimal degrees [-90, 90].")] double Lat,
+    [property: Description("WGS-84 longitude in decimal degrees [-180, 180].")] double Lon,
+    [property: Description("Id of the route to insert into; omit to use the active route.")] string? RouteId = null,
+    [property: Description("Optional author-assigned ordinal (S-421 routeWaypointID).")] int? Number = null,
+    [property: Description("Optional waypoint name.")] string? Name = null,
+    [property: Description("Optional flag pinning the waypoint so it must not be moved.")] bool? Fixed = null,
+    [property: Description("Optional planned turn radius at the waypoint, in nautical miles.")] double? TurnRadiusNm = null);
+
+/// <summary>Inserts a waypoint at a given index of a route.</summary>
+internal sealed class InsertWaypointTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "insert_waypoint";
+
+    /// <summary>Creates a new <see cref="InsertWaypointTool"/>.</summary>
+    public InsertWaypointTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        InsertWaypointRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (ValidateLatLon(request.Lat, request.Lon) is { } latLonError)
+            return Task.FromResult(ToolResult<RouteDetail>.Err(latLonError));
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<RouteDetail>.Err(error!);
+
+            if (request.Index < 0 || request.Index > route.Waypoints.Count)
+                return ToolResult<RouteDetail>.Err(new InvalidArgument(
+                    "index",
+                    $"value {request.Index} is outside the insertable range [0, {route.Waypoints.Count}]"));
+
+            var waypoint = route.InsertWaypoint(request.Index, new GeoPosition(request.Lat, request.Lon));
+            if (HasWaypointMetadata(request.Number, request.Name, request.Fixed, request.TurnRadiusNm))
+            {
+                ApplyWaypointMetadata(waypoint, request.Number, request.Name, request.Fixed, request.TurnRadiusNm);
+                route.NotifyChanged();
+            }
+            return Ok(route, Routes);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// move_waypoint
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="MoveWaypointTool"/>.</summary>
+[Description("Request for move_waypoint: move an existing waypoint to a new position.")]
+internal sealed record MoveWaypointRequest(
+    [property: Description("Index of the waypoint to move in [0, waypointCount).")] int Index,
+    [property: Description("New WGS-84 latitude in decimal degrees [-90, 90].")] double Lat,
+    [property: Description("New WGS-84 longitude in decimal degrees [-180, 180].")] double Lon,
+    [property: Description("Id of the route to edit; omit to use the active route.")] string? RouteId = null);
+
+/// <summary>Moves an existing waypoint to a new position.</summary>
+internal sealed class MoveWaypointTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "move_waypoint";
+
+    /// <summary>Creates a new <see cref="MoveWaypointTool"/>.</summary>
+    public MoveWaypointTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        MoveWaypointRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (ValidateLatLon(request.Lat, request.Lon) is { } latLonError)
+            return Task.FromResult(ToolResult<RouteDetail>.Err(latLonError));
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<RouteDetail>.Err(error!);
+
+            if (request.Index < 0 || request.Index >= route.Waypoints.Count)
+                return ToolResult<RouteDetail>.Err(new InvalidArgument(
+                    "index",
+                    $"value {request.Index} is outside the waypoint range [0, {route.Waypoints.Count - 1}]"));
+
+            route.MoveWaypoint(request.Index, new GeoPosition(request.Lat, request.Lon));
+            return Ok(route, Routes);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// delete_waypoint
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="DeleteWaypointTool"/>.</summary>
+[Description("Request for delete_waypoint: remove a waypoint, merging the adjacent legs.")]
+internal sealed record DeleteWaypointRequest(
+    [property: Description("Index of the waypoint to remove in [0, waypointCount).")] int Index,
+    [property: Description("Id of the route to edit; omit to use the active route.")] string? RouteId = null);
+
+/// <summary>Removes a waypoint from a route.</summary>
+internal sealed class DeleteWaypointTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "delete_waypoint";
+
+    /// <summary>Creates a new <see cref="DeleteWaypointTool"/>.</summary>
+    public DeleteWaypointTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        DeleteWaypointRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<RouteDetail>.Err(error!);
+
+            if (request.Index < 0 || request.Index >= route.Waypoints.Count)
+                return ToolResult<RouteDetail>.Err(new InvalidArgument(
+                    "index",
+                    $"value {request.Index} is outside the waypoint range [0, {route.Waypoints.Count - 1}]"));
+
+            route.RemoveWaypoint(request.Index);
+            return Ok(route, Routes);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// set_leg_attributes
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="SetLegAttributesTool"/>.</summary>
+/// <remarks>
+/// Every attribute is optional and overwrites the corresponding leg field
+/// when supplied; an omitted (null) field leaves the existing value
+/// unchanged. There is no facility to clear a previously-set field in this
+/// version.
+/// </remarks>
+[Description("Request for set_leg_attributes: update one leg's geometry type and/or navigational envelope. All attributes optional; supplied values overwrite, omitted values are left unchanged.")]
+internal sealed record SetLegAttributesRequest(
+    [property: Description("Index of the leg to edit in [0, legCount); leg i joins waypoint i to waypoint i+1.")] int LegIndex,
+    [property: Description("Id of the route to edit; omit to use the active route.")] string? RouteId = null,
+    [property: Description("Leg path geometry: \"loxodrome\" (rhumb line) or \"geodesic\" (great circle).")] string? GeometryType = null,
+    [property: Description("Starboard cross-track distance limit in metres.")] double? StarboardCrossTrackDistanceLimitMeters = null,
+    [property: Description("Port cross-track distance limit in metres.")] double? PortCrossTrackDistanceLimitMeters = null,
+    [property: Description("Starboard channel limit in metres.")] double? StarboardChannelLimitMeters = null,
+    [property: Description("Port channel limit in metres.")] double? PortChannelLimitMeters = null,
+    [property: Description("Safety contour for the leg in metres.")] double? SafetyContourMeters = null,
+    [property: Description("Safety depth for the leg in metres.")] double? SafetyDepthMeters = null,
+    [property: Description("Minimum speed over ground in knots.")] double? SpeedOverGroundMinKnots = null,
+    [property: Description("Maximum speed over ground in knots.")] double? SpeedOverGroundMaxKnots = null,
+    [property: Description("Minimum speed through water in knots.")] double? SpeedThroughWaterMinKnots = null,
+    [property: Description("Maximum speed through water in knots.")] double? SpeedThroughWaterMaxKnots = null,
+    [property: Description("Planned draft for the leg in metres.")] double? DraftMeters = null,
+    [property: Description("Static under-keel clearance in metres.")] double? StaticUnderKeelClearanceMeters = null,
+    [property: Description("Dynamic under-keel clearance in metres.")] double? DynamicUnderKeelClearanceMeters = null,
+    [property: Description("Safety margin in metres.")] double? SafetyMarginMeters = null,
+    [property: Description("Free-text note for the leg.")] string? Note = null);
+
+/// <summary>Updates a single route leg's geometry type and navigational envelope.</summary>
+internal sealed class SetLegAttributesTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "set_leg_attributes";
+
+    /// <summary>Creates a new <see cref="SetLegAttributesTool"/>.</summary>
+    public SetLegAttributesTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        SetLegAttributesRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        RouteLegGeometryType? geometry = null;
+        if (request.GeometryType is not null)
+        {
+            if (!TryParseGeometry(request.GeometryType, out var parsed))
+                return Task.FromResult(ToolResult<RouteDetail>.Err(new InvalidArgument(
+                    "geometryType",
+                    $"value '{request.GeometryType}' is not one of: loxodrome, geodesic")));
+            geometry = parsed;
+        }
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<RouteDetail>.Err(error!);
+
+            if (request.LegIndex < 0 || request.LegIndex >= route.Legs.Count)
+                return ToolResult<RouteDetail>.Err(new InvalidArgument(
+                    "legIndex",
+                    $"value {request.LegIndex} is outside the leg range [0, {route.Legs.Count - 1}]"));
+
+            var leg = route.Legs[request.LegIndex];
+            if (geometry.HasValue) leg.GeometryType = geometry.Value;
+            if (request.StarboardCrossTrackDistanceLimitMeters.HasValue) leg.StarboardCrossTrackDistanceLimitMeters = request.StarboardCrossTrackDistanceLimitMeters;
+            if (request.PortCrossTrackDistanceLimitMeters.HasValue) leg.PortCrossTrackDistanceLimitMeters = request.PortCrossTrackDistanceLimitMeters;
+            if (request.StarboardChannelLimitMeters.HasValue) leg.StarboardChannelLimitMeters = request.StarboardChannelLimitMeters;
+            if (request.PortChannelLimitMeters.HasValue) leg.PortChannelLimitMeters = request.PortChannelLimitMeters;
+            if (request.SafetyContourMeters.HasValue) leg.SafetyContourMeters = request.SafetyContourMeters;
+            if (request.SafetyDepthMeters.HasValue) leg.SafetyDepthMeters = request.SafetyDepthMeters;
+            if (request.SpeedOverGroundMinKnots.HasValue) leg.SpeedOverGroundMinKnots = request.SpeedOverGroundMinKnots;
+            if (request.SpeedOverGroundMaxKnots.HasValue) leg.SpeedOverGroundMaxKnots = request.SpeedOverGroundMaxKnots;
+            if (request.SpeedThroughWaterMinKnots.HasValue) leg.SpeedThroughWaterMinKnots = request.SpeedThroughWaterMinKnots;
+            if (request.SpeedThroughWaterMaxKnots.HasValue) leg.SpeedThroughWaterMaxKnots = request.SpeedThroughWaterMaxKnots;
+            if (request.DraftMeters.HasValue) leg.DraftMeters = request.DraftMeters;
+            if (request.StaticUnderKeelClearanceMeters.HasValue) leg.StaticUnderKeelClearanceMeters = request.StaticUnderKeelClearanceMeters;
+            if (request.DynamicUnderKeelClearanceMeters.HasValue) leg.DynamicUnderKeelClearanceMeters = request.DynamicUnderKeelClearanceMeters;
+            if (request.SafetyMarginMeters.HasValue) leg.SafetyMarginMeters = request.SafetyMarginMeters;
+            if (request.Note is not null) leg.Note = request.Note;
+
+            route.NotifyChanged();
+            return Ok(route, Routes);
+        });
+    }
+
+    private static bool TryParseGeometry(string value, out RouteLegGeometryType type)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "loxodrome":
+            case "rhumb":
+            case "rhumbline":
+                type = RouteLegGeometryType.Loxodrome;
+                return true;
+            case "geodesic":
+            case "greatcircle":
+            case "great_circle":
+                type = RouteLegGeometryType.Geodesic;
+                return true;
+            default:
+                type = RouteLegGeometryType.Loxodrome;
+                return false;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// set_route_info
+// ---------------------------------------------------------------------------
+
+/// <summary>Request for <see cref="SetRouteInfoTool"/>.</summary>
+/// <remarks>
+/// Every field is optional and overwrites the corresponding route-info value
+/// when supplied; omitted fields are left unchanged. Supplying any vessel
+/// field lazily creates the vessel block.
+/// </remarks>
+[Description("Request for set_route_info: update a route's metadata (name, author, ports, validity) and vessel particulars. All fields optional; supplied values overwrite, omitted values are left unchanged.")]
+internal sealed record SetRouteInfoRequest(
+    [property: Description("Id of the route to edit; omit to use the active route.")] string? RouteId = null,
+    [property: Description("Route name.")] string? Name = null,
+    [property: Description("Route author / originator.")] string? Author = null,
+    [property: Description("Free-text route description.")] string? Description = null,
+    [property: Description("Departure port identifier.")] string? DeparturePortId = null,
+    [property: Description("Arrival port identifier.")] string? ArrivalPortId = null,
+    [property: Description("Planned start of validity (UTC ISO-8601).")] DateTimeOffset? ValidityStart = null,
+    [property: Description("Planned end of validity (UTC ISO-8601).")] DateTimeOffset? ValidityEnd = null,
+    [property: Description("Vessel name (creates the vessel block when supplied).")] string? VesselName = null,
+    [property: Description("Vessel MMSI (creates the vessel block when supplied).")] string? VesselMmsi = null,
+    [property: Description("Vessel IMO number (creates the vessel block when supplied).")] string? VesselImo = null,
+    [property: Description("Vessel call sign (creates the vessel block when supplied).")] string? VesselCallsign = null,
+    [property: Description("Vessel overall length in metres (creates the vessel block when supplied).")] double? VesselLengthMeters = null,
+    [property: Description("Vessel beam in metres (creates the vessel block when supplied).")] double? VesselBeamMeters = null);
+
+/// <summary>Updates a route's metadata and vessel particulars.</summary>
+internal sealed class SetRouteInfoTool : RouteToolBase
+{
+    /// <summary>Public tool name as exposed over MCP.</summary>
+    public const string Name = "set_route_info";
+
+    /// <summary>Creates a new <see cref="SetRouteInfoTool"/>.</summary>
+    public SetRouteInfoTool(RoutesService routes, IRouteEditInvoker invoker)
+        : base(routes, invoker) { }
+
+    /// <summary>Executes the tool.</summary>
+    public Task<ToolResult<RouteDetail>> InvokeAsync(
+        SetRouteInfoRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Invoker.InvokeAsync(() =>
+        {
+            var route = Resolve(request.RouteId, out var error);
+            if (route is null)
+                return ToolResult<RouteDetail>.Err(error!);
+
+            var info = route.Info;
+            if (request.Name is not null) info.Name = request.Name;
+            if (request.Author is not null) info.Author = request.Author;
+            if (request.Description is not null) info.Description = request.Description;
+            if (request.DeparturePortId is not null) info.DeparturePortId = request.DeparturePortId;
+            if (request.ArrivalPortId is not null) info.ArrivalPortId = request.ArrivalPortId;
+            if (request.ValidityStart.HasValue) info.ValidityStart = request.ValidityStart;
+            if (request.ValidityEnd.HasValue) info.ValidityEnd = request.ValidityEnd;
+
+            var hasVesselField = request.VesselName is not null || request.VesselMmsi is not null
+                || request.VesselImo is not null || request.VesselCallsign is not null
+                || request.VesselLengthMeters.HasValue || request.VesselBeamMeters.HasValue;
+            if (hasVesselField)
+            {
+                var vessel = info.Vessel ??= new RouteVesselInfo();
+                if (request.VesselName is not null) vessel.Name = request.VesselName;
+                if (request.VesselMmsi is not null) vessel.Mmsi = request.VesselMmsi;
+                if (request.VesselImo is not null) vessel.Imo = request.VesselImo;
+                if (request.VesselCallsign is not null) vessel.Callsign = request.VesselCallsign;
+                if (request.VesselLengthMeters.HasValue) vessel.LengthMeters = request.VesselLengthMeters;
+                if (request.VesselBeamMeters.HasValue) vessel.BeamMeters = request.VesselBeamMeters;
+            }
+
+            route.NotifyChanged();
+            return Ok(route, Routes);
+        });
+    }
+}

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -119,6 +119,36 @@ and projects to EPSG:3857 (Web Mercator) for display. Coverage
 grids tagged with UTM-band CRSs (typical for S-102) are reprojected
 on the fly via ProjNet.
 
+## Routes
+
+The viewer can hold a collection of editable **routes** — ordered
+waypoints joined by legs — that persist on the map independently of
+the transient **Measure** ruler. Routes are first-class objects an
+agent can also create and manipulate over the
+[MCP server](#optional-mcp-server) so the *compose → inspect →
+refine* loop against loaded datasets stays in one place.
+
+- **Route Edit Mode** (route button in the top-right map toolbar):
+  click on the water to append a waypoint, drag a waypoint to move
+  it, click an existing leg to insert a waypoint that splits it,
+  and right-click (or select + `Delete`) to remove one. `Backspace`
+  drops the last waypoint. The status bar shows the latest leg's
+  distance/bearing and the route total.
+- **Routes panel** (route icon in the activity bar): lists every
+  route (add / remove / rename / select the active one) and the
+  active route's waypoints with per-leg distance, initial bearing,
+  and geometry type. Each leg can be toggled between a **rhumb line**
+  (loxodrome, the ECDIS default) and a **great circle** (geodesic),
+  which the overlay densifies into a curved arc in Mercator space.
+- **Promote a measurement**: the *From measurement* button copies the
+  current Measure Mode path into a new route, then switches to Route
+  Edit Mode so it can be refined.
+
+The active route is emphasised on the map; inactive routes recede so
+several routes can coexist legibly. The model mirrors the in-repo
+S-421 route schema (`Route` → `RouteWaypoint` → `RouteLeg`), keeping a
+future S-421 export a near-mechanical projection.
+
 ## Layer stack
 
 The **Layer Stack** panel collects every visible layer into the

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -564,7 +564,7 @@ sets the bind address (loopback recommended). Any MCP flag implies
 `--mcp-port-file <PATH>` writes the bound endpoint URI to a file once
 the server is listening (the endpoint is also echoed to stdout as
 `[MCP] listening on …`). A CLI-driven MCP run never persists the
-bound port back to the user's `settings.json`. Eleven viewer-only tools
+bound port back to the user's `settings.json`. Twenty-one viewer-only tools
 are injected when the server starts: `render_to_image` (read-only —
 captures a PNG snapshot from a clone of the live map),
 `set_viewport` (mutating — drives the live navigator to a bbox or
@@ -584,10 +584,16 @@ on-screen paint: frame duration, interval, and per-style draw-call
 breakdown, for measuring rendering performance), `open_dataset`
 (mutating — loads a file or exchange set through the viewer's own
 open code path and reports the resulting catalog id(s), bbox, and
-load duration), and `close_dataset` (mutating — unloads a dataset by
-catalog id, tolerating unknown ids gracefully), and
+load duration), `close_dataset` (mutating — unloads a dataset by
+catalog id, tolerating unknown ids gracefully),
 `close_all_datasets` (mutating — unloads every currently-loaded
-dataset in one call). See
+dataset in one call), and the **route-editing family** that lets an
+agent build and refine persistent routes shown live in the **Routes**
+panel and route overlay: `create_route`, `list_routes` (read-only),
+`get_route` (read-only), `delete_route`, `append_waypoint`,
+`insert_waypoint`, `move_waypoint`, `delete_waypoint`,
+`set_leg_attributes`, and `set_route_info` (all mutating; fields mirror
+the in-repo S-421 model). See
 `docs/mcp-server.md` for the full catalogue and the read-only /
 mutating split.
 

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -439,6 +439,56 @@ internal static class Strings
     public static string Status_MeasureNoData => Get(nameof(Status_MeasureNoData));
     public static string Status_MeasureLegLabel => Get(nameof(Status_MeasureLegLabel));
 
+    // Routing
+    public static string Route_LegLabel => Get(nameof(Route_LegLabel));
+    public static string Tooltip_RouteEditMode => Get(nameof(Tooltip_RouteEditMode));
+    public static string Menu_RouteEditMode => Get(nameof(Menu_RouteEditMode));
+    public static string Status_RouteEditNoData => Get(nameof(Status_RouteEditNoData));
+    public static string Status_RouteLeg => Get(nameof(Status_RouteLeg));
+    public static string Status_RouteTotal => Get(nameof(Status_RouteTotal));
+    public static string Pane_Routes => Get(nameof(Pane_Routes));
+    public static string Tooltip_RoutesPanel => Get(nameof(Tooltip_RoutesPanel));
+    public static string Routes_NewRouteNameFormat => Get(nameof(Routes_NewRouteNameFormat));
+    public static string Routes_NoRoutes => Get(nameof(Routes_NoRoutes));
+    public static string Routes_NoActiveRoute => Get(nameof(Routes_NoActiveRoute));
+    public static string Routes_WaypointsHeader => Get(nameof(Routes_WaypointsHeader));
+    public static string Routes_TotalDistanceFormat => Get(nameof(Routes_TotalDistanceFormat));
+    public static string Routes_WaypointRowFormat => Get(nameof(Routes_WaypointRowFormat));
+    public static string Routes_LegRowFormat => Get(nameof(Routes_LegRowFormat));
+    public static string Button_AddRoute => Get(nameof(Button_AddRoute));
+    public static string Tooltip_AddRoute => Get(nameof(Tooltip_AddRoute));
+    public static string Button_RemoveRoute => Get(nameof(Button_RemoveRoute));
+    public static string Tooltip_RemoveRoute => Get(nameof(Tooltip_RemoveRoute));
+    public static string Button_PromoteMeasurement => Get(nameof(Button_PromoteMeasurement));
+    public static string Tooltip_PromoteMeasurement => Get(nameof(Tooltip_PromoteMeasurement));
+    public static string Button_DeleteWaypoint => Get(nameof(Button_DeleteWaypoint));
+    public static string Tooltip_DeleteWaypoint => Get(nameof(Tooltip_DeleteWaypoint));
+    public static string Button_ToggleLegGeometry => Get(nameof(Button_ToggleLegGeometry));
+    public static string Tooltip_ToggleLegGeometry => Get(nameof(Tooltip_ToggleLegGeometry));
+    public static string Routes_GeometryLoxodrome => Get(nameof(Routes_GeometryLoxodrome));
+    public static string Routes_GeometryGeodesic => Get(nameof(Routes_GeometryGeodesic));
+    public static string Routes_GeometryMixed => Get(nameof(Routes_GeometryMixed));
+    public static string Routes_RouteMetaFormat => Get(nameof(Routes_RouteMetaFormat));
+    public static string Routes_DetailMetaFormat => Get(nameof(Routes_DetailMetaFormat));
+    public static string Routes_DetailMetaWithGeometryFormat => Get(nameof(Routes_DetailMetaWithGeometryFormat));
+    public static string Routes_WaypointNameFormat => Get(nameof(Routes_WaypointNameFormat));
+    public static string Routes_WaypointCoordFormat => Get(nameof(Routes_WaypointCoordFormat));
+    public static string Routes_LegMetaFormat => Get(nameof(Routes_LegMetaFormat));
+    public static string Button_InsertWaypoint => Get(nameof(Button_InsertWaypoint));
+    public static string Tooltip_InsertWaypoint => Get(nameof(Tooltip_InsertWaypoint));
+    public static string Button_ReverseRoute => Get(nameof(Button_ReverseRoute));
+    public static string Tooltip_ReverseRoute => Get(nameof(Tooltip_ReverseRoute));
+    public static string Button_DoneRouteEdit => Get(nameof(Button_DoneRouteEdit));
+    public static string Tooltip_DoneRouteEdit => Get(nameof(Tooltip_DoneRouteEdit));
+    public static string Menu_RenameRoute => Get(nameof(Menu_RenameRoute));
+    public static string Menu_ReverseRoute => Get(nameof(Menu_ReverseRoute));
+    public static string Menu_RemoveRoute => Get(nameof(Menu_RemoveRoute));
+    public static string Menu_InsertWaypointAfter => Get(nameof(Menu_InsertWaypointAfter));
+    public static string Menu_DeleteWaypoint => Get(nameof(Menu_DeleteWaypoint));
+    public static string Tooltip_RouteRowMenu => Get(nameof(Tooltip_RouteRowMenu));
+    public static string Tooltip_WaypointRowMenu => Get(nameof(Tooltip_WaypointRowMenu));
+    public static string Tooltip_EditRouteName => Get(nameof(Tooltip_EditRouteName));
+
     // ECDIS Display Planes
     public static string EcdisPanel_DisplayPlanesHeader => Get(nameof(EcdisPanel_DisplayPlanesHeader));
     public static string DisplayPlane_UnderRadar => Get(nameof(DisplayPlane_UnderRadar));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1203,6 +1203,152 @@
     <value>{0:0.0} NM @ {1:000}°T</value>
   </data>
 
+  <!-- Routing -->
+  <data name="Route_LegLabel" xml:space="preserve">
+    <value>{0:0.0} NM @ {1:000}°T</value>
+  </data>
+  <data name="Tooltip_RouteEditMode" xml:space="preserve">
+    <value>Edit route (click to add waypoints, drag to move)</value>
+  </data>
+  <data name="Menu_RouteEditMode" xml:space="preserve">
+    <value>Route Edit Mode</value>
+  </data>
+  <data name="Status_RouteEditNoData" xml:space="preserve">
+    <value>Click on the map to add waypoints; drag a waypoint to move it, Backspace removes the last.</value>
+  </data>
+  <data name="Status_RouteLeg" xml:space="preserve">
+    <value>Leg {0}: {1:0.0} NM @ {2:000}°T</value>
+  </data>
+  <data name="Status_RouteTotal" xml:space="preserve">
+    <value>Total: {0:0.0} NM</value>
+  </data>
+  <data name="Pane_Routes" xml:space="preserve">
+    <value>Routes</value>
+  </data>
+  <data name="Tooltip_RoutesPanel" xml:space="preserve">
+    <value>Show the routes panel</value>
+  </data>
+  <data name="Routes_NewRouteNameFormat" xml:space="preserve">
+    <value>Route {0}</value>
+  </data>
+  <data name="Routes_NoRoutes" xml:space="preserve">
+    <value>No routes yet. Add a route or promote a measurement.</value>
+  </data>
+  <data name="Routes_NoActiveRoute" xml:space="preserve">
+    <value>Select a route to view its waypoints and legs.</value>
+  </data>
+  <data name="Routes_WaypointsHeader" xml:space="preserve">
+    <value>Waypoints &amp; legs</value>
+  </data>
+  <data name="Routes_TotalDistanceFormat" xml:space="preserve">
+    <value>{0} waypoints · {1:0.0} NM total</value>
+  </data>
+  <data name="Routes_WaypointRowFormat" xml:space="preserve">
+    <value>{0}. {1:0.0000}, {2:0.0000}</value>
+  </data>
+  <data name="Routes_LegRowFormat" xml:space="preserve">
+    <value>{0:0.0} NM @ {1:000}°T</value>
+  </data>
+  <data name="Button_AddRoute" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="Tooltip_AddRoute" xml:space="preserve">
+    <value>Add a new empty route and start editing it</value>
+  </data>
+  <data name="Button_RemoveRoute" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="Tooltip_RemoveRoute" xml:space="preserve">
+    <value>Remove the selected route</value>
+  </data>
+  <data name="Button_PromoteMeasurement" xml:space="preserve">
+    <value>From measurement</value>
+  </data>
+  <data name="Tooltip_PromoteMeasurement" xml:space="preserve">
+    <value>Create a route from the current measurement path</value>
+  </data>
+  <data name="Button_DeleteWaypoint" xml:space="preserve">
+    <value>Delete waypoint</value>
+  </data>
+  <data name="Tooltip_DeleteWaypoint" xml:space="preserve">
+    <value>Delete the selected waypoint from the active route</value>
+  </data>
+  <data name="Button_ToggleLegGeometry" xml:space="preserve">
+    <value>Toggle leg geometry</value>
+  </data>
+  <data name="Tooltip_ToggleLegGeometry" xml:space="preserve">
+    <value>Switch the selected leg between rhumb line and great circle</value>
+  </data>
+  <data name="Routes_GeometryLoxodrome" xml:space="preserve">
+    <value>Rhumb</value>
+  </data>
+  <data name="Routes_GeometryGeodesic" xml:space="preserve">
+    <value>Great circle</value>
+  </data>
+  <data name="Routes_GeometryMixed" xml:space="preserve">
+    <value>Mixed</value>
+  </data>
+  <data name="Routes_RouteMetaFormat" xml:space="preserve">
+    <value>{0} WP · {1:0.0} NM</value>
+  </data>
+  <data name="Routes_DetailMetaFormat" xml:space="preserve">
+    <value>{0} WP · {1:0.0} NM</value>
+  </data>
+  <data name="Routes_DetailMetaWithGeometryFormat" xml:space="preserve">
+    <value>{0} WP · {1:0.0} NM · {2}</value>
+  </data>
+  <data name="Routes_WaypointNameFormat" xml:space="preserve">
+    <value>Waypoint {0}</value>
+  </data>
+  <data name="Routes_WaypointCoordFormat" xml:space="preserve">
+    <value>{0:0.0000}, {1:0.0000}</value>
+  </data>
+  <data name="Routes_LegMetaFormat" xml:space="preserve">
+    <value>{0:0.0} NM · {1:000}°T</value>
+  </data>
+  <data name="Button_InsertWaypoint" xml:space="preserve">
+    <value>Insert</value>
+  </data>
+  <data name="Tooltip_InsertWaypoint" xml:space="preserve">
+    <value>Insert a waypoint after the selected one</value>
+  </data>
+  <data name="Button_ReverseRoute" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="Tooltip_ReverseRoute" xml:space="preserve">
+    <value>Reverse the direction of the active route</value>
+  </data>
+  <data name="Button_DoneRouteEdit" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="Tooltip_DoneRouteEdit" xml:space="preserve">
+    <value>Finish editing and leave route edit mode</value>
+  </data>
+  <data name="Menu_RenameRoute" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="Menu_ReverseRoute" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="Menu_RemoveRoute" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="Menu_InsertWaypointAfter" xml:space="preserve">
+    <value>Insert waypoint after</value>
+  </data>
+  <data name="Menu_DeleteWaypoint" xml:space="preserve">
+    <value>Delete waypoint</value>
+  </data>
+  <data name="Tooltip_RouteRowMenu" xml:space="preserve">
+    <value>Route actions</value>
+  </data>
+  <data name="Tooltip_WaypointRowMenu" xml:space="preserve">
+    <value>Waypoint actions</value>
+  </data>
+  <data name="Tooltip_EditRouteName" xml:space="preserve">
+    <value>Rename this route</value>
+  </data>
+
   <!-- ECDIS Display Planes -->
   <data name="EcdisPanel_DisplayPlanesHeader" xml:space="preserve">
     <value>Display Planes</value>

--- a/src/EncDotNet.S100.Viewer/Routing/Route.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/Route.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Geodesy;
+
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// A first-class, persistent, editable route: an ordered list of
+/// <see cref="RouteWaypoint"/>s plus the <see cref="RouteLeg"/>s joining
+/// them and route-level <see cref="RouteInfo"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the mutable counterpart to the immutable S-421 reader projection
+/// (<see cref="EncDotNet.S100.Datasets.S421.DataModel.S421Route"/>). It is
+/// the formalisation of a Measure Mode path: where
+/// <see cref="EncDotNet.S100.Viewer.Tools.MeasurePathState"/> is a transient
+/// ruler, a <see cref="Route"/> is a named, editable object that survives
+/// beyond a single gesture and can be manipulated by the interactive editor
+/// and by agents over the MCP endpoint.
+/// </para>
+/// <para>
+/// The route maintains the invariant that the number of legs is always
+/// <c>max(0, waypointCount - 1)</c>, with leg <c>i</c> joining waypoint
+/// <c>i</c> to waypoint <c>i+1</c>. All structural mutations go through this
+/// type's methods so the invariant and the <see cref="Changed"/> event stay
+/// consistent. Leg attributes are preserved across waypoint edits wherever
+/// the underlying geographic segment is preserved.
+/// </para>
+/// </remarks>
+public sealed class Route
+{
+    private readonly List<RouteWaypoint> _waypoints = new();
+    private readonly List<RouteLeg> _legs = new();
+
+    /// <summary>
+    /// Creates an empty route.
+    /// </summary>
+    /// <param name="id">Stable identifier for the route. When <c>null</c> or
+    /// whitespace a new GUID-based id is generated.</param>
+    /// <param name="name">Optional initial route name, copied into
+    /// <see cref="Info"/>.</param>
+    public Route(string? id = null, string? name = null)
+    {
+        Id = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("n") : id;
+        Info = new RouteInfo { Name = name };
+    }
+
+    /// <summary>Stable identifier, unique within a <see cref="RouteCollection"/>.</summary>
+    public string Id { get; }
+
+    /// <summary>Route-level metadata. Never <c>null</c>.</summary>
+    public RouteInfo Info { get; }
+
+    /// <summary>
+    /// Convenience accessor for <see cref="RouteInfo.Name"/>.
+    /// </summary>
+    public string? Name
+    {
+        get => Info.Name;
+        set
+        {
+            if (Info.Name == value)
+                return;
+            Info.Name = value;
+            OnChanged();
+        }
+    }
+
+    /// <summary>Waypoints in route order.</summary>
+    public IReadOnlyList<RouteWaypoint> Waypoints => _waypoints;
+
+    /// <summary>
+    /// Legs in route order. <c>Legs[i]</c> joins <c>Waypoints[i]</c> to
+    /// <c>Waypoints[i+1]</c>; the count is always
+    /// <c>max(0, Waypoints.Count - 1)</c>.
+    /// </summary>
+    public IReadOnlyList<RouteLeg> Legs => _legs;
+
+    /// <summary>
+    /// Raised after any structural or attribute change to the route, its
+    /// waypoints, or its legs made through this type's methods. Direct
+    /// mutation of a <see cref="RouteLeg"/> or <see cref="RouteInfo"/>
+    /// property does not raise this event; call <see cref="NotifyChanged"/>
+    /// to signal such edits.
+    /// </summary>
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Appends a waypoint to the end of the route, adding a trailing leg
+    /// when this produces a second-or-later waypoint.
+    /// </summary>
+    /// <param name="position">The new waypoint's position.</param>
+    /// <returns>The created waypoint.</returns>
+    public RouteWaypoint AppendWaypoint(GeoPosition position)
+        => InsertWaypoint(_waypoints.Count, position);
+
+    /// <summary>
+    /// Inserts a waypoint at <paramref name="index"/>, splitting or
+    /// extending the leg list so the leg invariant is preserved. Leg
+    /// attributes on the segment being split are retained on the segment
+    /// leading into the new waypoint; the new outgoing segment starts with
+    /// default leg attributes.
+    /// </summary>
+    /// <param name="index">Insertion index in <c>[0, Waypoints.Count]</c>.</param>
+    /// <param name="position">The new waypoint's position.</param>
+    /// <returns>The created waypoint.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is outside <c>[0, Waypoints.Count]</c>.
+    /// </exception>
+    public RouteWaypoint InsertWaypoint(int index, GeoPosition position)
+    {
+        if (index < 0 || index > _waypoints.Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        var waypoint = new RouteWaypoint { Position = position };
+        _waypoints.Insert(index, waypoint);
+
+        // Adding the second-or-later waypoint always introduces exactly one
+        // new leg. For an insert at the front the new leg leads the list; for
+        // any other insert it sits immediately after the (now-shortened)
+        // preceding leg, clamped to the current leg count for an append.
+        if (_waypoints.Count >= 2)
+        {
+            var legIndex = index == 0 ? 0 : Math.Min(index, _legs.Count);
+            _legs.Insert(legIndex, new RouteLeg());
+        }
+
+        OnChanged();
+        return waypoint;
+    }
+
+    /// <summary>
+    /// Moves the waypoint at <paramref name="index"/> to a new position. The
+    /// adjacent legs keep their attributes; their distances and bearings are
+    /// recomputed on the next call to <see cref="ComputeLegMetrics"/>.
+    /// </summary>
+    /// <param name="index">Index of the waypoint to move.</param>
+    /// <param name="position">The new position.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not a valid waypoint index.
+    /// </exception>
+    public void MoveWaypoint(int index, GeoPosition position)
+    {
+        if (index < 0 || index >= _waypoints.Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        var waypoint = _waypoints[index];
+        if (waypoint.Position.Equals(position))
+            return;
+
+        waypoint.Position = position;
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Removes the waypoint at <paramref name="index"/>, merging the two
+    /// legs that met at it into one (whose attributes are those of the
+    /// inbound leg) when the waypoint is interior, or dropping the single
+    /// dangling leg when it is an endpoint.
+    /// </summary>
+    /// <param name="index">Index of the waypoint to remove.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not a valid waypoint index.
+    /// </exception>
+    public void RemoveWaypoint(int index)
+    {
+        if (index < 0 || index >= _waypoints.Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        var wasLast = index == _waypoints.Count - 1;
+        _waypoints.RemoveAt(index);
+
+        if (_legs.Count > 0)
+        {
+            // Removing the trailing waypoint drops the final leg; removing any
+            // other drops the leg leaving that waypoint, so the inbound leg's
+            // attributes survive on the merged segment.
+            var legIndex = wasLast ? _legs.Count - 1 : index;
+            _legs.RemoveAt(legIndex);
+        }
+
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Removes all waypoints and legs, returning the route to empty.
+    /// </summary>
+    public void Clear()
+    {
+        if (_waypoints.Count == 0 && _legs.Count == 0)
+            return;
+        _waypoints.Clear();
+        _legs.Clear();
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Reverses the order of the route's waypoints (and, correspondingly, its
+    /// legs), so the former end becomes the new start. Each leg's attributes
+    /// travel with the geographic segment it described, so a leg's geometry
+    /// type and navigational envelope are preserved on the same pair of
+    /// waypoints after the reversal.
+    /// </summary>
+    public void Reverse()
+    {
+        if (_waypoints.Count < 2)
+            return;
+
+        _waypoints.Reverse();
+        _legs.Reverse();
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Computes the distance and initial bearing of the leg at
+    /// <paramref name="legIndex"/> from its waypoint positions and geometry
+    /// type.
+    /// </summary>
+    /// <param name="legIndex">Index of the leg in <c>[0, Legs.Count)</c>.</param>
+    /// <returns>The computed leg metrics.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="legIndex"/> is not a valid leg index.
+    /// </exception>
+    public RouteLegMetrics ComputeLegMetrics(int legIndex)
+    {
+        if (legIndex < 0 || legIndex >= _legs.Count)
+            throw new ArgumentOutOfRangeException(nameof(legIndex));
+
+        var a = _waypoints[legIndex].Position;
+        var b = _waypoints[legIndex + 1].Position;
+        var leg = _legs[legIndex];
+
+        double distance;
+        double bearing;
+        if (leg.GeometryType == RouteLegGeometryType.Geodesic)
+        {
+            distance = MarineGeodesy.GreatCircleDistanceNm(a.Latitude, a.Longitude, b.Latitude, b.Longitude);
+            bearing = MarineGeodesy.GreatCircleInitialBearingDegrees(a.Latitude, a.Longitude, b.Latitude, b.Longitude);
+        }
+        else
+        {
+            distance = MarineGeodesy.RhumbDistanceNm(a.Latitude, a.Longitude, b.Latitude, b.Longitude);
+            bearing = MarineGeodesy.RhumbBearingDegrees(a.Latitude, a.Longitude, b.Latitude, b.Longitude);
+        }
+
+        return new RouteLegMetrics(legIndex, distance, bearing);
+    }
+
+    /// <summary>
+    /// Computes metrics for every leg in route order.
+    /// </summary>
+    /// <returns>One <see cref="RouteLegMetrics"/> per leg.</returns>
+    public IReadOnlyList<RouteLegMetrics> ComputeAllLegMetrics()
+    {
+        var result = new List<RouteLegMetrics>(_legs.Count);
+        for (var i = 0; i < _legs.Count; i++)
+            result.Add(ComputeLegMetrics(i));
+        return result;
+    }
+
+    /// <summary>
+    /// Total length of the route in nautical miles, summed across all legs
+    /// using each leg's geometry type.
+    /// </summary>
+    /// <returns>The total distance in nautical miles (0 for a route with
+    /// fewer than two waypoints).</returns>
+    public double TotalDistanceNm()
+    {
+        double total = 0.0;
+        for (var i = 0; i < _legs.Count; i++)
+            total += ComputeLegMetrics(i).DistanceNm;
+        return total;
+    }
+
+    /// <summary>
+    /// Raises <see cref="Changed"/> to signal an in-place edit to a leg or
+    /// route-info property that did not go through one of this type's
+    /// mutating methods.
+    /// </summary>
+    public void NotifyChanged() => OnChanged();
+
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/src/EncDotNet.S100.Viewer/Routing/RouteCollection.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/RouteCollection.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// An ordered set of named <see cref="Route"/>s with at most one designated
+/// <em>active</em> route — the one the interactive editor and agent MCP
+/// tools target by default. Mirrors how loaded datasets are managed as a
+/// list with a current selection.
+/// </summary>
+/// <remarks>
+/// The collection raises <see cref="Changed"/> when routes are added or
+/// removed and when the active route changes, and re-raises each member
+/// route's own <see cref="Route.Changed"/> so a single subscriber can drive
+/// rendering and UI updates for the whole set.
+/// </remarks>
+public sealed class RouteCollection
+{
+    private readonly List<Route> _routes = new();
+    private Route? _activeRoute;
+
+    /// <summary>All routes, in insertion order.</summary>
+    public IReadOnlyList<Route> Routes => _routes;
+
+    /// <summary>
+    /// The active route, or <c>null</c> when the collection is empty. Adding
+    /// the first route makes it active; removing the active route promotes
+    /// the previous route (or the new first route) to active.
+    /// </summary>
+    public Route? ActiveRoute => _activeRoute;
+
+    /// <summary>
+    /// Raised when the set of routes or the active route changes, or when
+    /// any member route raises its own <see cref="Route.Changed"/>.
+    /// </summary>
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Creates a new route, adds it to the collection, and makes it active.
+    /// </summary>
+    /// <param name="name">Optional route name.</param>
+    /// <param name="id">Optional stable id; generated when omitted. Must be
+    /// unique within the collection.</param>
+    /// <returns>The created route.</returns>
+    /// <exception cref="ArgumentException">A route with the same
+    /// <see cref="Route.Id"/> already exists.</exception>
+    public Route CreateRoute(string? name = null, string? id = null)
+    {
+        var route = new Route(id, name);
+        Add(route);
+        return route;
+    }
+
+    /// <summary>
+    /// Adds an existing route to the collection, making it active.
+    /// </summary>
+    /// <param name="route">The route to add.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="route"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">A route with the same
+    /// <see cref="Route.Id"/> already exists.</exception>
+    public void Add(Route route)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        if (_routes.Any(r => r.Id == route.Id))
+            throw new ArgumentException($"A route with id '{route.Id}' already exists.", nameof(route));
+
+        _routes.Add(route);
+        route.Changed += OnRouteChanged;
+        _activeRoute = route;
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Removes <paramref name="route"/> from the collection.
+    /// </summary>
+    /// <param name="route">The route to remove.</param>
+    /// <returns><c>true</c> if the route was present and removed.</returns>
+    public bool Remove(Route route)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        var position = _routes.IndexOf(route);
+        if (position < 0)
+            return false;
+
+        _routes.RemoveAt(position);
+        route.Changed -= OnRouteChanged;
+
+        if (ReferenceEquals(_activeRoute, route))
+        {
+            // Promote the nearest remaining route: the one now at the removed
+            // slot, else the new last route, else none.
+            _activeRoute = _routes.Count == 0
+                ? null
+                : _routes[Math.Min(position, _routes.Count - 1)];
+        }
+
+        OnChanged();
+        return true;
+    }
+
+    /// <summary>
+    /// Sets the active route. Pass <c>null</c> to clear the selection.
+    /// </summary>
+    /// <param name="route">A route already in the collection, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the active route changed.</returns>
+    /// <exception cref="ArgumentException"><paramref name="route"/> is not in
+    /// this collection.</exception>
+    public bool SetActiveRoute(Route? route)
+    {
+        if (route is not null && !_routes.Contains(route))
+            throw new ArgumentException("Route is not part of this collection.", nameof(route));
+
+        if (ReferenceEquals(_activeRoute, route))
+            return false;
+
+        _activeRoute = route;
+        OnChanged();
+        return true;
+    }
+
+    /// <summary>
+    /// Finds a route by its <see cref="Route.Id"/>.
+    /// </summary>
+    /// <param name="id">The id to look up.</param>
+    /// <returns>The matching route, or <c>null</c> when none matches.</returns>
+    public Route? FindById(string id)
+        => _routes.FirstOrDefault(r => r.Id == id);
+
+    private void OnRouteChanged(object? sender, EventArgs e) => OnChanged();
+
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/src/EncDotNet.S100.Viewer/Routing/RouteInfo.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/RouteInfo.cs
@@ -1,0 +1,61 @@
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// Mutable route-level metadata, mirroring the S-421 <c>RouteInfo</c>
+/// information type
+/// (<see cref="EncDotNet.S100.Datasets.S421.DataModel.S421RouteInfo"/>).
+/// Every <see cref="Route"/> owns exactly one instance; all fields are
+/// optional.
+/// </summary>
+public sealed class RouteInfo
+{
+    /// <summary>Route name shown to the user (S-421 <c>routeInfoName</c>).</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Route author / originator (S-421 <c>routeInfoAuthor</c>).</summary>
+    public string? Author { get; set; }
+
+    /// <summary>Free-text description (S-421 <c>routeInfoDescription</c>).</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Departure port identifier (S-421 <c>routeInfoDeparturePortID1</c>).</summary>
+    public string? DeparturePortId { get; set; }
+
+    /// <summary>Arrival port identifier (S-421 <c>routeInfoArrivalPortID1</c>).</summary>
+    public string? ArrivalPortId { get; set; }
+
+    /// <summary>Planned start of validity, UTC (S-421 <c>routeInfoValidityStart</c>).</summary>
+    public DateTimeOffset? ValidityStart { get; set; }
+
+    /// <summary>Planned end of validity, UTC (S-421 <c>routeInfoValidityEnd</c>).</summary>
+    public DateTimeOffset? ValidityEnd { get; set; }
+
+    /// <summary>Vessel the route is planned for; absent until populated.</summary>
+    public RouteVesselInfo? Vessel { get; set; }
+}
+
+/// <summary>
+/// Mutable vessel metadata carried by a <see cref="RouteInfo"/>, mirroring
+/// the S-421 <c>routeInfoVessel*</c> attributes
+/// (<see cref="EncDotNet.S100.Datasets.S421.DataModel.S421VesselInfo"/>).
+/// </summary>
+public sealed class RouteVesselInfo
+{
+    /// <summary>Vessel name (S-421 <c>routeInfoVesselName</c>).</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Maritime Mobile Service Identity (S-421 <c>routeInfoVesselMMSI</c>).</summary>
+    public string? Mmsi { get; set; }
+
+    /// <summary>IMO number (S-421 <c>routeInfoVesselIMO</c>).</summary>
+    public string? Imo { get; set; }
+
+    /// <summary>Call sign (S-421 <c>routeInfoVesselCallsign</c>).</summary>
+    public string? Callsign { get; set; }
+
+    /// <summary>Overall length, in metres (S-421 <c>routeInfoVesselLength</c>).</summary>
+    public double? LengthMeters { get; set; }
+
+    /// <summary>Beam, in metres (S-421 <c>routeInfoVesselBeam</c>).</summary>
+    public double? BeamMeters { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/Routing/RouteLeg.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/RouteLeg.cs
@@ -1,0 +1,77 @@
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// The mutable navigational envelope of a single route leg — the segment
+/// joining two consecutive <see cref="RouteWaypoint"/>s of a
+/// <see cref="Route"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A leg does not store its own endpoints: leg <c>i</c> always joins
+/// waypoint <c>i</c> to waypoint <c>i+1</c> of the owning route, so the
+/// geometry follows automatically when waypoints move or are inserted /
+/// deleted. Distance and bearing are computed on demand by
+/// <see cref="Route.ComputeLegMetrics"/> using <see cref="GeometryType"/>.
+/// </para>
+/// <para>
+/// The optional attribute fields mirror the S-421 <c>RouteWaypointLeg</c>
+/// projection
+/// (<see cref="EncDotNet.S100.Datasets.S421.DataModel.S421Leg"/>); their
+/// units match S-421 (metres for distances/limits, knots for speeds) so a
+/// route exports to S-421 GML with a direct mapping. All are nullable: a
+/// freshly created leg carries only its geometry type.
+/// </para>
+/// </remarks>
+public sealed class RouteLeg
+{
+    /// <summary>
+    /// How the leg's path is defined. Defaults to
+    /// <see cref="RouteLegGeometryType.Loxodrome"/> (the ECDIS convention).
+    /// </summary>
+    public RouteLegGeometryType GeometryType { get; set; } = RouteLegGeometryType.Loxodrome;
+
+    /// <summary>Starboard cross-track distance limit, in metres (S-421 <c>routeWaypointLegStarboardXTDL</c>).</summary>
+    public double? StarboardCrossTrackDistanceLimitMeters { get; set; }
+
+    /// <summary>Port cross-track distance limit, in metres (S-421 <c>routeWaypointLegPortXTDL</c>).</summary>
+    public double? PortCrossTrackDistanceLimitMeters { get; set; }
+
+    /// <summary>Starboard channel limit, in metres (S-421 <c>routeWaypointLegStarboardCL</c>).</summary>
+    public double? StarboardChannelLimitMeters { get; set; }
+
+    /// <summary>Port channel limit, in metres (S-421 <c>routeWaypointLegPortCL</c>).</summary>
+    public double? PortChannelLimitMeters { get; set; }
+
+    /// <summary>Safety contour for this leg, in metres (S-421 <c>routeWaypointLegSafetyContour</c>).</summary>
+    public double? SafetyContourMeters { get; set; }
+
+    /// <summary>Safety depth for this leg, in metres (S-421 <c>routeWaypointLegSafetyDepth</c>).</summary>
+    public double? SafetyDepthMeters { get; set; }
+
+    /// <summary>Minimum speed over ground, in knots (S-421 <c>routeWaypointLegSOGMin</c>).</summary>
+    public double? SpeedOverGroundMinKnots { get; set; }
+
+    /// <summary>Maximum speed over ground, in knots (S-421 <c>routeWaypointLegSOGMax</c>).</summary>
+    public double? SpeedOverGroundMaxKnots { get; set; }
+
+    /// <summary>Minimum speed through water, in knots (S-421 <c>routeWaypointLegSTWMin</c>).</summary>
+    public double? SpeedThroughWaterMinKnots { get; set; }
+
+    /// <summary>Maximum speed through water, in knots (S-421 <c>routeWaypointLegSTWMax</c>).</summary>
+    public double? SpeedThroughWaterMaxKnots { get; set; }
+
+    /// <summary>Planned draft for this leg, in metres (S-421 <c>routeWaypointLegDraft</c>).</summary>
+    public double? DraftMeters { get; set; }
+
+    /// <summary>Static under-keel clearance, in metres (S-421 <c>routeWaypointLegStaticUKC</c>).</summary>
+    public double? StaticUnderKeelClearanceMeters { get; set; }
+
+    /// <summary>Dynamic under-keel clearance, in metres (S-421 <c>routeWaypointLegDynamicUKC</c>).</summary>
+    public double? DynamicUnderKeelClearanceMeters { get; set; }
+
+    /// <summary>Safety margin, in metres (S-421 <c>routeWaypointLegSafetyMargin</c>).</summary>
+    public double? SafetyMarginMeters { get; set; }
+
+    /// <summary>Free-text note for this leg (S-421 <c>routeWaypointLegNote</c>).</summary>
+    public string? Note { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/Routing/RouteLegGeometryType.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/RouteLegGeometryType.cs
@@ -1,0 +1,24 @@
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// How a route leg's path between two consecutive waypoints is defined.
+/// The numeric values match the S-421 <c>routeWaypointLegGeometryType</c>
+/// enumerator codes (S-421 Annex A) so an editable route projects onto an
+/// S-421 <see cref="EncDotNet.S100.Datasets.S421.DataModel.S421Leg"/>
+/// without remapping.
+/// </summary>
+public enum RouteLegGeometryType
+{
+    /// <summary>
+    /// Loxodrome (rhumb line) — a path of constant true bearing. This is
+    /// the ECDIS default and matches the Measure Mode read-out. S-421
+    /// code <c>1</c>.
+    /// </summary>
+    Loxodrome = 1,
+
+    /// <summary>
+    /// Geodesic (great circle) — the shortest path over the sphere; the
+    /// bearing changes continuously along the leg. S-421 code <c>2</c>.
+    /// </summary>
+    Geodesic = 2,
+}

--- a/src/EncDotNet.S100.Viewer/Routing/RouteLegMetrics.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/RouteLegMetrics.cs
@@ -1,0 +1,18 @@
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// Computed geometry of one route leg: its ordinal plus the distance and
+/// initial true bearing derived from the adjacent waypoint positions and
+/// the leg's <see cref="RouteLeg.GeometryType"/>.
+/// </summary>
+/// <param name="LegIndex">Zero-based index of the leg within its route (leg
+/// <c>i</c> joins waypoint <c>i</c> to waypoint <c>i+1</c>).</param>
+/// <param name="DistanceNm">Leg length in nautical miles.</param>
+/// <param name="InitialBearingDegrees">Initial true bearing in degrees,
+/// clockwise from true north, in the range [0°, 360°). For a loxodrome this
+/// is constant along the leg; for a geodesic it is the bearing at the
+/// departure waypoint.</param>
+public readonly record struct RouteLegMetrics(
+    int LegIndex,
+    double DistanceNm,
+    double InitialBearingDegrees);

--- a/src/EncDotNet.S100.Viewer/Routing/RouteWaypoint.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/RouteWaypoint.cs
@@ -1,0 +1,44 @@
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Viewer.Routing;
+
+/// <summary>
+/// A single, mutable waypoint in an editable <see cref="Route"/>. Fields
+/// mirror the S-421 <c>RouteWaypoint</c> projection
+/// (<see cref="EncDotNet.S100.Datasets.S421.DataModel.S421Waypoint"/>) so a
+/// route can be exported to S-421 GML with a near-mechanical mapping.
+/// </summary>
+/// <remarks>
+/// Unlike the immutable S-421 reader projection, this type is mutable: the
+/// interactive editor and the agent MCP tools both manipulate waypoints in
+/// place. Mutations are routed through <see cref="Route"/> so the owning
+/// route can keep its leg list and change notifications consistent.
+/// </remarks>
+public sealed class RouteWaypoint
+{
+    /// <summary>
+    /// The waypoint's geographic position (WGS-84, decimal degrees).
+    /// </summary>
+    public GeoPosition Position { get; internal set; }
+
+    /// <summary>
+    /// The author-assigned ordinal (S-421 <c>routeWaypointID</c>). Optional;
+    /// the route's geometric order is authoritative regardless of this value.
+    /// </summary>
+    public int? Number { get; set; }
+
+    /// <summary>Human-readable waypoint name (S-421 <c>routeWaypointName</c>).</summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Whether the waypoint position is fixed and must not be moved
+    /// (S-421 <c>routeWaypointFixed</c>).
+    /// </summary>
+    public bool? Fixed { get; set; }
+
+    /// <summary>
+    /// Planned turn radius at this waypoint, in nautical miles
+    /// (S-421 <c>routeWaypointTurnRadius</c>).
+    /// </summary>
+    public double? TurnRadiusNm { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
+++ b/src/EncDotNet.S100.Viewer/Services/McpServerHost.cs
@@ -33,6 +33,7 @@ internal sealed class McpServerHost : IAsyncDisposable
     private readonly IRenderActivityMonitor? _renderActivityMonitor;
     private readonly IDatasetLoadGateway? _loadGateway;
     private readonly EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipHelm? _ownShipHelm;
+    private readonly RoutesService? _routesService;
     private readonly ILoggerFactory? _loggers;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -48,7 +49,8 @@ internal sealed class McpServerHost : IAsyncDisposable
         GlobalTimeService? globalTime = null,
         IRenderActivityMonitor? renderActivityMonitor = null,
         IDatasetLoadGateway? loadGateway = null,
-        EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipHelm? ownShipHelm = null)
+        EncDotNet.S100.Viewer.Services.DynamicSources.OwnShip.IOwnShipHelm? ownShipHelm = null,
+        RoutesService? routesService = null)
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(settings);
@@ -60,6 +62,7 @@ internal sealed class McpServerHost : IAsyncDisposable
         _renderActivityMonitor = renderActivityMonitor;
         _loadGateway = loadGateway;
         _ownShipHelm = ownShipHelm;
+        _routesService = routesService;
         _loggers = loggers;
     }
 
@@ -298,6 +301,20 @@ internal sealed class McpServerHost : IAsyncDisposable
         if (_ownShipHelm is not null)
         {
             tools.Add(SetOwnShipMcpAdapter.Create(new SetOwnShipTool(_ownShipHelm)));
+        }
+        if (_routesService is not null)
+        {
+            var invoker = new DispatcherRouteEditInvoker();
+            tools.Add(CreateRouteMcpAdapter.Create(new CreateRouteTool(_routesService, invoker)));
+            tools.Add(ListRoutesMcpAdapter.Create(new ListRoutesTool(_routesService, invoker)));
+            tools.Add(GetRouteMcpAdapter.Create(new GetRouteTool(_routesService, invoker)));
+            tools.Add(DeleteRouteMcpAdapter.Create(new DeleteRouteTool(_routesService, invoker)));
+            tools.Add(AppendWaypointMcpAdapter.Create(new AppendWaypointTool(_routesService, invoker)));
+            tools.Add(InsertWaypointMcpAdapter.Create(new InsertWaypointTool(_routesService, invoker)));
+            tools.Add(MoveWaypointMcpAdapter.Create(new MoveWaypointTool(_routesService, invoker)));
+            tools.Add(DeleteWaypointMcpAdapter.Create(new DeleteWaypointTool(_routesService, invoker)));
+            tools.Add(SetLegAttributesMcpAdapter.Create(new SetLegAttributesTool(_routesService, invoker)));
+            tools.Add(SetRouteInfoMcpAdapter.Create(new SetRouteInfoTool(_routesService, invoker)));
         }
         return tools.Count == 0 ? null : tools;
     }

--- a/src/EncDotNet.S100.Viewer/Services/RoutesService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/RoutesService.cs
@@ -1,0 +1,84 @@
+using System;
+using EncDotNet.S100.Viewer.Routing;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Application-scoped owner of the editable <see cref="RouteCollection"/>
+/// plus the transient editor selection (which waypoint of the active route
+/// is currently highlighted). A single source of truth shared by the route
+/// overlay renderer, the <c>RouteEditTool</c>, the routes side panel, and
+/// the agent-facing MCP route tools.
+/// </summary>
+/// <remarks>
+/// Routes are persistent: unlike the Measure Mode overlay, which only
+/// exists while its tool is active, the route overlay reflects this
+/// collection at all times. The service re-raises
+/// <see cref="RouteCollection.Changed"/> and adds its own
+/// <see cref="SelectionChanged"/> so a host controller can drive a single
+/// redraw path.
+/// </remarks>
+internal sealed class RoutesService
+{
+    /// <summary>The editable route collection. Never <c>null</c>.</summary>
+    public RouteCollection Routes { get; } = new();
+
+    private int? _selectedWaypointIndex;
+
+    /// <summary>
+    /// Index of the highlighted waypoint within
+    /// <see cref="RouteCollection.ActiveRoute"/>, or <c>null</c> when none
+    /// is selected. Cleared automatically whenever the active route changes
+    /// or the index would fall out of range.
+    /// </summary>
+    public int? SelectedWaypointIndex
+    {
+        get => _selectedWaypointIndex;
+        set
+        {
+            var normalized = Normalize(value);
+            if (_selectedWaypointIndex == normalized)
+                return;
+            _selectedWaypointIndex = normalized;
+            SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Raised when the collection changes (routes added/removed, active
+    /// route changed, or any member route edited) or when the selection
+    /// changes. Subscribers typically rebuild the overlay and refresh the
+    /// side panel.
+    /// </summary>
+    public event EventHandler? Changed;
+
+    /// <summary>Raised when <see cref="SelectedWaypointIndex"/> changes.</summary>
+    public event EventHandler? SelectionChanged;
+
+    public RoutesService()
+    {
+        Routes.Changed += (_, _) =>
+        {
+            // Keep the selection valid as routes/waypoints change.
+            var normalized = Normalize(_selectedWaypointIndex);
+            if (normalized != _selectedWaypointIndex)
+            {
+                _selectedWaypointIndex = normalized;
+                SelectionChanged?.Invoke(this, EventArgs.Empty);
+            }
+            Changed?.Invoke(this, EventArgs.Empty);
+        };
+
+        SelectionChanged += (_, _) => Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private int? Normalize(int? candidate)
+    {
+        if (candidate is not { } index || index < 0)
+            return null;
+        var active = Routes.ActiveRoute;
+        if (active is null || index >= active.Waypoints.Count)
+            return null;
+        return index;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Tools/MapToolContext.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/MapToolContext.cs
@@ -17,6 +17,7 @@ internal sealed class MapToolContext
     private readonly Action<string?> _setStatusSummary;
     private readonly Action _refreshGraphics;
     private readonly Func<Point, (double Lat, double Lon)?> _screenToLatLon;
+    private readonly Func<(double Lat, double Lon), Point?> _latLonToScreen;
 
     public MapToolContext(
         MapControl mapControl,
@@ -24,7 +25,8 @@ internal sealed class MapToolContext
         Action<ILayer> removeLayer,
         Action<string?> setStatusSummary,
         Action refreshGraphics,
-        Func<Point, (double Lat, double Lon)?> screenToLatLon)
+        Func<Point, (double Lat, double Lon)?> screenToLatLon,
+        Func<(double Lat, double Lon), Point?> latLonToScreen)
     {
         ArgumentNullException.ThrowIfNull(mapControl);
         ArgumentNullException.ThrowIfNull(addLayer);
@@ -32,6 +34,7 @@ internal sealed class MapToolContext
         ArgumentNullException.ThrowIfNull(setStatusSummary);
         ArgumentNullException.ThrowIfNull(refreshGraphics);
         ArgumentNullException.ThrowIfNull(screenToLatLon);
+        ArgumentNullException.ThrowIfNull(latLonToScreen);
 
         MapControl = mapControl;
         _addLayer = addLayer;
@@ -39,6 +42,7 @@ internal sealed class MapToolContext
         _setStatusSummary = setStatusSummary;
         _refreshGraphics = refreshGraphics;
         _screenToLatLon = screenToLatLon;
+        _latLonToScreen = latLonToScreen;
     }
 
     /// <summary>
@@ -73,4 +77,12 @@ internal sealed class MapToolContext
     /// the Mercator pole limit).
     /// </summary>
     public (double Lat, double Lon)? ScreenToLatLon(Point screen) => _screenToLatLon(screen);
+
+    /// <summary>
+    /// Converts a WGS-84 lat/lon to a pointer position in
+    /// <see cref="MapControl"/> client coordinates, or <c>null</c> when no
+    /// viewport is available. Used by editing tools for hit-testing screen
+    /// gestures against world-space features (e.g. grabbing a waypoint).
+    /// </summary>
+    public Point? LatLonToScreen((double Lat, double Lon) world) => _latLonToScreen(world);
 }

--- a/src/EncDotNet.S100.Viewer/Tools/RouteEditTool.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/RouteEditTool.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Input;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Interactive editor for the active <see cref="Route"/> in the shared
+/// <see cref="RoutesService"/>. Click on empty water appends a waypoint (or
+/// inserts one when the click lands on an existing leg); drag a waypoint to
+/// move it; click a waypoint to select it; right-click or Delete removes a
+/// waypoint; Backspace removes the last.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="MeasureTool"/>, this tool owns no overlay layer: the
+/// route overlay is host-managed and persistent, and redraws reactively
+/// when the tool mutates the model (via <see cref="RoutesService"/>). The
+/// tool only translates pointer gestures into model edits and publishes a
+/// status summary. Drag detection mirrors the measure tool — a press/move
+/// beyond <see cref="DragThresholdPx"/> off a waypoint falls through to
+/// Mapsui as a pan.
+/// </remarks>
+internal sealed class RouteEditTool : IMapTool
+{
+    public const string ToolId = "route-edit";
+
+    /// <summary>Click vs. drag threshold (DIPs).</summary>
+    private const double DragThresholdPx = 3.0;
+
+    /// <summary>Pointer-to-waypoint hit radius (DIPs).</summary>
+    private const double WaypointHitRadiusPx = 10.0;
+
+    /// <summary>Pointer-to-segment hit tolerance for insert (DIPs).</summary>
+    private const double SegmentHitTolerancePx = 6.0;
+
+    private readonly RoutesService _routes;
+    private MapToolContext? _context;
+    private Point? _pressPosition;
+    private bool _pressIsLeftButton;
+    private int? _dragWaypointIndex;
+    private bool _dragActive;
+
+    public RouteEditTool(RoutesService routes)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        _routes = routes;
+    }
+
+    public string Id => ToolId;
+
+    private Cursor? _cursor;
+    /// <inheritdoc />
+    public Cursor? Cursor => _cursor ??= new Cursor(StandardCursorType.Cross);
+
+    public void OnActivated(MapToolContext context)
+    {
+        _context = context;
+        // Ensure there is a route to edit so the first click has a target.
+        if (_routes.Routes.ActiveRoute is null)
+            CreateRoute();
+        PushSummary();
+    }
+
+    public void OnDeactivated()
+    {
+        _context?.SetStatusSummary(null);
+        _context = null;
+        _pressPosition = null;
+        _pressIsLeftButton = false;
+        _dragWaypointIndex = null;
+        _dragActive = false;
+    }
+
+    public bool OnPointerPressed(PointerPressedEventArgs e)
+    {
+        if (_context is null) return false;
+        var props = e.GetCurrentPoint(_context.MapControl).Properties;
+        var pos = e.GetPosition(_context.MapControl);
+
+        if (props.IsRightButtonPressed)
+        {
+            // Right-click deletes the waypoint under the cursor, if any.
+            var hit = HitTestWaypoint(pos);
+            if (hit is { } index && _routes.Routes.ActiveRoute is { } route)
+            {
+                route.RemoveWaypoint(index);
+                _routes.SelectedWaypointIndex = null;
+                PushSummary();
+            }
+            return true; // always consume so no context menu pops up
+        }
+
+        if (props.IsLeftButtonPressed)
+        {
+            _pressPosition = pos;
+            _pressIsLeftButton = true;
+            _dragActive = false;
+            _dragWaypointIndex = HitTestWaypoint(pos);
+
+            // Pressing on a waypoint begins a potential drag — consume so
+            // Mapsui doesn't pan. Pressing empty water lets pan win until we
+            // know (on release) that it was a click.
+            return _dragWaypointIndex is not null;
+        }
+
+        return false;
+    }
+
+    public bool OnPointerMoved(PointerEventArgs e)
+    {
+        if (_context is null || !_pressIsLeftButton || _dragWaypointIndex is not { } index)
+            return false;
+
+        var pos = e.GetPosition(_context.MapControl);
+        if (!_dragActive && _pressPosition is { } press)
+        {
+            var dx = pos.X - press.X;
+            var dy = pos.Y - press.Y;
+            if ((dx * dx + dy * dy) <= DragThresholdPx * DragThresholdPx)
+                return true; // not yet a drag, but keep consuming
+            _dragActive = true;
+        }
+
+        var world = _context.ScreenToLatLon(pos);
+        if (world is { } w && _routes.Routes.ActiveRoute is { } route && index < route.Waypoints.Count)
+        {
+            route.MoveWaypoint(index, new GeoPosition(w.Lat, w.Lon));
+            _routes.SelectedWaypointIndex = index;
+            PushSummary();
+        }
+        return true;
+    }
+
+    public bool OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        if (_context is null || !_pressIsLeftButton || _pressPosition is not { } press)
+            return false;
+
+        _pressIsLeftButton = false;
+        var release = e.GetPosition(_context.MapControl);
+        var draggedIndex = _dragWaypointIndex;
+        var wasDragActive = _dragActive;
+        _pressPosition = null;
+        _dragWaypointIndex = null;
+        _dragActive = false;
+
+        var dx = release.X - press.X;
+        var dy = release.Y - press.Y;
+        var isClick = (dx * dx + dy * dy) <= DragThresholdPx * DragThresholdPx;
+
+        if (draggedIndex is { } index)
+        {
+            // Pressed on a waypoint: a click (no drag) selects it; a drag was
+            // already applied live in OnPointerMoved.
+            if (!wasDragActive)
+                _routes.SelectedWaypointIndex = index;
+            PushSummary();
+            return true;
+        }
+
+        if (!isClick)
+            return false; // empty-water drag → Mapsui handled the pan
+
+        var world = _context.ScreenToLatLon(release);
+        if (world is not { } w)
+            return false;
+
+        var active = _routes.Routes.ActiveRoute ?? CreateRoute();
+        var position = new GeoPosition(w.Lat, w.Lon);
+
+        // If the click lands on an existing leg, insert a waypoint that
+        // splits it; otherwise append to the end of the route.
+        var legIndex = HitTestLeg(release);
+        if (legIndex is { } li)
+        {
+            var inserted = active.InsertWaypoint(li + 1, position);
+            _routes.SelectedWaypointIndex = li + 1;
+            _ = inserted;
+        }
+        else
+        {
+            active.AppendWaypoint(position);
+            _routes.SelectedWaypointIndex = active.Waypoints.Count - 1;
+        }
+
+        PushSummary();
+        return true;
+    }
+
+    public bool OnDoubleTapped(TappedEventArgs e) => true; // suppress zoom-on-double-tap
+
+    public bool OnAction(MapToolAction action)
+    {
+        if (_routes.Routes.ActiveRoute is not { } route || route.Waypoints.Count == 0)
+            return false;
+
+        switch (action)
+        {
+            case MapToolAction.Backstep:
+                route.RemoveWaypoint(route.Waypoints.Count - 1);
+                _routes.SelectedWaypointIndex = null;
+                PushSummary();
+                return true;
+
+            case MapToolAction.Discard:
+                var target = _routes.SelectedWaypointIndex ?? route.Waypoints.Count - 1;
+                if (target >= 0 && target < route.Waypoints.Count)
+                {
+                    route.RemoveWaypoint(target);
+                    _routes.SelectedWaypointIndex = null;
+                    PushSummary();
+                    return true;
+                }
+                return false;
+
+            case MapToolAction.Commit:
+                if (_routes.SelectedWaypointIndex is null)
+                    return false;
+                _routes.SelectedWaypointIndex = null;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private Route CreateRoute()
+    {
+        var name = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Routes_NewRouteNameFormat,
+            _routes.Routes.Routes.Count + 1);
+        return _routes.Routes.CreateRoute(name);
+    }
+
+    /// <summary>
+    /// Returns the index of the active-route waypoint within
+    /// <see cref="WaypointHitRadiusPx"/> of <paramref name="screen"/>, or
+    /// <c>null</c>. The nearest qualifying waypoint wins.
+    /// </summary>
+    private int? HitTestWaypoint(Point screen)
+    {
+        if (_context is null || _routes.Routes.ActiveRoute is not { } route)
+            return null;
+
+        int? best = null;
+        var bestDistSq = WaypointHitRadiusPx * WaypointHitRadiusPx;
+        for (var i = 0; i < route.Waypoints.Count; i++)
+        {
+            var p = route.Waypoints[i].Position;
+            if (_context.LatLonToScreen((p.Latitude, p.Longitude)) is not { } s)
+                continue;
+            var dx = s.X - screen.X;
+            var dy = s.Y - screen.Y;
+            var distSq = dx * dx + dy * dy;
+            if (distSq <= bestDistSq)
+            {
+                bestDistSq = distSq;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Returns the index of the active-route leg whose screen-space segment
+    /// passes within <see cref="SegmentHitTolerancePx"/> of
+    /// <paramref name="screen"/>, or <c>null</c>.
+    /// </summary>
+    private int? HitTestLeg(Point screen)
+    {
+        if (_context is null || _routes.Routes.ActiveRoute is not { } route)
+            return null;
+
+        int? best = null;
+        var bestDist = SegmentHitTolerancePx;
+        for (var i = 0; i < route.Legs.Count; i++)
+        {
+            var a = route.Waypoints[i].Position;
+            var b = route.Waypoints[i + 1].Position;
+            if (_context.LatLonToScreen((a.Latitude, a.Longitude)) is not { } pa ||
+                _context.LatLonToScreen((b.Latitude, b.Longitude)) is not { } pb)
+                continue;
+
+            var dist = DistancePointToSegment(screen, pa, pb);
+            if (dist <= bestDist)
+            {
+                bestDist = dist;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    private static double DistancePointToSegment(Point p, Point a, Point b)
+    {
+        var abx = b.X - a.X;
+        var aby = b.Y - a.Y;
+        var lenSq = abx * abx + aby * aby;
+        if (lenSq < 1e-9)
+        {
+            var ddx = p.X - a.X;
+            var ddy = p.Y - a.Y;
+            return Math.Sqrt(ddx * ddx + ddy * ddy);
+        }
+
+        var t = ((p.X - a.X) * abx + (p.Y - a.Y) * aby) / lenSq;
+        t = Math.Clamp(t, 0.0, 1.0);
+        var projX = a.X + t * abx;
+        var projY = a.Y + t * aby;
+        var dx = p.X - projX;
+        var dy = p.Y - projY;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    private void PushSummary()
+    {
+        _context?.SetStatusSummary(FormatSummary());
+    }
+
+    /// <summary>Builds the status-bar summary for the active route.</summary>
+    internal string? FormatSummary()
+    {
+        var route = _routes.Routes.ActiveRoute;
+        if (route is null || route.Waypoints.Count == 0)
+            return Strings.Status_RouteEditNoData;
+
+        if (route.Legs.Count == 0)
+            return Strings.Status_RouteEditNoData;
+
+        var last = route.ComputeLegMetrics(route.Legs.Count - 1);
+        var legText = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Status_RouteLeg,
+            last.LegIndex + 1,
+            last.DistanceNm,
+            last.InitialBearingDegrees);
+        var totalText = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Status_RouteTotal,
+            route.TotalDistanceNm());
+        return $"{legText}  |  {totalText}";
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Tools/RouteOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/RouteOverlayLayer.cs
@@ -1,0 +1,235 @@
+using System.Collections.Generic;
+using System.Globalization;
+using EncDotNet.S100.Viewer.Geodesy;
+using EncDotNet.S100.Viewer.Routing;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Projections;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using MapsuiColor = Mapsui.Styles.Color;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// Builds the persistent Mapsui <see cref="MemoryLayer"/> overlay for the
+/// editable route collection. Unlike <see cref="MeasureOverlayLayer"/> (a
+/// transient ruler shown only while its tool is active) this overlay
+/// reflects every <see cref="Route"/> in the collection at all times; the
+/// active route and the selected waypoint are emphasised.
+/// </summary>
+/// <remarks>
+/// Like the measure overlay it is rebuilt from scratch on every change —
+/// route feature counts are small (waypoints, legs, labels) so the cost is
+/// negligible and the renderer stays declarative. Geodesic legs are
+/// densified via <see cref="MarineGeodesy.GreatCircleIntermediatePoints"/>
+/// so they read as curves, while loxodrome legs draw as straight Mercator
+/// segments (matching their constant-bearing nature).
+/// </remarks>
+internal static class RouteOverlayLayer
+{
+    /// <summary>Stable layer name; reused so the host can find/remove it.</summary>
+    public const string LayerName = "Route Overlay";
+
+    /// <summary>Number of straight segments used to approximate a geodesic leg.</summary>
+    private const int GeodesicSegments = 24;
+
+    private const float ActiveLineOpacity = 0.85f;
+    private const float InactiveLineOpacity = 0.4f;
+
+    private static MapsuiColor Lighten((byte R, byte G, byte B) c, float mix = 0.55f)
+    {
+        byte M(byte v) => (byte)(v + (255 - v) * mix);
+        return new MapsuiColor(M(c.R), M(c.G), M(c.B));
+    }
+
+    private static MapsuiColor Desaturate((byte R, byte G, byte B) c)
+    {
+        // Pull toward mid-grey so inactive routes recede behind the active one.
+        var gray = (byte)((c.R + c.G + c.B) / 3);
+        byte M(byte v) => (byte)((v + gray) / 2);
+        return new MapsuiColor(M(c.R), M(c.G), M(c.B));
+    }
+
+    /// <summary>Creates a fresh, empty overlay layer.</summary>
+    public static MemoryLayer Create() => new()
+    {
+        Name = LayerName,
+        Style = null,
+        Features = new List<IFeature>(),
+    };
+
+    /// <summary>
+    /// Replaces <paramref name="layer"/>'s features with a freshly built
+    /// representation of <paramref name="routes"/>, emphasising the active
+    /// route and the waypoint at <paramref name="selectedWaypointIndex"/>
+    /// (within the active route). Caller invalidates the map afterwards.
+    /// </summary>
+    public static void Update(
+        MemoryLayer layer,
+        RouteCollection routes,
+        int? selectedWaypointIndex,
+        MeasureOverlayAppearance appearance)
+    {
+        var (labelBg, labelFg, labelHalo) = appearance.IsDarkTheme
+            ? (new MapsuiColor(38, 38, 42, 235), new MapsuiColor(245, 245, 245), new MapsuiColor(0, 0, 0, 200))
+            : (new MapsuiColor(248, 248, 250, 235), new MapsuiColor(20, 20, 24), new MapsuiColor(255, 255, 255, 200));
+
+        var features = new List<IFeature>();
+
+        foreach (var route in routes.Routes)
+        {
+            var isActive = ReferenceEquals(route, routes.ActiveRoute);
+            var accent = appearance.Accent;
+            var lineColor = isActive
+                ? new MapsuiColor(accent.R, accent.G, accent.B)
+                : Desaturate(accent);
+            var fillColor = isActive ? Lighten(accent) : Desaturate(accent);
+
+            var densified = DensifyRoute(route);
+            if (densified.Count >= 2)
+                AddPolyline(features, densified, lineColor, isActive ? ActiveLineOpacity : InactiveLineOpacity);
+
+            // Per-leg distance/bearing labels only on the active route to
+            // keep the chart legible when several routes overlap.
+            if (isActive)
+            {
+                var metrics = route.ComputeAllLegMetrics();
+                for (var i = 0; i < metrics.Count; i++)
+                {
+                    var a = route.Waypoints[i].Position;
+                    var b = route.Waypoints[i + 1].Position;
+                    AddLegLabel(features, a, b, metrics[i], labelBg, labelFg, labelHalo);
+                }
+            }
+
+            for (var i = 0; i < route.Waypoints.Count; i++)
+            {
+                var pos = route.Waypoints[i].Position;
+                var selected = isActive && selectedWaypointIndex == i;
+                AddWaypointMarker(features, pos.Latitude, pos.Longitude, i + 1, fillColor, lineColor, selected);
+            }
+        }
+
+        layer.Features = features;
+        layer.DataHasChanged();
+    }
+
+    /// <summary>
+    /// Flattens a route into a single ordered point list, densifying
+    /// geodesic legs into great-circle arcs and leaving loxodrome legs as
+    /// straight segments.
+    /// </summary>
+    private static List<(double Lat, double Lon)> DensifyRoute(Route route)
+    {
+        var points = new List<(double Lat, double Lon)>();
+        if (route.Waypoints.Count == 0)
+            return points;
+
+        var first = route.Waypoints[0].Position;
+        points.Add((first.Latitude, first.Longitude));
+
+        for (var i = 0; i < route.Legs.Count; i++)
+        {
+            var a = route.Waypoints[i].Position;
+            var b = route.Waypoints[i + 1].Position;
+            if (route.Legs[i].GeometryType == RouteLegGeometryType.Geodesic)
+            {
+                var arc = MarineGeodesy.GreatCircleIntermediatePoints(
+                    a.Latitude, a.Longitude, b.Latitude, b.Longitude, GeodesicSegments);
+                // Skip the first arc point (== current end) to avoid duplicates.
+                for (var j = 1; j < arc.Count; j++)
+                    points.Add(arc[j]);
+            }
+            else
+            {
+                points.Add((b.Latitude, b.Longitude));
+            }
+        }
+
+        return points;
+    }
+
+    private static void AddPolyline(List<IFeature> features, IReadOnlyList<(double Lat, double Lon)> points, MapsuiColor strokeColor, float opacity)
+    {
+        foreach (var subPath in MarineGeodesy.SplitAtAntimeridian(points))
+        {
+            if (subPath.Count < 2) continue;
+            var coords = new Coordinate[subPath.Count];
+            for (var i = 0; i < subPath.Count; i++)
+            {
+                var (mx, my) = SphericalMercator.FromLonLat(subPath[i].Lon, subPath[i].Lat);
+                coords[i] = new Coordinate(mx, my);
+            }
+
+            var feature = new GeometryFeature(new LineString(coords));
+            feature.Styles.Add(new VectorStyle
+            {
+                Line = new Pen { Color = strokeColor, Width = 4.0 },
+                Opacity = opacity,
+            });
+            features.Add(feature);
+        }
+    }
+
+    private static void AddLegLabel(
+        List<IFeature> features,
+        EncDotNet.S100.DataModel.GeoPosition a,
+        EncDotNet.S100.DataModel.GeoPosition b,
+        RouteLegMetrics metrics,
+        MapsuiColor backgroundColor,
+        MapsuiColor foregroundColor,
+        MapsuiColor haloColor)
+    {
+        var (ax, ay) = SphericalMercator.FromLonLat(a.Longitude, a.Latitude);
+        var (bx, by) = SphericalMercator.FromLonLat(b.Longitude, b.Latitude);
+        var feature = new GeometryFeature(new Point((ax + bx) / 2.0, (ay + by) / 2.0));
+
+        var text = string.Format(
+            CultureInfo.CurrentCulture,
+            EncDotNet.S100.Viewer.Resources.Strings.Route_LegLabel,
+            metrics.DistanceNm,
+            metrics.InitialBearingDegrees);
+
+        feature.Styles.Add(new LabelStyle
+        {
+            Text = text,
+            Font = new Font { FontFamily = "Menlo,Consolas,Courier New,monospace", Size = 12 },
+            ForeColor = foregroundColor,
+            BackColor = new Brush(backgroundColor),
+            Halo = new Pen { Color = haloColor, Width = 2.5 },
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+            Offset = new Offset(0, -14),
+        });
+        features.Add(feature);
+    }
+
+    private static void AddWaypointMarker(List<IFeature> features, double lat, double lon, int index, MapsuiColor fillColor, MapsuiColor borderColor, bool selected)
+    {
+        var (mx, my) = SphericalMercator.FromLonLat(lon, lat);
+        var disc = new GeometryFeature(new Point(mx, my));
+        disc.Styles.Add(new SymbolStyle
+        {
+            SymbolType = SymbolType.Ellipse,
+            // Selected waypoint is drawn larger with a heavier outline.
+            SymbolScale = selected ? 1.25 : 0.9,
+            Fill = new Brush { Color = fillColor },
+            Outline = new Pen { Color = borderColor, Width = selected ? 3.0 : 2.0 },
+        });
+        features.Add(disc);
+
+        var labelFeature = new GeometryFeature(new Point(mx, my));
+        labelFeature.Styles.Add(new LabelStyle
+        {
+            Text = index.ToString(CultureInfo.InvariantCulture),
+            Font = new Font { FontFamily = "Menlo,Consolas,Courier New,monospace", Size = 11, Bold = true },
+            ForeColor = new MapsuiColor(0, 0, 0),
+            BackColor = new Brush(MapsuiColor.Transparent),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+        });
+        features.Add(labelFeature);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -21,6 +21,9 @@ internal sealed class MainViewModel : ViewModelBase
     private readonly IThemeService _theme;
     private readonly IRecentFilesService _recentFiles;
     private readonly INotificationService _notifications;
+    private readonly RoutesService _routes;
+    private readonly MeasureTool _measureTool;
+    private readonly RouteEditTool _routeEditTool;
     private readonly ShadUI.DialogManager _dialogManager;
     private readonly Func<FeedbackDialogViewModel>? _feedbackDialogFactory;
 
@@ -586,6 +589,50 @@ internal sealed class MainViewModel : ViewModelBase
     public ICommand ToggleMeasureModeCommand { get; }
 
     /// <summary>
+    /// The application-scoped editable route store. Exposed so the host
+    /// window can drive the persistent route overlay and the routes side
+    /// panel can bind to it.
+    /// </summary>
+    public RoutesService RoutesService => _routes;
+
+    /// <summary>
+    /// True when the interactive route editor tool is active. Mirrors
+    /// <see cref="MapToolController.ActiveToolId"/> like
+    /// <see cref="IsMeasureModeActive"/>.
+    /// </summary>
+    public bool IsRouteEditModeActive => Tools.IsActive(RouteEditTool.ToolId);
+
+    /// <summary>
+    /// True when the tool-owned status summary should be shown — i.e. while
+    /// either Measure Mode or Route Edit Mode is active.
+    /// </summary>
+    public bool IsToolSummaryVisible => IsMeasureModeActive || IsRouteEditModeActive;
+
+    /// <summary>Toggles the interactive route editor tool on/off.</summary>
+    public ICommand ToggleRouteEditModeCommand { get; }
+
+    /// <summary>
+    /// Activates the interactive route editor tool. Unlike
+    /// <see cref="ToggleRouteEditModeCommand"/> this never turns the tool
+    /// off, so it is safe to bind to an explicit "edit" affordance.
+    /// </summary>
+    public ICommand EnterRouteEditModeCommand { get; }
+
+    /// <summary>
+    /// Deactivates the interactive route editor tool when it is active.
+    /// Bound to the Routes panel's "Done" action so finishing an edit
+    /// returns the map to its default (no-tool) state.
+    /// </summary>
+    public ICommand ExitRouteEditModeCommand { get; }
+
+    /// <summary>
+    /// Promotes the current Measure Mode path into a new editable route and
+    /// switches to the route editor. Enabled only when the measurement has
+    /// at least two waypoints.
+    /// </summary>
+    public ICommand PromoteMeasurementToRouteCommand { get; }
+
+    /// <summary>
     /// Discrete tool actions wired to keyboard accelerators; current
     /// active tool decides what (if anything) to do.
     /// </summary>
@@ -730,6 +777,29 @@ internal sealed class MainViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Copies the current Measure Mode path into a brand-new editable route,
+    /// makes it the active route, and switches to the route editor tool so
+    /// the user can immediately refine it.
+    /// </summary>
+    private void PromoteMeasurementToRoute()
+    {
+        var waypoints = _measureTool.State.Waypoints;
+        if (waypoints.Count < 2)
+            return;
+
+        var name = string.Format(
+            System.Globalization.CultureInfo.CurrentCulture,
+            Strings.Routes_NewRouteNameFormat,
+            _routes.Routes.Routes.Count + 1);
+        var route = _routes.Routes.CreateRoute(name);
+        foreach (var (lat, lon) in waypoints)
+            route.AppendWaypoint(new EncDotNet.S100.DataModel.GeoPosition(lat, lon));
+
+        _routes.SelectedWaypointIndex = null;
+        Tools.Activate(RouteEditTool.ToolId);
+    }
+
     private void AttachToMcpServer()
     {
         if (_attachedMcpServer is { } prev)
@@ -846,7 +916,8 @@ internal sealed class MainViewModel : ViewModelBase
         Func<FeedbackDialogViewModel>? feedbackDialogFactory = null,
         IEnumerable<IActivityTab>? activityTabs = null,
         McpServerHost? mcpServerHost = null,
-        IStatusPresenter? statusPresenter = null)
+        IStatusPresenter? statusPresenter = null,
+        RoutesService? routes = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(featureCatalogues);
@@ -879,6 +950,7 @@ internal sealed class MainViewModel : ViewModelBase
         _isDarkTheme = themeService.IsDarkTheme;
         _statusPresenter = statusPresenter;
         _mcpServerHost = mcpServerHost;
+        _routes = routes ?? new RoutesService();
 
         // PR-M3: debounced settings writer used by the splitter-size
         // setters. 500 ms window coalesces rapid drag updates into one
@@ -902,8 +974,11 @@ internal sealed class MainViewModel : ViewModelBase
             };
         }
 
+        _measureTool = new MeasureTool(measureAppearance);
+        _routeEditTool = new RouteEditTool(_routes);
         Tools.Register(new PickTool());
-        Tools.Register(new MeasureTool(measureAppearance));
+        Tools.Register(_measureTool);
+        Tools.Register(_routeEditTool);
 
         FeatureCatalogues = featureCatalogues;
         PortrayalCatalogues = portrayalCatalogues;
@@ -1010,6 +1085,14 @@ internal sealed class MainViewModel : ViewModelBase
         TogglePickModeCommand = new RelayCommand(() => Tools.Toggle(PickTool.ToolId));
         ExitPickModeCommand = new RelayCommand(() => Tools.Activate(null));
         ToggleMeasureModeCommand = new RelayCommand(() => Tools.Toggle(MeasureTool.ToolId));
+        ToggleRouteEditModeCommand = new RelayCommand(() => Tools.Toggle(RouteEditTool.ToolId));
+        EnterRouteEditModeCommand = new RelayCommand(() => Tools.Activate(RouteEditTool.ToolId));
+        ExitRouteEditModeCommand = new RelayCommand(
+            () => Tools.Activate(null),
+            () => Tools.IsActive(RouteEditTool.ToolId));
+        PromoteMeasurementToRouteCommand = new RelayCommand(
+            PromoteMeasurementToRoute,
+            () => _measureTool.State.Waypoints.Count >= 2);
         ToolCommitCommand = new RelayCommand(
             () => Tools.OnAction(MapToolAction.Commit),
             () => Tools.ActiveTool != null);
@@ -1033,8 +1116,12 @@ internal sealed class MainViewModel : ViewModelBase
                 OnPropertyChanged(nameof(IsPickModeActive));
             }
             OnPropertyChanged(nameof(IsMeasureModeActive));
+            OnPropertyChanged(nameof(IsRouteEditModeActive));
+            OnPropertyChanged(nameof(IsToolSummaryVisible));
             ((RelayCommand)ToolCommitCommand).NotifyCanExecuteChanged();
             ((RelayCommand)ToolBackstepCommand).NotifyCanExecuteChanged();
+            ((RelayCommand)PromoteMeasurementToRouteCommand).NotifyCanExecuteChanged();
+            ((RelayCommand)ExitRouteEditModeCommand).NotifyCanExecuteChanged();
         };
 
         ToggleThemeCommand = new RelayCommand(() => IsDarkTheme = _theme.ToggleTheme());

--- a/src/EncDotNet.S100.Viewer/ViewModels/RoutesPanelViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/RoutesPanelViewModel.cs
@@ -1,0 +1,547 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Services;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// View-model for the Routes activity-bar panel. Presents the editable
+/// <see cref="RouteCollection"/> owned by <see cref="RoutesService"/>: the
+/// list of routes (with add / rename / reverse / remove / select), and the
+/// active route's waypoint-and-leg timeline (numbered waypoints interleaved
+/// with the legs that join them, with insert / delete / leg-geometry toggle).
+/// All mutations flow back into the shared <see cref="RoutesService"/>, so the
+/// map overlay and the <c>RouteEditTool</c> stay in lock-step with the panel.
+/// </summary>
+internal sealed class RoutesPanelViewModel : ViewModelBase
+{
+    private readonly RoutesService _routes;
+    private bool _suppressSync;
+
+    public RoutesPanelViewModel(RoutesService routes)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        _routes = routes;
+
+        Routes = new ObservableCollection<RouteRowViewModel>();
+        Timeline = new ObservableCollection<RouteTimelineRowViewModel>();
+
+        AddRouteCommand = new RelayCommand(AddRoute);
+        RemoveRouteCommand = new RelayCommand<RouteRowViewModel>(RemoveRoute);
+        RenameRouteCommand = new RelayCommand<RouteRowViewModel>(RenameRoute);
+        ReverseRouteCommand = new RelayCommand<RouteRowViewModel>(ReverseRoute);
+
+        ReverseActiveRouteCommand = new RelayCommand(ReverseActiveRoute, () => HasActiveRoute);
+        InsertAfterSelectedCommand = new RelayCommand(
+            InsertAfterSelected,
+            () => _routes.SelectedWaypointIndex is not null);
+
+        BeginRenameCommand = new RelayCommand(BeginRename, () => HasActiveRoute);
+        CommitRenameCommand = new RelayCommand(CommitRename);
+        CancelRenameCommand = new RelayCommand(CancelRename);
+
+        SelectWaypointCommand = new RelayCommand<RouteWaypointRowViewModel>(SelectWaypoint);
+        InsertWaypointAfterCommand = new RelayCommand<RouteWaypointRowViewModel>(InsertWaypointAfter);
+        DeleteWaypointAtCommand = new RelayCommand<RouteWaypointRowViewModel>(DeleteWaypointAt);
+        ToggleLegGeometryAtCommand = new RelayCommand<RouteLegRowViewModel>(ToggleLegGeometryAt);
+
+        DeleteWaypointCommand = new RelayCommand(
+            DeleteSelectedWaypoint,
+            () => _routes.SelectedWaypointIndex is not null);
+
+        _routes.Changed += (_, _) => Rebuild();
+        Rebuild();
+    }
+
+    /// <summary>The routes in the collection, in creation order.</summary>
+    public ObservableCollection<RouteRowViewModel> Routes { get; }
+
+    /// <summary>
+    /// Ordered timeline rows for the active route: a
+    /// <see cref="RouteWaypointRowViewModel"/> for each waypoint, interleaved
+    /// with a <see cref="RouteLegRowViewModel"/> for each leg joining two
+    /// consecutive waypoints.
+    /// </summary>
+    public ObservableCollection<RouteTimelineRowViewModel> Timeline { get; }
+
+    private RouteRowViewModel? _selectedRoute;
+    /// <summary>
+    /// The currently selected route row. Setting it makes the underlying
+    /// route the collection's active route.
+    /// </summary>
+    public RouteRowViewModel? SelectedRoute
+    {
+        get => _selectedRoute;
+        set
+        {
+            if (!SetProperty(ref _selectedRoute, value))
+                return;
+            if (!_suppressSync)
+                _routes.Routes.SetActiveRoute(value?.Route);
+        }
+    }
+
+    /// <summary>True when the collection has at least one route.</summary>
+    public bool HasRoutes => Routes.Count > 0;
+
+    /// <summary>True when there is an active route to inspect.</summary>
+    public bool HasActiveRoute => _routes.Routes.ActiveRoute is not null;
+
+    /// <summary>Placeholder shown when no routes exist.</summary>
+    public string EmptyText => Strings.Routes_NoRoutes;
+
+    /// <summary>Placeholder shown when routes exist but none is active.</summary>
+    public string NoActiveRouteText => Strings.Routes_NoActiveRoute;
+
+    private string? _activeRouteName;
+    /// <summary>Display name of the active route (null when none).</summary>
+    public string? ActiveRouteName
+    {
+        get => _activeRouteName;
+        private set => SetProperty(ref _activeRouteName, value);
+    }
+
+    private string? _activeRouteDetailMeta;
+    /// <summary>
+    /// Waypoint-count, total-distance and predominant-geometry summary for the
+    /// active route (e.g. "4 WP · 4.1 NM · Rhumb").
+    /// </summary>
+    public string? ActiveRouteDetailMeta
+    {
+        get => _activeRouteDetailMeta;
+        private set => SetProperty(ref _activeRouteDetailMeta, value);
+    }
+
+    private bool _isRenamingActiveRoute;
+    /// <summary>True while the active route name is being edited inline.</summary>
+    public bool IsRenamingActiveRoute
+    {
+        get => _isRenamingActiveRoute;
+        private set => SetProperty(ref _isRenamingActiveRoute, value);
+    }
+
+    private string? _renameText;
+    /// <summary>Working copy of the route name bound to the inline editor.</summary>
+    public string? RenameText
+    {
+        get => _renameText;
+        set => SetProperty(ref _renameText, value);
+    }
+
+    public ICommand AddRouteCommand { get; }
+    public ICommand RemoveRouteCommand { get; }
+    public ICommand RenameRouteCommand { get; }
+    public ICommand ReverseRouteCommand { get; }
+    public ICommand ReverseActiveRouteCommand { get; }
+    public ICommand InsertAfterSelectedCommand { get; }
+    public ICommand BeginRenameCommand { get; }
+    public ICommand CommitRenameCommand { get; }
+    public ICommand CancelRenameCommand { get; }
+    public ICommand SelectWaypointCommand { get; }
+    public ICommand InsertWaypointAfterCommand { get; }
+    public ICommand DeleteWaypointAtCommand { get; }
+    public ICommand ToggleLegGeometryAtCommand { get; }
+    public ICommand DeleteWaypointCommand { get; }
+
+    private void AddRoute()
+    {
+        var name = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Routes_NewRouteNameFormat,
+            _routes.Routes.Routes.Count + 1);
+        _routes.Routes.CreateRoute(name);
+    }
+
+    private void RemoveRoute(RouteRowViewModel? row)
+    {
+        var route = row?.Route ?? SelectedRoute?.Route;
+        if (route is not null)
+            _routes.Routes.Remove(route);
+    }
+
+    private void RenameRoute(RouteRowViewModel? row)
+    {
+        if (row?.Route is { } route)
+        {
+            _routes.Routes.SetActiveRoute(route);
+            BeginRename();
+        }
+    }
+
+    private void ReverseRoute(RouteRowViewModel? row)
+    {
+        row?.Route.Reverse();
+    }
+
+    private void ReverseActiveRoute()
+    {
+        _routes.Routes.ActiveRoute?.Reverse();
+    }
+
+    private void BeginRename()
+    {
+        if (_routes.Routes.ActiveRoute is not { } route)
+            return;
+        RenameText = route.Name;
+        IsRenamingActiveRoute = true;
+    }
+
+    private void CommitRename()
+    {
+        if (!IsRenamingActiveRoute)
+            return;
+        IsRenamingActiveRoute = false;
+        if (_routes.Routes.ActiveRoute is { } route)
+            route.Name = string.IsNullOrWhiteSpace(RenameText) ? route.Name : RenameText;
+    }
+
+    private void CancelRename()
+    {
+        IsRenamingActiveRoute = false;
+    }
+
+    private void SelectWaypoint(RouteWaypointRowViewModel? row)
+    {
+        if (row is null)
+            return;
+        _routes.SelectedWaypointIndex = row.Index;
+    }
+
+    private void InsertAfterSelected()
+    {
+        if (_routes.SelectedWaypointIndex is { } index)
+            InsertAfter(index);
+    }
+
+    private void InsertWaypointAfter(RouteWaypointRowViewModel? row)
+    {
+        if (row is not null)
+            InsertAfter(row.Index);
+    }
+
+    private void InsertAfter(int index)
+    {
+        if (_routes.Routes.ActiveRoute is not { } route)
+            return;
+        if (index < 0 || index >= route.Waypoints.Count)
+            return;
+
+        GeoPosition position;
+        if (index + 1 < route.Waypoints.Count)
+        {
+            // Midpoint of the leg leaving the selected waypoint.
+            var a = route.Waypoints[index].Position;
+            var b = route.Waypoints[index + 1].Position;
+            position = new GeoPosition(
+                (a.Latitude + b.Latitude) / 2.0,
+                (a.Longitude + b.Longitude) / 2.0);
+        }
+        else
+        {
+            // Selected waypoint is the last one: extend along the inbound
+            // bearing by mirroring the previous waypoint about it, or just
+            // nudge east when the route has a single waypoint.
+            var last = route.Waypoints[index].Position;
+            if (index > 0)
+            {
+                var prev = route.Waypoints[index - 1].Position;
+                position = new GeoPosition(
+                    last.Latitude + (last.Latitude - prev.Latitude),
+                    last.Longitude + (last.Longitude - prev.Longitude));
+            }
+            else
+            {
+                position = new GeoPosition(last.Latitude, last.Longitude + 0.01);
+            }
+        }
+
+        route.InsertWaypoint(index + 1, position);
+        _routes.SelectedWaypointIndex = index + 1;
+    }
+
+    private void DeleteSelectedWaypoint()
+    {
+        if (_routes.SelectedWaypointIndex is { } index)
+            DeleteWaypointIndex(index);
+    }
+
+    private void DeleteWaypointAt(RouteWaypointRowViewModel? row)
+    {
+        if (row is not null)
+            DeleteWaypointIndex(row.Index);
+    }
+
+    private void DeleteWaypointIndex(int index)
+    {
+        if (_routes.Routes.ActiveRoute is { } route &&
+            index >= 0 && index < route.Waypoints.Count)
+        {
+            route.RemoveWaypoint(index);
+            _routes.SelectedWaypointIndex = null;
+        }
+    }
+
+    private void ToggleLegGeometryAt(RouteLegRowViewModel? row)
+    {
+        if (_routes.Routes.ActiveRoute is not { } route ||
+            row is null ||
+            row.LegIndex < 0 || row.LegIndex >= route.Legs.Count)
+        {
+            return;
+        }
+
+        var leg = route.Legs[row.LegIndex];
+        leg.GeometryType = leg.GeometryType == RouteLegGeometryType.Geodesic
+            ? RouteLegGeometryType.Loxodrome
+            : RouteLegGeometryType.Geodesic;
+        route.NotifyChanged();
+    }
+
+    private void Rebuild()
+    {
+        _suppressSync = true;
+        try
+        {
+            Routes.Clear();
+            RouteRowViewModel? activeRow = null;
+            foreach (var route in _routes.Routes.Routes)
+            {
+                var isActive = ReferenceEquals(route, _routes.Routes.ActiveRoute);
+                var row = new RouteRowViewModel(route, isActive, RouteMeta(route));
+                Routes.Add(row);
+                if (isActive)
+                    activeRow = row;
+            }
+
+            SelectedRoute = activeRow;
+            RebuildTimeline();
+        }
+        finally
+        {
+            _suppressSync = false;
+        }
+
+        OnPropertyChanged(nameof(HasRoutes));
+        OnPropertyChanged(nameof(HasActiveRoute));
+        ((RelayCommand)ReverseActiveRouteCommand).NotifyCanExecuteChanged();
+        ((RelayCommand)InsertAfterSelectedCommand).NotifyCanExecuteChanged();
+        ((RelayCommand)DeleteWaypointCommand).NotifyCanExecuteChanged();
+        ((RelayCommand)BeginRenameCommand).NotifyCanExecuteChanged();
+    }
+
+    private void RebuildTimeline()
+    {
+        Timeline.Clear();
+        if (_routes.Routes.ActiveRoute is not { } route)
+        {
+            ActiveRouteName = null;
+            ActiveRouteDetailMeta = null;
+            return;
+        }
+
+        ActiveRouteName = route.Name;
+
+        var metrics = route.ComputeAllLegMetrics();
+        var selected = _routes.SelectedWaypointIndex;
+        for (var i = 0; i < route.Waypoints.Count; i++)
+        {
+            var wp = route.Waypoints[i];
+            var label = string.IsNullOrWhiteSpace(wp.Name)
+                ? string.Format(CultureInfo.CurrentCulture, Strings.Routes_WaypointNameFormat, i + 1)
+                : wp.Name!;
+            var coords = string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.Routes_WaypointCoordFormat,
+                wp.Position.Latitude,
+                wp.Position.Longitude);
+            Timeline.Add(new RouteWaypointRowViewModel(i, i + 1, label, coords, InsertWaypointAfterCommand, DeleteWaypointAtCommand)
+            {
+                IsSelected = selected == i,
+                IsFirst = i == 0,
+                IsLast = i == route.Waypoints.Count - 1,
+            });
+
+            if (i < metrics.Count)
+            {
+                var m = metrics[i];
+                var legText = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Routes_LegMetaFormat,
+                    m.DistanceNm,
+                    m.InitialBearingDegrees);
+                var isGeodesic = route.Legs[i].GeometryType == RouteLegGeometryType.Geodesic;
+                var geometryText = isGeodesic
+                    ? Strings.Routes_GeometryGeodesic
+                    : Strings.Routes_GeometryLoxodrome;
+                Timeline.Add(new RouteLegRowViewModel(i, legText, geometryText, isGeodesic));
+            }
+        }
+
+        var total = route.TotalDistanceNm();
+        ActiveRouteDetailMeta = route.Legs.Count == 0
+            ? string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.Routes_DetailMetaFormat,
+                route.Waypoints.Count,
+                total)
+            : string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.Routes_DetailMetaWithGeometryFormat,
+                route.Waypoints.Count,
+                total,
+                PredominantGeometry(route));
+    }
+
+    private static string RouteMeta(Route route)
+        => string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.Routes_RouteMetaFormat,
+            route.Waypoints.Count,
+            route.TotalDistanceNm());
+
+    private static string PredominantGeometry(Route route)
+    {
+        var geodesic = 0;
+        var loxodrome = 0;
+        foreach (var leg in route.Legs)
+        {
+            if (leg.GeometryType == RouteLegGeometryType.Geodesic)
+                geodesic++;
+            else
+                loxodrome++;
+        }
+
+        if (geodesic > 0 && loxodrome > 0)
+            return Strings.Routes_GeometryMixed;
+        return geodesic > 0 ? Strings.Routes_GeometryGeodesic : Strings.Routes_GeometryLoxodrome;
+    }
+}
+
+/// <summary>A single route row in the routes list.</summary>
+internal sealed class RouteRowViewModel : ViewModelBase
+{
+    public RouteRowViewModel(Route route, bool isActive, string meta)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        Route = route;
+        _isActive = isActive;
+        Meta = meta;
+    }
+
+    /// <summary>The underlying editable route.</summary>
+    public Route Route { get; }
+
+    /// <summary>Display name of the route.</summary>
+    public string? Name => Route.Name;
+
+    /// <summary>Waypoint-count + total-distance summary (e.g. "4 WP · 4.1 NM").</summary>
+    public string Meta { get; }
+
+    private bool _isActive;
+    /// <summary>True when this is the collection's active route.</summary>
+    public bool IsActive
+    {
+        get => _isActive;
+        set => SetProperty(ref _isActive, value);
+    }
+}
+
+/// <summary>
+/// Base type for a row in the active route's waypoint/leg timeline. Concrete
+/// rows are <see cref="RouteWaypointRowViewModel"/> and
+/// <see cref="RouteLegRowViewModel"/>.
+/// </summary>
+internal abstract class RouteTimelineRowViewModel : ViewModelBase
+{
+}
+
+/// <summary>A numbered waypoint row in the timeline.</summary>
+internal sealed class RouteWaypointRowViewModel : RouteTimelineRowViewModel
+{
+    public RouteWaypointRowViewModel(
+        int index,
+        int number,
+        string label,
+        string coords,
+        ICommand insertAfterCommand,
+        ICommand deleteCommand)
+    {
+        Index = index;
+        Number = number;
+        Label = label;
+        Coords = coords;
+        InsertAfterCommand = insertAfterCommand;
+        DeleteCommand = deleteCommand;
+    }
+
+    /// <summary>
+    /// Insert-a-waypoint-after command, surfaced on the row so the overflow
+    /// <c>MenuFlyout</c> can bind to its own <see cref="ViewModelBase"/>
+    /// DataContext. Ancestor bindings (e.g. <c>$parent[ItemsControl]</c>) do
+    /// not resolve from inside a flyout popup, but the inherited DataContext
+    /// does, so command access must live on the row item itself.
+    /// </summary>
+    public ICommand InsertAfterCommand { get; }
+
+    /// <summary>
+    /// Delete-this-waypoint command, surfaced on the row for the same
+    /// flyout-binding reason as <see cref="InsertAfterCommand"/>.
+    /// </summary>
+    public ICommand DeleteCommand { get; }
+
+    /// <summary>Zero-based waypoint index within the active route.</summary>
+    public int Index { get; }
+
+    /// <summary>One-based display number shown in the timeline circle.</summary>
+    public int Number { get; }
+
+    /// <summary>Waypoint name or a "Waypoint N" fallback.</summary>
+    public string Label { get; }
+
+    /// <summary>Latitude/longitude, pre-formatted for the muted subtitle.</summary>
+    public string Coords { get; }
+
+    private bool _isSelected;
+    /// <summary>True when this is the highlighted waypoint.</summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    /// <summary>True for the first waypoint (no inbound connector).</summary>
+    public bool IsFirst { get; init; }
+
+    /// <summary>True for the last waypoint (no outbound connector).</summary>
+    public bool IsLast { get; init; }
+}
+
+/// <summary>A leg row sitting between two waypoint rows in the timeline.</summary>
+internal sealed class RouteLegRowViewModel : RouteTimelineRowViewModel
+{
+    public RouteLegRowViewModel(int legIndex, string legText, string geometryText, bool isGeodesic)
+    {
+        LegIndex = legIndex;
+        LegText = legText;
+        GeometryText = geometryText;
+        IsGeodesic = isGeodesic;
+    }
+
+    /// <summary>Zero-based leg index within the active route.</summary>
+    public int LegIndex { get; }
+
+    /// <summary>Distance/bearing of the leg, pre-formatted (e.g. "1.6 NM · 070°T").</summary>
+    public string LegText { get; }
+
+    /// <summary>Geometry chip label ("Rhumb" / "Great circle").</summary>
+    public string GeometryText { get; }
+
+    /// <summary>True when the leg uses great-circle geometry.</summary>
+    public bool IsGeodesic { get; }
+}

--- a/src/EncDotNet.S100.Viewer/Views/RoutesView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/RoutesView.axaml
@@ -1,0 +1,404 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:views="using:EncDotNet.S100.Viewer.Views"
+             xmlns:ic="using:FluentIcons.Avalonia"
+             x:Class="EncDotNet.S100.Viewer.Views.RoutesView"
+             x:DataType="vm:RoutesPanelViewModel">
+
+    <UserControl.Styles>
+        <!--
+          Full-width selectable waypoint row. The accent left bar and the
+          low-opacity accent tint live on the row Border so the selection
+          spans the whole list width (content + overflow), matching the
+          `accentList` language used by the Datasets / Search / Pick lists.
+          The inner hit button is a bare, chrome-free click target; hover
+          and selection visuals are driven by the parent Border's pseudo /
+          selected classes.
+        -->
+        <!--
+          Full-width selectable waypoint row. This mirrors the `accentList`
+          ListBoxItem template (a "3,*" grid with a rounded accent bar plus a
+          tinted content panel) so the waypoint list lines up pixel-for-pixel
+          with the routes list above it. Hover/selection visuals are driven by
+          the root grid's pseudo/selected classes; a full-area, chrome-free
+          hit button sits beneath the (non-hit-testable) row visuals so a click
+          anywhere on the row selects the waypoint.
+        -->
+        <Style Selector="Grid.wpRow">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="MinHeight" Value="46" />
+            <Setter Property="Margin" Value="0,1" />
+        </Style>
+        <Style Selector="Border.wpBar">
+            <Setter Property="Width" Value="3" />
+            <Setter Property="CornerRadius" Value="1.5" />
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="Grid.wpRow.selected Border.wpBar">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="Border.wpTint">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Opacity" Value="0" />
+            <Setter Property="IsHitTestVisible" Value="False" />
+        </Style>
+        <Style Selector="Grid.wpRow:pointerover Border.wpTint">
+            <Setter Property="Opacity" Value="0.06" />
+        </Style>
+        <Style Selector="Grid.wpRow.selected Border.wpTint">
+            <Setter Property="Opacity" Value="0.12" />
+        </Style>
+
+        <!-- Full-area click target for the waypoint row. The templated Border
+             carries the (transparent) background so the entire row area is
+             hit-testable, not just where content happens to sit. -->
+        <Style Selector="Button.wpHit">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}" />
+                </ControlTemplate>
+            </Setter>
+        </Style>
+
+        <!-- Numbered timeline circle: outlined by default, filled accent when
+             its waypoint is selected. -->
+        <Style Selector="Border.wpCircle">
+            <Setter Property="Width" Value="22" />
+            <Setter Property="Height" Value="22" />
+            <Setter Property="CornerRadius" Value="11" />
+            <Setter Property="BorderThickness" Value="1.5" />
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}" />
+            <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="Grid.wpRow.selected Border.wpCircle">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="TextBlock.wpNum">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="Grid.wpRow.selected TextBlock.wpNum">
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="TextBlock.wpLabel">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+        <Style Selector="Grid.wpRow.selected TextBlock.wpLabel">
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+        </Style>
+
+        <!-- Vertical connector segment drawn in the rail of each leg row so
+             consecutive waypoint circles read as a single timeline spine. The
+             rail width (28) and leading offset match the waypoint circle so
+             the line passes through the circle centres. -->
+        <Style Selector="Border.legConnector">
+            <Setter Property="Width" Value="2" />
+            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="Background" Value="{DynamicResource BorderColor}" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+        </Style>
+
+        <!-- Leg geometry pill. -->
+        <Style Selector="Button.geoChip">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="7,1" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="FontSize" Value="10" />
+        </Style>
+        <Style Selector="Button.geoChip.geodesic">
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+        </Style>
+    </UserControl.Styles>
+
+    <DockPanel LastChildFill="True">
+
+        <!-- Route-collection header actions (the host pane supplies the
+             "ROUTES" title above this row). -->
+        <Border DockPanel.Dock="Top" Padding="8,4,6,4">
+            <Grid ColumnDefinitions="*,Auto,Auto">
+                <Button Grid.Column="1"
+                        Classes="Icon"
+                        Command="{Binding $parent[Window].((vm:MainViewModel)DataContext).PromoteMeasurementToRouteCommand}"
+                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_PromoteMeasurement}">
+                    <ic:FluentIcon Icon="Ruler" IconVariant="Regular" FontSize="16" />
+                </Button>
+                <Button Grid.Column="2"
+                        Classes="Icon"
+                        Command="{Binding AddRouteCommand}"
+                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_AddRoute}">
+                    <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="16" />
+                </Button>
+            </Grid>
+        </Border>
+
+        <!-- Empty state. -->
+        <views:PlaceholderView DockPanel.Dock="Top"
+                               IsVisible="{Binding !HasRoutes}"
+                               Icon="Flow"
+                               Header="{x:Static loc:Strings.Pane_Routes}"
+                               Description="{Binding EmptyText}" />
+
+        <!-- Main body: routes list (top) over the active route detail. -->
+        <Grid RowDefinitions="Auto,Auto,*" IsVisible="{Binding HasRoutes}">
+
+            <!-- Routes list. -->
+            <ListBox Grid.Row="0"
+                     x:Name="RouteList"
+                     MaxHeight="200"
+                     ItemsSource="{Binding Routes}"
+                     SelectedItem="{Binding SelectedRoute, Mode=TwoWay}"
+                     Classes="accentList"
+                     Background="Transparent"
+                     BorderThickness="0"
+                     Padding="0"
+                     Margin="8,2,8,4"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="vm:RouteRowViewModel">
+                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                            <ic:FluentIcon Grid.Column="0"
+                                           Icon="Flow"
+                                           IconVariant="Filled"
+                                           FontSize="16"
+                                           VerticalAlignment="Center" />
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding Name}"
+                                           Classes="accentListTitle"
+                                           FontWeight="SemiBold"
+                                           TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{Binding Meta}"
+                                           FontSize="11"
+                                           Opacity="0.6" />
+                            </StackPanel>
+                            <Button Grid.Column="2"
+                                    Classes="Icon"
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_RouteRowMenu}">
+                                <ic:FluentIcon Icon="MoreHorizontal" IconVariant="Regular" FontSize="16" />
+                                <Button.Flyout>
+                                    <MenuFlyout>
+                                        <MenuItem Header="{x:Static loc:Strings.Menu_RenameRoute}"
+                                                  Command="{Binding $parent[ListBox].((vm:RoutesPanelViewModel)DataContext).RenameRouteCommand}"
+                                                  CommandParameter="{Binding}" />
+                                        <MenuItem Header="{x:Static loc:Strings.Menu_ReverseRoute}"
+                                                  Command="{Binding $parent[ListBox].((vm:RoutesPanelViewModel)DataContext).ReverseRouteCommand}"
+                                                  CommandParameter="{Binding}" />
+                                        <Separator />
+                                        <MenuItem Header="{x:Static loc:Strings.Menu_RemoveRoute}"
+                                                  Command="{Binding $parent[ListBox].((vm:RoutesPanelViewModel)DataContext).RemoveRouteCommand}"
+                                                  CommandParameter="{Binding}" />
+                                    </MenuFlyout>
+                                </Button.Flyout>
+                            </Button>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <!-- Active-route detail header: name (+ inline rename) and meta. -->
+            <Border Grid.Row="1"
+                    IsVisible="{Binding HasActiveRoute}"
+                    Padding="11,6,8,6"
+                    BorderBrush="{DynamicResource BorderColor}"
+                    BorderThickness="0,1,0,1">
+                <StackPanel Spacing="2">
+                    <Grid ColumnDefinitions="*,Auto"
+                          IsVisible="{Binding !IsRenamingActiveRoute}">
+                        <TextBlock Grid.Column="0"
+                                   Text="{Binding ActiveRouteName}"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis" />
+                        <Button Grid.Column="1"
+                                Classes="Icon"
+                                Command="{Binding BeginRenameCommand}"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_EditRouteName}">
+                            <ic:FluentIcon Icon="Edit" IconVariant="Regular" FontSize="14" />
+                        </Button>
+                    </Grid>
+                    <TextBox Text="{Binding RenameText, Mode=TwoWay}"
+                             FontSize="13"
+                             Padding="4,2"
+                             IsVisible="{Binding IsRenamingActiveRoute}">
+                        <TextBox.KeyBindings>
+                            <KeyBinding Gesture="Enter" Command="{Binding CommitRenameCommand}" />
+                            <KeyBinding Gesture="Escape" Command="{Binding CancelRenameCommand}" />
+                        </TextBox.KeyBindings>
+                    </TextBox>
+                    <TextBlock Text="{Binding ActiveRouteDetailMeta}"
+                               FontSize="11"
+                               Opacity="0.6" />
+                </StackPanel>
+            </Border>
+
+            <!-- Active-route waypoint/leg timeline. -->
+            <Grid Grid.Row="2" RowDefinitions="*,Auto">
+                <ScrollViewer Grid.Row="0"
+                              IsVisible="{Binding HasActiveRoute}"
+                              HorizontalScrollBarVisibility="Disabled">
+                    <ItemsControl x:Name="TimelineItems"
+                                  ItemsSource="{Binding Timeline}"
+                                  Margin="8,2,8,4">
+                        <ItemsControl.DataTemplates>
+                            <!-- Waypoint row. The accent bar + tint live on
+                                 the row Border so selection spans the full
+                                 width (content + overflow). The inner grid's
+                                 8,5 margin matches the `accentList` content
+                                 padding so this list lines up with the routes
+                                 list above it. -->
+                            <DataTemplate x:DataType="vm:RouteWaypointRowViewModel">
+                                <Grid Classes="wpRow"
+                                      Classes.selected="{Binding IsSelected}"
+                                      ColumnDefinitions="3,*">
+                                    <Border Grid.Column="0" Classes="wpBar" />
+                                    <Panel Grid.Column="1">
+                                        <Border Classes="wpTint" />
+                                        <!-- Full-area select target (bottom layer). -->
+                                        <Button Classes="wpHit"
+                                                Command="{Binding $parent[ItemsControl].((vm:RoutesPanelViewModel)DataContext).SelectWaypointCommand}"
+                                                CommandParameter="{Binding}" />
+                                        <!-- Row visuals (top layer). The circle/text
+                                             are non-hit-testable so clicks fall through
+                                             to the select target; only the overflow
+                                             button captures its own clicks. -->
+                                        <Grid ColumnDefinitions="*,Auto" Margin="8,5">
+                                            <Grid Grid.Column="0"
+                                                  ColumnDefinitions="28,*"
+                                                  ColumnSpacing="8"
+                                                  IsHitTestVisible="False">
+                                                <Border Grid.Column="0" Classes="wpCircle">
+                                                    <TextBlock Classes="wpNum"
+                                                               Text="{Binding Number}" />
+                                                </Border>
+                                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                    <TextBlock Classes="wpLabel"
+                                                               Text="{Binding Label}" />
+                                                    <TextBlock Text="{Binding Coords}"
+                                                               FontSize="11"
+                                                               Opacity="0.55"
+                                                               FontFamily="Menlo,Consolas,Courier New,monospace" />
+                                                </StackPanel>
+                                            </Grid>
+                                            <!-- Overflow menu. The flyout binds to
+                                                 commands surfaced on the row VM:
+                                                 ancestor bindings do not resolve
+                                                 across the flyout popup, but the
+                                                 inherited DataContext does. -->
+                                            <Button Grid.Column="1"
+                                                    Classes="Icon"
+                                                    VerticalAlignment="Center"
+                                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_WaypointRowMenu}">
+                                                <ic:FluentIcon Icon="MoreHorizontal" IconVariant="Regular" FontSize="16" />
+                                                <Button.Flyout>
+                                                    <MenuFlyout>
+                                                        <MenuItem Header="{x:Static loc:Strings.Menu_InsertWaypointAfter}"
+                                                                  Command="{Binding InsertAfterCommand}"
+                                                                  CommandParameter="{Binding}" />
+                                                        <MenuItem Header="{x:Static loc:Strings.Menu_DeleteWaypoint}"
+                                                                  Command="{Binding DeleteCommand}"
+                                                                  CommandParameter="{Binding}" />
+                                                    </MenuFlyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </Grid>
+                                    </Panel>
+                                </Grid>
+                            </DataTemplate>
+                            <!-- Leg row (sits between two waypoint rows). The
+                                 11px left margin (3px accent bar + 8px content
+                                 margin) lines the connector up with the
+                                 waypoint circle centres above and below. -->
+                            <DataTemplate x:DataType="vm:RouteLegRowViewModel">
+                                <Grid ColumnDefinitions="28,*" ColumnSpacing="8" Margin="11,5,8,5">
+                                    <Border Grid.Column="0" Classes="legConnector" />
+                                    <StackPanel Grid.Column="1"
+                                                Orientation="Horizontal"
+                                                Spacing="8"
+                                                VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding LegText}"
+                                                   FontSize="11"
+                                                   Opacity="0.75"
+                                                   VerticalAlignment="Center" />
+                                        <Button Classes="geoChip"
+                                                Classes.geodesic="{Binding IsGeodesic}"
+                                                Content="{Binding GeometryText}"
+                                                Command="{Binding $parent[ItemsControl].((vm:RoutesPanelViewModel)DataContext).ToggleLegGeometryAtCommand}"
+                                                CommandParameter="{Binding}"
+                                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ToggleLegGeometry}" />
+                                    </StackPanel>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.DataTemplates>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <!-- No-active-route hint. -->
+                <TextBlock Grid.Row="0"
+                           Text="{Binding NoActiveRouteText}"
+                           FontSize="11"
+                           Opacity="0.55"
+                           TextWrapping="Wrap"
+                           Margin="12,8"
+                           VerticalAlignment="Top"
+                           IsVisible="{Binding !HasActiveRoute}" />
+
+                <!-- Footer action bar. -->
+                <Border Grid.Row="1"
+                        IsVisible="{Binding HasActiveRoute}"
+                        Padding="8,6,8,8"
+                        BorderBrush="{DynamicResource BorderColor}"
+                        BorderThickness="0,1,0,0">
+                    <Grid ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="6">
+                        <Button Grid.Column="0"
+                                Classes="Outline"
+                                VerticalContentAlignment="Center"
+                                Command="{Binding InsertAfterSelectedCommand}"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_InsertWaypoint}">
+                            <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                                <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="14" VerticalAlignment="Center" />
+                                <TextBlock Text="{x:Static loc:Strings.Button_InsertWaypoint}" FontSize="12" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                        <Button Grid.Column="1"
+                                Classes="Outline"
+                                VerticalContentAlignment="Center"
+                                Command="{Binding ReverseActiveRouteCommand}"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ReverseRoute}">
+                            <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                                <ic:FluentIcon Icon="ArrowSwap" IconVariant="Regular" FontSize="14" VerticalAlignment="Center" />
+                                <TextBlock Text="{x:Static loc:Strings.Button_ReverseRoute}" FontSize="12" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                        <Button Grid.Column="3"
+                                Classes="Primary"
+                                VerticalContentAlignment="Center"
+                                Content="{x:Static loc:Strings.Button_DoneRouteEdit}"
+                                Command="{Binding $parent[Window].((vm:MainViewModel)DataContext).ExitRouteEditModeCommand}"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_DoneRouteEdit}" />
+                    </Grid>
+                </Border>
+            </Grid>
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/RoutesView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/RoutesView.axaml.cs
@@ -1,0 +1,15 @@
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// Routes activity panel: lists the editable routes and the active route's
+/// waypoints/legs. Bound to <see cref="ViewModels.RoutesPanelViewModel"/>.
+/// </summary>
+public partial class RoutesView : UserControl
+{
+    public RoutesView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -130,4 +130,45 @@ public class MainViewModelPickModeTests
 
         Assert.Equal(2, fired);
     }
+
+    [Fact]
+    public void ToggleRouteEditModeCommand_FlipsState()
+    {
+        var vm = CreateViewModel();
+
+        vm.ToggleRouteEditModeCommand.Execute(null);
+        Assert.True(vm.IsRouteEditModeActive);
+
+        vm.ToggleRouteEditModeCommand.Execute(null);
+        Assert.False(vm.IsRouteEditModeActive);
+    }
+
+    [Fact]
+    public void RouteEditMode_AndPickMode_AreMutuallyExclusive()
+    {
+        var vm = CreateViewModel();
+
+        vm.IsPickModeActive = true;
+        vm.ToggleRouteEditModeCommand.Execute(null);
+
+        Assert.True(vm.IsRouteEditModeActive);
+        Assert.False(vm.IsPickModeActive);
+    }
+
+    [Fact]
+    public void PromoteMeasurementToRouteCommand_DisabledWithoutMeasurement()
+    {
+        var vm = CreateViewModel();
+        Assert.False(vm.PromoteMeasurementToRouteCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void IsToolSummaryVisible_TrueWhileRouteEditing()
+    {
+        var vm = CreateViewModel();
+        Assert.False(vm.IsToolSummaryVisible);
+
+        vm.ToggleRouteEditModeCommand.Execute(null);
+        Assert.True(vm.IsToolSummaryVisible);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/MarineGeodesyTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MarineGeodesyTests.cs
@@ -94,4 +94,88 @@ public class MarineGeodesyTests
         var split = MarineGeodesy.SplitAtAntimeridian(System.Array.Empty<(double, double)>());
         Assert.Empty(split);
     }
+
+    [Fact]
+    public void GreatCircleDistance_NewYorkToLisbon_MatchesReference()
+    {
+        // Reference great-circle distance ≈ 5414 km / 2923 NM.
+        var nm = MarineGeodesy.GreatCircleDistanceNm(40.7128, -74.0060, 38.7223, -9.1393);
+        Assert.InRange(nm, 2900.0, 2945.0);
+    }
+
+    [Fact]
+    public void GreatCircleDistance_IsShorterThanRhumbOnHighLatitudeEastWestLeg()
+    {
+        var gc = MarineGeodesy.GreatCircleDistanceNm(60.0, -10.0, 60.0, 10.0);
+        var rl = MarineGeodesy.RhumbDistanceNm(60.0, -10.0, 60.0, 10.0);
+        Assert.True(gc < rl);
+    }
+
+    [Fact]
+    public void GreatCircleDistance_ZeroLengthLeg_IsZero()
+    {
+        var nm = MarineGeodesy.GreatCircleDistanceNm(45.0, -10.0, 45.0, -10.0);
+        Assert.Equal(0.0, nm, precision: 6);
+    }
+
+    [Fact]
+    public void GreatCircleInitialBearing_PureEastAlongEquator_Returns090()
+    {
+        // Along the equator the great circle coincides with the parallel, so
+        // the initial bearing is due east.
+        var deg = MarineGeodesy.GreatCircleInitialBearingDegrees(0.0, 0.0, 0.0, 10.0);
+        Assert.InRange(deg, 89.99, 90.01);
+    }
+
+    [Fact]
+    public void GreatCircleInitialBearing_NorthernEastWardLeg_StartsNorthOfEast()
+    {
+        // Heading east at a positive latitude, the great circle initially
+        // bears north of due east (poleward), unlike the constant-east rhumb.
+        var deg = MarineGeodesy.GreatCircleInitialBearingDegrees(60.0, -10.0, 60.0, 10.0);
+        Assert.InRange(deg, 0.0, 90.0);
+    }
+
+    [Fact]
+    public void GreatCircleIntermediatePoints_ReturnsSegmentsPlusOnePoints()
+    {
+        var pts = MarineGeodesy.GreatCircleIntermediatePoints(0.0, 0.0, 0.0, 30.0, 6);
+        Assert.Equal(7, pts.Count);
+        Assert.Equal(0.0, pts[0].Lat, 6);
+        Assert.Equal(0.0, pts[0].Lon, 6);
+        Assert.Equal(0.0, pts[^1].Lat, 6);
+        Assert.Equal(30.0, pts[^1].Lon, 6);
+    }
+
+    [Fact]
+    public void GreatCircleIntermediatePoints_EquatorLeg_StaysOnEquator()
+    {
+        var pts = MarineGeodesy.GreatCircleIntermediatePoints(0.0, -20.0, 0.0, 20.0, 8);
+        foreach (var (lat, _) in pts)
+            Assert.InRange(lat, -1e-6, 1e-6);
+    }
+
+    [Fact]
+    public void GreatCircleIntermediatePoints_NorthernLeg_BowsPoleward()
+    {
+        // The mid-arc of a high-latitude east-west leg lies poleward of the
+        // straight rhumb (constant-latitude) line.
+        var pts = MarineGeodesy.GreatCircleIntermediatePoints(60.0, -30.0, 60.0, 30.0, 10);
+        var mid = pts[pts.Count / 2];
+        Assert.True(mid.Lat > 60.0);
+    }
+
+    [Fact]
+    public void GreatCircleIntermediatePoints_CoincidentPoints_ReturnsEndpoints()
+    {
+        var pts = MarineGeodesy.GreatCircleIntermediatePoints(12.0, 34.0, 12.0, 34.0, 5);
+        Assert.Equal(2, pts.Count);
+    }
+
+    [Fact]
+    public void GreatCircleIntermediatePoints_SegmentsClampedToAtLeastOne()
+    {
+        var pts = MarineGeodesy.GreatCircleIntermediatePoints(0.0, 0.0, 0.0, 10.0, 0);
+        Assert.Equal(2, pts.Count);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/RouteCollectionTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RouteCollectionTests.cs
@@ -1,0 +1,158 @@
+using EncDotNet.S100.Viewer.Routing;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RouteCollectionTests
+{
+    [Fact]
+    public void NewCollection_IsEmptyWithNoActiveRoute()
+    {
+        var collection = new RouteCollection();
+        Assert.Empty(collection.Routes);
+        Assert.Null(collection.ActiveRoute);
+    }
+
+    [Fact]
+    public void CreateRoute_AddsAndActivates()
+    {
+        var collection = new RouteCollection();
+        var route = collection.CreateRoute("Channel");
+        Assert.Single(collection.Routes);
+        Assert.Same(route, collection.ActiveRoute);
+        Assert.Equal("Channel", route.Name);
+    }
+
+    [Fact]
+    public void CreateRoute_SecondRoute_BecomesActive()
+    {
+        var collection = new RouteCollection();
+        collection.CreateRoute("first");
+        var second = collection.CreateRoute("second");
+        Assert.Same(second, collection.ActiveRoute);
+    }
+
+    [Fact]
+    public void Add_DuplicateId_Throws()
+    {
+        var collection = new RouteCollection();
+        collection.CreateRoute(id: "dup");
+        Assert.Throws<ArgumentException>(() => collection.Add(new Route("dup")));
+    }
+
+    [Fact]
+    public void Remove_ActiveRoute_PromotesNeighbour()
+    {
+        var collection = new RouteCollection();
+        var a = collection.CreateRoute("a");
+        var b = collection.CreateRoute("b");
+        var c = collection.CreateRoute("c");
+
+        collection.SetActiveRoute(b);
+        Assert.True(collection.Remove(b));
+
+        // Slot of removed route now holds c.
+        Assert.Same(c, collection.ActiveRoute);
+        Assert.Equal(2, collection.Routes.Count);
+        Assert.DoesNotContain(b, collection.Routes);
+        Assert.Contains(a, collection.Routes);
+    }
+
+    [Fact]
+    public void Remove_LastRemaining_ClearsActive()
+    {
+        var collection = new RouteCollection();
+        var a = collection.CreateRoute("a");
+        collection.Remove(a);
+        Assert.Null(collection.ActiveRoute);
+        Assert.Empty(collection.Routes);
+    }
+
+    [Fact]
+    public void Remove_NonMember_ReturnsFalse()
+    {
+        var collection = new RouteCollection();
+        Assert.False(collection.Remove(new Route()));
+    }
+
+    [Fact]
+    public void Remove_NonActiveRoute_LeavesActiveUnchanged()
+    {
+        var collection = new RouteCollection();
+        var a = collection.CreateRoute("a");
+        var b = collection.CreateRoute("b");
+        collection.SetActiveRoute(a);
+
+        collection.Remove(b);
+
+        Assert.Same(a, collection.ActiveRoute);
+    }
+
+    [Fact]
+    public void SetActiveRoute_NonMember_Throws()
+    {
+        var collection = new RouteCollection();
+        collection.CreateRoute("a");
+        Assert.Throws<ArgumentException>(() => collection.SetActiveRoute(new Route()));
+    }
+
+    [Fact]
+    public void SetActiveRoute_Null_ClearsSelection()
+    {
+        var collection = new RouteCollection();
+        collection.CreateRoute("a");
+        Assert.True(collection.SetActiveRoute(null));
+        Assert.Null(collection.ActiveRoute);
+    }
+
+    [Fact]
+    public void FindById_ReturnsMatchOrNull()
+    {
+        var collection = new RouteCollection();
+        var a = collection.CreateRoute(id: "route-x");
+        Assert.Same(a, collection.FindById("route-x"));
+        Assert.Null(collection.FindById("missing"));
+    }
+
+    [Fact]
+    public void Changed_RaisedOnAddRemoveAndActiveChange()
+    {
+        var collection = new RouteCollection();
+        var count = 0;
+        collection.Changed += (_, _) => count++;
+
+        var a = collection.CreateRoute("a"); // add
+        var b = collection.CreateRoute("b"); // add
+        collection.SetActiveRoute(a);        // active change
+        collection.Remove(b);                // remove
+
+        Assert.Equal(4, count);
+    }
+
+    [Fact]
+    public void Changed_BubblesFromMemberRouteEdits()
+    {
+        var collection = new RouteCollection();
+        var route = collection.CreateRoute("a");
+        var count = 0;
+        collection.Changed += (_, _) => count++;
+
+        route.AppendWaypoint(new EncDotNet.S100.DataModel.GeoPosition(40.0, -74.0));
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Changed_NotRaisedAfterRouteRemoved()
+    {
+        var collection = new RouteCollection();
+        var route = collection.CreateRoute("a");
+        collection.Remove(route);
+
+        var count = 0;
+        collection.Changed += (_, _) => count++;
+        route.AppendWaypoint(new EncDotNet.S100.DataModel.GeoPosition(40.0, -74.0));
+
+        Assert.Equal(0, count);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RouteEditToolTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RouteEditToolTests.cs
@@ -1,0 +1,59 @@
+using System;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Tools;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RouteEditToolTests
+{
+    [Fact]
+    public void Constructor_NullRoutes_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new RouteEditTool(null!));
+    }
+
+    [Fact]
+    public void Id_IsStable()
+    {
+        var tool = new RouteEditTool(new RoutesService());
+        Assert.Equal(RouteEditTool.ToolId, tool.Id);
+    }
+
+    [Fact]
+    public void FormatSummary_NoActiveRoute_ReturnsNoDataText()
+    {
+        var tool = new RouteEditTool(new RoutesService());
+        Assert.Equal(Strings.Status_RouteEditNoData, tool.FormatSummary());
+    }
+
+    [Fact]
+    public void FormatSummary_SingleWaypoint_ReturnsNoDataText()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+
+        var tool = new RouteEditTool(svc);
+        Assert.Equal(Strings.Status_RouteEditNoData, tool.FormatSummary());
+    }
+
+    [Fact]
+    public void FormatSummary_TwoWaypoints_IncludesTotalDistance()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+
+        var tool = new RouteEditTool(svc);
+        var summary = tool.FormatSummary();
+
+        Assert.NotNull(summary);
+        Assert.NotEqual(Strings.Status_RouteEditNoData, summary);
+        // One degree of longitude on the equator ≈ 60 NM.
+        Assert.Contains("60", summary);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RouteMcpToolsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RouteMcpToolsTests.cs
@@ -1,0 +1,357 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using EncDotNet.S100.Mcp.Tools;
+using EncDotNet.S100.Viewer.McpTools;
+using EncDotNet.S100.Viewer.Services;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for the agent-facing route MCP tools. The tools are exercised
+/// with an inline <see cref="IRouteEditInvoker"/> so no Avalonia dispatcher
+/// is required.
+/// </summary>
+public class RouteMcpToolsTests
+{
+    /// <summary>Runs the action inline and counts invocations.</summary>
+    private sealed class InlineRouteEditInvoker : IRouteEditInvoker
+    {
+        public int Invocations { get; private set; }
+
+        public Task<T> InvokeAsync<T>(System.Func<T> action)
+        {
+            Invocations++;
+            return Task.FromResult(action());
+        }
+    }
+
+    private static (RoutesService routes, InlineRouteEditInvoker invoker) Make()
+        => (new RoutesService(), new InlineRouteEditInvoker());
+
+    private static T Value<T>(ToolResult<T> result)
+    {
+        Assert.True(result.TryGetValue(out var value), "expected a success result");
+        return value!;
+    }
+
+    private static ToolError Error<T>(ToolResult<T> result)
+    {
+        Assert.True(result.TryGetError(out var error), "expected an error result");
+        return error!;
+    }
+
+    // ----- create / list / get / delete -----------------------------------
+
+    [Fact]
+    public async Task CreateRoute_adds_active_route_and_marshals()
+    {
+        var (routes, invoker) = Make();
+        var tool = new CreateRouteTool(routes, invoker);
+
+        var detail = Value(await tool.InvokeAsync(new CreateRouteRequest(Name: "Transit", Id: "r1")));
+
+        Assert.Equal("r1", detail.RouteId);
+        Assert.Equal("Transit", detail.Name);
+        Assert.True(detail.IsActive);
+        Assert.Empty(detail.Waypoints);
+        Assert.Same(routes.Routes.FindById("r1"), routes.Routes.ActiveRoute);
+        Assert.Equal(1, invoker.Invocations);
+    }
+
+    [Fact]
+    public async Task CreateRoute_duplicate_id_is_invalid_argument()
+    {
+        var (routes, invoker) = Make();
+        var tool = new CreateRouteTool(routes, invoker);
+        await tool.InvokeAsync(new CreateRouteRequest(Id: "dup"));
+
+        var error = Error(await tool.InvokeAsync(new CreateRouteRequest(Id: "dup")));
+
+        Assert.IsType<InvalidArgument>(error);
+        Assert.Equal("invalid_argument", error.Code);
+    }
+
+    [Fact]
+    public async Task ListRoutes_reports_all_routes_and_active()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "a"));
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "b"));
+
+        var result = Value(await new ListRoutesTool(routes, invoker).InvokeAsync(new ListRoutesRequest()));
+
+        Assert.Equal(2, result.Routes.Count);
+        Assert.Equal("b", result.ActiveRouteId);
+        Assert.Contains(result.Routes, r => r is { RouteId: "b", IsActive: true });
+    }
+
+    [Fact]
+    public async Task GetRoute_defaults_to_active_route()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "act"));
+
+        var detail = Value(await new GetRouteTool(routes, invoker).InvokeAsync(new GetRouteRequest()));
+
+        Assert.Equal("act", detail.RouteId);
+    }
+
+    [Fact]
+    public async Task GetRoute_unknown_id_is_route_not_found()
+    {
+        var (routes, invoker) = Make();
+
+        var error = Error(await new GetRouteTool(routes, invoker).InvokeAsync(new GetRouteRequest("nope")));
+
+        Assert.IsType<RouteNotFound>(error);
+        Assert.Equal("route_not_found", error.Code);
+    }
+
+    [Fact]
+    public async Task GetRoute_with_no_routes_reports_active_sentinel()
+    {
+        var (routes, invoker) = Make();
+
+        var error = Error(await new GetRouteTool(routes, invoker).InvokeAsync(new GetRouteRequest()));
+
+        var notFound = Assert.IsType<RouteNotFound>(error);
+        Assert.Equal("(active)", notFound.RouteId);
+    }
+
+    [Fact]
+    public async Task DeleteRoute_removes_and_reports_new_active()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "a"));
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "b"));
+
+        var result = Value(await new DeleteRouteTool(routes, invoker).InvokeAsync(new DeleteRouteRequest("b")));
+
+        Assert.True(result.Deleted);
+        Assert.Equal("b", result.RouteId);
+        Assert.Equal("a", result.ActiveRouteId);
+        Assert.Null(routes.Routes.FindById("b"));
+    }
+
+    // ----- waypoint editing ------------------------------------------------
+
+    [Fact]
+    public async Task AppendWaypoint_adds_point_with_metadata()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+
+        var detail = Value(await new AppendWaypointTool(routes, invoker).InvokeAsync(
+            new AppendWaypointRequest(47.6, -122.3, Name: "WP1", Number: 1, TurnRadiusNm: 0.5)));
+
+        var wp = Assert.Single(detail.Waypoints);
+        Assert.Equal(47.6, wp.Lat);
+        Assert.Equal(-122.3, wp.Lon);
+        Assert.Equal("WP1", wp.Name);
+        Assert.Equal(1, wp.Number);
+        Assert.Equal(0.5, wp.TurnRadiusNm);
+    }
+
+    [Fact]
+    public async Task AppendWaypoint_invalid_latitude_is_rejected()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+
+        var error = Error(await new AppendWaypointTool(routes, invoker).InvokeAsync(
+            new AppendWaypointRequest(120.0, 0.0)));
+
+        var invalid = Assert.IsType<InvalidArgument>(error);
+        Assert.Equal("lat", invalid.Parameter);
+    }
+
+    [Fact]
+    public async Task AppendWaypoint_with_no_active_route_is_route_not_found()
+    {
+        var (routes, invoker) = Make();
+
+        var error = Error(await new AppendWaypointTool(routes, invoker).InvokeAsync(
+            new AppendWaypointRequest(10.0, 10.0)));
+
+        Assert.IsType<RouteNotFound>(error);
+    }
+
+    [Fact]
+    public async Task InsertWaypoint_builds_legs_and_validates_index()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+        var append = new AppendWaypointTool(routes, invoker);
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 0.0));
+        await append.InvokeAsync(new AppendWaypointRequest(1.0, 0.0));
+
+        var insert = new InsertWaypointTool(routes, invoker);
+        var detail = Value(await insert.InvokeAsync(new InsertWaypointRequest(1, 0.5, 0.0)));
+
+        Assert.Equal(3, detail.Waypoints.Count);
+        Assert.Equal(2, detail.Legs.Count);
+        Assert.Equal(0.5, detail.Waypoints[1].Lat);
+
+        var error = Error(await insert.InvokeAsync(new InsertWaypointRequest(99, 0.5, 0.0)));
+        var invalid = Assert.IsType<InvalidArgument>(error);
+        Assert.Equal("index", invalid.Parameter);
+    }
+
+    [Fact]
+    public async Task MoveWaypoint_updates_position_and_validates_index()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+        var append = new AppendWaypointTool(routes, invoker);
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 0.0));
+
+        var move = new MoveWaypointTool(routes, invoker);
+        var detail = Value(await move.InvokeAsync(new MoveWaypointRequest(0, 5.0, 6.0)));
+        Assert.Equal(5.0, detail.Waypoints[0].Lat);
+        Assert.Equal(6.0, detail.Waypoints[0].Lon);
+
+        var error = Error(await move.InvokeAsync(new MoveWaypointRequest(7, 1.0, 1.0)));
+        Assert.Equal("index", Assert.IsType<InvalidArgument>(error).Parameter);
+    }
+
+    [Fact]
+    public async Task DeleteWaypoint_removes_point_and_validates_index()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+        var append = new AppendWaypointTool(routes, invoker);
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 0.0));
+        await append.InvokeAsync(new AppendWaypointRequest(1.0, 1.0));
+
+        var del = new DeleteWaypointTool(routes, invoker);
+        var detail = Value(await del.InvokeAsync(new DeleteWaypointRequest(0)));
+        Assert.Single(detail.Waypoints);
+        Assert.Empty(detail.Legs);
+
+        var error = Error(await del.InvokeAsync(new DeleteWaypointRequest(5)));
+        Assert.Equal("index", Assert.IsType<InvalidArgument>(error).Parameter);
+    }
+
+    // ----- leg attributes / route info -------------------------------------
+
+    [Fact]
+    public async Task SetLegAttributes_updates_geometry_and_envelope()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+        var append = new AppendWaypointTool(routes, invoker);
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 0.0));
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 10.0));
+
+        var tool = new SetLegAttributesTool(routes, invoker);
+        var detail = Value(await tool.InvokeAsync(new SetLegAttributesRequest(
+            0, GeometryType: "geodesic",
+            StarboardCrossTrackDistanceLimitMeters: 185.2,
+            SafetyContourMeters: 10.0,
+            Note: "mid-channel")));
+
+        var leg = Assert.Single(detail.Legs);
+        Assert.Equal("geodesic", leg.GeometryType);
+        Assert.Equal(185.2, leg.StarboardCrossTrackDistanceLimitMeters);
+        Assert.Equal(10.0, leg.SafetyContourMeters);
+        Assert.Equal("mid-channel", leg.Note);
+    }
+
+    [Fact]
+    public async Task SetLegAttributes_rejects_unknown_geometry()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+        var append = new AppendWaypointTool(routes, invoker);
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 0.0));
+        await append.InvokeAsync(new AppendWaypointRequest(0.0, 1.0));
+
+        var error = Error(await new SetLegAttributesTool(routes, invoker).InvokeAsync(
+            new SetLegAttributesRequest(0, GeometryType: "spiral")));
+
+        Assert.Equal("geometryType", Assert.IsType<InvalidArgument>(error).Parameter);
+    }
+
+    [Fact]
+    public async Task SetLegAttributes_validates_leg_index()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+
+        var error = Error(await new SetLegAttributesTool(routes, invoker).InvokeAsync(
+            new SetLegAttributesRequest(0)));
+
+        Assert.Equal("legIndex", Assert.IsType<InvalidArgument>(error).Parameter);
+    }
+
+    [Fact]
+    public async Task SetRouteInfo_updates_metadata_and_creates_vessel()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+
+        var detail = Value(await new SetRouteInfoTool(routes, invoker).InvokeAsync(
+            new SetRouteInfoRequest(
+                Name: "Pilotage", Author: "Pilot", DeparturePortId: "PORTA",
+                VesselName: "MV Test", VesselMmsi: "366000000", VesselLengthMeters: 180.0)));
+
+        Assert.Equal("Pilotage", detail.Name);
+        Assert.Equal("Pilot", detail.Info.Author);
+        Assert.Equal("PORTA", detail.Info.DeparturePortId);
+        Assert.NotNull(detail.Info.Vessel);
+        Assert.Equal("MV Test", detail.Info.Vessel!.Name);
+        Assert.Equal("366000000", detail.Info.Vessel.Mmsi);
+        Assert.Equal(180.0, detail.Info.Vessel.LengthMeters);
+    }
+
+    [Fact]
+    public async Task Mutation_raises_routes_service_changed()
+    {
+        var (routes, invoker) = Make();
+        await new CreateRouteTool(routes, invoker).InvokeAsync(new CreateRouteRequest(Id: "r"));
+
+        var raised = 0;
+        routes.Changed += (_, _) => raised++;
+
+        await new AppendWaypointTool(routes, invoker).InvokeAsync(new AppendWaypointRequest(1.0, 1.0));
+
+        Assert.True(raised > 0);
+    }
+
+    // ----- adapter wire shapes ---------------------------------------------
+
+    [Fact]
+    public void Adapter_success_payload_is_camel_case_route_detail()
+    {
+        var routes = new RoutesService();
+        var route = routes.Routes.CreateRoute("Demo", "rid");
+        var detail = RouteProjection.Detail(route, routes);
+
+        var call = CreateRouteMcpAdapter.TranslateResult(ToolResult<RouteDetail>.Ok(detail));
+
+        Assert.False(call.IsError);
+        var text = Assert.IsType<TextContentBlock>(call.Content.Single()).Text;
+        using var doc = JsonDocument.Parse(text);
+        Assert.Equal("rid", doc.RootElement.GetProperty("routeId").GetString());
+        Assert.Equal("Demo", doc.RootElement.GetProperty("name").GetString());
+        Assert.True(doc.RootElement.GetProperty("isActive").GetBoolean());
+        Assert.True(doc.RootElement.TryGetProperty("waypoints", out _));
+    }
+
+    [Fact]
+    public void Adapter_failure_payload_has_code_message_details()
+    {
+        var call = GetRouteMcpAdapter.TranslateResult(
+            ToolResult<RouteDetail>.Err(new RouteNotFound("ghost")));
+
+        Assert.True(call.IsError);
+        var text = Assert.IsType<TextContentBlock>(call.Content.Single()).Text;
+        using var doc = JsonDocument.Parse(text);
+        Assert.Equal("route_not_found", doc.RootElement.GetProperty("code").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("message").GetString()));
+        Assert.Equal("ghost", doc.RootElement.GetProperty("details").GetProperty("routeId").GetString());
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RouteTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RouteTests.cs
@@ -1,0 +1,302 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Routing;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RouteTests
+{
+    private static GeoPosition P(double lat, double lon) => new(lat, lon);
+
+    [Fact]
+    public void NewRoute_IsEmptyWithGeneratedIdAndInfo()
+    {
+        var route = new Route();
+        Assert.False(string.IsNullOrWhiteSpace(route.Id));
+        Assert.Empty(route.Waypoints);
+        Assert.Empty(route.Legs);
+        Assert.NotNull(route.Info);
+        Assert.Equal(0.0, route.TotalDistanceNm());
+    }
+
+    [Fact]
+    public void Ctor_UsesSuppliedIdAndName()
+    {
+        var route = new Route("route-1", "Approach");
+        Assert.Equal("route-1", route.Id);
+        Assert.Equal("Approach", route.Name);
+        Assert.Equal("Approach", route.Info.Name);
+    }
+
+    [Fact]
+    public void AppendWaypoint_FirstWaypoint_AddsNoLeg()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        Assert.Single(route.Waypoints);
+        Assert.Empty(route.Legs);
+    }
+
+    [Fact]
+    public void AppendWaypoint_SecondWaypoint_AddsOneLeg()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(41.0, -73.0));
+        Assert.Equal(2, route.Waypoints.Count);
+        Assert.Single(route.Legs);
+    }
+
+    [Fact]
+    public void LegInvariant_HoldsAfterAppends()
+    {
+        var route = new Route();
+        for (var i = 0; i < 5; i++)
+            route.AppendWaypoint(P(40.0 + i, -74.0));
+        Assert.Equal(5, route.Waypoints.Count);
+        Assert.Equal(4, route.Legs.Count);
+    }
+
+    [Fact]
+    public void InsertWaypoint_AtFront_PrependsLegAndPreservesExistingLegAttributes()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(41.0, -73.0));
+        route.Legs[0].Note = "original";
+
+        route.InsertWaypoint(0, P(39.0, -75.0));
+
+        Assert.Equal(3, route.Waypoints.Count);
+        Assert.Equal(2, route.Legs.Count);
+        // The fresh leg leads; the original segment keeps its note.
+        Assert.Null(route.Legs[0].Note);
+        Assert.Equal("original", route.Legs[1].Note);
+    }
+
+    [Fact]
+    public void InsertWaypoint_InMiddle_KeepsInboundLegAttributes()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0)); // wp0
+        route.AppendWaypoint(P(42.0, -72.0)); // wp1
+        route.Legs[0].Note = "leg-a";
+
+        route.InsertWaypoint(1, P(41.0, -73.0)); // split leg0
+
+        Assert.Equal(3, route.Waypoints.Count);
+        Assert.Equal(2, route.Legs.Count);
+        // Inbound half retains the attributes; outbound half is fresh.
+        Assert.Equal("leg-a", route.Legs[0].Note);
+        Assert.Null(route.Legs[1].Note);
+    }
+
+    [Fact]
+    public void InsertWaypoint_OutOfRange_Throws()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => route.InsertWaypoint(5, P(1, 1)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => route.InsertWaypoint(-1, P(1, 1)));
+    }
+
+    [Fact]
+    public void RemoveWaypoint_Interior_MergesLegsKeepingInboundAttributes()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0)); // wp0
+        route.AppendWaypoint(P(41.0, -73.0)); // wp1
+        route.AppendWaypoint(P(42.0, -72.0)); // wp2
+        route.Legs[0].Note = "in";
+        route.Legs[1].Note = "out";
+
+        route.RemoveWaypoint(1);
+
+        Assert.Equal(2, route.Waypoints.Count);
+        Assert.Single(route.Legs);
+        Assert.Equal("in", route.Legs[0].Note);
+    }
+
+    [Fact]
+    public void RemoveWaypoint_Last_DropsTrailingLeg()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(41.0, -73.0));
+        route.AppendWaypoint(P(42.0, -72.0));
+        route.Legs[0].Note = "keep";
+
+        route.RemoveWaypoint(2);
+
+        Assert.Equal(2, route.Waypoints.Count);
+        Assert.Single(route.Legs);
+        Assert.Equal("keep", route.Legs[0].Note);
+    }
+
+    [Fact]
+    public void RemoveWaypoint_First_DropsLeadingLeg()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(41.0, -73.0));
+        route.AppendWaypoint(P(42.0, -72.0));
+        route.Legs[1].Note = "survivor";
+
+        route.RemoveWaypoint(0);
+
+        Assert.Equal(2, route.Waypoints.Count);
+        Assert.Single(route.Legs);
+        Assert.Equal("survivor", route.Legs[0].Note);
+    }
+
+    [Fact]
+    public void RemoveWaypoint_DownToOne_LeavesNoLegs()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(41.0, -73.0));
+        route.RemoveWaypoint(0);
+        Assert.Single(route.Waypoints);
+        Assert.Empty(route.Legs);
+    }
+
+    [Fact]
+    public void MoveWaypoint_UpdatesPositionAndMetrics()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(40.0, -73.0));
+        var before = route.ComputeLegMetrics(0).DistanceNm;
+
+        route.MoveWaypoint(1, P(40.0, -72.0));
+
+        Assert.Equal(P(40.0, -72.0), route.Waypoints[1].Position);
+        Assert.True(route.ComputeLegMetrics(0).DistanceNm > before);
+    }
+
+    [Fact]
+    public void Clear_EmptiesWaypointsAndLegs()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(40.0, -74.0));
+        route.AppendWaypoint(P(41.0, -73.0));
+        route.Clear();
+        Assert.Empty(route.Waypoints);
+        Assert.Empty(route.Legs);
+    }
+
+    [Fact]
+    public void ComputeLegMetrics_Loxodrome_PureEastBearingIs090()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(0.0, 0.0));
+        route.AppendWaypoint(P(0.0, 10.0));
+        var m = route.ComputeLegMetrics(0);
+        Assert.Equal(0, m.LegIndex);
+        Assert.InRange(m.InitialBearingDegrees, 89.9, 90.1);
+        Assert.True(m.DistanceNm > 0);
+    }
+
+    [Fact]
+    public void ComputeLegMetrics_GeodesicVsLoxodrome_DifferOnLongEastWestLeg()
+    {
+        var loxo = new Route();
+        loxo.AppendWaypoint(P(60.0, -10.0));
+        loxo.AppendWaypoint(P(60.0, 10.0));
+
+        var geo = new Route();
+        geo.AppendWaypoint(P(60.0, -10.0));
+        geo.AppendWaypoint(P(60.0, 10.0));
+        geo.Legs[0].GeometryType = RouteLegGeometryType.Geodesic;
+
+        var loxoDist = loxo.ComputeLegMetrics(0).DistanceNm;
+        var geoDist = geo.ComputeLegMetrics(0).DistanceNm;
+
+        // At high latitude the great circle is shorter than the rhumb line.
+        Assert.True(geoDist < loxoDist);
+    }
+
+    [Fact]
+    public void TotalDistanceNm_SumsAllLegs()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(0.0, 0.0));
+        route.AppendWaypoint(P(0.0, 10.0));
+        route.AppendWaypoint(P(0.0, 20.0));
+
+        var sum = route.ComputeLegMetrics(0).DistanceNm + route.ComputeLegMetrics(1).DistanceNm;
+        Assert.Equal(sum, route.TotalDistanceNm(), 6);
+    }
+
+    [Fact]
+    public void ComputeLegMetrics_InvalidIndex_Throws()
+    {
+        var route = new Route();
+        route.AppendWaypoint(P(0.0, 0.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => route.ComputeLegMetrics(0));
+    }
+
+    [Fact]
+    public void Changed_RaisedOnStructuralEdits()
+    {
+        var route = new Route();
+        var count = 0;
+        route.Changed += (_, _) => count++;
+
+        route.AppendWaypoint(P(0.0, 0.0));
+        route.AppendWaypoint(P(0.0, 1.0));
+        route.MoveWaypoint(0, P(0.1, 0.0));
+        route.RemoveWaypoint(0);
+
+        Assert.Equal(4, count);
+    }
+
+    [Fact]
+    public void Name_SetterRaisesChangedOnlyWhenValueDiffers()
+    {
+        var route = new Route(name: "a");
+        var count = 0;
+        route.Changed += (_, _) => count++;
+
+        route.Name = "a";   // no change
+        route.Name = "b";   // change
+        Assert.Equal(1, count);
+        Assert.Equal("b", route.Name);
+    }
+
+    [Fact]
+    public void Reverse_ReversesWaypointsAndLegsPreservingGeometry()
+    {
+        var route = new Route(name: "r");
+        route.AppendWaypoint(P(0.0, 0.0));
+        route.AppendWaypoint(P(0.0, 1.0));
+        route.AppendWaypoint(P(0.0, 2.0));
+        route.Legs[0].GeometryType = RouteLegGeometryType.Geodesic;
+
+        var changed = 0;
+        route.Changed += (_, _) => changed++;
+        route.Reverse();
+
+        Assert.Equal(1, changed);
+        Assert.Equal(2.0, route.Waypoints[0].Position.Longitude, 6);
+        Assert.Equal(1.0, route.Waypoints[1].Position.Longitude, 6);
+        Assert.Equal(0.0, route.Waypoints[2].Position.Longitude, 6);
+        // The geodesic leg travels with its geographic segment: it described
+        // the 0->1 segment, which after reversal is the trailing leg (1->0).
+        Assert.Equal(RouteLegGeometryType.Geodesic, route.Legs[1].GeometryType);
+        Assert.Equal(RouteLegGeometryType.Loxodrome, route.Legs[0].GeometryType);
+    }
+
+    [Fact]
+    public void Reverse_NoOpForFewerThanTwoWaypoints()
+    {
+        var route = new Route(name: "r");
+        route.AppendWaypoint(P(0.0, 0.0));
+
+        var changed = 0;
+        route.Changed += (_, _) => changed++;
+        route.Reverse();
+
+        Assert.Equal(0, changed);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RoutesPanelViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RoutesPanelViewModelTests.cs
@@ -1,0 +1,242 @@
+using System.Linq;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RoutesPanelViewModelTests
+{
+    private static (RoutesService Service, RoutesPanelViewModel Vm) Create()
+    {
+        var svc = new RoutesService();
+        var vm = new RoutesPanelViewModel(svc);
+        return (svc, vm);
+    }
+
+    private static RouteLegRowViewModel FirstLegRow(RoutesPanelViewModel vm)
+        => vm.Timeline.OfType<RouteLegRowViewModel>().First();
+
+    [Fact]
+    public void Initial_NoRoutes()
+    {
+        var (_, vm) = Create();
+        Assert.False(vm.HasRoutes);
+        Assert.Empty(vm.Routes);
+        Assert.Null(vm.SelectedRoute);
+    }
+
+    [Fact]
+    public void AddRouteCommand_AddsAndSelectsRoute()
+    {
+        var (svc, vm) = Create();
+
+        vm.AddRouteCommand.Execute(null);
+
+        Assert.True(vm.HasRoutes);
+        Assert.Single(vm.Routes);
+        Assert.NotNull(vm.SelectedRoute);
+        Assert.Same(svc.Routes.ActiveRoute, vm.SelectedRoute!.Route);
+    }
+
+    [Fact]
+    public void RemoveRouteCommand_RemovesSelectedRoute()
+    {
+        var (svc, vm) = Create();
+        vm.AddRouteCommand.Execute(null);
+
+        vm.RemoveRouteCommand.Execute(null);
+
+        Assert.False(vm.HasRoutes);
+        Assert.Empty(svc.Routes.Routes);
+    }
+
+    [Fact]
+    public void RemoveRouteCommand_RemovesPassedRow()
+    {
+        var (svc, vm) = Create();
+        vm.AddRouteCommand.Execute(null);
+        vm.AddRouteCommand.Execute(null);
+        var firstRow = vm.Routes[0];
+
+        vm.RemoveRouteCommand.Execute(firstRow);
+
+        Assert.Single(svc.Routes.Routes);
+        Assert.DoesNotContain(svc.Routes.Routes, r => ReferenceEquals(r, firstRow.Route));
+    }
+
+    [Fact]
+    public void SelectingRoute_SetsActiveRoute()
+    {
+        var (svc, vm) = Create();
+        vm.AddRouteCommand.Execute(null);
+        var first = svc.Routes.Routes[0];
+        vm.AddRouteCommand.Execute(null);
+        var second = svc.Routes.Routes[1];
+
+        var firstRow = vm.Routes.First(r => r.Route == first);
+        vm.SelectedRoute = firstRow;
+
+        Assert.Same(first, svc.Routes.ActiveRoute);
+        Assert.NotSame(second, svc.Routes.ActiveRoute);
+    }
+
+    [Fact]
+    public void Timeline_InterleavesWaypointsAndLegs()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+        route.AppendWaypoint(new GeoPosition(0, 2));
+
+        Assert.Equal(5, vm.Timeline.Count);
+        Assert.IsType<RouteWaypointRowViewModel>(vm.Timeline[0]);
+        Assert.IsType<RouteLegRowViewModel>(vm.Timeline[1]);
+        Assert.IsType<RouteWaypointRowViewModel>(vm.Timeline[2]);
+        Assert.IsType<RouteLegRowViewModel>(vm.Timeline[3]);
+        Assert.IsType<RouteWaypointRowViewModel>(vm.Timeline[4]);
+        Assert.NotNull(vm.ActiveRouteDetailMeta);
+        Assert.Equal("R1", vm.ActiveRouteName);
+    }
+
+    [Fact]
+    public void SelectWaypointCommand_HighlightsRow()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+
+        var secondWp = vm.Timeline.OfType<RouteWaypointRowViewModel>().First(w => w.Index == 1);
+        vm.SelectWaypointCommand.Execute(secondWp);
+
+        Assert.Equal(1, svc.SelectedWaypointIndex);
+        var highlighted = vm.Timeline.OfType<RouteWaypointRowViewModel>().First(w => w.Index == 1);
+        Assert.True(highlighted.IsSelected);
+    }
+
+    [Fact]
+    public void DeleteWaypointCommand_RemovesSelectedWaypoint()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+        route.AppendWaypoint(new GeoPosition(0, 2));
+
+        svc.SelectedWaypointIndex = 1;
+        vm.DeleteWaypointCommand.Execute(null);
+
+        Assert.Equal(2, route.Waypoints.Count);
+    }
+
+    [Fact]
+    public void WaypointRow_InsertAfterCommand_InsertsAfterThatRow()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 2));
+
+        var firstWp = vm.Timeline.OfType<RouteWaypointRowViewModel>().First(w => w.Index == 0);
+        firstWp.InsertAfterCommand.Execute(firstWp);
+
+        Assert.Equal(3, route.Waypoints.Count);
+        Assert.Equal(1.0, route.Waypoints[1].Position.Longitude, 6);
+    }
+
+    [Fact]
+    public void WaypointRow_DeleteCommand_RemovesThatRow()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+        route.AppendWaypoint(new GeoPosition(0, 2));
+
+        var middleWp = vm.Timeline.OfType<RouteWaypointRowViewModel>().First(w => w.Index == 1);
+        middleWp.DeleteCommand.Execute(middleWp);
+
+        Assert.Equal(2, route.Waypoints.Count);
+        Assert.Equal(0, route.Waypoints[0].Position.Longitude, 6);
+        Assert.Equal(2, route.Waypoints[1].Position.Longitude, 6);
+    }
+
+    [Fact]
+    public void ToggleLegGeometryAtCommand_FlipsLegGeometry()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+
+        Assert.Equal(RouteLegGeometryType.Loxodrome, route.Legs[0].GeometryType);
+
+        vm.ToggleLegGeometryAtCommand.Execute(FirstLegRow(vm));
+
+        Assert.Equal(RouteLegGeometryType.Geodesic, route.Legs[0].GeometryType);
+    }
+
+    [Fact]
+    public void InsertAfterSelectedCommand_InsertsMidpoint()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 2));
+
+        svc.SelectedWaypointIndex = 0;
+        vm.InsertAfterSelectedCommand.Execute(null);
+
+        Assert.Equal(3, route.Waypoints.Count);
+        Assert.Equal(1.0, route.Waypoints[1].Position.Longitude, 6);
+        Assert.Equal(1, svc.SelectedWaypointIndex);
+    }
+
+    [Fact]
+    public void ReverseActiveRouteCommand_ReversesWaypointOrder()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(0, 1));
+        route.AppendWaypoint(new GeoPosition(0, 2));
+
+        vm.ReverseActiveRouteCommand.Execute(null);
+
+        Assert.Equal(2.0, route.Waypoints[0].Position.Longitude, 6);
+        Assert.Equal(0.0, route.Waypoints[2].Position.Longitude, 6);
+    }
+
+    [Fact]
+    public void RenameFlow_UpdatesRouteName()
+    {
+        var (svc, vm) = Create();
+        vm.AddRouteCommand.Execute(null);
+
+        vm.BeginRenameCommand.Execute(null);
+        Assert.True(vm.IsRenamingActiveRoute);
+        vm.RenameText = "Approach";
+        vm.CommitRenameCommand.Execute(null);
+
+        Assert.False(vm.IsRenamingActiveRoute);
+        Assert.Equal("Approach", svc.Routes.ActiveRoute!.Name);
+    }
+
+    [Fact]
+    public void CancelRename_LeavesRouteNameUnchanged()
+    {
+        var (svc, vm) = Create();
+        var route = svc.Routes.CreateRoute("Original");
+
+        vm.BeginRenameCommand.Execute(null);
+        vm.RenameText = "Changed";
+        vm.CancelRenameCommand.Execute(null);
+
+        Assert.False(vm.IsRenamingActiveRoute);
+        Assert.Equal("Original", route.Name);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RoutesServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RoutesServiceTests.cs
@@ -1,0 +1,95 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RoutesServiceTests
+{
+    [Fact]
+    public void Changed_FiresWhenRouteEdited()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        var fired = 0;
+        svc.Changed += (_, _) => fired++;
+
+        route.AppendWaypoint(new GeoPosition(10, 20));
+
+        Assert.True(fired >= 1);
+    }
+
+    [Fact]
+    public void SelectedWaypointIndex_ClampsToActiveRouteWaypoints()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(1, 1));
+
+        svc.SelectedWaypointIndex = 5; // out of range
+        Assert.Null(svc.SelectedWaypointIndex);
+
+        svc.SelectedWaypointIndex = 1;
+        Assert.Equal(1, svc.SelectedWaypointIndex);
+    }
+
+    [Fact]
+    public void SelectedWaypointIndex_NegativeBecomesNull()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+
+        svc.SelectedWaypointIndex = -3;
+        Assert.Null(svc.SelectedWaypointIndex);
+    }
+
+    [Fact]
+    public void SelectionChanged_RaisedOnChange()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(1, 1));
+
+        var fired = 0;
+        svc.SelectionChanged += (_, _) => fired++;
+
+        svc.SelectedWaypointIndex = 1;
+        Assert.Equal(1, fired);
+
+        // Setting to the same value does not re-raise.
+        svc.SelectedWaypointIndex = 1;
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void RemovingWaypoint_NormalizesNowInvalidSelection()
+    {
+        var svc = new RoutesService();
+        var route = svc.Routes.CreateRoute("R1");
+        route.AppendWaypoint(new GeoPosition(0, 0));
+        route.AppendWaypoint(new GeoPosition(1, 1));
+        svc.SelectedWaypointIndex = 1;
+
+        route.RemoveWaypoint(1);
+
+        Assert.Null(svc.SelectedWaypointIndex);
+    }
+
+    [Fact]
+    public void ChangingActiveRoute_ClearsSelectionWhenOutOfRange()
+    {
+        var svc = new RoutesService();
+        var r1 = svc.Routes.CreateRoute("R1");
+        r1.AppendWaypoint(new GeoPosition(0, 0));
+        r1.AppendWaypoint(new GeoPosition(1, 1));
+        svc.SelectedWaypointIndex = 1;
+
+        var r2 = svc.Routes.CreateRoute("R2"); // becomes active, has 0 waypoints
+        svc.Routes.SetActiveRoute(r2);
+
+        Assert.Null(svc.SelectedWaypointIndex);
+    }
+}


### PR DESCRIPTION
## Summary

Today an agent driving the viewer over MCP can reason about loaded charts but can only *describe* a route in prose; users only have ephemeral measurements that vanish. This PR turns routing into a first-class, persistent, agent-manipulable feature of the viewer, modeled on the in-repo S-421 route schema.

It lands Phases 1-3 of #365:

- **Phase 1 - Route domain model** (`Routing/`): headless `Route`, `RouteCollection`, `RouteWaypoint`, `RouteLeg` (+ computed `RouteLegMetrics`), `RouteInfo`, and `RouteLegGeometryType` (loxodrome / geodesic). Leg distances and bearings are derived via the existing `MarineGeodesy` helper. `RoutesService` is the single DI-singleton source of truth, raising a `Changed` event consumed by the UI.
- **Phase 2 - Interactive editor UI**: a Routes side panel (`RoutesView` + `RoutesPanelViewModel`), an on-map `RouteOverlayLayer` (numbered waypoints, leg lines, distance/bearing labels), and a `RouteEditTool` for click-to-place editing. All user-facing strings go through `Strings.resx`.
- **Phase 3 - Agent MCP route tools**: ten tools exposed over the viewer's MCP endpoint so an agent can close the create -> inspect -> refine loop directly against loaded data: `create_route`, `list_routes`, `get_route`, `delete_route`, `append_waypoint`, `insert_waypoint`, `move_waypoint`, `delete_waypoint`, `set_leg_attributes`, `set_route_info`.

**Key design decision (threading):** MCP tools run on Kestrel threads, but `RoutesService.Changed` drives UI-bound collections and the map overlay with Avalonia UI affinity. Rather than marshal in the view models, each route tool runs all model access (mutation + projection) through an `IRouteEditInvoker` seam. Production uses `DispatcherRouteEditInvoker` (UI thread); tests inject an inline invoker, keeping the inner tools fully headless-testable. Mutating tools return the complete `RouteDetail` projection so the agent always sees the updated route.

This was validated end-to-end: a blackbox subagent given only the MCP endpoint (no source access) queried real UKHO S-101 Solent cells and built a coherent 7-waypoint inbound route to Portsmouth Harbour, which rendered correctly on the chart.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A - change is purely infrastructural (build, CI, docs, tooling)

The route model is shaped after the S-421 Route Plan object model (Route / RouteWaypoint / RouteWaypointLeg / RouteInfo) so a future S-421 writer (deferred Phase 4) can serialize it directly. No S-421 encoding/portrayal code is touched in this PR.

**Spec section references cited in code/docs:** S-421 Annex A feature catalogue (Route, RouteWaypoint, RouteWaypointLeg, RouteInfo) for the route object model.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New suites: `RouteTests`, `RouteCollectionTests`, `RoutesServiceTests`, `RoutesPanelViewModelTests`, `RouteEditToolTests`, and `RouteMcpToolsTests` (22 tests covering each tool's happy path plus validation, route-not-found, index-range, and adapter JSON wire shapes). Full viewer suite: 1215 passed / 1 skipped.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

`docs/mcp-server.md` gains the ten route-tool rows, a route-editing workflow section, and a sample prompt; the viewer README route family description is updated.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. All additions are new files plus an optional `routesService` parameter on the `McpServerHost` constructor (defaulted to null), so existing construction paths are unaffected.

Part of #365 (Phase 4, the S-421 writer / import / check_route, remains deferred).