### PR TITLE
Clear pick highlight on empty map click and panel close

### DIFF
--- a/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
@@ -341,14 +341,51 @@ internal sealed class MapInteractionController
             return;
         }
 
-        // Outside Pick Mode, plain single-tap is a no-op so it doesn't fight
-        // with double-tap-to-zoom (the first tap of a double-tap also fires
-        // here).
+        // Outside Pick Mode, a plain single-tap clears the current pick (and
+        // its map highlight) when there is one — the "click empty space to
+        // deselect" convention. With no pick to clear it stays a no-op so it
+        // doesn't fight with double-tap-to-zoom (the first tap of a double-tap
+        // also fires here; clearing on it is harmless). A tap while a map tool
+        // (e.g. Measure) is active is left for the tool and never clears.
         if (!_viewModel.IsPickModeActive)
+        {
+            if (ShouldClearPickOnTap(
+                    pickModeActive: false,
+                    toolActive: _toolController?.ActiveTool is not null,
+                    pickModifierActive: false,
+                    hasPick: _viewModel.PickReport.HasPick))
+            {
+                _viewModel.PickReport.Clear();
+            }
+
             return;
+        }
 
         PerformPickAt(e);
     }
+
+    /// <summary>
+    /// Decides whether a plain (unmodified) single-tap on the map should clear
+    /// the current pick. Extracted as a pure function so the rule can be unit
+    /// tested without an Avalonia <see cref="MapControl"/>.
+    /// </summary>
+    /// <param name="pickModeActive">Whether Pick Mode is active.</param>
+    /// <param name="toolActive">Whether a map tool (e.g. Measure) is active.</param>
+    /// <param name="pickModifierActive">
+    /// Whether the platform pick modifier (Cmd/Ctrl) was held — a modifier-click
+    /// is a one-shot pick, never a clear.
+    /// </param>
+    /// <param name="hasPick">Whether there is a current pick to clear.</param>
+    /// <returns>
+    /// <c>true</c> only when not in Pick Mode, no tool is active, no pick
+    /// modifier is held, and a pick is present.
+    /// </returns>
+    internal static bool ShouldClearPickOnTap(
+        bool pickModeActive,
+        bool toolActive,
+        bool pickModifierActive,
+        bool hasPick)
+        => !pickModeActive && !toolActive && !pickModifierActive && hasPick;
 
     /// <summary>
     /// Returns true when the modifier state captured at the most recent

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -1042,7 +1042,16 @@ internal sealed class MainViewModel : ViewModelBase
             switch (dock)
             {
                 case TabDock.Left: IsLeftDockOpen = false; break;
-                case TabDock.Right: IsRightDockOpen = false; break;
+                case TabDock.Right:
+                    IsRightDockOpen = false;
+                    // Dismissing the Pick Report should also drop the map
+                    // highlight so the report and overlay stay in sync, and so
+                    // a subsequent pick re-fires HasPick false→true and
+                    // re-opens the dock. Only clear when the dock being closed
+                    // is actually showing the Pick Report.
+                    if (ReferenceEquals(_selectedRightTab?.ViewModel, PickReport))
+                        PickReport.Clear();
+                    break;
                 case TabDock.Bottom: IsBottomDockOpen = false; break;
             }
         });

--- a/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MainViewModelPickModeTests.cs
@@ -7,6 +7,8 @@ using EncDotNet.S100.Portrayals;
 using EncDotNet.S100.Viewer.Catalogs;
 using EncDotNet.S100.Viewer.Services;
 using EncDotNet.S100.Viewer.ViewModels;
+using EncDotNet.S100.Viewer.ViewModels.Activities;
+using EncDotNet.S100.Viewer.Views;
 using Mapsui.Layers;
 
 namespace EncDotNet.S100.Viewer.Tests;
@@ -52,7 +54,9 @@ public class MainViewModelPickModeTests
         public event Action<string>? ActiveChanged { add { } remove { } }
     }
 
