### PR TITLE
Promote the scene IR + headless Skia renderer to first-class versioned packages (#399)

### DIFF
--- a/docs/embedding-the-renderer.md
+++ b/docs/embedding-the-renderer.md
@@ -1,0 +1,135 @@
+# Embedding the renderer
+
+The batteries-included [`EncDotNet.S100`](getting-started.md) facade is the
+easiest way to open a dataset and render it to an image. But if you already have
+a display list (or want to build a scene yourself) and only need the
+**renderer**, you can depend on two small, headless, Mapsui-free packages
+instead of the whole facade:
+
+| Package | Role |
+|---|---|
+| [`EncDotNet.S100.Rendering.Scene`](https://github.com/philliphoff/EncDotNet.S100/blob/main/src/EncDotNet.S100.Rendering.Scene/README.md) | The backend-neutral **scene IR** — `VectorScene`, the `PaintOp` hierarchy, `VectorSceneBuilder`, `ColorResolver`, `ScaleVisibility`, `WebMercator`. Depends only on `EncDotNet.S100.Core` and `EncDotNet.S100.Portrayals`. |
+| [`EncDotNet.S100.Renderers.Skia`](https://github.com/philliphoff/EncDotNet.S100/blob/main/src/EncDotNet.S100.Renderers.Skia/README.md) | The headless **SkiaSharp rasteriser** — `SkiaDisplayListRenderer`, `HeadlessVectorRenderer`, `CoverageHeadlessRenderer`, `HeadlessCompositeRenderer`. |
+
+Neither package references Mapsui, Avalonia, or any GUI framework, so this is the
+seam to embed into a tile-serving web API, a batch image job, or the library half
+of a future web/WASM target.
+
+```sh
+dotnet add package EncDotNet.S100.Renderers.Skia
+```
+
+Adding the renderer transitively brings in the scene IR. Add
+`EncDotNet.S100.Rendering.Scene` explicitly if you build a `VectorScene` without
+touching Skia types.
+
+## The two layers
+
+The renderer is split into two seams so the portrayal-correctness logic and the
+rasteriser stay independent:
+
+1. **Lowering** — a `DrawingInstruction` display list (S-100 Part 9 portrayal
+   output) is lowered into a `VectorScene`: an ordered list of fully-resolved
+   `PaintOp`s in EPSG:3857 metres with sizes in logical pixels and colours
+   resolved to `RgbaColor`. This is `VectorSceneBuilder` (in `Rendering.Scene`).
+2. **Rasterising** — a `VectorScene` + `Viewport` is drawn to an `SKBitmap` by
+   `SkiaDisplayListRenderer` (in `Renderers.Skia`). Because every backend
+   consumes the same IR, the same scene can be driven through a different
+   backend for apples-to-apples comparison.
+
+## Rendering a display list in one call
+
+If you have a display list plus the catalogue providers (symbol SVG, line style,
+colour palette), `HeadlessVectorRenderer.Render` does both steps and auto-fits
+the viewport to the scene extent:
+
+```csharp
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+
+SKBitmap bitmap = HeadlessVectorRenderer.Render(
+    instructions,          // IReadOnlyList<DrawingInstruction>
+    geometryProvider,      // IFeatureGeometryProvider
+    palette,               // ColorPalette
+    symbolProvider,        // Func<string, string?>?  (name -> SVG)
+    lineStyleProvider,     // Func<string, LineStyle?>?
+    symbolScale: 1.0,
+    textScale: 1.0,
+    widthPixels: 1024,
+    heightPixels: 1024,
+    background: RgbaColor.Transparent);
+
+using var image = SKImage.FromBitmap(bitmap);
+using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+File.WriteAllBytes("out.png", data.ToArray());
+```
+
+## Rendering into an explicit viewport
+
+For a tile server (or any caller that owns the projection), lower the scene once
+and draw it onto your own canvas / viewport with `SkiaDisplayListRenderer`:
+
+```csharp
+using EncDotNet.S100.Rendering.Scene;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+
+VectorScene scene = new VectorSceneBuilder
+{
+    ResolveColor = ColorResolver.Create(palette), // Func<string?, RgbaColor>, required
+    // SymbolResolver / LineStyleProvider / PatternResolver are optional
+}.Build(instructions, geometryProvider);
+
+var renderer = new SkiaDisplayListRenderer
+{
+    Background = RgbaColor.Transparent,
+    HonorScaleVisibility = true, // an explicit viewport carries a real scale
+};
+
+// Render == allocate a bitmap and draw:
+SKBitmap tile = renderer.Render(scene, viewport);
+
+// …or draw onto an existing canvas (compositing an overlay, etc.):
+renderer.RenderOnto(canvas, scene, viewport);
+```
+
+Set `HonorScaleVisibility = false` when the viewport is synthesised from a fitted
+extent (an auto-fit / "render the whole dataset" call), because a fitted scale
+denominator is not the dataset's compilation scale and would wrongly cull
+scale-ranged detail.
+
+## Compositing multiple datasets
+
+To paint several vector and coverage datasets into one image with a shared
+viewport, wrap each as a `CompositeLayer` (`VectorCompositeLayer` /
+`CoverageCompositeLayer`) and paint the ordered stack with
+`HeadlessCompositeRenderer`. The cross-dataset ordering / suppression *decision*
+(S-98 interoperability) is made upstream; this renderer only paints the resolved
+stack.
+
+## Coverage products
+
+Coverage products (S-102 / S-104 / S-111) rasterise through
+`CoverageHeadlessRenderer` (whole-layer, auto-fit) or `SkiaCoverageRenderer`
+(`ICoverageRenderer<SKBitmap>`, cell → colour) rather than the vector path.
+
+## Stability & versioning
+
+The **stable, supported surface** is the documented type set of each package
+(see their READMEs). `internal` and undocumented types are implementation detail
+and may change at any time.
+
+All `EncDotNet.S100.*` packages share **one version**, derived from the release
+git tag — there is no per-package version, and these two packages move in lockstep
+with the facade. Versioning follows [Semantic Versioning](https://semver.org/):
+once past `1.0.0`, a breaking change to a documented surface lands only in a
+**major** bump. While the version is below `1.0.0`, the surface is still settling
+— breaking changes may occur in a minor bump and will be called out in the
+release notes.
+
+## Linux arm64 note
+
+When you publish a `linux-arm64` executable that uses the Skia renderer, reference
+the self-contained SkiaSharp native in your **application** project — see the
+[`Renderers.Skia` README](https://github.com/philliphoff/EncDotNet.S100/blob/main/src/EncDotNet.S100.Renderers.Skia/README.md#linux-arm64-native-dependency)
+([issue #23](https://github.com/philliphoff/EncDotNet.S100/issues/23)).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -10,6 +10,8 @@
   href: mcp-server.md
 - name: Command-line rendering
   href: cli.md
+- name: Embedding the renderer
+  href: embedding-the-renderer.md
 - name: Design notes
   items:
     - name: Dynamic feature sources

--- a/src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj
+++ b/src/EncDotNet.S100.Renderers.Skia/EncDotNet.S100.Renderers.Skia.csproj
@@ -4,10 +4,9 @@
   <PropertyGroup>
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup>
-    <TargetFramework />
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <Description>Headless SkiaSharp rasteriser for the IHO S-100 portrayal pipeline. Renders the backend-neutral scene IR from EncDotNet.S100.Rendering.Scene (VectorScene / PaintOp) to an image with no GUI or map framework: SkiaDisplayListRenderer.RenderOnto, HeadlessVectorRenderer, CoverageHeadlessRenderer, and the multi-layer HeadlessCompositeRenderer. Lets a consumer embed just the renderer + IR without the EncDotNet.S100 facade or Mapsui.</Description>
+    <PackageTags>S-100;rendering;SkiaSharp;headless;rasteriser;portrayal;IHO;hydrography;ECDIS</PackageTags>
     <!-- Ship the self-contained SkiaSharp Linux native so the headless render
          path works on arm64 and on hosts without fontconfig (issue #23). -->
     <UseSkiaSharpLinuxNoDependencies>true</UseSkiaSharpLinuxNoDependencies>

--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -8,7 +8,6 @@ This library renders S-100 coverage and vector data to SkiaSharp bitmaps. It han
 
 - **`SkiaCoverageRenderer`** — `ICoverageRenderer<SKBitmap>` implementation that maps coverage grid cells to pixel colors.
 - **`SkiaSvgRasterizer`** — rasterizes SVG portrayal symbols to tiled pattern bitmaps.
-- **`SkiaColorExtensions`** — helpers for converting between `RgbaColor` and `SKColor`.
 
 ### Shared vector rendering core (now `EncDotNet.S100.Rendering.Scene`)
 
@@ -96,6 +95,31 @@ to an `SKBitmap`:
 ```sh
 dotnet add package EncDotNet.S100.Renderers.Skia
 ```
+
+This pulls in [`EncDotNet.S100.Rendering.Scene`](../EncDotNet.S100.Rendering.Scene/README.md)
+(the scene IR) transitively. Together they let you **embed just the renderer +
+IR** — build or lower a `VectorScene` and rasterise it headlessly — without the
+batteries-included `EncDotNet.S100` facade or any Mapsui/GUI dependency. See the
+[Embedding the renderer](https://github.com/philliphoff/EncDotNet.S100/blob/main/docs/embedding-the-renderer.md)
+guide for the end-to-end path.
+
+## Stability & versioning
+
+The **stable, supported surface** of this package is the headless rendering
+entry points: `SkiaDisplayListRenderer` (incl. its `RenderOnto` overloads),
+`HeadlessVectorRenderer`, `CoverageHeadlessRenderer`, `HeadlessCompositeRenderer`,
+the `CompositeLayer` family (`VectorCompositeLayer`, `CoverageCompositeLayer`),
+`OverlayDrawOptions`, `LabelDeclutterer`, `SkiaCoverageRenderer`,
+`SkiaCoverageArrowRenderer`, and `SkiaSvgRasterizer`. Types that are `internal`
+or undocumented (e.g. colour/font helpers, diagnostics) are implementation
+detail and may change at any time.
+
+All `EncDotNet.S100.*` packages share **one version**, derived from the release
+git tag (there is no per-package version). Versioning follows
+[Semantic Versioning](https://semver.org/): once past `1.0.0`, a breaking change
+to the stable surface above lands only in a **major** bump. While the version is
+below `1.0.0`, the surface is still settling — breaking changes may occur in a
+minor bump and will be called out in the release notes.
 
 ## Linux arm64 native dependency
 

--- a/src/EncDotNet.S100.Renderers.Skia/SkiaColorExtensions.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/SkiaColorExtensions.cs
@@ -5,8 +5,11 @@ namespace EncDotNet.S100.Renderers.Skia;
 
 /// <summary>
 /// Extension methods for converting <see cref="RgbaColor"/> to SkiaSharp types.
+/// Internal: not part of the package's public/stable surface — it exists only to
+/// support this assembly's rendering paths. Consumers embedding the renderer work
+/// with the scene IR (<c>VectorScene</c> / <c>PaintOp</c>), not SkiaSharp colours.
 /// </summary>
-public static class SkiaColorExtensions
+internal static class SkiaColorExtensions
 {
     /// <summary>Converts an <see cref="RgbaColor"/> to an <see cref="SKColor"/>.</summary>
     public static SKColor ToSkia(this RgbaColor color) =>

--- a/src/EncDotNet.S100.Rendering.Scene/EncDotNet.S100.Rendering.Scene.csproj
+++ b/src/EncDotNet.S100.Rendering.Scene/EncDotNet.S100.Rendering.Scene.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <Description>Backend-neutral vector scene intermediate representation (IR) for the IHO S-100 portrayal pipeline: VectorScene and the PaintOp hierarchy (point/line/area/pattern/text), VectorSceneBuilder, ColorResolver, ScaleVisibility, and WebMercator projection. Depends only on EncDotNet.S100.Core and EncDotNet.S100.Portrayals — no SkiaSharp, Mapsui, or GUI framework — so any rendering backend can consume the same resolved scene. Pairs with EncDotNet.S100.Renderers.Skia for headless rasterisation without the EncDotNet.S100 facade.</Description>
+    <PackageTags>S-100;portrayal;rendering;IR;VectorScene;headless;IHO;hydrography;ECDIS</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EncDotNet.S100.Rendering.Scene/README.md
+++ b/src/EncDotNet.S100.Rendering.Scene/README.md
@@ -26,3 +26,32 @@ Mapsui, or any GUI framework.
 Because every backend consumes the same `VectorScene`, the IR is the A/B seam:
 identical portrayal can be driven through different rendering backends for
 apples-to-apples comparison.
+
+## Installation
+
+```sh
+dotnet add package EncDotNet.S100.Rendering.Scene
+```
+
+This package is Mapsui-free and GUI-free. Pair it with
+[`EncDotNet.S100.Renderers.Skia`](../EncDotNet.S100.Renderers.Skia/README.md) to
+rasterise a scene headlessly **without** taking the batteries-included
+`EncDotNet.S100` facade. See the
+[Embedding the renderer](https://github.com/philliphoff/EncDotNet.S100/blob/main/docs/embedding-the-renderer.md)
+guide for the end-to-end path.
+
+## Stability & versioning
+
+The **stable, supported surface** of this package is the set of types documented
+in [What lives here](#what-lives-here): `VectorScene`, the `PaintOp` hierarchy
+(`PointPaintOp`, `LinePaintOp`, `AreaPaintOp`, `PatternAreaPaintOp`,
+`TextPaintOp`), `VectorSceneBuilder`, `ColorResolver`, `ScaleVisibility`, and
+`WebMercator`. Types that are `internal` or undocumented are implementation
+detail and may change at any time.
+
+All `EncDotNet.S100.*` packages share **one version**, derived from the release
+git tag (there is no per-package version). Versioning follows
+[Semantic Versioning](https://semver.org/): once past `1.0.0`, a breaking change
+to the stable surface above lands only in a **major** bump. While the version is
+below `1.0.0`, the surface is still settling — breaking changes may occur in a
+minor bump and will be called out in the release notes.


### PR DESCRIPTION
## Summary

Promotes the two actually-reusable headless building blocks — the renderer-neutral scene IR (`EncDotNet.S100.Rendering.Scene`) and the headless Skia rasteriser (`EncDotNet.S100.Renderers.Skia`) — from transitive-only dependencies of the facade to **first-class, embeddable NuGet packages with a stated stability policy**. This is a packaging + API-stability + docs effort with **zero rendering-behaviour changes**.

Closes #399.

## What changed

**1. Explicit packaging metadata**
- `Rendering.Scene.csproj` and `Renderers.Skia.csproj` now carry `IsPackable`, a focused `Description`, and `PackageTags` (consistent with how the facade / `Datasets.Pipelines` / `Crs.ProjNet` are packaged). Version / Authors / license / README wiring is still inherited, and CI already packs+pushes every packable project — so no workflow changes were needed.
- Collapsed a duplicated `<PropertyGroup>` in `Renderers.Skia.csproj` while adding the metadata.

**2. Stability / versioning policy (docs-only)**
- Prose "Stability & versioning" sections in both project READMEs plus the new guide. No `PublicApiAnalyzers` / PublicAPI baselines and **no per-package version floor**: all `EncDotNet.S100.*` packages keep the single repo-wide, git-tag-driven version and move in lockstep with the facade. The documented type set is the stable surface; `internal`/undocumented types are implementation detail. SemVer applies once past `1.0.0`.

**3. New "embed just the renderer" guide**
- `docs/embedding-the-renderer.md` (+ `toc.yml` entry) documents consuming the IR + headless renderer directly (build/lower a `VectorScene` → `SkiaDisplayListRenderer.RenderOnto` / `HeadlessVectorRenderer.Render`), Mapsui-free, without the facade. Code examples were verified against the real APIs (`VectorSceneBuilder` required-init, `ColorResolver.Create`).

**4. Transitive-type audit / sealing**
- Whole-repo cross-package usage check: `LabelDeclutterer` (used by the Mapsui renderer) and `SkiaSvgRasterizer` (used by the Mapsui renderer + `Datasets.Pipelines`) are consumed across package boundaries, so they **stay public**. Only `SkiaColorExtensions` had no cross-package consumer, so it was **internalized** to keep the stable surface minimal (the one `Pipelines.Tests` use reaches it via the existing `InternalsVisibleTo`). `Telemetry` / `RendererFonts` were already internal.

## Verification
- `Renderers.Skia`, `Rendering.Scene`, `Renderers.Mapsui`, the `EncDotNet.S100` facade, `Pipelines.Tests`, and `VisualRegression.Tests` all build clean (0 warnings under `TreatWarningsAsErrors`).
- `Pipelines.Tests`: 802 passed / 1 skipped / 0 failed.
- Both packages `dotnet pack` successfully; verified the packed `.nuspec` carries the new description/tags and ships the README.

## Related
- Complements the headless backbone work in #398 and builds directly on the S-98 headless compositor extracted in #401.