### PR TITLE
Make the tiled render subsystem the default

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -394,7 +394,7 @@ env var always wins over the persisted viewer setting. The remaining variables
 The **render subsystem switch** (A/B), the TiledScene **scene mode**
 (tiled vs single surface), and the **tiled optimization knobs** (gutter,
 in-memory / disk / GPU budgets, prediction, disk cache) are likewise bound in
-the viewer under **Settings → Render subsystem (experimental)** (issue #331),
+the viewer under **Settings → Render subsystem** (issue #331),
 backed by the same [`RenderingOptimizations`](RenderingOptimizations.cs) store.
 The env vars below seed and (when set explicitly) pin those too, disabling the
 matching UI control. Some knobs are read each frame and apply live (subsystem,

--- a/src/EncDotNet.S100.Renderers.Mapsui/RenderingOptimizations.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/RenderingOptimizations.cs
@@ -186,10 +186,10 @@ public static class RenderingOptimizations
     /// <summary>
     /// Selects the active base-plane chart render subsystem (the A/B switch for
     /// the tiled/async render-subsystem redesign). <see cref="RenderSubsystemKind.Mapsui"/>
-    /// is today's Mapsui feature/style/layer path (the "A" arm);
-    /// <see cref="RenderSubsystemKind.TiledScene"/> selects the new tiled/async
+    /// is the established Mapsui feature/style/layer path (the "A" arm);
+    /// <see cref="RenderSubsystemKind.TiledScene"/> selects the tiled/async
     /// subsystem (the "B" arm). Seeded from <c>S100_RENDER_SUBSYSTEM</c>
-    /// (<c>mapsui</c> | <c>tiledscene</c>); default <see cref="RenderSubsystemKind.Mapsui"/>.
+    /// (<c>mapsui</c> | <c>tiledscene</c>); default <see cref="RenderSubsystemKind.TiledScene"/>.
     /// </summary>
     public static RenderSubsystemKind RenderSubsystem
     {
@@ -376,7 +376,7 @@ public static class RenderingOptimizations
         var raw = Environment.GetEnvironmentVariable("S100_RENDER_SUBSYSTEM");
         if (string.IsNullOrEmpty(raw))
         {
-            return (RenderSubsystemKind.Mapsui, false);
+            return (RenderSubsystemKind.TiledScene, false);
         }
 
         var kind = raw.Trim().ToLowerInvariant() switch
@@ -447,14 +447,15 @@ public enum RenderSubsystemKind
 {
     /// <summary>
     /// The established Mapsui feature/style/layer rendering path (the "A" arm).
-    /// This is the default and the baseline against which the new subsystem is
-    /// measured.
+    /// Retained as a selectable fallback; <see cref="TiledScene"/> is now the
+    /// default and the baseline against which this path is compared.
     /// </summary>
     Mapsui = 0,
 
     /// <summary>
-    /// The new tiled/async predictive render subsystem that rasterises the base
-    /// plane directly from the <c>VectorScene</c> IR (the "B" arm).
+    /// The tiled/async predictive render subsystem that rasterises the base
+    /// plane directly from the <c>VectorScene</c> IR (the "B" arm). This is the
+    /// default subsystem.
     /// </summary>
     TiledScene = 1,
 }

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -880,31 +880,31 @@
     <value>Speed up panning and zooming on dense charts. All are on by default; turn one off only to compare rendering behaviour.</value>
   </data>
   <data name="Settings_RenderSubsystemSubsection" xml:space="preserve">
-    <value>Render subsystem (experimental)</value>
+    <value>Render subsystem</value>
   </data>
   <data name="Settings_RenderSubsystemSubsection_Help" xml:space="preserve">
-    <value>Choose the base-plane render subsystem and, for the experimental tiled pipeline, tune its caching. Environment variables set before launch override these and disable the matching control.</value>
+    <value>Choose the base-plane render subsystem and, for the tiled pipeline, tune its caching.</value>
   </data>
   <data name="Settings_RenderSubsystem" xml:space="preserve">
     <value>Subsystem</value>
   </data>
   <data name="Tooltip_RenderSubsystem" xml:space="preserve">
-    <value>Select the base-plane render subsystem: "Mapsui" is the established feature/style/layer path (A); "Tiled scene" is the experimental async tiled pipeline that rasterizes the chart from the vector scene on worker threads (B). Switching re-renders live.</value>
+    <value>Select the base-plane render subsystem. "Standard" is the established feature/style/layer path; "Tiled" rasterizes the chart from the vector scene on worker threads for faster panning and zooming. Switching re-renders live.</value>
   </data>
   <data name="Settings_RenderSubsystem_Mapsui" xml:space="preserve">
-    <value>Mapsui (A)</value>
+    <value>Standard</value>
   </data>
   <data name="Settings_RenderSubsystem_TiledScene" xml:space="preserve">
-    <value>Tiled scene (B)</value>
+    <value>Tiled</value>
   </data>
   <data name="Settings_SceneMode" xml:space="preserve">
     <value>Scene mode</value>
   </data>
   <data name="Tooltip_SceneMode" xml:space="preserve">
-    <value>Within the tiled subsystem, choose "Tiled" (a pyramid of cached tiles — the default) or "Single surface" (one rasterized image composited under translation). Changing re-renders live.</value>
+    <value>Within the Tiled subsystem, choose "Tile pyramid" (a pyramid of cached tiles — the default) or "Single surface" (one rasterized image composited under translation). Changing re-renders live.</value>
   </data>
   <data name="Settings_SceneMode_Tiled" xml:space="preserve">
-    <value>Tiled</value>
+    <value>Tile pyramid</value>
   </data>
   <data name="Settings_SceneMode_Single" xml:space="preserve">
     <value>Single surface</value>

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -541,7 +541,7 @@ internal sealed class SettingsViewModel : ViewModelBase
     private RenderSubsystemKind _renderSubsystem;
     /// <summary>
     /// The active base-plane render subsystem — "A" (<see cref="RenderSubsystemKind.Mapsui"/>)
-    /// vs the experimental "B" (<see cref="RenderSubsystemKind.TiledScene"/>).
+    /// vs the "B" (<see cref="RenderSubsystemKind.TiledScene"/>).
     /// Read per-render, so switching rebinds the active subsystem on the next
     /// re-render. Disabled when pinned by <c>S100_RENDER_SUBSYSTEM</c>.
     /// </summary>
@@ -572,7 +572,7 @@ internal sealed class SettingsViewModel : ViewModelBase
     /// </summary>
     public bool MapsuiSelected => _renderSubsystem == RenderSubsystemKind.Mapsui;
 
-    /// <summary>True when the experimental "B" (TiledScene) arm is selected — gates the knob panel.</summary>
+    /// <summary>True when the "B" (TiledScene) arm is selected — gates the knob panel.</summary>
     public bool TiledSceneSelected => _renderSubsystem == RenderSubsystemKind.TiledScene;
 
     /// <summary>True when the tiled base plane is active (B arm + tiled scene mode) — gates the tiled knobs.</summary>

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -203,9 +203,9 @@ internal sealed class ViewerSettings
 
     /// <summary>
     /// Active base-plane render subsystem (issue #331). One of "Mapsui" (the "A"
-    /// arm) or "TiledScene" (the experimental "B" arm), matching
+    /// arm) or "TiledScene" (the "B" arm), matching
     /// <see cref="Renderers.Mapsui.RenderSubsystemKind"/>. <see langword="null"/>
-    /// → best default ("Mapsui"). Mirrors
+    /// → best default ("TiledScene"). Mirrors
     /// <c>RenderingOptimizations.RenderSubsystem</c> /
     /// <c>S100_RENDER_SUBSYSTEM</c>.
     /// </summary>

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -177,9 +177,36 @@
                 <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding BasemapEnabled}" />
             </Grid>
 
-            <!-- Rendering optimizations (Settings → Map) — shown for the
-                 "A" (Mapsui) subsystem only, so the panel never lists knobs
-                 that don't apply to the active renderer. -->
+            <!-- Render subsystem A/B + tiled knobs (issue #331) -->
+            <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystemSubsection}"
+                       FontSize="12"
+                       FontWeight="SemiBold"
+                       Margin="0,8,0,0" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystemSubsection_Help}"
+                       FontSize="11"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystem}"
+                           FontSize="12" />
+                <ComboBox ItemsSource="{Binding AvailableRenderSubsystems}"
+                          SelectedItem="{Binding SelectedRenderSubsystem}"
+                          IsEnabled="{Binding RenderSubsystemEditable}"
+                          ToolTip.Tip="{x:Static loc:Strings.Tooltip_RenderSubsystem}"
+                          MinWidth="160"
+                          HorizontalAlignment="Left">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={x:Static viewer:RenderSubsystemNameConverter.Instance}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+
+            <!-- "Standard" (Mapsui) optimizations — shown below the subsystem
+                 selector, and only when the Standard arm is selected, so the
+                 panel never lists knobs that don't apply to the active
+                 renderer. -->
             <StackPanel Spacing="16" IsVisible="{Binding MapsuiSelected}">
                 <StackPanel Spacing="16">
                     <TextBlock Text="{x:Static loc:Strings.Settings_MapOptimizationsSubsection}"
@@ -215,32 +242,6 @@
                         <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding GeometrySimplificationEnabled}" />
                     </Grid>
                 </StackPanel>
