### PR TITLE
Add About dialog with GitHub-release update notifications

### DIFF
--- a/.github/skills/viewer-evaluation/SKILL.md
+++ b/.github/skills/viewer-evaluation/SKILL.md
@@ -65,6 +65,20 @@ diffs across a code change.
 Use when you need to load → reframe → toggle palette/time-step → screenshot
 repeatedly within one process, or to read structured timing.
 
+### C. Hand-off to a human for manual GUI testing
+When you launch the viewer for the **user** to click through (e.g. to
+verify a dialog or interaction), it must outlive your shell session. A
+plain `nohup … & disown` from a sync/attached command is killed when the
+command's session is torn down — the GUI window dies seconds later.
+**Always launch detached** so the process is fully independent:
+
+- Use the `bash` tool with `mode: "async"` **and** `detach: true`. Do
+  *not* rely on `& disown` in a sync command for hand-off runs.
+- The process survives session shutdown; stop it explicitly with
+  `kill -9 <pid>` (never name-based kills) when the user is done.
+- Confirm it stayed up (`pgrep -f EncDotNet.S100.Viewer/bin`) before
+  telling the user it's ready.
+
 ## Procedure for mode B
 
 ### 1. Build, then launch the binary (not `dotnet run`)
@@ -77,6 +91,11 @@ nohup src/EncDotNet.S100.Viewer/bin/Release/net10.0/<rid>/EncDotNet.S100.Viewer 
   --data-dir /tmp/eval/data --mcp --mcp-port-file /tmp/eval/mcp.url \
   >/tmp/eval/viewer.log 2>&1 & disown
 ```
+
+> For runs the **user** will interact with (or that must persist past
+> the current command), launch via the `bash` tool with
+> `mode: "async", detach: true` instead of `& disown` — an attached
+> launch is killed with the session and the window dies. See mode C.
 
 - `--data-dir <PATH>` → **fully isolated instance**: settings, crash
   markers, and all disk caches are re-rooted under the folder. Point it

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
@@ -60,6 +61,44 @@ public partial class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+        ConfigureMacApplicationMenu();
+    }
+
+    /// <summary>
+    /// On macOS, replaces the auto-generated application-menu "About"
+    /// item (which would otherwise show Avalonia's built-in about box)
+    /// with one that opens this app's About dialog.
+    /// </summary>
+    /// <remarks>
+    /// The macOS application menu is read from
+    /// <see cref="NativeMenu.GetMenu(Avalonia.AvaloniaObject)"/> on the
+    /// <see cref="Application"/> exactly once, early during framework
+    /// setup (after <see cref="Initialize"/> but before the main window
+    /// exists). Setting it here ensures Avalonia adopts our menu instead
+    /// of synthesizing the default; the standard Services/Hide/Quit items
+    /// are appended to it automatically. The About item is wired on other
+    /// platforms through the Help menu instead (see
+    /// <see cref="Services.NativeMenuBuilder"/>).
+    /// </remarks>
+    private void ConfigureMacApplicationMenu()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return;
+
+        var aboutItem = new NativeMenuItem(Strings.Menu_About);
+        aboutItem.Click += (_, _) =>
+        {
+            try
+            {
+                Services.GetRequiredService<MainViewModel>().ShowAboutCommand.Execute(null);
+            }
+            catch (InvalidOperationException)
+            {
+                // Services not yet initialized; ignore the early click.
+            }
+        };
+
+        NativeMenu.SetMenu(this, new NativeMenu { aboutItem });
     }
 
     public override void OnFrameworkInitializationCompleted()
@@ -110,6 +149,8 @@ public partial class App : Application
         // dialog now that the singleton manager exists.
         s_services.GetRequiredService<ShadUI.DialogManager>()
             .Register<Views.FeedbackDialogView, ViewModels.FeedbackDialogViewModel>();
+        s_services.GetRequiredService<ShadUI.DialogManager>()
+            .Register<Views.AboutDialogView, ViewModels.AboutDialogViewModel>();
 
         // Interpose the translation-invariant vector path cache (solid
         // polygons + solid-stroked, resolution-simplified lines) before
@@ -490,6 +531,25 @@ public partial class App : Application
         services.AddTransient<FeedbackDialogViewModel>();
         services.AddSingleton<Func<FeedbackDialogViewModel>>(sp =>
             sp.GetRequiredService<FeedbackDialogViewModel>);
+
+        // About dialog + GitHub-release update check (issue #379).
+        services.AddSingleton<IUrlOpener>(sp =>
+            new ProcessUrlOpener(sp.GetService<ILogger<ProcessUrlOpener>>()));
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.Updates.IAppVersionProvider>(
+            _ => new EncDotNet.S100.Viewer.Services.Updates.AssemblyAppVersionProvider());
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.Updates.IGitHubReleaseClient>(sp =>
+            new EncDotNet.S100.Viewer.Services.Updates.GitHubReleaseClient(
+                new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(10) },
+                sp.GetService<ILogger<EncDotNet.S100.Viewer.Services.Updates.GitHubReleaseClient>>()));
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.Updates.IUpdateService>(sp =>
+            new EncDotNet.S100.Viewer.Services.Updates.UpdateService(
+                sp.GetRequiredService<EncDotNet.S100.Viewer.Services.Updates.IGitHubReleaseClient>(),
+                sp.GetRequiredService<EncDotNet.S100.Viewer.Services.Updates.IAppVersionProvider>(),
+                sp.GetRequiredService<ViewerSettings>(),
+                sp.GetRequiredService<TimeProvider>()));
+        services.AddTransient<AboutDialogViewModel>();
+        services.AddSingleton<Func<AboutDialogViewModel>>(sp =>
+            sp.GetRequiredService<AboutDialogViewModel>);
 
         services.AddSingleton<IDatasetLoaderService, DatasetLoaderService>();
         services.AddSingleton<IPickService, PickService>();

--- a/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
+++ b/src/EncDotNet.S100.Viewer/EncDotNet.S100.Viewer.csproj
@@ -14,6 +14,18 @@
     <UseSkiaSharpLinuxNoDependencies>true</UseSkiaSharpLinuxNoDependencies>
   </PropertyGroup>
 
+  <!--
+    Build date surfaced by the About dialog (issue #379). Defaults to the
+    UTC build date; CI may override with -p:BuildDate=YYYY-MM-DD. Embedded as
+    assembly metadata and read via AssemblyMetadataAttribute at runtime.
+  -->
+  <PropertyGroup>
+    <BuildDate Condition="'$(BuildDate)' == ''">$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd"))</BuildDate>
+  </PropertyGroup>
+  <ItemGroup>
+    <AssemblyMetadata Include="BuildDate" Value="$(BuildDate)" />
+  </ItemGroup>
+
   <ItemGroup>
     <!--
       Avalonia window icon. Loaded via avares://… in MainWindow.axaml.

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -422,6 +422,36 @@ viewer has a built-in **Report Feedback** experience:
 No data leaves your machine until you choose to create the GitHub
 issue, and nothing is uploaded by the viewer itself.
 
+## About and software updates
+
+The **Help → About EncDotNet.S100 Viewer** menu opens an About dialog
+that shows the running **version** (and the build's informational
+version + commit SHA + build date) and checks GitHub for a newer
+release:
+
+- The version comes from the assembly's informational version, which is
+  injected from the release git tag at build time (local/dev builds
+  report `0.0.0-dev`).
+- When opened, the dialog checks the repository's
+  [latest GitHub release](https://github.com/philliphoff/EncDotNet.S100/releases)
+  and reports either **"You're up to date"** or **"Update available —
+  X.Y.Z"** with release highlights, the publish date, and the asset
+  size. The check is non-blocking and fails silently when offline.
+- **Update now** opens the release page so you can download the build
+  for your platform (the viewer does not self-update). **Release notes**
+  opens the full notes on GitHub.
+- **Skip** mutes *proactive* notifications (toasts) for that release only
+  — the About dialog still truthfully shows the update so you can install
+  it later, and you're still notified of *later* releases. The skipped
+  version is remembered in your settings (`SkippedUpdateVersion`).
+- Update checks are throttled to roughly once per day and can be turned
+  off entirely; dev builds never check (so `0.0.0-dev` shows a neutral
+  "update checks unavailable" panel). To exercise the live check against
+  the real GitHub API from a dev build, launch with `S100_UPDATE_FORCE=1`
+  — it bypasses the dev-build gate for manual/agent verification only and
+  must never be set in shipped builds. See issue #379 for the broader
+  update-notification design.
+
 ### Crash recovery (next-startup reporting)
 
 Some crashes — a native fault in the GPU/SkiaSharp stack, an

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -187,6 +187,42 @@ internal static class Strings
     public static string Menu_PickMode => Get(nameof(Menu_PickMode));
     public static string Menu_Help => Get(nameof(Menu_Help));
     public static string Menu_ReportFeedback => Get(nameof(Menu_ReportFeedback));
+    public static string Menu_About => Get(nameof(Menu_About));
+
+    // About dialog
+    public static string About_Title => Get(nameof(About_Title));
+    public static string About_CloseTooltip => Get(nameof(About_CloseTooltip));
+    public static string About_ProductName => Get(nameof(About_ProductName));
+    public static string About_ProductSubtitle => Get(nameof(About_ProductSubtitle));
+    public static string About_CopyrightFormat => Get(nameof(About_CopyrightFormat));
+    public static string About_BuiltWith => Get(nameof(About_BuiltWith));
+    public static string About_VersionFormat => Get(nameof(About_VersionFormat));
+    public static string About_BuildFormat => Get(nameof(About_BuildFormat));
+    public static string About_Checking => Get(nameof(About_Checking));
+    public static string About_UpToDate => Get(nameof(About_UpToDate));
+    public static string About_LastCheckedFormat => Get(nameof(About_LastCheckedFormat));
+    public static string About_LastCheckedNever => Get(nameof(About_LastCheckedNever));
+    public static string About_CheckNow => Get(nameof(About_CheckNow));
+    public static string About_CheckNowTooltip => Get(nameof(About_CheckNowTooltip));
+    public static string About_UpdateAvailableFormat => Get(nameof(About_UpdateAvailableFormat));
+    public static string About_ReleasedFormat => Get(nameof(About_ReleasedFormat));
+    public static string About_UpdateNow => Get(nameof(About_UpdateNow));
+    public static string About_UpdateNowTooltip => Get(nameof(About_UpdateNowTooltip));
+    public static string About_ReleaseNotes => Get(nameof(About_ReleaseNotes));
+    public static string About_ReleaseNotesTooltip => Get(nameof(About_ReleaseNotesTooltip));
+    public static string About_Skip => Get(nameof(About_Skip));
+    public static string About_SkipTooltip => Get(nameof(About_SkipTooltip));
+    public static string About_UpdateSkipped => Get(nameof(About_UpdateSkipped));
+    public static string About_CheckFailed => Get(nameof(About_CheckFailed));
+    public static string About_ChecksDisabled => Get(nameof(About_ChecksDisabled));
+    public static string About_License => Get(nameof(About_License));
+    public static string About_LicenseTooltip => Get(nameof(About_LicenseTooltip));
+    public static string About_ThirdPartyNotices => Get(nameof(About_ThirdPartyNotices));
+    public static string About_ThirdPartyNoticesTooltip => Get(nameof(About_ThirdPartyNoticesTooltip));
+    public static string About_Time_JustNow => Get(nameof(About_Time_JustNow));
+    public static string About_Time_MinutesAgo => Get(nameof(About_Time_MinutesAgo));
+    public static string About_Time_HoursAgo => Get(nameof(About_Time_HoursAgo));
+    public static string About_Time_DaysAgo => Get(nameof(About_Time_DaysAgo));
 
     // Feedback dialog
     public static string Feedback_DialogTitle => Get(nameof(Feedback_DialogTitle));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -2054,4 +2054,106 @@
   <data name="Tooltip_Helm_Starboard" xml:space="preserve">
     <value>Alter course 5° to starboard</value>
   </data>
+  <data name="Menu_About" xml:space="preserve">
+    <value>About S-100 Viewer</value>
+  </data>
+  <data name="About_Title" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="About_CloseTooltip" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="About_ProductName" xml:space="preserve">
+    <value>S-100 Viewer</value>
+  </data>
+  <data name="About_ProductSubtitle" xml:space="preserve">
+    <value>S-100 and related spec dataset viewer</value>
+  </data>
+  <data name="About_CopyrightFormat" xml:space="preserve">
+    <value>© {0} EncDotNet</value>
+  </data>
+  <data name="About_BuiltWith" xml:space="preserve">
+    <value>Built with Avalonia, a cross-platform UI framework. Made possible by the generous support of its contributors and community.</value>
+  </data>
+  <data name="About_VersionFormat" xml:space="preserve">
+    <value>Version {0}</value>
+  </data>
+  <data name="About_BuildFormat" xml:space="preserve">
+    <value>build {0}</value>
+  </data>
+  <data name="About_Checking" xml:space="preserve">
+    <value>Checking for updates…</value>
+  </data>
+  <data name="About_UpToDate" xml:space="preserve">
+    <value>You're up to date</value>
+  </data>
+  <data name="About_LastCheckedFormat" xml:space="preserve">
+    <value>Last checked {0}</value>
+  </data>
+  <data name="About_LastCheckedNever" xml:space="preserve">
+    <value>Not checked yet</value>
+  </data>
+  <data name="About_CheckNow" xml:space="preserve">
+    <value>Check now</value>
+  </data>
+  <data name="About_CheckNowTooltip" xml:space="preserve">
+    <value>Check GitHub for a newer release now</value>
+  </data>
+  <data name="About_UpdateAvailableFormat" xml:space="preserve">
+    <value>Update available — {0}</value>
+  </data>
+  <data name="About_ReleasedFormat" xml:space="preserve">
+    <value>Released {0}</value>
+  </data>
+  <data name="About_UpdateNow" xml:space="preserve">
+    <value>Update now</value>
+  </data>
+  <data name="About_UpdateNowTooltip" xml:space="preserve">
+    <value>Open the release page to download the update</value>
+  </data>
+  <data name="About_ReleaseNotes" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="About_ReleaseNotesTooltip" xml:space="preserve">
+    <value>View the full release notes on GitHub</value>
+  </data>
+  <data name="About_Skip" xml:space="preserve">
+    <value>Skip</value>
+  </data>
+  <data name="About_SkipTooltip" xml:space="preserve">
+    <value>Skip this version — you'll still be notified of later releases</value>
+  </data>
+  <data name="About_UpdateSkipped" xml:space="preserve">
+    <value>Notifications muted for this version</value>
+  </data>
+  <data name="About_CheckFailed" xml:space="preserve">
+    <value>Couldn't check for updates. Check your connection and try again.</value>
+  </data>
+  <data name="About_ChecksDisabled" xml:space="preserve">
+    <value>Automatic update checks are turned off.</value>
+  </data>
+  <data name="About_License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="About_LicenseTooltip" xml:space="preserve">
+    <value>View the license on GitHub</value>
+  </data>
+  <data name="About_ThirdPartyNotices" xml:space="preserve">
+    <value>Third-party notices</value>
+  </data>
+  <data name="About_ThirdPartyNoticesTooltip" xml:space="preserve">
+    <value>View third-party notices on GitHub</value>
+  </data>
+  <data name="About_Time_JustNow" xml:space="preserve">
+    <value>just now</value>
+  </data>
+  <data name="About_Time_MinutesAgo" xml:space="preserve">
+    <value>{0} minutes ago</value>
+  </data>
+  <data name="About_Time_HoursAgo" xml:space="preserve">
+    <value>{0} hours ago</value>
+  </data>
+  <data name="About_Time_DaysAgo" xml:space="preserve">
+    <value>{0} days ago</value>
+  </data>
 </root>

--- a/src/EncDotNet.S100.Viewer/Services/IUrlOpener.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IUrlOpener.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Opens an external URL in the user's default browser. Abstracted so
+/// view-models that link out (e.g. the About dialog's "Update now") can be
+/// unit-tested without launching a real browser.
+/// </summary>
+internal interface IUrlOpener
+{
+    /// <summary>Opens <paramref name="url"/> in the default browser.</summary>
+    void Open(string url);
+}
+
+/// <summary>
+/// Default <see cref="IUrlOpener"/> that shell-launches the URL. Best-effort:
+/// a launch failure is logged and swallowed rather than surfaced to the user.
+/// </summary>
+internal sealed class ProcessUrlOpener : IUrlOpener
+{
+    private readonly ILogger<ProcessUrlOpener>? _logger;
+
+    public ProcessUrlOpener(ILogger<ProcessUrlOpener>? logger = null) => _logger = logger;
+
+    /// <inheritdoc />
+    public void Open(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to open URL {Url}.", url);
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/NativeMenuBuilder.cs
@@ -116,9 +116,19 @@ internal sealed class NativeMenuBuilder
 
         var reportFeedbackItem = new NativeMenuItem(Strings.Menu_ReportFeedback);
         reportFeedbackItem.Click += (_, _) => _viewModel.ShowFeedbackCommand.Execute(null);
+
+        // On macOS the About item lives in the application menu (see
+        // App.ConfigureMacApplicationMenu); elsewhere it belongs in Help.
+        var helpSubMenu = new NativeMenu { reportFeedbackItem };
+        if (!OperatingSystem.IsMacOS())
+        {
+            var aboutItem = new NativeMenuItem(Strings.Menu_About);
+            aboutItem.Click += (_, _) => _viewModel.ShowAboutCommand.Execute(null);
+            helpSubMenu.Add(aboutItem);
+        }
         var helpMenu = new NativeMenuItem(Strings.Menu_Help)
         {
-            Menu = new NativeMenu { reportFeedbackItem },
+            Menu = helpSubMenu,
         };
 
         var nativeMenu = new NativeMenu { fileMenu, viewMenu, helpMenu };

--- a/src/EncDotNet.S100.Viewer/Services/Updates/AppVersionInfo.cs
+++ b/src/EncDotNet.S100.Viewer/Services/Updates/AppVersionInfo.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace EncDotNet.S100.Viewer.Services.Updates;
+
+/// <summary>
+/// Immutable description of the running application's version, surfaced by
+/// the About dialog. Derived from assembly metadata so it always reflects
+/// the version injected at build time (<c>-p:Version=…</c>).
+/// </summary>
+/// <param name="Version">
+/// The release version without build metadata (e.g. <c>"2.4.1"</c> or the
+/// local <c>"0.0.0-dev"</c> default from <c>Directory.Build.props</c>).
+/// </param>
+/// <param name="InformationalVersion">
+/// The full informational version including any <c>+&lt;sha&gt;</c> source
+/// revision suffix appended by the SDK (e.g. <c>"2.4.1+a1f9c20…"</c>).
+/// </param>
+/// <param name="CommitSha">
+/// The short git commit SHA parsed from <paramref name="InformationalVersion"/>,
+/// or <see langword="null"/> when no source revision is embedded.
+/// </param>
+/// <param name="BuildDate">
+/// The UTC build date embedded via the <c>BuildDate</c> assembly metadata,
+/// or <see langword="null"/> when unavailable.
+/// </param>
+internal sealed record AppVersionInfo(
+    string Version,
+    string InformationalVersion,
+    string? CommitSha,
+    DateOnly? BuildDate)
+{
+    /// <summary>
+    /// True when this is an unversioned local development build (the
+    /// <c>0.0.0-dev</c> / <c>0.0.0</c> default). Update checks are skipped
+    /// for such builds because there is no meaningful release to compare.
+    /// </summary>
+    public bool IsDevelopmentBuild =>
+        Version.StartsWith("0.0.0", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Supplies the running application's <see cref="AppVersionInfo"/>.
+/// </summary>
+internal interface IAppVersionProvider
+{
+    /// <summary>Gets the current application version information.</summary>
+    AppVersionInfo Current { get; }
+}
+
+/// <summary>
+/// Default <see cref="IAppVersionProvider"/> that reads version metadata
+/// from a supplied assembly (the entry assembly in the running app).
+/// </summary>
+internal sealed class AssemblyAppVersionProvider : IAppVersionProvider
+{
+    /// <inheritdoc />
+    public AppVersionInfo Current { get; }
+
+    /// <summary>
+    /// Creates a provider reading from <paramref name="assembly"/>, or the
+    /// entry/executing assembly when none is supplied.
+    /// </summary>
+    public AssemblyAppVersionProvider(Assembly? assembly = null)
+    {
+        var asm = assembly
+            ?? Assembly.GetEntryAssembly()
+            ?? typeof(AssemblyAppVersionProvider).Assembly;
+
+        Current = FromAssembly(asm);
+    }
+
+    /// <summary>
+    /// Builds an <see cref="AppVersionInfo"/> from an assembly's
+    /// informational version and <c>BuildDate</c> metadata. Exposed for
+    /// unit testing the parsing logic.
+    /// </summary>
+    internal static AppVersionInfo FromAssembly(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
+
+        var (version, sha) = ParseInformationalVersion(informational);
+
+        DateOnly? buildDate = null;
+        var buildDateRaw = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, "BuildDate", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        if (!string.IsNullOrWhiteSpace(buildDateRaw)
+            && DateOnly.TryParse(buildDateRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            buildDate = parsed;
+        }
+
+        return new AppVersionInfo(version, informational, sha, buildDate);
+    }
+
+    /// <summary>
+    /// Splits an informational version into its release version (the part
+    /// before any <c>+</c> build-metadata) and the short commit SHA (the
+    /// first 7 characters of the build metadata when present).
+    /// </summary>
+    internal static (string Version, string? Sha) ParseInformationalVersion(string informational)
+    {
+        if (string.IsNullOrWhiteSpace(informational))
+            return ("0.0.0", null);
+
+        var plus = informational.IndexOf('+');
+        if (plus < 0)
+            return (informational, null);
+
+        var version = informational[..plus];
+        var metadata = informational[(plus + 1)..];
+        if (string.IsNullOrWhiteSpace(metadata))
+            return (version, null);
+
+        // SourceLink embeds the full 40-char SHA; show a short form.
+        var sha = metadata.Length > 7 ? metadata[..7] : metadata;
+        return (version, sha);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/Updates/GitHubReleaseClient.cs
+++ b/src/EncDotNet.S100.Viewer/Services/Updates/GitHubReleaseClient.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace EncDotNet.S100.Viewer.Services.Updates;
+
+/// <summary>
+/// <see cref="IGitHubReleaseClient"/> backed by the public GitHub Releases
+/// REST API. Reads <c>GET /repos/{owner}/{repo}/releases/latest</c>, which
+/// returns the most recent published, non-pre-release release.
+/// </summary>
+/// <remarks>
+/// The call is unauthenticated (60 requests/hour/IP); the update service
+/// throttles checks to stay well within that. All failures resolve to
+/// <see langword="null"/> so an offline or rate-limited viewer simply shows
+/// "couldn't check" rather than erroring.
+/// </remarks>
+internal sealed class GitHubReleaseClient : IGitHubReleaseClient
+{
+    /// <summary>Owner of the repository releases are published under.</summary>
+    public const string RepositoryOwner = "philliphoff";
+
+    /// <summary>Repository name releases are published under.</summary>
+    public const string RepositoryName = "EncDotNet.S100";
+
+    /// <summary>Browser URL of the repository's releases page (Tier-1 update target).</summary>
+    public const string ReleasesPageUrl =
+        $"https://github.com/{RepositoryOwner}/{RepositoryName}/releases";
+
+    /// <summary>Browser URL of the repository license.</summary>
+    public const string LicenseUrl =
+        $"https://github.com/{RepositoryOwner}/{RepositoryName}/blob/main/LICENSE";
+
+    /// <summary>Browser URL of the repository's third-party notices document.</summary>
+    public const string ThirdPartyNoticesUrl =
+        $"https://github.com/{RepositoryOwner}/{RepositoryName}/blob/main/THIRD-PARTY-NOTICES.md";
+
+    /// <summary>Browser URL of the repository (third-party notices fallback).</summary>
+    public const string RepositoryUrl =
+        $"https://github.com/{RepositoryOwner}/{RepositoryName}";
+
+    private const string LatestReleaseUrl =
+        $"https://api.github.com/repos/{RepositoryOwner}/{RepositoryName}/releases/latest";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<GitHubReleaseClient>? _logger;
+
+    public GitHubReleaseClient(HttpClient httpClient, ILogger<GitHubReleaseClient>? logger = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GitHubRelease?> GetLatestReleaseAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
+            // GitHub requires a User-Agent and recommends pinning the API version.
+            request.Headers.UserAgent.TryParseAdd($"{RepositoryName}-Viewer");
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+
+            using var response = await _httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger?.LogDebug("GitHub releases request returned {Status}.", response.StatusCode);
+                return null;
+            }
+
+            await using var stream = await response.Content
+                .ReadAsStreamAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            using var document = await JsonDocument
+                .ParseAsync(stream, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return Parse(document.RootElement);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to query the latest GitHub release.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Projects a GitHub <c>releases/latest</c> JSON payload into a
+    /// <see cref="GitHubRelease"/>. Exposed for unit testing the mapping.
+    /// </summary>
+    internal static GitHubRelease? Parse(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!root.TryGetProperty("tag_name", out var tagElement)
+            || tagElement.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var tag = tagElement.GetString();
+        if (string.IsNullOrWhiteSpace(tag))
+            return null;
+
+        string? name = root.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String
+            ? n.GetString()
+            : null;
+        string? htmlUrl = root.TryGetProperty("html_url", out var h) && h.ValueKind == JsonValueKind.String
+            ? h.GetString()
+            : null;
+        string? body = root.TryGetProperty("body", out var b) && b.ValueKind == JsonValueKind.String
+            ? b.GetString()
+            : null;
+
+        DateTimeOffset? publishedAt = null;
+        if (root.TryGetProperty("published_at", out var p)
+            && p.ValueKind == JsonValueKind.String
+            && DateTimeOffset.TryParse(p.GetString(), out var parsed))
+        {
+            publishedAt = parsed;
+        }
+
+        var isPrerelease = root.TryGetProperty("prerelease", out var pr)
+            && pr.ValueKind == JsonValueKind.True;
+
+        long? largestAsset = null;
+        if (root.TryGetProperty("assets", out var assets) && assets.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var asset in assets.EnumerateArray())
+            {
+                if (asset.TryGetProperty("size", out var size)
+                    && size.ValueKind == JsonValueKind.Number
+                    && size.TryGetInt64(out var bytes))
+                {
+                    largestAsset = Math.Max(largestAsset ?? 0, bytes);
+                }
+            }
+        }
+
+        return new GitHubRelease(tag, name, htmlUrl, body, publishedAt, isPrerelease, largestAsset);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/Updates/ReleaseVersion.cs
+++ b/src/EncDotNet.S100.Viewer/Services/Updates/ReleaseVersion.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace EncDotNet.S100.Viewer.Services.Updates;
+
+/// <summary>
+/// Minimal lenient SemVer comparison sufficient for the viewer's
+/// <c>MAJOR.MINOR.PATCH</c> release tags. A leading <c>v</c> and any
+/// pre-release (<c>-…</c>) or build-metadata (<c>+…</c>) suffix are
+/// ignored; the numeric core is compared via <see cref="System.Version"/>.
+/// </summary>
+internal static class ReleaseVersion
+{
+    /// <summary>
+    /// Attempts to parse a release version string (e.g. <c>"v2.5.0"</c>,
+    /// <c>"2.5.0"</c>, <c>"2.5.0-rc.1"</c>) into a normalised
+    /// <see cref="System.Version"/>. Returns <see langword="false"/> for
+    /// null/empty or non-numeric input.
+    /// </summary>
+    public static bool TryParse(string? value, out Version version)
+    {
+        version = new Version(0, 0, 0);
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var span = value.Trim();
+        if (span.StartsWith('v') || span.StartsWith('V'))
+            span = span[1..];
+
+        // Drop pre-release / build metadata; keep only the numeric core.
+        var cut = span.IndexOfAny(['-', '+']);
+        if (cut >= 0)
+            span = span[..cut];
+
+        if (span.Length == 0)
+            return false;
+
+        // System.Version requires at least MAJOR.MINOR; pad a bare MAJOR.
+        if (!span.Contains('.'))
+            span += ".0";
+
+        return Version.TryParse(span, out var parsed) && Assign(parsed, out version);
+
+        static bool Assign(Version parsed, out Version target)
+        {
+            // Normalise unspecified components (-1) to 0 so 2.5 == 2.5.0.
+            target = new Version(
+                Math.Max(parsed.Major, 0),
+                Math.Max(parsed.Minor, 0),
+                Math.Max(parsed.Build, 0));
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="candidate"/> is a
+    /// strictly newer release than <paramref name="current"/>. Unparseable
+    /// inputs are treated as "not newer" (fail safe — never nag on garbage).
+    /// </summary>
+    public static bool IsNewer(string? candidate, string? current)
+    {
+        if (!TryParse(candidate, out var candidateVersion))
+            return false;
+        if (!TryParse(current, out var currentVersion))
+            return false;
+
+        return candidateVersion > currentVersion;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/Updates/UpdateService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/Updates/UpdateService.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncDotNet.S100.Viewer.Services.Updates;
+
+/// <summary>
+/// Metadata for a single published GitHub release, as consumed by the
+/// update checker. A trimmed projection of the GitHub Releases REST API
+/// (<c>GET /repos/{owner}/{repo}/releases/latest</c>).
+/// </summary>
+/// <param name="TagName">The release tag (e.g. <c>"v2.5.0"</c>).</param>
+/// <param name="Name">The release display name, when set.</param>
+/// <param name="HtmlUrl">The browser URL of the release page.</param>
+/// <param name="Body">The raw markdown release notes.</param>
+/// <param name="PublishedAt">When the release was published, in UTC.</param>
+/// <param name="IsPrerelease">Whether GitHub flagged this as a pre-release.</param>
+/// <param name="LargestAssetBytes">
+/// The size of the largest attached asset in bytes, used as an approximate
+/// download size, or <see langword="null"/> when no assets are attached.
+/// </param>
+internal sealed record GitHubRelease(
+    string TagName,
+    string? Name,
+    string? HtmlUrl,
+    string? Body,
+    DateTimeOffset? PublishedAt,
+    bool IsPrerelease,
+    long? LargestAssetBytes);
+
+/// <summary>
+/// Fetches release metadata from GitHub. Abstracted so the update logic can
+/// be unit-tested without network access.
+/// </summary>
+internal interface IGitHubReleaseClient
+{
+    /// <summary>
+    /// Gets the latest published, non-pre-release release for the configured
+    /// repository, or <see langword="null"/> when none exists or the request
+    /// fails (callers must treat failure as "no update information").
+    /// </summary>
+    Task<GitHubRelease?> GetLatestReleaseAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// The outcome category of an update check.
+/// </summary>
+internal enum UpdateAvailability
+{
+    /// <summary>Checks are disabled (user setting) or this is a dev build.</summary>
+    Disabled,
+
+    /// <summary>The running version is the latest known release.</summary>
+    UpToDate,
+
+    /// <summary>A newer release is available (and not skipped).</summary>
+    UpdateAvailable,
+
+    /// <summary>The check could not complete (offline / API error).</summary>
+    CheckFailed,
+}
+
+/// <summary>
+/// The result of an update check, including the latest release when one was
+/// found. Immutable so it can be handed straight to the About view-model.
+/// </summary>
+internal sealed record UpdateStatus
+{
+    /// <summary>The outcome category.</summary>
+    public required UpdateAvailability Availability { get; init; }
+
+    /// <summary>
+    /// When the check completed, or <see langword="null"/> for a check that
+    /// never ran (e.g. <see cref="UpdateAvailability.Disabled"/>).
+    /// </summary>
+    public DateTimeOffset? CheckedAtUtc { get; init; }
+
+    /// <summary>The latest release, when one was retrieved.</summary>
+    public GitHubRelease? LatestRelease { get; init; }
+
+    /// <summary>
+    /// The latest release version (tag without the leading <c>v</c>), when
+    /// <see cref="Availability"/> is <see cref="UpdateAvailability.UpdateAvailable"/>.
+    /// </summary>
+    public string? LatestVersion { get; init; }
+
+    /// <summary>
+    /// True when the user chose to "skip" this version: the About dialog still
+    /// shows the update truthfully, but proactive notifications (e.g. toasts)
+    /// for this version are suppressed.
+    /// </summary>
+    public bool IsSkipped { get; init; }
+
+    /// <summary>A disabled result (checks off or dev build).</summary>
+    public static UpdateStatus Disabled { get; } =
+        new() { Availability = UpdateAvailability.Disabled };
+}
+
+/// <summary>
+/// Determines whether a newer release of the viewer is available, applying
+/// the user's "skip this version" choice and de-duplicating checks within a
+/// throttle window. Pure orchestration over <see cref="IGitHubReleaseClient"/>
+/// and <see cref="IAppVersionProvider"/>; no UI or network concerns.
+/// </summary>
+internal interface IUpdateService
+{
+    /// <summary>
+    /// Checks for a newer release. When <paramref name="force"/> is
+    /// <see langword="false"/> the check is skipped (and the cached status
+    /// returned) if a check ran within the throttle window. Network/parse
+    /// failures resolve to <see cref="UpdateAvailability.CheckFailed"/> —
+    /// the method never throws for those.
+    /// </summary>
+    Task<UpdateStatus> CheckForUpdatesAsync(bool force, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists a "skip this version" choice so the user is not prompted for
+    /// <paramref name="version"/> again, while still being notified about any
+    /// later release.
+    /// </summary>
+    void SkipVersion(string version);
+
+    /// <summary>Enables or disables automatic update checks.</summary>
+    void SetUpdateChecksEnabled(bool enabled);
+
+    /// <summary>Whether automatic update checks are currently enabled.</summary>
+    bool UpdateChecksEnabled { get; }
+}
+
+/// <summary>
+/// Default <see cref="IUpdateService"/>. Compares the running version against
+/// the latest GitHub release, honours the persisted skip/enable settings, and
+/// throttles network checks to at most once per <see cref="ThrottleWindow"/>.
+/// </summary>
+internal sealed class UpdateService : IUpdateService
+{
+    /// <summary>Minimum spacing between non-forced network checks.</summary>
+    public static readonly TimeSpan ThrottleWindow = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// When set to <c>1</c>, forces a live update check even for development
+    /// builds, ignoring the <see cref="AppVersionInfo.IsDevelopmentBuild"/>
+    /// gate. Intended only for manual/agent verification of the dialog against
+    /// the real GitHub API; never set in shipped builds.
+    /// </summary>
+    private const string ForceCheckEnvVar = "S100_UPDATE_FORCE";
+
+    private readonly IGitHubReleaseClient _releaseClient;
+    private readonly IAppVersionProvider _versionProvider;
+    private readonly ViewerSettings _settings;
+    private readonly TimeProvider _timeProvider;
+    private readonly bool _forceCheck =
+        Environment.GetEnvironmentVariable(ForceCheckEnvVar) == "1";
+    private UpdateStatus? _lastStatus;
+
+    public UpdateService(
+        IGitHubReleaseClient releaseClient,
+        IAppVersionProvider versionProvider,
+        ViewerSettings settings,
+        TimeProvider timeProvider)
+    {
+        _releaseClient = releaseClient ?? throw new ArgumentNullException(nameof(releaseClient));
+        _versionProvider = versionProvider ?? throw new ArgumentNullException(nameof(versionProvider));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    /// <inheritdoc />
+    public bool UpdateChecksEnabled => _settings.UpdateCheckEnabled;
+
+    /// <inheritdoc />
+    public async Task<UpdateStatus> CheckForUpdatesAsync(bool force, CancellationToken cancellationToken = default)
+    {
+        var current = _versionProvider.Current;
+
+        // No meaningful comparison for an unversioned local build, unless the
+        // developer/agent opts in via S100_UPDATE_FORCE to exercise the live check.
+        if ((current.IsDevelopmentBuild && !_forceCheck) || !_settings.UpdateCheckEnabled)
+        {
+            return _lastStatus = UpdateStatus.Disabled;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        // Throttle: reuse the last computed status when a check ran recently,
+        // unless the caller forces a fresh check (e.g. "Check now").
+        if (!force
+            && _lastStatus is { } cached
+            && _settings.LastUpdateCheckUtc is { } last
+            && now - last < ThrottleWindow)
+        {
+            return cached;
+        }
+
+        GitHubRelease? release;
+        try
+        {
+            release = await _releaseClient.GetLatestReleaseAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return _lastStatus = new UpdateStatus
+            {
+                Availability = UpdateAvailability.CheckFailed,
+                CheckedAtUtc = now,
+            };
+        }
+
+        _settings.LastUpdateCheckUtc = now;
+
+        if (release is null)
+        {
+            TrySaveSettings();
+            return _lastStatus = new UpdateStatus
+            {
+                Availability = UpdateAvailability.CheckFailed,
+                CheckedAtUtc = now,
+            };
+        }
+
+        var latestVersion = NormalizeTag(release.TagName);
+        _settings.LastKnownLatestVersion = latestVersion;
+        TrySaveSettings();
+
+        // A newer release is always reported as "available" in the dialog. The
+        // user's "skip" choice only mutes proactive notifications for it, so we
+        // surface that as a flag rather than pretending we're up to date.
+        var newerThanCurrent = ReleaseVersion.IsNewer(latestVersion, current.Version);
+        var isSkipped = !string.IsNullOrEmpty(_settings.SkippedUpdateVersion)
+            && !ReleaseVersion.IsNewer(latestVersion, _settings.SkippedUpdateVersion);
+
+        if (newerThanCurrent)
+        {
+            return _lastStatus = new UpdateStatus
+            {
+                Availability = UpdateAvailability.UpdateAvailable,
+                CheckedAtUtc = now,
+                LatestRelease = release,
+                LatestVersion = latestVersion,
+                IsSkipped = isSkipped,
+            };
+        }
+
+        return _lastStatus = new UpdateStatus
+        {
+            Availability = UpdateAvailability.UpToDate,
+            CheckedAtUtc = now,
+            LatestRelease = release,
+            LatestVersion = latestVersion,
+        };
+    }
+
+    /// <inheritdoc />
+    public void SkipVersion(string version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return;
+
+        _settings.SkippedUpdateVersion = NormalizeTag(version);
+        TrySaveSettings();
+
+        // Keep showing the update; just mark it skipped so notifications mute.
+        if (_lastStatus is { Availability: UpdateAvailability.UpdateAvailable } status)
+        {
+            _lastStatus = status with { IsSkipped = true };
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetUpdateChecksEnabled(bool enabled)
+    {
+        _settings.UpdateCheckEnabled = enabled;
+        TrySaveSettings();
+        if (!enabled)
+            _lastStatus = UpdateStatus.Disabled;
+    }
+
+    private static string NormalizeTag(string tag)
+    {
+        var trimmed = tag.Trim();
+        return trimmed.StartsWith('v') || trimmed.StartsWith('V') ? trimmed[1..] : trimmed;
+    }
+
+    private void TrySaveSettings()
+    {
+        try
+        {
+            _settings.Save();
+        }
+        catch
+        {
+            // Best-effort persistence; a failed write must not break the check.
+        }
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/AboutDialogViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/AboutDialogViewModel.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EncDotNet.S100.Viewer.Resources;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Services.Updates;
+using ShadUI;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// View-model backing the "About" modal dialog. Surfaces the running
+/// application version and drives the GitHub-release update check, including
+/// the "skip this version" and "stop checking" choices (issue #379).
+/// </summary>
+/// <remarks>
+/// The dialog is hosted by ShadUI's <see cref="DialogManager"/>; the
+/// view-model closes itself through that manager. The update check is kicked
+/// off (non-forced) by <see cref="InitializeAsync"/> when the dialog opens.
+/// </remarks>
+internal sealed class AboutDialogViewModel : ViewModelBase
+{
+    private readonly DialogManager _dialogManager;
+    private readonly IUpdateService _updateService;
+    private readonly IAppVersionProvider _versionProvider;
+    private readonly IUrlOpener _urlOpener;
+    private readonly TimeProvider _timeProvider;
+
+    public AboutDialogViewModel(
+        DialogManager dialogManager,
+        IUpdateService updateService,
+        IAppVersionProvider versionProvider,
+        IUrlOpener urlOpener,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(dialogManager);
+        ArgumentNullException.ThrowIfNull(updateService);
+        ArgumentNullException.ThrowIfNull(versionProvider);
+        ArgumentNullException.ThrowIfNull(urlOpener);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _dialogManager = dialogManager;
+        _updateService = updateService;
+        _versionProvider = versionProvider;
+        _urlOpener = urlOpener;
+        _timeProvider = timeProvider;
+
+        CheckNowCommand = new AsyncRelayCommand(() => RunCheckAsync(force: true), () => !IsChecking);
+        UpdateNowCommand = new RelayCommand(UpdateNow);
+        ReleaseNotesCommand = new RelayCommand(OpenReleaseNotes);
+        SkipCommand = new RelayCommand(Skip);
+        DisableChecksCommand = new RelayCommand(DisableChecks);
+        LicenseCommand = new RelayCommand(() => _urlOpener.Open(GitHubReleaseClient.LicenseUrl));
+        ThirdPartyNoticesCommand = new RelayCommand(() => _urlOpener.Open(GitHubReleaseClient.ThirdPartyNoticesUrl));
+        CloseCommand = new RelayCommand(() => _dialogManager.Close(this));
+    }
+
+    // ---- Branding / static product info -----------------------------------
+
+    /// <summary>The product display name shown next to the app icon.</summary>
+    public string ProductName => Strings.About_ProductName;
+
+    /// <summary>The one-line product subtitle under the name.</summary>
+    public string ProductSubtitle => Strings.About_ProductSubtitle;
+
+    /// <summary>The footer copyright line.</summary>
+    public string Copyright =>
+        string.Format(CultureInfo.CurrentCulture, Strings.About_CopyrightFormat, _timeProvider.GetUtcNow().Year);
+
+    /// <summary>The "Built with…" attribution paragraph.</summary>
+    public string BuiltWith => Strings.About_BuiltWith;
+
+    // ---- Version ----------------------------------------------------------
+
+    /// <summary>The headline "Version X.Y.Z" line.</summary>
+    public string VersionLine =>
+        string.Format(CultureInfo.CurrentCulture, Strings.About_VersionFormat, _versionProvider.Current.Version);
+
+    /// <summary>
+    /// The secondary build line: full informational version plus the build
+    /// date when one is embedded (e.g. <c>"build 2.4.1+a1f9c20 · 2026-06-18"</c>).
+    /// </summary>
+    public string BuildLine
+    {
+        get
+        {
+            var info = _versionProvider.Current;
+            var core = info.CommitSha is { Length: > 0 } sha
+                ? $"{info.Version}+{sha}"
+                : info.Version;
+            var line = string.Format(CultureInfo.CurrentCulture, Strings.About_BuildFormat, core);
+            if (info.BuildDate is { } date)
+                line += $" · {date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
+            return line;
+        }
+    }
+
+    // ---- Update-check state ----------------------------------------------
+
+    private bool _isChecking;
+    /// <summary>True while an update check is in flight (shows a spinner).</summary>
+    public bool IsChecking
+    {
+        get => _isChecking;
+        private set
+        {
+            if (SetProperty(ref _isChecking, value))
+            {
+                OnPropertyChanged(nameof(ShowUpToDate));
+                OnPropertyChanged(nameof(ShowUpdateAvailable));
+                OnPropertyChanged(nameof(ShowDisabled));
+                OnPropertyChanged(nameof(ShowCheckFailed));
+                OnPropertyChanged(nameof(ShowStatusRow));
+                OnPropertyChanged(nameof(CanSkip));
+                ((AsyncRelayCommand)CheckNowCommand).NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    private UpdateStatus _status = UpdateStatus.Disabled;
+    private UpdateStatus Status
+    {
+        get => _status;
+        set
+        {
+            _status = value;
+            OnPropertyChanged(nameof(ShowUpToDate));
+            OnPropertyChanged(nameof(ShowUpdateAvailable));
+            OnPropertyChanged(nameof(ShowDisabled));
+            OnPropertyChanged(nameof(ShowCheckFailed));
+            OnPropertyChanged(nameof(ShowStatusRow));
+            OnPropertyChanged(nameof(UpToDateLastChecked));
+            OnPropertyChanged(nameof(UpdateAvailableHeader));
+            OnPropertyChanged(nameof(UpdateReleasedLine));
+            OnPropertyChanged(nameof(IsUpdateSkipped));
+            OnPropertyChanged(nameof(CanSkip));
+        }
+    }
+
+    /// <summary>True when the available update was skipped (notifications muted).</summary>
+    public bool IsUpdateSkipped => Status.IsSkipped;
+
+    /// <summary>Whether the Skip action is offered (only for unskipped updates).</summary>
+    public bool CanSkip => ShowUpdateAvailable && !Status.IsSkipped;
+
+    /// <summary>Whether the green "up to date" panel is shown.</summary>
+    public bool ShowUpToDate => !IsChecking && Status.Availability == UpdateAvailability.UpToDate;
+
+    /// <summary>Whether the blue "update available" panel is shown.</summary>
+    public bool ShowUpdateAvailable => !IsChecking && Status.Availability == UpdateAvailability.UpdateAvailable;
+
+    /// <summary>Whether the neutral "checks disabled / dev build" panel is shown.</summary>
+    public bool ShowDisabled => !IsChecking && Status.Availability == UpdateAvailability.Disabled;
+
+    /// <summary>Whether the "couldn't check" panel is shown.</summary>
+    public bool ShowCheckFailed => !IsChecking && Status.Availability == UpdateAvailability.CheckFailed;
+
+    /// <summary>Whether any status row (spinner or a result panel) is shown.</summary>
+    public bool ShowStatusRow => true;
+
+    /// <summary>The "Last checked …" caption under the up-to-date heading.</summary>
+    public string UpToDateLastChecked
+    {
+        get
+        {
+            if (Status.CheckedAtUtc is { } checkedAt)
+                return string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.About_LastCheckedFormat,
+                    RelativeTime(checkedAt));
+            return Strings.About_LastCheckedNever;
+        }
+    }
+
+    /// <summary>The "Update available — X.Y.Z" heading.</summary>
+    public string UpdateAvailableHeader =>
+        string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.About_UpdateAvailableFormat,
+            Status.LatestVersion ?? string.Empty);
+
+    /// <summary>
+    /// The "Released … · NN MB" sub-line for the update panel. The size is
+    /// omitted when no asset size is known.
+    /// </summary>
+    public string UpdateReleasedLine
+    {
+        get
+        {
+            var release = Status.LatestRelease;
+            if (release is null)
+                return string.Empty;
+
+            var released = release.PublishedAt is { } published
+                ? string.Format(CultureInfo.CurrentCulture, Strings.About_ReleasedFormat, RelativeTime(published))
+                : string.Empty;
+
+            if (release.LargestAssetBytes is { } bytes and > 0)
+            {
+                var size = FormatSize(bytes);
+                return released.Length > 0 ? $"{released} · {size}" : size;
+            }
+
+            return released;
+        }
+    }
+
+    // ---- Commands ---------------------------------------------------------
+
+    /// <summary>Forces a fresh update check.</summary>
+    public ICommand CheckNowCommand { get; }
+
+    /// <summary>Opens the latest release page so the user can download it (Tier 1).</summary>
+    public ICommand UpdateNowCommand { get; }
+
+    /// <summary>Opens the latest release's notes page.</summary>
+    public ICommand ReleaseNotesCommand { get; }
+
+    /// <summary>Skips the current release while staying subscribed to later ones.</summary>
+    public ICommand SkipCommand { get; }
+
+    /// <summary>Turns automatic update checks off.</summary>
+    public ICommand DisableChecksCommand { get; }
+
+    /// <summary>Opens the license in the browser.</summary>
+    public ICommand LicenseCommand { get; }
+
+    /// <summary>Opens third-party notices in the browser.</summary>
+    public ICommand ThirdPartyNoticesCommand { get; }
+
+    /// <summary>Closes the dialog.</summary>
+    public ICommand CloseCommand { get; }
+
+    /// <summary>
+    /// Kicks off the initial (non-forced) update check. Call once after the
+    /// dialog is shown.
+    /// </summary>
+    public Task InitializeAsync() => RunCheckAsync(force: false);
+
+    private async Task RunCheckAsync(bool force)
+    {
+        IsChecking = true;
+        try
+        {
+            Status = await _updateService.CheckForUpdatesAsync(force).ConfigureAwait(true);
+        }
+        finally
+        {
+            IsChecking = false;
+        }
+    }
+
+    private void UpdateNow()
+    {
+        var url = Status.LatestRelease?.HtmlUrl ?? GitHubReleaseClient.ReleasesPageUrl;
+        _urlOpener.Open(url);
+    }
+
+    private void OpenReleaseNotes()
+    {
+        var url = Status.LatestRelease?.HtmlUrl ?? GitHubReleaseClient.ReleasesPageUrl;
+        _urlOpener.Open(url);
+    }
+
+    private void Skip()
+    {
+        if (Status.LatestVersion is { Length: > 0 } version)
+        {
+            _updateService.SkipVersion(version);
+            // Stay truthful: keep showing the update, just mark it skipped so
+            // future proactive notifications are muted.
+            Status = Status with { IsSkipped = true };
+        }
+    }
+
+    private void DisableChecks()
+    {
+        _updateService.SetUpdateChecksEnabled(false);
+        Status = UpdateStatus.Disabled;
+    }
+
+    /// <summary>
+    /// Formats a past instant as a coarse, localized "… ago" string relative
+    /// to now (just now / minutes / hours / days).
+    /// </summary>
+    private string RelativeTime(DateTimeOffset instant)
+    {
+        var delta = _timeProvider.GetUtcNow() - instant;
+        if (delta < TimeSpan.Zero)
+            delta = TimeSpan.Zero;
+
+        if (delta.TotalMinutes < 1)
+            return Strings.About_Time_JustNow;
+        if (delta.TotalMinutes < 60)
+            return string.Format(CultureInfo.CurrentCulture, Strings.About_Time_MinutesAgo, (int)delta.TotalMinutes);
+        if (delta.TotalHours < 24)
+            return string.Format(CultureInfo.CurrentCulture, Strings.About_Time_HoursAgo, (int)delta.TotalHours);
+        return string.Format(CultureInfo.CurrentCulture, Strings.About_Time_DaysAgo, (int)delta.TotalDays);
+    }
+
+    /// <summary>Formats a byte count as a compact MB/KB string.</summary>
+    private static string FormatSize(long bytes)
+    {
+        const double mb = 1024d * 1024d;
+        const double kb = 1024d;
+        if (bytes >= mb)
+            return string.Format(CultureInfo.CurrentCulture, "{0:0.#} MB", bytes / mb);
+        return string.Format(CultureInfo.CurrentCulture, "{0:0.#} KB", bytes / kb);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -26,6 +26,7 @@ internal sealed class MainViewModel : ViewModelBase
     private readonly RouteEditTool _routeEditTool;
     private readonly ShadUI.DialogManager _dialogManager;
     private readonly Func<FeedbackDialogViewModel>? _feedbackDialogFactory;
+    private readonly Func<AboutDialogViewModel>? _aboutDialogFactory;
 
     /// <summary>
     /// The persistent MCP port-conflict notification, held so the
@@ -682,6 +683,12 @@ internal sealed class MainViewModel : ViewModelBase
     /// </summary>
     public ICommand ShowFeedbackCommand { get; }
 
+    /// <summary>
+    /// Opens the "About" modal dialog (version info + update check).
+    /// Triggered from the Help menu.
+    /// </summary>
+    public ICommand ShowAboutCommand { get; }
+
     // ─── Exchange-set progress + banner (es3-progress) ────────────────────
 
     private bool _isExchangeSetLoading;
@@ -914,6 +921,7 @@ internal sealed class MainViewModel : ViewModelBase
         INotificationService notifications,
         ShadUI.DialogManager? dialogManager = null,
         Func<FeedbackDialogViewModel>? feedbackDialogFactory = null,
+        Func<AboutDialogViewModel>? aboutDialogFactory = null,
         IEnumerable<IActivityTab>? activityTabs = null,
         McpServerHost? mcpServerHost = null,
         IStatusPresenter? statusPresenter = null,
@@ -946,6 +954,7 @@ internal sealed class MainViewModel : ViewModelBase
         // an unhosted manager to keep the DialogManager property non-null.
         _dialogManager = dialogManager ?? new ShadUI.DialogManager();
         _feedbackDialogFactory = feedbackDialogFactory;
+        _aboutDialogFactory = aboutDialogFactory;
         DialogManager = _dialogManager;
         _isDarkTheme = themeService.IsDarkTheme;
         _statusPresenter = statusPresenter;
@@ -1136,6 +1145,7 @@ internal sealed class MainViewModel : ViewModelBase
         ToggleThemeCommand = new RelayCommand(() => IsDarkTheme = _theme.ToggleTheme());
 
         ShowFeedbackCommand = new AsyncRelayCommand(ShowFeedbackAsync);
+        ShowAboutCommand = new AsyncRelayCommand(ShowAboutAsync);
 
         // Keep IsDarkTheme in sync when the theme is changed via paths
         // other than ToggleThemeCommand (e.g. the SettingsView chrome
@@ -1298,5 +1308,23 @@ internal sealed class MainViewModel : ViewModelBase
             .Dismissible()
             .WithMaxWidth(620)
             .Show();
+    }
+
+    private async Task ShowAboutAsync()
+    {
+        if (_aboutDialogFactory is null)
+        {
+            return;
+        }
+
+        var dialog = _aboutDialogFactory();
+        _dialogManager.CreateDialog(dialog)
+            .Dismissible()
+            .WithMaxWidth(480)
+            .Show();
+
+        // Kick off the (throttled) update check after the dialog is shown so
+        // the UI appears immediately and the network call resolves into it.
+        await dialog.InitializeAsync().ConfigureAwait(true);
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -74,6 +74,34 @@ internal sealed class ViewerSettings
     public string ChromeTheme { get; set; } = "Light";
 
     /// <summary>
+    /// Whether the viewer checks GitHub for a newer release. Default
+    /// <see langword="true"/>; the user can turn it off from the About
+    /// dialog. See issue #379.
+    /// </summary>
+    public bool UpdateCheckEnabled { get; set; } = true;
+
+    /// <summary>
+    /// The release version the user chose to "skip"; the update prompt stays
+    /// silent for it but still fires for any later release. <c>null</c> when
+    /// nothing has been skipped. Stored without the leading <c>v</c>.
+    /// </summary>
+    public string? SkippedUpdateVersion { get; set; }
+
+    /// <summary>
+    /// UTC timestamp of the last completed update check, used to throttle
+    /// network checks to roughly once per day. <c>null</c> until the first
+    /// check runs.
+    /// </summary>
+    public DateTimeOffset? LastUpdateCheckUtc { get; set; }
+
+    /// <summary>
+    /// The latest release version seen by the most recent check (tag without
+    /// the leading <c>v</c>), cached for display. <c>null</c> until a check
+    /// has succeeded.
+    /// </summary>
+    public string? LastKnownLatestVersion { get; set; }
+
+    /// <summary>
     /// Id of the last-selected left-dock activity tab, or <c>null</c> if
     /// none was open. Name kept for back-compat with pre-PR-M3 settings
     /// files; the corresponding right- and bottom-dock fields are

--- a/src/EncDotNet.S100.Viewer/Views/AboutDialogView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/AboutDialogView.axaml
@@ -1,0 +1,248 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:EncDotNet.S100.Viewer.ViewModels"
+             xmlns:loc="using:EncDotNet.S100.Viewer.Resources"
+             xmlns:ic="using:FluentIcons.Avalonia"
+             x:Class="EncDotNet.S100.Viewer.Views.AboutDialogView"
+             x:DataType="vm:AboutDialogViewModel"
+             Width="460">
+
+    <UserControl.Styles>
+        <!-- Link-style button: no chrome, accent-coloured text that
+             underlines on hover. Used for the footer License and
+             third-party notices actions so they read as hyperlinks
+             rather than command buttons. -->
+        <Style Selector="Button.link">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="2,2" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Padding="{TemplateBinding Padding}"
+                                      Background="Transparent"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center" />
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="TextBlock.linktext">
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+            <Setter Property="FontSize" Value="13" />
+        </Style>
+        <Style Selector="Button.link:pointerover TextBlock.linktext">
+            <Setter Property="TextDecorations" Value="Underline" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto,*,Auto">
+
+        <!-- Header: title only. The dialog host (ShadUI) supplies the
+             close button in the top-right corner, so the view must not
+             draw its own or two close buttons appear. The right margin
+             keeps the title clear of that host close button. -->
+        <TextBlock Grid.Row="0"
+                   Text="{x:Static loc:Strings.About_Title}"
+                   FontSize="15"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center"
+                   Margin="20,12,44,10" />
+
+        <Border Grid.Row="0" Height="1" VerticalAlignment="Bottom"
+                Background="{DynamicResource BorderColor}" Opacity="0.6" />
+
+        <!-- Body -->
+        <StackPanel Grid.Row="1" Margin="20,14,20,8" Spacing="16" MinHeight="220">
+
+            <!-- Icon + product name -->
+            <StackPanel Orientation="Horizontal" Spacing="14">
+                <Image Source="avares://EncDotNet.S100.Viewer/Branding/AppIcon.png"
+                       Width="56" Height="56"
+                       VerticalAlignment="Center" />
+                <StackPanel VerticalAlignment="Center" Spacing="2">
+                    <TextBlock Text="{Binding ProductName}"
+                               FontSize="20"
+                               FontWeight="Bold" />
+                    <TextBlock Text="{Binding ProductSubtitle}"
+                               FontSize="13"
+                               Opacity="0.7" />
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Version -->
+            <StackPanel Spacing="2">
+                <TextBlock Text="{Binding VersionLine}"
+                           FontSize="26"
+                           FontWeight="Bold" />
+                <SelectableTextBlock Text="{Binding BuildLine}"
+                                     FontSize="12"
+                                     Opacity="0.6"
+                                     FontFamily="Menlo,Consolas,Courier New,monospace" />
+            </StackPanel>
+
+            <!-- Status: checking -->
+            <Border IsVisible="{Binding IsChecking}"
+                    MinHeight="60"
+                    Background="{DynamicResource MutedBackgroundColor}"
+                    CornerRadius="8"
+                    Padding="14,12">
+                <TextBlock Text="{x:Static loc:Strings.About_Checking}"
+                           VerticalAlignment="Center"
+                           Opacity="0.8" />
+            </Border>
+
+            <!-- Status: up to date -->
+            <Border IsVisible="{Binding ShowUpToDate}"
+                    MinHeight="60"
+                    Background="#1416A34A"
+                    BorderBrush="#5516A34A"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="14,12">
+                <Grid ColumnDefinitions="Auto,*,Auto">
+                    <ic:FluentIcon Grid.Column="0"
+                                   Icon="CheckmarkCircle" IconVariant="Filled" FontSize="28"
+                                   Foreground="#16A34A"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,12,0" />
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                        <TextBlock Text="{x:Static loc:Strings.About_UpToDate}"
+                                   FontWeight="SemiBold"
+                                   Foreground="#16A34A" />
+                        <TextBlock Text="{Binding UpToDateLastChecked}"
+                                   FontSize="12"
+                                   Opacity="0.7" />
+                    </StackPanel>
+                    <Button Grid.Column="2"
+                            Classes="link"
+                            Command="{Binding CheckNowCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.About_CheckNowTooltip}">
+                        <TextBlock Classes="linktext" Text="{x:Static loc:Strings.About_CheckNow}" />
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- Status: update available -->
+            <Border IsVisible="{Binding ShowUpdateAvailable}"
+                    BorderBrush="{DynamicResource AccentBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                <StackPanel>
+                    <!-- Heading -->
+                    <Grid ColumnDefinitions="Auto,*" Background="#14007ACC" Margin="0">
+                        <ic:FluentIcon Grid.Column="0"
+                                       Icon="ArrowDownload" IconVariant="Filled" FontSize="28"
+                                       Foreground="{DynamicResource AccentBrush}"
+                                       VerticalAlignment="Center"
+                                       Margin="14,12,12,12" />
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1" Margin="0,12,14,12">
+                            <TextBlock Text="{Binding UpdateAvailableHeader}"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource AccentBrush}" />
+                            <TextBlock Text="{Binding UpdateReleasedLine}"
+                                       FontSize="12"
+                                       Opacity="0.7" />
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Actions -->
+                    <StackPanel Margin="14,12,14,14" Spacing="12">
+                        <StackPanel Orientation="Horizontal" Spacing="14" VerticalAlignment="Center">
+                            <Button Classes="Primary"
+                                    Command="{Binding UpdateNowCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.About_UpdateNowTooltip}">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <ic:FluentIcon Icon="ArrowDownload" IconVariant="Regular" FontSize="15"
+                                                   VerticalAlignment="Center" />
+                                    <TextBlock Text="{x:Static loc:Strings.About_UpdateNow}"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Button>
+                            <Button Classes="link"
+                                    Command="{Binding ReleaseNotesCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.About_ReleaseNotesTooltip}">
+                                <TextBlock Classes="linktext" Text="{x:Static loc:Strings.About_ReleaseNotes}" />
+                            </Button>
+                            <Button Classes="link"
+                                    IsVisible="{Binding CanSkip}"
+                                    Command="{Binding SkipCommand}"
+                                    ToolTip.Tip="{x:Static loc:Strings.About_SkipTooltip}">
+                                <TextBlock Classes="linktext" Text="{x:Static loc:Strings.About_Skip}" />
+                            </Button>
+                            <TextBlock Text="{x:Static loc:Strings.About_UpdateSkipped}"
+                                       IsVisible="{Binding IsUpdateSkipped}"
+                                       VerticalAlignment="Center"
+                                       FontSize="12"
+                                       Opacity="0.7" />
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Status: check failed -->
+            <Border IsVisible="{Binding ShowCheckFailed}"
+                    Background="{DynamicResource MutedBackgroundColor}"
+                    CornerRadius="8"
+                    Padding="14,12">
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Grid.Column="0"
+                               Text="{x:Static loc:Strings.About_CheckFailed}"
+                               TextWrapping="Wrap"
+                               VerticalAlignment="Center"
+                               Opacity="0.8" />
+                    <Button Grid.Column="1"
+                            Classes="link"
+                            Command="{Binding CheckNowCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.About_CheckNowTooltip}">
+                        <TextBlock Classes="linktext" Text="{x:Static loc:Strings.About_CheckNow}" />
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- Status: checks disabled -->
+            <Border IsVisible="{Binding ShowDisabled}"
+                    Background="{DynamicResource MutedBackgroundColor}"
+                    CornerRadius="8"
+                    Padding="14,12">
+                <TextBlock Text="{x:Static loc:Strings.About_ChecksDisabled}"
+                           TextWrapping="Wrap"
+                           Opacity="0.8" />
+            </Border>
+
+            <!-- Built with -->
+            <TextBlock Text="{Binding BuiltWith}"
+                       FontSize="12"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+        </StackPanel>
+
+        <!-- Footer -->
+        <Border Grid.Row="2"
+                Background="{DynamicResource MutedBackgroundColor}"
+                BorderBrush="{DynamicResource BorderColor}"
+                BorderThickness="0,1,0,0">
+            <Grid ColumnDefinitions="*,Auto,Auto" Margin="20,8">
+                <TextBlock Grid.Column="0"
+                           Text="{Binding Copyright}"
+                           VerticalAlignment="Center"
+                           FontSize="12"
+                           Opacity="0.7" />
+                <Button Grid.Column="1"
+                        Classes="link"
+                        Command="{Binding LicenseCommand}"
+                        ToolTip.Tip="{x:Static loc:Strings.About_LicenseTooltip}">
+                    <TextBlock Classes="linktext" Text="{x:Static loc:Strings.About_License}" />
+                </Button>
+                <Button Grid.Column="2"
+                        Classes="link"
+                        Margin="16,0,0,0"
+                        Command="{Binding ThirdPartyNoticesCommand}"
+                        ToolTip.Tip="{x:Static loc:Strings.About_ThirdPartyNoticesTooltip}">
+                    <TextBlock Classes="linktext" Text="{x:Static loc:Strings.About_ThirdPartyNotices}" />
+                </Button>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/EncDotNet.S100.Viewer/Views/AboutDialogView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/AboutDialogView.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+
+namespace EncDotNet.S100.Viewer.Views;
+
+/// <summary>
+/// Code-behind for the "About" modal dialog content. The view is resolved
+/// from <see cref="ViewModels.AboutDialogViewModel"/> via the ShadUI dialog
+/// manager registration in <c>App.axaml.cs</c>.
+/// </summary>
+public partial class AboutDialogView : UserControl
+{
+    public AboutDialogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/AboutDialogViewTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/AboutDialogViewTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Services.Updates;
+using EncDotNet.S100.Viewer.ViewModels;
+using EncDotNet.S100.Viewer.Views;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Smoke test that the About dialog's AXAML loads and binds against its
+/// view-model without error (issue #379). Catches XAML/compiled-binding
+/// regressions that the pure view-model tests cannot.
+/// </summary>
+public sealed class AboutDialogViewTests
+{
+    private sealed class StubUpdateService : IUpdateService
+    {
+        public bool UpdateChecksEnabled => true;
+        public Task<UpdateStatus> CheckForUpdatesAsync(bool force, CancellationToken cancellationToken = default)
+            => Task.FromResult(new UpdateStatus
+            {
+                Availability = UpdateAvailability.UpdateAvailable,
+                CheckedAtUtc = DateTimeOffset.UtcNow,
+                LatestVersion = "2.5.0",
+                LatestRelease = new GitHubRelease(
+                    "v2.5.0", "v2.5.0", "https://example/2.5.0", "* Item",
+                    DateTimeOffset.UtcNow.AddDays(-3), false, 50_331_648),
+            });
+        public void SkipVersion(string version) { }
+        public void SetUpdateChecksEnabled(bool enabled) { }
+    }
+
+    private sealed class StubVersionProvider : IAppVersionProvider
+    {
+        public AppVersionInfo Current { get; } =
+            new("2.4.1", "2.4.1+a1f9c20", "a1f9c20", new DateOnly(2026, 6, 18));
+    }
+
+    private sealed class StubUrlOpener : IUrlOpener
+    {
+        public string? LastUrl { get; private set; }
+        public void Open(string url) => LastUrl = url;
+    }
+
+    private static AboutDialogViewModel CreateViewModel() => new(
+        new ShadUI.DialogManager(),
+        new StubUpdateService(),
+        new StubVersionProvider(),
+        new StubUrlOpener(),
+        TimeProvider.System);
+
+    [Fact]
+    public void View_LoadsAndBinds_WithoutError()
+    {
+        HeadlessTest.Run(() =>
+        {
+            var vm = CreateViewModel();
+            var view = new AboutDialogView { DataContext = vm };
+
+            var window = new Window { Content = view, Width = 480, Height = 640 };
+            window.Show();
+            window.Measure(new Size(480, 640));
+            window.Arrange(new Rect(0, 0, 480, 640));
+
+            Assert.NotNull(view.DataContext);
+            window.Close();
+        });
+    }
+
+    [Fact]
+    public void ViewModel_FormatsVersionAndBuildLines()
+    {
+        var vm = CreateViewModel();
+
+        Assert.Equal("Version 2.4.1", vm.VersionLine);
+        Assert.Equal("build 2.4.1+a1f9c20 · 2026-06-18", vm.BuildLine);
+    }
+
+    [Fact]
+    public async Task ViewModel_Initialize_PopulatesUpdateAvailableState()
+    {
+        var vm = CreateViewModel();
+
+        await vm.InitializeAsync();
+
+        Assert.True(vm.ShowUpdateAvailable);
+        Assert.False(vm.IsChecking);
+        Assert.Equal("Update available — 2.5.0", vm.UpdateAvailableHeader);
+    }
+
+    [Fact]
+    public async Task ViewModel_Initialize_RaisesShowUpdateAvailableNotification()
+    {
+        var vm = CreateViewModel();
+        var raised = new System.Collections.Generic.List<string>();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is { } name)
+                raised.Add(name);
+        };
+
+        await vm.InitializeAsync();
+
+        Assert.Contains(nameof(vm.ShowUpdateAvailable), raised);
+        Assert.Contains(nameof(vm.IsChecking), raised);
+    }
+
+    [Fact]
+    public async Task ViewModel_Skip_KeepsUpdateVisibleAndMutes()
+    {
+        var vm = CreateViewModel();
+        await vm.InitializeAsync();
+
+        Assert.True(vm.CanSkip);
+        Assert.False(vm.IsUpdateSkipped);
+
+        vm.SkipCommand.Execute(null);
+
+        Assert.True(vm.ShowUpdateAvailable);
+        Assert.True(vm.IsUpdateSkipped);
+        Assert.False(vm.CanSkip);
+    }
+
+    [Fact]
+    public void ThirdPartyNoticesCommand_OpensNoticesDocument()
+    {
+        var opener = new StubUrlOpener();
+        var vm = new AboutDialogViewModel(
+            new ShadUI.DialogManager(),
+            new StubUpdateService(),
+            new StubVersionProvider(),
+            opener,
+            TimeProvider.System);
+
+        vm.ThirdPartyNoticesCommand.Execute(null);
+
+        Assert.Equal(GitHubReleaseClient.ThirdPartyNoticesUrl, opener.LastUrl);
+        Assert.EndsWith("/THIRD-PARTY-NOTICES.md", GitHubReleaseClient.ThirdPartyNoticesUrl);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/GitHubReleaseClientIntegrationTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/GitHubReleaseClientIntegrationTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.Services.Updates;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Live integration test exercising the real <see cref="GitHubReleaseClient"/>
+/// against the public GitHub Releases API for this repository (issue #379).
+/// Network-gated: set <c>S100_UPDATE_INTEGRATION=1</c> to opt in, so CI and
+/// offline runs skip it. The unit-level mapping is covered separately by the
+/// non-network <c>GitHubReleaseClient.Parse</c> tests.
+/// </summary>
+public sealed class GitHubReleaseClientIntegrationTests
+{
+    [SkippableFact]
+    public async Task GetLatestReleaseAsync_HitsRealRepository_ReturnsPublishedRelease()
+    {
+        Skip.If(
+            Environment.GetEnvironmentVariable("S100_UPDATE_INTEGRATION") != "1",
+            "S100_UPDATE_INTEGRATION not set; skipping live GitHub call.");
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        var client = new GitHubReleaseClient(http);
+
+        var release = await client.GetLatestReleaseAsync();
+
+        Assert.NotNull(release);
+        Assert.False(string.IsNullOrWhiteSpace(release!.TagName));
+        Assert.Contains(
+            $"{GitHubReleaseClient.RepositoryOwner}/{GitHubReleaseClient.RepositoryName}",
+            release.HtmlUrl);
+    }
+
+    [SkippableFact]
+    public async Task UpdateService_WithOldVersion_ReportsUpdateAvailable()
+    {
+        Skip.If(
+            Environment.GetEnvironmentVariable("S100_UPDATE_INTEGRATION") != "1",
+            "S100_UPDATE_INTEGRATION not set; skipping live GitHub call.");
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        var client = new GitHubReleaseClient(http);
+        var versions = new FixedVersionProvider("0.1.0");
+        var settings = new ViewerSettings
+        {
+            SettingsFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"about-{Guid.NewGuid():N}.json"),
+            IsReadOnly = true,
+        };
+        var service = new UpdateService(client, versions, settings, TimeProvider.System);
+
+        var status = await service.CheckForUpdatesAsync(force: true);
+
+        Assert.Equal(UpdateAvailability.UpdateAvailable, status.Availability);
+        Assert.False(string.IsNullOrWhiteSpace(status.LatestVersion));
+    }
+
+    private sealed class FixedVersionProvider(string version) : IAppVersionProvider
+    {
+        public AppVersionInfo Current { get; } = new(version, version, null, null);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/UpdateServiceTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/UpdateServiceTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services.Updates;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers the update-notification logic that backs the About dialog
+/// (issue #379): version parsing, SemVer comparison, the
+/// <see cref="UpdateService"/> decision/skip/throttle behaviour, and the
+/// GitHub release JSON mapping.
+/// </summary>
+public sealed class UpdateServiceTests
+{
+    private sealed class FakeReleaseClient : IGitHubReleaseClient
+    {
+        private readonly Func<GitHubRelease?> _factory;
+        public int CallCount { get; private set; }
+
+        public FakeReleaseClient(GitHubRelease? release) => _factory = () => release;
+        public FakeReleaseClient(Func<GitHubRelease?> factory) => _factory = factory;
+
+        public Task<GitHubRelease?> GetLatestReleaseAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(_factory());
+        }
+    }
+
+    private sealed class FakeVersionProvider(AppVersionInfo current) : IAppVersionProvider
+    {
+        public AppVersionInfo Current { get; } = current;
+    }
+
+    private static AppVersionInfo Version(string version) => new(version, version, null, null);
+
+    private static ViewerSettings InMemorySettings() => new()
+    {
+        SettingsFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"about-{Guid.NewGuid():N}.json"),
+        IsReadOnly = true,
+    };
+
+    private static GitHubRelease Release(
+        string tag,
+        string? body = null,
+        DateTimeOffset? publishedAt = null,
+        long? assetBytes = null) =>
+        new(tag, tag, $"https://example/{tag}", body, publishedAt, false, assetBytes);
+
+    private static UpdateService CreateService(
+        IGitHubReleaseClient client,
+        string currentVersion,
+        ViewerSettings settings,
+        FakeTimeProvider time) =>
+        new(client, new FakeVersionProvider(Version(currentVersion)), settings, time);
+
+    // ---- ReleaseVersion ---------------------------------------------------
+
+    [Theory]
+    [InlineData("2.5.0", "2.4.1", true)]
+    [InlineData("v2.5.0", "2.4.1", true)]
+    [InlineData("2.4.1", "2.4.1", false)]
+    [InlineData("2.4.0", "2.4.1", false)]
+    [InlineData("2.5", "2.4.9", true)]
+    [InlineData("2.5.0-rc.1", "2.4.1", true)]
+    [InlineData("garbage", "2.4.1", false)]
+    [InlineData("2.5.0", "", false)]
+    public void IsNewer_ComparesSemanticVersions(string candidate, string current, bool expected)
+    {
+        Assert.Equal(expected, ReleaseVersion.IsNewer(candidate, current));
+    }
+
+    // ---- Version provider parsing ----------------------------------------
+
+    [Theory]
+    [InlineData("2.4.1+a1f9c20abcdef", "2.4.1", "a1f9c20")]
+    [InlineData("2.4.1", "2.4.1", null)]
+    [InlineData("0.0.0-dev", "0.0.0-dev", null)]
+    public void ParseInformationalVersion_SplitsVersionAndShortSha(string input, string version, string? sha)
+    {
+        var (parsedVersion, parsedSha) = AssemblyAppVersionProvider.ParseInformationalVersion(input);
+        Assert.Equal(version, parsedVersion);
+        Assert.Equal(sha, parsedSha);
+    }
+
+    [Theory]
+    [InlineData("0.0.0-dev", true)]
+    [InlineData("0.0.0", true)]
+    [InlineData("2.4.1", false)]
+    public void IsDevelopmentBuild_DetectsDefaultVersion(string version, bool expected)
+    {
+        Assert.Equal(expected, Version(version).IsDevelopmentBuild);
+    }
+
+    // ---- UpdateService decisions -----------------------------------------
+
+    [Fact]
+    public async Task CheckForUpdates_DevBuild_ReturnsDisabledWithoutNetwork()
+    {
+        var client = new FakeReleaseClient(Release("v9.9.9"));
+        var time = new FakeTimeProvider();
+        var service = CreateService(client, "0.0.0-dev", InMemorySettings(), time);
+
+        var status = await service.CheckForUpdatesAsync(force: true);
+
+        Assert.Equal(UpdateAvailability.Disabled, status.Availability);
+        Assert.Equal(0, client.CallCount);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_DevBuildWithForceEnv_PerformsLiveCheck()
+    {
+        var prior = Environment.GetEnvironmentVariable("S100_UPDATE_FORCE");
+        Environment.SetEnvironmentVariable("S100_UPDATE_FORCE", "1");
+        try
+        {
+            var client = new FakeReleaseClient(Release("v9.9.9"));
+            var time = new FakeTimeProvider();
+            var service = CreateService(client, "0.0.0-dev", InMemorySettings(), time);
+
+            var status = await service.CheckForUpdatesAsync(force: true);
+
+            Assert.Equal(UpdateAvailability.UpdateAvailable, status.Availability);
+            Assert.Equal(1, client.CallCount);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("S100_UPDATE_FORCE", prior);
+        }
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_NewerRelease_ReportsUpdateAvailable()
+    {
+        var client = new FakeReleaseClient(Release("v2.5.0", body: "* New thing"));
+        var time = new FakeTimeProvider();
+        var service = CreateService(client, "2.4.1", InMemorySettings(), time);
+
+        var status = await service.CheckForUpdatesAsync(force: true);
+
+        Assert.Equal(UpdateAvailability.UpdateAvailable, status.Availability);
+        Assert.Equal("2.5.0", status.LatestVersion);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_SameVersion_ReportsUpToDate()
+    {
+        var client = new FakeReleaseClient(Release("v2.4.1"));
+        var time = new FakeTimeProvider();
+        var service = CreateService(client, "2.4.1", InMemorySettings(), time);
+
+        var status = await service.CheckForUpdatesAsync(force: true);
+
+        Assert.Equal(UpdateAvailability.UpToDate, status.Availability);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_NullRelease_ReportsCheckFailed()
+    {
+        var client = new FakeReleaseClient((GitHubRelease?)null);
+        var time = new FakeTimeProvider();
+        var service = CreateService(client, "2.4.1", InMemorySettings(), time);
+
+        var status = await service.CheckForUpdatesAsync(force: true);
+
+        Assert.Equal(UpdateAvailability.CheckFailed, status.Availability);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_ClientThrows_ReportsCheckFailed()
+    {
+        var client = new FakeReleaseClient(() => throw new InvalidOperationException("boom"));
+        var time = new FakeTimeProvider();
+        var service = CreateService(client, "2.4.1", InMemorySettings(), time);
+
+        var status = await service.CheckForUpdatesAsync(force: true);
+
+        Assert.Equal(UpdateAvailability.CheckFailed, status.Availability);
+    }
+
+    [Fact]
+    public async Task SkipVersion_KeepsUpdateVisibleButMarksSkipped_LaterReleaseUnskipped()
+    {
+        var settings = InMemorySettings();
+        var time = new FakeTimeProvider();
+
+        // 2.5.0 is available; user skips it.
+        var service = CreateService(new FakeReleaseClient(Release("v2.5.0")), "2.4.1", settings, time);
+        var available = await service.CheckForUpdatesAsync(force: true);
+        Assert.Equal(UpdateAvailability.UpdateAvailable, available.Availability);
+        Assert.False(available.IsSkipped);
+
+        service.SkipVersion("2.5.0");
+        Assert.Equal("2.5.0", settings.SkippedUpdateVersion);
+
+        // Re-checking 2.5.0 still reports it as available (the dialog stays
+        // truthful), but flagged as skipped so notifications stay muted.
+        var afterSkip = await service.CheckForUpdatesAsync(force: true);
+        Assert.Equal(UpdateAvailability.UpdateAvailable, afterSkip.Availability);
+        Assert.True(afterSkip.IsSkipped);
+
+        // A later release is available and not skipped.
+        var newerService = CreateService(new FakeReleaseClient(Release("v2.6.0")), "2.4.1", settings, time);
+        var newer = await newerService.CheckForUpdatesAsync(force: true);
+        Assert.Equal(UpdateAvailability.UpdateAvailable, newer.Availability);
+        Assert.False(newer.IsSkipped);
+        Assert.Equal("2.6.0", newer.LatestVersion);
+    }
+
+    [Fact]
+    public async Task SetUpdateChecksEnabled_False_DisablesChecks()
+    {
+        var settings = InMemorySettings();
+        var time = new FakeTimeProvider();
+        var client = new FakeReleaseClient(Release("v2.5.0"));
+        var service = CreateService(client, "2.4.1", settings, time);
+
+        service.SetUpdateChecksEnabled(false);
+
+        Assert.False(settings.UpdateCheckEnabled);
+        var status = await service.CheckForUpdatesAsync(force: true);
+        Assert.Equal(UpdateAvailability.Disabled, status.Availability);
+        Assert.Equal(0, client.CallCount);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_Throttles_NonForcedChecksWithinWindow()
+    {
+        var settings = InMemorySettings();
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var client = new FakeReleaseClient(Release("v2.5.0"));
+        var service = CreateService(client, "2.4.1", settings, time);
+
+        await service.CheckForUpdatesAsync(force: true);
+        Assert.Equal(1, client.CallCount);
+
+        // Within the throttle window, a non-forced check reuses the cache.
+        time.Advance(TimeSpan.FromHours(1));
+        await service.CheckForUpdatesAsync(force: false);
+        Assert.Equal(1, client.CallCount);
+
+        // Past the window, a non-forced check hits the network again.
+        time.Advance(UpdateService.ThrottleWindow);
+        await service.CheckForUpdatesAsync(force: false);
+        Assert.Equal(2, client.CallCount);
+    }
+
+    // ---- JSON mapping ----------------------------------------------------
+
+    [Fact]
+    public void GitHubReleaseClient_Parse_MapsCoreFieldsAndLargestAsset()
+    {
+        const string json = """
+        {
+            "tag_name": "v2.5.0",
+            "name": "v2.5.0",
+            "html_url": "https://github.com/owner/repo/releases/tag/v2.5.0",
+            "body": "* Item",
+            "published_at": "2026-06-25T12:00:00Z",
+            "prerelease": false,
+            "assets": [
+                { "size": 1048576 },
+                { "size": 50331648 }
+            ]
+        }
+        """;
+
+        using var doc = JsonDocument.Parse(json);
+        var release = GitHubReleaseClient.Parse(doc.RootElement);
+
+        Assert.NotNull(release);
+        Assert.Equal("v2.5.0", release!.TagName);
+        Assert.Equal("https://github.com/owner/repo/releases/tag/v2.5.0", release.HtmlUrl);
+        Assert.False(release.IsPrerelease);
+        Assert.Equal(50331648, release.LargestAssetBytes);
+        Assert.Equal(new DateTimeOffset(2026, 6, 25, 12, 0, 0, TimeSpan.Zero), release.PublishedAt);
+    }
+
+    [Fact]
+    public void GitHubReleaseClient_Parse_MissingTag_ReturnsNull()
+    {
+        using var doc = JsonDocument.Parse("""{ "name": "no tag" }""");
+        Assert.Null(GitHubReleaseClient.Parse(doc.RootElement));
+    }
+}


### PR DESCRIPTION
Closes a first slice of #379: an **About** dialog that reports the running version and surfaces newer GitHub releases (Tier 1 — links out to the release page; no self-update).

## What's in
- **About dialog** showing product name/subtitle, version (with build SHA + date), copyright, and link-style License / third-party notices.
- **Update check** against the repo's latest GitHub release on open: shows *up to date*, *update available — X.Y.Z*, *checks unavailable* (dev build), or *couldn't check*. Non-blocking; fails silently offline; throttled to ~once/day.
- **Skip = mute notifications only.** The dialog stays truthful (still shows the update) but marks it skipped so future proactive notifications are suppressed; later releases reset. (Toasts themselves deferred to a follow-up PR.)
- **macOS integration:** the native app-menu *About* now opens this dialog; Help *About* used on other platforms.
- **UX:** larger result icons, height-stable checking/result rows, link-style action buttons scoped so tooltips render normally.
- **Build stamping:** `BuildDate` embedded as assembly metadata; `S100_UPDATE_FORCE=1` forces a live check on dev builds for manual/agent verification.

## Tests
- `UpdateService` decisions, version comparison, skip semantics, throttle; dialog binding + skip behavior; network-gated live integration tests. Full viewer suite: 1305 passed, 3 gated skips.

## Deferred
- Proactive toast notifications (will honor the `IsSkipped` flag).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>