### PR TITLE
Fix headless render auto-fit collapse for antimeridian S-411 datasets (#413)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -132,7 +132,12 @@ Two behaviours differ from the single-dataset form:
   only. Render an S-101 cell singly if you need its updates folded in.
 
 When no `--bbox` / `--center`+`--scale` is supplied, the compositor auto-fits
-the union extent of all layers to the requested `--width` × `--height`.
+the union extent of all layers to the requested `--width` × `--height`. The
+auto-fit is **antimeridian-aware**: datasets whose geometry straddles the ±180°
+seam (e.g. an S-411 Alaska product spanning ~175°E → ~225°E) are framed on their
+true, narrow extent instead of collapsing to a near-global viewport (issue #413).
+This applies to both single-dataset renders and `--layer` / exchange-set
+composites.
 
 ### Compositing a whole exchange set / directory
 

--- a/src/EncDotNet.S100.Core/Gml/GmlCoordinateParser.cs
+++ b/src/EncDotNet.S100.Core/Gml/GmlCoordinateParser.cs
@@ -12,10 +12,25 @@ namespace EncDotNet.S100.Features;
 /// longitude second) as required by S-100 Part 10b §6.2. Separator handling
 /// tolerates both standard whitespace and comma-separated tokens (a
 /// producer-bug compensation seen in some real-world S-122 and S-128 datasets).
+/// A second producer-bug compensation auto-corrects longitude-first axis order
+/// (seen in the US NWS S-411 sea-ice product) using the physical latitude bound
+/// of ±90° — see <see cref="NormalizeAxisOrder"/>.
 /// </remarks>
 public static class GmlCoordinateParser
 {
     private static readonly char[] Separators = [' ', '\t', '\n', '\r', ','];
+
+    /// <summary>
+    /// Corrects a parsed ordinate pair for producer axis-order violations.
+    /// S-100 Part 10b §6.2 mandates latitude-first for <c>EPSG:4326</c>, but some
+    /// real-world datasets (e.g. the US NWS S-411 sea-ice product) encode
+    /// longitude first. Latitude is physically bounded to ±90°, so when the
+    /// first ordinate's magnitude exceeds 90° while the second's does not, the
+    /// pair is unambiguously longitude-first and is swapped. This is a strict
+    /// no-op for all conformant latitude-first data (which never has |lat| &gt; 90°).
+    /// </summary>
+    private static (double Latitude, double Longitude) NormalizeAxisOrder(double first, double second)
+        => Math.Abs(first) > 90.0 && Math.Abs(second) <= 90.0 ? (second, first) : (first, second);
 
     /// <summary>
     /// Parses a <c>gml:pos</c> value into a single coordinate pair.
@@ -25,10 +40,10 @@ public static class GmlCoordinateParser
     {
         var parts = posValue.Split(Separators, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length >= 2 &&
-            double.TryParse(parts[0], CultureInfo.InvariantCulture, out var lat) &&
-            double.TryParse(parts[1], CultureInfo.InvariantCulture, out var lon))
+            double.TryParse(parts[0], CultureInfo.InvariantCulture, out var first) &&
+            double.TryParse(parts[1], CultureInfo.InvariantCulture, out var second))
         {
-            return (lat, lon);
+            return NormalizeAxisOrder(first, second);
         }
         return null;
     }
@@ -43,10 +58,10 @@ public static class GmlCoordinateParser
 
         for (int i = 0; i + 1 < parts.Length; i += 2)
         {
-            if (double.TryParse(parts[i], CultureInfo.InvariantCulture, out var lat) &&
-                double.TryParse(parts[i + 1], CultureInfo.InvariantCulture, out var lon))
+            if (double.TryParse(parts[i], CultureInfo.InvariantCulture, out var first) &&
+                double.TryParse(parts[i + 1], CultureInfo.InvariantCulture, out var second))
             {
-                coords.Add((lat, lon));
+                coords.Add(NormalizeAxisOrder(first, second));
             }
         }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
@@ -170,18 +170,7 @@ public sealed class HeadlessCompositor
             StringComparer.Ordinal);
 
         var lowered = new List<CompositeLayer>(ruled.Count);
-        bool hasBounds = false;
-        double minX = double.MaxValue, minY = double.MaxValue;
-        double maxX = double.MinValue, maxY = double.MinValue;
-
-        void Expand(double loX, double loY, double hiX, double hiY)
-        {
-            hasBounds = true;
-            if (loX < minX) minX = loX;
-            if (loY < minY) minY = loY;
-            if (hiX > maxX) maxX = hiX;
-            if (hiY > maxY) maxY = hiY;
-        }
+        var bounds = new SeamAwareBoundsAccumulator();
 
         foreach (var item in ruled)
         {
@@ -194,26 +183,26 @@ public sealed class HeadlessCompositor
                 {
                     var scene = LowerVector(vector, options.HiddenCategories);
                     lowered.Add(new VectorCompositeLayer(scene, honorScaleVisibility: false));
-                    if (HeadlessVectorRenderer.TryGetWorldBounds(scene, out var vx0, out var vy0, out var vx1, out var vy1))
-                        Expand(vx0, vy0, vx1, vy1);
+                    bounds.AddScene(scene);
                     break;
                 }
 
                 case CoverageStackPayload coverage:
                 {
-                    if (TryLowerCoverage(coverage, out var layer, out var cx0, out var cy0, out var cx1, out var cy1))
+                    if (TryLowerCoverage(coverage, out var layer, out var west, out var east, out var south, out var north))
                     {
                         lowered.Add(layer);
-                        Expand(cx0, cy0, cx1, cy1);
+                        bounds.AddLonLatBox(west, east, south, north);
                     }
                     break;
                 }
             }
         }
 
-        // 4. Resolve the shared viewport: explicit wins; otherwise fit the union.
+        // 4. Resolve the shared viewport: explicit wins; otherwise seam-aware
+        //    auto-fit of the union extent.
         var viewport = options.Viewport
-            ?? BuildUnionViewport(hasBounds, minX, minY, maxX, maxY, options.Width, options.Height);
+            ?? BuildUnionViewport(bounds, options.Width, options.Height);
 
         // 5. Paint.
         var renderer = new HeadlessCompositeRenderer { Background = options.Background };
