### PR TITLE
Persist viewer routes to a JSON store in the data directory

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -283,6 +283,13 @@ public partial class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            // Load persisted routes before the main window (and its route
+            // overlay / panel) are built so they observe the saved set on
+            // first render; the coordinator then writes changes back.
+            var routePersistence =
+                s_services.GetRequiredService<EncDotNet.S100.Viewer.Services.RoutePersistenceService>();
+            routePersistence.Initialize();
+
             desktop.MainWindow = s_services.GetRequiredService<MainWindow>();
 
             // Drain the tiled renderer's background Skia workers before the
@@ -292,7 +299,12 @@ public partial class App : Application
             // alike. Without this, the managed runtime can begin destroying
             // libSkiaSharp while a worker is mid-rasterise → native SIGSEGV.
             desktop.ShutdownRequested += (_, _) =>
+            {
+                // Flush any pending debounced route save so the last edit is
+                // not lost to the debounce window.
+                routePersistence.Flush();
                 EncDotNet.S100.Renderers.Mapsui.S100VectorTileRenderer.ShutdownAndDrain(TimeSpan.FromSeconds(5));
+            };
         }
 
         base.OnFrameworkInitializationCompleted();
@@ -396,6 +408,11 @@ public partial class App : Application
         services.AddSingleton<ScreenshotService>();
         services.AddSingleton<EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider, MeasureOverlayAppearanceProvider>();
         services.AddSingleton<EncDotNet.S100.Viewer.Services.RoutesService>();
+        // Loads persisted routes at startup and writes them back (debounced)
+        // on change, so user/agent routes survive a restart. Eagerly
+        // initialized in OnFrameworkInitializationCompleted and flushed on
+        // ShutdownRequested.
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.RoutePersistenceService>();
 
         // Phase 3 services: dataset orchestration, pick dispatch, file dialogs
         services.AddSingleton<GlobalTimeService>();

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -23,7 +23,9 @@ dotnet run --project src/EncDotNet.S100.Viewer
 
 User settings (recent files, panel layout, ECDIS overrides, vessel
 geometry, …) are persisted per user; the viewer ignores or migrates
-older settings shapes silently rather than refusing to start.
+older settings shapes silently rather than refusing to start. Editable
+[routes](#routes) are persisted separately in `routes.json` (see that
+section).
 
 ## Linux runtime prerequisites
 
@@ -148,6 +150,14 @@ The active route is emphasised on the map; inactive routes recede so
 several routes can coexist legibly. The model mirrors the in-repo
 S-421 route schema (`Route` → `RouteWaypoint` → `RouteLeg`), keeping a
 future S-421 export a near-mechanical projection.
+
+Routes are **persisted across restarts**: the collection is saved to a
+`routes.json` file in the viewer data directory (alongside
+`settings.json`, and re-rooted under `--data-dir` / `S100_DATA_DIR`
+when one is in use). Saved routes load at startup and changes — from
+either the editor or an agent over MCP — are written back (debounced),
+with a final flush on exit. An `--ephemeral` run still loads any
+existing routes but never writes, leaving the persisted file untouched.
 
 ## Layer stack
 

