### PR TITLE
Fix cross-antimeridian viewer rendering and add zoom limits

### DIFF
--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -571,6 +571,19 @@ origin (not the viewport), a constant-zoom pan re-uses every interior tile and
 only the newly-exposed perimeter rasterises — pan cost scales with *perimeter,
 not area*.
 
+**Antimeridian / continuous-longitude datasets.** The grid is world-anchored at
+`[-Extent, +Extent]` (±180°), but the tile enumeration keeps a **continuous** X
+frame: `TileGrid.VisibleTileRange` / `PredictedTiles` clamp only the **Y**
+(latitude) index at the poles and leave the **X** (longitude) index unclamped
+(the span is capped to one world so an extreme zoom-out cannot repeat columns).
+An antimeridian-spanning dataset kept in a continuous frame (e.g. the US NWS
+S-411 sea-ice product, ~175°E → ~225°E) therefore tiles into columns at index
+`>= perAxis`, whose `TileWorldBounds` map back to the correct world-X east of
++180°. Correspondingly, `RasterizeTile` sets `EnableSeamWrap = false` on its
+`SkiaDisplayListRenderer` so the headless seam-wrap does not teleport the
+off-tile vertices of large continuous polygons across the world (which
+previously collapsed such datasets into a thin ±180° sliver).
+
 Each frame the UI thread snaps the live resolution to the nearest band, blits
 the **best available** tile for every visible slot, each hard-clipped to its
 core over a rendered **gutter** (`S100_VECTOR_TILE_GUTTER`, default 64 DIP) so

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -575,7 +575,7 @@ not area*.
 `[-Extent, +Extent]` (±180°), but the tile enumeration keeps a **continuous** X
 frame: `TileGrid.VisibleTileRange` / `PredictedTiles` clamp only the **Y**
 (latitude) index at the poles and leave the **X** (longitude) index unclamped
-(the span is capped to one world so an extreme zoom-out cannot repeat columns).
+(an absolute guard of 4096 columns prevents runaway allocation at pathological zoom-out, but the span is otherwise unclamped so every visible column is enumerated).
 An antimeridian-spanning dataset kept in a continuous frame (e.g. the US NWS
 S-411 sea-ice product, ~175°E → ~225°E) therefore tiles into columns at index
 `>= perAxis`, whose `TileWorldBounds` map back to the correct world-X east of

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSceneRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSceneRenderer.cs
@@ -338,6 +338,11 @@ public static class S100VectorSceneRenderer
                 {
                     Background = SceneRgbaColor.Transparent,
                     HonorScaleVisibility = true,
+                    // Draw the scene once at its true continuous EPSG:3857
+                    // position (matching the tiled path). Seam-wrap would
+                    // left-edge-wrap antimeridian data whose viewport spans past
+                    // ±180°, smearing it; keep it off so the data stays put.
+                    EnableSeamWrap = false,
                 };
 
                 var rasterStart = Stopwatch.GetTimestamp();

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSceneRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorSceneRenderer.cs
@@ -428,8 +428,12 @@ public static class S100VectorSceneRenderer
         var minY = request.CenterY - halfHeightMetres;
         var maxY = request.CenterY + halfHeightMetres;
 
-        var (minLon, minLat) = WebMercator.ToLonLat(minX, minY);
-        var (maxLon, maxLat) = WebMercator.ToLonLat(maxX, maxY);
+        // Lossless (unclamped) inverse so WorldToScreen reproduces these exact
+        // world bounds — clamping a pole-overhanging edge back to ±85° would
+        // drift geometry poleward when a high-latitude cell is zoomed out. See
+        // WebMercator.ToLonLat.
+        var (minLon, minLat) = WebMercator.ToLonLat(minX, minY, clampLatitude: false);
+        var (maxLon, maxLat) = WebMercator.ToLonLat(maxX, maxY, clampLatitude: false);
 
         var widthPx = (int)Math.Round(recordWidthDip * request.DeviceScale);
         var heightPx = (int)Math.Round(recordHeightDip * request.DeviceScale);

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -343,6 +343,14 @@ public static class S100VectorTileRenderer
     {
         Background = SceneRgbaColor.Transparent,
         HonorScaleVisibility = true,
+        // The overlay draws the live symbol/text layer over the base tiles,
+        // which carry already-continuous EPSG:3857 geometry (antimeridian data
+        // keeps longitudes beyond ±180° without wrapping). The seam-wrap is a
+        // headless single-viewport auto-fit concern; enabling it here would
+        // left-edge-wrap the overlay off the fixed tile positions, so the
+        // symbols/labels would slide away from their features. Keep it off so
+        // the overlay stays locked to the base's continuous frame.
+        EnableSeamWrap = false,
     };
 
     // Stateless, render-thread-only label declutter for the live overlay. S-100

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -1653,8 +1653,14 @@ public static class S100VectorTileRenderer
         // device-scale matrix then keeps them crisp on HiDPI).
         var halfWorldW = widthDip * resolution * 0.5;
         var halfWorldH = heightDip * resolution * 0.5;
