### PR TITLE
CLI: composite multiple datasets in `s100 render` (#402)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,8 @@
 # Command-line rendering (`s100`)
 
 `EncDotNet.S100.Cli` is a cross-platform .NET console tool, invoked as **`s100`**,
-that renders any supported S-100 dataset to a PNG, JPEG, or WebP image, and
+that renders any supported S-100 dataset — or a **composite** of several — to a
+PNG, JPEG, or WebP image, and
 **validates** datasets and exchange sets against the normative rule packs. It
 drives the same portrayal and validation pipelines as the Avalonia viewer, but
 rasterises through the Mapsui-free Skia *headless* renderers so it can run
@@ -12,7 +13,7 @@ It offers four subcommands:
 
 | Command | Purpose |
 |---|---|
-| `s100 render <dataset> <output>` | Render a dataset to an image (PNG, JPEG, or WebP). |
+| `s100 render <dataset> <output>`<br>`s100 render --layer … <output>` | Render one dataset — or composite several with `--layer` — to an image (PNG, JPEG, or WebP). |
 | `s100 validate <dataset-or-exchange-set>` | Validate against the spec's normative rule pack (plus exchange-set signature/checksum integrity), with compiler-style output and suppression. |
 | `s100 info <dataset>` | Show the detected spec, edition, headless-render capability, and (for time-series datasets) the available time steps. |
 | `s100 list-specs` | List the supported product specifications and which support headless rendering. |
@@ -61,6 +62,10 @@ dotnet run --project tools/EncDotNet.S100.Cli -- validate exchange-set/
 # Render the 7th time step at night-palette, larger canvas
 dotnet run --project tools/EncDotNet.S100.Cli -- \
     render currents.h5 currents.png --time-step 6 --palette night -w 2048 -h 1536
+
+# Composite several products into one chart (repeated --layer + output)
+dotnet run --project tools/EncDotNet.S100.Cli -- \
+    render --layer enc.000 --layer bathy.h5 --layer warnings.gml chart.png
 ```
 
 ## How it works
@@ -87,6 +92,43 @@ stack is involved, so it runs anywhere .NET does.
 | `--quality <1-100>` | `90` | Encoder quality for lossy formats (`jpeg`, `webp`). Ignored for `png`. |
 | `--no-text` | off | Suppress text/label drawing instructions (shorthand for `--hide text`). |
 | `--hide <list>` | _none_ | Suppress drawing-instruction categories — any of `text`, `points`, `lines`, `areas` — useful for clean fills on label-dense products such as S-411 sea-ice. |
+
+## Compositing multiple datasets
+
+Pass a dataset per `--layer` (repeatable) to stack several products into one
+image via the renderer-neutral **S-98 interoperability** engine. The output path
+is the trailing positional argument or `-o|--output`:
+
+```bash
+s100 render --layer enc.000 --layer bathy.h5 --layer warnings.gml chart.png
+s100 render --layer enc.000 --layer bathy.h5 -o chart.png --bbox -1.5,50.0,-1.0,50.5
+s100 render --layer enc.000 --layer bathy.h5 chart.png --center -1.25,50.25 --scale 50000
+```
+
+The `--palette`, `--symbol-scale`, `--text-scale`, `--time-step`,
+`--background`, `--width`/`--height`, `--format`/`--quality`, and
+`--hide`/`--no-text` options apply as in the single-dataset form; suppression
+(`--hide`/`--no-text`) is **global** — it applies to every layer.
+
+| Composite-only option | Default | Description |
+|---|---|---|
+| `--layer <path>` | _none_ | Add a dataset as a layer (repeatable). Any `--layer` selects the composite form. |
+| `-o`, `--output <path>` | _positional_ | Output image path (alternative to the positional `<output>`). |
+| `--bbox <minLon,minLat,maxLon,maxLat>` | union auto-fit | Explicit shared viewport as a WGS-84 bounding box. Mutually exclusive with `--center`/`--scale`. |
+| `--center <lon,lat>` + `--scale <denominator>` | union auto-fit | Explicit shared viewport by centre + scale denominator (e.g. `--center -1.25,50.25 --scale 50000`). |
+
+Two behaviours differ from the single-dataset form:
+
+- **Ordering.** The S-98 authority orders layers by display plane, so the
+  `--layer` order is only a **within-plane tiebreak** — hand-ordering layers
+  generally has no visible effect (an S-102 surface is already placed above an
+  S-101 chart by its plane).
+- **S-101 updates.** The composite form does **not** apply S-101
+  sequential/sibling updates; `--no-updates` applies to the single-dataset form
+  only. Render an S-101 cell singly if you need its updates folded in.
+
+When no `--bbox` / `--center`+`--scale` is supplied, the compositor auto-fits
+the union extent of all layers to the requested `--width` × `--height`.
 
 ## Capabilities
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
@@ -2,6 +2,7 @@ using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Datasets.Pipelines.Portrayal;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Coverage;
+using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Rendering.Scene;
 using EncDotNet.S100.Renderers.Skia;
 using EncDotNet.S100.Renderers.Skia.Scene;
@@ -72,6 +73,14 @@ public sealed class HeadlessCompositeOptions
     /// <see cref="MarinerSettings.Default"/>.
     /// </summary>
     public MarinerSettings? Mariner { get; init; }
+
+    /// <summary>
+    /// Drawing-instruction categories (areas, lines, points, text) to suppress
+    /// globally across every vector layer in the composite. Defaults to
+    /// <see cref="DrawingInstructionCategory.None"/> (draw everything).
+    /// </summary>
+    public DrawingInstructionCategory HiddenCategories { get; init; }
+        = DrawingInstructionCategory.None;
 }
 
 /// <summary>
@@ -183,7 +192,7 @@ public sealed class HeadlessCompositor
             {
                 case VectorStackPayload vector:
                 {
-                    var scene = LowerVector(vector);
+                    var scene = LowerVector(vector, options.HiddenCategories);
                     lowered.Add(new VectorCompositeLayer(scene, honorScaleVisibility: false));
                     if (HeadlessVectorRenderer.TryGetWorldBounds(scene, out var vx0, out var vy0, out var vx1, out var vy1))
                         Expand(vx0, vy0, vx1, vy1);
@@ -249,7 +258,7 @@ public sealed class HeadlessCompositor
             nameof(input));
     }
 
-    private static VectorScene LowerVector(VectorStackPayload payload)
+    private static VectorScene LowerVector(VectorStackPayload payload, DrawingInstructionCategory hiddenCategories)
     {
         var result = payload.Result;
         var sub = payload.SubLayer;
@@ -261,7 +270,8 @@ public sealed class HeadlessCompositor
             result.LineStyleProvider,
             result.SymbolScale,
             result.TextScale,
-            result.AreaFillProvider);
+            result.AreaFillProvider,
+            hiddenCategories);
     }
 
     private bool TryLowerCoverage(

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -120,6 +120,12 @@ public static class HeadlessVectorRenderer
     /// <param name="symbolScale">Global symbol scale factor.</param>
     /// <param name="textScale">Global text scale factor.</param>
     /// <param name="areaFillProvider">Optional resolver for area-fill catalogue entries (tiled patterns).</param>
+    /// <param name="hiddenCategories">
+    /// Drawing-instruction categories (areas, lines, points, text) to omit from
+    /// the lowered scene. Defaults to
+    /// <see cref="DrawingInstructionCategory.None"/> (lower everything). Used by
+    /// the multi-layer compositor to apply a global suppression across layers.
+    /// </param>
     /// <returns>The resolved vector scene.</returns>
     public static VectorScene BuildScene(
         IReadOnlyList<DrawingInstruction> instructions,
@@ -129,10 +135,14 @@ public static class HeadlessVectorRenderer
         Func<string, LineStyle?>? lineStyleProvider,
         double symbolScale,
         double textScale,
-        Func<string, AreaFill?>? areaFillProvider = null)
+        Func<string, AreaFill?>? areaFillProvider = null,
+        DrawingInstructionCategory hiddenCategories = DrawingInstructionCategory.None)
     {
         ArgumentNullException.ThrowIfNull(instructions);
         ArgumentNullException.ThrowIfNull(geometryProvider);
+
+        if (hiddenCategories != DrawingInstructionCategory.None)
+            instructions = FilterInstructions(instructions, hiddenCategories);
 
         var builder = new VectorSceneBuilder
         {

--- a/src/EncDotNet.S100/PngS100DatasetRenderer.cs
+++ b/src/EncDotNet.S100/PngS100DatasetRenderer.cs
@@ -180,6 +180,7 @@ public sealed class PngS100DatasetRenderer : IS100DatasetRenderer<byte[]>, IS100
                 Background = options.Background ?? new RgbaColor(255, 255, 255, 255),
                 Viewport = options.Viewport,
                 Mariner = mariner,
+                HiddenCategories = options.HiddenCategories,
             };
 
             using var bitmap = compositor.Render(inputs, compositeOptions);
@@ -229,6 +230,7 @@ public sealed class PngS100DatasetRenderer : IS100DatasetRenderer<byte[]>, IS100
             TextScale = options.TextScale,
             TimeStep = options.TimeStep,
             Background = options.Background,
+            HiddenCategories = options.HiddenCategories,
         };
         return FacadeRenderContextBuilder.Build(processor, rendererOptions) with { Mariner = mariner };
     }

--- a/src/EncDotNet.S100/S100CompositeOptions.cs
+++ b/src/EncDotNet.S100/S100CompositeOptions.cs
@@ -1,4 +1,5 @@
 using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
 
 namespace EncDotNet.S100;
 
@@ -37,6 +38,15 @@ public sealed class S100CompositeOptions
     /// Background fill colour. When <c>null</c>, an opaque white background is used.
     /// </summary>
     public RgbaColor? Background { get; init; }
+
+    /// <summary>
+    /// Drawing-instruction categories (areas, lines, points, text) to suppress
+    /// from every layer in the composite. Applied globally — the same suppression
+    /// is passed to each layer's portrayal pipeline. Default
+    /// <see cref="DrawingInstructionCategory.None"/>.
+    /// </summary>
+    public DrawingInstructionCategory HiddenCategories { get; init; }
+        = DrawingInstructionCategory.None;
 
     /// <summary>
     /// Explicit shared viewport for all layers. When <c>null</c> the compositor

--- a/tests/EncDotNet.S100.Cli.Tests/CompositeViewportBuilderTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/CompositeViewportBuilderTests.cs
@@ -1,0 +1,68 @@
+using EncDotNet.S100.Cli.Infrastructure;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="CompositeViewportBuilder"/>: the CLI helper that
+/// maps <c>--bbox</c> / <c>--center</c>+<c>--scale</c> into a shared
+/// <see cref="EncDotNet.S100.Pipelines.Viewport"/>.
+/// </summary>
+public sealed class CompositeViewportBuilderTests
+{
+    [Theory]
+    [InlineData("-1.5,50.0,-1.0,50.5", 4, true)]
+    [InlineData("-1.25,50.25", 2, true)]
+    [InlineData("1,2,3", 4, false)]
+    [InlineData("1,2,3,4,5", 4, false)]
+    [InlineData("a,b,c,d", 4, false)]
+    [InlineData("", 2, false)]
+    public void TryParseDoubles_enforces_arity_and_numeric_tokens(string value, int expected, bool ok)
+    {
+        bool parsed = CompositeViewportBuilder.TryParseDoubles(value, expected, out var values);
+        Assert.Equal(ok, parsed);
+        if (ok)
+            Assert.Equal(expected, values.Length);
+    }
+
+    [Fact]
+    public void FromBoundingBox_frames_the_box_and_keeps_pixel_dimensions()
+    {
+        var viewport = CompositeViewportBuilder.FromBoundingBox(
+            minLon: -1.5, minLat: 50.0, maxLon: -1.0, maxLat: 50.5, width: 400, height: 400);
+
+        Assert.Equal(400, viewport.WidthPixels);
+        Assert.Equal(400, viewport.HeightPixels);
+
+        // The box is fully contained (aspect expansion only ever grows the
+        // extent), and the requested extent's centre is preserved.
+        Assert.True(viewport.MinLongitude <= -1.5 + 1e-9);
+        Assert.True(viewport.MaxLongitude >= -1.0 - 1e-9);
+        Assert.True(viewport.MinLatitude <= 50.0 + 1e-9);
+        Assert.True(viewport.MaxLatitude >= 50.5 - 1e-9);
+
+        Assert.Equal(-1.25, (viewport.MinLongitude + viewport.MaxLongitude) / 2.0, 6);
+        Assert.True(viewport.ScaleDenominator > 0);
+    }
+
+    [Fact]
+    public void FromCenterScale_centres_on_the_point_and_recovers_the_scale()
+    {
+        const double centerLon = -1.25;
+        const double centerLat = 50.25;
+        const double scale = 50_000;
+
+        var viewport = CompositeViewportBuilder.FromCenterScale(
+            centerLon, centerLat, scale, width: 512, height: 512);
+
+        Assert.Equal(512, viewport.WidthPixels);
+        Assert.Equal(512, viewport.HeightPixels);
+
+        Assert.Equal(centerLon, (viewport.MinLongitude + viewport.MaxLongitude) / 2.0, 6);
+        Assert.Equal(centerLat, (viewport.MinLatitude + viewport.MaxLatitude) / 2.0, 4);
+
+        // The round-trip through the compositor's denom maths recovers the
+        // requested scale to within a fraction of a percent (the small residual
+        // is the mercator non-linearity between the centre and mean latitude).
+        Assert.InRange(viewport.ScaleDenominator, scale * 0.99, scale * 1.01);
+    }
+}

--- a/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
+++ b/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
@@ -31,6 +31,8 @@
   <ItemGroup>
     <Content Include="..\datasets\S127\marine_curve.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\marine_curve.gml" />
     <Content Include="..\datasets\S57\US5MA1BO\US5MA1BO.000" CopyToOutputDirectory="PreserveNewest" Link="TestData\US5MA1BO.000" />
+    <Content Include="..\datasets\S124\navwarn_surface.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S124\navwarn_surface.gml" />
+    <Content Include="..\datasets\S125\aton_point.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S125\aton_point.gml" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCompositeCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCompositeCommandTests.cs
@@ -1,0 +1,146 @@
+using EncDotNet.S100.Cli.Infrastructure;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// End-to-end smoke tests for the composite (<c>--layer</c>) grammar of
+/// <c>s100 render</c>, exercised in-process against the committed synthetic
+/// S-124 and S-125 GML fixtures (mirroring the facade's composite test).
+/// </summary>
+public sealed class RenderCompositeCommandTests
+{
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    private static string S124 => Path.Combine(AppContext.BaseDirectory, "TestData", "S124", "navwarn_surface.gml");
+    private static string S125 => Path.Combine(AppContext.BaseDirectory, "TestData", "S125", "aton_point.gml");
+
+    [SkippableFact]
+    public void Composite_two_layers_writes_a_valid_png_at_requested_dimensions()
+    {
+        Skip.IfNot(File.Exists(S124) && File.Exists(S125), "S-124 and S-125 fixtures not both present.");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-comp-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", "--layer", S124, "--layer", S125, output, "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            var bytes = File.ReadAllBytes(output);
+            Assert.Equal(PngSignature, bytes[..PngSignature.Length]);
+
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+            Assert.Equal(320, bitmap!.Width);
+            Assert.Equal(240, bitmap.Height);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Composite_with_output_option_writes_a_valid_png()
+    {
+        Skip.IfNot(File.Exists(S124) && File.Exists(S125), "S-124 and S-125 fixtures not both present.");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-comp-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", "--layer", S124, "--layer", S125, "-o", output, "--width", "256", "--height", "256"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+            var bytes = File.ReadAllBytes(output);
+            Assert.Equal(PngSignature, bytes[..PngSignature.Length]);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Composite_with_explicit_bbox_writes_a_valid_png()
+    {
+        Skip.IfNot(File.Exists(S124) && File.Exists(S125), "S-124 and S-125 fixtures not both present.");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-comp-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", "--layer", S124, "--layer", S125, output,
+                 "--bbox", "-180,-85,180,85", "--width", "256", "--height", "256"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+            Assert.Equal(256, bitmap!.Width);
+            Assert.Equal(256, bitmap.Height);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Composite_with_missing_layer_returns_nonzero()
+    {
+        Skip.IfNot(File.Exists(S124), "S-124 fixture not present.");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-comp-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(
+            ["render", "--layer", S124, "--layer", "does-not-exist.gml", output]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [SkippableFact]
+    public void Composite_with_two_positional_arguments_returns_nonzero()
+    {
+        Skip.IfNot(File.Exists(S124) && File.Exists(S125), "S-124 and S-125 fixtures not both present.");
+
+        // With --layer, only a single positional (the output) is allowed.
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-comp-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(
+            ["render", "--layer", S124, "extra-arg", output]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Bbox_in_single_dataset_form_returns_nonzero()
+    {
+        var dataset = Path.Combine(AppContext.BaseDirectory, "TestData", "marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(
+            ["render", dataset, output, "--bbox", "-1.5,50.0,-1.0,50.5"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Center_without_scale_returns_nonzero()
+    {
+        var dataset = Path.Combine(AppContext.BaseDirectory, "TestData", "marine_curve.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(
+            ["render", "--layer", dataset, output, "--center", "-1.25,50.25"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+}

--- a/tests/EncDotNet.S100.Tests/FacadeTests.cs
+++ b/tests/EncDotNet.S100.Tests/FacadeTests.cs
@@ -161,6 +161,43 @@ public sealed class FacadeTests
             () => renderer.RenderAsync(Array.Empty<S100Layer>(), new S100CompositeOptions()));
     }
 
+    [SkippableFact]
+    public async Task PngRenderer_Composite_HiddenCategories_ChangesOutput()
+    {
+        Skip.IfNot(File.Exists(S124Surface) && File.Exists(S125Point),
+            "S-124 and S-125 fixtures not both present.");
+
+        using var a = S100Dataset.Open(S124Surface);
+        using var b = S100Dataset.Open(S125Point);
+        using var renderer = new PngS100DatasetRenderer();
+
+        var layers = new[]
+        {
+            new S100Layer { Dataset = a },
+            new S100Layer { Dataset = b },
+        };
+
+        byte[] shown = await renderer.RenderAsync(
+            layers, new S100CompositeOptions { Width = 256, Height = 256 });
+
+        // Suppressing every drawing-instruction category must reach each layer's
+        // pipeline in the composite (the option is applied globally), yielding a
+        // different image than the fully-drawn composite.
+        var allHidden = EncDotNet.S100.Pipelines.Vector.DrawingInstructionCategory.Areas
+            | EncDotNet.S100.Pipelines.Vector.DrawingInstructionCategory.Lines
+            | EncDotNet.S100.Pipelines.Vector.DrawingInstructionCategory.Points
+            | EncDotNet.S100.Pipelines.Vector.DrawingInstructionCategory.Text;
+
+        byte[] hidden = await renderer.RenderAsync(
+            layers,
+            new S100CompositeOptions { Width = 256, Height = 256, HiddenCategories = allHidden });
+
+        AssertIsPng(shown);
+        AssertIsPng(hidden);
+        Assert.False(shown.SequenceEqual(hidden),
+            "Hiding all categories should change the composited output.");
+    }
+
     private static void AssertIsPng(byte[] bytes)
     {
         Assert.NotNull(bytes);

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Globalization;
 using EncDotNet.S100.Cli.Infrastructure;
+using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
-using EncDotNet.S100.Datasets.Pipelines;
 using SkiaSharp;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -12,20 +12,62 @@ using Spectre.Console.Cli;
 namespace EncDotNet.S100.Cli.Commands;
 
 /// <summary>
-/// <c>s100 render &lt;dataset&gt; &lt;output&gt;</c> — detects the dataset's product
-/// specification, runs its portrayal pipeline through the Mapsui-free Skia
-/// headless renderer, and writes a PNG image.
+/// <c>s100 render</c> renders one or more S-100 datasets to an image. Two
+/// grammars are supported:
+/// <list type="bullet">
+///   <item><description>
+///     <c>render &lt;dataset&gt; &lt;output&gt;</c> — the single-dataset form:
+///     detects the dataset's product specification and rasterises it through the
+///     Mapsui-free Skia headless renderer.
+///   </description></item>
+///   <item><description>
+///     <c>render --layer A --layer B … &lt;output&gt;</c> — the composite form:
+///     stacks several products into one image via the renderer-neutral S-98
+///     interoperability engine (<see cref="IS100CompositeRenderer{TResult}"/>).
+///   </description></item>
+/// </list>
 /// </summary>
+/// <remarks>
+/// Two behaviours differ between the forms and are surfaced in <c>--help</c>:
+/// (1) the composite form does <b>not</b> apply S-101 sequential/sibling updates
+/// (the single-dataset form still does); and (2) the S-98 authority orders
+/// layers by display plane, so <c>--layer</c> order is only a within-plane
+/// tiebreak — hand-ordering layers generally has no effect.
+/// </remarks>
 internal sealed class RenderCommand : Command<RenderCommand.Settings>
 {
     /// <summary>Maximum supported output dimension (per axis), to guard against OOM.</summary>
     private const int MaxDimension = 16384;
 
-    internal sealed class Settings : DatasetCommandSettings
+    internal sealed class Settings : CommandSettings
     {
-        [CommandArgument(1, "<output>")]
-        [Description("Path of the image to write. The format is inferred from the file extension unless --format is given.")]
-        public string OutputPath { get; init; } = string.Empty;
+        [CommandArgument(0, "[input]")]
+        [Description("Single-dataset form: the dataset to render. Composite form (with --layer and no -o): the output image path.")]
+        public string? Input { get; init; }
+
+        [CommandArgument(1, "[output]")]
+        [Description("Single-dataset form: the output image path. The format is inferred from the file extension unless --format is given.")]
+        public string? OutputArgument { get; init; }
+
+        [CommandOption("--layer <PATH>")]
+        [Description("Add a dataset as a composite layer (repeatable). When any --layer is given, several products are composited into one image. Note: the S-98 authority orders layers by display plane, so --layer order is only a within-plane tiebreak.")]
+        public string[] Layers { get; init; } = [];
+
+        [CommandOption("-o|--output <PATH>")]
+        [Description("Output image path. Required (or given positionally) for the composite form; optional alternative to the positional <output> for the single-dataset form.")]
+        public string? OutputOption { get; init; }
+
+        [CommandOption("--bbox <BBOX>")]
+        [Description("Composite only: explicit shared viewport as a WGS-84 bounding box 'minLon,minLat,maxLon,maxLat' (e.g. --bbox -1.5,50.0,-1.0,50.5). Mutually exclusive with --center/--scale. When omitted, the compositor auto-fits the union of all layers.")]
+        public string? BoundingBox { get; init; }
+
+        [CommandOption("--center <CENTER>")]
+        [Description("Composite only: explicit shared viewport centre 'lon,lat' (e.g. --center -1.25,50.25). Must be used with --scale.")]
+        public string? Center { get; init; }
+
+        [CommandOption("--scale <DENOMINATOR>")]
+        [Description("Composite only: explicit shared viewport scale denominator (e.g. --scale 50000 for 1:50000). Must be used with --center.")]
+        public double? Scale { get; init; }
 
         [CommandOption("--format")]
         [Description("Output image format: png, jpeg (jpg), or webp. Default: inferred from the output file extension, falling back to png.")]
@@ -71,26 +113,42 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         public string? Background { get; init; }
 
         [CommandOption("--no-text")]
-        [Description("Suppress text/label drawing instructions. Equivalent to --hide text.")]
+        [Description("Suppress text/label drawing instructions. Equivalent to --hide text. In the composite form the suppression is global (applies to every layer).")]
         [DefaultValue(false)]
         public bool NoText { get; init; }
 
         [CommandOption("--hide")]
-        [Description("Comma-separated list of drawing-instruction categories to suppress: text, points, lines, areas (e.g. --hide text,points). Combines additively with --no-text.")]
+        [Description("Comma-separated list of drawing-instruction categories to suppress: text, points, lines, areas (e.g. --hide text,points). Combines additively with --no-text. In the composite form the suppression is global (applies to every layer).")]
         public string? Hide { get; init; }
+
+        [CommandOption("--debug")]
+        [Description("Show full stack traces on error, and surface host/Lua portrayal diagnostics on stderr.")]
+        public bool Debug { get; init; }
+
+        [CommandOption("--no-updates")]
+        [Description("Single-dataset form only: do not apply sibling S-101 sequential updates (.001, .002, …) found alongside an .000 base cell. By default they are applied best-effort. The composite form never applies updates.")]
+        [DefaultValue(false)]
+        public bool NoUpdates { get; init; }
+
+        /// <summary>Whether this invocation composites multiple layers.</summary>
+        public bool IsComposite => Layers.Length > 0;
+
+        /// <summary>
+        /// Resolves the output path for the current grammar, or <c>null</c> when
+        /// none is determinable. Mirrors the resolution enforced by
+        /// <see cref="Validate"/>.
+        /// </summary>
+        public string? ResolveOutputPath()
+        {
+            if (OutputOption is not null)
+                return OutputOption;
+            if (IsComposite)
+                return string.IsNullOrWhiteSpace(OutputArgument) ? Input : null;
+            return OutputArgument;
+        }
 
         public override ValidationResult Validate()
         {
-            var baseResult = base.Validate();
-            if (!baseResult.Successful)
-                return baseResult;
-
-            if (string.IsNullOrWhiteSpace(OutputPath))
-                return ValidationResult.Error("An output path is required.");
-
-            if (!TryResolveFormat(Format, OutputPath, out _, out var formatError))
-                return ValidationResult.Error(formatError);
-
             if (Quality is < 1 or > 100)
                 return ValidationResult.Error("--quality must be between 1 and 100.");
 
@@ -113,9 +171,93 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 return ValidationResult.Error(
                     $"Invalid --hide value '{badToken}'. Use a comma-separated list of: text, points, lines, areas.");
 
-            var dir = Path.GetDirectoryName(Path.GetFullPath(OutputPath));
+            string? output;
+            if (IsComposite)
+            {
+                foreach (var layer in Layers)
+                {
+                    if (string.IsNullOrWhiteSpace(layer))
+                        return ValidationResult.Error("A --layer value cannot be empty.");
+                    if (!File.Exists(layer))
+                        return ValidationResult.Error($"Layer file not found: {layer}");
+                }
+
+                if (OutputOption is not null)
+                {
+                    if (!string.IsNullOrWhiteSpace(Input) || !string.IsNullOrWhiteSpace(OutputArgument))
+                        return ValidationResult.Error(
+                            "With --layer and --output, do not also pass a positional argument.");
+                    output = OutputOption;
+                }
+                else
+                {
+                    if (!string.IsNullOrWhiteSpace(OutputArgument))
+                        return ValidationResult.Error(
+                            "With --layer, pass a single output path (or use -o|--output); two positional arguments were given.");
+                    output = Input;
+                }
+
+                if (string.IsNullOrWhiteSpace(output))
+                    return ValidationResult.Error(
+                        "An output path is required (positional <output> or -o|--output).");
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(Input))
+                    return ValidationResult.Error("A dataset path is required (or use --layer to composite).");
+                if (!File.Exists(Input))
+                    return ValidationResult.Error($"Dataset file not found: {Input}");
+
+                output = OutputOption ?? OutputArgument;
+                if (string.IsNullOrWhiteSpace(output))
+                    return ValidationResult.Error("An output path is required.");
+            }
+
+            if (!TryResolveFormat(Format, output, out _, out var formatError))
+                return ValidationResult.Error(formatError);
+
+            var viewportResult = ValidateViewport();
+            if (!viewportResult.Successful)
+                return viewportResult;
+
+            var dir = Path.GetDirectoryName(Path.GetFullPath(output));
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 return ValidationResult.Error($"Output directory does not exist: {dir}");
+
+            return ValidationResult.Success();
+        }
+
+        private ValidationResult ValidateViewport()
+        {
+            bool hasBbox = !string.IsNullOrWhiteSpace(BoundingBox);
+            bool hasCenter = !string.IsNullOrWhiteSpace(Center);
+            bool hasScale = Scale is not null;
+
+            if ((hasBbox || hasCenter || hasScale) && !IsComposite)
+                return ValidationResult.Error(
+                    "--bbox, --center, and --scale apply only to the composite form (use --layer).");
+
+            if (hasBbox && (hasCenter || hasScale))
+                return ValidationResult.Error("--bbox cannot be combined with --center/--scale.");
+
+            if (hasCenter != hasScale)
+                return ValidationResult.Error("--center and --scale must be used together.");
+
+            if (hasBbox)
+            {
+                if (!CompositeViewportBuilder.TryParseDoubles(BoundingBox!, 4, out var bb))
+                    return ValidationResult.Error(
+                        "--bbox must be four numbers: minLon,minLat,maxLon,maxLat.");
+                if (bb[0] >= bb[2] || bb[1] >= bb[3])
+                    return ValidationResult.Error(
+                        "--bbox requires minLon < maxLon and minLat < maxLat.");
+            }
+
+            if (hasCenter && !CompositeViewportBuilder.TryParseDoubles(Center!, 2, out _))
+                return ValidationResult.Error("--center must be two numbers: lon,lat.");
+
+            if (hasScale && Scale <= 0)
+                return ValidationResult.Error("--scale must be a positive denominator.");
 
             return ValidationResult.Success();
         }
@@ -123,19 +265,28 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
 
     public override int Execute(CommandContext context, Settings settings)
     {
+        return settings.IsComposite
+            ? ExecuteComposite(settings)
+            : ExecuteSingle(settings);
+    }
+
+    private static int ExecuteSingle(Settings settings)
+    {
         using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
+        var datasetPath = settings.Input!;
+        var outputPath = settings.ResolveOutputPath()!;
         var (factory, catalogueManager) = ProcessorFactoryBuilder.Build();
         try
         {
-            var spec = DatasetPipelineFactory.DetectProductSpec(settings.DatasetPath);
+            var spec = DatasetPipelineFactory.DetectProductSpec(datasetPath);
             if (spec is null)
             {
                 AnsiConsole.MarkupLineInterpolated(
-                    $"[red]Could not detect an S-100 product specification for:[/] {settings.DatasetPath}");
+                    $"[red]Could not detect an S-100 product specification for:[/] {datasetPath}");
                 return 2;
             }
 
-            var processor = DatasetProcessorLoader.Create(factory, spec, settings);
+            var processor = DatasetProcessorLoader.Create(factory, spec, datasetPath, settings.NoUpdates);
 
             // Non-blocking: warn (on stderr) when the dataset's declared
             // edition diverges from what this build implements. Rendering still
@@ -153,16 +304,8 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
             }
 
             TryParsePalette(settings.Palette, out var palette);
-            RgbaColor? background = null;
-            if (settings.Background is not null && TryParseHexColor(settings.Background, out var bg))
-                background = bg;
-
-            var hidden = DrawingInstructionCategory.None;
-            if (settings.Hide is not null
-                && TryParseHideCategories(settings.Hide, out var parsedHide, out _))
-                hidden |= parsedHide;
-            if (settings.NoText)
-                hidden |= DrawingInstructionCategory.Text;
+            RgbaColor? background = ResolveBackground(settings);
+            var hidden = ResolveHiddenCategories(settings);
 
             var renderContext = RenderContextBuilder.Build(
                 processor, palette, settings.SymbolScale, settings.TextScale, settings.TimeStep, hidden);
@@ -171,50 +314,143 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 .RenderHeadlessAsync(settings.Width, settings.Height, renderContext, background)
                 .GetAwaiter().GetResult();
 
-            TryResolveFormat(settings.Format, settings.OutputPath, out var format, out _);
-            WriteImage(bitmap, settings.OutputPath, format, settings.Quality);
+            TryResolveFormat(settings.Format, outputPath, out var format, out _);
+            WriteImage(bitmap, outputPath, format, settings.Quality);
 
             AnsiConsole.MarkupLineInterpolated(
-                $"[green]Wrote[/] {settings.OutputPath} ([grey]{spec}, {format}, {bitmap.Width}x{bitmap.Height}[/])");
+                $"[green]Wrote[/] {outputPath} ([grey]{spec}, {format}, {bitmap.Width}x{bitmap.Height}[/])");
             return 0;
-        }
-        catch (NotSupportedException ex)
-        {
-            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
-            if (settings.Debug)
-                AnsiConsole.WriteException(ex);
-            return 4;
-        }
-        catch (S100DatasetNotSupportedException ex)
-        {
-            // Distinct from NotSupportedException (e.g. the dcf8 headless path):
-            // readers raise this for recognised-but-not-yet-implemented spec
-            // features such as data coding format 1 (irregular fixed-station
-            // time series). It does not derive from NotSupportedException, so it
-            // needs its own catch to avoid falling through to the generic exit-1
-            // path. See issue #253.
-            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
-            if (settings.Debug)
-                AnsiConsole.WriteException(ex);
-            return 4;
-        }
-        catch (S100DatasetSchemaException ex)
-        {
-            AnsiConsole.MarkupLineInterpolated($"[yellow]Non-conforming dataset:[/] {ex.Message}");
-            if (settings.Debug)
-                AnsiConsole.WriteException(ex);
-            return 5;
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLineInterpolated($"[red]Error:[/] {ex.Message}");
-            if (settings.Debug)
-                AnsiConsole.WriteException(ex);
-            return 1;
+            return HandleException(ex, settings.Debug);
         }
         finally
         {
             catalogueManager.Dispose();
+        }
+    }
+
+    private static int ExecuteComposite(Settings settings)
+    {
+        using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
+        var outputPath = settings.ResolveOutputPath()!;
+
+        var datasets = new List<S100Dataset>(settings.Layers.Length);
+        try
+        {
+            var specNames = new List<string>(settings.Layers.Length);
+            var layers = new List<S100Layer>(settings.Layers.Length);
+            foreach (var layerPath in settings.Layers)
+            {
+                var dataset = S100Dataset.Open(layerPath);
+                datasets.Add(dataset);
+                layers.Add(new S100Layer { Dataset = dataset });
+                specNames.Add(DatasetPipelineFactory.DetectProductSpec(layerPath) ?? "unknown");
+            }
+
+            TryParsePalette(settings.Palette, out var palette);
+            var options = new S100CompositeOptions
+            {
+                Width = settings.Width,
+                Height = settings.Height,
+                Palette = palette,
+                SymbolScale = settings.SymbolScale,
+                TextScale = settings.TextScale,
+                TimeStep = settings.TimeStep,
+                Background = ResolveBackground(settings),
+                HiddenCategories = ResolveHiddenCategories(settings),
+                Viewport = ResolveViewport(settings),
+            };
+
+            using var renderer = new PngS100DatasetRenderer();
+            byte[] png = renderer.RenderAsync(layers, options).GetAwaiter().GetResult();
+
+            TryResolveFormat(settings.Format, outputPath, out var format, out _);
+            using var bitmap = SKBitmap.Decode(png)
+                ?? throw new NotSupportedException("The composite renderer produced an image that could not be decoded.");
+            WriteImage(bitmap, outputPath, format, settings.Quality);
+
+            AnsiConsole.MarkupLineInterpolated(
+                $"[green]Wrote[/] {outputPath} ([grey]composite of {layers.Count} layer(s): {string.Join(", ", specNames)}; {format}, {bitmap.Width}x{bitmap.Height}[/])");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            return HandleException(ex, settings.Debug);
+        }
+        finally
+        {
+            foreach (var dataset in datasets)
+                dataset.Dispose();
+        }
+    }
+
+    private static RgbaColor? ResolveBackground(Settings settings)
+    {
+        if (settings.Background is not null && TryParseHexColor(settings.Background, out var bg))
+            return bg;
+        return null;
+    }
+
+    private static DrawingInstructionCategory ResolveHiddenCategories(Settings settings)
+    {
+        var hidden = DrawingInstructionCategory.None;
+        if (settings.Hide is not null
+            && TryParseHideCategories(settings.Hide, out var parsedHide, out _))
+            hidden |= parsedHide;
+        if (settings.NoText)
+            hidden |= DrawingInstructionCategory.Text;
+        return hidden;
+    }
+
+    private static Viewport? ResolveViewport(Settings settings)
+    {
+        if (!string.IsNullOrWhiteSpace(settings.BoundingBox)
+            && CompositeViewportBuilder.TryParseDoubles(settings.BoundingBox, 4, out var bb))
+        {
+            return CompositeViewportBuilder.FromBoundingBox(
+                bb[0], bb[1], bb[2], bb[3], settings.Width, settings.Height);
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Center) && settings.Scale is { } scale
+            && CompositeViewportBuilder.TryParseDoubles(settings.Center, 2, out var c))
+        {
+            return CompositeViewportBuilder.FromCenterScale(
+                c[0], c[1], scale, settings.Width, settings.Height);
+        }
+
+        return null;
+    }
+
+    private static int HandleException(Exception ex, bool debug)
+    {
+        switch (ex)
+        {
+            case NotSupportedException:
+                AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+                if (debug) AnsiConsole.WriteException(ex);
+                return 4;
+
+            // Distinct from NotSupportedException (e.g. the dcf8 headless path):
+            // readers raise this for recognised-but-not-yet-implemented spec
+            // features such as data coding format 1 (irregular fixed-station
+            // time series). It does not derive from NotSupportedException, so it
+            // needs its own case to avoid the generic exit-1 path. See issue #253.
+            case S100DatasetNotSupportedException:
+                AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+                if (debug) AnsiConsole.WriteException(ex);
+                return 4;
+
+            case S100DatasetSchemaException:
+                AnsiConsole.MarkupLineInterpolated($"[yellow]Non-conforming dataset:[/] {ex.Message}");
+                if (debug) AnsiConsole.WriteException(ex);
+                return 5;
+
+            default:
+                AnsiConsole.MarkupLineInterpolated($"[red]Error:[/] {ex.Message}");
+                if (debug) AnsiConsole.WriteException(ex);
+                return 1;
         }
     }
 

--- a/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+++ b/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EncDotNet.S100\EncDotNet.S100.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -17,10 +17,12 @@ internal static class CliApp
             config.SetApplicationName("s100");
 
             config.AddCommand<RenderCommand>("render")
-                .WithDescription("Render an S-100 dataset to a PNG image.")
+                .WithDescription("Render one S-100 dataset — or composite several with --layer — to an image (PNG, JPEG, or WebP).")
                 .WithExample("render", "dataset.h5", "out.png")
                 .WithExample("render", "warnings.gml", "out.png", "--width", "2048", "--height", "1536")
-                .WithExample("render", "currents.h5", "out.png", "--time-step", "2", "--palette", "night");
+                .WithExample("render", "currents.h5", "out.png", "--time-step", "2", "--palette", "night")
+                .WithExample("render", "--layer", "enc.000", "--layer", "bathy.h5", "--layer", "warnings.gml", "chart.png")
+                .WithExample("render", "--layer", "enc.000", "--layer", "bathy.h5", "-o", "chart.png", "--bbox", "-1.5,50.0,-1.0,50.5");
 
             config.AddCommand<ValidateCommand>("validate")
                 .WithDescription("Validate an S-100 dataset against its product specification's normative rule pack, or verify an exchange set's integrity (S-100 Part 15 signatures, or S-57 / S-63 CATALOG.031 CRCs).")

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CompositeViewportBuilder.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CompositeViewportBuilder.cs
@@ -1,0 +1,170 @@
+using System.Globalization;
+using EncDotNet.S100.Pipelines;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Builds an explicit shared <see cref="Viewport"/> for a composite render from
+/// the CLI's viewport flags — either a geographic bounding box
+/// (<c>--bbox minLon,minLat,maxLon,maxLat</c>) or a centre + scale
+/// (<c>--center lon,lat --scale N</c>). When neither is supplied the compositor
+/// falls back to its union auto-fit (see
+/// <c>HeadlessCompositor.BuildUnionViewport</c>), whose EPSG:3857 aspect-fit and
+/// scale-denominator maths this helper mirrors so an explicit box behaves
+/// identically to the auto-fit for the same extent.
+/// </summary>
+internal static class CompositeViewportBuilder
+{
+    // EPSG:3857 sphere radius (WGS-84 semi-major axis), in metres. Matches
+    // EncDotNet.S100.Rendering.Scene.WebMercator.EarthRadius.
+    private const double EarthRadius = 6378137.0;
+
+    // S-100 Part 9 §11.1: 1 px = 0.28 mm = 0.00028 m on the nominal display
+    // surface at 96 DPI. Matches ScaleVisibility.DenomToResolutionMetres.
+    private const double DenomToResolutionMetres = 0.00028;
+
+    private const double DegToRad = Math.PI / 180.0;
+    private const double RadToDeg = 180.0 / Math.PI;
+
+    /// <summary>Practical EPSG:3857 latitude limit (±85.05112878°).</summary>
+    private const double MaxLatitude = 85.05112878;
+
+    /// <summary>
+    /// Builds a viewport that frames the WGS-84 bounding box
+    /// [<paramref name="minLon"/>, <paramref name="minLat"/>] –
+    /// [<paramref name="maxLon"/>, <paramref name="maxLat"/>] in a
+    /// <paramref name="width"/> × <paramref name="height"/> pixel image,
+    /// expanding the smaller axis so the box's aspect matches the output (no
+    /// distortion), mirroring the compositor's union auto-fit.
+    /// </summary>
+    public static Viewport FromBoundingBox(
+        double minLon, double minLat, double maxLon, double maxLat, int width, int height)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        var (minX, minY) = FromLonLat(minLon, minLat);
+        var (maxX, maxY) = FromLonLat(maxLon, maxLat);
+
+        double spanX = maxX - minX;
+        double spanY = maxY - minY;
+
+        // Expand the smaller dimension so the extent's aspect matches the output.
+        double viewAspect = (double)width / height;
+        double dataAspect = spanY > 0 ? spanX / spanY : viewAspect;
+        if (dataAspect > viewAspect)
+        {
+            double targetSpanY = spanX / viewAspect;
+            double grow = (targetSpanY - spanY) / 2.0;
+            minY -= grow; maxY += grow;
+        }
+        else
+        {
+            double targetSpanX = spanY * viewAspect;
+            double grow = (targetSpanX - spanX) / 2.0;
+            minX -= grow; maxX += grow;
+        }
+
+        return BuildViewport(minX, minY, maxX, maxY, width, height);
+    }
+
+    /// <summary>
+    /// Builds a viewport centred on (<paramref name="centerLon"/>,
+    /// <paramref name="centerLat"/>) at the given scale denominator
+    /// (e.g. 25000 for 1:25 000) for a <paramref name="width"/> ×
+    /// <paramref name="height"/> pixel image.
+    /// </summary>
+    public static Viewport FromCenterScale(
+        double centerLon, double centerLat, double scaleDenominator, int width, int height)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(scaleDenominator);
+
+        var (centerX, centerY) = FromLonLat(centerLon, centerLat);
+
+        // Invert the compositor's denom maths: it derives
+        //   denom = (spanX / width) * cos(midLat) / DenomToResolutionMetres,
+        // so the EPSG:3857 span for a target denom is
+        //   spanX = denom * DenomToResolutionMetres * width / cos(midLat).
+        double clampedLat = Math.Clamp(centerLat, -MaxLatitude, MaxLatitude);
+        double cosLat = Math.Cos(clampedLat * DegToRad);
+        if (cosLat <= 0)
+            cosLat = double.Epsilon;
+
+        double metresPerPixel = scaleDenominator * DenomToResolutionMetres / cosLat;
+        double halfSpanX = metresPerPixel * width / 2.0;
+        double halfSpanY = metresPerPixel * height / 2.0;
+
+        return BuildViewport(
+            centerX - halfSpanX, centerY - halfSpanY,
+            centerX + halfSpanX, centerY + halfSpanY,
+            width, height);
+    }
+
+    /// <summary>
+    /// Parses a comma-separated list of invariant-culture doubles (e.g.
+    /// <c>"-1.5,50.0,-1.0,50.5"</c>) with an exact expected arity. Returns
+    /// <see langword="false"/> when the arity or any token is invalid.
+    /// </summary>
+    public static bool TryParseDoubles(string value, int expected, out double[] values)
+    {
+        values = Array.Empty<double>();
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var tokens = value.Split(',', StringSplitOptions.TrimEntries);
+        if (tokens.Length != expected)
+            return false;
+
+        var parsed = new double[expected];
+        for (int i = 0; i < expected; i++)
+        {
+            if (!double.TryParse(tokens[i], NumberStyles.Float, CultureInfo.InvariantCulture, out parsed[i])
+                || !double.IsFinite(parsed[i]))
+                return false;
+        }
+
+        values = parsed;
+        return true;
+    }
+
+    private static Viewport BuildViewport(
+        double minX, double minY, double maxX, double maxY, int width, int height)
+    {
+        var (minLon, minLat) = ToLonLat(minX, minY);
+        var (maxLon, maxLat) = ToLonLat(maxX, maxY);
+
+        double midLatRad = (minLat + maxLat) * 0.5 * DegToRad;
+        double groundMetresPerPixel = (maxX - minX) / width * Math.Cos(midLatRad);
+        double denom = groundMetresPerPixel / DenomToResolutionMetres;
+
+        return new Viewport
+        {
+            MinLongitude = minLon,
+            MaxLongitude = maxLon,
+            MinLatitude = minLat,
+            MaxLatitude = maxLat,
+            WidthPixels = width,
+            HeightPixels = height,
+            ScaleDenominator = denom > 0 ? denom : 1.0,
+        };
+    }
+
+    private static (double X, double Y) FromLonLat(double longitude, double latitude)
+    {
+        double lat = Math.Clamp(latitude, -MaxLatitude, MaxLatitude);
+        double x = EarthRadius * longitude * DegToRad;
+        double y = EarthRadius * Math.Log(Math.Tan(Math.PI / 4.0 + lat * DegToRad / 2.0));
+        return (x, y);
+    }
+
+    private static (double Longitude, double Latitude) ToLonLat(double x, double y)
+    {
+        double longitude = x / EarthRadius * RadToDeg;
+        double latitude = (2.0 * Math.Atan(Math.Exp(y / EarthRadius)) - Math.PI / 2.0) * RadToDeg;
+        if (double.IsNaN(latitude) || latitude < -MaxLatitude) latitude = -MaxLatitude;
+        else if (latitude > MaxLatitude) latitude = MaxLatitude;
+        return (longitude, latitude);
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Infrastructure/DatasetProcessorLoader.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/DatasetProcessorLoader.cs
@@ -28,22 +28,40 @@ internal static class DatasetProcessorLoader
         string spec,
         DatasetCommandSettings settings)
     {
-        ArgumentNullException.ThrowIfNull(factory);
         ArgumentNullException.ThrowIfNull(settings);
+        return Create(factory, spec, settings.DatasetPath, settings.NoUpdates);
+    }
 
-        if (spec == "S-101" && !settings.NoUpdates)
+    /// <summary>
+    /// Creates a processor for <paramref name="datasetPath"/>, applying discovered
+    /// S-101 updates unless <paramref name="noUpdates"/> is set.
+    /// </summary>
+    /// <param name="factory">The configured pipeline factory.</param>
+    /// <param name="spec">The detected product specification (e.g. <c>"S-101"</c>).</param>
+    /// <param name="datasetPath">Path to the dataset file.</param>
+    /// <param name="noUpdates">When <see langword="true"/>, sibling S-101 updates are not applied.</param>
+    public static IDatasetProcessor Create(
+        DatasetPipelineFactory factory,
+        string spec,
+        string datasetPath,
+        bool noUpdates)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentException.ThrowIfNullOrEmpty(datasetPath);
+
+        if (spec == "S-101" && !noUpdates)
         {
-            var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(settings.DatasetPath);
+            var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(datasetPath);
             if (updates.Count > 0)
             {
-                var processor = factory.CreateS101ProcessorWithUpdates(settings.DatasetPath, updates);
+                var processor = factory.CreateS101ProcessorWithUpdates(datasetPath, updates);
                 if (processor is S101DatasetProcessor { UpdateReport: { } report })
                     ReportUpdateOutcome(report);
                 return processor;
             }
         }
 
-        return factory.CreateProcessor(settings.DatasetPath);
+        return factory.CreateProcessor(datasetPath);
     }
 
     private static void ReportUpdateOutcome(S101UpdateReport report)

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -1,7 +1,8 @@
 # EncDotNet.S100.Cli (`s100`)
 
 A small, cross-platform command-line tool for working with S-100 datasets. Its
-primary command renders any supported dataset to a PNG, JPEG, or WebP image by
+primary command renders any supported dataset — or a composite of several,
+via repeated `--layer` — to a PNG, JPEG, or WebP image by
 running the dataset's portrayal pipeline through the Mapsui-free Skia *headless*
 it can also report a dataset's product specification (`info`) and validate a
 dataset against its specification's normative rule pack (`validate`). It is
@@ -86,14 +87,28 @@ same step that signs the viewer, so it runs without Gatekeeper prompts.
 
 ## Commands
 
-### `s100 render <dataset> <output>`
+### `s100 render <dataset> <output>` (single dataset)
+### `s100 render --layer <dataset> … <output>` (composite)
 
-Detects the product specification of `<dataset>`, runs its portrayal pipeline,
-and writes an image to `<output>`. The output format (PNG, JPEG, or WebP) is
-inferred from the file extension unless `--format` is given.
+Detects the product specification of each input, runs its portrayal pipeline,
+and writes an image. Two grammars are supported:
+
+- **Single dataset** — `s100 render <dataset> <output>` renders one dataset.
+- **Composite** — `s100 render --layer A --layer B … <output>` stacks several
+  products into one image via the renderer-neutral S-98 interoperability
+  engine. `--layer` is repeatable; the output path is either the trailing
+  positional argument or `-o|--output`.
+
+The output format (PNG, JPEG, or WebP) is inferred from the file extension
+unless `--format` is given.
 
 | Option | Default | Description |
 |---|---|---|
+| `--layer <path>` | _none_ | Add a dataset as a composite layer (repeatable). When any `--layer` is given, the composite grammar is used. |
+| `-o`, `--output <path>` | _positional_ | Output image path. Required (or given positionally) for the composite form; an alternative to the positional `<output>` for the single form. |
+| `--bbox <minLon,minLat,maxLon,maxLat>` | union auto-fit | **Composite only.** Explicit shared viewport as a WGS-84 bounding box (e.g. `--bbox -1.5,50.0,-1.0,50.5`). Mutually exclusive with `--center`/`--scale`. |
+| `--center <lon,lat>` | union auto-fit | **Composite only.** Explicit shared viewport centre. Must be used with `--scale`. |
+| `--scale <denominator>` | union auto-fit | **Composite only.** Explicit shared viewport scale denominator (e.g. `--scale 50000` for 1:50 000). Must be used with `--center`. |
 | `-w`, `--width` | `1024` | Output image width in pixels. |
 | `-h`, `--height` | `768` | Output image height in pixels. |
 | `--palette` | `day` | Colour palette: `day`, `dusk`, or `night`. |
@@ -103,9 +118,9 @@ inferred from the file extension unless `--format` is given.
 | `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
 | `--format <fmt>` | inferred from extension, else `png` | Output image format: `png`, `jpeg` (`jpg`), or `webp`. When omitted, the format is inferred from the output file extension; an unrecognised extension falls back to `png`. An explicit `--format` that conflicts with a recognised output extension is rejected. |
 | `--quality <1-100>` | `90` | Encoder quality for lossy formats (`jpeg`, `webp`). Ignored for `png`. |
-| `--no-text` | off | Suppress text/label drawing instructions. Shorthand for `--hide text`. |
-| `--hide <list>` | _none_ | Comma-separated list of drawing-instruction categories to suppress: `text`, `points`, `lines`, `areas` (e.g. `--hide text,points`). Combines additively with `--no-text`. Useful for label-dense products such as S-411 sea-ice, where the egg-code text overlaps fills at preview scales — `--no-text` yields a BSIS-style "clean fill" preview. |
-| `--no-updates` | off | Do not apply S-101 sequential updates. By default, when the dataset is an S-101 base cell (`….000`), any sibling update files (`….001`, `….002`, …) in the same directory are applied best-effort before rendering so the cell is drawn at its up-to-date state (S-100 Part 10a). |
+| `--no-text` | off | Suppress text/label drawing instructions. Shorthand for `--hide text`. In the composite form the suppression is global (applies to every layer). |
+| `--hide <list>` | _none_ | Comma-separated list of drawing-instruction categories to suppress: `text`, `points`, `lines`, `areas` (e.g. `--hide text,points`). Combines additively with `--no-text`. In the composite form the suppression is global. Useful for label-dense products such as S-411 sea-ice, where the egg-code text overlaps fills at preview scales — `--no-text` yields a BSIS-style "clean fill" preview. |
+| `--no-updates` | off | **Single form only.** Do not apply S-101 sequential updates. By default, when the dataset is an S-101 base cell (`….000`), any sibling update files (`….001`, `….002`, …) in the same directory are applied best-effort before rendering so the cell is drawn at its up-to-date state (S-100 Part 10a). |
 | `--debug` | off | Print full stack traces on error. |
 
 ```bash
@@ -117,11 +132,30 @@ s100 render NL4NZ110.000 cell.png                          # applies .001/.002/�
 s100 render NL4NZ110.000 base.png --no-updates             # render the base cell only
 s100 render warnings.gml warnings.jpg --quality 85         # JPEG (format inferred from .jpg)
 s100 render warnings.gml preview.webp                      # WebP preview
+
+# Composite several products into one chart:
+s100 render --layer enc.000 --layer bathy.h5 --layer warnings.gml chart.png
+s100 render --layer enc.000 --layer bathy.h5 -o chart.png --bbox -1.5,50.0,-1.0,50.5
+s100 render --layer enc.000 --layer bathy.h5 chart.png --center -1.25,50.25 --scale 50000
 ```
 
+> **Composite ordering.** The S-98 authority orders layers by display plane,
+> so the order in which you pass `--layer` is only a **within-plane tiebreak** —
+> hand-ordering layers generally has no visible effect. Explicitly ordering an
+> S-102 bathymetry surface above an S-101 chart, for example, is unnecessary:
+> the plane assignment already places it correctly.
+>
+> **Composite viewport.** When no `--bbox` / `--center`+`--scale` is given the
+> compositor auto-fits the union extent of all layers to the requested
+> `--width` × `--height`.
+>
+> **Composite and S-101 updates.** The composite form does **not** apply S-101
+> sequential/sibling updates — `--no-updates` applies to the single-dataset
+> form only. Render an S-101 cell singly if you need its updates folded in.
+
 > **S-101 sequential updates.** When pointed at an S-101 base cell
-> (`….000`), `render` and `info` discover sibling update files
-> (`….001`, `….002`, …) in the same directory and apply them in order
+> (`….000`), the single-dataset `render` and `info` discover sibling update
+> files (`….001`, `….002`, …) in the same directory and apply them in order
 > before processing the cell, mirroring how an exchange set is loaded
 > in the viewer. Application is best-effort: a missing, out-of-order, or
 > unreadable update is reported but never blocks the command. Pass


### PR DESCRIPTION
## Summary

Exposes the already-shipped headless multi-layer composite engine (`IS100CompositeRenderer<byte[]>` / `PngS100DatasetRenderer`) through the `s100 render` CLI.

### Repeated `--layer` grammar (with back-compat)
- `s100 render --layer a.000 --layer b.h5 --layer c.gml out.png` composites several S-100 datasets into one image via the facade `IS100CompositeRenderer<byte[]>`, which runs the renderer-neutral S-98 interoperability engine.
- The single `s100 render <dataset> <output>` form is unchanged — any `--layer` selects the composite form.
- `-o|--output <path>` sets the output in either form (alternative to the positional `<output>`).

### Composite viewport flags
- `--bbox <minLon,minLat,maxLon,maxLat>` — explicit shared viewport as a WGS-84 bounding box.
- `--center <lon,lat> --scale <denominator>` — explicit shared viewport by centre + scale denominator.
- These are mapped to a `Viewport` by the new `CompositeViewportBuilder`. When omitted, the compositor **auto-fits the union extent** of all layers to the requested `--width` × `--height`. `--bbox` is mutually exclusive with `--center`/`--scale`; the flags are composite-only.

### Output formats
- jpeg/webp composite output is produced by decoding the facade's PNG bytes and re-encoding through the existing `WriteImage` path (no new SKBitmap-returning facade overload — that belongs to a follow-up, relates to #156).

### Global suppression — additive `S100CompositeOptions.HiddenCategories`
- Added `S100CompositeOptions.HiddenCategories` so `--hide`/`--no-text` apply across **all** layers.
- Note: this required threading the categories through `HeadlessCompositor.LowerVector` → `HeadlessVectorRenderer.BuildScene` (reusing the existing private `FilterInstructions`), because the composite path built sub-layer instructions **without filtering** and never consumed hidden categories at all — setting them on the per-sublayer `RenderContext` alone had no effect. All changes are additive/optional params; no other callers are affected.

## Documented limitations
The `--help`, README, and `docs/cli.md` note the two behavioural differences from the single-dataset form:
1. **No S-101 updates on the composite path** — the composite form does not apply S-101 sequential/sibling updates; `--no-updates` applies to the single-dataset form only.
2. **S-98 plane ordering** — the S-98 authority orders layers by display plane, so `--layer` order is only a **within-plane tiebreak**.

## Tests
- Composite CLI tests using S-124 (`navwarn_surface.gml`) + S-125 (`aton_point.gml`) fixtures.
- `--bbox` parsing, single-path back-compat, and `CompositeViewportBuilder` unit tests.
- Facade `HiddenCategories` test asserting the composite path actually suppresses.
- Full solution builds clean (0 warnings); tests green — CLI 95, facade 11, pipelines 802.

## Scope / follow-ups
- The exchange-set/directory "composite everything" convenience is intentionally deferred (#407).
- An SKBitmap-returning composite facade overload is deferred (relates to #156).

Closes #402
Relates to #398/#401, #399/#403, #400/#404, and follow-up #407.