-            </StackPanel>
-
-            <!-- Render subsystem A/B + tiled knobs (issue #331) -->
-            <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystemSubsection}"
-                       FontSize="12"
-                       FontWeight="SemiBold"
-                       Margin="0,8,0,0" />
-            <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystemSubsection_Help}"
-                       FontSize="11"
-                       Opacity="0.6"
-                       TextWrapping="Wrap" />
-            <StackPanel Spacing="6">
-                <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystem}"
-                           FontSize="12" />
-                <ComboBox ItemsSource="{Binding AvailableRenderSubsystems}"
-                          SelectedItem="{Binding SelectedRenderSubsystem}"
-                          IsEnabled="{Binding RenderSubsystemEditable}"
-                          ToolTip.Tip="{x:Static loc:Strings.Tooltip_RenderSubsystem}"
-                          MinWidth="160"
-                          HorizontalAlignment="Left">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding Converter={x:Static viewer:RenderSubsystemNameConverter.Instance}}" />
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                </ComboBox>
             </StackPanel>
 
             <!-- "B" (tiled scene) knobs — shown only when the B arm is selected -->

--- a/tests/EncDotNet.S100.Pipelines.Tests/RenderingOptimizationsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/RenderingOptimizationsTests.cs
@@ -82,14 +82,14 @@ public class RenderingOptimizationsTests
     }
 
     [Fact]
