### PR TITLE
Add map scale and refine cursor lat/long in viewer status bar

### DIFF
--- a/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/LatLonFormatter.cs
@@ -19,12 +19,17 @@ internal static class LatLonFormatter
 
     /// <summary>
     /// Formats a (latitude, longitude) pair in degrees-decimal-minutes form.
-    /// Degrees are space-padded (latitude to two characters, longitude to
-    /// three) so that the readout occupies a stable width without using
-    /// leading zeros.
+    /// Degrees are zero-padded (latitude to two digits, longitude to three)
+    /// so the readout keeps a stable width when rendered with tabular figures.
     /// </summary>
     public static string Format(double latitude, double longitude) =>
         $"{FormatDegMin(latitude, 'N', 'S', 2)}  {FormatDegMin(longitude, 'E', 'W', 3)}";
+
+    /// <summary>Formats just the latitude component, e.g. <c>"50°46.024'N"</c>.</summary>
+    public static string FormatLatitude(double latitude) => FormatDegMin(latitude, 'N', 'S', 2);
+
+    /// <summary>Formats just the longitude component, e.g. <c>"001°15.558'W"</c>.</summary>
+    public static string FormatLongitude(double longitude) => FormatDegMin(longitude, 'E', 'W', 3);
 
     /// <summary>
     /// Formats a (latitude, longitude) pair as signed decimal degrees,
@@ -50,7 +55,7 @@ internal static class LatLonFormatter
             min = 0.0;
         }
 
-        var degText = deg.ToString(CultureInfo.InvariantCulture).PadLeft(degWidth);
+        var degText = deg.ToString(CultureInfo.InvariantCulture).PadLeft(degWidth, '0');
         return string.Create(
             CultureInfo.InvariantCulture,
             $"{degText}°{min.ToString("00.000", CultureInfo.InvariantCulture)}'{hemi}");

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml
@@ -187,24 +187,65 @@
                            Text="{Binding McpStatusText}"
                            IsVisible="{Binding IsMcpRunning}"
                            FontSize="12"
-                           FontFamily="Menlo,Consolas,Courier New,monospace"
+                           FontFeatures="+tnum"
                            Opacity="0.7"
                            VerticalAlignment="Center"
                            Margin="12,0,0,0"
                            ToolTip.Tip="{Binding McpTooltipText}" />
-                <TextBlock DockPanel.Dock="Right"
-                           Text="{Binding MouseLatLonText}"
-                           FontSize="12"
-                           FontFamily="Menlo,Consolas,Courier New,monospace"
-                           Opacity="0.7"
-                           VerticalAlignment="Center"
-                           Margin="12,0,0,0"
-                           ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
+                <!-- Cursor lat/lon then scale, fixed to the right edge.
+                     Scale is right-most so it never shifts when the lat/lon
+                     readout disappears (cursor off the map). -->
+                <StackPanel DockPanel.Dock="Right"
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center">
+                    <ic:FluentIcon Icon="MyLocation" IconVariant="Regular" FontSize="14"
+                                   Opacity="0.6"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0"
+                                   IsVisible="{Binding IsMouseLatLonVisible}"
+                                   ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
+                    <TextBlock Text="{Binding MouseLatText}"
+                               FontSize="12"
+                               FontFeatures="+tnum"
+                               Opacity="0.75"
+                               MinWidth="74"
+                               TextAlignment="Right"
+                               VerticalAlignment="Center"
+                               ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
+                    <TextBlock Text="{Binding MouseLonText}"
+                               FontSize="12"
+                               FontFeatures="+tnum"
+                               Opacity="0.75"
+                               MinWidth="80"
+                               TextAlignment="Right"
+                               VerticalAlignment="Center"
+                               Margin="10,0,0,0"
+                               ToolTip.Tip="{x:Static loc:Strings.Tooltip_MouseLatLon}" />
+                    <Border Width="1" Height="13"
+                            Margin="12,0"
+                            Background="{DynamicResource BorderColor}"
+                            IsVisible="{Binding IsMapScaleVisible}" />
+                    <TextBlock Text="{x:Static loc:Strings.Status_ScaleLabel}"
+                               FontSize="12"
+                               Opacity="0.5"
+                               VerticalAlignment="Center"
+                               IsVisible="{Binding IsMapScaleVisible}"
+                               Margin="0,0,6,0"
+                               ToolTip.Tip="{x:Static loc:Strings.Tooltip_MapScale}" />
+                    <TextBlock Text="{Binding MapScaleText}"
+                               FontSize="12"
+                               FontFeatures="+tnum"
+                               Opacity="0.75"
+                               MinWidth="92"
+                               TextAlignment="Right"
+                               VerticalAlignment="Center"
+                               ToolTip.Tip="{x:Static loc:Strings.Tooltip_MapScale}" />
+                </StackPanel>
                 <TextBlock DockPanel.Dock="Right"
                            Text="{Binding MeasureSummary}"
                            IsVisible="{Binding IsToolSummaryVisible}"
                            FontSize="12"
