### PR TITLE
samples(s411): dynamic ZIP discovery + BSIS quicklook comparison

### DIFF
--- a/samples/s411-previews/README.md
+++ b/samples/s411-previews/README.md
@@ -9,6 +9,12 @@ download the published S-411 exchange-set ZIPs, extract the GML dataset, and
 rasterise a PNG. Here the rendering is done entirely by `s100 render` — so the
 same machinery the desktop viewer uses also drives an unattended batch job.
 
+The published ZIP names are dated and rotate (often daily). Instead of
+hard-coding a snapshot, the script **discovers the current ZIP** for each region
+by scanning the live portal index for a stable per-region pattern, so it keeps
+working day-to-day. A `COMPARE=1` mode additionally downloads the matching BSIS
+quicklook(s) next to our render for side-by-side inspection.
+
 ## Prerequisites
 
 - .NET 10 SDK
@@ -29,11 +35,21 @@ samples/s411-previews/s411_previews.sh
 
 # Choose an output directory and explicit regions
 samples/s411-previews/s411_previews.sh /tmp/out north-atlantic hudson-bay
+
+# Render every known region
+samples/s411-previews/s411_previews.sh /tmp/out all
+
+# Render + fetch the BSIS quicklooks for side-by-side comparison
+COMPARE=1 samples/s411-previews/s411_previews.sh /tmp/out cw-greenland
 ```
 
-Available region keys: `north-atlantic`, `canada-east`, `hudson-bay`,
-`alaska`, `nw-greenland`. Add more by extending the `region_zip` lookup with
-file names from the BSIS portal.
+Available region keys: `cw-greenland`, `nw-greenland`, `ne-greenland`,
+`se-greenland`, `sw-greenland`, `ce-greenland`, `cape-farewell`, `qaanaaq`
+(DMI Greenland); `canada-east`, `hudson-bay`, `eastern-arctic`,
+`western-arctic` (CIS); `alaska` (US NWS); `north-atlantic` (Met.no). Use `all`
+to render them all. Add more by extending the `region_zip_pattern` /
+`region_conc_image` / `region_sod_image` lookups with entries from the BSIS
+portal.
 
 ### Environment overrides
 
@@ -43,6 +59,7 @@ file names from the BSIS portal.
 | `WIDTH` / `HEIGHT` | `1600` | Output size in pixels. |
 | `PALETTE` | `day` | `day` \| `dusk` \| `night`. |
 | `EXTRA_OPTS` | _empty_ | Extra flags forwarded verbatim to `s100 render` (e.g. `--no-text`). |
+| `COMPARE` | `0` | When `1`, also download the BSIS quicklook(s) for each region to `previews/<key>.bsis-conc.png` / `.bsis-sod.png`. If ImageMagick's `montage` is on `PATH`, a combined `previews/<key>.compare.png` contact sheet is produced. |
 
 ```bash
 # Use an installed global tool and a larger night-palette canvas
@@ -54,16 +71,22 @@ S100="s100" WIDTH=2048 HEIGHT=2048 PALETTE=night \
 
 ```
 <out-dir>/
+  data/ILP_S411.shtml        cached portal index (used for ZIP discovery)
   data/<region>.zip          downloaded exchange set
   data/<region>/...          extracted contents
   previews/<region>.png      rendered preview
+  previews/<region>.bsis-conc.png   BSIS concentration quicklook   (COMPARE=1)
+  previews/<region>.bsis-sod.png    BSIS stage-of-development quicklook (COMPARE=1)
+  previews/<region>.compare.png     contact sheet, if `montage` present (COMPARE=1)
 ```
 
 ## Notes & caveats
 
-- **The ZIP file names on the BSIS portal are dated and rotate** (often daily).
-  The keys here point at a snapshot; if a download 404s, refresh the file name
-  from <https://www.bsis-ice.de/IcePortal/ILP_S411.shtml>.
+- **Current ZIPs are discovered automatically.** The script scans the live
+  portal index for a stable per-region pattern (the rotating date is wildcarded)
+  and picks the most recent match, so it keeps working as the portal updates. If
+  a region stops resolving, its file-name scheme likely changed — update the
+  `region_zip_pattern` entry from <https://www.bsis-ice.de/IcePortal/ILP_S411.shtml>.
 - **Clean-fill previews:** to mirror the BSIS portal's text-free look, pass
   `--no-text` to the CLI (or set `EXTRA_OPTS=--no-text` and have the script
   forward it). For example:
