### PR TITLE
Fix S-101 degenerate world bounds for single-file open_dataset loads

### DIFF
--- a/src/EncDotNet.S100.Datasets.S101/S101VectorSource.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101VectorSource.cs
@@ -323,6 +323,19 @@ public sealed class S101VectorSource : IVectorSource
             }
         }
 
+        // Most S-101 cells store their extent in curve geometry, not isolated
+        // point records: a cell built entirely from curves/surfaces has no
+        // Point/MultiPoint records, so the boundary vertices live in each
+        // curve segment's intermediate coordinates. Fold those in too, or the
+        // extent collapses to (0,0,0,0) and callers fall back to world bounds.
+        foreach (var seg in doc.CurveSegments.Values)
+        {
+            foreach (var (y, x) in seg.IntermediateCoordinates)
+            {
+                UpdateBounds(y / cmfy, x / cmfx);
+            }
+        }
+
         if (!hasCoords)
         {
             return new BoundingBox(0, 0, 0, 0);

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101VectorSourceExtentTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101VectorSourceExtentTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Immutable;
+using EncDotNet.S100.Datasets.S101;
+using Xunit;
+
+namespace EncDotNet.S100.Datasets.S101.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="S101VectorSource"/> extent computation.
+/// </summary>
+/// <remarks>
+/// Motivated by issue #274: cells whose geometry is entirely curves/surfaces
+/// carry no Point/MultiPoint records, so the extent collapsed to (0,0,0,0).
+/// The MCP <c>open_dataset</c> tool then fell back to world bounds
+/// (-90/-180/90/180), making single-file S-101 loads impossible to target.
+/// The boundary vertices live in each curve segment's intermediate
+/// coordinates, which the extent computation must fold in.
+/// </remarks>
+public sealed class S101VectorSourceExtentTests
+{
+    [Fact]
+    public void Extent_CurvesOnlyCell_ReflectsCurveCoordinates()
+    {
+        var dataset = S101Dataset.FromDocument(BuildCurvesOnlyDocument());
+
+        var extent = new S101VectorSource(dataset).Metadata.Extent;
+
+        Assert.Equal(0, extent.SouthLatitude);
+        Assert.Equal(0, extent.WestLongitude);
+        Assert.Equal(10, extent.NorthLatitude);
+        Assert.Equal(10, extent.EastLongitude);
+    }
+
+    private static S101Document BuildCurvesOnlyDocument()
+    {
+        // A 0..10 square boundary stored purely as curve-segment intermediate
+        // coordinates — no Point or MultiPoint records.
+        var curve = new S101CurveSegmentRecord
+        {
+            RecordId = 10,
+            PointAssociations = ImmutableArray<S101PointAssociation>.Empty,
+            IntermediateCoordinates = ImmutableArray.Create((0, 0), (0, 10), (10, 10), (10, 0)),
+        };
+
+        return new S101Document
+        {
+            Identification = new S101DatasetIdentification { DatasetName = "TEST.000" },
+            StructureInfo = new S101DatasetStructureInfo
+            {
+                CoordinateMultiplicationFactorX = 1,
+                CoordinateMultiplicationFactorY = 1,
+                CoordinateMultiplicationFactorZ = 1,
+            },
+            FeatureTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            AttributeTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            Points = ImmutableDictionary<uint, S101PointRecord>.Empty,
+            CurveSegments = new[] { curve }.ToImmutableDictionary(c => c.RecordId),
+            CompositeCurves = ImmutableDictionary<uint, S101CompositeCurveRecord>.Empty,
+            Surfaces = ImmutableDictionary<uint, S101SurfaceRecord>.Empty,
+            Features = ImmutableArray<S101FeatureRecord>.Empty,
+            InformationTypes = ImmutableDictionary<uint, S101InformationRecord>.Empty,
+            InformationTypeCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            InformationAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            FeatureAssociationCatalogue = ImmutableDictionary<ushort, string>.Empty,
+            RoleCatalogue = ImmutableDictionary<ushort, string>.Empty,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

The MCP `open_dataset` tool reported degenerate world bounds (`-90/-180/90/180`) for S-101 single-file (`.000`) loads, so an agent driving the viewer could not target a loaded cell from the result alone. Root cause: `S101VectorSource.ComputeExtent()` only scanned `Points`/`MultiPoints` records. Real S-101 cells are predominantly curves/surfaces with no isolated point records, so the extent collapsed to `(0,0,0,0)`, which `ComputeS101Bounds` treats as degenerate and falls back to `WorldBounds`.

The fix folds curve-segment intermediate coordinates (with COMF applied) into the extent computation, so curves-only cells produce their true WGS-84 bounds. The cell boundary vertices live in those intermediate coordinates, so single-file loads now report self-sufficient bounds for viewport targeting.

Fixes: #274

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [ ] N/A

**Spec section references cited in code/docs:** S-100 Part 10a coordinate multiplication factors (COMF) for decimal-degree conversion.

## Tests

- [x] Added/updated xunit tests under `tests/` (`S101VectorSourceExtentTests`: curves-only doc yields non-degenerate extent)
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally (S101 95 passed, Viewer 1322 passed)

## Documentation

- [ ] N/A — internal bug fix, no public API or behaviour-doc change

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None.