-    public void RenderSubsystem_DefaultsToMapsui_WhenNotEnvPinned()
+    public void RenderSubsystem_DefaultsToTiledScene_WhenNotEnvPinned()
     {
         if (RenderingOptimizations.RenderSubsystemEnvExplicit)
         {
             return; // pinned by S100_RENDER_SUBSYSTEM; default not observable
         }
 
-        Assert.Equal(RenderSubsystemKind.Mapsui, RenderingOptimizations.RenderSubsystem);
+        Assert.Equal(RenderSubsystemKind.TiledScene, RenderingOptimizations.RenderSubsystem);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/SettingsViewModelRenderSubsystemTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/SettingsViewModelRenderSubsystemTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace EncDotNet.S100.Viewer.Tests;
 
 /// <summary>
-/// Covers the Settings → "Render subsystem (experimental)" knobs (issue #331):
+/// Covers the Settings → "Render subsystem" knobs (issue #331):
 /// the A/B subsystem switch, the tiled scene mode, and the "B" tiled-pipeline
 /// optimization knobs. Each mirrors a <see cref="RenderingOptimizations"/>
 /// value, defaults to the "best" set, persists through <see cref="ViewerSettings"/>,
@@ -34,9 +34,9 @@ public class SettingsViewModelRenderSubsystemTests
 
         var vm = new SettingsViewModel(NewSettings());
 
-        Assert.Equal(RenderSubsystemKind.Mapsui, vm.SelectedRenderSubsystem);
+        Assert.Equal(RenderSubsystemKind.TiledScene, vm.SelectedRenderSubsystem);
         Assert.Equal(VectorSceneMode.Tiled, vm.SelectedSceneMode);
-        Assert.False(vm.TiledSceneSelected);
+        Assert.True(vm.TiledSceneSelected);
         Assert.True(vm.TilePredictionEnabled);
         Assert.True(vm.TileGpuResidencyEnabled);
         Assert.True(vm.TileDiskCacheEnabled);
@@ -63,7 +63,7 @@ public class SettingsViewModelRenderSubsystemTests
         Assert.Equal(VectorSceneMode.Single, vm.SelectedSceneMode);
 
         // Restore the global renderer flags so cross-test ordering is unaffected.
-        vm.SelectedRenderSubsystem = RenderSubsystemKind.Mapsui;
+        vm.SelectedRenderSubsystem = RenderSubsystemKind.TiledScene;
         vm.SelectedSceneMode = VectorSceneMode.Tiled;
     }
 