--- a/src/EncDotNet.S100.Viewer/Routing/Persistence/RouteStore.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/Persistence/RouteStore.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using EncDotNet.S100.DataModel;
+
+namespace EncDotNet.S100.Viewer.Routing.Persistence;
+
+/// <summary>
+/// Reads and writes the viewer's editable <see cref="RouteCollection"/> to a
+/// JSON file (<c>routes.json</c>) in the viewer data directory. Translates
+/// between the behaviour-bearing domain types and the flat
+/// <see cref="RouteStoreDocument"/> DTO graph used on disk.
+/// </summary>
+/// <remarks>
+/// Loading is tolerant: a missing file, an empty/whitespace file, malformed
+/// JSON, or a document whose <see cref="RouteStoreDocument.SchemaVersion"/>
+/// this build does not understand all leave the supplied collection
+/// untouched rather than throwing, so a corrupt file never blocks viewer
+/// startup. Structural anomalies within an otherwise-valid document (a leg
+/// count that disagrees with the waypoint count, a waypoint with no
+/// coordinates) are repaired by reconstructing legs through the
+/// <see cref="Route"/> API and clamping to the available data.
+/// </remarks>
+internal static class RouteStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Serializes <paramref name="routes"/> to <paramref name="path"/>,
+    /// creating the containing directory when needed. The write is staged
+    /// through a sibling temporary file and moved into place so a crash
+    /// mid-write cannot leave a half-written <c>routes.json</c>.
+    /// </summary>
+    /// <param name="routes">The collection to persist.</param>
+    /// <param name="path">Destination file path.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="routes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is null or whitespace.</exception>
+    public static void Save(RouteCollection routes, string path)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("A routes file path is required.", nameof(path));
+
+        var document = ToDocument(routes);
+
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = JsonSerializer.Serialize(document, SerializerOptions);
+
+        var tempPath = path + ".tmp";
+        File.WriteAllText(tempPath, json);
+        // File.Move with overwrite is atomic on the same volume on the
+        // platforms the viewer targets, so a reader never sees a partial file.
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// Loads routes from <paramref name="path"/> into
+    /// <paramref name="routes"/>, replacing whatever the collection currently
+    /// holds. A missing, empty, malformed, or unrecognised-version file
+    /// leaves the collection empty and reports success (<c>false</c> return
+    /// only signals "nothing was loaded", never a hard failure).
+    /// </summary>
+    /// <param name="routes">The collection to populate.</param>
+    /// <param name="path">Source file path.</param>
+    /// <returns><c>true</c> when at least one route was loaded.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="routes"/> is <c>null</c>.</exception>
+    public static bool Load(RouteCollection routes, string path)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+
+        ClearAll(routes);
+
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return false;
+
+        RouteStoreDocument? document;
+        try
+        {
+            var json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return false;
+            document = JsonSerializer.Deserialize<RouteStoreDocument>(json, SerializerOptions);
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            // Corrupt or unreadable file: start with no routes rather than
+            // failing the load. The next save overwrites the bad file.
+            return false;
+        }
+
+        if (document is null || document.SchemaVersion != RouteStoreDocument.CurrentSchemaVersion)
+            return false;
+
+        return Populate(routes, document);
+    }
+
+    private static RouteStoreDocument ToDocument(RouteCollection routes)
+    {
+        var document = new RouteStoreDocument
+        {
+            ActiveRouteId = routes.ActiveRoute?.Id,
+        };
+
+        foreach (var route in routes.Routes)
+        {
+            var routeDocument = new RouteDocument
+            {
+                Id = route.Id,
+                Info = ToDocument(route.Info),
+            };
+
+            foreach (var waypoint in route.Waypoints)
+            {
+                routeDocument.Waypoints.Add(new RouteWaypointDocument
+                {
+                    Latitude = waypoint.Position.Latitude,
+                    Longitude = waypoint.Position.Longitude,
+                    Number = waypoint.Number,
+                    Name = waypoint.Name,
+                    Fixed = waypoint.Fixed,
+                    TurnRadiusNm = waypoint.TurnRadiusNm,
+                });
+            }
+
+            foreach (var leg in route.Legs)
+                routeDocument.Legs.Add(ToDocument(leg));
+
+            document.Routes.Add(routeDocument);
+        }
+
+        return document;
+    }
+
+    private static RouteInfoDocument ToDocument(RouteInfo info) => new()
+    {
+        Name = info.Name,
+        Author = info.Author,
+        Description = info.Description,
+        DeparturePortId = info.DeparturePortId,
+        ArrivalPortId = info.ArrivalPortId,
+        ValidityStart = info.ValidityStart,
+        ValidityEnd = info.ValidityEnd,
+        Vessel = info.Vessel is { } v
+            ? new RouteVesselInfoDocument
+            {
+                Name = v.Name,
+                Mmsi = v.Mmsi,
+                Imo = v.Imo,
+                Callsign = v.Callsign,
+                LengthMeters = v.LengthMeters,
+                BeamMeters = v.BeamMeters,
+            }
+            : null,
+    };
+
+    private static RouteLegDocument ToDocument(RouteLeg leg) => new()
+    {
+        GeometryType = leg.GeometryType.ToString(),
+        StarboardCrossTrackDistanceLimitMeters = leg.StarboardCrossTrackDistanceLimitMeters,
+        PortCrossTrackDistanceLimitMeters = leg.PortCrossTrackDistanceLimitMeters,
+        StarboardChannelLimitMeters = leg.StarboardChannelLimitMeters,
+        PortChannelLimitMeters = leg.PortChannelLimitMeters,
+        SafetyContourMeters = leg.SafetyContourMeters,
+        SafetyDepthMeters = leg.SafetyDepthMeters,
+        SpeedOverGroundMinKnots = leg.SpeedOverGroundMinKnots,
+        SpeedOverGroundMaxKnots = leg.SpeedOverGroundMaxKnots,
+        SpeedThroughWaterMinKnots = leg.SpeedThroughWaterMinKnots,
+        SpeedThroughWaterMaxKnots = leg.SpeedThroughWaterMaxKnots,
+        DraftMeters = leg.DraftMeters,
+        StaticUnderKeelClearanceMeters = leg.StaticUnderKeelClearanceMeters,
+        DynamicUnderKeelClearanceMeters = leg.DynamicUnderKeelClearanceMeters,
+        SafetyMarginMeters = leg.SafetyMarginMeters,
+        Note = leg.Note,
+    };
+
+    private static bool Populate(RouteCollection routes, RouteStoreDocument document)
+    {
+        var loadedAny = false;
+
+        foreach (var routeDocument in document.Routes)
+        {
+            Route route;
+            try
+            {
+                route = routes.CreateRoute(routeDocument.Info?.Name, routeDocument.Id);
+            }
+            catch (ArgumentException)
+            {
+                // Duplicate id in a hand-edited file: skip the offender and
+                // keep loading the rest.
+                continue;
+            }
+
+            ApplyInfo(route.Info, routeDocument.Info);
+
+            foreach (var waypointDocument in routeDocument.Waypoints)
+            {
+                var waypoint = route.AppendWaypoint(
+                    new GeoPosition(waypointDocument.Latitude, waypointDocument.Longitude));
+                waypoint.Number = waypointDocument.Number;
+                waypoint.Name = waypointDocument.Name;
+                waypoint.Fixed = waypointDocument.Fixed;
+                waypoint.TurnRadiusNm = waypointDocument.TurnRadiusNm;
+            }
+
+            // The route rebuilt its own legs as waypoints were appended; copy
+            // the persisted leg attributes onto the matching segments, tolerant
+            // of a document whose leg count disagrees with the waypoint count.
+            var legCount = Math.Min(route.Legs.Count, routeDocument.Legs.Count);
+            for (var i = 0; i < legCount; i++)
+                ApplyLeg(route.Legs[i], routeDocument.Legs[i]);
+
+            loadedAny = true;
+        }
+
+        // Restore the active route; CreateRoute left the last-added route
+        // active, so only override when a different one was persisted.
+        if (document.ActiveRouteId is { } activeId && routes.FindById(activeId) is { } active)
+            routes.SetActiveRoute(active);
+
+        return loadedAny;
+    }
+
+    private static void ApplyInfo(RouteInfo info, RouteInfoDocument? document)
+    {
+        if (document is null)
+            return;
+
+        // Name is seeded by CreateRoute; the rest start null.
+        info.Name = document.Name;
+        info.Author = document.Author;
+        info.Description = document.Description;
+        info.DeparturePortId = document.DeparturePortId;
+        info.ArrivalPortId = document.ArrivalPortId;
+        info.ValidityStart = document.ValidityStart;
+        info.ValidityEnd = document.ValidityEnd;
+        info.Vessel = document.Vessel is { } v
+            ? new RouteVesselInfo
+            {
+                Name = v.Name,
+                Mmsi = v.Mmsi,
+                Imo = v.Imo,
+                Callsign = v.Callsign,
+                LengthMeters = v.LengthMeters,
+                BeamMeters = v.BeamMeters,
+            }
+            : null;
+    }
+
+    private static void ApplyLeg(RouteLeg leg, RouteLegDocument document)
+    {
+        leg.GeometryType = Enum.TryParse<RouteLegGeometryType>(document.GeometryType, ignoreCase: true, out var geometry)
+            ? geometry
+            : RouteLegGeometryType.Loxodrome;
+        leg.StarboardCrossTrackDistanceLimitMeters = document.StarboardCrossTrackDistanceLimitMeters;
+        leg.PortCrossTrackDistanceLimitMeters = document.PortCrossTrackDistanceLimitMeters;
+        leg.StarboardChannelLimitMeters = document.StarboardChannelLimitMeters;
+        leg.PortChannelLimitMeters = document.PortChannelLimitMeters;
+        leg.SafetyContourMeters = document.SafetyContourMeters;
+        leg.SafetyDepthMeters = document.SafetyDepthMeters;
+        leg.SpeedOverGroundMinKnots = document.SpeedOverGroundMinKnots;
+        leg.SpeedOverGroundMaxKnots = document.SpeedOverGroundMaxKnots;
+        leg.SpeedThroughWaterMinKnots = document.SpeedThroughWaterMinKnots;
+        leg.SpeedThroughWaterMaxKnots = document.SpeedThroughWaterMaxKnots;
+        leg.DraftMeters = document.DraftMeters;
+        leg.StaticUnderKeelClearanceMeters = document.StaticUnderKeelClearanceMeters;
+        leg.DynamicUnderKeelClearanceMeters = document.DynamicUnderKeelClearanceMeters;
+        leg.SafetyMarginMeters = document.SafetyMarginMeters;
+        leg.Note = document.Note;
+    }
+
+    private static void ClearAll(RouteCollection routes)
+    {
+        // Snapshot first: Remove mutates the underlying list.
+        foreach (var route in new List<Route>(routes.Routes))
+            routes.Remove(route);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Routing/Persistence/RouteStoreDocument.cs
+++ b/src/EncDotNet.S100.Viewer/Routing/Persistence/RouteStoreDocument.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Routing.Persistence;
+
+/// <summary>
+/// The on-disk JSON shape of the viewer's saved routes. A deliberately
+/// flat, nullable mirror of the in-memory <see cref="RouteCollection"/>
+/// object graph: the domain types carry behaviour, invariants, and
+/// <c>internal</c> setters that do not round-trip through
+/// <c>System.Text.Json</c> directly, so persistence goes through these
+/// plain data-transfer records instead.
+/// </summary>
+/// <remarks>
+/// The field names follow the S-421 attribute vocabulary the domain types
+/// already document so a saved route reads consistently with an exported
+/// S-421 GML route plan. <see cref="SchemaVersion"/> guards forward
+/// migrations: an unknown future version is treated as unreadable and the
+/// viewer starts with no routes rather than mis-parsing.
+/// </remarks>
+internal sealed class RouteStoreDocument
+{
+    /// <summary>
+    /// The schema version this codebase reads and writes. Bump when the
+    /// shape changes incompatibly so older builds reject newer files.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>Schema version of the persisted document.</summary>
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+    /// <summary>
+    /// <see cref="Route.Id"/> of the route that was active at save time,
+    /// or <c>null</c> when the collection had no active route.
+    /// </summary>
+    public string? ActiveRouteId { get; set; }
+
+    /// <summary>All saved routes, in collection order.</summary>
+    public List<RouteDocument> Routes { get; set; } = new();
+}
+
+/// <summary>Persisted form of a single <see cref="Route"/>.</summary>
+internal sealed class RouteDocument
+{
+    /// <summary>Stable route id (<see cref="Route.Id"/>).</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Route-level metadata.</summary>
+    public RouteInfoDocument? Info { get; set; }
+
+    /// <summary>Waypoints in route order.</summary>
+    public List<RouteWaypointDocument> Waypoints { get; set; } = new();
+
+    /// <summary>
+    /// Legs in route order; <c>Legs[i]</c> joins <c>Waypoints[i]</c> to
+    /// <c>Waypoints[i+1]</c>, so a well-formed document has
+    /// <c>max(0, Waypoints.Count - 1)</c> legs.
+    /// </summary>
+    public List<RouteLegDocument> Legs { get; set; } = new();
+}
+
+/// <summary>Persisted form of a <see cref="RouteInfo"/>.</summary>
+internal sealed class RouteInfoDocument
+{
+    /// <inheritdoc cref="RouteInfo.Name"/>
+    public string? Name { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.Author"/>
+    public string? Author { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.Description"/>
+    public string? Description { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.DeparturePortId"/>
+    public string? DeparturePortId { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.ArrivalPortId"/>
+    public string? ArrivalPortId { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.ValidityStart"/>
+    public DateTimeOffset? ValidityStart { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.ValidityEnd"/>
+    public DateTimeOffset? ValidityEnd { get; set; }
+
+    /// <inheritdoc cref="RouteInfo.Vessel"/>
+    public RouteVesselInfoDocument? Vessel { get; set; }
+}
+
+/// <summary>Persisted form of a <see cref="RouteVesselInfo"/>.</summary>
+internal sealed class RouteVesselInfoDocument
+{
+    /// <inheritdoc cref="RouteVesselInfo.Name"/>
+    public string? Name { get; set; }
+
+    /// <inheritdoc cref="RouteVesselInfo.Mmsi"/>
+    public string? Mmsi { get; set; }
+
+    /// <inheritdoc cref="RouteVesselInfo.Imo"/>
+    public string? Imo { get; set; }
+
+    /// <inheritdoc cref="RouteVesselInfo.Callsign"/>
+    public string? Callsign { get; set; }
+
+    /// <inheritdoc cref="RouteVesselInfo.LengthMeters"/>
+    public double? LengthMeters { get; set; }
+
+    /// <inheritdoc cref="RouteVesselInfo.BeamMeters"/>
+    public double? BeamMeters { get; set; }
+}
+
+/// <summary>Persisted form of a <see cref="RouteWaypoint"/>.</summary>
+internal sealed class RouteWaypointDocument
+{
+    /// <summary>Latitude in decimal degrees, positive north (WGS-84).</summary>
+    public double Latitude { get; set; }
+
+    /// <summary>Longitude in decimal degrees, positive east (WGS-84).</summary>
+    public double Longitude { get; set; }
+
+    /// <inheritdoc cref="RouteWaypoint.Number"/>
+    public int? Number { get; set; }
+
+    /// <inheritdoc cref="RouteWaypoint.Name"/>
+    public string? Name { get; set; }
+
+    /// <inheritdoc cref="RouteWaypoint.Fixed"/>
+    public bool? Fixed { get; set; }
+
+    /// <inheritdoc cref="RouteWaypoint.TurnRadiusNm"/>
+    public double? TurnRadiusNm { get; set; }
+}
+
+/// <summary>Persisted form of a <see cref="RouteLeg"/>.</summary>
+internal sealed class RouteLegDocument
+{
+    /// <summary>
+    /// Leg path definition, persisted by enumerator name
+    /// (<see cref="RouteLegGeometryType"/>). Unknown values fall back to
+    /// <see cref="RouteLegGeometryType.Loxodrome"/> on load.
+    /// </summary>
+    public string? GeometryType { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.StarboardCrossTrackDistanceLimitMeters"/>
+    public double? StarboardCrossTrackDistanceLimitMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.PortCrossTrackDistanceLimitMeters"/>
+    public double? PortCrossTrackDistanceLimitMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.StarboardChannelLimitMeters"/>
+    public double? StarboardChannelLimitMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.PortChannelLimitMeters"/>
+    public double? PortChannelLimitMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SafetyContourMeters"/>
+    public double? SafetyContourMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SafetyDepthMeters"/>
+    public double? SafetyDepthMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SpeedOverGroundMinKnots"/>
+    public double? SpeedOverGroundMinKnots { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SpeedOverGroundMaxKnots"/>
+    public double? SpeedOverGroundMaxKnots { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SpeedThroughWaterMinKnots"/>
+    public double? SpeedThroughWaterMinKnots { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SpeedThroughWaterMaxKnots"/>
+    public double? SpeedThroughWaterMaxKnots { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.DraftMeters"/>
+    public double? DraftMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.StaticUnderKeelClearanceMeters"/>
+    public double? StaticUnderKeelClearanceMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.DynamicUnderKeelClearanceMeters"/>
+    public double? DynamicUnderKeelClearanceMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.SafetyMarginMeters"/>
+    public double? SafetyMarginMeters { get; set; }
+
+    /// <inheritdoc cref="RouteLeg.Note"/>
+    public string? Note { get; set; }
+}

--- a/src/EncDotNet.S100.Viewer/Services/RoutePersistenceService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/RoutePersistenceService.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Threading;
+using EncDotNet.S100.Viewer.Routing.Persistence;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Bridges the in-memory <see cref="RoutesService"/> to the on-disk
+/// <c>routes.json</c> store: loads saved routes once at startup and writes
+/// them back (debounced) whenever the route set changes, so a user's (or an
+/// agent's) routes survive a viewer restart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The coordinator is deliberately thin — all serialization lives in
+/// <see cref="RouteStore"/>. It subscribes to
+/// <see cref="RouteCollection.Changed"/> (not the broader
+/// <see cref="RoutesService.Changed"/>) so transient editor-selection
+/// changes, which are not persisted, do not trigger redundant writes.
+/// </para>
+/// <para>
+/// Saves are coalesced behind a short debounce timer because a single user
+/// gesture (e.g. building a multi-waypoint route) raises many change events
+/// in quick succession; <see cref="Flush"/> forces any pending write out
+/// synchronously and is called on shutdown. When the run is read-only
+/// (<c>--ephemeral</c>) the coordinator still loads the user's existing
+/// routes but never writes, leaving the persisted file untouched.
+/// </para>
+/// </remarks>
+internal sealed class RoutePersistenceService : IDisposable
+{
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(750);
+
+    private readonly RoutesService _routes;
+    private readonly string _path;
+    private readonly bool _readOnly;
+    private readonly object _gate = new();
+
+    private Timer? _debounce;
+    private bool _initialized;
+    private bool _loading;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates the coordinator for the supplied route service, resolving the
+    /// store path and read-only policy from the run's data paths and
+    /// settings. Construction does no I/O; call <see cref="Initialize"/> once
+    /// the rest of startup is ready.
+    /// </summary>
+    /// <param name="routes">The application route service to persist.</param>
+    /// <param name="dataPaths">Provides the <c>routes.json</c> location.</param>
+    /// <param name="settings">Supplies the read-only (<c>--ephemeral</c>) flag.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <c>null</c>.</exception>
+    public RoutePersistenceService(RoutesService routes, ViewerDataPaths dataPaths, ViewerSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        ArgumentNullException.ThrowIfNull(dataPaths);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        _routes = routes;
+        _path = dataPaths.RoutesFilePath;
+        _readOnly = settings.IsReadOnly;
+    }
+
+    /// <summary>
+    /// Loads persisted routes into the route service and begins tracking
+    /// subsequent changes for save. Idempotent: a second call is a no-op.
+    /// A load failure is swallowed (the service starts with no routes) so a
+    /// corrupt file never blocks startup.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized)
+            return;
+        _initialized = true;
+
+        _loading = true;
+        try
+        {
+            RouteStore.Load(_routes.Routes, _path);
+        }
+        catch
+        {
+            // Best-effort: RouteStore.Load already absorbs the expected I/O
+            // and JSON faults; this guards against anything unforeseen so the
+            // viewer still launches with an empty route set.
+        }
+        finally
+        {
+            _loading = false;
+        }
+
+        // Persist structural route changes only; selection changes flow
+        // through RoutesService.Changed, which we intentionally ignore here.
+        _routes.Routes.Changed += OnRoutesChanged;
+    }
+
+    private void OnRoutesChanged(object? sender, EventArgs e)
+    {
+        if (_loading || _readOnly || _disposed)
+            return;
+        ScheduleSave();
+    }
+
+    private void ScheduleSave()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _debounce ??= new Timer(_ => SaveNow());
+            _debounce.Change(DebounceDelay, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>
+    /// Writes the current route set to disk immediately, cancelling any
+    /// pending debounced save. A no-op for read-only runs. Exposed for tests
+    /// and used by <see cref="Flush"/>.
+    /// </summary>
+    public void SaveNow()
+    {
+        lock (_gate)
+        {
+            _debounce?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+
+        if (_readOnly)
+            return;
+
+        try
+        {
+            RouteStore.Save(_routes.Routes, _path);
+        }
+        catch
+        {
+            // Best-effort persistence: a failed save must not crash the app
+            // or block shutdown. The next change reschedules another attempt.
+        }
+    }
+
+    /// <summary>
+    /// Forces any pending debounced save to complete synchronously. Call on
+    /// shutdown so the final edit is not lost to the debounce window.
+    /// </summary>
+    public void Flush() => SaveNow();
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _debounce?.Dispose();
+            _debounce = null;
+        }
+
+        _routes.Routes.Changed -= OnRoutesChanged;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewerDataPaths.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerDataPaths.cs
@@ -70,6 +70,19 @@ internal sealed class ViewerDataPaths
         ?? (_baseDirectory is { } b ? Path.Combine(b, "settings.json")
             : Path.Combine(DefaultSettingsDirectory, "settings.json"));
 
+    /// <summary>
+    /// Absolute path of the persisted <c>routes.json</c> file holding the
+    /// user's editable routes. Re-rooted under the base directory when one
+    /// is in use (so an isolated <c>--data-dir</c> instance keeps its routes
+    /// self-contained) and sits alongside <see cref="SettingsFilePath"/>
+    /// otherwise. Unlike the settings file it is not affected by the
+    /// <c>--settings</c> override, which pins only the settings file.
+    /// </summary>
+    public string RoutesFilePath =>
+        _baseDirectory is { } b
+            ? Path.Combine(b, "routes.json")
+            : Path.Combine(DefaultSettingsDirectory, "routes.json");
+
     /// <summary>Directory holding unclean-shutdown crash markers.</summary>
     public string CrashMarkersDirectory =>
         _baseDirectory is { } b

--- a/tests/EncDotNet.S100.Viewer.Tests/RoutePersistenceServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RoutePersistenceServiceTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Routing.Persistence;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RoutePersistenceServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly ViewerDataPaths _paths;
+
+    public RoutePersistenceServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "RoutePersistenceTests_" + Guid.NewGuid().ToString("n"));
+        _paths = new ViewerDataPaths(_dir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort temp cleanup.
+        }
+    }
+
+    [Fact]
+    public void Initialize_LoadsPersistedRoutesIntoService()
+    {
+        // Seed a routes.json directly through the store.
+        var seed = new RouteCollection();
+        var route = seed.CreateRoute("Seeded", "route-1");
+        route.AppendWaypoint(new GeoPosition(1, 2));
+        route.AppendWaypoint(new GeoPosition(3, 4));
+        RouteStore.Save(seed, _paths.RoutesFilePath);
+
+        var routes = new RoutesService();
+        using var persistence = new RoutePersistenceService(routes, _paths, new ViewerSettings());
+        persistence.Initialize();
+
+        var loaded = Assert.Single(routes.Routes.Routes);
+        Assert.Equal("route-1", loaded.Id);
+        Assert.Equal(2, loaded.Waypoints.Count);
+    }
+
+    [Fact]
+    public void Flush_AfterChange_WritesRoutesToDisk()
+    {
+        var routes = new RoutesService();
+        using var persistence = new RoutePersistenceService(routes, _paths, new ViewerSettings());
+        persistence.Initialize();
+
+        var route = routes.Routes.CreateRoute("New", "route-9");
+        route.AppendWaypoint(new GeoPosition(10, 20));
+
+        persistence.Flush();
+
+        Assert.True(File.Exists(_paths.RoutesFilePath));
+
+        var reread = new RouteCollection();
+        RouteStore.Load(reread, _paths.RoutesFilePath);
+        var persisted = Assert.Single(reread.Routes);
+        Assert.Equal("route-9", persisted.Id);
+    }
+
+    [Fact]
+    public void ReadOnly_DoesNotWriteOnFlush()
+    {
+        var routes = new RoutesService();
+        using var persistence = new RoutePersistenceService(
+            routes, _paths, new ViewerSettings { IsReadOnly = true });
+        persistence.Initialize();
+
+        routes.Routes.CreateRoute("Ephemeral");
+
+        persistence.Flush();
+
+        Assert.False(File.Exists(_paths.RoutesFilePath));
+    }
+
+    [Fact]
+    public void ReadOnly_StillLoadsExistingRoutes()
+    {
+        var seed = new RouteCollection();
+        seed.CreateRoute("Existing", "route-1");
+        RouteStore.Save(seed, _paths.RoutesFilePath);
+
+        var routes = new RoutesService();
+        using var persistence = new RoutePersistenceService(
+            routes, _paths, new ViewerSettings { IsReadOnly = true });
+        persistence.Initialize();
+
+        Assert.Single(routes.Routes.Routes);
+    }
+
+    [Fact]
+    public void Initialize_IsIdempotent()
+    {
+        var routes = new RoutesService();
+        using var persistence = new RoutePersistenceService(routes, _paths, new ViewerSettings());
+        persistence.Initialize();
+        persistence.Initialize(); // second call must be a no-op, not throw.
+
+        routes.Routes.CreateRoute("One");
+        persistence.Flush();
+
+        var reread = new RouteCollection();
+        RouteStore.Load(reread, _paths.RoutesFilePath);
+        Assert.Single(reread.Routes);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/RouteStoreTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/RouteStoreTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Viewer.Routing;
+using EncDotNet.S100.Viewer.Routing.Persistence;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class RouteStoreTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _path;
+
+    public RouteStoreTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "RouteStoreTests_" + Guid.NewGuid().ToString("n"));
+        _path = Path.Combine(_dir, "routes.json");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort temp cleanup.
+        }
+    }
+
+    [Fact]
+    public void Save_Then_Load_RoundTripsRoutesWaypointsLegsAndActive()
+    {
+        var source = new RouteCollection();
+
+        var first = source.CreateRoute("First", "route-1");
+        first.Info.Author = "Skipper";
+        first.Info.Description = "Coastal hop";
+        first.Info.ArrivalPortId = "GBSOU";
+        first.Info.Vessel = new RouteVesselInfo { Name = "MV Test", Mmsi = "232003000", LengthMeters = 120.5 };
+        var w0 = first.AppendWaypoint(new GeoPosition(50.1, -1.2));
+        w0.Name = "Departure";
+        w0.Number = 1;
+        w0.Fixed = true;
+        w0.TurnRadiusNm = 0.3;
+        first.AppendWaypoint(new GeoPosition(50.4, -1.5));
+        first.Legs[0].GeometryType = RouteLegGeometryType.Geodesic;
+        first.Legs[0].SpeedOverGroundMaxKnots = 18.0;
+        first.Legs[0].Note = "Mind the shoal";
+
+        // A second route, left active, with no legs (single waypoint).
+        var second = source.CreateRoute("Second", "route-2");
+        second.AppendWaypoint(new GeoPosition(10, 20));
+        source.SetActiveRoute(second);
+
+        RouteStore.Save(source, _path);
+
+        Assert.True(File.Exists(_path));
+
+        var loaded = new RouteCollection();
+        var any = RouteStore.Load(loaded, _path);
+
+        Assert.True(any);
+        Assert.Equal(2, loaded.Routes.Count);
+        Assert.Equal("route-2", loaded.ActiveRoute?.Id);
+
+        var loadedFirst = loaded.FindById("route-1");
+        Assert.NotNull(loadedFirst);
+        Assert.Equal("First", loadedFirst!.Name);
+        Assert.Equal("Skipper", loadedFirst.Info.Author);
+        Assert.Equal("Coastal hop", loadedFirst.Info.Description);
+        Assert.Equal("GBSOU", loadedFirst.Info.ArrivalPortId);
+        Assert.Equal("MV Test", loadedFirst.Info.Vessel?.Name);
+        Assert.Equal("232003000", loadedFirst.Info.Vessel?.Mmsi);
+        Assert.Equal(120.5, loadedFirst.Info.Vessel?.LengthMeters);
+
+        Assert.Equal(2, loadedFirst.Waypoints.Count);
+        Assert.Equal(new GeoPosition(50.1, -1.2), loadedFirst.Waypoints[0].Position);
+        Assert.Equal("Departure", loadedFirst.Waypoints[0].Name);
+        Assert.Equal(1, loadedFirst.Waypoints[0].Number);
+        Assert.True(loadedFirst.Waypoints[0].Fixed);
+        Assert.Equal(0.3, loadedFirst.Waypoints[0].TurnRadiusNm);
+
+        Assert.Single(loadedFirst.Legs);
+        Assert.Equal(RouteLegGeometryType.Geodesic, loadedFirst.Legs[0].GeometryType);
+        Assert.Equal(18.0, loadedFirst.Legs[0].SpeedOverGroundMaxKnots);
+        Assert.Equal("Mind the shoal", loadedFirst.Legs[0].Note);
+
+        var loadedSecond = loaded.FindById("route-2");
+        Assert.NotNull(loadedSecond);
+        Assert.Single(loadedSecond!.Waypoints);
+        Assert.Empty(loadedSecond.Legs);
+    }
+
+    [Fact]
+    public void Load_MissingFile_LeavesCollectionEmptyAndReturnsFalse()
+    {
+        var routes = new RouteCollection();
+        routes.CreateRoute("Stale"); // pre-existing content must be cleared.
+
+        var any = RouteStore.Load(routes, _path);
+
+        Assert.False(any);
+        Assert.Empty(routes.Routes);
+        Assert.Null(routes.ActiveRoute);
+    }
+
+    [Fact]
+    public void Load_CorruptJson_LeavesCollectionEmptyAndReturnsFalse()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(_path, "{ this is not valid json ]");
+
+        var routes = new RouteCollection();
+        routes.CreateRoute("Stale");
+
+        var any = RouteStore.Load(routes, _path);
+
+        Assert.False(any);
+        Assert.Empty(routes.Routes);
+    }
+
+    [Fact]
+    public void Load_UnknownSchemaVersion_IsIgnored()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(_path, "{ \"SchemaVersion\": 9999, \"Routes\": [ { \"Id\": \"x\" } ] }");
+
+        var routes = new RouteCollection();
+        var any = RouteStore.Load(routes, _path);
+
+        Assert.False(any);
+        Assert.Empty(routes.Routes);
+    }
+
+    [Fact]
+    public void Load_LegCountExceedingWaypoints_IsClampedNotThrown()
+    {
+        Directory.CreateDirectory(_dir);
+        // One waypoint but two legs: a malformed but parseable document.
+        File.WriteAllText(_path,
+            "{ \"SchemaVersion\": 1, \"Routes\": [ { \"Id\": \"x\", \"Waypoints\": " +
+            "[ { \"Latitude\": 1, \"Longitude\": 2 } ], \"Legs\": [ {}, {} ] } ] }");
+
+        var routes = new RouteCollection();
+        var any = RouteStore.Load(routes, _path);
+
+        Assert.True(any);
+        var route = Assert.Single(routes.Routes);
+        Assert.Single(route.Waypoints);
+        Assert.Empty(route.Legs);
+    }
+
+    [Fact]
+    public void Save_OverwritesExistingFile()
+    {
+        var first = new RouteCollection();
+        first.CreateRoute("Only", "route-1");
+        RouteStore.Save(first, _path);
+
+        var second = new RouteCollection();
+        second.CreateRoute("Replacement", "route-2");
+        RouteStore.Save(second, _path);
+
+        var loaded = new RouteCollection();
+        RouteStore.Load(loaded, _path);
+
+        var route = Assert.Single(loaded.Routes);
+        Assert.Equal("route-2", route.Id);
+    }
+}


### PR DESCRIPTION
## Summary

Routes created in the viewer (via the interactive editor or an agent over the MCP server) were held only in memory by `RoutesService` and lost when the viewer closed. The word "persistent" in the existing route docs referred only to the on-map overlay surviving longer than the transient Measure ruler, not to durable storage.

This adds a simple `routes.json` store in the viewer data directory so routes survive a restart.

The approach keeps `RoutesService` a pure in-memory model and layers persistence beside it:

- `ViewerDataPaths.RoutesFilePath` puts `routes.json` next to `settings.json`, inheriting the existing `--data-dir` / `S100_DATA_DIR` re-rooting so an isolated instance stays self-contained.
- `RouteStore` does tolerant JSON load/save, mapping the behaviour-bearing `RouteCollection` graph to/from flat DTOs (the domain types have `internal` setters and rebuild their own legs, so they don't round-trip directly). A missing, empty, malformed, or unknown-schema-version file leaves the collection empty rather than throwing, and writes go through a temp file + atomic move so a crash mid-write can't corrupt the store.
- `RoutePersistenceService` loads once at startup, debounce-saves (750ms) on `RouteCollection.Changed` so a multi-waypoint build coalesces into one write, and flushes on shutdown. It subscribes to the collection's `Changed` rather than `RoutesService.Changed` so transient editor-selection changes don't trigger redundant writes. `--ephemeral` runs load existing routes but never write.
- App wiring loads routes before the main window builds (so the overlay/panel observe them on first render) and flushes on `ShutdownRequested`.

Verified end-to-end by driving the real viewer headlessly over its MCP server: created a route, confirmed `routes.json` was written by the debounce path, `kill -9`'d the process (bypassing the graceful flush), relaunched against the same data dir, and confirmed the route reloaded identically. Also confirmed an `--ephemeral` relaunch loads the route but leaves the file byte-identical.

This is intentionally a simple local store. Exporting/importing routes as S-421 GML route plans (which the repo already supports) is a sensible follow-up, not part of this PR.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:**

N/A. The persisted field names follow the S-421 attribute vocabulary the route domain types already document, but no new spec-derived constants were introduced.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

`RouteStoreTests` cover round-trip (routes, info, vessel, waypoints, legs, active route), missing/corrupt/unknown-version/malformed files, and overwrite. `RoutePersistenceServiceTests` cover load-on-init, save-on-change via flush, read-only (no write), read-only-still-loads, and idempotent init. The full viewer suite passes (1267 passed, 1 pre-existing skip). None of these need real data files.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Updated the viewer README Routes section to describe persistence, the `routes.json` location, and the `--ephemeral` behaviour. New types carry XML doc comments.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies (uses `System.Text.Json`).

## Breaking changes

None. New file; no existing routes to migrate.

Closes #376