-                           FontFamily="Menlo,Consolas,Courier New,monospace"
+                           FontFeatures="+tnum"
                            Opacity="0.85"
                            VerticalAlignment="Center"
                            Margin="12,0,0,0" />

--- a/src/EncDotNet.S100.Viewer/MapScaleFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/MapScaleFormatter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Globalization;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Formats a web-mercator viewport resolution as a representative map-scale
+/// denominator (e.g. <c>"1:180 000"</c>) for display in the status bar. The
+/// scale is approximate: it corrects for web-mercator latitude distortion and
+/// assumes the OGC standardized rendering pixel size of 0.28&#160;mm.
+/// </summary>
+internal static class MapScaleFormatter
+{
+    /// <summary>Empty when no scale is available.</summary>
+    public const string Placeholder = "";
+
+    private const double EarthRadiusMeters = 6378137.0;
+
+    // OGC standardized rendering pixel size (0.28 mm), the conventional basis
+    // for converting ground-meters-per-pixel into a 1:N map-scale denominator.
+    private const double PixelSizeMeters = 0.00028;
+
+    /// <summary>
+    /// Formats the scale denominator for the given EPSG:3857 viewport.
+    /// </summary>
+    /// <param name="mercatorResolution">Resolution in mercator meters per pixel.</param>
+    /// <param name="mercatorCenterY">Mercator Y of the viewport center, used to correct for latitude distortion.</param>
+    /// <returns>A string like <c>"1:180 000"</c>, or <see cref="Placeholder"/> when no scale is available.</returns>
+    public static string Format(double mercatorResolution, double mercatorCenterY)
+    {
+        if (double.IsNaN(mercatorResolution) || mercatorResolution <= 0)
+            return Placeholder;
+
+        var latitudeRadians = Math.Atan(Math.Sinh(mercatorCenterY / EarthRadiusMeters));
+        var groundMetersPerPixel = mercatorResolution * Math.Cos(latitudeRadians);
+        if (groundMetersPerPixel <= 0 || double.IsNaN(groundMetersPerPixel))
+            return Placeholder;
+
+        var denominator = groundMetersPerPixel / PixelSizeMeters;
+        var rounded = RoundToSignificant(denominator);
+
+        // Space-grouped thousands, e.g. "180 000", to read cleanly on charts.
+        return "1:" + rounded.ToString("#,0", SpaceGroupFormat);
+    }
+
+    private static double RoundToSignificant(double value)
+    {
+        if (value <= 0)
+            return 0;
+        var magnitude = Math.Pow(10, Math.Floor(Math.Log10(value)) - 2);
+        return Math.Round(value / magnitude) * magnitude;
+    }
+
+    private static readonly NumberFormatInfo SpaceGroupFormat = new()
+    {
+        NumberGroupSeparator = "\u00A0",
+        NumberGroupSizes = [3],
+    };
+}

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -174,6 +174,8 @@ internal static class Strings
     public static string Tooltip_TimelinePreviousStep => Get(nameof(Tooltip_TimelinePreviousStep));
     public static string Tooltip_TimelineNextStep => Get(nameof(Tooltip_TimelineNextStep));
     public static string Tooltip_MouseLatLon => Get(nameof(Tooltip_MouseLatLon));