@@ -277,31 +266,31 @@ public sealed class HeadlessCompositor
     private bool TryLowerCoverage(
         CoverageStackPayload payload,
         out CompositeLayer layer,
-        out double minX, out double minY, out double maxX, out double maxY)
+        out double west, out double east, out double south, out double north)
     {
         layer = null!;
-        minX = minY = maxX = maxY = 0;
+        west = east = south = north = 0;
 
         switch (payload.SubLayer)
         {
             case GridCoverageSubLayer grid:
             {
-                var (west, east, south, north, nativeToWgs84) = ReprojectExtent(grid.Coverage, grid.Viewport);
-                layer = new CoverageCompositeLayer(grid.Coverage, west, east, south, north, nativeToWgs84: nativeToWgs84);
-                (minX, minY, maxX, maxY) = MercatorBoundsOf(west, east, south, north);
+                var (w, e, s, n, nativeToWgs84) = ReprojectExtent(grid.Coverage, grid.Viewport);
+                layer = new CoverageCompositeLayer(grid.Coverage, w, e, s, n, nativeToWgs84: nativeToWgs84);
+                west = w; east = e; south = s; north = n;
                 return true;
             }
 
             case ArrowCoverageSubLayer arrow:
             {
-                var (west, east, south, north, nativeToWgs84) = ReprojectExtent(arrow.Coverage, arrow.Viewport);
+                var (w, e, s, n, nativeToWgs84) = ReprojectExtent(arrow.Coverage, arrow.Viewport);
                 var arrowRenderer = new SkiaCoverageArrowRenderer
                 {
                     SymbolProvider = arrow.SymbolProvider,
                     BaseSymbolScale = arrow.BaseSymbolScale,
                 };
-                layer = new CoverageCompositeLayer(arrow.Coverage, west, east, south, north, arrowRenderer, nativeToWgs84);
-                (minX, minY, maxX, maxY) = MercatorBoundsOf(west, east, south, north);
+                layer = new CoverageCompositeLayer(arrow.Coverage, w, e, s, n, arrowRenderer, nativeToWgs84);
+                west = w; east = e; south = s; north = n;
                 return true;
             }
 
@@ -332,21 +321,13 @@ public sealed class HeadlessCompositor
         return (west, east, south, north, nativeToWgs84);
     }
 
-    private static (double MinX, double MinY, double MaxX, double MaxY) MercatorBoundsOf(
-        double west, double east, double south, double north)
-    {
-        var (minX, minY) = WebMercator.FromLonLat(west, south);
-        var (maxX, maxY) = WebMercator.FromLonLat(east, north);
-        return (Math.Min(minX, maxX), Math.Min(minY, maxY), Math.Max(minX, maxX), Math.Max(minY, maxY));
-    }
-
     private static Viewport BuildUnionViewport(
-        bool hasBounds, double minX, double minY, double maxX, double maxY, int widthPixels, int heightPixels)
+        SeamAwareBoundsAccumulator bounds, int widthPixels, int heightPixels)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthPixels);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightPixels);
 
-        if (!hasBounds)
+        if (!bounds.TryResolve(out double minX, out double minY, out double maxX, out double maxY))
         {
             minX = -1000; minY = -1000; maxX = 1000; maxY = 1000;
         }

--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -61,9 +61,12 @@ exactly one place:
 - **`ColorResolver`** — S-100 colour-token resolution (palette + inline hex).
 
 **Scope (spike):** the IR currently covers point, line, solid-area, and text
