### PR TITLE
Restructure Datasets panel into Exchange sets / Datasets tabs

### DIFF
--- a/.github/skills/viewer-evaluation/SKILL.md
+++ b/.github/skills/viewer-evaluation/SKILL.md
@@ -78,6 +78,15 @@ nohup src/EncDotNet.S100.Viewer/bin/Release/net10.0/<rid>/EncDotNet.S100.Viewer 
   >/tmp/eval/viewer.log 2>&1 & disown
 ```
 
+> **Always launch the viewer fully detached.** From the agent's bash
+> tool, use `mode: "async"` **with `detach: true`** (this `setsid`-wraps
+> the process so it survives the bash session). A plain sync call — even
+> with `nohup … & disown` — leaves the viewer parented to the bash
+> session, so it gets **reaped the moment that call returns** and the
+> window dies on its own with no error in the log. The `nohup …& disown`
+> form above is only correct inside an already-detached async shell. When
+> done, stop it explicitly with `kill -9 <pid>` (see below).
+
 - `--data-dir <PATH>` → **fully isolated instance**: settings, crash
   markers, and all disk caches are re-rooted under the folder. Point it
   at an empty temp dir for a guaranteed-fresh viewer (no local profile

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -107,6 +107,32 @@ and translated to the in-memory S-101 model so they render through
 the S-101 portrayal pipeline. This is best-effort, not an S-52
 implementation.
 
+## The Datasets panel
+
+Loaded data is organised in the **Datasets** activity panel as two
+tabs above a pinned **inspector**:
+
+- **Exchange sets** — a two-level tree that nests each dataset under
+  the exchange set (its *source*) it came from. Each source row carries
+  a member count, the set's signature/integrity badge, a per-source
+  show/hide toggle (which fans out to every member dataset), and a
+  close button that unloads the whole set. There is no reordering here —
+  render order is a cross-source concern and lives in the Datasets tab.
+  Loose, individually-loaded files do not appear on this tab.
+- **Datasets** — the flat render-order list of *every* loaded dataset
+  (exchange-set-backed and loose alike), with per-row visibility,
+  reorder (drag, the ▲/▼ buttons, or the context menu), isolate, and
+  remove, plus a bulk show-all / hide-all / reset-opacity toolbar.
+
+The **inspector** below the tabs reflects whichever item is selected.
+Selecting a dataset (in either tab) shows its **DATASET / LAYERS /
+VALIDATION** sub-tabs; selecting an exchange-set source row instead
+shows that set's metadata (producer, issue date, dataset count,
+signature, source path). The split between the tabs and the inspector
+is draggable and persisted. The panel opens on the Exchange sets tab,
+unless only loose datasets are loaded, in which case it opens on the
+Datasets tab.
+
 ## The map view
 
 A Mapsui-backed map fills the centre of the window with an

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -58,7 +58,6 @@ internal static class Strings
     // Datasets panel — outer tabs, sources tree, and exchange-set inspector
     public static string Pane_Tab_ExchangeSets => Get(nameof(Pane_Tab_ExchangeSets));
     public static string Pane_Tab_Datasets => Get(nameof(Pane_Tab_Datasets));
-    public static string Pane_Sources => Get(nameof(Pane_Sources));
     public static string Pane_ExchangeSets_Empty => Get(nameof(Pane_ExchangeSets_Empty));
     public static string Pane_InspectorSelectPlaceholder => Get(nameof(Pane_InspectorSelectPlaceholder));
     public static string Pane_ExchangeSetField_Source => Get(nameof(Pane_ExchangeSetField_Source));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -54,6 +54,18 @@ internal static class Strings
     public static string Pane_DatasetTab_Layers => Get(nameof(Pane_DatasetTab_Layers));
     public static string Pane_DatasetTab_NoLayers => Get(nameof(Pane_DatasetTab_NoLayers));
     public static string Pane_DatasetTab_Validation => Get(nameof(Pane_DatasetTab_Validation));
+
+    // Datasets panel — outer tabs, sources tree, and exchange-set inspector
+    public static string Pane_Tab_ExchangeSets => Get(nameof(Pane_Tab_ExchangeSets));
+    public static string Pane_Tab_Datasets => Get(nameof(Pane_Tab_Datasets));
+    public static string Pane_Sources => Get(nameof(Pane_Sources));
+    public static string Pane_ExchangeSets_Empty => Get(nameof(Pane_ExchangeSets_Empty));
+    public static string Pane_InspectorSelectPlaceholder => Get(nameof(Pane_InspectorSelectPlaceholder));
+    public static string Pane_ExchangeSetField_Source => Get(nameof(Pane_ExchangeSetField_Source));
+    public static string Pane_ExchangeSetField_Producer => Get(nameof(Pane_ExchangeSetField_Producer));
+    public static string Pane_ExchangeSetField_Issued => Get(nameof(Pane_ExchangeSetField_Issued));
+    public static string Pane_ExchangeSetField_Datasets => Get(nameof(Pane_ExchangeSetField_Datasets));
+    public static string Pane_ExchangeSetField_Path => Get(nameof(Pane_ExchangeSetField_Path));
     public static string Pane_Validation_NoFindings => Get(nameof(Pane_Validation_NoFindings));
     public static string Pane_Validation_NoRulePack => Get(nameof(Pane_Validation_NoRulePack));
     public static string Pane_Validation_CountsSummaryFormat => Get(nameof(Pane_Validation_CountsSummaryFormat));
@@ -145,6 +157,8 @@ internal static class Strings
     public static string Pane_ExchangeSetHeader_Count => Get(nameof(Pane_ExchangeSetHeader_Count));
     public static string Pane_ExchangeSetHeader_Unsupported => Get(nameof(Pane_ExchangeSetHeader_Unsupported));
     public static string Tooltip_CloseExchangeSet => Get(nameof(Tooltip_CloseExchangeSet));
+    public static string Tooltip_ToggleExchangeSetVisibility => Get(nameof(Tooltip_ToggleExchangeSetVisibility));
+    public static string Tooltip_AddSource => Get(nameof(Tooltip_AddSource));
     public static string Tooltip_SignatureVerified => Get(nameof(Tooltip_SignatureVerified));
     public static string Tooltip_SignatureUnsigned => Get(nameof(Tooltip_SignatureUnsigned));
     public static string Tooltip_SignatureInvalid => Get(nameof(Tooltip_SignatureInvalid));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -250,13 +250,10 @@
     <value>Open a dataset or exchange set</value>
   </data>
   <data name="Pane_Tab_ExchangeSets" xml:space="preserve">
-    <value>Exchange sets</value>
+    <value>EXCHANGE SETS</value>
   </data>
   <data name="Pane_Tab_Datasets" xml:space="preserve">
-    <value>Datasets</value>
-  </data>
-  <data name="Pane_Sources" xml:space="preserve">
-    <value>SOURCES</value>
+    <value>DATASETS</value>
   </data>
   <data name="Pane_ExchangeSets_Empty" xml:space="preserve">
     <value>No exchange sets loaded. Open an exchange set to see its datasets here.</value>

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -243,6 +243,42 @@
   <data name="Tooltip_CloseExchangeSet" xml:space="preserve">
     <value>Close this exchange set and remove every dataset it contributed</value>
   </data>
+  <data name="Tooltip_ToggleExchangeSetVisibility" xml:space="preserve">
+    <value>Show or hide every dataset in this exchange set</value>
+  </data>
+  <data name="Tooltip_AddSource" xml:space="preserve">
+    <value>Open a dataset or exchange set</value>
+  </data>
+  <data name="Pane_Tab_ExchangeSets" xml:space="preserve">
+    <value>Exchange sets</value>
+  </data>
+  <data name="Pane_Tab_Datasets" xml:space="preserve">
+    <value>Datasets</value>
+  </data>
+  <data name="Pane_Sources" xml:space="preserve">
+    <value>SOURCES</value>
+  </data>
+  <data name="Pane_ExchangeSets_Empty" xml:space="preserve">
+    <value>No exchange sets loaded. Open an exchange set to see its datasets here.</value>
+  </data>
+  <data name="Pane_InspectorSelectPlaceholder" xml:space="preserve">
+    <value>Select an exchange set or dataset to view its properties.</value>
+  </data>
+  <data name="Pane_ExchangeSetField_Source" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="Pane_ExchangeSetField_Producer" xml:space="preserve">
+    <value>Producer</value>
+  </data>
+  <data name="Pane_ExchangeSetField_Issued" xml:space="preserve">
+    <value>Issued</value>
+  </data>
+  <data name="Pane_ExchangeSetField_Datasets" xml:space="preserve">
+    <value>Datasets</value>
+  </data>
+  <data name="Pane_ExchangeSetField_Path" xml:space="preserve">
+    <value>Path</value>
+  </data>
   <data name="Tooltip_SignatureVerified" xml:space="preserve">
     <value>All digital signatures verified</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -473,28 +473,188 @@ internal sealed class DatasetsViewModel : ViewModelBase
     /// </summary>
     public ObservableCollection<ExchangeSetHeader> ExchangeSetHeaders { get; } = new();
 
-    private DatasetEntry? _selectedEntry;
+    private DatasetEntry? _selectedDataset;
     /// <summary>
-    /// The dataset row currently highlighted in the panel. Drives the
-    /// Properties sub-panel (opacity slider + sub-layer list).
+    /// The dataset row currently highlighted in the <b>Datasets</b> tab's
+    /// flat list. Bound TwoWay to that list's selection. When the Datasets
+    /// tab is active this drives the pinned inspector via
+    /// <see cref="SelectedEntry"/>.
     /// </summary>
-    public DatasetEntry? SelectedEntry
+    public DatasetEntry? SelectedDataset
     {
-        get => _selectedEntry;
+        get => _selectedDataset;
         set
         {
-            if (!ReferenceEquals(_selectedEntry, value))
+            if (!ReferenceEquals(_selectedDataset, value))
             {
-                _selectedEntry = value;
+                _selectedDataset = value;
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(HasSelection));
+                RecomputeInspection();
             }
         }
     }
 
-    /// <summary>True when a dataset row is selected; controls visibility
-    /// of the Properties sub-panel.</summary>
-    public bool HasSelection => _selectedEntry is not null;
+    private object? _selectedSourceNode;
+    /// <summary>
+    /// The node selected in the <b>Exchange sets</b> tab's source tree.
+    /// Either an <see cref="ExchangeSetHeader"/> (a source) or a
+    /// <see cref="DatasetEntry"/> (a nested dataset). Bound TwoWay to the
+    /// tree's selection. When the Exchange sets tab is active this drives
+    /// the pinned inspector.
+    /// </summary>
+    public object? SelectedSourceNode
+    {
+        get => _selectedSourceNode;
+        set
+        {
+            if (!ReferenceEquals(_selectedSourceNode, value))
+            {
+                _selectedSourceNode = value;
+                OnPropertyChanged();
+                RecomputeInspection();
+            }
+        }
+    }
+
+    /// <summary>Tab index constant for the Exchange sets tab.</summary>
+    public const int ExchangeSetsTabIndex = 0;
+
+    /// <summary>Tab index constant for the Datasets tab.</summary>
+    public const int DatasetsTabIndex = 1;
+
+    private bool _suppressTabUserFlag;
+    private bool _userSelectedTab;
+    private int _activeTabIndex = ExchangeSetsTabIndex;
+    /// <summary>
+    /// Active tab in the panel: <see cref="ExchangeSetsTabIndex"/> (0) or
+    /// <see cref="DatasetsTabIndex"/> (1). Bound TwoWay to the
+    /// <c>TabControl.SelectedIndex</c>. A genuine user switch pins the
+    /// choice so the conditional default (see
+    /// <see cref="ApplyDefaultTab"/>) stops overriding it.
+    /// </summary>
+    public int ActiveTabIndex
+    {
+        get => _activeTabIndex;
+        set
+        {
+            if (_activeTabIndex == value) return;
+            _activeTabIndex = value;
+            if (!_suppressTabUserFlag) _userSelectedTab = true;
+            OnPropertyChanged();
+            RecomputeInspection();
+        }
+    }
+
+    private DatasetEntry? _inspectedDataset;
+    private ExchangeSetHeader? _inspectedExchangeSet;
+
+    /// <summary>
+    /// The dataset reflected in the pinned inspector (DATASET / LAYERS /
+    /// VALIDATION). Normally derived from the active tab's selection via
+    /// <see cref="RecomputeInspection"/>, but also directly settable so
+    /// hosts/tests can drive the inspector (and the on-map validation
+    /// overlay that <see cref="Services.ValidationOverlayService"/> keys
+    /// off it) without going through a selection control.
+    /// </summary>
+    public DatasetEntry? SelectedEntry
+    {
+        get => _inspectedDataset;
+        set
+        {
+            if (!ReferenceEquals(_inspectedDataset, value))
+            {
+                _inspectedDataset = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(HasSelection));
+                OnPropertyChanged(nameof(HasNoInspectorSelection));
+            }
+        }
+    }
+
+    /// <summary>The exchange set reflected in the pinned inspector when a
+    /// source node (not a dataset) is selected on the Exchange sets tab.</summary>
+    public ExchangeSetHeader? InspectedExchangeSet => _inspectedExchangeSet;
+
+    /// <summary>True when the inspector targets a dataset; controls
+    /// visibility of the dataset inspector variant.</summary>
+    public bool HasSelection => _inspectedDataset is not null;
+
+    /// <summary>True when the inspector targets an exchange set; controls
+    /// visibility of the exchange-set inspector variant.</summary>
+    public bool HasExchangeSetSelection => _inspectedExchangeSet is not null;
+
+    /// <summary>True when nothing is selected; shows the inspector's
+    /// "select an item" placeholder.</summary>
+    public bool HasNoInspectorSelection =>
+        _inspectedDataset is null && _inspectedExchangeSet is null;
+
+    /// <summary>True when at least one exchange set is loaded; lets the
+    /// Exchange sets tab swap its empty-state for the source tree.</summary>
+    public bool HasExchangeSets => ExchangeSetHeaders.Count > 0;
+
+    private void RecomputeInspection()
+    {
+        DatasetEntry? dataset;
+        ExchangeSetHeader? exchangeSet = null;
+
+        if (_activeTabIndex == DatasetsTabIndex)
+        {
+            dataset = _selectedDataset;
+        }
+        else
+        {
+            switch (_selectedSourceNode)
+            {
+                case ExchangeSetHeader header:
+                    exchangeSet = header;
+                    dataset = null;
+                    break;
+                case DatasetEntry entry:
+                    dataset = entry;
+                    break;
+                default:
+                    dataset = null;
+                    break;
+            }
+        }
+
+        var datasetChanged = !ReferenceEquals(_inspectedDataset, dataset);
+        var exchangeSetChanged = !ReferenceEquals(_inspectedExchangeSet, exchangeSet);
+        if (!datasetChanged && !exchangeSetChanged) return;
+
+        _inspectedDataset = dataset;
+        _inspectedExchangeSet = exchangeSet;
+
+        if (datasetChanged) OnPropertyChanged(nameof(SelectedEntry));
+        if (exchangeSetChanged) OnPropertyChanged(nameof(InspectedExchangeSet));
+        OnPropertyChanged(nameof(HasSelection));
+        OnPropertyChanged(nameof(HasExchangeSetSelection));
+        OnPropertyChanged(nameof(HasNoInspectorSelection));
+    }
+
+    /// <summary>
+    /// Applies the conditional default tab: the Exchange sets tab unless
+    /// only loose (non-exchange-set) datasets are loaded, in which case
+    /// the Datasets tab. A genuine user tab switch pins the choice and
+    /// suppresses this. The pin resets once the panel empties.
+    /// </summary>
+    private void ApplyDefaultTab()
+    {
+        if (IsEmpty)
+        {
+            _userSelectedTab = false;
+        }
+
+        if (_userSelectedTab) return;
+
+        var desired = HasExchangeSets ? ExchangeSetsTabIndex : DatasetsTabIndex;
+        if (_activeTabIndex != desired)
+        {
+            _suppressTabUserFlag = true;
+            ActiveTabIndex = desired;
+            _suppressTabUserFlag = false;
+        }
+    }
 
     /// <summary>
     /// True when no datasets are loaded. Drives the Datasets panel's
@@ -604,6 +764,35 @@ internal sealed class DatasetsViewModel : ViewModelBase
                         entry.ZoomDispatcher = _zoomDispatcher;
                 }
             }
+
+            RebuildExchangeSetGrouping();
+            ApplyDefaultTab();
+
+            // A removed dataset may have been the inspected one; drop the
+            // selection so the inspector doesn't dangle on a gone entry.
+            if (e.OldItems is not null)
+            {
+                foreach (var item in e.OldItems)
+                {
+                    if (ReferenceEquals(item, _selectedDataset)) SelectedDataset = null;
+                    if (ReferenceEquals(item, _selectedSourceNode)) SelectedSourceNode = null;
+                }
+            }
+        };
+
+        ExchangeSetHeaders.CollectionChanged += (_, e) =>
+        {
+            OnPropertyChanged(nameof(HasExchangeSets));
+            RebuildExchangeSetGrouping();
+            ApplyDefaultTab();
+
+            if (e.OldItems is not null)
+            {
+                foreach (var item in e.OldItems)
+                {
+                    if (ReferenceEquals(item, _selectedSourceNode)) SelectedSourceNode = null;
+                }
+            }
         };
 
         // Auto-unregister entries from the global time service when they
@@ -690,6 +879,40 @@ internal sealed class DatasetsViewModel : ViewModelBase
     {
         ArgumentNullException.ThrowIfNull(header);
         ExchangeSetHeaders.Remove(header);
+    }
+
+    /// <summary>
+    /// Reconciles each <see cref="ExchangeSetHeader.Datasets"/> child
+    /// collection so it contains exactly the <see cref="Entries"/> whose
+    /// <see cref="DatasetEntry.Source"/> matches that header, in the same
+    /// relative order they occupy in <see cref="Entries"/>. Loose entries
+    /// (no backing source) are not nested anywhere — they appear only in
+    /// the Datasets tab. Called whenever <see cref="Entries"/> or
+    /// <see cref="ExchangeSetHeaders"/> change.
+    /// </summary>
+    private void RebuildExchangeSetGrouping()
+    {
+        foreach (var header in ExchangeSetHeaders)
+        {
+            var members = Entries.Where(e => ReferenceEquals(e.Source, header.Source)).ToList();
+
+            // Fast path: already in sync (same items, same order).
+            if (header.Datasets.Count == members.Count)
+            {
+                var same = true;
+                for (var i = 0; i < members.Count; i++)
+                {
+                    if (!ReferenceEquals(header.Datasets[i], members[i])) { same = false; break; }
+                }
+                if (same) continue;
+            }
+
+            header.Datasets.Clear();
+            foreach (var member in members)
+            {
+                header.Datasets.Add(member);
+            }
+        }
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetHeader.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -76,6 +80,30 @@ internal sealed partial class ExchangeSetHeader : ViewModelBase
     /// registering service.</summary>
     public ICommand CloseCommand { get; }
 
+    /// <summary>
+    /// Member datasets contributed by this exchange set, in the same
+    /// relative order they occupy in
+    /// <see cref="DatasetsViewModel.Entries"/>. Maintained by the owning
+    /// <see cref="DatasetsViewModel"/> so the Exchange sets tab can nest
+    /// each source's datasets beneath it. This is a view (not a reorder
+    /// surface) — render order lives in the Datasets tab.
+    /// </summary>
+    public ObservableCollection<DatasetEntry> Datasets { get; } = new();
+
+    /// <summary>Number of loaded member datasets currently nested under
+    /// this source (the count badge in the Exchange sets tree).</summary>
+    public int MemberCount => Datasets.Count;
+
+    /// <summary>True when at least one member dataset is visible. Drives
+    /// the source row's show/hide (eye) icon. Toggling
+    /// <see cref="ToggleVisibilityCommand"/> hides all members when any
+    /// are visible, otherwise shows all.</summary>
+    public bool IsAnyDatasetVisible => Datasets.Any(d => d.IsVisible);
+
+    /// <summary>Shows or hides every member dataset in one shot: hides all
+    /// when any are currently visible, otherwise shows all.</summary>
+    public ICommand ToggleVisibilityCommand { get; }
+
     public ExchangeSetHeader(
         IAssetSource source,
         string sourcePath,
@@ -100,6 +128,48 @@ internal sealed partial class ExchangeSetHeader : ViewModelBase
         _loadedCount = datasetCount;
         _unsupportedCount = 0;
         CloseCommand = new RelayCommand(() => closeAction(this));
+        ToggleVisibilityCommand = new RelayCommand(ToggleVisibility);
+
+        Datasets.CollectionChanged += OnDatasetsCollectionChanged;
+    }
+
+    private void ToggleVisibility()
+    {
+        var hide = IsAnyDatasetVisible;
+        foreach (var dataset in Datasets)
+        {
+            dataset.IsVisible = !hide;
+        }
+    }
+
+    private void OnDatasetsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (var item in e.OldItems.OfType<DatasetEntry>())
+            {
+                item.PropertyChanged -= OnMemberPropertyChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (var item in e.NewItems.OfType<DatasetEntry>())
+            {
+                item.PropertyChanged += OnMemberPropertyChanged;
+            }
+        }
+
+        OnPropertyChanged(nameof(MemberCount));
+        OnPropertyChanged(nameof(IsAnyDatasetVisible));
+    }
+
+    private void OnMemberPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(DatasetEntry.IsVisible))
+        {
+            OnPropertyChanged(nameof(IsAnyDatasetVisible));
+        }
     }
 
     private static string BuildMetadataSummary(int loadedCount, int unsupportedCount, string? producer, string? issueDate)

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -66,19 +66,16 @@
         </Style>
 
         <!--
-          ShadUI's default TabControl template wraps the tab strip and
-          the content presenter in a StackPanel, which measures its
-          children with infinite height. That means a ScrollViewer
-          placed inside a TabItem never receives a bounded height and
-          so never scrolls — instead the StackPanel grows past the
-          available space and the bottom of the content is clipped.
-          We replace the template (only for `.CenteredTabs`) with a
-          DockPanel so the tab strip stays sticky at the top and the
-          ContentPresenter fills the remaining height, giving any
-          ScrollViewer inside a TabItem a bounded height to scroll
-          within. The inner Border centres the tab headers — replacing
-          the upstream HorizontalAlignment="Left" — without needing
-          the earlier `/template/ ... Border` selector workaround.
+          The inspector tabs (Dataset / Layers / Validation) share the
+          ShadUI pill styling used by the outer panel tabs: a rounded
+          track holding the tabs with an animated selection pill behind
+          the active tab. As with `OuterTabs`, we override only the
+          *template* (swapping ShadUI's outer StackPanel for a DockPanel
+          so a ScrollViewer inside a TabItem gets a bounded height and
+          scrolls rather than overflowing). The base ShadUI TabControl
+          ControlTheme still supplies the sliding-pill behavior
+          (UseSlidingPill) and the horizontal items panel; the default
+          ShadUI TabItem theme styles the individual tabs.
         -->
         <Style Selector="TabControl.CenteredTabs">
             <Setter Property="Template">
@@ -88,15 +85,41 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}">
                         <DockPanel LastChildFill="True">
-                            <Border DockPanel.Dock="Top"
-                                    Background="{DynamicResource TabItemsBackgroundColor}"
-                                    CornerRadius="{DynamicResource LgCornerRadius}"
-                                    HorizontalAlignment="Center"
-                                    Padding="2,4,2,0"
-                                    Margin="0,0,0,8">
-                                <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}"
-                                                Name="PART_ItemsPresenter" />
-                            </Border>
+                            <LayoutTransformControl DockPanel.Dock="Top"
+                                                    HorizontalAlignment="Center"
+                                                    Margin="0,0,0,8"
+                                                    Name="LayoutTransform">
+                                <Border Background="{DynamicResource TabItemsBackgroundColor}"
+                                        CornerRadius="{DynamicResource LgCornerRadius}"
+                                        HorizontalAlignment="Center"
+                                        Padding="2,4,2,0">
+                                    <Panel>
+                                        <Canvas IsHitTestVisible="False">
+                                            <Border Background="{DynamicResource TabItemSelectedColor}"
+                                                    BoxShadow="{DynamicResource Shadow}"
+                                                    Canvas.Left="0"
+                                                    Canvas.Top="0"
+                                                    CornerRadius="{DynamicResource MdCornerRadius}"
+                                                    Height="0"
+                                                    Opacity="0"
+                                                    Width="0"
+                                                    x:Name="PART_SelectionPill">
+                                                <Border.Transitions>
+                                                    <Transitions>
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="(Canvas.Left)" />
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="(Canvas.Top)" />
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="Width" />
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="Height" />
+                                                        <DoubleTransition Duration="0:0:0.20" Easing="CubicEaseOut" Property="Opacity" />
+                                                    </Transitions>
+                                                </Border.Transitions>
+                                            </Border>
+                                        </Canvas>
+                                        <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}"
+                                                        Name="PART_ItemsPresenter" />
+                                    </Panel>
+                                </Border>
+                            </LayoutTransformControl>
                             <ContentPresenter Content="{TemplateBinding SelectedContent}"
                                               ContentTemplate="{TemplateBinding SelectedContentTemplate}"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -258,6 +281,22 @@
                 </ControlTemplate>
             </Setter>
         </Style>
+        <!--
+          The outer panel tabs share the inspector tabs' title-strip
+          typography (see `CenteredTabs > TabItem`): small, normal
+          weight, and letter-spaced. LetterSpacing isn't a TabItem
+          property, so we apply it via a HeaderTemplate that wraps the
+          header string in a TextBlock.
+        -->
+        <Style Selector="TabControl.OuterTabs > TabItem">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="HeaderTemplate">
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" LetterSpacing="1" />
+                </DataTemplate>
+            </Setter>
+        </Style>
 
         <!--
           Small monochrome count pill used on source rows in the Exchange
@@ -406,20 +445,12 @@
                 <!-- ── Exchange sets tab: source → dataset tree, no reorder. -->
                 <TabItem Header="{x:Static loc:Strings.Pane_Tab_ExchangeSets}">
                     <DockPanel LastChildFill="True">
-                        <!-- SOURCES sub-header with an Add affordance. -->
+                        <!-- Add-source affordance, left-aligned. -->
                         <Grid DockPanel.Dock="Top"
-                              ColumnDefinitions="*,Auto"
                               Margin="8,0,8,6">
-                            <TextBlock Grid.Column="0"
-                                       Text="{x:Static loc:Strings.Pane_Sources}"
-                                       FontSize="11"
-                                       FontWeight="SemiBold"
-                                       LetterSpacing="1"
-                                       Opacity="0.6"
-                                       VerticalAlignment="Center" />
-                            <Button Grid.Column="1"
-                                    x:Name="SourcesAddButton"
+                            <Button x:Name="SourcesAddButton"
                                     Classes="Icon"
+                                    HorizontalAlignment="Left"
                                     ToolTip.Tip="{x:Static loc:Strings.Tooltip_AddSource}">
                                 <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="14" />
                             </Button>
@@ -548,6 +579,7 @@
                              dataset. "Isolate" is per-row (context menu). -->
                         <StackPanel DockPanel.Dock="Top"
                                     Orientation="Horizontal"
+                                    HorizontalAlignment="Left"
                                     Spacing="4"
                                     Margin="8,0,8,4">
                             <Button Classes="Icon"

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -164,10 +164,15 @@
         </Style>
 
         <!--
-          Outer panel tabs (Exchange sets / Datasets). Same DockPanel
-          template trick as `.CenteredTabs` so a TreeView/ListBox inside a
-          TabItem gets a bounded height to scroll within, but rendered as a
-          full-width title strip with an underline rule rather than a pill.
+          Outer panel tabs (Exchange sets / Datasets) rendered with ShadUI's
+          pill styling: a rounded track holding the two tabs with an animated
+          selection pill behind the active tab. We override only the *template*
+          (swapping ShadUI's outer StackPanel for a DockPanel) so the inner
+          TreeView/ListBox in each tab gets a bounded height and scrolls rather
+          than overflowing and crowding the inspector below. The base ShadUI
+          TabControl ControlTheme still supplies the sliding-pill behavior
+          (UseSlidingPill) and the horizontal items panel, and the default
+          ShadUI TabItem theme styles the individual tabs.
         -->
         <Style Selector="TabControl.OuterTabs">
             <Setter Property="Template">
@@ -177,14 +182,41 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}">
                         <DockPanel LastChildFill="True">
-                            <Border DockPanel.Dock="Top"
-                                    BorderBrush="{DynamicResource BorderColor}"
-                                    BorderThickness="0,0,0,1"
-                                    Margin="0,0,0,6">
-                                <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}"
-                                                Name="PART_ItemsPresenter"
-                                                HorizontalAlignment="Center" />
-                            </Border>
+                            <LayoutTransformControl DockPanel.Dock="Top"
+                                                    HorizontalAlignment="Center"
+                                                    Margin="0,0,0,6"
+                                                    Name="LayoutTransform">
+                                <Border Background="{DynamicResource TabItemsBackgroundColor}"
+                                        CornerRadius="{DynamicResource LgCornerRadius}"
+                                        HorizontalAlignment="Center"
+                                        Padding="2,4,2,0">
+                                    <Panel>
+                                        <Canvas IsHitTestVisible="False">
+                                            <Border Background="{DynamicResource TabItemSelectedColor}"
+                                                    BoxShadow="{DynamicResource Shadow}"
+                                                    Canvas.Left="0"
+                                                    Canvas.Top="0"
+                                                    CornerRadius="{DynamicResource MdCornerRadius}"
+                                                    Height="0"
+                                                    Opacity="0"
+                                                    Width="0"
+                                                    x:Name="PART_SelectionPill">
+                                                <Border.Transitions>
+                                                    <Transitions>
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="(Canvas.Left)" />
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="(Canvas.Top)" />
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="Width" />
+                                                        <DoubleTransition Duration="0:0:0.30" Easing="CubicEaseOut" Property="Height" />
+                                                        <DoubleTransition Duration="0:0:0.20" Easing="CubicEaseOut" Property="Opacity" />
+                                                    </Transitions>
+                                                </Border.Transitions>
+                                            </Border>
+                                        </Canvas>
+                                        <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}"
+                                                        Name="PART_ItemsPresenter" />
+                                    </Panel>
+                                </Border>
+                            </LayoutTransformControl>
                             <ContentPresenter Content="{TemplateBinding SelectedContent}"
                                               ContentTemplate="{TemplateBinding SelectedContentTemplate}"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -195,10 +227,6 @@
                     </Border>
                 </ControlTemplate>
             </Setter>
-        </Style>
-        <Style Selector="TabControl.OuterTabs > TabItem">
-            <Setter Property="FontSize" Value="13" />
-            <Setter Property="Padding" Value="14,6" />
         </Style>
 
         <!--
@@ -222,6 +250,23 @@
             <Setter Property="CornerRadius" Value="4" />
             <Setter Property="Padding" Value="6,1" />
             <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+
+        <!--
+          Exchange-sets tree rows adopt the same selection treatment as the
+          app-wide `accentList` (a 3px accent bar plus a low-opacity accent
+          tint) so selecting a source or a nested dataset looks identical to
+          selecting a row in the flat Datasets list. The accent visuals live
+          in the row DataTemplates (bound to the owning TreeViewItem's
+          IsSelected); here we stretch rows full-width, expand sources by
+          default, and suppress Fluent's own selection fill to avoid a
+          double highlight.
+        -->
+        <Style Selector="TreeView.accentTree TreeViewItem">
+            <Setter Property="IsExpanded" Value="True" />
+        </Style>
+        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="Transparent" />
         </Style>
     </UserControl.Styles>
 
@@ -298,6 +343,7 @@
                              is a cross-source concern and lives in the
                              Datasets tab, so there is no reordering here. -->
                         <TreeView IsVisible="{Binding HasExchangeSets}"
+                                  Classes="accentTree"
                                   ItemsSource="{Binding ExchangeSetHeaders}"
                                   SelectedItem="{Binding SelectedSourceNode, Mode=TwoWay}"
                                   Background="Transparent"
@@ -309,9 +355,20 @@
                                      per-source show/hide and close. -->
                                 <TreeDataTemplate DataType="vm:ExchangeSetHeader"
                                                   ItemsSource="{Binding Datasets}">
-                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto"
-                                          ColumnSpacing="6"
-                                          Background="Transparent">
+                                    <Grid ColumnDefinitions="3,*">
+                                        <Border Grid.Column="0"
+                                                Width="3"
+                                                CornerRadius="1.5"
+                                                Background="{DynamicResource AccentBrush}"
+                                                IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
+                                        <Panel Grid.Column="1">
+                                            <Border Background="{DynamicResource AccentBrush}"
+                                                    Opacity="0.12"
+                                                    CornerRadius="4"
+                                                    IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
+                                            <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto"
+                                                  ColumnSpacing="6"
+                                                  Margin="4,2">
                                         <Button Grid.Column="0"
                                                 Classes="Icon"
                                                 Command="{Binding ToggleVisibilityCommand}"
@@ -360,13 +417,26 @@
                                                 ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseExchangeSet}">
                                             <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
                                         </Button>
+                                            </Grid>
+                                        </Panel>
                                     </Grid>
                                 </TreeDataTemplate>
                                 <!-- Nested dataset row: per-item show/hide + spec tag. -->
                                 <DataTemplate DataType="vm:DatasetEntry">
-                                    <Grid ColumnDefinitions="Auto,*,Auto"
-                                          ColumnSpacing="6"
-                                          Background="Transparent">
+                                    <Grid ColumnDefinitions="3,*">
+                                        <Border Grid.Column="0"
+                                                Width="3"
+                                                CornerRadius="1.5"
+                                                Background="{DynamicResource AccentBrush}"
+                                                IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
+                                        <Panel Grid.Column="1">
+                                            <Border Background="{DynamicResource AccentBrush}"
+                                                    Opacity="0.12"
+                                                    CornerRadius="4"
+                                                    IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
+                                            <Grid ColumnDefinitions="Auto,*,Auto"
+                                                  ColumnSpacing="6"
+                                                  Margin="4,2">
                                         <Button Grid.Column="0"
                                                 Classes="Icon"
                                                 Command="{Binding ToggleVisibilityCommand}"
@@ -390,6 +460,8 @@
                                                        FontWeight="SemiBold"
                                                        Opacity="0.8" />
                                         </Border>
+                                            </Grid>
+                                        </Panel>
                                     </Grid>
                                 </DataTemplate>
                             </TreeView.DataTemplates>

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -6,6 +6,7 @@
              xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
              xmlns:bh="using:EncDotNet.S100.Viewer.Behaviors"
              xmlns:conv="using:EncDotNet.S100.Viewer"
+             xmlns:converters="using:Avalonia.Controls.Converters"
              xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
              x:Class="EncDotNet.S100.Viewer.Views.DatasetsView"
              x:DataType="vm:DatasetsViewModel">
@@ -15,6 +16,35 @@
         <conv:SignatureStatusConverter x:Key="SignatureStatusUnsignedConverter" Match="Unsigned" />
         <conv:SignatureStatusConverter x:Key="SignatureStatusInvalidConverter" Match="Invalid,Untrusted,Mixed,Error" />
         <conv:SignatureStatusConverter x:Key="SignatureStatusCheckingConverter" Match="Checking,Unknown" />
+
+        <!-- Indent step for nested Exchange-sets tree rows (matches the
+             SimpleTheme default so the disclosure chevron lines up). -->
+        <x:Double x:Key="AccentTreeIndent">16</x:Double>
+
+        <!-- Disclosure chevron for the Exchange-sets tree: a small triangle
+             that rotates from pointing-right (collapsed) to pointing-down
+             (expanded), mirroring the SimpleTheme TreeViewItem chevron. -->
+        <ControlTheme x:Key="AccentTreeChevronTheme" TargetType="ToggleButton">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Width="14"
+                            Height="12"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="Transparent">
+                        <Path HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Data="M 0 2 L 4 6 L 0 10 Z"
+                              Fill="{DynamicResource ThemeForegroundBrush}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked">
+                <Setter Property="RenderTransform">
+                    <RotateTransform Angle="45" />
+                </Setter>
+            </Style>
+        </ControlTheme>
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -254,19 +284,81 @@
 
         <!--
           Exchange-sets tree rows adopt the same selection treatment as the
-          app-wide `accentList` (a 3px accent bar plus a low-opacity accent
-          tint) so selecting a source or a nested dataset looks identical to
-          selecting a row in the flat Datasets list. The accent visuals live
-          in the row DataTemplates (bound to the owning TreeViewItem's
-          IsSelected); here we stretch rows full-width, expand sources by
-          default, and suppress Fluent's own selection fill to avoid a
-          double highlight.
+          app-wide `accentList` (a 3px accent bar at the row's left edge, a
+          low-opacity accent tint, and an accent-coloured title). SimpleTheme
+          (the base theme behind ShadUI) paints a solid `SelectionBorder`
+          fill on selection, so we retemplate TreeViewItem entirely: the focus
+          host is deliberately *not* named `SelectionBorder` to dodge the base
+          ControlTheme's solid highlight, the bar/tint live in our own parts,
+          and SimpleTheme's indent converter keeps nested rows aligned.
         -->
         <Style Selector="TreeView.accentTree TreeViewItem">
             <Setter Property="IsExpanded" Value="True" />
+            <Setter Property="Padding" Value="2" />
+            <Setter Property="Margin" Value="0,1" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <StackPanel>
+                        <Grid ColumnDefinitions="3,*">
+                            <Border Name="PART_Bar"
+                                    Grid.Column="0"
+                                    Width="3"
+                                    CornerRadius="1.5"
+                                    Background="Transparent" />
+                            <Panel Grid.Column="1">
+                                <Border Name="PART_Tint"
+                                        Background="{DynamicResource AccentBrush}"
+                                        Opacity="0"
+                                        CornerRadius="4" />
+                                <Border Background="Transparent"
+                                        Focusable="True"
+                                        TemplatedControl.IsTemplateFocusTarget="True">
+                                    <Grid Name="PART_Header" ColumnDefinitions="16,*">
+                                        <Grid.Margin>
+                                            <MultiBinding Converter="{x:Static converters:TreeViewItemIndentConverter.Instance}">
+                                                <Binding Path="Level" RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <DynamicResource ResourceKey="AccentTreeIndent" />
+                                            </MultiBinding>
+                                        </Grid.Margin>
+                                        <ToggleButton Name="PART_ExpandCollapseChevron"
+                                                      Focusable="False"
+                                                      Background="Transparent"
+                                                      IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                                                      Theme="{StaticResource AccentTreeChevronTheme}" />
+                                        <ContentPresenter Name="PART_HeaderPresenter"
+                                                          Grid.Column="1"
+                                                          Background="Transparent"
+                                                          Padding="{TemplateBinding Padding}"
+                                                          HorizontalContentAlignment="Stretch"
+                                                          VerticalContentAlignment="Center"
+                                                          Content="{TemplateBinding Header}"
+                                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                          Focusable="False" />
+                                    </Grid>
+                                </Border>
+                            </Panel>
+                        </Grid>
+                        <ItemsPresenter Name="PART_ItemsPresenter"
+                                        IsVisible="{TemplateBinding IsExpanded}"
+                                        ItemsPanel="{TemplateBinding ItemsPanel}" />
+                    </StackPanel>
+                </ControlTemplate>
+            </Setter>
         </Style>
-        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ Border#PART_LayoutRoot">
-            <Setter Property="Background" Value="Transparent" />
+        <Style Selector="TreeView.accentTree TreeViewItem:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+        <Style Selector="TreeView.accentTree TreeViewItem:pointerover /template/ Border#PART_Tint">
+            <Setter Property="Opacity" Value="0.06" />
+        </Style>
+        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ Border#PART_Tint">
+            <Setter Property="Opacity" Value="0.12" />
+        </Style>
+        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ Border#PART_Bar">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+        </Style>
+        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ ContentPresenter#PART_HeaderPresenter TextBlock.accentTreeTitle">
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
         </Style>
     </UserControl.Styles>
 
@@ -355,20 +447,8 @@
                                      per-source show/hide and close. -->
                                 <TreeDataTemplate DataType="vm:ExchangeSetHeader"
                                                   ItemsSource="{Binding Datasets}">
-                                    <Grid ColumnDefinitions="3,*">
-                                        <Border Grid.Column="0"
-                                                Width="3"
-                                                CornerRadius="1.5"
-                                                Background="{DynamicResource AccentBrush}"
-                                                IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
-                                        <Panel Grid.Column="1">
-                                            <Border Background="{DynamicResource AccentBrush}"
-                                                    Opacity="0.12"
-                                                    CornerRadius="4"
-                                                    IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
-                                            <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto"
-                                                  ColumnSpacing="6"
-                                                  Margin="4,2">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto"
+                                          ColumnSpacing="6">
                                         <Button Grid.Column="0"
                                                 Classes="Icon"
                                                 Command="{Binding ToggleVisibilityCommand}"
@@ -382,6 +462,7 @@
                                             </Panel>
                                         </Button>
                                         <TextBlock Grid.Column="1"
+                                                   Classes="accentTreeTitle"
                                                    Text="{Binding DisplayName}"
                                                    FontWeight="SemiBold"
                                                    VerticalAlignment="Center"
@@ -417,26 +498,12 @@
                                                 ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseExchangeSet}">
                                             <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
                                         </Button>
-                                            </Grid>
-                                        </Panel>
                                     </Grid>
                                 </TreeDataTemplate>
                                 <!-- Nested dataset row: per-item show/hide + spec tag. -->
                                 <DataTemplate DataType="vm:DatasetEntry">
-                                    <Grid ColumnDefinitions="3,*">
-                                        <Border Grid.Column="0"
-                                                Width="3"
-                                                CornerRadius="1.5"
-                                                Background="{DynamicResource AccentBrush}"
-                                                IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
-                                        <Panel Grid.Column="1">
-                                            <Border Background="{DynamicResource AccentBrush}"
-                                                    Opacity="0.12"
-                                                    CornerRadius="4"
-                                                    IsVisible="{Binding $parent[TreeViewItem].IsSelected}" />
-                                            <Grid ColumnDefinitions="Auto,*,Auto"
-                                                  ColumnSpacing="6"
-                                                  Margin="4,2">
+                                    <Grid ColumnDefinitions="Auto,*,Auto"
+                                          ColumnSpacing="6">
                                         <Button Grid.Column="0"
                                                 Classes="Icon"
                                                 Command="{Binding ToggleVisibilityCommand}"
@@ -450,6 +517,7 @@
                                             </Panel>
                                         </Button>
                                         <TextBlock Grid.Column="1"
+                                                   Classes="accentTreeTitle"
                                                    Text="{Binding DisplayName}"
                                                    VerticalAlignment="Center"
                                                    Opacity="{Binding RowOpacity}"
@@ -460,8 +528,6 @@
                                                        FontWeight="SemiBold"
                                                        Opacity="0.8" />
                                         </Border>
-                                            </Grid>
-                                        </Panel>
                                     </Grid>
                                 </DataTemplate>
                             </TreeView.DataTemplates>

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -162,145 +162,283 @@
         <Style Selector="Button.FindingRow:not(:disabled)">
             <Setter Property="Cursor" Value="Hand" />
         </Style>
+
+        <!--
+          Outer panel tabs (Exchange sets / Datasets). Same DockPanel
+          template trick as `.CenteredTabs` so a TreeView/ListBox inside a
+          TabItem gets a bounded height to scroll within, but rendered as a
+          full-width title strip with an underline rule rather than a pill.
+        -->
+        <Style Selector="TabControl.OuterTabs">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                        <DockPanel LastChildFill="True">
+                            <Border DockPanel.Dock="Top"
+                                    BorderBrush="{DynamicResource BorderColor}"
+                                    BorderThickness="0,0,0,1"
+                                    Margin="0,0,0,6">
+                                <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}"
+                                                Name="PART_ItemsPresenter"
+                                                HorizontalAlignment="Center" />
+                            </Border>
+                            <ContentPresenter Content="{TemplateBinding SelectedContent}"
+                                              ContentTemplate="{TemplateBinding SelectedContentTemplate}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              Margin="{TemplateBinding Padding}"
+                                              Name="PART_SelectedContentHost"
+                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        </DockPanel>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="TabControl.OuterTabs > TabItem">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Padding" Value="14,6" />
+        </Style>
+
+        <!--
+          Small monochrome count pill used on source rows in the Exchange
+          sets tree (the "2" / "1" badges in the mockup).
+        -->
+        <Style Selector="Border.CountBadge">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}" />
+            <Setter Property="CornerRadius" Value="9" />
+            <Setter Property="Padding" Value="8,1" />
+            <Setter Property="MinWidth" Value="22" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+
+        <!--
+          Spec tag (e.g. "S-101") shown on nested dataset rows in the
+          Exchange sets tree.
+        -->
+        <Style Selector="Border.SpecTag">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Padding" Value="6,1" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
     </UserControl.Styles>
 
-    <DockPanel>
-        <!-- Exchange-set header rows: one per loaded exchange set,
-             stacked above the bulk-action toolbar. Each row exposes a
-             Close button that removes every dataset contributed by
-             that set. -->
-        <ItemsControl DockPanel.Dock="Top"
-                      ItemsSource="{Binding ExchangeSetHeaders}"
-                      HorizontalAlignment="Stretch"
-                      Margin="8,4,8,0">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <StackPanel Orientation="Vertical" />
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate DataType="vm:ExchangeSetHeader">
-                    <Border BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                            BorderThickness="1"
-                            CornerRadius="4"
-                            Padding="8,6"
-                            Margin="0,0,0,4"
-                            HorizontalAlignment="Stretch">
-                        <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto,Auto">
-                            <TextBlock Grid.Column="0" Grid.Row="0"
-                                       Text="{Binding DisplayName}"
-                                       FontWeight="SemiBold"
-                                       TextTrimming="CharacterEllipsis"
-                                       ToolTip.Tip="{Binding SourcePath}" />
-                            <TextBlock Grid.Column="0" Grid.Row="1"
-                                       Classes="Caption"
-                                       Opacity="0.75"
-                                       Text="{Binding MetadataSummary}"
-                                       TextTrimming="CharacterEllipsis"
-                                       ToolTip.Tip="{Binding MetadataSummary}" />
-                            <!-- Signature verification badge -->
-                            <Panel Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                                   VerticalAlignment="Center"
-                                   Margin="4,0,0,0"
-                                   ToolTip.Tip="{Binding SignatureTooltip}"
-                                   IsVisible="{Binding SignatureStatus, Converter={x:Static ObjectConverters.IsNotNull}}">
-                                <ic:FluentIcon FontSize="20"
-                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusVerifiedConverter}}"
-                                               Icon="ShieldCheckmark" IconVariant="Filled"
-                                               Foreground="#16a34a" />
-                                <ic:FluentIcon FontSize="20"
-                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusUnsignedConverter}}"
-                                               Icon="ShieldDismiss" IconVariant="Regular"
-                                               Opacity="0.5" />
-                                <ic:FluentIcon FontSize="20"
-                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusInvalidConverter}}"
-                                               Icon="ShieldError" IconVariant="Filled"
-                                               Foreground="#dc2626" />
-                                <ic:FluentIcon FontSize="20"
-                                               IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusCheckingConverter}}"
-                                               Icon="Shield" IconVariant="Regular"
-                                               Opacity="0.4" />
-                            </Panel>
-                            <Button Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                                    Classes="Icon"
-                                    VerticalAlignment="Center"
-                                    Margin="6,0,0,0"
-                                    Command="{Binding CloseCommand}"
-                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseExchangeSet}">
-                                <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
-                            </Button>
-                        </Grid>
-                    </Border>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-            <ItemsControl.Styles>
-                <!-- Force each generated container to stretch the full
-                     pane width. Without this, ShadUI's default
-                     ContentPresenter sizing leaves the Border at
-                     intrinsic content width, which can let the inner
-                     Grid measure children with infinity and skip
-                     TextTrimming. -->
-                <Style Selector="ItemsControl > ContentPresenter">
-                    <Setter Property="HorizontalAlignment" Value="Stretch" />
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                </Style>
-            </ItemsControl.Styles>
-        </ItemsControl>
-
-        <!-- Bulk-action toolbar: applies to every loaded dataset.
-             "Isolate" is per-row (right-click context menu) because it
-             needs a target. -->
-        <StackPanel DockPanel.Dock="Top"
-                    Orientation="Horizontal"
-                    Spacing="4"
-                    Margin="8,4,8,0"
-                    IsVisible="{Binding !IsEmpty}">
-            <Button Classes="Icon"
-                    x:Name="ToolbarAddButton"
-                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_AddDataset}">
-                <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="14" />
-            </Button>
-            <Button Classes="Icon"
-                    Command="{Binding ShowAllCommand}"
-                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShowAllDatasets}">
-                <ic:FluentIcon Icon="Eye" IconVariant="Regular" FontSize="14" />
-            </Button>
-            <Button Classes="Icon"
-                    Command="{Binding HideAllCommand}"
-                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_HideAllDatasets}">
-                <ic:FluentIcon Icon="EyeOff" IconVariant="Regular" FontSize="14" />
-            </Button>
-            <Button Classes="Icon"
-                    Command="{Binding ResetOpacityCommand}"
-                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ResetDatasetOpacity}">
-                <ic:FluentIcon Icon="ArrowReset" IconVariant="Regular" FontSize="14" />
-            </Button>
+    <Panel>
+        <!-- Empty-state placeholder: shown across the whole panel when no
+             datasets are loaded. Hides the tabbed lists and the inspector
+             so the "Open Dataset" affordance is the sole focus. -->
+        <StackPanel IsVisible="{Binding IsEmpty}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="8">
+            <views:PlaceholderView Icon="Layer"
+                                   Header="{x:Static loc:Strings.Datasets_EmptyTitle}"
+                                   Description="{x:Static loc:Strings.Datasets_EmptyDescription}" />
+            <Button x:Name="EmptyAddButton"
+                    Classes="Outline"
+                    Content="{x:Static loc:Strings.Button_OpenDataset}"
+                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenDataset}"
+                    HorizontalAlignment="Center" />
         </StackPanel>
 
-        <!-- Master/detail layout: the dataset list takes the top portion
-             and the Properties sub-panel docks at the bottom, separated
-             by the standard PaneSplitter. The sub-panel collapses when
-             nothing is selected so the list takes the full height. -->
-        <Grid>
+        <!-- Populated state: two tabs (Exchange sets / Datasets) above a
+             pinned inspector, separated by the standard PaneSplitter. The
+             inspector reflects the active tab's selection — an exchange set
+             or a dataset. Only one list shows at a time, so a long load
+             list never crowds the inspector's space below. -->
+        <Grid IsVisible="{Binding !IsEmpty}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="2*" MinHeight="80" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" MinHeight="80" />
             </Grid.RowDefinitions>
 
-            <!-- Dataset list (master). ListBox lets a row be selected so
-                 the Properties sub-panel can target it. Padding/margin
-                 zeroed on items so the entire row hit-tests for click-
-                 to-select and right-click. -->
-            <ListBox Grid.Row="0"
-                     x:Name="DatasetList"
+            <TabControl Grid.Row="0"
+                        Classes="OuterTabs"
+                        Padding="0"
+                        SelectedIndex="{Binding ActiveTabIndex, Mode=TwoWay}">
+
+                <!-- ── Exchange sets tab: source → dataset tree, no reorder. -->
+                <TabItem Header="{x:Static loc:Strings.Pane_Tab_ExchangeSets}">
+                    <DockPanel LastChildFill="True">
+                        <!-- SOURCES sub-header with an Add affordance. -->
+                        <Grid DockPanel.Dock="Top"
+                              ColumnDefinitions="*,Auto"
+                              Margin="8,0,8,6">
+                            <TextBlock Grid.Column="0"
+                                       Text="{x:Static loc:Strings.Pane_Sources}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold"
+                                       LetterSpacing="1"
+                                       Opacity="0.6"
+                                       VerticalAlignment="Center" />
+                            <Button Grid.Column="1"
+                                    x:Name="SourcesAddButton"
+                                    Classes="Icon"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_AddSource}">
+                                <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="14" />
+                            </Button>
+                        </Grid>
+
+                        <!-- Empty message when no exchange sets are loaded
+                             (loose datasets live only in the Datasets tab). -->
+                        <TextBlock DockPanel.Dock="Top"
+                                   IsVisible="{Binding !HasExchangeSets}"
+                                   Text="{x:Static loc:Strings.Pane_ExchangeSets_Empty}"
+                                   Opacity="0.6"
+                                   TextWrapping="Wrap"
+                                   Margin="16"
+                                   HorizontalAlignment="Center"
+                                   TextAlignment="Center" />
+
+                        <!-- Two-level tree: each source expands to its
+                             datasets with per-item show/hide. Render order
+                             is a cross-source concern and lives in the
+                             Datasets tab, so there is no reordering here. -->
+                        <TreeView IsVisible="{Binding HasExchangeSets}"
+                                  ItemsSource="{Binding ExchangeSetHeaders}"
+                                  SelectedItem="{Binding SelectedSourceNode, Mode=TwoWay}"
+                                  Background="Transparent"
+                                  BorderThickness="0"
+                                  Margin="4,0,4,0"
+                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                            <TreeView.DataTemplates>
+                                <!-- Source row: name, count badge, signature,
+                                     per-source show/hide and close. -->
+                                <TreeDataTemplate DataType="vm:ExchangeSetHeader"
+                                                  ItemsSource="{Binding Datasets}">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto"
+                                          ColumnSpacing="6"
+                                          Background="Transparent">
+                                        <Button Grid.Column="0"
+                                                Classes="Icon"
+                                                Command="{Binding ToggleVisibilityCommand}"
+                                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ToggleExchangeSetVisibility}"
+                                                VerticalAlignment="Center">
+                                            <Panel>
+                                                <ic:FluentIcon Icon="Eye" IconVariant="Regular" FontSize="16"
+                                                               IsVisible="{Binding IsAnyDatasetVisible}" />
+                                                <ic:FluentIcon Icon="EyeOff" IconVariant="Regular" FontSize="16"
+                                                               IsVisible="{Binding !IsAnyDatasetVisible}" />
+                                            </Panel>
+                                        </Button>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding DisplayName}"
+                                                   FontWeight="SemiBold"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip.Tip="{Binding SourcePath}" />
+                                        <Border Grid.Column="2" Classes="CountBadge">
+                                            <TextBlock Text="{Binding MemberCount}"
+                                                       FontSize="11"
+                                                       TextAlignment="Center" />
+                                        </Border>
+                                        <Panel Grid.Column="3"
+                                               VerticalAlignment="Center"
+                                               Margin="2,0,0,0"
+                                               ToolTip.Tip="{Binding SignatureTooltip}"
+                                               IsVisible="{Binding SignatureStatus, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                            <ic:FluentIcon FontSize="18"
+                                                           IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusVerifiedConverter}}"
+                                                           Icon="ShieldCheckmark" IconVariant="Filled" Foreground="#16a34a" />
+                                            <ic:FluentIcon FontSize="18"
+                                                           IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusUnsignedConverter}}"
+                                                           Icon="ShieldDismiss" IconVariant="Regular" Opacity="0.5" />
+                                            <ic:FluentIcon FontSize="18"
+                                                           IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusInvalidConverter}}"
+                                                           Icon="ShieldError" IconVariant="Filled" Foreground="#dc2626" />
+                                            <ic:FluentIcon FontSize="18"
+                                                           IsVisible="{Binding SignatureStatus, Converter={StaticResource SignatureStatusCheckingConverter}}"
+                                                           Icon="Shield" IconVariant="Regular" Opacity="0.4" />
+                                        </Panel>
+                                        <Button Grid.Column="4"
+                                                Classes="Icon"
+                                                VerticalAlignment="Center"
+                                                Command="{Binding CloseCommand}"
+                                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_CloseExchangeSet}">
+                                            <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
+                                        </Button>
+                                    </Grid>
+                                </TreeDataTemplate>
+                                <!-- Nested dataset row: per-item show/hide + spec tag. -->
+                                <DataTemplate DataType="vm:DatasetEntry">
+                                    <Grid ColumnDefinitions="Auto,*,Auto"
+                                          ColumnSpacing="6"
+                                          Background="Transparent">
+                                        <Button Grid.Column="0"
+                                                Classes="Icon"
+                                                Command="{Binding ToggleVisibilityCommand}"
+                                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_ToggleDatasetVisibility}"
+                                                VerticalAlignment="Center">
+                                            <Panel>
+                                                <ic:FluentIcon Icon="Eye" IconVariant="Regular" FontSize="14"
+                                                               IsVisible="{Binding IsVisible}" />
+                                                <ic:FluentIcon Icon="EyeOff" IconVariant="Regular" FontSize="14"
+                                                               IsVisible="{Binding !IsVisible}" />
+                                            </Panel>
+                                        </Button>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding DisplayName}"
+                                                   VerticalAlignment="Center"
+                                                   Opacity="{Binding RowOpacity}"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <Border Grid.Column="2" Classes="SpecTag">
+                                            <TextBlock Text="{Binding ProductSpec}"
+                                                       FontSize="10"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.8" />
+                                        </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </TreeView.DataTemplates>
+                        </TreeView>
+                    </DockPanel>
+                </TabItem>
+
+                <!-- ── Datasets tab: flat render-order list with reorder. -->
+                <TabItem Header="{x:Static loc:Strings.Pane_Tab_Datasets}">
+                    <DockPanel LastChildFill="True">
+                        <!-- Bulk-action toolbar: applies to every loaded
+                             dataset. "Isolate" is per-row (context menu). -->
+                        <StackPanel DockPanel.Dock="Top"
+                                    Orientation="Horizontal"
+                                    Spacing="4"
+                                    Margin="8,0,8,4">
+                            <Button Classes="Icon"
+                                    x:Name="ToolbarAddButton"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_AddDataset}">
+                                <ic:FluentIcon Icon="Add" IconVariant="Regular" FontSize="14" />
+                            </Button>
+                            <Button Classes="Icon"
+                                    Command="{Binding ShowAllCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShowAllDatasets}">
+                                <ic:FluentIcon Icon="Eye" IconVariant="Regular" FontSize="14" />
+                            </Button>
+                            <Button Classes="Icon"
+                                    Command="{Binding HideAllCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_HideAllDatasets}">
+                                <ic:FluentIcon Icon="EyeOff" IconVariant="Regular" FontSize="14" />
+                            </Button>
+                            <Button Classes="Icon"
+                                    Command="{Binding ResetOpacityCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_ResetDatasetOpacity}">
+                                <ic:FluentIcon Icon="ArrowReset" IconVariant="Regular" FontSize="14" />
+                            </Button>
+                        </StackPanel>
+
+                        <!-- Flat dataset list (render order). Padding/margin
+                             zeroed on items so the entire row hit-tests for
+                             click-to-select and right-click. -->
+                        <ListBox x:Name="DatasetList"
                      ItemsSource="{Binding Entries}"
-                     SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                     SelectedItem="{Binding SelectedDataset, Mode=TwoWay}"
                      Classes="accentList"
                      Background="Transparent"
                      BorderThickness="0"
                      Padding="0"
-                     Margin="8,4,8,0"
+                     Margin="8,0,8,0"
                      DoubleTapped="OnDatasetDoubleTapped"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <ListBox.ItemTemplate>
@@ -401,8 +539,11 @@
                             </Grid>
                         </Border>
                     </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
+                        </ListBox.ItemTemplate>
+                        </ListBox>
+                    </DockPanel>
+                </TabItem>
+            </TabControl>
 
             <!-- Splitter between list and properties. The 1px hairline is
                  a separate non-hit-testing border; the GridSplitter sits
@@ -429,15 +570,78 @@
                  from the list selection above; no header needed. -->
             <Border Grid.Row="2" ClipToBounds="True">
                 <Panel>
-                    <!-- Empty-state placeholder -->
-                    <TextBlock IsVisible="{Binding !HasSelection}"
-                               Text="{x:Static loc:Strings.Pane_DatasetSelectPlaceholder}"
+                    <!-- Empty-state placeholder (nothing selected in either tab). -->
+                    <TextBlock IsVisible="{Binding HasNoInspectorSelection}"
+                               Text="{x:Static loc:Strings.Pane_InspectorSelectPlaceholder}"
                                Opacity="0.6"
                                TextWrapping="Wrap"
                                Margin="16"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center"
                                TextAlignment="Center" />
+
+                    <!-- Exchange-set metadata view (source-node selection). -->
+                    <ScrollViewer IsVisible="{Binding HasExchangeSetSelection}"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto"
+                                  Margin="0,8,0,0">
+                        <StackPanel Spacing="12" Margin="8,8,8,8">
+                            <Grid ColumnDefinitions="Auto,*" RowSpacing="6" ColumnSpacing="12">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Opacity="0.6"
+                                           Text="{x:Static loc:Strings.Pane_ExchangeSetField_Source}" />
+                                <TextBlock Grid.Row="0" Grid.Column="1"
+                                           Text="{Binding InspectedExchangeSet.DisplayName}"
+                                           TextWrapping="Wrap" FontWeight="SemiBold" />
+                                <TextBlock Grid.Row="1" Grid.Column="0" Opacity="0.6"
+                                           Text="{x:Static loc:Strings.Pane_ExchangeSetField_Producer}"
+                                           IsVisible="{Binding InspectedExchangeSet.Producer, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <TextBlock Grid.Row="1" Grid.Column="1"
+                                           Text="{Binding InspectedExchangeSet.Producer}"
+                                           TextWrapping="Wrap"
+                                           IsVisible="{Binding InspectedExchangeSet.Producer, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <TextBlock Grid.Row="2" Grid.Column="0" Opacity="0.6"
+                                           Text="{x:Static loc:Strings.Pane_ExchangeSetField_Issued}"
+                                           IsVisible="{Binding InspectedExchangeSet.IssueDate, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <TextBlock Grid.Row="2" Grid.Column="1"
+                                           Text="{Binding InspectedExchangeSet.IssueDate}"
+                                           IsVisible="{Binding InspectedExchangeSet.IssueDate, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <TextBlock Grid.Row="3" Grid.Column="0" Opacity="0.6"
+                                           Text="{x:Static loc:Strings.Pane_ExchangeSetField_Datasets}" />
+                                <TextBlock Grid.Row="3" Grid.Column="1"
+                                           Text="{Binding InspectedExchangeSet.MemberCount}" />
+                                <TextBlock Grid.Row="4" Grid.Column="0" Opacity="0.6"
+                                           Text="{x:Static loc:Strings.Pane_ExchangeSetField_Path}" />
+                                <TextBlock Grid.Row="4" Grid.Column="1"
+                                           Text="{Binding InspectedExchangeSet.SourcePath}"
+                                           TextWrapping="Wrap" FontSize="11" Opacity="0.8" />
+                            </Grid>
+                            <StackPanel Orientation="Horizontal" Spacing="6"
+                                        ToolTip.Tip="{Binding InspectedExchangeSet.SignatureTooltip}">
+                                <ic:FluentIcon FontSize="18"
+                                               IsVisible="{Binding InspectedExchangeSet.SignatureStatus, Converter={StaticResource SignatureStatusVerifiedConverter}}"
+                                               Icon="ShieldCheckmark" IconVariant="Filled" Foreground="#16a34a" />
+                                <ic:FluentIcon FontSize="18"
+                                               IsVisible="{Binding InspectedExchangeSet.SignatureStatus, Converter={StaticResource SignatureStatusUnsignedConverter}}"
+                                               Icon="ShieldDismiss" IconVariant="Regular" Opacity="0.5" />
+                                <ic:FluentIcon FontSize="18"
+                                               IsVisible="{Binding InspectedExchangeSet.SignatureStatus, Converter={StaticResource SignatureStatusInvalidConverter}}"
+                                               Icon="ShieldError" IconVariant="Filled" Foreground="#dc2626" />
+                                <ic:FluentIcon FontSize="18"
+                                               IsVisible="{Binding InspectedExchangeSet.SignatureStatus, Converter={StaticResource SignatureStatusCheckingConverter}}"
+                                               Icon="Shield" IconVariant="Regular" Opacity="0.4" />
+                                <TextBlock Text="{Binding InspectedExchangeSet.SignatureTooltip}"
+                                           VerticalAlignment="Center" FontSize="12" Opacity="0.8"
+                                           TextTrimming="CharacterEllipsis" />
+                            </StackPanel>
+                        </StackPanel>
+                    </ScrollViewer>
 
                     <TabControl Classes="CenteredTabs"
                                 IsVisible="{Binding HasSelection}"
@@ -643,28 +847,6 @@
                 </Panel>
             </Border>
 
-            <!-- Empty-state placeholder: shown in the master (list) row
-                 when no datasets are loaded, centered within that area so
-                 it doesn't drift over the Properties sub-panel below.
-                 Declared after the list so it sits above the (otherwise
-                 transparent) ListBox, keeping the inline "Open Dataset"
-                 button hit-testable. The button sits directly below the
-                 placeholder and disappears once a dataset is present (the
-                 menu, the toolbar "+" and drag-and-drop remain available). -->
-            <StackPanel Grid.Row="0"
-                        IsVisible="{Binding IsEmpty}"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Spacing="8">
-                <views:PlaceholderView Icon="Layer"
-                                       Header="{x:Static loc:Strings.Datasets_EmptyTitle}"
-                                       Description="{x:Static loc:Strings.Datasets_EmptyDescription}" />
-                <Button x:Name="EmptyAddButton"
-                        Classes="Outline"
-                        Content="{x:Static loc:Strings.Button_OpenDataset}"
-                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenDataset}"
-                        HorizontalAlignment="Center" />
-            </StackPanel>
         </Grid>
-    </DockPanel>
+    </Panel>
 </UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml
@@ -311,6 +311,7 @@
                                         Opacity="0"
                                         CornerRadius="4" />
                                 <Border Background="Transparent"
+                                        Margin="6,0,0,0"
                                         Focusable="True"
                                         TemplatedControl.IsTemplateFocusTarget="True">
                                     <Grid Name="PART_Header" ColumnDefinitions="16,*">
@@ -357,8 +358,13 @@
         <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ Border#PART_Bar">
             <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
         </Style>
-        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ ContentPresenter#PART_HeaderPresenter TextBlock.accentTreeTitle">
-            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+        <!-- Recolour the selected row's primary text to the accent, mirroring
+             accentList's accentListTitle. Driven through inherited
+             TextElement.Foreground on this item's own header presenter (so it
+             never bleeds into nested rows); the secondary count badge and spec
+             tag pin their own foreground below to stay neutral. -->
+        <Style Selector="TreeView.accentTree TreeViewItem:selected /template/ ContentPresenter#PART_HeaderPresenter">
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentBrush}" />
         </Style>
     </UserControl.Styles>
 
@@ -462,7 +468,6 @@
                                             </Panel>
                                         </Button>
                                         <TextBlock Grid.Column="1"
-                                                   Classes="accentTreeTitle"
                                                    Text="{Binding DisplayName}"
                                                    FontWeight="SemiBold"
                                                    VerticalAlignment="Center"
@@ -471,6 +476,7 @@
                                         <Border Grid.Column="2" Classes="CountBadge">
                                             <TextBlock Text="{Binding MemberCount}"
                                                        FontSize="11"
+                                                       Foreground="{DynamicResource ForegroundColor}"
                                                        TextAlignment="Center" />
                                         </Border>
                                         <Panel Grid.Column="3"
@@ -517,7 +523,6 @@
                                             </Panel>
                                         </Button>
                                         <TextBlock Grid.Column="1"
-                                                   Classes="accentTreeTitle"
                                                    Text="{Binding DisplayName}"
                                                    VerticalAlignment="Center"
                                                    Opacity="{Binding RowOpacity}"
@@ -526,6 +531,7 @@
                                             <TextBlock Text="{Binding ProductSpec}"
                                                        FontSize="10"
                                                        FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource ForegroundColor}"
                                                        Opacity="0.8" />
                                         </Border>
                                     </Grid>

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
@@ -16,6 +16,7 @@ public partial class DatasetsView : UserControl
         InitializeComponent();
         EmptyAddButton.Click += OnAddClick;
         ToolbarAddButton.Click += OnAddClick;
+        SourcesAddButton.Click += OnAddClick;
     }
 
     private async void OnAddClick(object? sender, RoutedEventArgs e)

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsPanelTabsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsPanelTabsTests.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers the Datasets-panel tabs refactor (issue #378): source→dataset
+/// grouping, per-source visibility fan-out, inspector selection
+/// coordination across the two tabs, and the conditional default tab.
+/// </summary>
+public class DatasetsPanelTabsTests
+{
+    private sealed class StubAssetSource : IAssetSource
+    {
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public void Dispose() { }
+    }
+
+    private sealed class NoopLoader : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
+    }
+
+    private static DatasetsViewModel NewVm() => new(new NoopLoader());
+
+    // ── Grouping ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Grouping_NestsDatasetsUnderTheirSource()
+    {
+        var vm = NewVm();
+        var srcA = new StubAssetSource();
+        var headerA = vm.RegisterExchangeSetHeader(srcA, "/a", null, null, 2, _ => { });
+
+        var d1 = vm.AddFromExchangeSet(srcA, "a/d1.000", "S-101");
+        var d2 = vm.AddFromExchangeSet(srcA, "a/d2.000", "S-101");
+
+        Assert.Equal(2, headerA.MemberCount);
+        Assert.Contains(d1, headerA.Datasets);
+        Assert.Contains(d2, headerA.Datasets);
+    }
+
+    [Fact]
+    public void Grouping_LooseDatasets_AreNotNestedUnderAnySource()
+    {
+        var vm = NewVm();
+        var srcA = new StubAssetSource();
+        var headerA = vm.RegisterExchangeSetHeader(srcA, "/a", null, null, 1, _ => { });
+
+        vm.AddFromExchangeSet(srcA, "a/d1.000", "S-101");
+        var loose = vm.Add("/disk/loose.000", "S-101");
+
+        Assert.DoesNotContain(loose, headerA.Datasets);
+        Assert.Equal(1, headerA.MemberCount);
+    }
+
+    [Fact]
+    public void Grouping_KeepsMembersInEntriesOrder()
+    {
+        var vm = NewVm();
+        var srcA = new StubAssetSource();
+        var headerA = vm.RegisterExchangeSetHeader(srcA, "/a", null, null, 2, _ => { });
+
+        // AddFromExchangeSet inserts at index 0, so the most recently added
+        // entry leads. The nested list must mirror that order.
+        var first = vm.AddFromExchangeSet(srcA, "a/d1.000", "S-101");
+        var second = vm.AddFromExchangeSet(srcA, "a/d2.000", "S-101");
+
+        Assert.Same(second, headerA.Datasets[0]);
+        Assert.Same(first, headerA.Datasets[1]);
+    }
+
+    [Fact]
+    public void Grouping_TwoSources_DoNotCrossContaminate()
+    {
+        var vm = NewVm();
+        var srcA = new StubAssetSource();
+        var srcB = new StubAssetSource();
+        var headerA = vm.RegisterExchangeSetHeader(srcA, "/a", null, null, 1, _ => { });
+        var headerB = vm.RegisterExchangeSetHeader(srcB, "/b", null, null, 1, _ => { });
+
+        var da = vm.AddFromExchangeSet(srcA, "a/d.000", "S-101");
+        var db = vm.AddFromExchangeSet(srcB, "b/d.000", "S-102");
+
+        Assert.Single(headerA.Datasets);
+        Assert.Single(headerB.Datasets);
+        Assert.Contains(da, headerA.Datasets);
+        Assert.Contains(db, headerB.Datasets);
+    }
+
+    // ── Per-source visibility fan-out ────────────────────────────────
+
+    [Fact]
+    public void SourceVisibility_HidesAllMembers_WhenAnyVisible()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var header = vm.RegisterExchangeSetHeader(src, "/a", null, null, 2, _ => { });
+        var d1 = vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+        var d2 = vm.AddFromExchangeSet(src, "a/d2.000", "S-101");
+
+        Assert.True(header.IsAnyDatasetVisible);
+
+        header.ToggleVisibilityCommand.Execute(null);
+
+        Assert.False(d1.IsVisible);
+        Assert.False(d2.IsVisible);
+        Assert.False(header.IsAnyDatasetVisible);
+    }
+
+    [Fact]
+    public void SourceVisibility_ShowsAllMembers_WhenAllHidden()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var header = vm.RegisterExchangeSetHeader(src, "/a", null, null, 2, _ => { });
+        var d1 = vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+        var d2 = vm.AddFromExchangeSet(src, "a/d2.000", "S-101");
+        d1.IsVisible = false;
+        d2.IsVisible = false;
+
+        Assert.False(header.IsAnyDatasetVisible);
+
+        header.ToggleVisibilityCommand.Execute(null);
+
+        Assert.True(d1.IsVisible);
+        Assert.True(d2.IsVisible);
+        Assert.True(header.IsAnyDatasetVisible);
+    }
+
+    [Fact]
+    public void SourceVisibility_IsAnyDatasetVisible_TracksMemberChanges()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var header = vm.RegisterExchangeSetHeader(src, "/a", null, null, 1, _ => { });
+        var d1 = vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+
+        var raised = false;
+        header.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ExchangeSetHeader.IsAnyDatasetVisible)) raised = true;
+        };
+
+        d1.IsVisible = false;
+
+        Assert.True(raised);
+        Assert.False(header.IsAnyDatasetVisible);
+    }
+
+    // ── Inspector selection coordination ─────────────────────────────
+
+    [Fact]
+    public void Selection_SourceNode_DrivesExchangeSetInspector()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var header = vm.RegisterExchangeSetHeader(src, "/a", "ACME", "2024-01-01", 1, _ => { });
+        vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+
+        vm.ActiveTabIndex = DatasetsViewModel.ExchangeSetsTabIndex;
+        vm.SelectedSourceNode = header;
+
+        Assert.True(vm.HasExchangeSetSelection);
+        Assert.False(vm.HasSelection);
+        Assert.False(vm.HasNoInspectorSelection);
+        Assert.Same(header, vm.InspectedExchangeSet);
+    }
+
+    [Fact]
+    public void Selection_NestedDataset_DrivesDatasetInspector()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        vm.RegisterExchangeSetHeader(src, "/a", null, null, 1, _ => { });
+        var d1 = vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+
+        vm.ActiveTabIndex = DatasetsViewModel.ExchangeSetsTabIndex;
+        vm.SelectedSourceNode = d1;
+
+        Assert.True(vm.HasSelection);
+        Assert.False(vm.HasExchangeSetSelection);
+        Assert.Same(d1, vm.SelectedEntry);
+        Assert.Null(vm.InspectedExchangeSet);
+    }
+
+    [Fact]
+    public void Selection_DatasetsTab_UsesFlatListSelection()
+    {
+        var vm = NewVm();
+        var d1 = vm.Add("/disk/loose.000", "S-101");
+
+        vm.ActiveTabIndex = DatasetsViewModel.DatasetsTabIndex;
+        vm.SelectedDataset = d1;
+
+        Assert.True(vm.HasSelection);
+        Assert.Same(d1, vm.SelectedEntry);
+        Assert.False(vm.HasExchangeSetSelection);
+    }
+
+    [Fact]
+    public void Selection_SwitchingTabs_RetargetsInspector()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var header = vm.RegisterExchangeSetHeader(src, "/a", null, null, 1, _ => { });
+        var nested = vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+        var loose = vm.Add("/disk/loose.000", "S-101");
+
+        vm.SelectedSourceNode = header;
+        vm.SelectedDataset = loose;
+
+        // Exchange sets tab active → exchange set inspected.
+        vm.ActiveTabIndex = DatasetsViewModel.ExchangeSetsTabIndex;
+        Assert.Same(header, vm.InspectedExchangeSet);
+        Assert.False(vm.HasSelection);
+
+        // Datasets tab active → the flat-list selection is inspected.
+        vm.ActiveTabIndex = DatasetsViewModel.DatasetsTabIndex;
+        Assert.Same(loose, vm.SelectedEntry);
+        Assert.Null(vm.InspectedExchangeSet);
+
+        // Sanity: nested entry is part of the source's children.
+        Assert.Contains(nested, header.Datasets);
+    }
+
+    [Fact]
+    public void Selection_NothingSelected_ShowsPlaceholder()
+    {
+        var vm = NewVm();
+        vm.Add("/disk/loose.000", "S-101");
+
+        Assert.True(vm.HasNoInspectorSelection);
+        Assert.False(vm.HasSelection);
+        Assert.False(vm.HasExchangeSetSelection);
+    }
+
+    // ── Conditional default tab ──────────────────────────────────────
+
+    [Fact]
+    public void DefaultTab_WithExchangeSets_IsExchangeSets()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        vm.RegisterExchangeSetHeader(src, "/a", null, null, 1, _ => { });
+        vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+
+        Assert.True(vm.HasExchangeSets);
+        Assert.Equal(DatasetsViewModel.ExchangeSetsTabIndex, vm.ActiveTabIndex);
+    }
+
+    [Fact]
+    public void DefaultTab_OnlyLooseDatasets_IsDatasets()
+    {
+        var vm = NewVm();
+        vm.Add("/disk/loose.000", "S-101");
+
+        Assert.False(vm.HasExchangeSets);
+        Assert.Equal(DatasetsViewModel.DatasetsTabIndex, vm.ActiveTabIndex);
+    }
+
+    [Fact]
+    public void DefaultTab_UserPin_IsNotOverriddenByLaterLoads()
+    {
+        var vm = NewVm();
+        vm.Add("/disk/loose.000", "S-101");
+        Assert.Equal(DatasetsViewModel.DatasetsTabIndex, vm.ActiveTabIndex);
+
+        // User explicitly switches to Exchange sets.
+        vm.ActiveTabIndex = DatasetsViewModel.ExchangeSetsTabIndex;
+
+        // A later loose load must not yank the tab back to Datasets.
+        vm.Add("/disk/loose2.000", "S-101");
+
+        Assert.Equal(DatasetsViewModel.ExchangeSetsTabIndex, vm.ActiveTabIndex);
+    }
+
+    [Fact]
+    public void DefaultTab_PinResets_WhenPanelEmpties()
+    {
+        var vm = NewVm();
+        var loose = vm.Add("/disk/loose.000", "S-101");
+        vm.ActiveTabIndex = DatasetsViewModel.ExchangeSetsTabIndex;
+
+        // Empty the panel; the pin resets so the default applies again.
+        vm.Entries.Remove(loose);
+        Assert.True(vm.IsEmpty);
+
+        // Now load an exchange set; default should pick Exchange sets.
+        var src = new StubAssetSource();
+        vm.RegisterExchangeSetHeader(src, "/a", null, null, 1, _ => { });
+        vm.AddFromExchangeSet(src, "a/d1.000", "S-101");
+
+        Assert.Equal(DatasetsViewModel.ExchangeSetsTabIndex, vm.ActiveTabIndex);
+    }
+
+    [Fact]
+    public void HasExchangeSets_FalseWhenNoneRegistered()
+    {
+        var vm = NewVm();
+        Assert.False(vm.HasExchangeSets);
+    }
+}


### PR DESCRIPTION
## Why

As loading exchange sets over individual datasets became common, the Datasets activity panel grew hard to use. Many exchange-set rows (which cannot be selected) pushed the selectable datasets down, leaving the inspector/properties pane almost no vertical room. This restructures the panel to keep both lists usable and the inspector readable.

Closes #378

## What changed

The single flat list is split into two internal tabs above a pinned inspector:

- **Exchange sets** tab shows a two-level tree (source -> its datasets) with per-item show/hide, expanded by default. It does not allow reordering, since render order is a cross-source concern.
- **Datasets** tab behaves as before: a flat, reorderable list with the bulk-action toolbar.
- The **inspector** shows whichever item is selected (exchange set or dataset), so it no longer competes with the lists for height.

## Styling

The panel was iterated to match the app's visual language:

- Both tab strips (outer Exchange sets / Datasets and the inner Dataset / Layers / Validation) use ShadUI's sliding-pill tabs with shared title-strip typography (small, letter-spaced, uppercase).
- The Exchange-sets tree adopts the app-wide `accentList` selection treatment: a 3px accent bar at the true left edge, a low-opacity accent tint, and an accent-recoloured title.
- Removed the redundant SOURCES sub-header (leaving just the add-source button) and left-aligned both command bars.

## Notes for reviewers

- All selection/typography styling lives in `DatasetsView.axaml`. The base theme behind ShadUI is Avalonia SimpleTheme (not Fluent), so the TreeViewItem is fully retemplated to avoid SimpleTheme's solid selection fill; part names and the indent converter are preserved so nested rows align and childless rows hide their chevron.
- The selected-title recolour is done by setting inherited `TextElement.Foreground` on the selected item's own header presenter (a `/template/ ... TextBlock` selector cannot cross into the DataTemplate namescope). It uses `{DynamicResource AccentBrush}` so it stays correct across Day/Dusk/Night palettes.

## Testing

- New `DatasetsPanelTabsTests.cs` covers the view-model tab/grouping behaviour.
- Full viewer suite: 1291 passed, 1 skipped.
- Verified end to end in the viewer with real S-101 trial cells loaded as exchange sets.