### PR TITLE
Bless and document the portrayal seam as a pluggable rendering-backend contract (#400)

### DIFF
--- a/EncDotNet.S100.slnx
+++ b/EncDotNet.S100.slnx
@@ -41,6 +41,7 @@
     <Project Path="tests/EncDotNet.S100.Diagnostics.Export.Tests/EncDotNet.S100.Diagnostics.Export.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.ExchangeSets.Tests/EncDotNet.S100.ExchangeSets.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.Pipelines.Tests/EncDotNet.S100.Pipelines.Tests.csproj" />
+    <Project Path="tests/EncDotNet.S100.Rendering.Scene.Tests/EncDotNet.S100.Rendering.Scene.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.VisualRegression.Tests/EncDotNet.S100.VisualRegression.Tests.csproj" />
     <Project Path="tests/EncDotNet.S100.VisualRegression/EncDotNet.S100.VisualRegression.csproj" />
     <Project Path="tests/EncDotNet.S100.Datasets.S101.Tests/EncDotNet.S100.Datasets.S101.Tests.csproj" />

--- a/docs/design/rendering-backend-contract.md
+++ b/docs/design/rendering-backend-contract.md
@@ -1,0 +1,255 @@
+# Rendering-backend contract (the portrayal seam)
+
+This document blesses and documents the **pluggable rendering-backend seam** in
+EncDotNet.S100: the point at which a fully-resolved, renderer-neutral portrayal
+scene is handed to a rendering backend. An embedder can implement a backend that
+targets neither SkiaSharp nor Mapsui — a GPU rasteriser, a server-side raster
+library, PDF, or SVG — by consuming exactly this contract.
+
+The seam is **vector-only** today. The coverage side is discussed under
+[Coverage: partially neutral](#coverage-partially-neutral-out-of-scope).
+
+## The seam end-to-end
+
+```
+IDatasetProcessor
+  └─ IVectorPortrayalSource.BuildVectorPortrayalAsync(context)
+        → VectorPortrayalResult            (Mapsui-free portrayal snapshot)
+             │                              sub-layers + palette + geometry/
+             │                              symbol/line/fill resolver delegates
+             ▼
+        VectorSceneBuilder  (EncDotNet.S100.Rendering.Scene)
+             │  lowers a Part 9 DrawingInstruction display list:
+             │  • sorts into Part 9 draw order
+             │  • resolves colours / symbols / line-styles / pattern tiles
+             │  • converts sizes mm → display px (1 px = 0.32 mm)
+             │  • projects geometry lat/lon → EPSG:3857
+             ▼
+        VectorScene { IReadOnlyList<PaintOp> }   ◄── the renderer-neutral IR
+             │      PointPaintOp / LinePaintOp / AreaPaintOp /
+             │      PatternAreaPaintOp / TextPaintOp
+             ▼
+        IVectorSceneRenderer<TSurface>.Render(surface, scene, viewport)
+             ├─ Skia   : SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
+             └─ (yours): SvgSceneRenderer, PdfSceneRenderer, …
+```
+
+Everything above `VectorScene` is S-100 portrayal correctness; everything below
+is backend-specific drawing. The IR is the contract between the two.
+
+### The three types you target
+
+| Type | Assembly | Role |
+|---|---|---|
+| `VectorScene` / `PaintOp` | `EncDotNet.S100.Rendering.Scene` | The IR: an ordered list of fully-resolved paint operations. |
+| `IVectorSceneRenderer<TSurface>` | `EncDotNet.S100.Rendering.Scene` | The named backend contract — implement this to draw a scene onto your surface. |
+| `WorldToScreen` | `EncDotNet.S100.Rendering.Scene` | The EPSG:3857 world → pixel affine derived from a `Viewport`. Backend-neutral (no Skia / Mapsui dependency). |
+
+`EncDotNet.S100.Rendering.Scene` depends only on `EncDotNet.S100.Core` and
+`EncDotNet.S100.Portrayals` — never on SkiaSharp, Mapsui, or any GUI framework —
+so a backend that references it inherits no rendering-stack dependency.
+
+## IR guarantees for alternate backends
+
+These are the invariants a backend may rely on. They are enforced by
+`VectorSceneBuilder`; see the XML docs on `PaintOp` for the authoritative
+wording.
+
+1. **World units are EPSG:3857 metres.** Every `World…` member on a `PaintOp`
+   is already projected (the `lat/lon → EPSG:3857` half of the S-100 Part 9
+   projection). Your backend supplies the second half — `EPSG:3857 → pixels` —
+   via `WorldToScreen.Create(viewport).Project(world)` or an equivalent affine.
+
+2. **Sizes are logical display pixels.** Stroke widths, dash lengths, offsets,
+   font size, and symbol scale are already in display pixels under the Part 9
+   §3.10.4 convention `1 px = 0.32 mm`. They are resolution-independent device
+   pixels — **not** world metres and **not** physical output pixels. A backend
+   that draws geometry through a world→screen transform **must not** pass size
+   values through that transform; realise them in device pixels directly
+   (reset/compensate the transform for stroke, symbol, and text realisation),
+   otherwise sizes scale with zoom.
+
+3. **Colours are resolved.** All colours are `RgbaColor` (`byte R, G, B, A`) —
+   palette token lookup and transparency are already applied. Symbols are
+   resolved to processed SVG (CSS classes inlined); pattern tiles are supplied
+   as PNG bytes.
+
+4. **Draw order is applied.** `VectorScene.Ops` is already in Part 9 draw order
+   (areas → lines → points → text within ascending drawing priority, under-radar
+   before over-radar). Draw the ops in list order.
+
+5. **SCAMIN is carried per op.** Each `PaintOp` carries `ScaleMinimum` /
+   `ScaleMaximum` as **scale denominators** (not backend resolutions). Apply the
+   same inclusion semantics every backend uses with
+   `ScaleVisibility.IsVisibleAtScale(op, viewport.ScaleDenominator)`; the Skia
+   backend gates on this when `HonorScaleVisibility` is set.
+
+## The two shipped backends as worked references
+
+The two in-tree backends consume the same IR but illustrate two integration
+shapes:
+
+- **Skia — pull / synchronous** (`EncDotNet.S100.Renderers.Skia`).
+  `SkiaDisplayListRenderer` implements `IVectorSceneRenderer<SKCanvas>`: given a
+  scene and a viewport it draws every op onto the canvas on demand, projecting
+  with `WorldToScreen` and realising sizes in device pixels. This is the
+  reference shape for a new backend — it maps one-to-one onto the interface.
+
+- **Mapsui — push / per-frame** (`EncDotNet.S100.Renderers.Mapsui`).
+  `S100VectorSceneRenderer` binds a `VectorScene` to a Mapsui layer
+  (`BindScene`) and renders on Mapsui's own per-frame schedule, letting the
+  navigator perform the `EPSG:3857 → screen` projection. It is a **conforming
+  consumer** of the IR rather than an implementer of
+  `IVectorSceneRenderer<TSurface>`: its asynchronous, navigator-driven model
+  does not fit a synchronous pull-render signature, and forcing it to would be a
+  leaky fit. Implement the interface when your backend can draw a scene to a
+  surface on demand; consume the IR directly (as Mapsui does) when it cannot.
+
+## Backend-specific carry-over limits
+
+- **North-up only.** `WorldToScreen` applies no rotation. Rotated-viewport
+  support (keeping labels upright, etc.) is a backend concern layered on top and
+  is not part of the IR.
+- **Pattern-fill clipping (#192).** `PatternAreaPaintOp` carries a pre-rasterised
+  PNG tile, but the IR does not carry the NetTopologySuite priority-clipping the
+  Mapsui pattern phase performs. A backend that lowers patterns from the IR
+  (as the headless Skia path does) may see lower-priority patterns bleed across
+  opaque overlay areas. Acceptance per #192 is "as closely as practical".
+- **Coverage is out of scope** (see next section).
+
+## Coverage: partially neutral (out of scope)
+
+The coverage side (`ICoveragePortrayalSource` → `CoveragePortrayalResult`) is
+only **partially** neutralised: it carries `StyledCoverageLayer`, `Viewport`,
+and pre-projected `PointGlyph`s rather than a `PaintOp`-style neutral op list.
+There is no coverage IR equivalent to `VectorScene` yet, so coverage products
+(S-102/S-104/S-111) are **not** part of the blessed backend contract in this
+revision. A coverage IR is possible future work; it is intentionally not
+introduced here.
+
+## Writing your own backend
+
+Implement `IVectorSceneRenderer<TSurface>` for your surface type, project with
+`WorldToScreen`, and lower each `PaintOp` subtype. The sketch below is an
+illustrative **SVG** backend that writes to a `TextWriter` and depends only on
+`EncDotNet.S100.Rendering.Scene` — no SkiaSharp, no Mapsui. It is a
+documentation snippet (not a shipped project); it shows the shape of the
+lowering rather than every production edge case.
+
+```csharp
+using System.Globalization;
+using EncDotNet.S100.Pipelines;             // Viewport, RgbaColor
+using EncDotNet.S100.Rendering.Scene;       // VectorScene, PaintOp, WorldToScreen, ScaleVisibility
+
+/// <summary>
+/// An illustrative SVG rendering backend: lowers a renderer-neutral
+/// <see cref="VectorScene"/> to an SVG document. Depends only on
+/// EncDotNet.S100.Rendering.Scene — proof that the seam is backend-agnostic.
+/// </summary>
+public sealed class SvgSceneRenderer : IVectorSceneRenderer<TextWriter>
+{
+    public void Render(TextWriter svg, VectorScene scene, Viewport viewport)
+    {
+        var t = WorldToScreen.Create(viewport);
+        double denom = viewport.ScaleDenominator;
+
+        svg.Write($"<svg xmlns=\"http://www.w3.org/2000/svg\" ");
+        svg.Write($"width=\"{viewport.WidthPixels}\" height=\"{viewport.HeightPixels}\">");
+
+        foreach (var op in scene.Ops)
+        {
+            // Guarantee 5: apply the same SCAMIN inclusion every backend uses.
+            if (!ScaleVisibility.IsVisibleAtScale(op, denom))
+                continue;
+
+            switch (op)
+            {
+                case AreaPaintOp area:
+                    // Geometry projects through the world→screen transform …
+                    svg.Write($"<path d=\"{RingPath(area.WorldShell, t)}");
+                    foreach (var hole in area.WorldHoles)
+                        svg.Write($" {RingPath(hole, t)}");
+                    // … but the outline WIDTH is a display-pixel size (guarantee 2):
+                    // it is emitted as-is, NOT scaled by the transform.
+                    svg.Write($"\" fill=\"{Rgb(area.Fill)}\" fill-rule=\"evenodd\" ");
+                    svg.Write($"stroke=\"{Rgb(area.OutlineColor)}\" ");
+                    svg.Write($"stroke-width=\"{Px(area.OutlineWidthPx)}\"/>");
+                    break;
+
+                case LinePaintOp line:
+                    svg.Write($"<polyline points=\"{Points(line.World, t)}\" fill=\"none\" ");
+                    svg.Write($"stroke=\"{Rgb(line.Color)}\" stroke-width=\"{Px(line.WidthPx)}\"");
+                    if (line.DashArrayPx is { Count: > 0 } dash)
+                        svg.Write($" stroke-dasharray=\"{string.Join(' ', dash)}\"");
+                    svg.Write("/>");
+                    break;
+
+                case PointPaintOp point:
+                    var (px, py) = t.Project(point.World);
+                    // point.Symbol.ProcessedSvg is ready-to-embed SVG content;
+                    // Symbol.Scale / pivot fractions place it. Fall back to a dot.
+                    if (point.Symbol is { } sym)
+                        EmbedSymbol(svg, sym, px, py, point.Rotation);
+                    else
+                        svg.Write($"<circle cx=\"{Px(px)}\" cy=\"{Px(py)}\" r=\"3\" " +
+                                  $"fill=\"{Rgb(point.FallbackColor)}\"/>");
+                    break;
+
+                case TextPaintOp text:
+                    var (tx, ty) = t.Project(text.World);
+                    svg.Write($"<text x=\"{Px(tx + text.OffsetXpx)}\" y=\"{Px(ty + text.OffsetYpx)}\" ");
+                    svg.Write($"font-size=\"{Px(text.FontSizePx)}\" fill=\"{Rgb(text.ForeColor)}\">");
+                    svg.Write(System.Security.SecurityElement.Escape(text.Text));
+                    svg.Write("</text>");
+                    break;
+
+                case PatternAreaPaintOp pattern:
+                    // pattern.TilePng is renderer-neutral PNG bytes → a <pattern>
+                    // referencing a data-URI <image>. (No priority-clipping — #192.)
+                    EmitPatternFill(svg, pattern, t);
+                    break;
+            }
+        }
+
+        svg.Write("</svg>");
+    }
+
+    private static string Rgb(RgbaColor c) =>
+        $"rgba({c.R},{c.G},{c.B},{(c.A / 255.0).ToString("0.###", CultureInfo.InvariantCulture)})";
+
+    private static string Px(double v) => v.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static string Points(IReadOnlyList<(double X, double Y)> ring, WorldToScreen t)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var w in ring)
+        {
+            var (x, y) = t.Project(w);
+            sb.Append(Px(x)).Append(',').Append(Px(y)).Append(' ');
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string RingPath(IReadOnlyList<(double X, double Y)> ring, WorldToScreen t)
+    {
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < ring.Count; i++)
+        {
+            var (x, y) = t.Project(ring[i]);
+            sb.Append(i == 0 ? 'M' : 'L').Append(Px(x)).Append(' ').Append(Px(y)).Append(' ');
+        }
+        return sb.Append('Z').ToString();
+    }
+
+    // EmbedSymbol / EmitPatternFill omitted for brevity: embed
+    // sym.ProcessedSvg at the projected anchor (shifted by the pivot fractions
+    // and scaled by sym.Scale in display px), and emit a <pattern> whose tile is
+    // a base64 data-URI built from pattern.TilePng.
+}
+```
+
+The parity that makes this possible is that `WorldToScreen` is now a
+backend-neutral helper in `EncDotNet.S100.Rendering.Scene` (it was previously
+private to the Skia renderer). See
+`tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenTests.cs` for the
+projection parity tests.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -24,3 +24,5 @@
       href: design/ais-zoom-gated-subscription.md
     - name: S-98 interoperability
       href: design/s98-interoperability.md
+    - name: Rendering-backend contract
+      href: design/rendering-backend-contract.md

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -26,7 +26,7 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 /// and text ops. Antimeridian crossing and Web-Mercator pole limits are out
 /// of scope.</para>
 /// </remarks>
-public sealed class SkiaDisplayListRenderer
+public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
 {
     /// <summary>Background colour cleared before painting. Defaults to transparent.</summary>
     public RgbaColor Background { get; set; } = RgbaColor.Transparent;
@@ -223,6 +223,18 @@ public sealed class SkiaDisplayListRenderer
     /// <param name="viewport">The live viewport whose projection places the ops.</param>
     public void RenderOnto(SKCanvas canvas, VectorScene scene, Viewport viewport)
         => RenderOnto(canvas, scene, viewport, pointCullBounds: null);
+
+    /// <summary>
+    /// Draws <paramref name="scene"/> onto <paramref name="surface"/> for the
+    /// pluggable <see cref="IVectorSceneRenderer{TSurface}"/> seam. Delegates to
+    /// <see cref="RenderOnto(SKCanvas, VectorScene, Viewport)"/>; the canvas is
+    /// neither cleared nor flushed.
+    /// </summary>
+    /// <param name="surface">The destination canvas.</param>
+    /// <param name="scene">The display list to draw, in Part 9 draw order.</param>
+    /// <param name="viewport">The viewport whose projection places the ops.</param>
+    void IVectorSceneRenderer<SKCanvas>.Render(SKCanvas surface, VectorScene scene, Viewport viewport)
+        => RenderOnto(surface, scene, viewport);
 
     /// <summary>
     /// As <see cref="RenderOnto(SKCanvas, VectorScene, Viewport)"/>, but culls
@@ -866,42 +878,3 @@ public sealed class SkiaDisplayListRenderer
     }
 }
 
-/// <summary>
-/// A linear EPSG:3857-world → screen-pixel affine derived from a
-/// <see cref="Viewport"/>. The viewport's geographic bounds are projected to
-/// EPSG:3857 and mapped to the pixel rectangle (origin top-left, +Y down).
-/// </summary>
-internal readonly struct WorldToScreen
-{
-    private readonly double _minX;
-    private readonly double _maxY;
-    private readonly double _scaleX;
-    private readonly double _scaleY;
-
-    private WorldToScreen(double minX, double maxY, double scaleX, double scaleY)
-    {
-        _minX = minX;
-        _maxY = maxY;
-        _scaleX = scaleX;
-        _scaleY = scaleY;
-    }
-
-    public static WorldToScreen Create(Viewport viewport)
-    {
-        var (minX, minY) = WebMercator.FromLonLat(viewport.MinLongitude, viewport.MinLatitude);
-        var (maxX, maxY) = WebMercator.FromLonLat(viewport.MaxLongitude, viewport.MaxLatitude);
-
-        double spanX = maxX - minX;
-        double spanY = maxY - minY;
-        double scaleX = spanX != 0 ? viewport.WidthPixels / spanX : 0;
-        double scaleY = spanY != 0 ? viewport.HeightPixels / spanY : 0;
-        return new WorldToScreen(minX, maxY, scaleX, scaleY);
-    }
-
-    public (float X, float Y) Project((double X, double Y) world)
-    {
-        float sx = (float)((world.X - _minX) * _scaleX);
-        float sy = (float)((_maxY - world.Y) * _scaleY);
-        return (sx, sy);
-    }
-}

--- a/src/EncDotNet.S100.Rendering.Scene/IVectorSceneRenderer.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/IVectorSceneRenderer.cs
@@ -1,0 +1,47 @@
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Rendering.Scene;
+
+/// <summary>
+/// The named contract a rendering backend implements to draw the
+/// backend-agnostic S-100 Part 9 vector intermediate representation
+/// (<see cref="VectorScene"/>) onto a backend-specific drawing surface.
+/// </summary>
+/// <remarks>
+/// <para>This is the <i>pluggable rendering-backend</i> seam. Portrayal
+/// (<c>IVectorPortrayalSource</c> → <c>VectorSceneBuilder</c>) resolves an
+/// S-100 dataset into a fully-resolved <see cref="VectorScene"/> — world
+/// coordinates in EPSG:3857 metres, sizes in logical display pixels, colours
+/// resolved to <c>RgbaColor</c>, symbols to processed SVG, ops in Part 9 draw
+/// order (see the unit contract on <see cref="PaintOp"/>). A backend that
+/// implements this interface consumes exactly that IR, so an embedder can plug
+/// in a renderer (GPU, server-side raster, PDF, SVG, …) that targets neither
+/// SkiaSharp nor Mapsui.</para>
+/// <para><b>Surface generality.</b> The surface type is a type parameter
+/// because backends draw onto different targets: the headless Skia backend
+/// draws to an <c>SKCanvas</c>; an SVG backend writes to a
+/// <c>System.IO.TextWriter</c> / <c>System.Xml.XmlWriter</c>. Implementations
+/// should project the ops' world coordinates to output pixels with
+/// <see cref="WorldToScreen"/> (or an equivalent viewport-derived affine) and
+/// realise <i>size</i> values (stroke widths, symbol scale, font size) directly
+/// in display pixels — <b>not</b> through the world → screen transform.</para>
+/// <para>Not every backend fits a synchronous, pull-style
+/// <see cref="Render(TSurface, VectorScene, Viewport)"/> call. The Mapsui
+/// backend, for example, binds a scene to a layer and renders on its own
+/// per-frame schedule; it is a <i>conforming consumer</i> of the same IR rather
+/// than an implementer of this interface. Implement this interface when your
+/// backend can draw a scene to a surface on demand.</para>
+/// </remarks>
+/// <typeparam name="TSurface">The backend-specific drawing surface.</typeparam>
+public interface IVectorSceneRenderer<in TSurface>
+{
+    /// <summary>
+    /// Draws the fully-resolved <paramref name="scene"/> onto
+    /// <paramref name="surface"/>, projecting world coordinates through the
+    /// affine derived from <paramref name="viewport"/>.
+    /// </summary>
+    /// <param name="surface">The backend-specific drawing surface.</param>
+    /// <param name="scene">The resolved paint operations, in Part 9 draw order.</param>
+    /// <param name="viewport">The display viewport (geographic bounds + pixel size) to project to.</param>
+    void Render(TSurface surface, VectorScene scene, Viewport viewport);
+}

--- a/src/EncDotNet.S100.Rendering.Scene/README.md
+++ b/src/EncDotNet.S100.Rendering.Scene/README.md
@@ -11,11 +11,23 @@ Mapsui, or any GUI framework.
 | Type | Role |
 |---|---|
 | `VectorScene` / `PaintOp` (+ `PointPaintOp`, `LinePaintOp`, `AreaPaintOp`, `PatternAreaPaintOp`, `TextPaintOp`) | Ordered list of fully-resolved paint operations — world coords in EPSG:3857 m, sizes in logical display px, colours resolved to `RgbaColor`, SCAMIN carried per-op. |
+| `IVectorSceneRenderer<TSurface>` | The named **rendering-backend contract**: implement it to draw a `VectorScene` onto a backend-specific surface. `SkiaDisplayListRenderer` implements `IVectorSceneRenderer<SKCanvas>`; the Mapsui renderer is a conforming consumer of the IR rather than an implementer. |
+| `WorldToScreen` | Backend-neutral EPSG:3857 world → pixel affine derived from a `Viewport` (the `EPSG:3857 → pixels` half of the Part 9 projection). Lets a Skia-free backend project the IR's world coordinates. |
 | `ResolvedSymbol`, `SymbolAsset` | Resolved point-symbol content + pivot (S-100 Part 9 §11.5). |
 | `VectorSceneBuilder` | Lowers a `DrawingInstruction` display list into a `VectorScene`. Pattern tiles are supplied as PNG bytes through an injected `Func<string, byte[]?>` delegate, so the builder stays rasteriser-free. |
 | `ColorResolver` | S-100 colour-token → `RgbaColor` resolution. |
 | `ScaleVisibility` | S-100 Part 9 §11.1 scale-visibility semantics (SCAMIN inclusion). |
 | `WebMercator` | Spherical EPSG:3857 forward projection (the `lat/lon → 3857` half of the S-100 Part 9 projection). |
+
+## The rendering-backend seam
+
+Because every backend consumes the same `VectorScene`, the IR is the blessed
+**pluggable rendering-backend contract**: an embedder can implement
+`IVectorSceneRenderer<TSurface>` (or consume the IR directly, as Mapsui does) to
+render S-100 portrayal through a non-Skia/non-Mapsui backend — GPU, server-side
+raster, PDF, SVG. See [`docs/design/rendering-backend-contract.md`](../../docs/design/rendering-backend-contract.md)
+for the end-to-end seam, the IR guarantees, the two shipped backends as worked
+references, and an illustrative SVG backend.
 
 ## Who consumes it
 

--- a/src/EncDotNet.S100.Rendering.Scene/WorldToScreen.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/WorldToScreen.cs
@@ -1,0 +1,76 @@
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Rendering.Scene;
+
+/// <summary>
+/// A linear <b>EPSG:3857-world → screen-pixel</b> affine derived from a
+/// <see cref="Viewport"/> — the second half of the S-100 Part 9 projection
+/// (<c>EPSG:3857 → screen pixels</c>) that a <see cref="PaintOp"/> deliberately
+/// leaves to each rendering backend (see the unit contract on
+/// <see cref="PaintOp"/>).
+/// </summary>
+/// <remarks>
+/// <para>The viewport's geographic bounds are projected to EPSG:3857 via
+/// <see cref="WebMercator.FromLonLat(double, double)"/> and mapped linearly to
+/// the pixel rectangle with origin top-left and screen-space <c>+Y</c> pointing
+/// <i>down</i> (northing decreases downward). The transform is north-up only —
+/// it applies no rotation.</para>
+/// <para>This helper is intentionally framework-neutral (it depends only on
+/// <see cref="Viewport"/> and <see cref="WebMercator"/>), so a rendering
+/// backend that does not use SkiaSharp or Mapsui can project the world
+/// coordinates carried on each <see cref="PaintOp"/> to output pixels without
+/// taking a dependency on either backend. It provides only the geometry
+/// (world → pixel) projection; <i>size</i> values on the IR are already in
+/// display pixels and must <b>not</b> be passed through this transform.</para>
+/// </remarks>
+public readonly struct WorldToScreen
+{
+    private readonly double _minX;
+    private readonly double _maxY;
+    private readonly double _scaleX;
+    private readonly double _scaleY;
+
+    private WorldToScreen(double minX, double maxY, double scaleX, double scaleY)
+    {
+        _minX = minX;
+        _maxY = maxY;
+        _scaleX = scaleX;
+        _scaleY = scaleY;
+    }
+
+    /// <summary>
+    /// Builds the world → screen affine for the supplied <paramref name="viewport"/>.
+    /// The viewport's geographic corners are projected to EPSG:3857 and mapped to
+    /// the <c>[0, WidthPixels] × [0, HeightPixels]</c> pixel rectangle. A viewport
+    /// with a zero-width or zero-height projected span yields a zero scale on that
+    /// axis (all coordinates collapse to the axis origin).
+    /// </summary>
+    /// <param name="viewport">The display viewport (geographic bounds + pixel size).</param>
+    /// <returns>The world → screen affine.</returns>
+    public static WorldToScreen Create(Viewport viewport)
+    {
+        ArgumentNullException.ThrowIfNull(viewport);
+
+        var (minX, minY) = WebMercator.FromLonLat(viewport.MinLongitude, viewport.MinLatitude);
+        var (maxX, maxY) = WebMercator.FromLonLat(viewport.MaxLongitude, viewport.MaxLatitude);
+
+        double spanX = maxX - minX;
+        double spanY = maxY - minY;
+        double scaleX = spanX != 0 ? viewport.WidthPixels / spanX : 0;
+        double scaleY = spanY != 0 ? viewport.HeightPixels / spanY : 0;
+        return new WorldToScreen(minX, maxY, scaleX, scaleY);
+    }
+
+    /// <summary>
+    /// Projects an EPSG:3857 world coordinate to a screen pixel (origin top-left,
+    /// <c>+Y</c> down).
+    /// </summary>
+    /// <param name="world">The world coordinate in EPSG:3857 metres.</param>
+    /// <returns>The screen pixel coordinate.</returns>
+    public (float X, float Y) Project((double X, double Y) world)
+    {
+        float sx = (float)((world.X - _minX) * _scaleX);
+        float sy = (float)((_maxY - world.Y) * _scaleY);
+        return (sx, sy);
+    }
+}

--- a/tests/EncDotNet.S100.Rendering.Scene.Tests/EncDotNet.S100.Rendering.Scene.Tests.csproj
+++ b/tests/EncDotNet.S100.Rendering.Scene.Tests/EncDotNet.S100.Rendering.Scene.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Rendering.Scene\EncDotNet.S100.Rendering.Scene.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenTests.cs
+++ b/tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenTests.cs
@@ -1,0 +1,115 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Rendering.Scene;
+
+namespace EncDotNet.S100.Rendering.Scene.Tests;
+
+/// <summary>
+/// Parity tests for <see cref="WorldToScreen"/> — the EPSG:3857 world → pixel
+/// affine extracted out of the Skia backend into the backend-neutral
+/// <c>Rendering.Scene</c> assembly (issue #400). Each case asserts the shared
+/// helper reproduces the exact projection the Skia renderer applied inline
+/// before extraction, so a Skia-free backend projects identically.
+/// </summary>
+public sealed class WorldToScreenTests
+{
+    private static Viewport MakeViewport(
+        double minLon, double minLat, double maxLon, double maxLat, int width, int height) =>
+        new()
+        {
+            MinLongitude = minLon,
+            MinLatitude = minLat,
+            MaxLongitude = maxLon,
+            MaxLatitude = maxLat,
+            WidthPixels = width,
+            HeightPixels = height,
+            ScaleDenominator = 50_000,
+        };
+
+    /// <summary>
+    /// The reference projection: the exact formula the Skia renderer used inline
+    /// (project the viewport corners to EPSG:3857, then map linearly to pixels
+    /// with origin top-left and +Y down). The extracted <see cref="WorldToScreen"/>
+    /// must match this bit-for-bit.
+    /// </summary>
+    private static (float X, float Y) ReferenceProject(Viewport vp, (double X, double Y) world)
+    {
+        var (minX, minY) = WebMercator.FromLonLat(vp.MinLongitude, vp.MinLatitude);
+        var (maxX, maxY) = WebMercator.FromLonLat(vp.MaxLongitude, vp.MaxLatitude);
+        double spanX = maxX - minX;
+        double spanY = maxY - minY;
+        double scaleX = spanX != 0 ? vp.WidthPixels / spanX : 0;
+        double scaleY = spanY != 0 ? vp.HeightPixels / spanY : 0;
+        float sx = (float)((world.X - minX) * scaleX);
+        float sy = (float)((maxY - world.Y) * scaleY);
+        return (sx, sy);
+    }
+
+    public static IEnumerable<object[]> Cases()
+    {
+        // Representative viewports (equatorial, mid-latitude, southern) and points
+        // (interior, both corners, mid-edge).
+        var equator = MakeViewport(-10, -5, 10, 5, 1024, 768);
+        var northSea = MakeViewport(2.0, 51.0, 5.0, 53.0, 1200, 900);
+        var southern = MakeViewport(150.0, -40.0, 155.0, -35.0, 800, 600);
+
+        foreach (var vp in new[] { equator, northSea, southern })
+        {
+            // Corners of the viewport in lon/lat, projected to world.
+            var (bl0, bl1) = WebMercator.FromLonLat(vp.MinLongitude, vp.MinLatitude);
+            var (tr0, tr1) = WebMercator.FromLonLat(vp.MaxLongitude, vp.MaxLatitude);
+            var midLon = (vp.MinLongitude + vp.MaxLongitude) / 2;
+            var midLat = (vp.MinLatitude + vp.MaxLatitude) / 2;
+            var (mid0, mid1) = WebMercator.FromLonLat(midLon, midLat);
+
+            yield return new object[] { vp, (bl0, bl1) };   // bottom-left
+            yield return new object[] { vp, (tr0, tr1) };   // top-right
+            yield return new object[] { vp, (mid0, mid1) }; // centre
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void Project_matches_reference_formula(Viewport vp, (double X, double Y) world)
+    {
+        var transform = WorldToScreen.Create(vp);
+
+        var (ax, ay) = transform.Project(world);
+        var (ex, ey) = ReferenceProject(vp, world);
+
+        Assert.Equal(ex, ax, 3);
+        Assert.Equal(ey, ay, 3);
+    }
+
+    [Fact]
+    public void Corners_map_to_pixel_rectangle()
+    {
+        var vp = MakeViewport(2.0, 51.0, 5.0, 53.0, 1200, 900);
+        var transform = WorldToScreen.Create(vp);
+
+        var bottomLeft = WebMercator.FromLonLat(vp.MinLongitude, vp.MinLatitude);
+        var topRight = WebMercator.FromLonLat(vp.MaxLongitude, vp.MaxLatitude);
+
+        var (blx, bly) = transform.Project(bottomLeft);
+        var (trx, trY) = transform.Project(topRight);
+
+        // Origin top-left, +Y down: bottom-left of the map is (0, height),
+        // top-right is (width, 0).
+        Assert.Equal(0f, blx, 3);
+        Assert.Equal(900f, bly, 3);
+        Assert.Equal(1200f, trx, 3);
+        Assert.Equal(0f, trY, 3);
+    }
+
+    [Fact]
+    public void Degenerate_viewport_collapses_to_axis_origin()
+    {
+        // Zero-width longitude span → x scale is 0; every point projects to x = 0.
+        var vp = MakeViewport(3.0, 51.0, 3.0, 53.0, 1000, 800);
+        var transform = WorldToScreen.Create(vp);
+
+        var world = WebMercator.FromLonLat(3.0, 52.0);
+        var (x, _) = transform.Project(world);
+
+        Assert.Equal(0f, x, 3);
+    }
+}


### PR DESCRIPTION
## Summary

Turns the *implied* vector portrayal seam into a **supported, documented, pluggable rendering-backend contract**. The renderer-neutral `VectorScene` / `PaintOp` IR (in `EncDotNet.S100.Rendering.Scene`) was already consumed by both shipped backends; this PR blesses that seam so an embedder can plug in a non-Skia/non-Mapsui backend (GPU, server-side raster, PDF, SVG) against a *named* contract. **Zero rendering-behaviour change.**

Closes #400.

## What changed

### Named backend contract — `IVectorSceneRenderer<TSurface>`
- New `IVectorSceneRenderer<in TSurface>` in `EncDotNet.S100.Rendering.Scene`: `void Render(TSurface surface, VectorScene scene, Viewport viewport)`. The surface is a type parameter because backends draw onto different targets (`SKCanvas`, `TextWriter`/`XmlWriter`, …).
- `SkiaDisplayListRenderer` now implements `IVectorSceneRenderer<SKCanvas>` via an explicit implementation delegating to its existing `RenderOnto` — the reference "pull / synchronous" backend shape.
- The **Mapsui** renderer is documented as a **conforming consumer** of the same IR (it binds a scene to a layer and renders per-frame on the navigator's schedule) rather than an implementer, since its async push model doesn't fit a synchronous pull-render signature.

### `WorldToScreen` extraction
- Extracted the EPSG:3857 world→pixel affine (`WorldToScreen`) out of `Renderers.Skia` into `EncDotNet.S100.Rendering.Scene` as a public, backend-neutral helper, so a Skia-free backend can project the IR's world coordinates without a Skia/Mapsui dependency. Skia now consumes the extracted helper (internal struct deleted) — behaviour-preserving.

### Documentation
- New `docs/design/rendering-backend-contract.md`: the seam end-to-end, the **5 IR guarantees** (EPSG:3857 world units; display-px sizes + the reset-transform rule for size realisation; resolved colours/symbols/PNG pattern tiles; Part 9 draw order already applied; per-op SCAMIN inclusion via `ScaleVisibility`), the **two shipped backends as pull-vs-push worked references**, **carry-over limits** (pattern-fill clipping #192, north-up-only), an **inline illustrative SVG backend snippet** (`SvgSceneRenderer : IVectorSceneRenderer<TextWriter>`, docs-only), and **coverage documented as out of scope** (`CoveragePortrayalResult` is only partially neutralised — no `PaintOp` equivalent yet).
- Wired `docs/toc.yml`; updated the `Rendering.Scene` README with the new contract + `WorldToScreen` rows and a rendering-backend-seam section.

### Tests
- New `tests/EncDotNet.S100.Rendering.Scene.Tests` with `WorldToScreen` projection **parity tests** (extracted helper vs the prior inline Skia formula across representative viewports/points, corner-to-pixel-rectangle mapping, degenerate-viewport collapse). Wired into `EncDotNet.S100.slnx`.

## Verification
- Full solution builds warning-free (`TreatWarningsAsErrors`).
- `Rendering.Scene.Tests`: 11/11 passed.
- `Pipelines.Tests`: 802 passed / 1 skipped — exercises the Skia headless scene path, confirming the extraction is behaviour-preserving.
- `Cli.Tests`: 80/80 passed.

## Related
- Complements the headless backbone work in #398 / #401.
- Overlaps with the scene-interchange / IR-as-versioned-surface direction (#399 / #403).