-        var (minLon, minLat) = WebMercator.ToLonLat(centerX - halfWorldW, centerY - halfWorldH);
-        var (maxLon, maxLat) = WebMercator.ToLonLat(centerX + halfWorldW, centerY + halfWorldH);
+        // Build the viewport's lat/lon corners with the lossless (unclamped)
+        // inverse so WorldToScreen re-projects back to these exact EPSG:3857
+        // bounds. Clamping here would pull a top/bottom edge that overhangs the
+        // Web-Mercator pole limit (common when a high-latitude dataset is zoomed
+        // out) back to ±85°, compressing the overlay's vertical span so labels
+        // drift poleward off their features. See WebMercator.ToLonLat.
+        var (minLon, minLat) = WebMercator.ToLonLat(centerX - halfWorldW, centerY - halfWorldH, clampLatitude: false);
+        var (maxLon, maxLat) = WebMercator.ToLonLat(centerX + halfWorldW, centerY + halfWorldH, clampLatitude: false);
 
         var viewport = new CoreViewport
         {
@@ -1821,8 +1827,13 @@ public static class S100VectorTileRenderer
             ? scene
             : new VectorScene(baseIndex.Query(fullMinX, fullMinY, fullMaxX, fullMaxY));
 
-        var (minLon, minLat) = WebMercator.ToLonLat(fullMinX, fullMinY);
-        var (maxLon, maxLat) = WebMercator.ToLonLat(fullMaxX, fullMaxY);
+        // Lossless (unclamped) inverse so WorldToScreen reproduces these exact
+        // tile bounds. The top tile row's gutter pushes fullMaxY just past the
+        // Web-Mercator pole limit (±π·EarthRadius); clamping there would squash
+        // the tile's vertical mapping and drift the base geometry poleward. See
+        // WebMercator.ToLonLat.
+        var (minLon, minLat) = WebMercator.ToLonLat(fullMinX, fullMinY, clampLatitude: false);
+        var (maxLon, maxLat) = WebMercator.ToLonLat(fullMaxX, fullMaxY, clampLatitude: false);
 
         var sizeDip = TileGrid.TileSizeDip + 2 * GutterDip;
         var px = (int)Math.Round(sizeDip * deviceScale);

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -1846,6 +1846,12 @@ public static class S100VectorTileRenderer
         {
             Background = SceneRgbaColor.Transparent,
             HonorScaleVisibility = true,
+            // Tiles carry already-continuous EPSG:3857 geometry (longitudes may
+            // exceed +180° without wrapping). The seam-wrap is a headless
+            // single-viewport auto-fit concern; under a narrow per-tile viewport
+            // east of +180° it would teleport far vertices of large polygons and
+            // smear them across the tile, so it is disabled here.
+            EnableSeamWrap = false,
         };
 
         return renderer.Render(tileScene, viewport);

--- a/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
@@ -200,9 +200,15 @@ internal static class TileGrid
     /// viewer's tiled render subsystem drew a thin sliver at ±180° while the
     /// non-tiled and headless paths framed it correctly). Instead the raw
     /// column indices are kept — <see cref="TileWorldBounds"/> maps them to the
-    /// correct continuous world position — and only the column <em>span</em> is
-    /// capped to one full world (<paramref name="perAxis"/> columns) so an
-    /// extreme zoom-out cannot enumerate unbounded repeats.
+    /// correct continuous world position — so a dataset kept in a continuous
+    /// frame is reachable at its true columns wherever the viewport is panned.
+    /// The span is <em>not</em> capped to one world: the chart data is drawn
+    /// exactly once at its true position (it is not world-copied like the
+    /// basemap), so every visible column must be enumerable or the data would
+    /// pop between world-copies as the pan crossed a world boundary. Only a
+    /// generous absolute guard bounds a pathological zoom-out, and it keeps the
+    /// window anchored at the left edge (never re-centred) so panning slides the
+    /// columns smoothly instead of flipping the enumerated world.
     /// </remarks>
     public static TileRange VisibleTileRange(
         double centerX, double centerY, double widthDip, double heightDip, double resolution, int band)
@@ -219,10 +225,15 @@ internal static class TileGrid
 
         var xStart = (int)Math.Floor((centerX - halfW + Extent) / size);
         var xEnd = (int)Math.Floor((centerX + halfW + Extent) / size);
-        // Cap the X span to one full world; never clamp X into [0, perAxis-1].
-        if (xEnd - xStart + 1 > perAxis)
+        // Enumerate every visible column (including those beyond the standard
+        // world for antimeridian data); never clamp X into [0, perAxis-1] and
+        // never re-anchor the window. A large absolute guard only bounds a
+        // pathological zoom-out — it is far beyond any realistic viewport, so it
+        // does not truncate the visible copies in practice.
+        const int MaxColumns = 4096;
+        if (xEnd - xStart + 1 > MaxColumns)
         {
-            xEnd = xStart + perAxis - 1;
+            xEnd = xStart + MaxColumns - 1;
         }
         // Y is inverted (XYZ): the top row (Y=0) is the northernmost.
         var yStart = (int)Math.Floor((Extent - (centerY + halfH)) / size);

--- a/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
@@ -159,9 +159,12 @@ internal static class TileGrid
     /// the north-up viewport centred at (<paramref name="centerX"/>,
     /// <paramref name="centerY"/>) in EPSG:3857, sized
     /// <paramref name="widthDip"/> × <paramref name="heightDip"/> DIP at
-    /// <paramref name="resolution"/> m/px. Indices are clamped to the band's
-    /// valid range, so a viewport overhanging the world edge yields no
-    /// out-of-range keys.
+    /// <paramref name="resolution"/> m/px. The <b>Y</b> (latitude) index is
+    /// clamped to the band's valid range (northing is bounded at the poles), so
+    /// a viewport overhanging the top/bottom yields no out-of-range row. The
+    /// <b>X</b> (longitude) index is <em>not</em> clamped: EPSG:3857 is periodic
+    /// east-west and continuous-frame antimeridian data projects to columns
+    /// outside <c>[0, perAxis-1]</c> (see <see cref="VisibleTileRange"/>).
     /// </summary>
     public static IReadOnlyList<TileKey> VisibleTiles(
         double centerX, double centerY, double widthDip, double heightDip, double resolution, int band)
@@ -180,11 +183,27 @@ internal static class TileGrid
     }
 
     /// <summary>
-    /// The inclusive, world-clamped tile-index range covering the north-up
-    /// viewport at <paramref name="band"/>. A degenerate viewport yields an empty
-    /// range (<c>XStart &gt; XEnd</c>). Shared by <see cref="VisibleTiles"/> and
+    /// The inclusive tile-index range covering the north-up viewport at
+    /// <paramref name="band"/>. A degenerate viewport yields an empty range
+    /// (<c>XStart &gt; XEnd</c>). Shared by <see cref="VisibleTiles"/> and
     /// <see cref="PredictedTiles"/> so both tile the viewport identically.
     /// </summary>