@@ -82,17 +82,17 @@ public class SettingsViewModelRenderSubsystemTests
 
         try
         {
-            vm.SelectedRenderSubsystem = RenderSubsystemKind.TiledScene;
+            vm.SelectedRenderSubsystem = RenderSubsystemKind.Mapsui;
 
-            Assert.Equal(nameof(RenderSubsystemKind.TiledScene), s.RenderSubsystem);
-            Assert.Equal(RenderSubsystemKind.TiledScene, RenderingOptimizations.RenderSubsystem);
-            Assert.True(vm.TiledSceneSelected);
+            Assert.Equal(nameof(RenderSubsystemKind.Mapsui), s.RenderSubsystem);
+            Assert.Equal(RenderSubsystemKind.Mapsui, RenderingOptimizations.RenderSubsystem);
+            Assert.True(vm.MapsuiSelected);
             Assert.Equal(1, reloads);
             Assert.True(File.Exists(s.SettingsFilePath));
         }
         finally
         {
-            vm.SelectedRenderSubsystem = RenderSubsystemKind.Mapsui;
+            vm.SelectedRenderSubsystem = RenderSubsystemKind.TiledScene;
             if (File.Exists(s.SettingsFilePath)) File.Delete(s.SettingsFilePath);
         }
     }
@@ -109,18 +109,19 @@ public class SettingsViewModelRenderSubsystemTests
         var vm = new SettingsViewModel(NewSettings());
         try
         {
-            Assert.False(vm.TiledModeActive); // A arm
+            vm.SelectedRenderSubsystem = RenderSubsystemKind.Mapsui;
+            Assert.False(vm.TiledModeActive); // Standard arm
 
             vm.SelectedRenderSubsystem = RenderSubsystemKind.TiledScene;
-            Assert.True(vm.TiledModeActive); // B + tiled (default)
+            Assert.True(vm.TiledModeActive); // Tiled arm + tiled scene mode (default)
 
             vm.SelectedSceneMode = VectorSceneMode.Single;
-            Assert.False(vm.TiledModeActive); // B + single
+            Assert.False(vm.TiledModeActive); // Tiled arm + single
         }
         finally
         {
             vm.SelectedSceneMode = VectorSceneMode.Tiled;
-            vm.SelectedRenderSubsystem = RenderSubsystemKind.Mapsui;
+            vm.SelectedRenderSubsystem = RenderSubsystemKind.TiledScene;
         }
     }
 


### PR DESCRIPTION
## Summary

The tiled/async render subsystem ("B", `TiledScene`) is feature-complete and measurably faster than the legacy Mapsui path ("A"), but it was still opt-in and labelled experimental. This PR flips the default base-plane subsystem to `TiledScene` and cleans up the Settings UI that exposes the switch (issue #347).

Behavioural change: with no `S100_RENDER_SUBSYSTEM` env var and no saved preference, the viewer now renders via the tiled pipeline. Mapsui remains selectable as a fallback.

UI changes (Settings -> Render subsystem):
- Renamed the user-facing modes to **Standard** (Mapsui) and **Tiled** (TiledScene). "A"/"B"/"Mapsui"/"TiledScene" stay internal only.
- Renamed the advanced scene-mode sub-option from "Tiled" to **Tile pyramid** so it no longer echoes the subsystem name (paired with "Single surface").
- Moved the Standard optimization toggles to sit *below* the subsystem selector, matching where the Tiled knobs already render, so both arms are laid out consistently.
- Dropped the "experimental" label and the environment-variable note from the subsection header, help text, and tooltip.

Tests were updated for the new default. Note for reviewers: a few render-subsystem view-model tests had `finally` blocks that restored the shared static `RenderingOptimizations.RenderSubsystem` back to `Mapsui` (the old default); with the default now `TiledScene` those restores would corrupt ordering for later default-observing tests, so they now reset to the seeded default and the "switch" test toggles to Mapsui (the non-default) to exercise a real change.

## Spec alignment

- [x] N/A - change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Updated `RenderingOptimizationsTests` (default now `TiledScene`) and `SettingsViewModelRenderSubsystemTests` (default/restore expectations). Full Viewer.Tests suite (1256 tests) passes; viewer builds clean and launches with `TiledScene` active by default.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Updated `EncDotNet.S100.Renderers.Mapsui/README.md` to drop the "experimental" label; XML doc comments on `RenderSubsystemKind` / `RenderingOptimizations.RenderSubsystem` / `ViewerSettings.RenderSubsystem` now reflect the new default.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

The default render subsystem changes from Mapsui to TiledScene for users with no env var and no saved preference. Mapsui stays selectable as a fallback, and any explicit `S100_RENDER_SUBSYSTEM` setting or saved preference is honoured unchanged.

Relates to #347