-    private static MainViewModel CreateViewModel()
+    private static MainViewModel CreateViewModel(
+        PickReportViewModel? pickReport = null,
+        IEnumerable<IActivityTab>? activityTabs = null)
     {
         // Construct in-memory settings (without invoking Save()) and a
         // throwaway catalogue manager. MainViewModel only touches the
@@ -71,7 +75,7 @@ public class MainViewModelPickModeTests
             layerStack: new LayerStackViewModel(new StubDatasetLoaderService()),
             search: new FeatureSearchViewModel(new StubFeatureSearchService(), new StubPickService()),
             settingsViewModel: new SettingsViewModel(settings),
-            pickReport: new PickReportViewModel(),
+            pickReport: pickReport ?? new PickReportViewModel(),
             timeline: new TimelineViewModel(new GlobalTimeService()),
             displayToolbar: new DisplayToolbarViewModel(new EcdisDisplayState()),
             textToolbar: new TextGroupToolbarViewModel(new EcdisDisplayState(), catalogues, datasets),
@@ -79,8 +83,29 @@ public class MainViewModelPickModeTests
             themeService: new StubThemeService(),
             recentFiles: new StubRecentFilesService(),
             measureAppearance: new StubMeasureOverlayAppearanceProvider(),
-            notifications: Notifications.TestNotifications.Create());
+            notifications: Notifications.TestNotifications.Create(),
+            activityTabs: activityTabs);
     }
+
+    /// <summary>
+    /// Builds a Right-dock activity tab hosting the supplied pick report,
+    /// mirroring the real registration in <c>App</c> (auto-open on content
+    /// signal). The icon factory is never invoked by these tests.
+    /// </summary>
+    private static IActivityTab CreatePickReportTab(PickReportViewModel pickReport) =>
+        new ActivityTab<PickReportViewModel, PickReportView>(
+            id: "PickReport",
+            order: 10,
+            title: "Pick",
+            tooltip: "Pick",
+            iconFactory: static () => new Avalonia.Controls.Border(),
+            viewModel: pickReport,
+            persistAsLastSelected: false,
+            dock: TabDock.Right,
+            autoOpenOnContentSignal: true);
+
+    private static readonly System.Collections.Generic.IReadOnlyList<PickAttribute> NoAttrs =
+        Array.Empty<PickAttribute>();
 
     [Fact]
     public void IsPickModeActive_DefaultsToFalse()
@@ -170,5 +195,41 @@ public class MainViewModelPickModeTests
 
         vm.ToggleRouteEditModeCommand.Execute(null);
         Assert.True(vm.IsToolSummaryVisible);
+    }
+
+    [Fact]
+    public void CloseDockCommand_Right_ClearsPickWhenPickReportShown()
+    {
+        // issue #374: dismissing the Pick Report must also drop the pick (and
+        // its map highlight) so the report and overlay stay in sync.
+        var pickReport = new PickReportViewModel();
+        var vm = CreateViewModel(pickReport, new[] { CreatePickReportTab(pickReport) });
+
+        pickReport.SetPick("FT", "FT name", "ref-1", "ds.000", "S-101", NoAttrs);
+        Assert.True(pickReport.HasPick);
+        Assert.True(vm.IsRightDockOpen);
+
+        vm.CloseDockCommand.Execute(TabDock.Right);
+
+        Assert.False(vm.IsRightDockOpen);
+        Assert.False(pickReport.HasPick);
+    }
+
+    [Fact]
+    public void CloseDockCommand_Right_ThenNewPick_ReopensDock()
+    {
+        // issue #374: after a manual close clears the pick, a fresh pick is a
+        // genuine HasPick false→true transition and re-opens the dock.
+        var pickReport = new PickReportViewModel();
+        var vm = CreateViewModel(pickReport, new[] { CreatePickReportTab(pickReport) });
+
+        pickReport.SetPick("FT", "FT name", "ref-1", "ds.000", "S-101", NoAttrs);
+        vm.CloseDockCommand.Execute(TabDock.Right);
+        Assert.False(vm.IsRightDockOpen);
+
+        pickReport.SetPick("FT2", "FT2 name", "ref-2", "ds.000", "S-101", NoAttrs);
+
+        Assert.True(pickReport.HasPick);
+        Assert.True(vm.IsRightDockOpen);
     }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/MapInteractionControllerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MapInteractionControllerTests.cs
