### PR TITLE
Add centralized Discord notifier for failed CI/Release/Docs/Performance runs

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,53 @@
+name: Notify
+
+# Centralized failure notifier. Rather than sprinkling `if: failure()` steps
+# across every job in every workflow, this watches the other workflows finish
+# and pings Discord whenever one of them concludes in failure. It therefore
+# also covers any jobs/workflows added later, with no further wiring.
+#
+# NOTE: `workflow_run` triggers are evaluated from the workflow file on the
+# repository's default branch, so this only takes effect once merged to main.
+on:
+  workflow_run:
+    workflows: [ "CI", "Release", "Docs", "Performance" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+
+jobs:
+  discord:
+    runs-on: ubuntu-latest
+    # Only alert on genuine failures of non-PR runs. Pull-request failures are
+    # already visible as checks on the PR, so excluding them keeps the channel
+    # signal-to-noise high. `timed_out` is treated as a failure; `cancelled`
+    # is usually intentional and is ignored.
+    if: >
+      (github.event.workflow_run.conclusion == 'failure' ||
+       github.event.workflow_run.conclusion == 'timed_out') &&
+      github.event.workflow_run.event != 'pull_request'
+    steps:
+      - name: Post failure to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          WF_NAME: ${{ github.event.workflow_run.name }}
+          WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WF_EVENT: ${{ github.event.workflow_run.event }}
+          WF_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WF_SHA: ${{ github.event.workflow_run.head_sha }}
+          WF_ACTOR: ${{ github.event.workflow_run.actor.login }}
+          WF_URL: ${{ github.event.workflow_run.html_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "::warning::DISCORD_WEBHOOK_URL secret is not set; skipping notification."
+            exit 0
+          fi
+          SHORT_SHA="${WF_SHA:0:7}"
+          CONTENT=$(printf '🔴 **%s** %s on `%s`\nRepo: `%s` · Trigger: `%s` · By: `%s` · Commit: `%s`\n%s' \
+            "$WF_NAME" "$WF_CONCLUSION" "$WF_BRANCH" \
+            "$REPO" "$WF_EVENT" "$WF_ACTOR" "$SHORT_SHA" "$WF_URL")
+          # Build the JSON body with jq so branch/actor/commit values can never
+          # break the payload, then POST it to the Discord webhook.
+          jq -n --arg content "$CONTENT" '{content: $content}' \
+            | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

macOS signing and notarization only run on `main` and release builds, so when they fail (for example, the recent Apple notary `403 - A required agreement is missing or has expired`) the run goes red but nobody is alerted, because PRs skip signing and post-merge `main` failures gate nothing.

This adds a single centralized failure notifier rather than sprinkling `if: failure()` steps across every job. A new `.github/workflows/notify.yml` listens for `workflow_run` completions of **CI, Release, Docs, and Performance** and posts to a Discord webhook whenever one of them concludes in `failure` or `timed_out`. Because it keys off run conclusion, it automatically covers any jobs or workflows added later, signing-related or not.

Design notes:

- **Non-PR only.** PR failures are already visible as checks on the pull request, so the notifier ignores `pull_request`-triggered runs to keep the channel signal-to-noise high. `cancelled` runs are ignored as usually intentional.
- **Safe payload.** The message is assembled with `jq` so branch/actor/commit values can't break the JSON, then POSTed with `curl` (no third-party action holds the webhook secret).
- **Graceful when unconfigured.** If the `DISCORD_WEBHOOK_URL` secret is absent the step no-ops with a warning instead of failing.

Each alert includes the workflow name, conclusion, branch, repo, trigger, actor, short commit, and a direct link to the failed run.

Follow-up to enable after merge: add a repo Actions secret `DISCORD_WEBHOOK_URL`. Note that `workflow_run` triggers only take effect once this file is on the default branch, so the notifier starts working after this merges to `main`.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A

## Tests

- [ ] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [ ] `dotnet test --configuration Release` passes locally

N/A — CI workflow change with no buildable/testable code. Validated the YAML parses and that the `jq`/`printf` payload builder produces valid JSON (including values with special characters).

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [ ] New public APIs have XML doc comments

N/A — no public API or user-facing library behaviour changed.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

N/A — no new dependencies; relies on `jq`/`curl` preinstalled on `ubuntu-latest`.

## Breaking changes

None.