+    public static string Tooltip_MapScale => Get(nameof(Tooltip_MapScale));
+    public static string Status_ScaleLabel => Get(nameof(Status_ScaleLabel));
 
     // Buttons / actions
     public static string Button_OpenDataset => Get(nameof(Button_OpenDataset));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1171,6 +1171,12 @@
   <data name="Tooltip_MouseLatLon" xml:space="preserve">
     <value>Latitude and longitude of the cursor on the map</value>
   </data>
+  <data name="Tooltip_MapScale" xml:space="preserve">
+    <value>Approximate map scale denominator (include this when reporting an issue)</value>
+  </data>
+  <data name="Status_ScaleLabel" xml:space="preserve">
+    <value>Scale</value>
+  </data>
 
   <!-- ECDIS Display Controls -->
   <data name="Pane_EcdisDisplay" xml:space="preserve">

--- a/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapInteractionController.cs
@@ -212,10 +212,11 @@ internal sealed class MapInteractionController
         }
     }
 
-    private static void UpdateScaleBar(ScaleBarView scaleBar, CompassRoseView compassRose, Viewport viewport)
+    private void UpdateScaleBar(ScaleBarView scaleBar, CompassRoseView compassRose, Viewport viewport)
     {
         scaleBar.UpdateForViewport(viewport.Resolution, viewport.CenterY);
         compassRose.UpdateForViewport(viewport.Rotation);
+        _viewModel.MapScaleText = MapScaleFormatter.Format(viewport.Resolution, viewport.CenterY);
     }
 
     private void OnMapMagnify(object? sender, PointerDeltaEventArgs e)
@@ -463,7 +464,8 @@ internal sealed class MapInteractionController
     private void OnMapPointerExited(object? sender, PointerEventArgs e)
     {
         _lastMouseScreenPos = null;
-        _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+        _viewModel.MouseLatText = LatLonFormatter.Placeholder;
+        _viewModel.MouseLonText = LatLonFormatter.Placeholder;
     }
 
     private void HandleViewportChangedForMouseLatLon()
@@ -488,7 +490,8 @@ internal sealed class MapInteractionController
             position.X > bounds.Width || position.Y > bounds.Height)
         {
             _lastMouseScreenPos = null;
-            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            _viewModel.MouseLatText = LatLonFormatter.Placeholder;
+            _viewModel.MouseLonText = LatLonFormatter.Placeholder;
             return;
         }
 
@@ -500,7 +503,8 @@ internal sealed class MapInteractionController
     {
         if (_mapControl?.Map?.Navigator is not { } navigator)
         {
-            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            _viewModel.MouseLatText = LatLonFormatter.Placeholder;
+            _viewModel.MouseLonText = LatLonFormatter.Placeholder;
             return;
         }
 
@@ -510,14 +514,16 @@ internal sealed class MapInteractionController
             double.IsInfinity(lat) || double.IsInfinity(lon) ||
             lat < -90.0 || lat > 90.0)
         {
-            _viewModel.MouseLatLonText = LatLonFormatter.Placeholder;
+            _viewModel.MouseLatText = LatLonFormatter.Placeholder;
+            _viewModel.MouseLonText = LatLonFormatter.Placeholder;
             return;
         }
 
         // Normalize longitude into the canonical [-180, 180] range so that
         // panning past the antimeridian still produces sensible readings.
         lon = ((lon + 540.0) % 360.0) - 180.0;