@@ -1,0 +1,63 @@
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers the pure clear-on-tap decision used by
+/// <see cref="MapInteractionController"/> when a plain (unmodified) single-tap
+/// lands on the map outside Pick Mode (issue #374).
+/// </summary>
+public sealed class MapInteractionControllerTests
+{
+    [Fact]
+    public void ShouldClearPickOnTap_ClearsWhenIdleTapWithPick()
+    {
+        Assert.True(MapInteractionController.ShouldClearPickOnTap(
+            pickModeActive: false,
+            toolActive: false,
+            pickModifierActive: false,
+            hasPick: true));
+    }
+
+    [Fact]
+    public void ShouldClearPickOnTap_NoPick_DoesNotClear()
+    {
+        Assert.False(MapInteractionController.ShouldClearPickOnTap(
+            pickModeActive: false,
+            toolActive: false,
+            pickModifierActive: false,
+            hasPick: false));
+    }
+
+    [Fact]
+    public void ShouldClearPickOnTap_InPickMode_DoesNotClear()
+    {
+        Assert.False(MapInteractionController.ShouldClearPickOnTap(
+            pickModeActive: true,
+            toolActive: false,
+            pickModifierActive: false,
+            hasPick: true));
+    }
+
+    [Fact]
+    public void ShouldClearPickOnTap_ToolActive_DoesNotClear()
+    {
+        Assert.False(MapInteractionController.ShouldClearPickOnTap(
+            pickModeActive: false,
+            toolActive: true,
+            pickModifierActive: false,
+            hasPick: true));
+    }
+
+    [Fact]
+    public void ShouldClearPickOnTap_ModifierHeld_DoesNotClear()
+    {
+        // A modifier-click is a one-shot pick, never a clear.
+        Assert.False(MapInteractionController.ShouldClearPickOnTap(
+            pickModeActive: false,
+            toolActive: false,
+            pickModifierActive: true,
+            hasPick: true));
+    }
+}


### PR DESCRIPTION
## Summary

The viewer recently gained a map highlight for the picked item of a pick report, but there was no user-facing way to clear it. Once a pick was made, the highlight stayed on the map indefinitely: closing the Pick Report panel only hid the dock and never cleared the pick state.

This PR gives the user two natural ways to dismiss a pick and its highlight:

- A plain single-click on the map (while not in Pick Mode, with no map tool active, and no pick modifier held) clears the current pick, following the common "click empty space to deselect" convention. The decision is factored into a small pure function, `MapInteractionController.ShouldClearPickOnTap`, so the rule is unit testable without an Avalonia `MapControl`.
- Closing the Pick Report dock now also clears the pick, so the report and the map overlay stay in sync.

A nice side effect of clearing on close: it resets `HasPick` to false, so a subsequent pick is a genuine `HasPick` false to true transition and re-fires `ContentBecameAvailable`, which re-opens the panel. This fixes a related annoyance where picking a feature after manually closing the panel did not bring the panel back.

Closes #374.

### Note for reviewers

The first tap of a double-tap-to-zoom also raises a single-tap, so double-tapping to zoom while a pick is active will also clear it. This is intentional (clearing is harmless there) and documented in a code comment, but worth a look if different behaviour is preferred.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A — viewer interaction behaviour only; no spec semantics touched.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New coverage: `MapInteractionControllerTests` (truth table for `ShouldClearPickOnTap`) and two `MainViewModelPickModeTests` cases (close clears the pick; a new pick re-opens a manually-closed dock). Full viewer suite passes (1263 passed, 1 skipped).

## Documentation

- [x] New public APIs have XML doc comments
- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed

No README/docs changes: the new seam is `internal`, and the behaviour change is small and self-describing.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.