@@ -79,3 +102,37 @@ S100="s100" WIDTH=2048 HEIGHT=2048 PALETTE=night \
   chosen directory is intentionally not committed.
 - Data © the respective ice services (CIS, DMI, Met.no, US NWS/NIC, AARI, SHN,
   …) via the BSIS Ice Portal; respect their terms of use.
+
+## Parity with the BSIS quicklooks
+
+The BSIS quicklooks are produced by a short bespoke Python script. Running this
+sample with `COMPARE=1` against today's data (e.g. DMI CentralWest-Greenland)
+shows how close `s100 render` gets to them, and where the honest gaps are.
+
+**What matches.** The underlying S-411 data is reproduced faithfully — ice-edge
+polygons, fjord tongues, and offshore patches line up with the BSIS
+concentration quicklook essentially polygon-for-polygon. Reading, parsing, and
+coverage of the live GML are not in question.
+
+**What differs.** `s100 render` rasterises the *chart layer* using the bundled
+S-411 portrayal catalogue; the BSIS script composes a full *figure*. Concretely:
+
+| Aspect | BSIS quicklook | `s100 render` today |
+|---|---|---|
+| **Basemap** | Blue ocean + white land + lat/lon graticule + title + axes | Ice polygons only, on a transparent/white canvas (no land/ocean layer) |
+| **Concentration palette** | Vivid WMO ramp (green→yellow→orange→red for low→high) | Muted tan/peach ramp from the bundled S-411 PC |
+| **Stage of development (SOD)** | Separate brown/green "thickness" map | Not produced (the bundled PC portrays concentration) |
+| **Projection** | Equirectangular (level rectangle) | Web-Mercator (slightly rotated) |
+| **Extent** | Fixed regional frame incl. surrounding coast | Auto-fit to the ice-polygon bounds |
+
+**Out of scope entirely.** Most BSIS region pages also publish ~12 **POLARIS**
+navigational-risk maps — one per ice class (PC1–PC7, 1As/1A/1B/1C, none),
+coloured by Risk Index Outcome. Those are a *computed decision-support product*,
+not a portrayal of the source data, and there is no POLARIS/RIO engine in this
+codebase. `COMPARE` mode therefore only fetches the CONC/SOD quicklooks.
+
+**Bottom line.** For the *data/geometry* this is effectively a drop-in; for a
+*standalone quicklook figure* it is not, chiefly because there is no basemap
+compositing and the concentration palette differs. Closing those would be
+feature work (a land/ocean context layer + a WMO concentration palette + an SOD
+portrayal), tracked separately from this sample.

--- a/samples/s411-previews/s411_previews.sh
+++ b/samples/s411-previews/s411_previews.sh
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
 #
-# PoC: generate S-411 sea-ice "quicklook" preview images using the s100 CLI.
+# PoC: generate S-411 sea-ice "quicklook" preview images using the s100 CLI,
+# and (optionally) fetch the matching BSIS Ice Portal quicklook for side-by-side
+# comparison.
 #
 # Mirrors the idea behind the BSIS Ice Portal previews
 # (https://www.bsis-ice.de/IcePortal/ILP_S411.shtml): download the published
 # S-411 exchange-set ZIPs, extract the GML dataset, and rasterise a PNG preview.
 # Here the rendering is done entirely by the EncDotNet.S100 `s100` CLI.
 #
+# The published ZIP file names are dated and rotate (often daily). Rather than
+# hard-coding a snapshot, this script *discovers the current ZIP* for each
+# region by scanning the live portal index for a stable per-region pattern.
+#
 # Usage:
 #   ./s411_previews.sh [OUT_DIR] [REGION ...]
 #
 #   OUT_DIR   Directory for downloaded data + previews (default: ./s411-previews)
 #   REGION    One or more region keys (see REGIONS below). Default: a small set.
+#             Use the special key `all` to render every known region.
 #
 # Environment:
 #   S100        Command used to invoke the CLI. Defaults to running the built
@@ -22,37 +29,104 @@
 #   EXTRA_OPTS    Extra flags passed verbatim to `s100 render` after the
 #                 standard --width/--height/--palette (e.g. --no-text for
 #                 BSIS-style clean fills, or --hide text,points).
+#   COMPARE       When set to 1, also download the BSIS quicklook(s) for each
+#                 region into previews/<key>.bsis-*.png. If ImageMagick's
+#                 `montage` is on PATH, a combined previews/<key>.compare.png
+#                 contact sheet (our render + BSIS CONC/SOD) is produced too.
 #
 set -euo pipefail
 
