### PR TITLE
CLI: composite an entire exchange set / directory in `s100 render` (#407)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ It offers four subcommands:
 
 | Command | Purpose |
 |---|---|
-| `s100 render <dataset> <output>`<br>`s100 render --layer … <output>` | Render one dataset — or composite several with `--layer` — to an image (PNG, JPEG, or WebP). |
+| `s100 render <dataset> <output>`<br>`s100 render --layer … <output>`<br>`s100 render <exchange-set> <output>` | Render one dataset — or composite several with `--layer`, or a whole exchange set / directory — to an image (PNG, JPEG, or WebP). |
 | `s100 validate <dataset-or-exchange-set>` | Validate against the spec's normative rule pack (plus exchange-set signature/checksum integrity), with compiler-style output and suppression. |
 | `s100 info <dataset>` | Show the detected spec, edition, headless-render capability, and (for time-series datasets) the available time steps. |
 | `s100 list-specs` | List the supported product specifications and which support headless rendering. |
@@ -66,6 +66,10 @@ dotnet run --project tools/EncDotNet.S100.Cli -- \
 # Composite several products into one chart (repeated --layer + output)
 dotnet run --project tools/EncDotNet.S100.Cli -- \
     render --layer enc.000 --layer bathy.h5 --layer warnings.gml chart.png
+
+# Composite an entire exchange set / directory (auto-detected)
+dotnet run --project tools/EncDotNet.S100.Cli -- \
+    render exchange-set/ chart.png
 ```
 
 ## How it works
@@ -129,6 +133,45 @@ Two behaviours differ from the single-dataset form:
 
 When no `--bbox` / `--center`+`--scale` is supplied, the compositor auto-fits
 the union extent of all layers to the requested `--width` × `--height`.
+
+### Compositing a whole exchange set / directory
+
+Rather than listing every `--layer` by hand, point `render` at an **exchange
+set** and composite everything discoverable in it (issue #407). The source may
+be a directory containing a top-level `CATALOG.XML`, a `CATALOG.XML` file, or a
+`.zip` archive whose root holds one — passed positionally (auto-detected) or via
+`--exchange-set` / `--from`:
+
+```bash
+s100 render exchange-set/ chart.png                     # positional directory
+s100 render exchange-set/CATALOG.XML chart.png          # positional catalogue
+s100 render --exchange-set set.zip -o chart.png         # explicit, ZIP
+s100 render --from set/ chart.png --only S101,S102      # restrict to some specs
+```
+
+The datasets are discovered with the same exchange-set reader the viewer and
+`validate` use, then composited through the identical S-98 engine — so every
+option above (`--bbox`/`--center`/`--scale`, palette, `--hide`/`--no-text`,
+etc.) applies unchanged. `--exchange-set`/`--from` is mutually exclusive with
+`--layer`.
+
+| Exchange-set option | Default | Description |
+|---|---|---|
+| `--exchange-set`, `--from <path>` | _positional_ | The exchange set to composite (directory / `CATALOG.XML` / `.zip`). A directory / `CATALOG.XML` / `.zip` passed positionally is auto-detected. |
+| `--only <specs>` | _all_ | Restrict compositing to a comma-separated list of product specifications (e.g. `--only S101,S128`; hyphenation and case are ignored). |
+
+Discovery notes:
+
+- **No S-101 updates.** Like the `--layer` form, the exchange-set form applies
+  **no** S-101 sequential/sibling updates: only base and single cells are
+  composited; update files (and orphan updates with no in-set base) are skipped.
+- **Partial sets.** Datasets whose product specification is unsupported, whose
+  file is missing, or that declare data protection (encryption — this CLI has no
+  decryption keys) are **skipped with a warning on stderr** rather than failing
+  the whole render. If nothing renderable remains, `render` exits non-zero.
+- **ZIP archives** are extracted to a uniquely-named temporary directory (cleaned
+  up after rendering, even on failure); a large exchange set therefore needs
+  transient temporary disk space of roughly its uncompressed size.
 
 ## Capabilities
 

--- a/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
+++ b/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
@@ -33,6 +33,7 @@
     <Content Include="..\datasets\S57\US5MA1BO\US5MA1BO.000" CopyToOutputDirectory="PreserveNewest" Link="TestData\US5MA1BO.000" />
     <Content Include="..\datasets\S124\navwarn_surface.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S124\navwarn_surface.gml" />
     <Content Include="..\datasets\S125\aton_point.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S125\aton_point.gml" />
+    <Content Include="..\datasets\ExchangeSets\Synthetic-Renderable\**\*" CopyToOutputDirectory="PreserveNewest" Link="TestData\ExchangeSet\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Cli.Tests/RenderExchangeSetCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderExchangeSetCommandTests.cs
@@ -1,0 +1,248 @@
+using System.IO.Compression;
+using EncDotNet.S100.Cli.Infrastructure;
+using SkiaSharp;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// End-to-end tests for the exchange-set / directory compositing grammar of
+/// <c>s100 render</c> (issue #407), exercised in-process against the committed
+/// <c>Synthetic-Renderable</c> exchange-set fixture (a real <c>CATALOG.XML</c>
+/// plus tiny synthetic S-124 and S-125 GML datasets and one unsupported entry).
+/// </summary>
+public sealed class RenderExchangeSetCommandTests
+{
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    private static string ExchangeSetDir =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", "ExchangeSet");
+
+    private static string CataloguePath => Path.Combine(ExchangeSetDir, "CATALOG.XML");
+
+    private static bool FixturePresent =>
+        File.Exists(CataloguePath)
+        && File.Exists(Path.Combine(ExchangeSetDir, "S124", "navwarn_surface.gml"))
+        && File.Exists(Path.Combine(ExchangeSetDir, "S125", "aton_point.gml"));
+
+    private static string TempOutput() =>
+        Path.Combine(Path.GetTempPath(), $"s100-cli-es-{Guid.NewGuid():N}.png");
+
+    private static void AssertValidPng(string output, int width, int height)
+    {
+        Assert.True(File.Exists(output));
+        var bytes = File.ReadAllBytes(output);
+        Assert.Equal(PngSignature, bytes[..PngSignature.Length]);
+        using var bitmap = SKBitmap.Decode(output);
+        Assert.NotNull(bitmap);
+        Assert.Equal(width, bitmap!.Width);
+        Assert.Equal(height, bitmap.Height);
+    }
+
+    [SkippableFact]
+    public void Positional_directory_composites_the_whole_set()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", ExchangeSetDir, output, "--width", "320", "--height", "240"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 320, 240);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Positional_catalogue_file_composites_the_whole_set()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", CataloguePath, output, "--width", "256", "--height", "256"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 256, 256);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Explicit_exchange_set_option_is_equivalent_to_positional()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", "--exchange-set", ExchangeSetDir, "-o", output, "--width", "256", "--height", "256"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 256, 256);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void From_alias_is_accepted()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", "--from", ExchangeSetDir, output, "--width", "200", "--height", "200"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 200, 200);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Only_filter_restricts_to_named_specs()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", ExchangeSetDir, output, "--only", "S124", "--width", "128", "--height", "128"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 128, 128);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Only_filter_matching_no_datasets_returns_nonzero()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        // The set contains S-124 and S-125 only; S-101 matches nothing.
+        var output = TempOutput();
+        int exit = CliApp.Build().Run(
+            ["render", ExchangeSetDir, output, "--only", "S101"]);
+
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [SkippableFact]
+    public void Zip_exchange_set_is_extracted_and_composited()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var zip = Path.Combine(Path.GetTempPath(), $"s100-cli-es-{Guid.NewGuid():N}.zip");
+        var output = TempOutput();
+        try
+        {
+            ZipFile.CreateFromDirectory(ExchangeSetDir, zip);
+
+            int exit = CliApp.Build().Run(
+                ["render", zip, output, "--width", "192", "--height", "192"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 192, 192);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+            if (File.Exists(zip)) File.Delete(zip);
+        }
+    }
+
+    [SkippableFact]
+    public void Explicit_bbox_applies_to_exchange_set_form()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", ExchangeSetDir, output,
+                 "--bbox", "-180,-85,180,85", "--width", "256", "--height", "256"]);
+
+            Assert.Equal(0, exit);
+            AssertValidPng(output, 256, 256);
+        }
+        finally
+        {
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+
+    [SkippableFact]
+    public void Layer_and_exchange_set_together_returns_nonzero()
+    {
+        Skip.IfNot(FixturePresent, "Synthetic-Renderable exchange-set fixture not present.");
+
+        var layer = Path.Combine(ExchangeSetDir, "S124", "navwarn_surface.gml");
+        var output = TempOutput();
+        int exit = CliApp.Build().Run(
+            ["render", "--layer", layer, "--exchange-set", ExchangeSetDir, "-o", output]);
+
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Only_without_exchange_set_returns_nonzero()
+    {
+        var dataset = Path.Combine(AppContext.BaseDirectory, "TestData", "S124", "navwarn_surface.gml");
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = TempOutput();
+        int exit = CliApp.Build().Run(
+            ["render", dataset, output, "--only", "S124"]);
+
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Non_exchange_set_directory_returns_nonzero()
+    {
+        // A directory with no CATALOG.XML is not an exchange set and cannot be
+        // a single dataset file either.
+        var emptyDir = Path.Combine(Path.GetTempPath(), $"s100-cli-empty-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(emptyDir);
+        var output = TempOutput();
+        try
+        {
+            int exit = CliApp.Build().Run(["render", emptyDir, output]);
+            Assert.NotEqual(0, exit);
+            Assert.False(File.Exists(output));
+        }
+        finally
+        {
+            if (Directory.Exists(emptyDir)) Directory.Delete(emptyDir, recursive: true);
+            if (File.Exists(output)) File.Delete(output);
+        }
+    }
+}

--- a/tests/datasets/ExchangeSets/README.md
+++ b/tests/datasets/ExchangeSets/README.md
@@ -12,6 +12,7 @@ dataset files because the tests inject a no-op
 |---|---|
 | `Synthetic-Mixed/` | Three entries: two supported (S-101, S-102) and one unsupported (S-999). Drives the partial-failure status banner and the header-registration path. |
 | `Synthetic-AllUnsupported/` | Two unsupported entries. Verifies that the loader disposes the set immediately and unregisters its header when nothing is dispatched. |
+| `Synthetic-Renderable/` | Two supported, **shipped** GML datasets (S-124 + S-125, copied from `tests/datasets/S124` and `tests/datasets/S125`) plus one unsupported entry. Unlike the other fixtures, the referenced dataset files exist, so `RenderExchangeSetCommandTests` (in `EncDotNet.S100.Cli.Tests`) can drive `s100 render` compositing of a whole exchange set / directory / `.zip` (issue #407). |
 
 For real-world catalogues see `tests/datasets/S101/CATALOG.XML`
 (and the matching `tests/datasets/S101.zip`) which is consumed by the

--- a/tests/datasets/ExchangeSets/Synthetic-Renderable/CATALOG.XML
+++ b/tests/datasets/ExchangeSets/Synthetic-Renderable/CATALOG.XML
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic, fully renderable exchange-set catalogue used by
+  RenderExchangeSetCommandTests to exercise the s100 render exchange-set
+  compositing (issue #407).
+
+  Unlike the sibling Synthetic-Mixed/ fixture, the dataset files referenced
+  here ARE shipped and are real (tiny) synthetic S-124 and S-125 GML
+  datasets copied from tests/datasets/S124 and tests/datasets/S125 (the
+  same fixtures the layer-composite CLI tests use), so the CLI can
+  discover, open, and composite them into a PNG.
+
+  Entries:
+    S124/navwarn_surface.gml      supported (S-124)
+    S125/aton_point.gml           supported (S-125)
+    Unsupported/placeholder.dat   unsupported product spec and unknown
+                                  extension; the resolver skips it with a
+                                  warning (partial-set behaviour).
+-->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc/5.0"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>SYNTH_RENDERABLE_v1</S100XC:identifier>
+    <S100XC:dateTime>2026-01-15T00:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:contact>
+    <S100XC:organization>
+      <gco:CharacterString>Synthetic Hydrographic Office</gco:CharacterString>
+    </S100XC:organization>
+  </S100XC:contact>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S124/navwarn_surface.gml</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-10</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-124</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.5.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-124</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S125/aton_point.gml</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-12</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-125</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.0.0</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-125</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>Unsupported/placeholder.dat</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-01-08</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>S-999</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>0.0.1</gco:CharacterString></S100XC:version>
+        <S100XC:productIdentifier>S-999</S100XC:productIdentifier>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>

--- a/tests/datasets/ExchangeSets/Synthetic-Renderable/S124/navwarn_surface.gml
+++ b/tests/datasets/ExchangeSets/Synthetic-Renderable/S124/navwarn_surface.gml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<S124:DataSet xmlns:S124="http://www.iho.int/S124/1.0"
+              xmlns:S100="http://www.iho.int/S100/profile/s100gml/1.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              gml:id="DS_NavWarn_Surface_Test">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-124</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <!-- Information type: NavwarnPreamble -->
+  <S124:imember>
+    <S124:NavwarnPreamble gml:id="info1">
+      <S124:messageSeriesIdentifier>
+        <S124:warningNumber>217</S124:warningNumber>
+        <S124:year>2026</S124:year>
+        <S124:productionAgency>UKHO</S124:productionAgency>
+      </S124:messageSeriesIdentifier>
+      <S124:generalArea>English Channel</S124:generalArea>
+      <S124:locality>Dover Strait</S124:locality>
+    </S124:NavwarnPreamble>
+  </S124:imember>
+
+  <!-- Information type: References -->
+  <S124:imember>
+    <S124:References gml:id="info2">
+      <S124:referenceCategory>1</S124:referenceCategory>
+      <S124:messageReference>NAVAREA I 0183/2026</S124:messageReference>
+    </S124:References>
+  </S124:imember>
+
+  <!-- Feature: NavwarnAreaAffected with surface geometry — restricted area off Dover -->
+  <S124:member>
+    <S124:NavwarnAreaAffected gml:id="f1">
+      <S124:geometry>
+        <S100:surfaceProperty>
+          <gml:Surface gml:id="s1">
+            <gml:patches>
+              <gml:PolygonPatch>
+                <gml:exterior>
+                  <gml:LinearRing>
+                    <gml:posList>51.0500 1.2000 51.0500 1.4000 51.1200 1.4000 51.1200 1.2000 51.0500 1.2000</gml:posList>
+                  </gml:LinearRing>
+                </gml:exterior>
+              </gml:PolygonPatch>
+            </gml:patches>
+          </gml:Surface>
+        </S100:surfaceProperty>
+      </S124:geometry>
+      <S124:restriction>2</S124:restriction>
+    </S124:NavwarnAreaAffected>
+  </S124:member>
+
+  <!-- Feature: NavwarnPart (point) inside the affected area — wreck -->
+  <S124:member>
+    <S124:NavwarnPart gml:id="f2">
+      <S124:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt1">
+            <gml:pos>51.0850 1.3000</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S124:geometry>
+      <S124:restriction>7</S124:restriction>
+      <S124:warningInformation>
+        <S124:information>Dangerous wreck. Depth 8.2m.</S124:information>
+      </S124:warningInformation>
+    </S124:NavwarnPart>
+  </S124:member>
+
+  <!-- Feature: NavwarnAreaAffected with surface + interior hole — exclusion zone with safe corridor -->
+  <S124:member>
+    <S124:NavwarnAreaAffected gml:id="f3">
+      <S124:geometry>
+        <S100:surfaceProperty>
+          <gml:Surface gml:id="s2">
+            <gml:patches>
+              <gml:PolygonPatch>
+                <gml:exterior>
+                  <gml:LinearRing>
+                    <gml:posList>51.0000 1.0000 51.0000 1.6000 51.1500 1.6000 51.1500 1.0000 51.0000 1.0000</gml:posList>
+                  </gml:LinearRing>
+                </gml:exterior>
+                <gml:interior>
+                  <gml:LinearRing>
+                    <gml:posList>51.0600 1.2500 51.0600 1.3500 51.1100 1.3500 51.1100 1.2500 51.0600 1.2500</gml:posList>
+                  </gml:LinearRing>
+                </gml:interior>
+              </gml:PolygonPatch>
+            </gml:patches>
+          </gml:Surface>
+        </S100:surfaceProperty>
+      </S124:geometry>
+      <S124:restriction>5</S124:restriction>
+    </S124:NavwarnAreaAffected>
+  </S124:member>
+
+</S124:DataSet>

--- a/tests/datasets/ExchangeSets/Synthetic-Renderable/S125/aton_point.gml
+++ b/tests/datasets/ExchangeSets/Synthetic-Renderable/S125/aton_point.gml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<S125:Dataset xmlns:S125="http://www.iho.int/S125/1.0"
+              xmlns:S100="http://www.iho.int/s100gml/5.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              gml:id="DS_S125_PointTest">
+
+  <S100:DatasetIdentificationInformation>
+    <S100:productIdentifier>S-125</S100:productIdentifier>
+  </S100:DatasetIdentificationInformation>
+
+  <S125:imember>
+    <S125:AtonStatusInformation gml:id="info1">
+      <S125:changeTypes>1</S125:changeTypes>
+      <S125:fixedDateRange>
+        <S125:dateStart>2026-01-01</S125:dateStart>
+        <S125:dateEnd>2026-03-31</S125:dateEnd>
+      </S125:fixedDateRange>
+    </S125:AtonStatusInformation>
+  </S125:imember>
+
+  <S125:member>
+    <S125:LateralBuoy gml:id="f1">
+      <S125:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt1">
+            <gml:pos>36.9500 -76.0133</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S125:geometry>
+      <S125:categoryOfLateralMark>1</S125:categoryOfLateralMark>
+      <S125:AtoNStatus xlink:href="#info1"/>
+    </S125:LateralBuoy>
+  </S125:member>
+
+  <S125:member>
+    <S125:Landmark gml:id="f2">
+      <S125:geometry>
+        <S100:pointProperty>
+          <gml:Point gml:id="pt2">
+            <gml:pos>37.0167 -76.3300</gml:pos>
+          </gml:Point>
+        </S100:pointProperty>
+      </S125:geometry>
+      <S125:objectName>
+        <S125:name>Cape Henry Light</S125:name>
+      </S125:objectName>
+    </S125:Landmark>
+  </S125:member>
+
+</S125:Dataset>

--- a/tests/datasets/ExchangeSets/Synthetic-Renderable/Unsupported/placeholder.dat
+++ b/tests/datasets/ExchangeSets/Synthetic-Renderable/Unsupported/placeholder.dat
@@ -1,0 +1,1 @@
+not an S-100 dataset

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -12,7 +12,7 @@ using Spectre.Console.Cli;
 namespace EncDotNet.S100.Cli.Commands;
 
 /// <summary>
-/// <c>s100 render</c> renders one or more S-100 datasets to an image. Two
+/// <c>s100 render</c> renders one or more S-100 datasets to an image. Three
 /// grammars are supported:
 /// <list type="bullet">
 ///   <item><description>
@@ -25,14 +25,23 @@ namespace EncDotNet.S100.Cli.Commands;
 ///     stacks several products into one image via the renderer-neutral S-98
 ///     interoperability engine (<see cref="IS100CompositeRenderer{TResult}"/>).
 ///   </description></item>
+///   <item><description>
+///     <c>render &lt;exchange-set&gt; &lt;output&gt;</c> (or
+///     <c>--exchange-set &lt;path&gt;</c>) — the exchange-set form: discovers
+///     every renderable dataset in a directory / <c>CATALOG.XML</c> /
+///     exchange-set <c>.zip</c> and composites them through the same engine.
+///   </description></item>
 /// </list>
 /// </summary>
 /// <remarks>
-/// Two behaviours differ between the forms and are surfaced in <c>--help</c>:
-/// (1) the composite form does <b>not</b> apply S-101 sequential/sibling updates
-/// (the single-dataset form still does); and (2) the S-98 authority orders
-/// layers by display plane, so <c>--layer</c> order is only a within-plane
-/// tiebreak — hand-ordering layers generally has no effect.
+/// Two behaviours differ between the single form and the two composite forms and
+/// are surfaced in <c>--help</c>: (1) the composite forms do <b>not</b> apply
+/// S-101 sequential/sibling updates (the single-dataset form still does); and
+/// (2) the S-98 authority orders layers by display plane, so <c>--layer</c>
+/// order is only a within-plane tiebreak — hand-ordering layers generally has no
+/// effect. In the exchange-set form, datasets whose product specification is
+/// unsupported, whose file is missing, or that declare data protection
+/// (encryption) are skipped with a warning on stderr rather than failing the set.
 /// </remarks>
 internal sealed class RenderCommand : Command<RenderCommand.Settings>
 {
@@ -52,6 +61,14 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         [CommandOption("--layer <PATH>")]
         [Description("Add a dataset as a composite layer (repeatable). When any --layer is given, several products are composited into one image. Note: the S-98 authority orders layers by display plane, so --layer order is only a within-plane tiebreak.")]
         public string[] Layers { get; init; } = [];
+
+        [CommandOption("--exchange-set|--from <PATH>")]
+        [Description("Composite every discoverable dataset in an exchange set: a directory containing a CATALOG.XML, a CATALOG.XML file, or a .zip archive whose root holds one. A directory/CATALOG.XML/.zip passed positionally is also auto-detected. Mutually exclusive with --layer. The composite applies no S-101 updates; data-protected and unsupported datasets are skipped with a warning.")]
+        public string? ExchangeSet { get; init; }
+
+        [CommandOption("--only <SPECS>")]
+        [Description("Exchange-set form only: restrict compositing to a comma-separated list of product specifications (e.g. --only S101,S128; hyphenation and case are ignored). Datasets of other specs discovered in the set are omitted.")]
+        public string? Only { get; init; }
 
         [CommandOption("-o|--output <PATH>")]
         [Description("Output image path. Required (or given positionally) for the composite form; optional alternative to the positional <output> for the single-dataset form.")]
@@ -130,8 +147,32 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         [DefaultValue(false)]
         public bool NoUpdates { get; init; }
 
-        /// <summary>Whether this invocation composites multiple layers.</summary>
+        /// <summary>Whether this invocation composites explicit <c>--layer</c> datasets.</summary>
         public bool IsComposite => Layers.Length > 0;
+
+        /// <summary>Whether an exchange set was named explicitly via <c>--exchange-set</c>/<c>--from</c>.</summary>
+        public bool IsExplicitExchangeSet => !string.IsNullOrWhiteSpace(ExchangeSet);
+
+        /// <summary>
+        /// Whether the positional <see cref="Input"/> is (auto-detected as) an
+        /// exchange set — a directory / <c>CATALOG.XML</c> / exchange-set
+        /// <c>.zip</c> — rather than a single dataset. Suppressed when
+        /// <c>--layer</c> or <c>--exchange-set</c> is in play.
+        /// </summary>
+        public bool IsPositionalExchangeSet =>
+            !IsComposite
+            && !IsExplicitExchangeSet
+            && !string.IsNullOrWhiteSpace(Input)
+            && ExchangeSetInput.LooksLikeExchangeSet(Input);
+
+        /// <summary>Whether this invocation composites an exchange set / directory.</summary>
+        public bool IsExchangeSetComposite => IsExplicitExchangeSet || IsPositionalExchangeSet;
+
+        /// <summary>Whether the composite viewport flags (<c>--bbox</c>/<c>--center</c>/<c>--scale</c>) apply.</summary>
+        public bool AllowsViewport => IsComposite || IsExchangeSetComposite;
+
+        /// <summary>The exchange-set source path for the exchange-set form.</summary>
+        public string? ExchangeSetSource => IsExplicitExchangeSet ? ExchangeSet : Input;
 
         /// <summary>
         /// Resolves the output path for the current grammar, or <c>null</c> when
@@ -142,8 +183,10 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         {
             if (OutputOption is not null)
                 return OutputOption;
-            if (IsComposite)
+            if (IsComposite || IsExplicitExchangeSet)
                 return string.IsNullOrWhiteSpace(OutputArgument) ? Input : null;
+            if (IsPositionalExchangeSet)
+                return OutputArgument;
             return OutputArgument;
         }
 
@@ -171,8 +214,56 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 return ValidationResult.Error(
                     $"Invalid --hide value '{badToken}'. Use a comma-separated list of: text, points, lines, areas.");
 
+            if (IsComposite && IsExplicitExchangeSet)
+                return ValidationResult.Error(
+                    "--layer and --exchange-set/--from cannot be combined. Use one or the other.");
+
+            if (Only is not null && !IsExchangeSetComposite)
+                return ValidationResult.Error(
+                    "--only applies only to the exchange-set form (use --exchange-set/--from or a positional exchange set).");
+
+            if (Only is not null && !TryParseOnlySpecs(Only, out _))
+                return ValidationResult.Error(
+                    "--only must be a comma-separated list of product specifications (e.g. S101,S128).");
+
             string? output;
-            if (IsComposite)
+            if (IsExchangeSetComposite)
+            {
+                var source = ExchangeSetSource;
+                if (string.IsNullOrWhiteSpace(source))
+                    return ValidationResult.Error("An exchange-set path is required.");
+                if (!ExchangeSetInput.LooksLikeExchangeSet(source))
+                    return ValidationResult.Error(
+                        $"Not an S-100 exchange set (expected a directory with CATALOG.XML, a CATALOG.XML, or an exchange-set .zip): {source}");
+
+                if (IsExplicitExchangeSet)
+                {
+                    if (OutputOption is not null)
+                    {
+                        if (!string.IsNullOrWhiteSpace(Input) || !string.IsNullOrWhiteSpace(OutputArgument))
+                            return ValidationResult.Error(
+                                "With --exchange-set and --output, do not also pass a positional argument.");
+                        output = OutputOption;
+                    }
+                    else
+                    {
+                        if (!string.IsNullOrWhiteSpace(OutputArgument))
+                            return ValidationResult.Error(
+                                "With --exchange-set, pass a single output path (or use -o|--output); two positional arguments were given.");
+                        output = Input;
+                    }
+                }
+                else
+                {
+                    // Positional exchange set: <exchange-set> is Input, output is arg1 or -o.
+                    output = OutputOption ?? OutputArgument;
+                }
+
+                if (string.IsNullOrWhiteSpace(output))
+                    return ValidationResult.Error(
+                        "An output path is required (positional <output> or -o|--output).");
+            }
+            else if (IsComposite)
             {
                 foreach (var layer in Layers)
                 {
@@ -233,9 +324,9 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
             bool hasCenter = !string.IsNullOrWhiteSpace(Center);
             bool hasScale = Scale is not null;
 
-            if ((hasBbox || hasCenter || hasScale) && !IsComposite)
+            if ((hasBbox || hasCenter || hasScale) && !AllowsViewport)
                 return ValidationResult.Error(
-                    "--bbox, --center, and --scale apply only to the composite form (use --layer).");
+                    "--bbox, --center, and --scale apply only to the composite forms (--layer or --exchange-set).");
 
             if (hasBbox && (hasCenter || hasScale))
                 return ValidationResult.Error("--bbox cannot be combined with --center/--scale.");
@@ -265,6 +356,8 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
 
     public override int Execute(CommandContext context, Settings settings)
     {
+        if (settings.IsExchangeSetComposite)
+            return ExecuteExchangeSetComposite(settings);
         return settings.IsComposite
             ? ExecuteComposite(settings)
             : ExecuteSingle(settings);
@@ -336,17 +429,75 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
         var outputPath = settings.ResolveOutputPath()!;
 
-        var datasets = new List<S100Dataset>(settings.Layers.Length);
+        var resolved = new List<(string Path, string Spec)>(settings.Layers.Length);
+        foreach (var layerPath in settings.Layers)
+            resolved.Add((layerPath, DatasetPipelineFactory.DetectProductSpec(layerPath) ?? "unknown"));
+
+        return RenderComposite(resolved, settings, outputPath, "composite");
+    }
+
+    private static int ExecuteExchangeSetComposite(Settings settings)
+    {
+        using var diagnosticTrace = settings.Debug ? DiagnosticTraceScope.ToStandardError() : null;
+        var source = settings.ExchangeSetSource!;
+        var outputPath = settings.ResolveOutputPath()!;
+
+        IReadOnlySet<string>? only = null;
+        if (settings.Only is not null && TryParseOnlySpecs(settings.Only, out var onlySpecs))
+            only = onlySpecs;
+
         try
         {
-            var specNames = new List<string>(settings.Layers.Length);
-            var layers = new List<S100Layer>(settings.Layers.Length);
-            foreach (var layerPath in settings.Layers)
+            using var resolution = ExchangeSetLayerResolution.Resolve(source, only);
+
+            // Surface discovery-time skips (unsupported spec, missing file,
+            // orphan update, data protection) on stderr so they are visible
+            // without polluting the success line on stdout.
+            foreach (var warning in resolution.Warnings)
+                Console.Error.WriteLine(warning);
+
+            if (resolution.Layers.Count == 0)
             {
-                var dataset = S100Dataset.Open(layerPath);
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]No renderable datasets were discovered in exchange set:[/] {source}");
+                return 2;
+            }
+
+            var resolved = resolution.Layers
+                .Select(l => (l.Path, l.Spec))
+                .ToList();
+
+            return RenderComposite(resolved, settings, outputPath, "exchange-set composite");
+        }
+        catch (Exception ex)
+        {
+            return HandleException(ex, settings.Debug);
+        }
+    }
+
+    /// <summary>
+    /// Opens each resolved dataset as a composite layer and renders them through
+    /// the renderer-neutral S-98 interoperability engine, writing the encoded
+    /// image to <paramref name="outputPath"/>. Shared by the <c>--layer</c> and
+    /// exchange-set forms.
+    /// </summary>
+    private static int RenderComposite(
+        IReadOnlyList<(string Path, string Spec)> resolved,
+        Settings settings,
+        string outputPath,
+        string label)
+    {
+        var datasets = new List<S100Dataset>(resolved.Count);
+        try
+        {
+            var specNames = new List<string>(resolved.Count);
+            var layers = new List<S100Layer>(resolved.Count);
+            foreach (var (path, spec) in resolved)
+            {
+                var dataset = S100Dataset.Open(path);
                 datasets.Add(dataset);
                 layers.Add(new S100Layer { Dataset = dataset });
-                specNames.Add(DatasetPipelineFactory.DetectProductSpec(layerPath) ?? "unknown");
+                specNames.Add(spec);
             }
 
             TryParsePalette(settings.Palette, out var palette);
@@ -372,7 +523,7 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
             WriteImage(bitmap, outputPath, format, settings.Quality);
 
             AnsiConsole.MarkupLineInterpolated(
-                $"[green]Wrote[/] {outputPath} ([grey]composite of {layers.Count} layer(s): {string.Join(", ", specNames)}; {format}, {bitmap.Width}x{bitmap.Height}[/])");
+                $"[green]Wrote[/] {outputPath} ([grey]{label} of {layers.Count} layer(s): {string.Join(", ", specNames)}; {format}, {bitmap.Width}x{bitmap.Height}[/])");
             return 0;
         }
         catch (Exception ex)
@@ -610,5 +761,21 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
             }
         }
         return true;
+    }
+
+    /// <summary>
+    /// Parses the <c>--only</c> value into a set of normalized product
+    /// specification tokens (hyphenation and case removed, e.g. <c>S-101</c> and
+    /// <c>s101</c> both normalize to <c>S101</c>). Returns <see langword="false"/>
+    /// when the value contains no non-empty tokens.
+    /// </summary>
+    internal static bool TryParseOnlySpecs(string value, out IReadOnlySet<string> specs)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            set.Add(ExchangeSetLayerResolution.NormalizeSpec(raw));
+
+        specs = set;
+        return set.Count > 0;
     }
 }

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -17,12 +17,14 @@ internal static class CliApp
             config.SetApplicationName("s100");
 
             config.AddCommand<RenderCommand>("render")
-                .WithDescription("Render one S-100 dataset — or composite several with --layer — to an image (PNG, JPEG, or WebP).")
+                .WithDescription("Render one S-100 dataset — or composite several (with --layer, or an entire exchange set) — to an image (PNG, JPEG, or WebP).")
                 .WithExample("render", "dataset.h5", "out.png")
                 .WithExample("render", "warnings.gml", "out.png", "--width", "2048", "--height", "1536")
                 .WithExample("render", "currents.h5", "out.png", "--time-step", "2", "--palette", "night")
                 .WithExample("render", "--layer", "enc.000", "--layer", "bathy.h5", "--layer", "warnings.gml", "chart.png")
-                .WithExample("render", "--layer", "enc.000", "--layer", "bathy.h5", "-o", "chart.png", "--bbox", "-1.5,50.0,-1.0,50.5");
+                .WithExample("render", "--layer", "enc.000", "--layer", "bathy.h5", "-o", "chart.png", "--bbox", "-1.5,50.0,-1.0,50.5")
+                .WithExample("render", "exchange-set/", "chart.png")
+                .WithExample("render", "--exchange-set", "exchange-set.zip", "-o", "chart.png", "--only", "S101,S102");
 
             config.AddCommand<ValidateCommand>("validate")
                 .WithDescription("Validate an S-100 dataset against its product specification's normative rule pack, or verify an exchange set's integrity (S-100 Part 15 signatures, or S-57 / S-63 CATALOG.031 CRCs).")

--- a/tools/EncDotNet.S100.Cli/Infrastructure/ExchangeSetLayerResolver.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/ExchangeSetLayerResolver.cs
@@ -1,0 +1,234 @@
+using System.IO.Compression;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.ExchangeSets;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// One dataset discovered in an exchange set and resolved to a local filesystem
+/// path, ready to be opened as a composite layer.
+/// </summary>
+/// <param name="Path">Absolute filesystem path to the dataset file.</param>
+/// <param name="Spec">The detected product specification (e.g. <c>"S-101"</c>).</param>
+/// <param name="RelativePath">The source-relative path, for diagnostics.</param>
+internal readonly record struct ResolvedExchangeSetLayer(string Path, string Spec, string RelativePath);
+
+/// <summary>
+/// Discovers the renderable datasets in an S-100 exchange set (a directory
+/// containing a top-level <c>CATALOG.XML</c>, a <c>CATALOG.XML</c> file, or a
+/// <c>.zip</c> archive whose root holds one) and resolves each to a local
+/// filesystem path, so <c>s100 render</c> can composite the whole set without
+/// the user enumerating every <c>--layer</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// S-100 Edition 5.2.1 Part 17. This is discovery + layer-list assembly on top
+/// of the composite engine exposed by #402: it parses the catalogue with
+/// <see cref="ExchangeCatalogueReader"/>, groups S-101 base cells and their
+/// sequential updates with <see cref="S101ExchangeSetUpdatePlan"/>, and returns
+/// the base/single datasets in catalogue order.
+/// </para>
+/// <para>
+/// Carrying over the #402 composite limitations: the composite path applies
+/// <b>no</b> S-101 sequential/sibling updates, so update files (and orphan
+/// updates) are intentionally skipped here — only base and single cells are
+/// composited. Datasets whose product specification is unsupported, whose file
+/// is missing, or that declare data protection (encryption, which this CLI
+/// cannot decrypt) are skipped with a warning rather than failing the whole
+/// render.
+/// </para>
+/// <para>
+/// A <c>.zip</c> exchange set is extracted to a uniquely-named temporary
+/// directory; the resolution owns that directory and deletes it on
+/// <see cref="Dispose"/>. Callers must therefore keep the resolution alive until
+/// the datasets have been rendered, then dispose it.
+/// </para>
+/// </remarks>
+internal sealed class ExchangeSetLayerResolution : IDisposable
+{
+    private readonly string? _tempDirectory;
+    private bool _disposed;
+
+    private ExchangeSetLayerResolution(
+        IReadOnlyList<ResolvedExchangeSetLayer> layers,
+        IReadOnlyList<string> warnings,
+        string? tempDirectory)
+    {
+        Layers = layers;
+        Warnings = warnings;
+        _tempDirectory = tempDirectory;
+    }
+
+    /// <summary>The resolved renderable datasets, in catalogue order.</summary>
+    public IReadOnlyList<ResolvedExchangeSetLayer> Layers { get; }
+
+    /// <summary>
+    /// Human-readable warnings for datasets that were discovered but skipped
+    /// (unsupported spec, missing file, orphan update, or data-protected).
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; }
+
+    /// <summary>
+    /// Resolves the renderable datasets in the exchange set at
+    /// <paramref name="path"/>.
+    /// </summary>
+    /// <param name="path">
+    /// A directory containing a top-level <c>CATALOG.XML</c>, a <c>CATALOG.XML</c>
+    /// file, or a <c>.zip</c> archive whose root holds one.
+    /// </param>
+    /// <param name="only">
+    /// When non-empty, restricts the result to datasets whose detected product
+    /// specification (case-insensitive, e.g. <c>S101</c> or <c>S-101</c>) is in
+    /// the set; other supported datasets are silently omitted.
+    /// </param>
+    /// <returns>The resolution (which the caller owns and must dispose).</returns>
+    /// <exception cref="FileNotFoundException">No catalogue was found.</exception>
+    public static ExchangeSetLayerResolution Resolve(string path, IReadOnlySet<string>? only = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        string? tempDirectory = null;
+        try
+        {
+            var (root, cataloguePath) = LocateCatalogue(path, ref tempDirectory);
+            var catalogue = ExchangeCatalogueReader.Read(cataloguePath);
+
+            var layers = new List<ResolvedExchangeSetLayer>();
+            var warnings = new List<string>();
+            var plan = S101ExchangeSetUpdatePlan.Build(catalogue.DatasetDiscoveryMetadata);
+
+            foreach (var item in plan)
+            {
+                var metadata = item.Base;
+                var relativePath = metadata.RelativePath;
+
+                // The composite path applies no S-101 updates, so an update with
+                // no base in this set has nothing to attach to and is dropped.
+                if (item.Kind == S101LoadItemKind.OrphanUpdate)
+                {
+                    warnings.Add($"Skipped orphan S-101 update (no base cell in set): {relativePath}");
+                    continue;
+                }
+
+                // This CLI has no decryption keys, so a data-protected dataset
+                // cannot be opened; skip it visibly rather than failing the set.
+                if (metadata.DataProtection)
+                {
+                    warnings.Add($"Skipped data-protected (encrypted) dataset: {relativePath}");
+                    continue;
+                }
+
+                var absolutePath = Path.GetFullPath(Path.Combine(root, relativePath));
+                if (!File.Exists(absolutePath))
+                {
+                    warnings.Add($"Skipped missing dataset file: {relativePath}");
+                    continue;
+                }
+
+                // Prefer the catalogue's declared product specification; fall
+                // back to content sniffing when the catalogue omits it (common
+                // for ISO 8211 / HDF5 sets), so such datasets are not spuriously
+                // reported as unsupported.
+                var spec = DatasetPipelineFactory.MapProductSpecificationToSpec(metadata.ProductSpecification)
+                    ?? DatasetPipelineFactory.DetectProductSpec(absolutePath);
+                if (spec is null)
+                {
+                    warnings.Add($"Skipped unsupported dataset (no known product specification): {relativePath}");
+                    continue;
+                }
+
+                if (only is { Count: > 0 } && !only.Contains(NormalizeSpec(spec)))
+                    continue;
+
+                layers.Add(new ResolvedExchangeSetLayer(absolutePath, spec, relativePath));
+            }
+
+            var resolution = new ExchangeSetLayerResolution(layers, warnings, tempDirectory);
+            tempDirectory = null; // ownership transferred to the resolution
+            return resolution;
+        }
+        finally
+        {
+            // If we extracted a ZIP but never handed ownership to a resolution
+            // (an exception above), clean the temp directory up now.
+            if (tempDirectory is not null)
+                TryDeleteDirectory(tempDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a spec token to the comparison form used for <c>--only</c>:
+    /// upper-cased with hyphens removed (so <c>S-101</c> and <c>s101</c> match).
+    /// </summary>
+    public static string NormalizeSpec(string spec) =>
+        spec.Replace("-", string.Empty, StringComparison.Ordinal).ToUpperInvariant();
+
+    private static (string Root, string CataloguePath) LocateCatalogue(string path, ref string? tempDirectory)
+    {
+        if (Directory.Exists(path))
+        {
+            var catalogue = FindCatalogueInDirectory(path)
+                ?? throw new FileNotFoundException($"No CATALOG.XML found in folder: {path}");
+            return (Path.GetFullPath(path), catalogue);
+        }
+
+        if (IsCatalogueFileName(Path.GetFileName(path)) && File.Exists(path))
+        {
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path))!;
+            return (directory, Path.GetFullPath(path));
+        }
+
+        if (IsZipPath(path) && File.Exists(path))
+        {
+            tempDirectory = Path.Combine(
+                Path.GetTempPath(), "s100-render-es-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+            ZipFile.ExtractToDirectory(path, tempDirectory);
+
+            var catalogue = FindCatalogueInDirectory(tempDirectory)
+                ?? throw new FileNotFoundException($"No root CATALOG.XML found in archive: {path}");
+            return (tempDirectory, catalogue);
+        }
+
+        throw new FileNotFoundException($"Not an S-100 exchange set: {path}");
+    }
+
+    private static string? FindCatalogueInDirectory(string folderPath)
+    {
+        try
+        {
+            return Directory
+                .EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(f => IsCatalogueFileName(Path.GetFileName(f)));
+        }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
+    }
+
+    private static bool IsCatalogueFileName(string? name) =>
+        string.Equals(name, "CATALOG.XML", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsZipPath(string path) =>
+        string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase);
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException) { /* best-effort cleanup */ }
+        catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        if (_tempDirectory is not null)
+            TryDeleteDirectory(_tempDirectory);
+    }
+}

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -2,7 +2,8 @@
 
 A small, cross-platform command-line tool for working with S-100 datasets. Its
 primary command renders any supported dataset — or a composite of several,
-via repeated `--layer` — to a PNG, JPEG, or WebP image by
+via repeated `--layer` or by pointing at an entire exchange set / directory —
+to a PNG, JPEG, or WebP image by
 running the dataset's portrayal pipeline through the Mapsui-free Skia *headless*
 it can also report a dataset's product specification (`info`) and validate a
 dataset against its specification's normative rule pack (`validate`). It is
@@ -89,15 +90,22 @@ same step that signs the viewer, so it runs without Gatekeeper prompts.
 
 ### `s100 render <dataset> <output>` (single dataset)
 ### `s100 render --layer <dataset> … <output>` (composite)
+### `s100 render <exchange-set> <output>` (exchange-set composite)
 
 Detects the product specification of each input, runs its portrayal pipeline,
-and writes an image. Two grammars are supported:
+and writes an image. Three grammars are supported:
 
 - **Single dataset** — `s100 render <dataset> <output>` renders one dataset.
 - **Composite** — `s100 render --layer A --layer B … <output>` stacks several
   products into one image via the renderer-neutral S-98 interoperability
   engine. `--layer` is repeatable; the output path is either the trailing
   positional argument or `-o|--output`.
+- **Exchange set** — `s100 render <exchange-set> <output>` (or
+  `--exchange-set`/`--from`) discovers and composites **every** renderable
+  dataset in a directory / `CATALOG.XML` / exchange-set `.zip`, so you don't have
+  to enumerate each `--layer`. Auto-detected when the positional input is a
+  directory, a `CATALOG.XML`, or an exchange-set `.zip`. Mutually exclusive with
+  `--layer`.
 
 The output format (PNG, JPEG, or WebP) is inferred from the file extension
 unless `--format` is given.
@@ -105,10 +113,12 @@ unless `--format` is given.
 | Option | Default | Description |
 |---|---|---|
 | `--layer <path>` | _none_ | Add a dataset as a composite layer (repeatable). When any `--layer` is given, the composite grammar is used. |
-| `-o`, `--output <path>` | _positional_ | Output image path. Required (or given positionally) for the composite form; an alternative to the positional `<output>` for the single form. |
-| `--bbox <minLon,minLat,maxLon,maxLat>` | union auto-fit | **Composite only.** Explicit shared viewport as a WGS-84 bounding box (e.g. `--bbox -1.5,50.0,-1.0,50.5`). Mutually exclusive with `--center`/`--scale`. |
-| `--center <lon,lat>` | union auto-fit | **Composite only.** Explicit shared viewport centre. Must be used with `--scale`. |
-| `--scale <denominator>` | union auto-fit | **Composite only.** Explicit shared viewport scale denominator (e.g. `--scale 50000` for 1:50 000). Must be used with `--center`. |
+| `--exchange-set`, `--from <path>` | _none_ | Composite an entire exchange set (directory / `CATALOG.XML` / `.zip`). A directory / `CATALOG.XML` / `.zip` passed positionally is also auto-detected. Mutually exclusive with `--layer`. |
+| `--only <specs>` | _all_ | **Exchange-set only.** Restrict compositing to a comma-separated list of product specifications (e.g. `--only S101,S128`; hyphenation and case are ignored). |
+| `-o`, `--output <path>` | _positional_ | Output image path. Required (or given positionally) for the composite forms; an alternative to the positional `<output>` for the single form. |
+| `--bbox <minLon,minLat,maxLon,maxLat>` | union auto-fit | **Composite forms only.** Explicit shared viewport as a WGS-84 bounding box (e.g. `--bbox -1.5,50.0,-1.0,50.5`). Mutually exclusive with `--center`/`--scale`. |
+| `--center <lon,lat>` | union auto-fit | **Composite forms only.** Explicit shared viewport centre. Must be used with `--scale`. |
+| `--scale <denominator>` | union auto-fit | **Composite forms only.** Explicit shared viewport scale denominator (e.g. `--scale 50000` for 1:50 000). Must be used with `--center`. |
 | `-w`, `--width` | `1024` | Output image width in pixels. |
 | `-h`, `--height` | `768` | Output image height in pixels. |
 | `--palette` | `day` | Colour palette: `day`, `dusk`, or `night`. |
@@ -137,6 +147,12 @@ s100 render warnings.gml preview.webp                      # WebP preview
 s100 render --layer enc.000 --layer bathy.h5 --layer warnings.gml chart.png
 s100 render --layer enc.000 --layer bathy.h5 -o chart.png --bbox -1.5,50.0,-1.0,50.5
 s100 render --layer enc.000 --layer bathy.h5 chart.png --center -1.25,50.25 --scale 50000
+
+# Composite an entire exchange set / directory / .zip:
+s100 render exchange-set/ chart.png                         # auto-detected directory
+s100 render exchange-set/CATALOG.XML chart.png              # auto-detected catalogue
+s100 render --exchange-set exchange-set.zip -o chart.png    # explicit, ZIP archive
+s100 render --from exchange-set/ chart.png --only S101,S102 # restrict to some specs
 ```
 
 > **Composite ordering.** The S-98 authority orders layers by display plane,
@@ -149,9 +165,20 @@ s100 render --layer enc.000 --layer bathy.h5 chart.png --center -1.25,50.25 --sc
 > compositor auto-fits the union extent of all layers to the requested
 > `--width` × `--height`.
 >
-> **Composite and S-101 updates.** The composite form does **not** apply S-101
+> **Composite and S-101 updates.** Neither composite form applies S-101
 > sequential/sibling updates — `--no-updates` applies to the single-dataset
 > form only. Render an S-101 cell singly if you need its updates folded in.
+>
+> **Exchange-set discovery.** The exchange-set form reuses the same
+> exchange-set reader the viewer and `validate` use. Only base and single cells
+> are composited (S-101 update files and orphan updates are skipped). Datasets
+> whose product specification is unsupported, whose file is missing, or that
+> declare data protection (encryption — this CLI has no decryption keys) are
+> **skipped with a warning on stderr** rather than failing the whole render; if
+> nothing renderable remains, `render` exits non-zero. A `.zip` exchange set is
+> extracted to a uniquely-named temporary directory (cleaned up after rendering,
+> even on failure), so a large set needs transient temporary disk space of
+> roughly its uncompressed size.
 
 > **S-101 sequential updates.** When pointed at an S-101 base cell
 > (`….000`), the single-dataset `render` and `info` discover sibling update
@@ -237,7 +264,7 @@ headless render path.
 |---|---|
 | `0` | Success. |
 | `1` | Unhandled error (use `--debug` for a stack trace). |
-| `2` | Product specification could not be detected. |
+| `2` | Product specification could not be detected (single dataset), or no renderable datasets were discovered in an exchange set. |
 | `3` | The detected spec does not support headless rendering. |
 | `4` | The dataset is recognised but its shape or encoding is unsupported — e.g. a fixed-station coverage, or a data coding format the reader does not yet implement (such as dcf1, irregular time series at fixed stations). |
 | `5` | The dataset is recognised but non-conforming (a required attribute, dataset, or group is missing or malformed). |


### PR DESCRIPTION
## Summary

Follow-up to #402 / #408 (the `--layer` composite grammar). This adds the convenience path requested in #407: point `s100 render` at an exchange set — a directory, a `CATALOG.XML`, or an exchange-set `.zip` — and it discovers and composites every renderable, supported dataset without enumerating each `--layer` by hand.

No rendering-engine changes: discovery assembles an `S100Layer` list and delegates to the same composite facade the `--layer` path uses.

## `ExchangeSetLayerResolver` (new CLI infrastructure)

- Parses the catalogue via `ExchangeCatalogueReader` (dir → `CATALOG.XML`; `.zip` → temp-extract then `CATALOG.XML`).
- Groups S-101 base cells + updates via `S101ExchangeSetUpdatePlan`. **The composite applies no S-101 sequential/sibling updates** (carried over from #402), so orphan updates and update siblings are skipped; base/single cells are kept.
- Maps each entry's product spec via `MapProductSpecificationToSpec`, with a content-sniff fallback (`DetectProductSpec`) when the catalogue omits the product specification.
- **Warn-and-skip** (to stderr, never fails the whole render) for: unsupported specs, missing files, and data-protected (encrypted) datasets — integrity/decryption issues are surfaced visibly.
- ZIP sets extract to a uniquely-named temp directory with robust cleanup on `Dispose` and via a `finally` guard even if resolution throws mid-way.

## `RenderCommand` grammar

- **Positional auto-detect** of a directory / `CATALOG.XML` / exchange-set `.zip` (via `ExchangeSetInput.LooksLikeExchangeSet`), **plus** an explicit `--exchange-set` (alias `--from`).
- The exchange-set path is **mutually exclusive with `--layer`** (validation error if both given).
- `--only <specs>` filter (e.g. `--only S101,S128`; hyphen- and case-insensitive).
- Exit code **2** when nothing renderable remains after discovery/filtering.
- All existing viewport/palette/hide options apply identically; the single-dataset and `--layer` forms are unchanged.

## Tests

- Committed fixture `tests/datasets/ExchangeSets/Synthetic-Renderable/` — a real `CATALOG.XML` referencing tiny committed S-124 + S-125 GML (supported) plus one unsupported entry.
- `RenderExchangeSetCommandTests` (12 tests): positional dir / `CATALOG.XML`, explicit `--exchange-set`, `--from` alias, `--only` (match + no-match), ZIP temp-extract (archive built at runtime — no committed binary), `--bbox`, `--layer`+`--exchange-set` conflict, `--only` without an exchange set, and a non-exchange-set directory.
- **106/106 CLI tests pass, 0 skipped.** Automated tests use committed fixtures only.

## Docs

- `RenderCommand` XML summary (now documents the three grammars), `CliApp` render description + examples, CLI `README.md` (grammar table, `--only`, ZIP temp-disk note, no-updates + partial-set caveats, broadened exit-code 2), and `docs/cli.md`.

## Manual verification (manual-only, not a test)

Ran against the UKHO S-101 trial exchange set (`S100_ROOT`): auto-discovered and composited **28 layers (27 S-101 cells + 1 S-128)** to a 1200×900 PNG, exit 0. Real charts render (land/depth/symbols/labels + magenta S-128 product boundaries). The UKHO set is referenced only for manual verification and is not used by any automated test.

Closes #407. Builds on #402 / #408.