-        _viewModel.MouseLatLonText = LatLonFormatter.Format(lat, lon);
+        _viewModel.MouseLatText = LatLonFormatter.FormatLatitude(lat);
+        _viewModel.MouseLonText = LatLonFormatter.FormatLongitude(lon);
     }
 
     private void OnMapPointerReleased(object? sender, PointerReleasedEventArgs e)

--- a/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/MainViewModel.cs
@@ -527,18 +527,56 @@ internal sealed class MainViewModel : ViewModelBase
     /// </summary>
     public ICommand ToggleTimelineCommand { get; }
 
-    private string _mouseLatLonText = LatLonFormatter.Placeholder;
+    private string _mouseLatText = LatLonFormatter.Placeholder;
     /// <summary>
-    /// Lat/long of the mouse cursor when it is over the map, formatted in
-    /// degrees-decimal-minutes (mariner-friendly). Set to
-    /// <see cref="LatLonFormatter.Placeholder"/> when the cursor is not over
-    /// the map.
+    /// Latitude component of the cursor readout (e.g. <c>"50°46.024'N"</c>),
+    /// shown in its own fixed-width status-bar cell so the longitude and the
+    /// adjacent scale text don't jitter as the value changes. Empty when the
+    /// cursor is not over the map.
     /// </summary>
-    public string MouseLatLonText
+    public string MouseLatText
     {
-        get => _mouseLatLonText;
-        set => SetProperty(ref _mouseLatLonText, value);
+        get => _mouseLatText;
+        set
+        {
+            if (SetProperty(ref _mouseLatText, value))
+                OnPropertyChanged(nameof(IsMouseLatLonVisible));
+        }
     }
+
+    private string _mouseLonText = LatLonFormatter.Placeholder;
+    /// <summary>
+    /// Longitude component of the cursor readout (e.g. <c>"001°15.558'W"</c>),
+    /// shown in its own fixed-width status-bar cell. Empty when the cursor is
+    /// not over the map.
+    /// </summary>
+    public string MouseLonText
+    {
+        get => _mouseLonText;
+        set => SetProperty(ref _mouseLonText, value);
+    }
+
+    /// <summary>True when the cursor is over the map and a lat/long is shown.</summary>
+    public bool IsMouseLatLonVisible => _mouseLatText.Length > 0;
+
+    private string _mapScaleText = string.Empty;
+    /// <summary>
+    /// The current map scale denominator, formatted as <c>"1:180 000"</c>,
+    /// shown in the status bar for issue-reporting and orientation. Empty
+    /// when no scale is available (e.g. before the first viewport update).
+    /// </summary>
+    public string MapScaleText
+    {
+        get => _mapScaleText;
+        set
+        {
+            if (SetProperty(ref _mapScaleText, value))
+                OnPropertyChanged(nameof(IsMapScaleVisible));
+        }
+    }
+
+    /// <summary>True when a map scale is available to display.</summary>
+    public bool IsMapScaleVisible => _mapScaleText.Length > 0;
 
     /// <summary>
     /// Toggles the right dock open/closed. Kept for the existing

--- a/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LatLonFormatterTests.cs
@@ -9,32 +9,32 @@ public class LatLonFormatterTests
     {
         // 12.5760278° = 12° 34.5617'
         var text = LatLonFormatter.Format(12.576028, 56.205750);
-        Assert.Equal("12°34.562'N   56°12.345'E", text);
+        Assert.Equal("12°34.562'N  056°12.345'E", text);
     }
 
     [Fact]
     public void Format_SouthWest_UsesCorrectHemispheres()
     {
         var text = LatLonFormatter.Format(-12.576028, -56.205750);
-        Assert.Equal("12°34.562'S   56°12.345'W", text);
+        Assert.Equal("12°34.562'S  056°12.345'W", text);
     }
 
     [Fact]
     public void Format_Equator_RendersAsNorthAndEast()
     {
         var text = LatLonFormatter.Format(0.0, 0.0);
-        Assert.Equal(" 0°00.000'N    0°00.000'E", text);
+        Assert.Equal("00°00.000'N  000°00.000'E", text);
     }
 
     [Fact]