-BASE_URL="https://www.bsis-ice.de/IcePortal/S411"
+BASE_URL="https://www.bsis-ice.de/IcePortal"
+ZIP_URL="$BASE_URL/S411"
+PORTAL_INDEX="$BASE_URL/ILP_S411.shtml"
 
-# region-key -> zip file name on the BSIS portal.
-# (A representative subset; add more from ILP_S411.shtml as needed.)
-# Implemented as a case lookup for portability with bash 3.2 (macOS default),
-# which lacks associative arrays.
-region_zip() {
+# ---------------------------------------------------------------------------
+# Region registry (bash 3.2 compatible — case lookups, no associative arrays).
+#
+# Each region key maps to:
+#   * a ZIP *pattern* (an extended-regexp matched against the portal index, with
+#     the rotating date replaced by a wildcard) — the current file is discovered
+#     at run time;
+#   * the BSIS quicklook image base name(s) under S411Preview/ for the
+#     concentration (CONC) and, where published, stage-of-development (SOD)
+#     views, used by COMPARE mode.
+# ---------------------------------------------------------------------------
+region_zip_pattern() {
   case "$1" in
-    north-atlantic) echo "S411_MetNo_ice20260605.zip" ;;
-    canada-east)    echo "S411_cis_SGRDREC_20260601T1800Z_pl_a.zip" ;;
-    hudson-bay)     echo "S411_cis_SGRDRHB_20260601T1800Z_pl_a.zip" ;;
-    alaska)         echo "S411_NWS_full_20260605.zip" ;;
-    nw-greenland)   echo "S411_DMI_202606032145_NorthWest_RIC.zip" ;;
+    cw-greenland)   echo 'S411_DMI_[0-9]+_CentralWest_RIC\.zip' ;;
+    nw-greenland)   echo 'S411_DMI_[0-9]+_NorthWest_RIC\.zip' ;;
+    ne-greenland)   echo 'S411_DMI_[0-9]+_NorthEast_RIC\.zip' ;;
+    se-greenland)   echo 'S411_DMI_[0-9]+_SouthEast_RIC\.zip' ;;
+    sw-greenland)   echo 'S411_DMI_[0-9]+_SouthWest_RIC\.zip' ;;
+    ce-greenland)   echo 'S411_DMI_[0-9]+_CentralEast_RIC\.zip' ;;
+    cape-farewell)  echo 'S411_DMI_[0-9]+_CapeFarewell_RIC\.zip' ;;
+    qaanaaq)        echo 'S411_DMI_[0-9]+_Qaanaaq_RIC\.zip' ;;
+    canada-east)    echo 'S411_cis_SGRDREC_[0-9A-Za-z]+_pl_a\.zip' ;;
+    hudson-bay)     echo 'S411_cis_SGRDRHB_[0-9A-Za-z]+_pl_a\.zip' ;;
+    eastern-arctic) echo 'S411_cis_SGRDREA_[0-9A-Za-z]+_pl_a\.zip' ;;
+    western-arctic) echo 'S411_cis_SGRDRWA_[0-9A-Za-z]+_pl_a\.zip' ;;
+    alaska)         echo 'S411_NWS_full_[0-9]+\.zip' ;;
+    north-atlantic) echo 'S411_MetNo_ice[0-9]+\.zip' ;;
     *)              echo "" ;;
   esac
 }
 
+region_conc_image() {
+  case "$1" in
+    cw-greenland)   echo "DMICentralwestCONC.png" ;;
+    nw-greenland)   echo "DMINorthWestCONC.png" ;;
+    ne-greenland)   echo "DMINorthEastCONC.png" ;;
+    se-greenland)   echo "DMISouthEastCONC.png" ;;
+    sw-greenland)   echo "DMISouthWestCONC.png" ;;
+    ce-greenland)   echo "DMICentralEastCONC.png" ;;
+    cape-farewell)  echo "DMICapeFarewellCONC.png" ;;
+    qaanaaq)        echo "DMIQaanaaqCONC.png" ;;
+    canada-east)    echo "CISEastCoastCONC.png" ;;
+    hudson-bay)     echo "CISHudsonbayCONC.png" ;;
+    eastern-arctic) echo "CISEasternarcticCONC.png" ;;
+    western-arctic) echo "CISWesternarcticCONC.png" ;;
+    alaska)         echo "AlaskaCONC.png" ;;
+    north-atlantic) echo "NISNorthatlanticCONC.png" ;;
+    *)              echo "" ;;
+  esac
+}
+
+region_sod_image() {
+  case "$1" in
+    cw-greenland)   echo "DMICentralwestSOD.png" ;;
+    nw-greenland)   echo "DMINorthWestSOD.png" ;;
+    ne-greenland)   echo "DMINorthEastSOD.png" ;;
+    se-greenland)   echo "DMISouthEastSOD.png" ;;
+    sw-greenland)   echo "DMISouthWestSOD.png" ;;
+    cape-farewell)  echo "DMICapeFarewellSOD.png" ;;
+    qaanaaq)        echo "DMIQaanaaqSOD.png" ;;
+    canada-east)    echo "CISEastCoastSOD.png" ;;
+    hudson-bay)     echo "CISHudsonbaySOD.png" ;;
+    eastern-arctic) echo "CISEasternarcticSOD.png" ;;
+    western-arctic) echo "CISWesternarcticSOD.png" ;;
+    alaska)         echo "AlaskaSOD.png" ;;
+    *)              echo "" ;;   # some regions publish no SOD quicklook
+  esac
+}
+
+ALL_REGIONS=(cw-greenland nw-greenland ne-greenland se-greenland sw-greenland \
+  ce-greenland cape-farewell qaanaaq canada-east hudson-bay eastern-arctic \
+  western-arctic alaska north-atlantic)
+
 OUT_DIR="${1:-./s411-previews}"
 shift || true
 SELECTED=("$@")
