### PR TITLE
Surface referenced text as cards in the pick panel

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/FeatureInfoBuilder.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/FeatureInfoBuilder.cs
@@ -228,6 +228,97 @@ public static class FeatureInfoBuilder
         return result;
     }
 
+    /// <summary>
+    /// <c>true</c> when <paramref name="attr"/> is a file-reference leaf
+    /// (see <see cref="FileReferenceAttributeCodes"/>) whose external text
+    /// has already been resolved (<see cref="PickAttribute.HasExternalText"/>).
+    /// Such rows are surfaced as standalone "referenced text" blocks rather
+    /// than crammed into the key/value attribute table.
+    /// </summary>
+    public static bool IsResolvedFileReference(PickAttribute attr)
+    {
+        ArgumentNullException.ThrowIfNull(attr);
+        return FileReferenceAttributeCodes.Contains(attr.Code) && attr.HasExternalText;
+    }
+
+    /// <summary>
+    /// Walks <paramref name="attributes"/> (including complex-attribute
+    /// children) and returns every resolved file-reference leaf in document
+    /// order. Used by presentation layers to lift externally referenced text
+    /// out of the attribute table into a dedicated section.
+    /// </summary>
+    public static IReadOnlyList<PickAttribute> CollectResolvedFileReferences(
+        IReadOnlyList<PickAttribute> attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        var result = new List<PickAttribute>();
+        CollectResolvedFileReferences(attributes, result);
+        return result;
+    }
+
+    private static void CollectResolvedFileReferences(
+        IReadOnlyList<PickAttribute> attributes, List<PickAttribute> sink)
+    {
+        foreach (var attr in attributes)
+        {
+            if (IsResolvedFileReference(attr))
+                sink.Add(attr);
+            if (attr.Children.Count > 0)
+                CollectResolvedFileReferences(attr.Children, sink);
+        }
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="attributes"/> with every resolved
+    /// file-reference leaf (see <see cref="IsResolvedFileReference"/>)
+    /// removed. Complex-attribute parents whose children become empty after
+    /// pruning are dropped as well, so the attribute table never shows a
+    /// header with no rows beneath it. The input list is returned unchanged
+    /// when it contains no resolved file references.
+    /// </summary>
+    public static IReadOnlyList<PickAttribute> WithoutResolvedFileReferences(
+        IReadOnlyList<PickAttribute> attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        if (CollectResolvedFileReferences(attributes).Count == 0)
+            return attributes;
+
+        var result = new List<PickAttribute>(attributes.Count);
+        foreach (var attr in attributes)
+        {
+            if (IsResolvedFileReference(attr))
+                continue;
+
+            if (attr.Children.Count == 0)
+            {
+                result.Add(attr);
+                continue;
+            }
+
+            var prunedChildren = WithoutResolvedFileReferences(attr.Children);
+            if (prunedChildren.Count == 0)
+                continue;
+
+            result.Add(ReferenceEquals(prunedChildren, attr.Children)
+                ? attr
+                : new PickAttribute
+                {
+                    Code = attr.Code,
+                    Name = attr.Name,
+                    RawValue = attr.RawValue,
+                    DisplayValue = attr.DisplayValue,
+                    DateTimeValue = attr.DateTimeValue,
+                    DateTimeRangeValue = attr.DateTimeRangeValue,
+                    DepthMetresValue = attr.DepthMetresValue,
+                    ExternalText = attr.ExternalText,
+                    Children = prunedChildren,
+                });
+        }
+
+        return result;
+    }
+
     private static bool ContainsFileReference(IReadOnlyList<PickAttribute> attributes)
     {
         foreach (var attr in attributes)

--- a/src/EncDotNet.S100.Datasets.Pipelines/README.md
+++ b/src/EncDotNet.S100.Datasets.Pipelines/README.md
@@ -259,7 +259,10 @@ for the full design rationale.
   `support/` directory. `S101DatasetProcessor` uses it (via
   `FeatureInfoBuilder.ResolveFileReferences`) to populate
   `PickAttribute.ExternalText`, so a pick / object-info consumer can show
-  the referenced text the way an ECDIS does.
+  the referenced text the way an ECDIS does. Presentation layers can
+  then call `FeatureInfoBuilder.CollectResolvedFileReferences` /
+  `WithoutResolvedFileReferences` to lift those resolved blocks out of the
+  key/value attribute table into a dedicated "referenced text" section.
 - `GmlDatasetProcessorBase` — common base for the GML-encoded vector
   processors (S-122 / S-124 / S-125 / S-127 / S-128 / S-129 / S-131 /
   S-201 / S-411 / S-421).

--- a/src/EncDotNet.S100.Viewer/App.axaml
+++ b/src/EncDotNet.S100.Viewer/App.axaml
@@ -52,6 +52,11 @@
                     <Color x:Key="BorderColor60">#1F0606</Color>
                     <Color x:Key="BorderColor30">#4C280808</Color>
                     <Color x:Key="OutlineColor">#301010</Color>
+
+                    <!-- Subtle fill for muted surfaces (section headers,
+                         zebra rows). A low-alpha white overlay reads as a
+                         faint lift against the near-black Night surfaces. -->
+                    <Color x:Key="MutedBackgroundColor">#14FFFFFF</Color>
                 </ResourceDictionary>
 
                 <!--
@@ -88,8 +93,20 @@
                     <Color x:Key="BorderColor60">#D4C8AE</Color>
                     <Color x:Key="BorderColor30">#4CC8B89A</Color>
                     <Color x:Key="OutlineColor">#DDD0B8</Color>
+
+                    <!-- Subtle fill for muted surfaces (section headers,
+                         zebra rows): a faintly deeper warm tint than the
+                         cream card surface. -->
+                    <Color x:Key="MutedBackgroundColor">#14000000</Color>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
+
+            <!-- Default subtle muted-surface fill for the Light / Dark
+                 chrome variants (which have no explicit theme dictionary
+                 here): a low-alpha black overlay reads as a light gray on
+                 the white-ish card surfaces. Night / Dusk override this in
+                 their dictionaries above. -->
+            <Color x:Key="MutedBackgroundColor">#12000000</Color>
         </ResourceDictionary>
     </Application.Resources>
 

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -117,6 +117,7 @@ internal static class Strings
     public static string Tooltip_FollowReference => Get(nameof(Tooltip_FollowReference));
     public static string Tooltip_CopyLocation => Get(nameof(Tooltip_CopyLocation));
     public static string Tooltip_CopyIdentity => Get(nameof(Tooltip_CopyIdentity));
+    public static string Tooltip_CopyReferencedText => Get(nameof(Tooltip_CopyReferencedText));
     public static string Tooltip_Search => Get(nameof(Tooltip_Search));
     public static string Tooltip_ClearSearch => Get(nameof(Tooltip_ClearSearch));
     public static string Tooltip_OpenSearchResult => Get(nameof(Tooltip_OpenSearchResult));
@@ -238,7 +239,7 @@ internal static class Strings
     public static string Pick_SpecFormat => Get(nameof(Pick_SpecFormat));
     public static string Pick_SourceFormat => Get(nameof(Pick_SourceFormat));
     public static string Pick_AttributesHeading => Get(nameof(Pick_AttributesHeading));
-    public static string Pick_FileReference_Header => Get(nameof(Pick_FileReference_Header));
+    public static string Pick_ReferencedTextHeader => Get(nameof(Pick_ReferencedTextHeader));
     public static string Pick_NoAttributes => Get(nameof(Pick_NoAttributes));
     public static string Pick_HitListHeader => Get(nameof(Pick_HitListHeader));
     public static string Pick_HitListItemFormat => Get(nameof(Pick_HitListItemFormat));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -593,8 +593,9 @@
   <data name="Pick_AttributesHeading" xml:space="preserve">
     <value>ATTRIBUTES</value>
   </data>
-  <data name="Pick_FileReference_Header" xml:space="preserve">
-    <value>Referenced text</value>
+  <data name="Pick_ReferencedTextHeader" xml:space="preserve">
+    <value>REFERENCED TEXT</value>
+    <comment>Header above the referenced-text cards (resolved fileReference content) in the Object Information panel.</comment>
   </data>
   <data name="Pick_NoAttributes" xml:space="preserve">
     <value>(no attributes)</value>
@@ -634,6 +635,9 @@
   </data>
   <data name="Tooltip_CopyIdentity" xml:space="preserve">
     <value>Copy this feature's name and identity to the clipboard</value>
+  </data>
+  <data name="Tooltip_CopyReferencedText" xml:space="preserve">
+    <value>Copy this referenced text to the clipboard</value>
   </data>
   <!-- Pick panel: station time-series chart -->
   <data name="Pick_Chart_Title_WaterLevel" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReferencedText.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReferencedText.cs
@@ -1,0 +1,88 @@
+using System;
+using EncDotNet.S100.Datasets.Pipelines;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// A single externally referenced text block surfaced in the Object
+/// Information panel's "Referenced text" section. Built from a resolved
+/// <c>fileReference</c> attribute (S-101 Feature Catalogue, aliases
+/// <c>TXTDSC</c> / <c>NTXTDS</c>): the attribute names an external text
+/// file co-located in the dataset's exchange set, and
+/// <see cref="PickAttribute.ExternalText"/> carries the resolved content.
+/// </summary>
+/// <remarks>
+/// The card promotes the file's first non-empty line to a
+/// <see cref="Title"/> heading and shows the remainder as <see cref="Body"/>,
+/// mirroring how these support files are authored (a short headline followed
+/// by the descriptive text). The full untouched content is preserved in
+/// <see cref="ClipboardText"/> so a copy action round-trips the original file.
+/// </remarks>
+internal sealed class PickReferencedText
+{
+    /// <summary>Heading shown at the top of the card (the file's first non-empty line).</summary>
+    public required string Title { get; init; }
+
+    /// <summary>The name of the referenced external text file (e.g. <c>101GB00N00549.TXT</c>).</summary>
+    public required string FileName { get; init; }
+
+    /// <summary>The referenced text below the heading; empty when the file is a single line.</summary>
+    public required string Body { get; init; }
+
+    /// <summary><c>true</c> when <see cref="Body"/> has displayable content.</summary>
+    public bool HasBody => !string.IsNullOrEmpty(Body);
+
+    /// <summary>The full, untouched referenced text used for the copy action.</summary>
+    public required string ClipboardText { get; init; }
+
+    /// <summary>
+    /// Builds a <see cref="PickReferencedText"/> from a resolved
+    /// file-reference attribute. The attribute's
+    /// <see cref="PickAttribute.RawValue"/> supplies the file name and its
+    /// <see cref="PickAttribute.ExternalText"/> supplies the content.
+    /// </summary>
+    public static PickReferencedText FromAttribute(PickAttribute attribute)
+    {
+        ArgumentNullException.ThrowIfNull(attribute);
+
+        var text = attribute.ExternalText ?? string.Empty;
+        var (title, body) = SplitHeadingAndBody(text);
+
+        // Fall back to the attribute's display name when the file is empty
+        // so the card still carries a meaningful heading.
+        if (string.IsNullOrEmpty(title))
+            title = attribute.DisplayName;
+
+        return new PickReferencedText
+        {
+            Title = title,
+            FileName = attribute.RawValue,
+            Body = body,
+            ClipboardText = text,
+        };
+    }
+
+    /// <summary>
+    /// Splits referenced text into its first non-empty line (the heading)
+    /// and the remaining body. Leading and trailing blank lines around each
+    /// part are trimmed; interior blank lines (paragraph breaks) are kept.
+    /// </summary>
+    internal static (string Title, string Body) SplitHeadingAndBody(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return (string.Empty, string.Empty);
+
+        var lines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+        var index = 0;
+        while (index < lines.Length && string.IsNullOrWhiteSpace(lines[index]))
+            index++;
+
+        if (index >= lines.Length)
+            return (string.Empty, string.Empty);
+
+        var title = lines[index].Trim();
+        var body = string.Join('\n', lines, index + 1, lines.Length - index - 1).Trim();
+        return (title, body);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -59,6 +59,9 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         CopyIdentityCommand = new RelayCommand(
             () => { var text = IdentityClipboardText; if (!string.IsNullOrEmpty(text)) CopyIdentityRequested?.Invoke(this, text); },
             () => _selectedHit is not null);
+        CopyReferencedTextCommand = new RelayCommand<PickReferencedText>(
+            t => { if (t is not null && !string.IsNullOrEmpty(t.ClipboardText)) CopyIdentityRequested?.Invoke(this, t.ClipboardText); },
+            t => t is not null && !string.IsNullOrEmpty(t.ClipboardText));
         NavigateCommand = new RelayCommand<FeatureReference>(
             r => { if (r is not null) NavigateRequested?.Invoke(this, r); },
             r => r is not null);
@@ -89,10 +92,28 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     private void ReformatAttributesFromSelectedHit()
     {
         if (_selectedHit is null) return;
-        var reformatted = ReformatTypedAttributes(_selectedHit.Attributes);
+        PopulateAttributeSections(ReformatTypedAttributes(_selectedHit.Attributes));
+    }
+
+    /// <summary>
+    /// Splits the reformatted attribute tree into the key/value
+    /// <see cref="Attributes"/> table and the standalone
+    /// <see cref="ReferencedTexts"/> cards, then publishes both. Resolved
+    /// <c>fileReference</c> rows (S-101 FC; alias TXTDSC / NTXTDS) are lifted
+    /// out of the table so their text is read as its own block rather than a
+    /// monospace dump inside the table.
+    /// </summary>
+    private void PopulateAttributeSections(IReadOnlyList<PickAttribute> reformatted)
+    {
         Attributes.Clear();
-        foreach (var a in reformatted) Attributes.Add(a);
+        foreach (var a in FeatureInfoBuilder.WithoutResolvedFileReferences(reformatted))
+            Attributes.Add(a);
         OnPropertyChanged(nameof(HasAttributes));
+
+        ReferencedTexts.Clear();
+        foreach (var fileRef in FeatureInfoBuilder.CollectResolvedFileReferences(reformatted))
+            ReferencedTexts.Add(PickReferencedText.FromAttribute(fileRef));
+        OnPropertyChanged(nameof(HasReferencedText));
     }
 
     private IReadOnlyList<PickAttribute> ReformatTypedAttributes(IReadOnlyList<PickAttribute> source)
@@ -376,6 +397,19 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     public bool HasAttributes => Attributes.Count > 0;
 
     /// <summary>
+    /// Externally referenced text blocks for the picked feature, lifted out
+    /// of <see cref="Attributes"/> from resolved <c>fileReference</c>
+    /// attributes (S-101 Feature Catalogue; aliases <c>TXTDSC</c> /
+    /// <c>NTXTDS</c>). Rendered in the panel as labelled cards with the full
+    /// text always visible, mirroring an ECDIS "show textual description"
+    /// affordance.
+    /// </summary>
+    public ObservableCollection<PickReferencedText> ReferencedTexts { get; } = new();
+
+    /// <summary>True when the current pick carries at least one referenced text block.</summary>
+    public bool HasReferencedText => ReferencedTexts.Count > 0;
+
+    /// <summary>
     /// xlink-style references the currently selected hit points to.
     /// Surfaced in the panel above the attributes table; clicking a row
     /// invokes <see cref="NavigateCommand"/> to re-open the panel on the
@@ -415,6 +449,14 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     /// the actual clipboard access.
     /// </summary>
     public ICommand CopyIdentityCommand { get; }
+
+    /// <summary>
+    /// Copies a <see cref="PickReferencedText"/> card's full text to the
+    /// clipboard. The command parameter is the card to copy; raises
+    /// <see cref="CopyIdentityRequested"/> with the text so the view owns the
+    /// actual clipboard access.
+    /// </summary>
+    public ICommand CopyReferencedTextCommand { get; }
 
     /// <summary>
     /// Raised when the user invokes <see cref="CopyLocationCommand"/>. The
@@ -538,6 +580,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
             // ApplyHitToDetailFields(null) cleared the detail fields;
             // re-raise the attribute panels so the view collapses them.
             OnPropertyChanged(nameof(HasAttributes));
+            OnPropertyChanged(nameof(HasReferencedText));
             OnPropertyChanged(nameof(HasReferences));
         }
     }
@@ -594,10 +637,12 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         DatasetFileName = null;
         ProductSpec = null;
         Attributes.Clear();
+        ReferencedTexts.Clear();
         References.Clear();
         Location = null;
         HasPick = false;
         OnPropertyChanged(nameof(HasAttributes));
+        OnPropertyChanged(nameof(HasReferencedText));
         OnPropertyChanged(nameof(HasReferences));
         OnPropertyChanged(nameof(HasMultipleHits));
         OnPropertyChanged(nameof(HasDynamicHits));
@@ -614,8 +659,10 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
             DatasetFileName = null;
             ProductSpec = null;
             Attributes.Clear();
+            ReferencedTexts.Clear();
             References.Clear();
             OnPropertyChanged(nameof(HasAttributes));
+            OnPropertyChanged(nameof(HasReferencedText));
             OnPropertyChanged(nameof(HasReferences));
             OnPropertyChanged(nameof(SelectedStationSeries));
             OnPropertyChanged(nameof(HasStationSeries));
@@ -629,10 +676,7 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         DatasetFileName = hit.DatasetFileName;
         ProductSpec = hit.ProductSpec;
 
-        Attributes.Clear();
-        foreach (var attr in ReformatTypedAttributes(hit.Attributes))
-            Attributes.Add(attr);
-        OnPropertyChanged(nameof(HasAttributes));
+        PopulateAttributeSections(ReformatTypedAttributes(hit.Attributes));
 
         References.Clear();
         foreach (var reference in hit.References)

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -71,22 +71,6 @@
                         </TextBlock>
                     </Grid>
                 </Grid>
-                <!--
-                    External text referenced by a `fileReference` attribute
-                    (S-101 FC; alias TXTDSC / NTXTDS): the value above is the
-                    file name, this expander reveals the resolved file content,
-                    mirroring an ECDIS "show textual description" affordance.
-                -->
-                <Expander Margin="0,6,0,0"
-                          Padding="0"
-                          Header="{x:Static loc:Strings.Pick_FileReference_Header}"
-                          IsVisible="{Binding HasExternalText}">
-                    <SelectableTextBlock Text="{Binding ExternalText}"
-                                         FontSize="12"
-                                         FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
-                                         TextWrapping="Wrap"
-                                         Margin="0,6,0,0" />
-                </Expander>
                 </StackPanel>
             </Border>
         </DataTemplate>
@@ -105,6 +89,65 @@
                               Margin="20,0,0,0"
                               ItemTemplate="{StaticResource AttributeCellTemplate}" />
             </StackPanel>
+        </DataTemplate>
+
+        <!--
+            Referenced-text card: a resolved `fileReference` (S-101 FC; alias
+            TXTDSC / NTXTDS) lifted out of the attribute table into its own
+            labelled block. Header row carries a document glyph, the file's
+            promoted heading, the source file name, and a copy button; the
+            body shows the full referenced text (always visible, no expander),
+            mirroring an ECDIS "show textual description" affordance.
+        -->
+        <DataTemplate x:Key="ReferencedTextCardTemplate" x:DataType="vm:PickReferencedText">
+            <Border BorderBrush="{DynamicResource BorderColor}"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Margin="0,0,0,8"
+                    ClipToBounds="True">
+                <StackPanel>
+                    <Grid ColumnDefinitions="Auto,*,Auto"
+                          Background="{DynamicResource MutedBackgroundColor}">
+                        <ic:FluentIcon Grid.Column="0"
+                                       Icon="DocumentText"
+                                       IconVariant="Regular"
+                                       FontSize="18"
+                                       Opacity="0.7"
+                                       VerticalAlignment="Center"
+                                       Margin="12,0,8,0" />
+                        <StackPanel Grid.Column="1"
+                                    Spacing="2"
+                                    Margin="0,10"
+                                    VerticalAlignment="Center">
+                            <TextBlock Text="{Binding Title}"
+                                       FontSize="14"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap" />
+                            <TextBlock Text="{Binding FileName}"
+                                       FontSize="11"
+                                       Opacity="0.6"
+                                       FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
+                                       TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
+                        <Button Grid.Column="2"
+                                VerticalAlignment="Top"
+                                Padding="6"
+                                Margin="4"
+                                Background="Transparent"
+                                Command="{Binding $parent[ItemsControl].((vm:PickReportViewModel)DataContext).CopyReferencedTextCommand}"
+                                CommandParameter="{Binding}"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_CopyReferencedText}">
+                            <ic:FluentIcon Icon="Copy" IconVariant="Regular" FontSize="16" />
+                        </Button>
+                    </Grid>
+                    <SelectableTextBlock Text="{Binding Body}"
+                                         FontSize="14"
+                                         LineHeight="22"
+                                         TextWrapping="Wrap"
+                                         Margin="14,12,14,14"
+                                         IsVisible="{Binding HasBody}" />
+                </StackPanel>
+            </Border>
         </DataTemplate>
     </UserControl.Resources>
 
@@ -531,6 +574,27 @@
                                    IsVisible="{Binding !HasAttributes}" />
                     </StackPanel>
                 </Expander>
+
+                <!--
+                    Referenced text. Resolved `fileReference` content lifted
+                    out of the attribute table above into standalone cards so
+                    the mariner can read it without an expander or a monospace
+                    table dump. Hidden when the pick has no referenced text.
+                -->
+                <Border BorderBrush="{DynamicResource BorderColor}"
+                        BorderThickness="0,1,0,0"
+                        Padding="0,8,0,0"
+                        IsVisible="{Binding HasReferencedText}">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="{x:Static loc:Strings.Pick_ReferencedTextHeader}"
+                                   FontSize="10"
+                                   FontWeight="Normal"
+                                   LetterSpacing="1"
+                                   Opacity="0.7" />
+                        <ItemsControl ItemsSource="{Binding ReferencedTexts}"
+                                      ItemTemplate="{StaticResource ReferencedTextCardTemplate}" />
+                    </StackPanel>
+                </Border>
             </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/tests/EncDotNet.S100.Viewer.Tests/FeatureInfoBuilderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/FeatureInfoBuilderTests.cs
@@ -247,4 +247,104 @@ public class FeatureInfoBuilderTests
             parent.Children, c => c.Code == "fileReference");
         Assert.Equal("Tidal stream data.", child.ExternalText);
     }