-ops. Pattern fills, antimeridian crossing, and Web-Mercator pole limits are not
-yet represented in the IR — pattern fills remain handled by the Mapsui renderer's
-dedicated pattern collection / priority-clip / insert phase.
+ops. Pattern fills and Web-Mercator pole limits are not yet represented in the
+IR — pattern fills remain handled by the Mapsui renderer's dedicated pattern
+collection / priority-clip / insert phase. Antimeridian (±180°) crossing **is**
+handled for the headless auto-fit: `SeamAwareBoundsAccumulator` (in
+`Rendering.Scene`) frames dateline-spanning datasets on their true extent and
+`WorldToScreen` wraps ops into the shifted window at draw time (issue #413).
 
 ### Headless rendering & compositing (`…Renderers.Skia.Scene`)
 
@@ -71,7 +74,8 @@ Standalone, Mapsui-free entry points that rasterise a whole dataset (or several)
 to an `SKBitmap`:
 
 - **`HeadlessVectorRenderer`** — lowers a Part 9 display list to a `VectorScene`
-  and rasterises it, auto-fitting the viewport to the scene extent. Its
+  and rasterises it, auto-fitting the viewport to the scene extent (seam-aware
+  across the ±180° antimeridian via `TryGetSeamAwareWorldBounds`). Its
   `BuildScene(...)` and `TryGetWorldBounds(...)` seams are reused by the
   compositor to lower a sub-layer and union its bounds against a *shared*
   viewport.

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -240,7 +240,7 @@ public static class HeadlessVectorRenderer
     {
         ArgumentNullException.ThrowIfNull(scene);
 
-        if (!TryGetWorldBounds(scene, out double minX, out double minY, out double maxX, out double maxY))
+        if (!TryGetSeamAwareWorldBounds(scene, out double minX, out double minY, out double maxX, out double maxY))
         {
             // No geometry — fall back to a small extent around the origin.
             minX = -1000; minY = -1000; maxX = 1000; maxY = 1000;
@@ -296,11 +296,37 @@ public static class HeadlessVectorRenderer
     }
 
     /// <summary>
+    /// Computes a <em>seam-aware</em> EPSG:3857 bounding box for the scene: when
+    /// the geometry straddles the ±180° antimeridian the returned window is
+    /// shifted into a contiguous longitude frame (its <paramref name="maxX"/> may
+    /// exceed +½ <see cref="WebMercator.Circumference"/>), so the fitted viewport
+    /// frames the data on its true extent instead of collapsing to a near-global
+    /// span (issue #413). Delegates the detection to
+    /// <see cref="SeamAwareBoundsAccumulator"/>. Returns <see langword="false"/>
+    /// when the scene has no geometry to bound.
+    /// </summary>
+    public static bool TryGetSeamAwareWorldBounds(
+        VectorScene scene, out double minX, out double minY, out double maxX, out double maxY)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+
+        var accumulator = new SeamAwareBoundsAccumulator();
+        accumulator.AddScene(scene);
+        return accumulator.TryResolve(out minX, out minY, out maxX, out maxY);
+    }
+
+    /// <summary>
     /// Computes the EPSG:3857 bounding box spanning every resolved paint op's
     /// world geometry. Returns <see langword="false"/> when the scene has no
     /// geometry to bound. Exposed so the multi-layer compositor can union each
     /// vector layer's projected extent into a shared viewport.
     /// </summary>
+    /// <remarks>
+    /// This is the <em>naive</em> min/max — it does not account for the ±180°
+    /// antimeridian seam. Use <see cref="TryGetSeamAwareWorldBounds"/> (or feed
+    /// the scene to a <see cref="SeamAwareBoundsAccumulator"/>) when fitting an
+    /// auto-viewport so datasets crossing the dateline are framed correctly.
+    /// </remarks>
     public static bool TryGetWorldBounds(
         VectorScene scene, out double minX, out double minY, out double maxX, out double maxY)
     {

--- a/src/EncDotNet.S100.Rendering.Scene/README.md
+++ b/src/EncDotNet.S100.Rendering.Scene/README.md
@@ -12,7 +12,8 @@ Mapsui, or any GUI framework.
 |---|---|
 | `VectorScene` / `PaintOp` (+ `PointPaintOp`, `LinePaintOp`, `AreaPaintOp`, `PatternAreaPaintOp`, `TextPaintOp`) | Ordered list of fully-resolved paint operations — world coords in EPSG:3857 m, sizes in logical display px, colours resolved to `RgbaColor`, SCAMIN carried per-op. |
 | `IVectorSceneRenderer<TSurface>` | The named **rendering-backend contract**: implement it to draw a `VectorScene` onto a backend-specific surface. `SkiaDisplayListRenderer` implements `IVectorSceneRenderer<SKCanvas>`; the Mapsui renderer is a conforming consumer of the IR rather than an implementer. |
-| `WorldToScreen` | Backend-neutral EPSG:3857 world → pixel affine derived from a `Viewport` (the `EPSG:3857 → pixels` half of the Part 9 projection). Lets a Skia-free backend project the IR's world coordinates. |
+| `WorldToScreen` | Backend-neutral EPSG:3857 world → pixel affine derived from a `Viewport` (the `EPSG:3857 → pixels` half of the Part 9 projection). Lets a Skia-free backend project the IR's world coordinates. Wraps ops across the ±180° antimeridian when the viewport is a seam-shifted frame (issue #413). |
+| `SeamAwareBoundsAccumulator` | Computes a seam-aware EPSG:3857 auto-fit extent: detects geometry straddling the ±180° antimeridian (via a longitude-occupancy histogram + largest-empty-arc heuristic) and shifts the western cluster into a contiguous world-X window so dateline-spanning datasets are framed on their true extent (issue #413). |
 | `ResolvedSymbol`, `SymbolAsset` | Resolved point-symbol content + pivot (S-100 Part 9 §11.5). |
 | `VectorSceneBuilder` | Lowers a `DrawingInstruction` display list into a `VectorScene`. Pattern tiles are supplied as PNG bytes through an injected `Func<string, byte[]?>` delegate, so the builder stays rasteriser-free. |
 | `ColorResolver` | S-100 colour-token → `RgbaColor` resolution. |

--- a/src/EncDotNet.S100.Rendering.Scene/SeamAwareBoundsAccumulator.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/SeamAwareBoundsAccumulator.cs
@@ -1,0 +1,302 @@
+namespace EncDotNet.S100.Rendering.Scene;
+
+/// <summary>
+/// Accumulates the EPSG:3857 extent of a headless render while remaining aware
+/// of the ±180° antimeridian seam, so the auto-fit viewport frames a dataset on
+/// its true extent even when its geometry wraps the dateline.
+/// </summary>
+/// <remarks>
+/// <para>A naive min/max over projected world-X collapses for antimeridian-
+/// spanning data (e.g. the Alaska NWS S-411 product, ~175°E → ~225°E): one
+/// cluster near +179° and another near −179° make the X-span ≈ the full world
+/// width, so the fitted viewport becomes near-global and every feature draws
+/// sub-pixel (issue #413).</para>
+/// <para>To detect the seam robustly the accumulator maintains a coarse
+/// longitude occupancy histogram (<see cref="BinCount"/> bins over
+/// [−180°, 180°)), tracking the exact observed [minX, maxX] per bin. On
+/// <see cref="TryResolve"/> it locates the <em>largest empty longitude arc</em>
+/// (the emptiest gap): if that gap is an interior band — rather than the arc
+/// that already wraps the seam — the data straddles ±180°, so the western
+/// cluster is shifted by one <see cref="WebMercator.Circumference"/> to produce
+/// a contiguous world-X window whose <c>maxX</c> may exceed +½ circumference.
+/// The paired <see cref="WorldToScreen"/> wrap re-homes the shifted ops at draw
+/// time.</para>
+/// <para>The seam logic only engages when the naive longitude span exceeds
+/// 180°; narrower extents (the overwhelming majority) take the fast path and
+/// behave exactly as the previous naive min/max fit. Genuinely wide / global
+/// datasets — whose emptiest gap is the seam-wrapping arc, not an interior band
+/// — also keep the naive extent, so the heuristic does not false-positive.</para>
+/// </remarks>
+public sealed class SeamAwareBoundsAccumulator
+{
+    /// <summary>Number of longitude occupancy bins (0.5° each).</summary>
+    public const int BinCount = 720;
+
+    private const double DegToRad = Math.PI / 180.0;
+    private const double RadToDeg = 180.0 / Math.PI;
+    private const double BinWidthDeg = 360.0 / BinCount;
+
+    private readonly bool[] _occupied = new bool[BinCount];
+    private readonly double[] _binMinX = new double[BinCount];
+    private readonly double[] _binMaxX = new double[BinCount];
+
+    private double _minY = double.MaxValue;
+    private double _maxY = double.MinValue;
+    private bool _any;
+
+    /// <summary>Creates an empty accumulator.</summary>
+    public SeamAwareBoundsAccumulator()
+    {
+        Array.Fill(_binMinX, double.MaxValue);
+        Array.Fill(_binMaxX, double.MinValue);
+    }
+
+    /// <summary>Whether any geometry has been accumulated.</summary>
+    public bool HasGeometry => _any;
+
+    /// <summary>
+    /// Accumulates every vertex of a resolved <see cref="VectorScene"/> — point
+    /// and text anchors, polyline vertices, and area shell + hole rings.
+    /// </summary>
+    /// <param name="scene">The lowered scene whose paint ops to bound.</param>
+    public void AddScene(VectorScene scene)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+
+        foreach (var op in scene.Ops)
+        {
+            switch (op)
+            {
+                case PointPaintOp p:
+                    Add(p.World.X, p.World.Y);
+                    break;
+                case TextPaintOp t:
+                    Add(t.World.X, t.World.Y);
+                    break;
+                case LinePaintOp l:
+                    foreach (var (x, y) in l.World) Add(x, y);
+                    break;
+                case AreaPaintOp a:
+                    foreach (var (x, y) in a.WorldShell) Add(x, y);
+                    foreach (var hole in a.WorldHoles)
+                        foreach (var (x, y) in hole) Add(x, y);
+                    break;
+                case PatternAreaPaintOp pa:
+                    foreach (var (x, y) in pa.WorldShell) Add(x, y);
+                    foreach (var hole in pa.WorldHoles)
+                        foreach (var (x, y) in hole) Add(x, y);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Accumulates a single EPSG:3857 world coordinate (metres).
+    /// </summary>
+    /// <param name="x">Easting in metres.</param>
+    /// <param name="y">Northing in metres.</param>
+    public void Add(double x, double y)
+    {
+        if (!double.IsFinite(x) || !double.IsFinite(y))
+            return;
+
+        _any = true;
+        if (y < _minY) _minY = y;
+        if (y > _maxY) _maxY = y;
+        MarkX(x);
+    }
+
+    /// <summary>
+    /// Accumulates a WGS-84 lon/lat bounding box (degrees), projecting its
+    /// corners to EPSG:3857 and marking every longitude bin it covers as
+    /// occupied so a wide extent (e.g. a coverage grid) does not introduce a
+    /// spurious interior gap. Boxes whose <paramref name="west"/> exceeds
+    /// <paramref name="east"/> are treated as crossing the ±180° seam.
+    /// </summary>
+    /// <param name="west">Western longitude edge, degrees.</param>
+    /// <param name="east">Eastern longitude edge, degrees.</param>
+    /// <param name="south">Southern latitude edge, degrees.</param>
+    /// <param name="north">Northern latitude edge, degrees.</param>
+    public void AddLonLatBox(double west, double east, double south, double north)
+    {
+        var (_, minY) = WebMercator.FromLonLat(0, Math.Min(south, north));
+        var (_, maxY) = WebMercator.FromLonLat(0, Math.Max(south, north));
+
+        _any = true;
+        if (minY < _minY) _minY = minY;
+        if (maxY > _maxY) _maxY = maxY;
+
+        if (west <= east)
+        {
+            MarkLonRange(west, east);
+        }
+        else
+        {
+            // Crosses the seam: [west, +180) ∪ [−180, east].
+            MarkLonRange(west, 180.0);
+            MarkLonRange(-180.0, east);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the accumulated geometry to a seam-aware EPSG:3857 window.
+    /// </summary>
+    /// <param name="minX">Resolved minimum easting, metres.</param>
+    /// <param name="minY">Resolved minimum northing, metres.</param>
+    /// <param name="maxX">
+    /// Resolved maximum easting, metres. May exceed +½
+    /// <see cref="WebMercator.Circumference"/> when the extent was shifted
+    /// across the antimeridian; the paired <see cref="WorldToScreen"/> wrap
+    /// re-homes ops into this window at draw time.
+    /// </param>
+    /// <param name="maxY">Resolved maximum northing, metres.</param>
+    /// <returns>
+    /// <see langword="true"/> when geometry was accumulated; otherwise
+    /// <see langword="false"/> (all outputs zero).
+    /// </returns>
+    public bool TryResolve(out double minX, out double minY, out double maxX, out double maxY)
+    {
+        minX = minY = maxX = maxY = 0;
+        if (!_any)
+            return false;
+
+        minY = _minY;
+        maxY = _maxY;
+
+        // Naive world-X extent over all occupied bins.
+        double naiveMinX = double.MaxValue, naiveMaxX = double.MinValue;
+        for (int i = 0; i < BinCount; i++)
+        {
+            if (!_occupied[i]) continue;
+            if (_binMinX[i] < naiveMinX) naiveMinX = _binMinX[i];
+            if (_binMaxX[i] > naiveMaxX) naiveMaxX = _binMaxX[i];
+        }
+
+        double naiveSpanLon = (naiveMaxX - naiveMinX) * RadToDeg / WebMercator.EarthRadius;
+        if (naiveSpanLon <= 180.0)
+        {
+            // Fast path: extent cannot be pathologically wide — no seam handling.
+            minX = naiveMinX;
+            maxX = naiveMaxX;
+            return true;
+        }
+
+        if (TryFindLargestInteriorGap(out int gapAfterBin))
+        {
+            // The emptiest longitude arc is an interior band, so the data wraps
+            // the ±180° seam. Bins at and below the gap are the western cluster;
+            // shift them by +one circumference to sit contiguously to the east
+            // of the higher-longitude cluster.
+            double westMaxXShifted = double.MinValue; // western cluster (shifted)
+            double eastMinX = double.MaxValue;        // eastern cluster (unshifted)
+            for (int i = 0; i < BinCount; i++)
+            {
+                if (!_occupied[i]) continue;
+                if (i <= gapAfterBin)
+                {
+                    double shifted = _binMaxX[i] + WebMercator.Circumference;
+                    if (shifted > westMaxXShifted) westMaxXShifted = shifted;
+                }
+                else
+                {
+                    if (_binMinX[i] < eastMinX) eastMinX = _binMinX[i];
+                }
+            }
+
+            minX = eastMinX;
+            maxX = westMaxXShifted;
+            return true;
+        }
+
+        // Largest gap is the seam-wrapping arc (genuinely wide / global data):
+        // the naive extent is already the tightest enclosure.
+        minX = naiveMinX;
+        maxX = naiveMaxX;
+        return true;
+    }
+
+    /// <summary>
+    /// Finds the largest run of empty bins. Returns <see langword="true"/> and
+    /// the index of the last occupied bin <em>before</em> that gap when the gap
+    /// is interior (i.e. it does not wrap the ±180° seam), signalling that the
+    /// data straddles the antimeridian. Returns <see langword="false"/> when the
+    /// largest gap is the seam-wrapping arc (no shift needed).
+    /// </summary>
+    private bool TryFindLargestInteriorGap(out int gapAfterBin)
+    {
+        gapAfterBin = -1;
+
+        int first = -1, last = -1;
+        for (int i = 0; i < BinCount; i++)
+        {
+            if (!_occupied[i]) continue;
+            if (first < 0) first = i;
+            last = i;
+        }
+
+        if (first < 0)
+            return false;
+
+        // The seam-wrapping gap: empty bins from after the last occupied bin,
+        // around through ±180°, to before the first occupied bin.
+        int wrapGap = (first + BinCount) - last - 1;
+
+        int bestGap = -1;
+        int bestGapAfterBin = -1;
+        int prev = -1;
+        for (int i = 0; i < BinCount; i++)
+        {
+            if (!_occupied[i]) continue;
+            if (prev >= 0)
+            {
+                int gap = i - prev - 1; // empty bins strictly between prev and i
+                if (gap > bestGap)
+                {
+                    bestGap = gap;
+                    bestGapAfterBin = prev;
+                }
+            }
+            prev = i;
+        }
+
+        if (bestGap <= 0 || bestGap <= wrapGap)
+            return false; // no interior gap dominates the seam-wrapping arc
+
+        gapAfterBin = bestGapAfterBin;
+        return true;
+    }
+
+    private void MarkX(double x)
+    {
+        double lon = x * RadToDeg / WebMercator.EarthRadius;
+        int bin = BinOf(lon);
+        _occupied[bin] = true;
+        if (x < _binMinX[bin]) _binMinX[bin] = x;
+        if (x > _binMaxX[bin]) _binMaxX[bin] = x;
+    }
+
+    private void MarkLonRange(double westLon, double eastLon)
+    {
+        int startBin = BinOf(westLon);
+        int endBin = BinOf(Math.Min(eastLon, 180.0 - 1e-9));
+        for (int i = startBin; i <= endBin; i++)
+        {
+            double loLon = -180.0 + i * BinWidthDeg;
+            double hiLon = loLon + BinWidthDeg;
+            double loX = loLon * DegToRad * WebMercator.EarthRadius;
+            double hiX = hiLon * DegToRad * WebMercator.EarthRadius;
+            _occupied[i] = true;
+            if (loX < _binMinX[i]) _binMinX[i] = loX;
+            if (hiX > _binMaxX[i]) _binMaxX[i] = hiX;
+        }
+    }
+
+    private static int BinOf(double lon)
+    {
+        double clamped = Math.Clamp(lon, -180.0, 180.0 - 1e-9);
+        int bin = (int)Math.Floor((clamped + 180.0) / BinWidthDeg);
+        if (bin < 0) bin = 0;
+        else if (bin >= BinCount) bin = BinCount - 1;
+        return bin;
+    }
+}

--- a/src/EncDotNet.S100.Rendering.Scene/WebMercator.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/WebMercator.cs
@@ -17,6 +17,14 @@ public static class WebMercator
     /// <summary>EPSG:3857 sphere radius (WGS-84 semi-major axis), in metres.</summary>
     public const double EarthRadius = 6378137.0;
 
+    /// <summary>
+    /// The full EPSG:3857 world width (and height at the projection limits), in
+    /// metres: one 360° trip around the equator (<c>2·π·<see cref="EarthRadius"/></c>
+    /// ≈ 4.0075×10⁷ m). Used by seam-aware auto-fit to shift longitudes that wrap
+    /// the ±180° antimeridian into a contiguous world-X window.
+    /// </summary>
+    public const double Circumference = 2.0 * Math.PI * EarthRadius;
+
     private const double DegToRad = Math.PI / 180.0;
 
     /// <summary>

--- a/src/EncDotNet.S100.Rendering.Scene/WorldToScreen.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/WorldToScreen.cs
@@ -29,13 +29,15 @@ public readonly struct WorldToScreen
     private readonly double _maxY;
     private readonly double _scaleX;
     private readonly double _scaleY;
+    private readonly bool _wrapX;
 
-    private WorldToScreen(double minX, double maxY, double scaleX, double scaleY)
+    private WorldToScreen(double minX, double maxY, double scaleX, double scaleY, bool wrapX)
     {
         _minX = minX;
         _maxY = maxY;
         _scaleX = scaleX;
         _scaleY = scaleY;
+        _wrapX = wrapX;
     }
 
     /// <summary>
@@ -45,6 +47,16 @@ public readonly struct WorldToScreen
     /// with a zero-width or zero-height projected span yields a zero scale on that
     /// axis (all coordinates collapse to the axis origin).
     /// </summary>
+    /// <remarks>
+    /// When the viewport is expressed in a longitude frame shifted across the
+    /// ±180° antimeridian (<c>MaxLongitude &gt; 180</c> or
+    /// <c>MinLongitude &lt; −180</c>, as produced by the seam-aware auto-fit —
+    /// see <see cref="SeamAwareBoundsAccumulator"/>), each op's world-X is wrapped
+    /// into <c>[minX, minX + <see cref="WebMercator.Circumference"/>)</c> before
+    /// projection so geometry on the far side of the seam registers in the shifted
+    /// window. For every normal viewport (which never exceeds ±180°) wrapping is
+    /// disabled, so partially off-screen features are never teleported.
+    /// </remarks>
     /// <param name="viewport">The display viewport (geographic bounds + pixel size).</param>
     /// <returns>The world → screen affine.</returns>
     public static WorldToScreen Create(Viewport viewport)
@@ -58,7 +70,8 @@ public readonly struct WorldToScreen
         double spanY = maxY - minY;
         double scaleX = spanX != 0 ? viewport.WidthPixels / spanX : 0;
         double scaleY = spanY != 0 ? viewport.HeightPixels / spanY : 0;
-        return new WorldToScreen(minX, maxY, scaleX, scaleY);
+        bool wrapX = viewport.MaxLongitude > 180.0 || viewport.MinLongitude < -180.0;
+        return new WorldToScreen(minX, maxY, scaleX, scaleY, wrapX);
     }
 
     /// <summary>
@@ -69,7 +82,18 @@ public readonly struct WorldToScreen
     /// <returns>The screen pixel coordinate.</returns>
     public (float X, float Y) Project((double X, double Y) world)
     {
-        float sx = (float)((world.X - _minX) * _scaleX);
+        double worldX = world.X;
+        if (_wrapX)
+        {
+            // Bring X into [_minX, _minX + circumference): a no-op for ops
+            // already inside the shifted window, and a +circumference shift for
+            // geometry on the far side of the antimeridian seam.
+            double dx = worldX - _minX;
+            dx -= Math.Floor(dx / WebMercator.Circumference) * WebMercator.Circumference;
+            worldX = _minX + dx;
+        }
+
+        float sx = (float)((worldX - _minX) * _scaleX);
         float sy = (float)((_maxY - world.Y) * _scaleY);
         return (sx, sy);
     }

--- a/tests/EncDotNet.S100.Core.Tests/GmlCoordinateParserTests.cs
+++ b/tests/EncDotNet.S100.Core.Tests/GmlCoordinateParserTests.cs
@@ -1,0 +1,80 @@
+using EncDotNet.S100.Features;
+
+namespace EncDotNet.S100.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="GmlCoordinateParser"/>, focusing on the axis-order
+/// producer-bug compensation (S-100 Part 10b §6.2 mandates latitude-first, but
+/// the US NWS S-411 sea-ice product encodes longitude-first). See issue #413.
+/// </summary>
+public class GmlCoordinateParserTests
+{
+    [Fact]
+    public void ParsePos_conformant_lat_first_is_unchanged()
+    {
+        var coord = GmlCoordinateParser.ParsePos("70.7762 -155.86");
+
+        Assert.NotNull(coord);
+        Assert.Equal(70.7762, coord!.Value.Latitude, 6);
+        Assert.Equal(-155.86, coord.Value.Longitude, 6);
+    }
+
+    [Fact]
+    public void ParsePos_lon_first_is_swapped_when_lat_slot_exceeds_90()
+    {
+        // NWS S-411 encoding: "<lon> <lat>" with lon in the 0–360 convention.
+        var coord = GmlCoordinateParser.ParsePos("205.8599 70.7762");
+
+        Assert.NotNull(coord);
+        Assert.Equal(70.7762, coord!.Value.Latitude, 6);
+        Assert.Equal(205.8599, coord.Value.Longitude, 6);
+    }
+
+    [Fact]
+    public void ParsePos_high_longitude_within_lat_bound_is_not_swapped()
+    {
+        // Genuine lat-first pair whose longitude (95°) is > 90 but sits in the
+        // second slot must NOT be swapped; the first ordinate is a valid latitude.
+        var coord = GmlCoordinateParser.ParsePos("60.0 95.0");
+
+        Assert.NotNull(coord);
+        Assert.Equal(60.0, coord!.Value.Latitude, 6);
+        Assert.Equal(95.0, coord.Value.Longitude, 6);
+    }
+
+    [Fact]
+    public void ParsePosList_lon_first_stream_is_swapped()
+    {
+        var coords = GmlCoordinateParser.ParsePosList("205.86 70.77 210.00 71.50 225.00 66.00");
+
+        Assert.Equal(3, coords.Length);
+        Assert.All(coords, c => Assert.InRange(c.Latitude, -90.0, 90.0));
+        Assert.Equal(205.86, coords[0].Longitude, 6);
+        Assert.Equal(70.77, coords[0].Latitude, 6);
+        Assert.Equal(225.00, coords[2].Longitude, 6);
+        Assert.Equal(66.00, coords[2].Latitude, 6);
+    }
+
+    [Fact]
+    public void ParsePosList_conformant_lat_first_stream_is_unchanged()
+    {
+        var coords = GmlCoordinateParser.ParsePosList("62.1414 -67.3632 66.3292 -65.5028");
+
+        Assert.Equal(2, coords.Length);
+        Assert.Equal(62.1414, coords[0].Latitude, 6);
+        Assert.Equal(-67.3632, coords[0].Longitude, 6);
+        Assert.Equal(66.3292, coords[1].Latitude, 6);
+        Assert.Equal(-65.5028, coords[1].Longitude, 6);
+    }
+
+    [Fact]
+    public void ParsePos_negative_lon_first_is_swapped()
+    {
+        // Longitude-first with a negative longitude beyond ±90° also swaps.
+        var coord = GmlCoordinateParser.ParsePos("-155.0 70.0");
+
+        Assert.NotNull(coord);
+        Assert.Equal(70.0, coord!.Value.Latitude, 6);
+        Assert.Equal(-155.0, coord.Value.Longitude, 6);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/HeadlessCompositorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/HeadlessCompositorTests.cs
@@ -131,6 +131,54 @@ public class HeadlessCompositorTests
         Assert.Equal(new SKColor(0xFF, 0xFF, 0xFF), center);
     }
 
+    [Fact]
+    public void Render_fits_union_across_antimeridian_without_collapsing()
+    {
+        // Two datasets on opposite sides of the ±180° seam (near +179° and
+        // −179°). A naive min/max union would frame a near-global extent and
+        // render blank; the seam-aware union auto-fit must frame the true
+        // (~4°) extent so both layers paint (issue #413).
+        var compositor = NewCompositor();
+        var east = VectorLayer(
+            datasetId: "east.000",
+            plane: S98DisplayPlane.BaseChartUnder,
+            fillHex: "#FF0000",
+            west: 178.0, east: 179.5, south: 64.0, north: 66.0);
+        var west = VectorLayer(
+            datasetId: "west.000",
+            plane: S98DisplayPlane.BaseChartUnder,
+            fillHex: "#FF0000",
+            west: -179.5, east: -178.0, south: 64.0, north: 66.0);
+
+        using var bitmap = compositor.Render(
+            new[] { east, west },
+            new HeadlessCompositeOptions
+            {
+                Width = 400,
+                Height = 400,
+                Background = new RgbaColor(255, 255, 255, 255),
+            });
+
+        // Both clusters must paint — one on each half of the canvas — proving
+        // the union fit did not collapse to a near-global viewport.
+        Assert.True(HasRedPixel(bitmap, 0, bitmap.Width / 2),
+            "Expected a painted feature in the left half of the composite.");
+        Assert.True(HasRedPixel(bitmap, bitmap.Width / 2, bitmap.Width),
+            "Expected a painted feature in the right half of the composite.");
+    }
+
+    private static bool HasRedPixel(SKBitmap bitmap, int xStart, int xEnd)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = xStart; x < xEnd; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red > 200 && p.Green < 80 && p.Blue < 80)
+                return true;
+        }
+        return false;
+    }
+
     // ----------------------------------------------------------------
     // Helpers
     // ----------------------------------------------------------------

--- a/tests/EncDotNet.S100.Rendering.Scene.Tests/SeamAwareBoundsAccumulatorTests.cs
+++ b/tests/EncDotNet.S100.Rendering.Scene.Tests/SeamAwareBoundsAccumulatorTests.cs
@@ -1,0 +1,114 @@
+using EncDotNet.S100.Rendering.Scene;
+
+namespace EncDotNet.S100.Rendering.Scene.Tests;
+
+/// <summary>
+/// Tests for <see cref="SeamAwareBoundsAccumulator"/> — the seam-aware EPSG:3857
+/// extent used by the headless auto-fit (issue #413). The key case: geometry
+/// straddling the ±180° antimeridian must resolve to a narrow, contiguous
+/// world-X window instead of a near-global span.
+/// </summary>
+public sealed class SeamAwareBoundsAccumulatorTests
+{
+    private const double DegToRad = Math.PI / 180.0;
+    private const double RadToDeg = 180.0 / Math.PI;
+
+    private static (double X, double Y) World(double lon, double lat) =>
+        WebMercator.FromLonLat(lon, lat);
+
+    private static double LonSpanDegrees(double minX, double maxX) =>
+        (maxX - minX) * RadToDeg / WebMercator.EarthRadius;
+
+    [Fact]
+    public void No_geometry_returns_false()
+    {
+        var acc = new SeamAwareBoundsAccumulator();
+        Assert.False(acc.TryResolve(out _, out _, out _, out _));
+    }
+
+    [Fact]
+    public void Normal_extent_matches_naive_min_max()
+    {
+        var acc = new SeamAwareBoundsAccumulator();
+        var (x0, y0) = World(2.0, 51.0);
+        var (x1, y1) = World(5.0, 53.0);
+        acc.Add(x0, y0);
+        acc.Add(x1, y1);
+
+        Assert.True(acc.TryResolve(out double minX, out double minY, out double maxX, out double maxY));
+        Assert.Equal(Math.Min(x0, x1), minX, 3);
+        Assert.Equal(Math.Max(x0, x1), maxX, 3);
+        Assert.Equal(Math.Min(y0, y1), minY, 3);
+        Assert.Equal(Math.Max(y0, y1), maxY, 3);
+        // No shift: the window stays within ±180°.
+        Assert.True(maxX <= WebMercator.Circumference / 2.0 + 1.0);
+    }
+
+    [Fact]
+    public void Antimeridian_extent_resolves_to_narrow_shifted_window()
+    {
+        // Two clusters: one near +179°, one near −179° (10° apart across the
+        // seam). The naive min/max would span ~358°; the seam-aware window must
+        // be ~10° wide and shifted so maxX exceeds +½ circumference.
+        var acc = new SeamAwareBoundsAccumulator();
+        foreach (var lon in new[] { 178.0, 179.0, 179.9 })
+            acc.Add(World(lon, 70.0).X, World(lon, 70.0).Y);
+        foreach (var lon in new[] { -179.9, -179.0, -178.0 })
+            acc.Add(World(lon, 71.0).X, World(lon, 71.0).Y);
+
+        Assert.True(acc.TryResolve(out double minX, out _, out double maxX, out _));
+
+        double spanDeg = LonSpanDegrees(minX, maxX);
+        Assert.InRange(spanDeg, 3.0, 30.0); // narrow, not near-global
+        // The western cluster was shifted +360°, so maxX runs past +180°.
+        Assert.True(maxX > WebMercator.Circumference / 2.0,
+            "Seam-shifted window should extend past +½ circumference.");
+        // Converting maxX back to longitude yields ~+182° (i.e. −178° + 360°).
+        double maxLon = maxX * RadToDeg / WebMercator.EarthRadius;
+        Assert.InRange(maxLon, 180.0, 185.0);
+    }
+
+    [Fact]
+    public void Truly_wide_extent_stays_naive()
+    {
+        // Data spread broadly across the globe (no single dominant empty arc):
+        // the emptiest gap is the seam-wrapping arc, so the naive extent is kept
+        // and no false seam-shift occurs.
+        var acc = new SeamAwareBoundsAccumulator();
+        for (double lon = -170; lon <= 170; lon += 20)
+            acc.Add(World(lon, 0.0).X, World(lon, 0.0).Y);
+
+        Assert.True(acc.TryResolve(out double minX, out _, out double maxX, out _));
+
+        double spanDeg = LonSpanDegrees(minX, maxX);
+        Assert.InRange(spanDeg, 300.0, 360.0); // remains wide, unshifted
+        Assert.True(maxX <= WebMercator.Circumference / 2.0 + 1.0);
+    }
+
+    [Fact]
+    public void LonLat_box_marks_occupancy_and_bounds_latitude()
+    {
+        var acc = new SeamAwareBoundsAccumulator();
+        acc.AddLonLatBox(west: 10.0, east: 40.0, south: 50.0, north: 60.0);
+
+        Assert.True(acc.TryResolve(out double minX, out double minY, out double maxX, out double maxY));
+        Assert.InRange(LonSpanDegrees(minX, maxX), 29.0, 31.0);
+        var (_, ySouth) = World(0, 50.0);
+        var (_, yNorth) = World(0, 60.0);
+        Assert.Equal(ySouth, minY, 0);
+        Assert.Equal(yNorth, maxY, 0);
+    }
+
+    [Fact]
+    public void LonLat_box_crossing_seam_is_detected()
+    {
+        // A single coverage box crossing the seam (west > east) must resolve to
+        // a narrow shifted window, not a near-global one.
+        var acc = new SeamAwareBoundsAccumulator();
+        acc.AddLonLatBox(west: 175.0, east: -155.0, south: 60.0, north: 72.0);
+
+        Assert.True(acc.TryResolve(out double minX, out _, out double maxX, out _));
+        Assert.InRange(LonSpanDegrees(minX, maxX), 25.0, 35.0);
+        Assert.True(maxX > WebMercator.Circumference / 2.0);
+    }
+}

--- a/tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenSeamWrapTests.cs
+++ b/tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenSeamWrapTests.cs
@@ -1,0 +1,77 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Rendering.Scene;
+
+namespace EncDotNet.S100.Rendering.Scene.Tests;
+
+/// <summary>
+/// Tests for the antimeridian seam-wrap in <see cref="WorldToScreen"/> (issue
+/// #413). A viewport expressed in a shifted longitude frame
+/// (<c>MaxLongitude &gt; 180</c>) must wrap ops on the far side of the ±180°
+/// seam into the visible window; a normal viewport must never wrap.
+/// </summary>
+public sealed class WorldToScreenSeamWrapTests
+{
+    private const double RadToDeg = 180.0 / Math.PI;
+
+    private static Viewport ShiftedViewport() => new()
+    {
+        // Frame [175°, 225°] — a contiguous window straddling the seam, as the
+        // seam-aware auto-fit produces for the Alaska NWS extent.
+        MinLongitude = 175.0,
+        MaxLongitude = 225.0,
+        MinLatitude = 60.0,
+        MaxLatitude = 72.0,
+        WidthPixels = 1000,
+        HeightPixels = 1000,
+        ScaleDenominator = 50_000,
+    };
+
+    [Fact]
+    public void Op_west_of_seam_wraps_into_the_shifted_window()
+    {
+        var transform = WorldToScreen.Create(ShiftedViewport());
+
+        // A feature at −135° (= +225° in the shifted frame) sits at the right
+        // edge; its raw world-X is negative and would fall far off-screen left
+        // without the wrap.
+        var world = WebMercator.FromLonLat(-135.0, 66.0);
+        var (x, _) = transform.Project(world);
+
+        Assert.InRange(x, 990f, 1010f); // right edge (~1000)
+    }
+
+    [Fact]
+    public void Op_east_of_seam_projects_near_left_edge()
+    {
+        var transform = WorldToScreen.Create(ShiftedViewport());
+
+        var world = WebMercator.FromLonLat(175.0, 66.0);
+        var (x, _) = transform.Project(world);
+
+        Assert.InRange(x, -5f, 5f); // left edge (~0)
+    }
+
+    [Fact]
+    public void Normal_viewport_does_not_wrap_offscreen_features()
+    {
+        // A conventional viewport (within ±180°) must leave an op that lies west
+        // of the viewport projecting to a negative pixel X — NOT teleported to
+        // the right edge.
+        var vp = new Viewport
+        {
+            MinLongitude = 2.0,
+            MaxLongitude = 5.0,
+            MinLatitude = 51.0,
+            MaxLatitude = 53.0,
+            WidthPixels = 1200,
+            HeightPixels = 900,
+            ScaleDenominator = 50_000,
+        };
+        var transform = WorldToScreen.Create(vp);
+
+        var world = WebMercator.FromLonLat(1.0, 52.0); // 1° west of the viewport
+        var (x, _) = transform.Project(world);
+
+        Assert.True(x < 0f, "A feature west of a normal viewport must stay off the left edge.");
+    }
+}

--- a/tests/EncDotNet.S100.VisualRegression.Tests/HeadlessVectorRendererAntimeridianTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/HeadlessVectorRendererAntimeridianTests.cs
@@ -1,0 +1,104 @@
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using EncDotNet.S100.Rendering.Scene;
+using SkiaSharp;
+
+namespace EncDotNet.S100.VisualRegression.Tests;
+
+/// <summary>
+/// Regression test for issue #413: the headless auto-fit must frame a dataset
+/// whose geometry straddles the ±180° antimeridian on its true (narrow) extent
+/// instead of collapsing to a near-global viewport that renders blank.
+/// </summary>
+public sealed class HeadlessVectorRendererAntimeridianTests
+{
+    private static readonly RgbaColor White = new(255, 255, 255, 255);
+
+    /// <summary>
+    /// Two point features on opposite sides of the seam: one near +179°, one
+    /// near −179° (a ~2° true extent across the dateline).
+    /// </summary>
+    private sealed class SeamGeometryProvider : IFeatureGeometryProvider
+    {
+        public FeatureGeometry? GetGeometry(string featureReference) => featureReference switch
+        {
+            "east" => new FeatureGeometry
+            {
+                Type = GeometryType.Point,
+                Coordinates = [(65.0, 179.0)], // (Latitude, Longitude)
+            },
+            "west" => new FeatureGeometry
+            {
+                Type = GeometryType.Point,
+                Coordinates = [(65.0, -179.0)], // (Latitude, Longitude)
+            },
+            _ => null,
+        };
+    }
+
+    private static IReadOnlyList<DrawingInstruction> SeamInstructions() =>
+    [
+        new PointInstruction { FeatureReference = "east", SymbolReference = "QUESMRK1" },
+        new PointInstruction { FeatureReference = "west", SymbolReference = "QUESMRK1" },
+    ];
+
+    private static ColorPalette TestPalette() => new("Test", new Dictionary<string, string>());
+
+    [Fact]
+    public void Fit_across_antimeridian_is_narrow_not_global()
+    {
+        var scene = HeadlessVectorRenderer.BuildScene(
+            SeamInstructions(),
+            new SeamGeometryProvider(),
+            TestPalette(),
+            symbolProvider: null,
+            lineStyleProvider: null,
+            symbolScale: 1.0,
+            textScale: 1.0);
+
+        var viewport = HeadlessVectorRenderer.FitViewport(scene, 400, 400);
+
+        // The framed longitude span must be a handful of degrees (the 2° extent
+        // plus padding / aspect growth), NOT near-global.
+        Assert.InRange(viewport.LongitudeSpan, 1.0, 60.0);
+        // The seam-shifted window runs past +180° in the resolved frame.
+        Assert.True(viewport.MaxLongitude > 180.0,
+            "Auto-fit across the antimeridian should produce a shifted (>180°) frame.");
+    }
+
+    [Fact]
+    public void Render_across_antimeridian_is_not_blank()
+    {
+        using var bitmap = HeadlessVectorRenderer.Render(
+            SeamInstructions(),
+            new SeamGeometryProvider(),
+            TestPalette(),
+            symbolProvider: null,
+            lineStyleProvider: null,
+            symbolScale: 1.0,
+            textScale: 1.0,
+            widthPixels: 400,
+            heightPixels: 400,
+            background: White);
+
+        // Both point features (fallback dots) must render — one on the left
+        // half, one on the right half — proving neither collapsed sub-pixel.
+        Assert.True(HasNonBackgroundPixel(bitmap, 0, bitmap.Width / 2),
+            "Expected a rendered feature in the left half of the canvas.");
+        Assert.True(HasNonBackgroundPixel(bitmap, bitmap.Width / 2, bitmap.Width),
+            "Expected a rendered feature in the right half of the canvas.");
+    }
+
+    private static bool HasNonBackgroundPixel(SKBitmap bitmap, int xStart, int xEnd)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+        for (int x = xStart; x < xEnd; x++)
+        {
+            var p = bitmap.GetPixel(x, y);
+            if (p.Red != White.R || p.Green != White.G || p.Blue != White.B)
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

The headless `s100 render` auto-fit viewport collapsed to a near-global / degenerate extent for datasets near the +/-180 degree antimeridian, producing a blank image. The real-world trigger is the Alaska NWS S-411 sea-ice product. This PR delivers two related fixes so those datasets frame and render correctly, and verifies the result end to end against live BSIS Ice Portal data.

Fixes: #413

**1. Seam-aware auto-fit (commit `aed1d28`).** A naive min/max over projected EPSG:3857 world-X spans nearly the full world width when geometry sits on both sides of the seam (one cluster near +179, another near -179), so the fitted viewport became near-global and every feature drew sub-pixel. The new `SeamAwareBoundsAccumulator` maintains a coarse longitude occupancy histogram, and when the naive longitude span exceeds 180 degrees it locates the largest empty arc: an interior gap means the data wraps the dateline, so the western cluster is shifted by one world circumference into a contiguous world-X window. A paired wrap in `WorldToScreen.Project` (gated on a viewport whose bounds exceed +/-180) re-homes ops on the far side of the seam at draw time. Genuinely global data (whose emptiest arc is the seam itself) keeps the naive extent, so the heuristic does not false-positive. Both the single (`HeadlessVectorRenderer`) and composite (`HeadlessCompositor`) auto-fit paths route through the accumulator.

**2. Longitude-first axis-order compensation (commit `b637fdb`).** While verifying against the real Alaska product I found it was still blank, but for a different root cause than the issue hypothesized. The NWS S-411 product does not cross +/-179 in (lat,lon) space; it encodes a contiguous 175 to 225 degrees E band (0 to 360 convention) and uses lon-first axis order (e.g. `205.86 70.77`), violating S-100 Part 10b section 6.2 (lat-first) under a standard EPSG:4326 srsName. `GmlCoordinateParser` reads lat-first per spec, so the "latitude" slot received 175 to 225 degrees, producing a NaN Web-Mercator northing; every vertex was then dropped and the viewport fell back to a degenerate extent. Since latitude is physically bounded to +/-90 degrees, the parser now swaps a pair when the first ordinate's magnitude exceeds 90 while the second's does not. This is a strict no-op for all conformant lat-first data and follows the parser's existing producer-bug compensation pattern (comma separators, split `pos`, missing ring wrappers).

### Verification

Ran the S-411 sample against live BSIS data for three regions. Alaska went from a blank canvas to a correctly framed chart matching the BSIS reference extent; the conformant Greenland and Hudson Bay products are unchanged.

| Region | non-background before | after |
|---|---|---|
| cw-greenland (DMI, lat-first) | 11.3% | 11.3% |
| hudson-bay (CIS, lat-first) | 28.0% | 28.0% |
| alaska (NWS, lon-first, antimeridian) | 0.0% (blank) | 56.1% |

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A - change is purely infrastructural (build, CI, docs, tooling)

The fix lives in the shared rendering core and GML coordinate parser, so it applies to every vector product through the common headless fit (S-101, S-122, S-124, S-125, S-127, S-128, S-131, S-201, S-411, S-421). S-411 is the observed real-world trigger.

**Spec section references cited in code/docs:** S-100 Part 10b section 6.2 (EPSG:4326 latitude-first axis order) is cited in `GmlCoordinateParser` for the axis-order compensation.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Added `SeamAwareBoundsAccumulatorTests` (6), `WorldToScreenSeamWrapTests` (3), `HeadlessVectorRendererAntimeridianTests` (single-render, asserts a narrow fitted extent and non-background pixels), a composite regression in `HeadlessCompositorTests`, and `GmlCoordinateParserTests` (6, covering the exact NWS coordinate strings, the conformant lat-first path, and the guard against a high longitude in the second slot). Full suite passes with 0 failures.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

Updated `docs/cli.md`, `src/EncDotNet.S100.Renderers.Skia/README.md`, and `src/EncDotNet.S100.Rendering.Scene/README.md`.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. The seam wrap is a no-op for every normal viewport (which never exceeds +/-180), and the axis-order swap is a no-op for all conformant lat-first data.