-if [[ ${#SELECTED[@]} -eq 0 ]]; then
-  SELECTED=(north-atlantic hudson-bay nw-greenland)
+if [[ ${#SELECTED[@]} -eq 1 && "${SELECTED[0]}" == "all" ]]; then
+  SELECTED=("${ALL_REGIONS[@]}")
+elif [[ ${#SELECTED[@]} -eq 0 ]]; then
+  SELECTED=(cw-greenland hudson-bay alaska)
 fi
 
 WIDTH="${WIDTH:-1600}"
 HEIGHT="${HEIGHT:-1600}"
 PALETTE="${PALETTE:-day}"
 EXTRA_OPTS="${EXTRA_OPTS:-}"
+COMPARE="${COMPARE:-0}"
 
 # Default invocation: run the built Release DLL. Override via $S100.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -62,28 +136,84 @@ S100="${S100:-dotnet "$DEFAULT_DLL"}"
 
 mkdir -p "$OUT_DIR/data" "$OUT_DIR/previews"
 
+# Cache the portal index once so per-region discovery does not re-fetch it.
+PORTAL_CACHE="$OUT_DIR/data/ILP_S411.shtml"
+echo "Fetching portal index: $PORTAL_INDEX"
+if ! curl -fsSL -o "$PORTAL_CACHE" "$PORTAL_INDEX"; then
+  echo "! could not fetch portal index — cannot discover current ZIP names" >&2
+  exit 1
+fi
+
 echo "Output dir : $OUT_DIR"
 echo "CLI        : $S100"
-echo "Size       : ${WIDTH}x${HEIGHT}  palette=$PALETTE"
+echo "Size       : ${WIDTH}x${HEIGHT}  palette=$PALETTE  compare=$COMPARE"
 echo "Regions    : ${SELECTED[*]}"
 echo
 
+# Discover the current ZIP file name for a region pattern from the cached index.
+# Dates are zero-padded (YYYYMMDD…), so a lexical sort yields chronological order
+# and `tail -1` picks the most recent.
+discover_zip() {
+  local pattern="$1"
+  grep -oE 'S411/[A-Za-z0-9_.-]+\.zip' "$PORTAL_CACHE" \
+    | sed 's#^S411/##' \
+    | grep -E "^$pattern$" \
+    | sort \
+    | tail -1
+}
+
+fetch_reference() {
+  # $1 region key, $2 output dir for previews
+  local key="$1" pdir="$2"
+  local conc sod
+  conc="$(region_conc_image "$key")"
+  sod="$(region_sod_image "$key")"
+  local -a refs=()
+  if [[ -n "$conc" ]]; then
+    if curl -fsSL -o "$pdir/$key.bsis-conc.png" "$BASE_URL/S411Preview/$conc"; then
+      echo "  bsis CONC -> $pdir/$key.bsis-conc.png"
+      refs+=("$pdir/$key.bsis-conc.png")
+    fi
+  fi
+  if [[ -n "$sod" ]]; then
+    if curl -fsSL -o "$pdir/$key.bsis-sod.png" "$BASE_URL/S411Preview/$sod"; then
+      echo "  bsis SOD  -> $pdir/$key.bsis-sod.png"
+      refs+=("$pdir/$key.bsis-sod.png")
+    fi
+  fi
+  # Build a combined contact sheet when ImageMagick is available.
+  if command -v montage >/dev/null 2>&1 && [[ ${#refs[@]} -gt 0 && -f "$pdir/$key.png" ]]; then
+    montage -label 's100 render' "$pdir/$key.png" \
+      $(for r in "${refs[@]}"; do echo -label "bsis $(basename "$r" | sed "s/^$key\.bsis-//; s/\.png$//")" "$r"; done) \
+      -tile x1 -geometry 400x400+6+6 -background white "$pdir/$key.compare.png" \
+      && echo "  compare   -> $pdir/$key.compare.png"
+  fi
+}
+
 render_region() {
   local key="$1"
-  local zip_name
-  zip_name="$(region_zip "$key")"
-  if [[ -z "$zip_name" ]]; then
+  local pattern
+  pattern="$(region_zip_pattern "$key")"
+  if [[ -z "$pattern" ]]; then
     echo "  ! unknown region '$key' — skipping"
     return 0
   fi
+
+  echo "[$key]"
+  local zip_name
+  zip_name="$(discover_zip "$pattern")"
+  if [[ -z "$zip_name" ]]; then
+    echo "  ! no current ZIP matching /$pattern/ on the portal — skipping"
+    return 0
+  fi
+  echo "  current $zip_name"
 
   local zip_path="$OUT_DIR/data/$key.zip"
   local extract_dir="$OUT_DIR/data/$key"
   local preview="$OUT_DIR/previews/$key.png"
 
-  echo "[$key]"
   echo "  downloading $zip_name"
-  if ! curl -fsSL -o "$zip_path" "$BASE_URL/$zip_name"; then
+  if ! curl -fsSL -o "$zip_path" "$ZIP_URL/$zip_name"; then
     echo "  ! download failed — skipping"
     return 0
   fi
@@ -106,6 +236,11 @@ render_region() {
     echo "  -> $preview"
   else
     echo "  ! render failed"
+    return 0
+  fi
+
+  if [[ "$COMPARE" == "1" ]]; then
+    fetch_reference "$key" "$OUT_DIR/previews"
   fi
   echo
 }


### PR DESCRIPTION
## Summary

Refreshes the `samples/s411-previews` sea-ice preview sample so it keeps working day-to-day and can be compared directly against the published [BSIS Ice Portal](https://www.bsis-ice.de/IcePortal/ILP_S411.shtml) quicklooks (which are generated by a bespoke Python script). This exercises the `s100` CLI end-to-end on live daily S-411 data and honestly documents how close it gets to being a drop-in replacement.

## What changed

**`s411_previews.sh`**
- **Dynamic ZIP discovery** — the previous hard-coded, dated ZIP names rotated daily and 404'd. The script now caches the live portal index once and resolves each region's *current* dated exchange-set ZIP via a stable per-region pattern (date wildcarded, most-recent wins).
- **Expanded region registry** — 14 regions across DMI (Greenland), CIS, US NWS, and Met.no (was 5), plus an `all` key.
- **`COMPARE=1` mode** — downloads the matching BSIS concentration (CONC) and stage-of-development (SOD) quicklooks next to our render, and builds a `montage` contact sheet when ImageMagick is available (skips it gracefully otherwise).

**`README.md`**
- Documents discovery, the new region keys, `COMPARE`, and the updated output layout.
- Adds a **"Parity with the BSIS quicklooks"** section stating the honest verdict.

## Parity findings (verified on live 2026-07-01 data, DMI CentralWest + CIS Hudson Bay)

- **Data/geometry: effectively drop-in.** Our ice-edge polygons, fjord tongues, and offshore patches match the BSIS concentration quicklook essentially polygon-for-polygon, across two independent sources.
- **Standalone figure: not yet.** The gaps are composition/palette, not data fidelity:
  - no basemap (land/ocean/graticule/title/axes) — biggest gap
  - muted bundled S-411 PC palette vs. the vivid WMO concentration ramp
  - no stage-of-development ("thickness") portrayal
  - Web-Mercator vs. equirectangular projection
- **Out of scope:** the ~12 per-region **POLARIS** ice-class risk maps are a computed decision-support product (no RIO engine exists in this codebase).

The biggest gap — a basemap — is filed as a follow-up (add a `--basemap` option to the CLI, reusing the viewer's embedded Natural Earth land layer).

## Testing

Sample/PoC shell code (no unit tests). Manually verified end-to-end against live data: DMI CentralWest-Greenland and CIS Hudson Bay both discover → download → render → fetch references; unknown region keys skip cleanly; `bash -n` clean.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>