+    /// <remarks>
+    /// The <b>Y</b> (latitude) axis is clamped to <c>[0, perAxis-1]</c>: the
+    /// Web-Mercator northing is physically bounded at the poles, so a viewport
+    /// overhanging the top/bottom yields no out-of-range row. The <b>X</b>
+    /// (longitude) axis is <em>not</em> clamped to the standard world, because
+    /// EPSG:3857 is periodic east-west and an antimeridian-spanning dataset
+    /// kept in a continuous longitude frame (e.g. the US NWS S-411 sea-ice
+    /// product, ~175°E → ~225°E) projects to world-X beyond ±<see cref="Extent"/>.
+    /// Clamping X collapsed such data into the boundary tile column (issue: the
+    /// viewer's tiled render subsystem drew a thin sliver at ±180° while the
+    /// non-tiled and headless paths framed it correctly). Instead the raw
+    /// column indices are kept — <see cref="TileWorldBounds"/> maps them to the
+    /// correct continuous world position — and only the column <em>span</em> is
+    /// capped to one full world (<paramref name="perAxis"/> columns) so an
+    /// extreme zoom-out cannot enumerate unbounded repeats.
+    /// </remarks>
     public static TileRange VisibleTileRange(
         double centerX, double centerY, double widthDip, double heightDip, double resolution, int band)
     {
@@ -200,13 +219,18 @@ internal static class TileGrid
 
         var xStart = (int)Math.Floor((centerX - halfW + Extent) / size);
         var xEnd = (int)Math.Floor((centerX + halfW + Extent) / size);
+        // Cap the X span to one full world; never clamp X into [0, perAxis-1].
+        if (xEnd - xStart + 1 > perAxis)
+        {
+            xEnd = xStart + perAxis - 1;
+        }
         // Y is inverted (XYZ): the top row (Y=0) is the northernmost.
         var yStart = (int)Math.Floor((Extent - (centerY + halfH)) / size);
         var yEnd = (int)Math.Floor((Extent - (centerY - halfH)) / size);
 
         return new TileRange(
-            Math.Clamp(xStart, 0, perAxis - 1),
-            Math.Clamp(xEnd, 0, perAxis - 1),
+            xStart,
+            xEnd,
             Math.Clamp(yStart, 0, perAxis - 1),
             Math.Clamp(yEnd, 0, perAxis - 1),
             perAxis);
@@ -294,8 +318,9 @@ internal static class TileGrid
         List<TileKey> result, HashSet<TileKey> seen, int band,
         int xStart, int xEnd, int yStart, int yEnd, int perAxis)
     {
-        xStart = Math.Clamp(xStart, 0, perAxis - 1);
-        xEnd = Math.Clamp(xEnd, 0, perAxis - 1);
+        // X is not clamped to the standard world (EPSG:3857 is periodic east-west
+        // and continuous-frame antimeridian data lives beyond ±Extent — see
+        // VisibleTileRange); only Y (latitude) is bounded at the poles.
         yStart = Math.Clamp(yStart, 0, perAxis - 1);
         yEnd = Math.Clamp(yEnd, 0, perAxis - 1);
         for (var y = yStart; y <= yEnd; y++)
@@ -321,7 +346,9 @@ internal static class TileGrid
 
         var size = TileWorldSize(band);
         var perAxis = TilesPerAxis(band);
-        var x = Math.Clamp((int)Math.Floor((centerX + Extent) / size), 0, perAxis - 1);
+        // X unclamped (periodic world / continuous-frame antimeridian data); Y
+        // clamped at the poles.
+        var x = (int)Math.Floor((centerX + Extent) / size);
         var y = Math.Clamp((int)Math.Floor((Extent - centerY) / size), 0, perAxis - 1);
         var key = new TileKey(band, x, y);
         if (seen.Add(key))

--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -67,6 +67,11 @@ collection / priority-clip / insert phase. Antimeridian (±180°) crossing **is*
 handled for the headless auto-fit: `SeamAwareBoundsAccumulator` (in
 `Rendering.Scene`) frames dateline-spanning datasets on their true extent and
 `WorldToScreen` wraps ops into the shifted window at draw time (issue #413).
+The seam-wrap is opt-out via `SkiaDisplayListRenderer.EnableSeamWrap` /
+`WorldToScreen.Create(viewport, allowSeamWrap)`: the Mapsui **tiled** subsystem
+disables it because it rasterises already-continuous geometry from narrow
+per-tile viewports, where wrapping would teleport off-tile vertices of large
+polygons back across the world (see the tiled renderer's `RasterizeTile`).
 
 ### Headless rendering & compositing (`…Renderers.Skia.Scene`)
 

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -295,13 +295,19 @@ public static class HeadlessVectorRenderer
             minX -= grow; maxX += grow;
         }
 
-        var (minLon, minLat) = WebMercator.ToLonLat(minX, minY);
-        var (maxLon, maxLat) = WebMercator.ToLonLat(maxX, maxY);
+        // Lossless (unclamped) inverse for the viewport corners so the renderer
+        // reproduces these exact world bounds (a pole-overhanging edge clamped
+        // to ±85° would drift geometry poleward). See WebMercator.ToLonLat.
+        var (minLon, minLat) = WebMercator.ToLonLat(minX, minY, clampLatitude: false);
+        var (maxLon, maxLat) = WebMercator.ToLonLat(maxX, maxY, clampLatitude: false);
 
         // Approximate scale denominator (used only if a caller re-enables
         // culling): mercator metres-per-pixel, corrected to ground metres by
         // cos(midLat), divided by the S-100 standard 0.00028 m/px screen pitch.
-        double midLatRad = (minLat + maxLat) * 0.5 * Math.PI / 180.0;
+        // Clamp the mid-latitude to the display limit so an overhanging edge
+        // cannot drive cos(midLat) to ~0 and blow up the denominator.
+        double midLat = Math.Clamp((minLat + maxLat) * 0.5, -WebMercator.MaxLatitude, WebMercator.MaxLatitude);
+        double midLatRad = midLat * Math.PI / 180.0;
         double groundMetresPerPixel = (maxX - minX) / widthPixels * Math.Cos(midLatRad);
         double denom = groundMetresPerPixel / ScaleVisibility.DenomToResolutionMetres;
 

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -43,6 +43,26 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
     public bool HonorScaleVisibility { get; set; } = true;
 
     /// <summary>
+    /// Whether to apply the antimeridian seam-wrap in <see cref="WorldToScreen"/>
+    /// (wrapping each op's world-X into the viewport's shifted longitude window
+    /// when <c>MaxLongitude &gt; 180</c> or <c>MinLongitude &lt; −180</c>).
+    /// Defaults to <see langword="true"/> so the headless single-viewport
+    /// auto-fit path (issue #413) can gather geometry across the ±180° seam.
+    /// <para>
+    /// The <b>tiled</b> subsystem sets this to <see langword="false"/>: it
+    /// rasterises each tile from a narrow per-tile viewport over geometry that is
+    /// already positioned in a <i>continuous</i> EPSG:3857 X frame (longitudes
+    /// may exceed +180° without wrapping). Under a per-tile window whose bounds
+    /// both lie east of +180°, the seam-wrap would teleport the far vertices of
+    /// large polygons that extend west of the tile back across the world,
+    /// smearing them across the tile. Disabling the wrap keeps continuous
+    /// geometry continuous; off-tile vertices simply project outside the tile
+    /// and are clipped.
+    /// </para>
+    /// </summary>
+    public bool EnableSeamWrap { get; set; } = true;
+
+    /// <summary>
     /// Process-wide cache of parsed symbol pictures keyed by the resolved SVG
     /// content (<see cref="ResolvedSymbol.ProcessedSvg"/>). Parsing an SVG into
     /// an <see cref="SKPicture"/> via <see cref="SKSvg.CreateFromSvg(string)"/>
@@ -283,7 +303,7 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
         ArgumentNullException.ThrowIfNull(viewport);
         ArgumentNullException.ThrowIfNull(options);
 
-        var transform = WorldToScreen.Create(viewport);
+        var transform = WorldToScreen.Create(viewport, EnableSeamWrap);
         double denom = viewport.ScaleDenominator;
 
         var cullBounds = options.PointCullBounds ?? new SKRect(

--- a/src/EncDotNet.S100.Rendering.Scene/WebMercator.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/WebMercator.cs
@@ -52,12 +52,45 @@ public static class WebMercator
     /// (x = easting, y = northing) back to a WGS-84 (longitude, latitude) pair
     /// in degrees. Latitude is clamped to ±<see cref="MaxLatitude"/>.
     /// </summary>
-    public static (double Longitude, double Latitude) ToLonLat(double x, double y)
+    public static (double Longitude, double Latitude) ToLonLat(double x, double y) =>
+        ToLonLat(x, y, clampLatitude: true);
+
+    /// <summary>
+    /// Inverse of <see cref="FromLonLat"/>: converts EPSG:3857 metres
+    /// (x = easting, y = northing) back to a WGS-84 (longitude, latitude) pair
+    /// in degrees.
+    /// </summary>
+    /// <param name="x">Easting in EPSG:3857 metres.</param>
+    /// <param name="y">Northing in EPSG:3857 metres.</param>
+    /// <param name="clampLatitude">
+    /// <see langword="true"/> to clamp latitude to ±<see cref="MaxLatitude"/>
+    /// (the practical Web-Mercator display limit). Pass <see langword="false"/>
+    /// when the result is only used to reconstruct the exact EPSG:3857 bounds
+    /// via <see cref="FromLonLat"/> — for example when building a render
+    /// viewport from world-metre bounds. Clamping there is <b>lossy</b>: a
+    /// viewport edge (or per-tile gutter) whose northing exceeds
+    /// ±<c>π·<see cref="EarthRadius"/></c> would be pulled back to the pole
+    /// limit, so the round-tripped span no longer matches the true world span
+    /// and the projected geometry drifts poleward, increasingly so with
+    /// latitude (seen when a high-latitude dataset such as the US NWS S-411
+    /// sea-ice product is zoomed out). Because a normal in-range viewport never
+    /// reaches the limit, disabling the clamp is a no-op except in that
+    /// overflow case, where it is the correct behaviour.
+    /// </param>
+    public static (double Longitude, double Latitude) ToLonLat(double x, double y, bool clampLatitude)
     {
         double longitude = x / EarthRadius * RadToDeg;
         double latitude = (2.0 * Math.Atan(Math.Exp(y / EarthRadius)) - Math.PI / 2.0) * RadToDeg;
-        if (double.IsNaN(latitude) || latitude < -MaxLatitude) latitude = -MaxLatitude;
-        else if (latitude > MaxLatitude) latitude = MaxLatitude;
+        if (double.IsNaN(latitude))
+        {
+            latitude = -MaxLatitude;
+        }
+        else if (clampLatitude)
+        {
+            if (latitude < -MaxLatitude) latitude = -MaxLatitude;
+            else if (latitude > MaxLatitude) latitude = MaxLatitude;
+        }
+
         return (longitude, latitude);
     }
 }

--- a/src/EncDotNet.S100.Rendering.Scene/WorldToScreen.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/WorldToScreen.cs
@@ -59,7 +59,26 @@ public readonly struct WorldToScreen
     /// </remarks>
     /// <param name="viewport">The display viewport (geographic bounds + pixel size).</param>
     /// <returns>The world → screen affine.</returns>
-    public static WorldToScreen Create(Viewport viewport)
+    public static WorldToScreen Create(Viewport viewport) => Create(viewport, allowSeamWrap: true);
+
+    /// <summary>
+    /// As <see cref="Create(Viewport)"/>, but with control over whether the
+    /// antimeridian seam-wrap is applied. When <paramref name="allowSeamWrap"/>
+    /// is <see langword="false"/>, world-X is never wrapped into the viewport's
+    /// longitude window even if the viewport is shifted across ±180°. The tiled
+    /// renderer passes <see langword="false"/> because it draws already-continuous
+    /// geometry from narrow per-tile viewports, where wrapping would smear
+    /// polygons that extend beyond a single tile (see the flag's remarks on the
+    /// tiled renderer).
+    /// </summary>
+    /// <param name="viewport">The display viewport (geographic bounds + pixel size).</param>
+    /// <param name="allowSeamWrap">
+    /// <see langword="true"/> to wrap world-X into a viewport shifted across the
+    /// ±180° seam (headless auto-fit); <see langword="false"/> to disable wrapping
+    /// (tiled continuous-X rasterisation).
+    /// </param>
+    /// <returns>The world → screen affine.</returns>
+    public static WorldToScreen Create(Viewport viewport, bool allowSeamWrap)
     {
         ArgumentNullException.ThrowIfNull(viewport);
 
@@ -70,9 +89,11 @@ public readonly struct WorldToScreen
         double spanY = maxY - minY;
         double scaleX = spanX != 0 ? viewport.WidthPixels / spanX : 0;
         double scaleY = spanY != 0 ? viewport.HeightPixels / spanY : 0;
-        bool wrapX = viewport.MaxLongitude > 180.0 || viewport.MinLongitude < -180.0;
+        bool wrapX = allowSeamWrap
+            && (viewport.MaxLongitude > 180.0 || viewport.MinLongitude < -180.0);
         return new WorldToScreen(minX, maxY, scaleX, scaleY, wrapX);
     }
+
 
     /// <summary>
     /// Projects an EPSG:3857 world coordinate to a screen pixel (origin top-left,

--- a/src/EncDotNet.S100.Viewer/BasemapLayerFactory.cs
+++ b/src/EncDotNet.S100.Viewer/BasemapLayerFactory.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using BruTile.Cache;
 using BruTile.Predefined;
+using EncDotNet.S100.Rendering.Scene;
 using EncDotNet.S100.Renderers.Skia.Scene;
+using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
 using Mapsui.Styles;
@@ -20,11 +22,47 @@ namespace EncDotNet.S100.Viewer;
 /// </summary>
 internal static class BasemapLayerFactory
 {
+    /// <summary>
+    /// Stable name for the basemap layer, in every mode. Used to identify and
+    /// live-replace it (it always sits at layer index 0, beneath the data).
+    /// </summary>
+    public const string LayerName = "Basemap";
+
     /// <summary>Land fill — a muted, parchment-like tone over the ENC water back-colour.</summary>
     private static readonly Color LandFill = new(
         NaturalEarthBasemap.LandFill.R,
         NaturalEarthBasemap.LandFill.G,
         NaturalEarthBasemap.LandFill.B);
+
+    /// <summary>
+    /// EPSG:3857 X offsets (metres) at which the offline land geometry is
+    /// repeated: the standard world (<c>0</c>) plus the immediately-adjacent
+    /// world copies one <see cref="WebMercator.Circumference"/> east and west.
+    /// A dataset kept in a continuous longitude frame that straddles the ±180°
+    /// antimeridian (e.g. the US NWS S-411 sea-ice product, ~175°E → ~225°E)
+    /// projects to world-X beyond ±180°; the ±1 copies put land beneath it
+    /// instead of leaving it to float over empty water.
+    /// </summary>
+    private static readonly double[] WorldCopyOffsetsX =
+    {
+        -WebMercator.Circumference,
+        0.0,
+        WebMercator.Circumference,
+    };
+
+    /// <summary>
+    /// The canonical single-world EPSG:3857 extent (a
+    /// <c>2·Extent × 2·Extent</c> square centred on the origin). The offline
+    /// basemap reports this as its <see cref="ILayer.Extent"/> even though its
+    /// features are repeated across adjacent world copies, so the world copies
+    /// do not inflate <see cref="Mapsui.Map.Extent"/> (which drives
+    /// "zoom to extent" and other auto-fit fallbacks).
+    /// </summary>
+    private static readonly MRect WorldExtent = new(
+        -WebMercator.Circumference / 2.0,
+        -WebMercator.Circumference / 2.0,
+        WebMercator.Circumference / 2.0,
+        WebMercator.Circumference / 2.0);
 
     /// <summary>
     /// Creates the basemap layer for <paramref name="mode"/>, or null for
@@ -41,6 +79,13 @@ internal static class BasemapLayerFactory
     {
         // Persist tiles so previously-viewed areas survive offline and
         // repeated launches; failures fall back to a network-only layer.
+        // NOTE: the OSM XYZ tile schema spans a single world ([-180°, +180°]),
+        // and Mapsui's tiling does not render horizontal world copies, so an
+        // antimeridian dataset in a continuous frame (see WorldCopyOffsetsX)
+        // has no online tiles beneath its portion east of +180°. Wrapping the
+        // tile source across world copies is a larger, separate change; the
+        // bundled offline basemap does provide world-copied land beneath such
+        // datasets.
         try
         {
             var cacheDir = Path.Combine(
@@ -49,7 +94,7 @@ internal static class BasemapLayerFactory
             var cache = new FileCache(cacheDir, "png");
             var source = KnownTileSources.Create(
                 KnownTileSource.OpenStreetMap, persistentCache: cache);
-            return new TileLayer(source) { Name = "Basemap" };
+            return new TileLayer(source) { Name = LayerName };
         }
         catch
         {
@@ -60,7 +105,7 @@ internal static class BasemapLayerFactory
     private static ILayer CreateOfflineLayer()
     {
         var features = LoadLandFeatures();
-        return new MemoryLayer("Basemap")
+        return new WorldCopiedLandLayer(LayerName)
         {
             Features = features,
             Style = new VectorStyle
@@ -72,42 +117,66 @@ internal static class BasemapLayerFactory
         };
     }
 
+    /// <summary>
+    /// A <see cref="MemoryLayer"/> whose land geometry is repeated across
+    /// adjacent world copies but which reports the canonical single-world
+    /// <see cref="WorldExtent"/>, so the extra copies never widen
+    /// <see cref="Mapsui.Map.Extent"/> and thus never blow "zoom to extent"
+    /// out to several worlds.
+    /// </summary>
+    private sealed class WorldCopiedLandLayer : MemoryLayer
+    {
+        public WorldCopiedLandLayer(string name) : base(name)
+        {
+        }
+
+        /// <inheritdoc />
+        public override MRect? Extent => WorldExtent;
+    }
+
     private static List<GeometryFeature> LoadLandFeatures()
     {
         // Reuse the shared headless loader so the viewer and the Mapsui-free
         // render path consume the same embedded Natural Earth asset and the
         // same projection (issue #411). The loader already projects rings to
         // EPSG:3857 metres — identical to Mapsui's SphericalMercator — so the
-        // world coordinates map straight onto NTS geometry.
+        // world coordinates map straight onto NTS geometry. Each polygon is
+        // emitted once per world copy (see WorldCopyOffsetsX) so continuous-
+        // frame antimeridian datasets have land beneath them; Mapsui culls
+        // features by envelope, so the off-screen copies cost only a bounds
+        // test per frame.
         var features = new List<GeometryFeature>();
-        foreach (var polygon in NaturalEarthBasemap.LandPolygons)
+        foreach (var offsetX in WorldCopyOffsetsX)
         {
-            var shell = ToLinearRing(polygon.WorldShell);
-            if (shell is null)
-                continue;
-
-            var holes = new List<LinearRing>(polygon.WorldHoles.Count);
-            foreach (var hole in polygon.WorldHoles)
+            foreach (var polygon in NaturalEarthBasemap.LandPolygons)
             {
-                var ring = ToLinearRing(hole);
-                if (ring is not null)
-                    holes.Add(ring);
-            }
+                var shell = ToLinearRing(polygon.WorldShell, offsetX);
+                if (shell is null)
+                    continue;
 
-            features.Add(new GeometryFeature(new Polygon(shell, holes.ToArray())));
+                var holes = new List<LinearRing>(polygon.WorldHoles.Count);
+                foreach (var hole in polygon.WorldHoles)
+                {
+                    var ring = ToLinearRing(hole, offsetX);
+                    if (ring is not null)
+                        holes.Add(ring);
+                }
+
+                features.Add(new GeometryFeature(new Polygon(shell, holes.ToArray())));
+            }
         }
 
         return features;
     }
 
-    private static LinearRing? ToLinearRing(IReadOnlyList<(double X, double Y)> world)
+    private static LinearRing? ToLinearRing(IReadOnlyList<(double X, double Y)> world, double offsetX)
     {
         if (world.Count < 4)
             return null;
 
         var coordinates = new Coordinate[world.Count];
         for (int i = 0; i < world.Count; i++)
-            coordinates[i] = new Coordinate(world[i].X, world[i].Y);
+            coordinates[i] = new Coordinate(world[i].X + offsetX, world[i].Y);
         return new LinearRing(coordinates);
     }
 }

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -326,6 +326,12 @@ public partial class MainWindow : ShadUI.Window
             App.Services.GetRequiredService<
                 EncDotNet.S100.Viewer.Services.MapViewportNotifier>()
                 .Bind(notifierNav);
+
+            // Clamp zoom in/out so the user cannot zoom to an unbounded,
+            // meaningless scale (e.g. many world copies off the edge of a
+            // cross-antimeridian dataset, or arbitrarily deep past chart
+            // resolution).
+            MapZoomLimits.Apply(notifierNav);
         }
 
         // PR-D2: dynamic-source overlay host. Registered *after* the

--- a/src/EncDotNet.S100.Viewer/MapScaleFormatter.cs
+++ b/src/EncDotNet.S100.Viewer/MapScaleFormatter.cs
@@ -18,7 +18,7 @@ internal static class MapScaleFormatter
 
     // OGC standardized rendering pixel size (0.28 mm), the conventional basis
     // for converting ground-meters-per-pixel into a 1:N map-scale denominator.
-    private const double PixelSizeMeters = 0.00028;
+    internal const double PixelSizeMeters = 0.00028;
 
     /// <summary>
     /// Formats the scale denominator for the given EPSG:3857 viewport.

--- a/src/EncDotNet.S100.Viewer/MapZoomLimits.cs
+++ b/src/EncDotNet.S100.Viewer/MapZoomLimits.cs
@@ -1,0 +1,63 @@
+using System;
+using Mapsui;
+
+namespace EncDotNet.S100.Viewer;
+
+/// <summary>
+/// Clamps how far the map can be zoomed in and out so the user cannot
+/// zoom to an unbounded, meaningless scale (e.g. hundreds of world copies
+/// off the edge of a cross-antimeridian dataset, or arbitrarily deep past
+/// the resolution of any chart data).
+/// </summary>
+/// <remarks>
+/// The bounds are expressed as representative 1:N map-scale denominators
+/// and converted to EPSG:3857 (web-mercator) resolution — metres per
+/// pixel — using the same OGC standardized rendering pixel size
+/// (0.28&#160;mm) as <see cref="MapScaleFormatter"/>. The conversion uses
+/// the equatorial approximation (no latitude correction) because Mapsui's
+/// zoom bounds are latitude-independent; the on-screen scale readout will
+/// therefore differ slightly from these nominal denominators at high
+/// latitude, which is acceptable for a coarse zoom guard.
+/// </remarks>
+internal static class MapZoomLimits
+{
+    /// <summary>
+    /// Coarsest permitted scale denominator (zoom-out floor). At this scale
+    /// roughly one world is visible, which is as far out as any chart view
+    /// is useful.
+    /// </summary>
+    public const double MaxScaleDenominator = 500_000_000.0;
+
+    /// <summary>
+    /// Finest permitted scale denominator (zoom-in ceiling). 1:1&#160;000 is
+    /// about the largest compilation scale used by S-100 chart data
+    /// (berthing/harbour detail); zooming closer only magnifies pixels.
+    /// </summary>
+    public const double MinScaleDenominator = 1_000.0;
+
+    /// <summary>
+    /// Converts a 1:N map-scale denominator to an EPSG:3857 resolution
+    /// (metres per pixel) at the equator.
+    /// </summary>
+    /// <param name="scaleDenominator">The scale denominator (the N in 1:N).</param>
+    /// <returns>The equatorial web-mercator resolution in metres per pixel.</returns>
+    public static double ResolutionForScale(double scaleDenominator) =>
+        scaleDenominator * MapScaleFormatter.PixelSizeMeters;
+
+    /// <summary>
+    /// Applies the zoom-in and zoom-out limits to the given navigator so all
+    /// zoom operations (wheel, pinch, buttons, zoom-to-box) are clamped.
+    /// </summary>
+    /// <param name="navigator">The map navigator to constrain.</param>
+    public static void Apply(Navigator navigator)
+    {
+        ArgumentNullException.ThrowIfNull(navigator);
+
+        var minResolution = ResolutionForScale(MinScaleDenominator);
+        var maxResolution = ResolutionForScale(MaxScaleDenominator);
+
+        // MMinMax orders its two arguments into Min (finest resolution /
+        // deepest zoom-in) and Max (coarsest resolution / farthest zoom-out).
+        navigator.OverrideZoomBounds = new MMinMax(minResolution, maxResolution);
+    }
+}

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -740,6 +740,18 @@ map to Online/None. Use None or Offline for offline operation, or for
 performance runs that want to measure only dataset rendering without
 basemap tile fetch / raster activity (issue #295).
 
+The **Offline** basemap repeats its Natural Earth land across the
+immediately-adjacent world copies (one circumference east and west), so
+a dataset kept in a continuous longitude frame across the ±180°
+antimeridian — e.g. the US NWS S-411 sea-ice product (~175°E → ~225°E) —
+has land beneath it instead of floating over empty water. The layer
+still reports a single-world extent, so "zoom to extent" is unaffected.
+The **Online** OpenStreetMap tiles are *not* world-copied (the XYZ tile
+schema spans one world and Mapsui's tiling does not wrap), so such a
+dataset shows no online tiles beneath the portion east of +180°; use the
+Offline basemap for antimeridian datasets. Wrapping the online tile
+source is a possible future enhancement.
+
 **Own-ship.** `--own-ship-pos <LAT,LON>` places the simulated
 own-ship at a WGS-84 position, `--own-ship-cog <DEG>` sets its course
 over ground (degrees true `[0, 360)`), and `--own-ship-sog <MS>` sets

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileGridTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileGridTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Rendering.Scene;
 using Xunit;
 
 namespace EncDotNet.S100.Pipelines.Tests;
@@ -110,18 +111,68 @@ public class TileGridTests
     }
 
     [Fact]
-    public void VisibleTiles_NeverEmitsOutOfRangeKeysAtWorldEdge()
+    public void VisibleTiles_ClampsYButNotXAtWorldEdge()
     {
-        // Viewport hard against the north-west corner; indices must clamp to 0.
+        // Viewport hard against the north-west corner. The Y (latitude) index is
+        // clamped at the pole, but the X (longitude) index is intentionally NOT
+        // clamped: EPSG:3857 is periodic east-west, so a viewport overhanging the
+        // west edge legitimately yields negative columns (their TileWorldBounds
+        // map to the continuous world position west of -Extent). The origin tile
+        // must still be emitted.
         var band = 3;
+        var perAxis = TileGrid.TilesPerAxis(band);
         var res = TileGrid.ResolutionForBand(band);
         var tiles = TileGrid.VisibleTiles(-TileGrid.Extent, TileGrid.Extent, 512, 512, res, band);
-        Assert.All(tiles, t =>
-        {
-            Assert.InRange(t.X, 0, TileGrid.TilesPerAxis(band) - 1);
-            Assert.InRange(t.Y, 0, TileGrid.TilesPerAxis(band) - 1);
-        });
+        Assert.All(tiles, t => Assert.InRange(t.Y, 0, perAxis - 1));
         Assert.Contains(new TileKey(band, 0, 0), tiles);
+        // The overhang past the west edge produces at least one negative column.
+        Assert.Contains(tiles, t => t.X < 0);
+    }
+
+    [Fact]
+    public void VisibleTiles_ContinuousAntimeridianFrame_EmitsColumnsBeyondWorld()
+    {
+        // Regression for the viewer's tiled subsystem drawing a thin ±180° sliver
+        // for antimeridian datasets kept in a continuous longitude frame (the US
+        // NWS S-411 sea-ice product, ~175°E → ~225°E). Geometry east of +180°
+        // projects to world-X beyond +Extent; the tile enumeration must emit the
+        // columns at index >= perAxis that cover it (not clamp them into the
+        // boundary column), and TileWorldBounds must map those columns back to the
+        // correct continuous world position.
+        var band = 6;
+        var perAxis = TileGrid.TilesPerAxis(band);
+        var res = TileGrid.ResolutionForBand(band);
+
+        // Centre the viewport at ~lon 200° (continuous, east of +180°).
+        var (centerX, _) = WebMercator.FromLonLat(200.0, 72.0);
+        Assert.True(centerX > TileGrid.Extent, "sanity: lon 200° projects east of +Extent");
+
+        var tiles = TileGrid.VisibleTiles(centerX, 0, 512, 512, res, band);
+        Assert.NotEmpty(tiles);
+        // At least one column lies beyond the standard world (index >= perAxis).
+        Assert.Contains(tiles, t => t.X >= perAxis);
+        // Every emitted column maps to a continuous world position east of the
+        // boundary — none is collapsed back to the ±180° edge column.
+        var eastTile = tiles.First(t => t.X >= perAxis);
+        var bounds = TileGrid.TileWorldBounds(eastTile);
+        Assert.True(bounds.MinX >= TileGrid.Extent,
+            $"east tile world MinX {bounds.MinX} should be >= +Extent {TileGrid.Extent}");
+        // The whole selection spans no more than one world (the X span is capped).
+        var span = tiles.Max(t => t.X) - tiles.Min(t => t.X) + 1;
+        Assert.True(span <= perAxis, $"X span {span} exceeds one world ({perAxis})");
+    }
+
+    [Fact]
+    public void VisibleTileRange_CapsXSpanToOneWorldOnExtremeZoomOut()
+    {
+        // A whole-world-wide viewport at band 0 (perAxis == 1) must not enumerate
+        // repeated columns: the span cap keeps it to a single column, matching the
+        // pre-existing single-world behaviour for normal (non-antimeridian) data.
+        var band = 0;
+        var perAxis = TileGrid.TilesPerAxis(band);
+        var res = TileGrid.ResolutionForBand(band);
+        var range = TileGrid.VisibleTileRange(0, 0, 4096, 4096, res, band);
+        Assert.Equal(perAxis, range.XEnd - range.XStart + 1);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileGridTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileGridTests.cs
@@ -157,22 +157,43 @@ public class TileGridTests
         var bounds = TileGrid.TileWorldBounds(eastTile);
         Assert.True(bounds.MinX >= TileGrid.Extent,
             $"east tile world MinX {bounds.MinX} should be >= +Extent {TileGrid.Extent}");
-        // The whole selection spans no more than one world (the X span is capped).
+        // The data is drawn once at its true continuous position (no world-copy
+        // duplication like the basemap), so a normal (screenful) viewport emits a
+        // single contiguous run of columns — no repeated world copy.
         var span = tiles.Max(t => t.X) - tiles.Min(t => t.X) + 1;
-        Assert.True(span <= perAxis, $"X span {span} exceeds one world ({perAxis})");
+        var distinctColumns = tiles.Select(t => t.X).Distinct().Count();
+        Assert.Equal(span, distinctColumns);
     }
 
     [Fact]
-    public void VisibleTileRange_CapsXSpanToOneWorldOnExtremeZoomOut()
+    public void VisibleTileRange_EnumeratesEveryVisibleColumn_NoOneWorldCap()
     {
-        // A whole-world-wide viewport at band 0 (perAxis == 1) must not enumerate
-        // repeated columns: the span cap keeps it to a single column, matching the
-        // pre-existing single-world behaviour for normal (non-antimeridian) data.
+        // Option B: chart data is drawn exactly once at its true continuous
+        // EPSG:3857 position (it is not world-copied like the basemap), so a wide
+        // multi-world viewport must enumerate every visible column instead of
+        // collapsing to a single world. Otherwise antimeridian data would pop
+        // between world-copies as the pan crossed a world boundary. A band-0
+        // (perAxis == 1) viewport several worlds wide therefore yields several
+        // columns, not one.
         var band = 0;
         var perAxis = TileGrid.TilesPerAxis(band);
         var res = TileGrid.ResolutionForBand(band);
         var range = TileGrid.VisibleTileRange(0, 0, 4096, 4096, res, band);
-        Assert.Equal(perAxis, range.XEnd - range.XStart + 1);
+        var span = range.XEnd - range.XStart + 1;
+        Assert.True(span > perAxis, $"expected multiple world columns, got span {span} (perAxis {perAxis})");
+    }
+
+    [Fact]
+    public void VisibleTileRange_GuardBoundsPathologicalZoomOut()
+    {
+        // The one-world cap is gone, but a generous absolute guard still bounds a
+        // pathological viewport so tile enumeration cannot allocate unbounded
+        // columns. The guard is far beyond any realistic viewport.
+        var band = 0;
+        var res = TileGrid.ResolutionForBand(band);
+        var range = TileGrid.VisibleTileRange(0, 0, 1_000_000_000, 4096, res, band);
+        var span = range.XEnd - range.XStart + 1;
+        Assert.True(span <= 4096, $"span {span} should be bounded by the absolute guard (4096)");
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Pipelines.Tests/TilePredictionTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TilePredictionTests.cs
@@ -145,9 +145,14 @@ public class TilePredictionTests
     }
 
     [Fact]
-    public void PredictedTiles_NeverEmitsOutOfRangeKeys()
+    public void PredictedTiles_ClampsYButNotXAtWorldCorner()
     {
         // Viewport hard against the world corner with a fan pointing off-world.
+        // The Y (latitude) index is clamped at the poles, but the X (longitude)
+        // index is intentionally NOT clamped: EPSG:3857 is periodic east-west and
+        // continuous-frame antimeridian data (and a fan pointing past the seam)
+        // legitimately produces columns outside [0, perAxis-1]. See
+        // TileGrid.VisibleTileRange for the rationale.
         var band = 4;
         var res = TileGrid.ResolutionForBand(band);
         var size = TileGrid.TileWorldSize(band);
@@ -157,7 +162,6 @@ public class TilePredictionTests
         Assert.All(predicted, k =>
         {
             var perAxis = TileGrid.TilesPerAxis(k.Band);
-            Assert.InRange(k.X, 0, perAxis - 1);
             Assert.InRange(k.Y, 0, perAxis - 1);
         });
     }

--- a/tests/EncDotNet.S100.Rendering.Scene.Tests/WebMercatorTests.cs
+++ b/tests/EncDotNet.S100.Rendering.Scene.Tests/WebMercatorTests.cs
@@ -1,0 +1,65 @@
+using EncDotNet.S100.Rendering.Scene;
+
+namespace EncDotNet.S100.Rendering.Scene.Tests;
+
+/// <summary>
+/// Tests for <see cref="WebMercator"/>, focused on the clamped vs. lossless
+/// inverse used when reconstructing a render viewport from EPSG:3857 world
+/// bounds. The lossless (<c>clampLatitude: false</c>) inverse must round-trip
+/// exactly through <see cref="WebMercator.FromLonLat"/> even for a northing
+/// beyond the ±85.05° pole limit; the clamped inverse must not, and the two
+/// must agree for any in-range northing. Regression cover for the high-latitude
+/// zoomed-out drift (US NWS S-411 sea-ice product) where clamping the viewport
+/// edge pulled geometry poleward off its labels.
+/// </summary>
+public sealed class WebMercatorTests
+{
+    private const double PoleExtent = System.Math.PI * WebMercator.EarthRadius;
+
+    [Fact]
+    public void ToLonLat_Unclamped_RoundTripsBeyondPoleExactly()
+    {
+        // A northing well beyond the pole limit (as produced by a zoomed-out
+        // viewport edge or a top-row tile gutter at high latitude).
+        double y = PoleExtent * 1.25;
+
+        var (_, lat) = WebMercator.ToLonLat(0, y, clampLatitude: false);
+        var (_, back) = WebMercator.FromLonLat(0, lat);
+
+        Assert.True(lat > WebMercator.MaxLatitude, $"expected lat beyond pole limit, got {lat}");
+        Assert.Equal(y, back, 3); // exact round-trip to the millimetre
+    }
+
+    [Fact]
+    public void ToLonLat_Clamped_DoesNotRoundTripBeyondPole()
+    {
+        double y = PoleExtent * 1.25;
+
+        var (_, lat) = WebMercator.ToLonLat(0, y, clampLatitude: true);
+        var (_, back) = WebMercator.FromLonLat(0, lat);
+
+        Assert.Equal(WebMercator.MaxLatitude, lat, 6);
+        // The clamp collapses the northing back to the pole extent, losing the
+        // overhang — this is exactly why viewport construction must not clamp.
+        Assert.Equal(PoleExtent, back, 0);
+        Assert.True(back < y);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(1_000_000.0)]
+    [InlineData(9_970_000.0)]   // ~66°N (S-411 south edge)
+    [InlineData(15_500_000.0)]  // ~80°N (S-411 north edge)
+    [InlineData(-15_500_000.0)]
+    public void ToLonLat_ClampedAndUnclamped_AgreeInRange(double y)
+    {
+        // For any northing inside the pole limit the clamp never triggers, so
+        // the two inverses are identical — the lossless variant is a no-op
+        // except in the overflow case.
+        var clamped = WebMercator.ToLonLat(0, y, clampLatitude: true);
+        var unclamped = WebMercator.ToLonLat(0, y, clampLatitude: false);
+
+        Assert.Equal(clamped.Latitude, unclamped.Latitude, 9);
+        Assert.Equal(clamped.Longitude, unclamped.Longitude, 9);
+    }
+}

--- a/tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenSeamWrapTests.cs
+++ b/tests/EncDotNet.S100.Rendering.Scene.Tests/WorldToScreenSeamWrapTests.cs
@@ -74,4 +74,41 @@ public sealed class WorldToScreenSeamWrapTests
 
         Assert.True(x < 0f, "A feature west of a normal viewport must stay off the left edge.");
     }
+
+    [Fact]
+    public void Shifted_viewport_with_wrap_disabled_does_not_teleport_far_ops()
+    {
+        // The tiled renderer disables the wrap (allowSeamWrap: false) because it
+        // draws already-continuous geometry from narrow per-tile viewports. Under
+        // a shifted window an op west of the viewport must project to a negative
+        // pixel X — NOT be wrapped +circumference to the right edge (which is what
+        // smeared large polygons across eastern tiles before the fix).
+        var transform = WorldToScreen.Create(ShiftedViewport(), allowSeamWrap: false);
+
+        // A feature at −135° has a large negative raw world-X. With the wrap on it
+        // would land at the right edge (see Op_west_of_seam_wraps_into_the_shifted_window);
+        // with the wrap off it must stay far off-screen left.
+        var world = WebMercator.FromLonLat(-135.0, 66.0);
+        var (x, _) = transform.Project(world);
+
+        Assert.True(x < 0f, "With wrap disabled, a far-west op must not be teleported into the window.");
+    }
+
+    [Fact]
+    public void Wrap_disabled_matches_wrap_enabled_for_in_window_ops()
+    {
+        // Disabling the wrap must not disturb ops already inside the shifted
+        // window (the common case for a per-tile viewport): both forms project
+        // them identically.
+        var vp = ShiftedViewport();
+        var wrapOn = WorldToScreen.Create(vp, allowSeamWrap: true);
+        var wrapOff = WorldToScreen.Create(vp, allowSeamWrap: false);
+
+        var world = WebMercator.FromLonLat(200.0, 66.0); // continuous, inside [175,225]
+        var (xOn, yOn) = wrapOn.Project(world);
+        var (xOff, yOff) = wrapOff.Project(world);
+
+        Assert.Equal(xOn, xOff, 3);
+        Assert.Equal(yOn, yOff, 3);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/BasemapLayerFactoryTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/BasemapLayerFactoryTests.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Linq;
+using EncDotNet.S100.Rendering.Scene;
 using EncDotNet.S100.Viewer;
 using Mapsui.Layers;
+using Mapsui.Nts;
 using Xunit;
 
 namespace EncDotNet.S100.Viewer.Tests;
@@ -7,10 +11,16 @@ namespace EncDotNet.S100.Viewer.Tests;
 /// <summary>
 /// Issue #295: the basemap factory builds the bundled offline Natural
 /// Earth land layer, returns nothing for <see cref="BasemapMode.None"/>,
-/// and an online tile layer for <see cref="BasemapMode.Online"/>.
+/// and an online tile layer for <see cref="BasemapMode.Online"/>. The
+/// offline layer additionally repeats its land across adjacent world
+/// copies so datasets kept in a continuous longitude frame across the
+/// ±180° antimeridian (e.g. the US NWS S-411 sea-ice product) have land
+/// beneath them.
 /// </summary>
 public class BasemapLayerFactoryTests
 {
+    private const double Extent = WebMercator.Circumference / 2.0;
+
     [Fact]
     public void None_ReturnsNull()
     {
@@ -22,8 +32,49 @@ public class BasemapLayerFactoryTests
     {
         var layer = BasemapLayerFactory.Create(BasemapMode.Offline);
 
-        var memory = Assert.IsType<MemoryLayer>(layer);
+        var memory = Assert.IsAssignableFrom<MemoryLayer>(layer);
         Assert.NotEmpty(memory.Features);
+    }
+
+    [Fact]
+    public void Offline_RepeatsLandAcrossAdjacentWorldCopies()
+    {
+        var layer = Assert.IsAssignableFrom<MemoryLayer>(
+            BasemapLayerFactory.Create(BasemapMode.Offline));
+
+        double minX = double.MaxValue;
+        double maxX = double.MinValue;
+        foreach (var feature in layer.Features.OfType<GeometryFeature>())
+        {
+            if (feature.Geometry is null)
+                continue;
+
+            var env = feature.Geometry.EnvelopeInternal;
+            minX = Math.Min(minX, env.MinX);
+            maxX = Math.Max(maxX, env.MaxX);
+        }
+
+        // The eastern (+1) copy must reach beyond +180° so continuous-frame
+        // S-411 ice east of the antimeridian has land under it; the western
+        // (-1) copy likewise reaches below -180°.
+        Assert.True(maxX > Extent, $"expected land east of +Extent, got maxX={maxX}");
+        Assert.True(minX < -Extent, $"expected land west of -Extent, got minX={minX}");
+    }
+
+    [Fact]
+    public void Offline_ReportsBoundedSingleWorldExtent()
+    {
+        var extent = Assert.IsAssignableFrom<MemoryLayer>(
+            BasemapLayerFactory.Create(BasemapMode.Offline)).Extent;
+
+        // Even though the geometry spans world copies, the layer must report
+        // only the canonical single world so the copies never inflate
+        // Map.Extent (which drives "zoom to extent").
+        Assert.NotNull(extent);
+        Assert.Equal(-Extent, extent!.MinX, 3);
+        Assert.Equal(-Extent, extent.MinY, 3);
+        Assert.Equal(Extent, extent.MaxX, 3);
+        Assert.Equal(Extent, extent.MaxY, 3);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Viewer.Tests/MapZoomLimitsTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/MapZoomLimitsTests.cs
@@ -1,0 +1,90 @@
+using EncDotNet.S100.Viewer;
+using Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class MapZoomLimitsTests
+{
+    [Fact]
+    public void ResolutionForScale_UsesEquatorialPixelSize()
+    {
+        // 1:500,000,000 * 0.00028 m/px = 140,000 m/px at the equator.
+        Assert.Equal(140_000.0, MapZoomLimits.ResolutionForScale(500_000_000.0), 6);
+        // 1:1,000 * 0.00028 = 0.28 m/px.
+        Assert.Equal(0.28, MapZoomLimits.ResolutionForScale(1_000.0), 9);
+    }
+
+    [Fact]
+    public void MinScaleIsFinerThanMaxScale()
+    {
+        Assert.True(MapZoomLimits.MinScaleDenominator < MapZoomLimits.MaxScaleDenominator);
+    }
+
+    [Fact]
+    public void Apply_SetsOverrideZoomBoundsFromScaleDenominators()
+    {
+        var navigator = new Navigator();
+
+        MapZoomLimits.Apply(navigator);
+
+        var bounds = navigator.OverrideZoomBounds;
+        Assert.NotNull(bounds);
+
+        var expectedMin = MapZoomLimits.ResolutionForScale(MapZoomLimits.MinScaleDenominator);
+        var expectedMax = MapZoomLimits.ResolutionForScale(MapZoomLimits.MaxScaleDenominator);
+
+        // MMinMax orders arguments: Min = finest resolution, Max = coarsest.
+        Assert.Equal(expectedMin, bounds!.Min, 9);
+        Assert.Equal(expectedMax, bounds.Max, 6);
+    }
+
+    [Fact]
+    public void Apply_ClampsZoomOutToMaxScale()
+    {
+        var navigator = new Navigator();
+        navigator.SetSize(800, 600);
+        MapZoomLimits.Apply(navigator);
+
+        // Exercise the same limiter path SetViewportWithLimit uses when the
+        // user zooms. Ask for a resolution far past the zoom-out floor.
+        var requested = navigator.Viewport with { Resolution = 10_000_000.0 };
+        var limited = navigator.Limiter.Limit(requested, navigator.PanBounds, navigator.ZoomBounds);
+
+        var maxResolution = MapZoomLimits.ResolutionForScale(MapZoomLimits.MaxScaleDenominator);
+        Assert.Equal(maxResolution, limited.Resolution, 6);
+    }
+
+    [Fact]
+    public void Apply_ClampsZoomInToMinScale()
+    {
+        var navigator = new Navigator();
+        navigator.SetSize(800, 600);
+        MapZoomLimits.Apply(navigator);
+
+        // Ask for a resolution far past the zoom-in ceiling.
+        var requested = navigator.Viewport with { Resolution = 0.0001 };
+        var limited = navigator.Limiter.Limit(requested, navigator.PanBounds, navigator.ZoomBounds);
+
+        var minResolution = MapZoomLimits.ResolutionForScale(MapZoomLimits.MinScaleDenominator);
+        Assert.Equal(minResolution, limited.Resolution, 9);
+    }
+
+    [Fact]
+    public void Apply_DoesNotConstrainPanning()
+    {
+        // The cross-antimeridian fix relies on being able to pan far beyond
+        // one world (into continuous EPSG:3857 space). Applying zoom limits
+        // must not introduce pan bounds that would clip that.
+        var navigator = new Navigator();
+        navigator.SetSize(800, 600);
+        MapZoomLimits.Apply(navigator);
+
+        Assert.Null(navigator.PanBounds);
+
+        var requested = navigator.Viewport with { CenterX = 30_000_000.0, Resolution = 1_000.0 };
+        var limited = navigator.Limiter.Limit(requested, navigator.PanBounds, navigator.ZoomBounds);
+
+        Assert.Equal(30_000_000.0, limited.CenterX, 3);
+    }
+}


### PR DESCRIPTION
## Summary

Cross-antimeridian, high-latitude datasets (e.g. the Alaska NWS S-411 sea ice grid, encoded in a continuous longitude frame that runs past +180 into 66-80N) rendered incorrectly in the viewer: features were duplicated across every visible world copy, labels slid off their features when panning/zooming, and geometry drifted poleward at low zoom. The CLI image renderer had already been fixed; this brings the interactive viewer to parity.

The fix renders the chart features exactly once at their true continuous EPSG:3857 position and tiles the offline basemap beneath them to fill the space that would otherwise be empty across the seam.

## Approach

- **Tile enumeration (`TileGrid.VisibleTileRange`):** removed the one-world column cap that re-centered the enumerated world and caused features to jump between world copies while panning. It now enumerates every visible column, left-edge-anchored, with a generous absolute guard so panning slides smoothly. Empty world-copy columns produce empty base queries, so nothing is duplicated.
- **Seam wrap:** disabled `EnableSeamWrap` on the tiled overlay and the single-surface scene renderer. The base tiles carry already-continuous geometry, so wrapping the overlay would slide symbols/labels off their features. With it off, the overlay stays locked to the base's continuous frame.
- **Poleward drift:** unclamped-latitude web-mercator conversion (from the earlier commit) keeps geometry and labels aligned at high latitude.
- **Basemap:** world-copies the offline basemap so the wrapped region under the data is filled rather than blank.
- **Zoom limits (`MapZoomLimits`, new):** clamps zoom-out (nominal 1:500,000,000) and zoom-in (nominal 1:1,000) via `Navigator.OverrideZoomBounds`, so the user can no longer zoom to an unbounded, meaningless scale. Bounds are equatorial web-mercator resolutions and deliberately leave `PanBounds` unset, so cross-meridian panning into continuous space is unaffected. `MapScaleFormatter.PixelSizeMeters` is now `internal` so the limits and the scale readout share one pixel-size constant.

## Non-obvious notes for reviewers

- The displayed scale at the zoom limits will read differently from the nominal denominators (e.g. ~1:350 and ~1:43M for this dataset) because the status-bar scale applies a `cos(latitude)` web-mercator correction while the zoom bounds are equatorial. At ~70N, `cos` is ~0.34, which accounts for the difference. Making the displayed number latitude-exact would require recomputing bounds on every pan for no real benefit, so the bounds stay nominal-equatorial. This is documented in the `MapZoomLimits` remarks.
- During development the viewer appeared to still show many feature copies; this turned out to be stale disk-cached tiles baked by earlier buggy dev builds. `RasterizeTile(key)` produces identical pixels between base and this branch (only tile enumeration changed), so no tile-cache `FormatVersion` bump is warranted; released users never ran the intermediate builds.

## Spec alignment

- [x] N/A - change is purely infrastructural (viewer/renderer behaviour; no spec semantics changed)

**Spec section references cited in code/docs:** N/A

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New/updated coverage: `MapZoomLimitsTests` (resolution math, bound ordering, both clamps via the limiter path, no pan constraint), `TileGridTests` (no one-world cap, pathological zoom-out guard, contiguous antimeridian columns), `WebMercatorTests`, and `WorldToScreenSeamWrapTests`. Pipelines 856 passed / 1 skipped; Viewer 1385 passed / 3 skipped.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (Renderers.Mapsui, Renderers.Skia, Viewer)
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (none added)

## Breaking changes

None.