-    public void Format_DegreesArePadWithSpaces_NotZeros()
+    public void Format_DegreesAreZeroPadded()
     {
         var text = LatLonFormatter.Format(1.0, 2.0);
-        Assert.Equal(" 1°00.000'N    2°00.000'E", text);
+        Assert.Equal("01°00.000'N  002°00.000'E", text);
     }
 
     [Fact]
-    public void Format_MaxDegreesFitWithoutPaddingSpaces()
+    public void Format_MaxDegreesFitWithoutTruncation()
     {
         var text = LatLonFormatter.Format(89.0, 179.0);
         Assert.Equal("89°00.000'N  179°00.000'E", text);
@@ -45,7 +45,7 @@ public class LatLonFormatterTests
     {
         // 0.5° → 30.0000 minutes; ensure no trailing rounding artifact.
         var text = LatLonFormatter.Format(45.5, 90.5);
-        Assert.Equal("45°30.000'N   90°30.000'E", text);
+        Assert.Equal("45°30.000'N  090°30.000'E", text);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/MapScaleFormatterTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MapScaleFormatterTests.cs
@@ -1,0 +1,32 @@
+using EncDotNet.S100.Viewer;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class MapScaleFormatterTests
+{
+    [Fact]
+    public void Format_InvalidResolution_ReturnsPlaceholder()
+    {
+        Assert.Equal(MapScaleFormatter.Placeholder, MapScaleFormatter.Format(0, 0));
+        Assert.Equal(MapScaleFormatter.Placeholder, MapScaleFormatter.Format(double.NaN, 0));
+        Assert.Equal(MapScaleFormatter.Placeholder, MapScaleFormatter.Format(-5, 0));
+    }
+
+    [Fact]
+    public void Format_AtEquator_ProducesScaleDenominator()
+    {
+        // At the equator (centerY = 0) there is no mercator distortion, so the
+        // denominator is resolution / 0.00028. A resolution of ~50.4 m/px gives
+        // 50.4 / 0.00028 = 180 000.
+        var text = MapScaleFormatter.Format(50.4, 0.0);
+        Assert.StartsWith("1:", text);
+        Assert.Equal("1:180\u00A0000", text);
+    }
+
+    [Fact]
+    public void Format_RoundsToThreeSignificantFigures()
+    {
+        var text = MapScaleFormatter.Format(50.4 * 1.234, 0.0);
+        Assert.Equal("1:222\u00A0000", text);
+    }
+}


### PR DESCRIPTION
## Summary

The viewer status bar showed only the cursor lat/long, in a monospaced font, with no map scale. This refines the readout and adds a map-scale denominator (handy to quote when reporting issues).

Key changes:
- New `MapScaleFormatter` converts the EPSG:3857 viewport resolution into an approximate `1:N` denominator (corrects for web-mercator latitude distortion, OGC 0.28 mm pixel, rounded to 3 significant figures); updated live on every viewport change.
- Cursor lat/long is split into two fixed-width, right-aligned cells (with a crosshair icon) so the W↔E hemisphere flip no longer jitters; the whole readout and its icon hide when the cursor leaves the map.
- Scale sits in the right-most fixed-width cell behind a divider so it stays anchored even as the lat/long readout clears.
- Status readouts switched from a monospaced font (`Menlo,Consolas,...`) to tabular figures (`+tnum`) in the standard app font.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A (viewer UI only)

## Tests

- [x] Added/updated xunit tests under `tests/`
- [ ] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Updated `LatLonFormatterTests` for zero-padded degrees; added `MapScaleFormatterTests`. 12 viewer formatter tests pass.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

## Breaking changes

None.