+
+    [Fact]
+    public void CollectResolvedFileReferences_ReturnsOnlyResolvedFileRefs()
+    {
+        var attrs = FeatureInfoBuilder.ResolveFileReferences(
+            FeatureInfoBuilder.BuildFlat(
+                new[]
+                {
+                    new KeyValuePair<string, string?>("objectName", "Caution Area"),
+                    new KeyValuePair<string, string?>("fileReference", "A.TXT"),
+                    new KeyValuePair<string, string?>("TXTDSC", "B.TXT"),
+                },
+                decoder: null),
+            name => name == "A.TXT" ? "Alpha." : name == "B.TXT" ? "Bravo." : null);
+
+        var refs = FeatureInfoBuilder.CollectResolvedFileReferences(attrs);
+
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("A.TXT", refs[0].RawValue);
+        Assert.Equal("Alpha.", refs[0].ExternalText);
+        Assert.Equal("B.TXT", refs[1].RawValue);
+    }
+
+    [Fact]
+    public void WithoutResolvedFileReferences_RemovesResolvedFileRefLeaves()
+    {
+        var attrs = FeatureInfoBuilder.ResolveFileReferences(
+            FeatureInfoBuilder.BuildFlat(
+                new[]
+                {
+                    new KeyValuePair<string, string?>("objectName", "Caution Area"),
+                    new KeyValuePair<string, string?>("fileReference", "A.TXT"),
+                },
+                decoder: null),
+            _ => "Alpha.");
+
+        var pruned = FeatureInfoBuilder.WithoutResolvedFileReferences(attrs);
+
+        var row = Assert.Single(pruned);
+        Assert.Equal("objectName", row.Code);
+    }
+
+    [Fact]
+    public void WithoutResolvedFileReferences_KeepsUnresolvedFileRef()
+    {
+        var attrs = FeatureInfoBuilder.BuildFlat(
+            new[] { new KeyValuePair<string, string?>("fileReference", "MISSING.TXT") },
+            decoder: null);
+
+        var pruned = FeatureInfoBuilder.WithoutResolvedFileReferences(attrs);
+
+        Assert.Same(attrs, pruned);
+        Assert.Equal("fileReference", Assert.Single(pruned).Code);
+    }
+
+    [Fact]
+    public void WithoutResolvedFileReferences_DropsComplexParentLeftEmpty()
+    {
+        var complex = new[]
+        {
+            new FeatureInfoBuilder.ComplexAttributeRow(
+                "information",
+                new[] { new KeyValuePair<string, string>("fileReference", "PANEL.TXT") }),
+        };
+
+        var attrs = FeatureInfoBuilder.ResolveFileReferences(
+            FeatureInfoBuilder.Build(
+                System.Array.Empty<KeyValuePair<string, string>>(), complex, decoder: null),
+            _ => "Tidal stream data.");
+
+        var pruned = FeatureInfoBuilder.WithoutResolvedFileReferences(attrs);
+
+        Assert.Empty(pruned);
+    }
+
+    [Fact]
+    public void WithoutResolvedFileReferences_KeepsComplexParentWithSurvivingChildren()
+    {
+        var complex = new[]
+        {
+            new FeatureInfoBuilder.ComplexAttributeRow(
+                "information",
+                new[]
+                {
+                    new KeyValuePair<string, string>("headline", "Caution"),
+                    new KeyValuePair<string, string>("fileReference", "PANEL.TXT"),
+                }),
+        };
+
+        var attrs = FeatureInfoBuilder.ResolveFileReferences(
+            FeatureInfoBuilder.Build(
+                System.Array.Empty<KeyValuePair<string, string>>(), complex, decoder: null),
+            _ => "Tidal stream data.");
+
+        var pruned = FeatureInfoBuilder.WithoutResolvedFileReferences(attrs);
+
+        var parent = Assert.Single(pruned);
+        var child = Assert.Single(parent.Children);
+        Assert.Equal("headline", child.Code);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReferencedTextTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReferencedTextTests.cs
@@ -1,0 +1,73 @@
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Viewer.ViewModels;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class PickReferencedTextTests
+{
+    [Fact]
+    public void FromAttribute_PromotesFirstLineToTitleAndKeepsBody()
+    {
+        var attr = new PickAttribute
+        {
+            Code = "fileReference",
+            RawValue = "101GB00N00549.TXT",
+            ExternalText = "ANCHORING RESTRICTED\n\nMariners are advised...",
+            Children = [],
+        };
+
+        var card = PickReferencedText.FromAttribute(attr);
+
+        Assert.Equal("ANCHORING RESTRICTED", card.Title);
+        Assert.Equal("Mariners are advised...", card.Body);
+        Assert.True(card.HasBody);
+        Assert.Equal("101GB00N00549.TXT", card.FileName);
+        Assert.Equal(attr.ExternalText, card.ClipboardText);
+    }
+
+    [Fact]
+    public void FromAttribute_SingleLineFileHasNoBody()
+    {
+        var attr = new PickAttribute
+        {
+            Code = "fileReference",
+            RawValue = "ONE.TXT",
+            ExternalText = "VESSEL REPORTING",
+            Children = [],
+        };
+
+        var card = PickReferencedText.FromAttribute(attr);
+
+        Assert.Equal("VESSEL REPORTING", card.Title);
+        Assert.Equal(string.Empty, card.Body);
+        Assert.False(card.HasBody);
+    }
+
+    [Fact]
+    public void FromAttribute_EmptyTextFallsBackToDisplayName()
+    {
+        var attr = new PickAttribute
+        {
+            Code = "fileReference",
+            Name = "File reference",
+            RawValue = "EMPTY.TXT",
+            ExternalText = "   \n  ",
+            Children = [],
+        };
+
+        var card = PickReferencedText.FromAttribute(attr);
+
+        Assert.Equal("File reference", card.Title);
+        Assert.Equal(string.Empty, card.Body);
+    }
+
+    [Fact]
+    public void SplitHeadingAndBody_NormalizesCrlfAndTrimsBlankLines()
+    {
+        var (title, body) = PickReferencedText.SplitHeadingAndBody(
+            "\r\n\r\nTITLE\r\n\r\nLine one.\r\nLine two.\r\n\r\n");
+
+        Assert.Equal("TITLE", title);
+        Assert.Equal("Line one.\nLine two.", body);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -43,6 +43,79 @@ public class PickReportViewModelTests
     }
 
     [Fact]
+    public void SetPick_LiftsResolvedFileReferenceIntoReferencedTexts()
+    {
+        var vm = new PickReportViewModel();
+
+        var fileRef = new PickAttribute
+        {
+            Code = "fileReference",
+            Name = "File Reference",
+            RawValue = "CAUTION.TXT",
+            DisplayValue = null,
+            ExternalText = "ANCHORING RESTRICTED\n\nBeware of strong currents.",
+            Children = [],
+        };
+
+        vm.SetPick("CautionArea", "Caution Area", "7", "test.000", "S-101",
+            new[] { Leaf("objectName", "Caution Area"), fileRef });
+
+        // The resolved file reference is pulled out of the attribute table…
+        var row = Assert.Single(vm.Attributes);
+        Assert.Equal("objectName", row.Code);
+
+        // …and surfaced as a referenced-text card with a promoted heading.
+        Assert.True(vm.HasReferencedText);
+        var card = Assert.Single(vm.ReferencedTexts);
+        Assert.Equal("ANCHORING RESTRICTED", card.Title);
+        Assert.Equal("CAUTION.TXT", card.FileName);
+        Assert.Equal("Beware of strong currents.", card.Body);
+        Assert.Equal(fileRef.ExternalText, card.ClipboardText);
+    }
+
+    [Fact]
+    public void SetPick_UnresolvedFileReferenceStaysInAttributeTable()
+    {
+        var vm = new PickReportViewModel();
+
+        var fileRef = new PickAttribute
+        {
+            Code = "fileReference",
+            Name = "File Reference",
+            RawValue = "MISSING.TXT",
+            DisplayValue = null,
+            Children = [],
+        };
+
+        vm.SetPick("CautionArea", "Caution Area", "7", "test.000", "S-101", new[] { fileRef });
+
+        Assert.False(vm.HasReferencedText);
+        Assert.Empty(vm.ReferencedTexts);
+        var row = Assert.Single(vm.Attributes);
+        Assert.Equal("MISSING.TXT", row.RawValue);
+    }
+
+    [Fact]
+    public void Clear_EmptiesReferencedTexts()
+    {
+        var vm = new PickReportViewModel();
+        var fileRef = new PickAttribute
+        {
+            Code = "fileReference",
+            RawValue = "CAUTION.TXT",
+            ExternalText = "Hazard.\nDetails.",
+            Children = [],
+        };
+        vm.SetPick("CautionArea", null, "7", "test.000", "S-101", new[] { fileRef });
+        Assert.True(vm.HasReferencedText);
+
+        vm.Clear();
+
+        Assert.False(vm.HasReferencedText);
+        Assert.Empty(vm.ReferencedTexts);
+    }
+
+    [Fact]
     public void SetPick_WithEmptyAttributes_ReportsHasAttributesFalse()
     {
         var vm = new PickReportViewModel();
@@ -61,7 +134,7 @@ public class PickReportViewModelTests
     }
 
     [Fact]
-    public void SetPick_PreservesExternalTextThroughReformat()
+    public void SetPick_PreservesReferencedTextThroughReformat()
     {
         var vm = new PickReportViewModel();
 
@@ -77,10 +150,11 @@ public class PickReportViewModelTests
 
         vm.SetPick("CautionArea", "Caution Area", "7", "test.000", "S-101", new[] { fileRef });
 
-        var row = Assert.Single(vm.Attributes);
-        Assert.True(row.HasExternalText);
-        Assert.Equal("Beware of strong currents.", row.ExternalText);
-        Assert.Equal("CAUTION.TXT", row.RawValue);
+        Assert.Empty(vm.Attributes);
+        var card = Assert.Single(vm.ReferencedTexts);
+        Assert.Equal("CAUTION.TXT", card.FileName);
+        Assert.Equal("Beware of strong currents.", card.Title);
+        Assert.Equal("Beware of strong currents.", card.ClipboardText);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

When you pick an S-101 feature whose `fileReference` attribute (S-101 FC; alias `TXTDSC` / `NTXTDS`) points at an external text file, the resolved content used to be crammed into the Object Information attribute table behind a plain expander. The monospace dump broke the key/value layout and pushed the remaining attributes (Language, Text) far below the fold.

This change lifts that content out of the attribute table into its own **REFERENCED TEXT** section, rendered as labelled cards with the full text always visible (no expander, no click). Each card shows a document glyph, a heading promoted from the file's first line, the source file name, and a copy button, with the body text set at a comfortable size and line spacing.

The split is done in the pipeline layer so it stays testable:

- `FeatureInfoBuilder` gains `CollectResolvedFileReferences` and `WithoutResolvedFileReferences` (both recursive; the latter also drops complex-attribute parents that are left empty after pruning) plus an `IsResolvedFileReference` predicate.
- `PickReferencedText` (viewer model) promotes the file's first non-empty line to a title, keeps the remainder as the body, and preserves the untouched text for the clipboard.
- `PickReportViewModel` exposes `ReferencedTexts` / `HasReferencedText` and a `CopyReferencedTextCommand`, splitting each pick's attributes into the pruned table plus the cards. Unresolved file references (file missing/unreadable) stay in the attribute table so their file name is not lost.

While building the header background I found that `MutedBackgroundColor` was referenced by both the new card header and the existing attribute zebra-striping but was **never defined** in any theme dictionary, so both rendered transparent. I defined it per chrome variant in `App.axaml`, which also activates the previously dead zebra-striping. Worth a careful look in the Night/Dusk palettes.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [ ] N/A

**Spec section references cited in code/docs:** `fileReference` simple attribute and its `information` complex-attribute binding, S-101 Feature Catalogue (aliases `TXTDSC` / `NTXTDS`); referenced text presentation mirrors the ECDIS "show textual description" affordance.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New/updated coverage: `FeatureInfoBuilder` collect/prune helpers, the view-model attribute split (resolved lifted out, unresolved retained, cleared on `Clear()`), and `PickReferencedText` title/body derivation. Viewer suite: 1227 passed, 1 skipped.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (Pipelines)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A, no new deps)

## Breaking changes

None. The `PickAttribute.ExternalText` data contract is unchanged; only the viewer presentation moved.