### PR TITLE
Fix S-411 exchange set folder failing to load on drag/drop

### DIFF
--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -53,20 +53,36 @@ public static class ExchangeCatalogueReader
             Comment = ReadCharacterString(root.Element(xc + "exchangeCatalogueComment")),
             DataServerIdentifier = (string?)root.Element(xc + "dataServerIdentifier"),
             Certificates = ReadCertificateBlock(root.Element(xc + "certificates")),
-            DatasetDiscoveryMetadata = root
-                .Element(xc + "datasetDiscoveryMetadata")?
-                .Elements()
-                .Where(e => e.Name.LocalName.EndsWith("_DatasetDiscoveryMetadata", StringComparison.Ordinal))
+            DatasetDiscoveryMetadata = CollectDiscoveryRecords(
+                    root, xc, "datasetDiscoveryMetadata", "_DatasetDiscoveryMetadata")
                 .Select(e => ReadDatasetDiscovery(e, xc, lan))
-                .ToList() ?? [],
+                .ToList(),
             SupportFileDiscoveryMetadata = ReadSupportFileDiscoveries(root, xc),
-            CatalogueDiscoveryMetadata = root
-                .Element(xc + "catalogueDiscoveryMetadata")?
-                .Elements()
-                .Where(e => e.Name.LocalName.EndsWith("_CatalogueDiscoveryMetadata", StringComparison.Ordinal))
+            CatalogueDiscoveryMetadata = CollectDiscoveryRecords(
+                    root, xc, "catalogueDiscoveryMetadata", "_CatalogueDiscoveryMetadata")
                 .Select(e => ReadCatalogueDiscovery(e, xc, lan))
-                .ToList() ?? [],
+                .ToList(),
         };
+    }
+
+    /// <summary>
+    /// Collects typed discovery records (e.g. <c>S100_DatasetDiscoveryMetadata</c>)
+    /// from a catalogue, tolerating both layouts seen in the wild. Modern
+    /// S-100 (Edition 5.x, Part 17) nests the records inside a wrapper
+    /// element (e.g. <c>datasetDiscoveryMetadata</c>); the legacy
+    /// <c>S100EC</c> schema used by some products — notably JCOMM/IHO
+    /// S-411 — places the same <c>*_DatasetDiscoveryMetadata</c> records
+    /// directly under the catalogue root with no wrapper. When the wrapper
+    /// is present its children are used; otherwise the root is scanned
+    /// directly.
+    /// </summary>
+    private static IEnumerable<XElement> CollectDiscoveryRecords(
+        XElement root, XNamespace xc, string wrapperName, string suffix)
+    {
+        var wrapper = root.Element(xc + wrapperName);
+        var candidates = wrapper?.Elements() ?? root.Elements();
+        return candidates.Where(
+            e => e.Name.LocalName.EndsWith(suffix, StringComparison.Ordinal));
     }
 
     private static ExchangeCatalogueContact? ReadContact(XElement? element, XNamespace xc)

--- a/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
+++ b/src/EncDotNet.S100.ExchangeSets/ExchangeCatalogueReader.cs
@@ -73,16 +73,29 @@ public static class ExchangeCatalogueReader
     /// <c>S100EC</c> schema used by some products — notably JCOMM/IHO
     /// S-411 — places the same <c>*_DatasetDiscoveryMetadata</c> records
     /// directly under the catalogue root with no wrapper. When the wrapper
-    /// is present its children are used; otherwise the root is scanned
-    /// directly.
+    /// contains typed records its children are used; otherwise the root is
+    /// scanned directly.
     /// </summary>
     private static IEnumerable<XElement> CollectDiscoveryRecords(
         XElement root, XNamespace xc, string wrapperName, string suffix)
     {
         var wrapper = root.Element(xc + wrapperName);
-        var candidates = wrapper?.Elements() ?? root.Elements();
-        return candidates.Where(
-            e => e.Name.LocalName.EndsWith(suffix, StringComparison.Ordinal));
+        if (wrapper is not null)
+        {
+            var wrappedMatches = wrapper
+                .Elements()
+                .Where(e => e.Name.LocalName.EndsWith(suffix, StringComparison.Ordinal))
+                .ToList();
+
+            if (wrappedMatches.Count > 0)
+            {
+                return wrappedMatches;
+            }
+        }
+
+        return root
+            .Elements()
+            .Where(e => e.Name.LocalName.EndsWith(suffix, StringComparison.Ordinal));
     }
 
     private static ExchangeCatalogueContact? ReadContact(XElement? element, XNamespace xc)

--- a/src/EncDotNet.S100.ExchangeSets/README.md
+++ b/src/EncDotNet.S100.ExchangeSets/README.md
@@ -39,6 +39,17 @@ are wrapped in product-specific elements and namespaces
 (e.g. `S102_DatasetDiscoveryMetadata` in `http://www.iho.int/s102/2.0/xc`),
 not just the generic `S100_DatasetDiscoveryMetadata`.
 
+### Legacy `S100EC` catalogue layout
+
+Modern S-100 (Edition 5.x, Part 17) nests discovery records inside a
+wrapper element such as `<datasetDiscoveryMetadata>`. Some products —
+notably JCOMM/IHO **S-411** sample sets (namespace
+`http://www.iho.int/S100EC`) — instead place the
+`S100_DatasetDiscoveryMetadata` records **directly under the catalogue
+root** with no wrapper. The reader tolerates both layouts: when the
+wrapper is present its children are read, otherwise the root is scanned
+directly.
+
 ## Digital Signature Verification
 
 The library implements the S-100 Part 15 Data Protection Scheme for **signature verification** and a complementary **checksum/integrity** dimension. Exchange sets may include per-file digital signatures (DSA or ECDSA P-256 over SHA-256) embedded in `CATALOG.XML`, along with a certificate block referencing the signing data provider. Independently of any signature, each file's SHA-256 digest is computed and its presence/readability confirmed, so even an **unsigned** exchange set can be checked for missing or corrupt files.

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -86,7 +86,9 @@ The viewer accepts:
 
 - **S-100 Exchange Sets** — point it at a directory containing a
   `CATALOG.XML` or at a `.zip` exchange-set archive, and it will
-  load every dataset entry the catalogue lists.
+  load every dataset entry the catalogue lists. The canonical
+  `CATALOG.XML` name and the `catalogue.xml` spelling used by some
+  products (e.g. JCOMM/IHO S-411 sample sets) are both recognised.
 - **S-57 / S-63 Exchange Sets** — point it at a directory containing a
   `CATALOG.031` (or drop the `CATALOG.031` file itself) and it will
   enumerate every base cell the catalogue lists, apply each cell's

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
@@ -48,6 +48,17 @@ internal static class ExchangeSetDetection
             CatalogueFileNames,
             n => string.Equals(n, fileName, StringComparison.OrdinalIgnoreCase));
 
+    private static string? PickCatalogueName(IEnumerable<string?> names) =>
+        names.OfType<string>()
+            .Where(IsCatalogueFileName)
+            .OrderBy(
+                name => string.Equals(
+                    name, CatalogueFileName, StringComparison.OrdinalIgnoreCase)
+                    ? 0
+                    : 1)
+            .ThenBy(name => name, StringComparer.Ordinal)
+            .FirstOrDefault();
+
     /// <summary>True when <paramref name="path"/> ends with
     /// <c>.zip</c> (case-insensitive).</summary>
     public static bool IsZipPath(string path) =>
@@ -76,13 +87,10 @@ internal static class ExchangeSetDetection
         try
         {
             if (!Directory.Exists(folderPath)) return null;
-            foreach (var file in Directory.EnumerateFiles(
-                folderPath, "*", SearchOption.TopDirectoryOnly))
-            {
-                var name = Path.GetFileName(file);
-                if (IsCatalogueFileName(name)) return name;
-            }
-            return null;
+            return PickCatalogueName(
+                Directory.EnumerateFiles(
+                        folderPath, "*", SearchOption.TopDirectoryOnly)
+                    .Select(Path.GetFileName));
         }
         catch (UnauthorizedAccessException) { return null; }
         catch (IOException) { return null; }
@@ -108,25 +116,23 @@ internal static class ExchangeSetDetection
         {
             if (!File.Exists(zipPath)) return null;
             using var archive = ZipFile.OpenRead(zipPath);
-            foreach (var entry in archive.Entries)
-            {
-                if (IsRootCatalogueEntry(entry)) return entry.FullName;
-            }
-            return null;
+            return PickCatalogueName(
+                archive.Entries
+                    .Where(IsRootEntry)
+                    .Select(entry => entry.FullName));
         }
         catch (InvalidDataException) { return null; }
         catch (UnauthorizedAccessException) { return null; }
         catch (IOException) { return null; }
     }
 
-    private static bool IsRootCatalogueEntry(ZipArchiveEntry entry)
+    private static bool IsRootEntry(ZipArchiveEntry entry)
     {
         // ZIP entry names use forward slashes per the spec; tolerate
         // backslashes too in case a producer wrote them. A "root"
         // entry has no separator at all.
         var name = entry.FullName;
-        if (name.Contains('/') || name.Contains('\\')) return false;
-        return IsCatalogueFileName(name);
+        return !name.Contains('/') && !name.Contains('\\');
     }
 
     /// <summary>True when <paramref name="path"/> is an S-57 / S-63 exchange set

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
@@ -20,12 +20,33 @@ namespace EncDotNet.S100.Viewer.Services;
 /// </remarks>
 internal static class ExchangeSetDetection
 {
-    /// <summary>The catalogue filename, matched case-insensitively.</summary>
+    /// <summary>The canonical S-100 catalogue filename (S-100 Part 17),
+    /// matched case-insensitively.</summary>
     private const string CatalogueFileName = "CATALOG.XML";
+
+    /// <summary>
+    /// Accepted exchange-set catalogue filenames, matched
+    /// case-insensitively. In addition to the canonical
+    /// <c>CATALOG.XML</c> (S-100 Part 17), several products in the wild
+    /// — notably JCOMM/IHO S-411 sample sets — name the catalogue
+    /// <c>catalogue.xml</c>. Both are recognised so their exchange sets
+    /// route to the exchange-set loader instead of silently falling
+    /// through to the single-file loader.
+    /// </summary>
+    private static readonly string[] CatalogueFileNames =
+    {
+        CatalogueFileName,
+        "CATALOGUE.XML",
+    };
 
     /// <summary>The S-57 / S-63 exchange-set catalogue filename, matched
     /// case-insensitively.</summary>
     private const string S57CatalogueFileName = "CATALOG.031";
+
+    private static bool IsCatalogueFileName(string fileName) =>
+        Array.Exists(
+            CatalogueFileNames,
+            n => string.Equals(n, fileName, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>True when <paramref name="path"/> ends with
     /// <c>.zip</c> (case-insensitive).</summary>
@@ -34,40 +55,68 @@ internal static class ExchangeSetDetection
         string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>True when <paramref name="folderPath"/> exists and
-    /// contains a <c>CATALOG.XML</c> at its top level
-    /// (case-insensitive). Returns <c>false</c> for any I/O or
-    /// permission failure.</summary>
-    public static bool LooksLikeExchangeSetFolder(string folderPath)
+    /// contains a recognised catalogue file (<c>CATALOG.XML</c> or
+    /// <c>catalogue.xml</c>) at its top level (case-insensitive).
+    /// Returns <c>false</c> for any I/O or permission failure.</summary>
+    public static bool LooksLikeExchangeSetFolder(string folderPath) =>
+        ResolveFolderCatalogueName(folderPath) is not null;
+
+    /// <summary>
+    /// Returns the actual top-level catalogue file name found in
+    /// <paramref name="folderPath"/> (preserving its on-disk casing and
+    /// spelling, e.g. <c>CATALOG.XML</c> or <c>catalogue.xml</c>), or
+    /// <c>null</c> when the folder does not exist, is inaccessible, or
+    /// contains no recognised catalogue. Callers pass the returned name
+    /// to <c>ExchangeSet.OpenAsync</c> so producers using the S-411
+    /// <c>catalogue.xml</c> convention resolve correctly.
+    /// </summary>
+    public static string? ResolveFolderCatalogueName(string folderPath)
     {
-        if (string.IsNullOrEmpty(folderPath)) return false;
+        if (string.IsNullOrEmpty(folderPath)) return null;
         try
         {
-            if (!Directory.Exists(folderPath)) return false;
-            return Directory.EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
-                .Any(f => string.Equals(
-                    Path.GetFileName(f), CatalogueFileName,
-                    StringComparison.OrdinalIgnoreCase));
+            if (!Directory.Exists(folderPath)) return null;
+            foreach (var file in Directory.EnumerateFiles(
+                folderPath, "*", SearchOption.TopDirectoryOnly))
+            {
+                var name = Path.GetFileName(file);
+                if (IsCatalogueFileName(name)) return name;
+            }
+            return null;
         }
-        catch (UnauthorizedAccessException) { return false; }
-        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
     }
 
     /// <summary>True when <paramref name="zipPath"/> is a readable
-    /// ZIP archive whose root contains a <c>CATALOG.XML</c> entry
-    /// (case-insensitive). Returns <c>false</c> for corrupt archives
-    /// or I/O failures.</summary>
-    public static bool LooksLikeExchangeSetZip(string zipPath)
+    /// ZIP archive whose root contains a recognised catalogue entry
+    /// (<c>CATALOG.XML</c> or <c>catalogue.xml</c>, case-insensitive).
+    /// Returns <c>false</c> for corrupt archives or I/O failures.</summary>
+    public static bool LooksLikeExchangeSetZip(string zipPath) =>
+        ResolveZipCatalogueEntry(zipPath) is not null;
+
+    /// <summary>
+    /// Returns the actual root-level catalogue entry name found in the
+    /// ZIP at <paramref name="zipPath"/> (preserving its stored casing
+    /// and spelling), or <c>null</c> when the archive is missing,
+    /// corrupt, or contains no recognised root catalogue.
+    /// </summary>
+    public static string? ResolveZipCatalogueEntry(string zipPath)
     {
-        if (string.IsNullOrEmpty(zipPath)) return false;
+        if (string.IsNullOrEmpty(zipPath)) return null;
         try
         {
-            if (!File.Exists(zipPath)) return false;
+            if (!File.Exists(zipPath)) return null;
             using var archive = ZipFile.OpenRead(zipPath);
-            return archive.Entries.Any(IsRootCatalogueEntry);
+            foreach (var entry in archive.Entries)
+            {
+                if (IsRootCatalogueEntry(entry)) return entry.FullName;
+            }
+            return null;
         }
-        catch (InvalidDataException) { return false; }
-        catch (UnauthorizedAccessException) { return false; }
-        catch (IOException) { return false; }
+        catch (InvalidDataException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
     }
 
     private static bool IsRootCatalogueEntry(ZipArchiveEntry entry)
@@ -77,8 +126,7 @@ internal static class ExchangeSetDetection
         // entry has no separator at all.
         var name = entry.FullName;
         if (name.Contains('/') || name.Contains('\\')) return false;
-        return string.Equals(
-            name, CatalogueFileName, StringComparison.OrdinalIgnoreCase);
+        return IsCatalogueFileName(name);
     }
 
     /// <summary>True when <paramref name="path"/> is an S-57 / S-63 exchange set

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -112,7 +112,12 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             source = OpenSource(folderOrZipPath);
             try
             {
-                exchangeSet = await ExchangeSet.OpenAsync(source, "CATALOG.XML", cancellationToken)
+                // Most producers use the canonical CATALOG.XML (S-100
+                // Part 17), but some — notably JCOMM/IHO S-411 sample
+                // sets — name it catalogue.xml. Resolve the actual name
+                // so the asset source opens the right entry.
+                var catalogueName = ResolveCatalogueName(folderOrZipPath);
+                exchangeSet = await ExchangeSet.OpenAsync(source, catalogueName, cancellationToken)
                     .ConfigureAwait(true);
             }
             catch (FileNotFoundException)
@@ -632,6 +637,28 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         }
         throw new FileNotFoundException(
             $"Exchange set source not found or not a folder/.zip: {path}", path);
+    }
+
+    /// <summary>
+    /// Resolves the relative catalogue name to open within the source at
+    /// <paramref name="path"/>. Folders and ZIP archives may use the
+    /// canonical <c>CATALOG.XML</c> or the S-411 <c>catalogue.xml</c>
+    /// spelling; the discovered name (preserving casing) is returned so
+    /// the asset source opens the correct entry. Falls back to
+    /// <c>CATALOG.XML</c> when nothing is found, letting the subsequent
+    /// open surface the standard "catalogue not found" message.
+    /// </summary>
+    private static string ResolveCatalogueName(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            return ExchangeSetDetection.ResolveFolderCatalogueName(path) ?? "CATALOG.XML";
+        }
+        if (ExchangeSetDetection.IsZipPath(path))
+        {
+            return ExchangeSetDetection.ResolveZipCatalogueEntry(path) ?? "CATALOG.XML";
+        }
+        return "CATALOG.XML";
     }
 
     private void EnsureCollectionSubscription()

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
@@ -70,9 +70,40 @@ public class ExchangeCatalogueReaderTests
     }
 
     [Fact]
-    public void Dataset_ExpectedHash_IsParsedFromHashMrn()
+    public void Read_LegacyS100EcSchema_ParsesDatasetsWithoutWrapper()
     {
+        // The legacy S100EC schema used by JCOMM/IHO S-411 places the
+        // S100_DatasetDiscoveryMetadata records directly under the
+        // catalogue root, with no <datasetDiscoveryMetadata> wrapper
+        // (unlike modern S-100 Part 17). The reader must still find them.
         const string xml = """
+            <ec:S100_ExchangeCatalogue xmlns:ec="http://www.iho.int/S100EC">
+                <ec:identifier>
+                    <ec:identifier>S411_TEST</ec:identifier>
+                    <ec:editionNumber>1.1.0</ec:editionNumber>
+                </ec:identifier>
+                <ec:S100_DatasetDiscoveryMetadata>
+                    <ec:fileName>S411_TEST.gml</ec:fileName>
+                    <ec:filePath>/data/S411_TEST.gml</ec:filePath>
+                    <ec:description>S-411 Ice Data Set</ec:description>
+                    <ec:editionNumber>1.1.0</ec:editionNumber>
+                    <ec:updateNumber>not applicable</ec:updateNumber>
+                </ec:S100_DatasetDiscoveryMetadata>
+            </ec:S100_ExchangeCatalogue>
+            """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        var catalogue = ExchangeCatalogueReader.Read(stream);
+
+        Assert.Equal("S411_TEST", catalogue.Identifier.Identifier);
+        var dataset = Assert.Single(catalogue.DatasetDiscoveryMetadata);
+        Assert.Equal("S411_TEST.gml", dataset.FileName);
+        Assert.Equal("/data/S411_TEST.gml", dataset.FilePath);
+    }
+
+    [Fact]
+    public void Dataset_ExpectedHash_IsParsedFromHashMrn()
+    {        const string xml = """
             <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
                 <S100XC:identifier>
                     <S100XC:identifier>TEST</S100XC:identifier>

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
@@ -103,7 +103,8 @@ public class ExchangeCatalogueReaderTests
 
     [Fact]
     public void Dataset_ExpectedHash_IsParsedFromHashMrn()
-    {        const string xml = """
+    {
+        const string xml = """
             <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
                 <S100XC:identifier>
                     <S100XC:identifier>TEST</S100XC:identifier>

--- a/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
+++ b/tests/EncDotNet.S100.ExchangeSets.Tests/ExchangeCatalogueReaderTests.cs
@@ -102,6 +102,31 @@ public class ExchangeCatalogueReaderTests
     }
 
     [Fact]
+    public void Read_EmptyDatasetWrapper_FallsBackToRootLevelDatasets()
+    {
+        const string xml = """
+            <S100XC:S100_ExchangeCatalogue xmlns:S100XC="http://www.iho.int/s100/xc/5.0">
+                <S100XC:identifier>
+                    <S100XC:identifier>TEST</S100XC:identifier>
+                    <S100XC:dateTime>2024-01-01</S100XC:dateTime>
+                </S100XC:identifier>
+                <S100XC:datasetDiscoveryMetadata />
+                <S100XC:S100_DatasetDiscoveryMetadata>
+                    <S100XC:fileName>test.000</S100XC:fileName>
+                    <S100XC:filePath>data/test.000</S100XC:filePath>
+                </S100XC:S100_DatasetDiscoveryMetadata>
+            </S100XC:S100_ExchangeCatalogue>
+            """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        var catalogue = ExchangeCatalogueReader.Read(stream);
+
+        var dataset = Assert.Single(catalogue.DatasetDiscoveryMetadata);
+        Assert.Equal("test.000", dataset.FileName);
+        Assert.Equal("data/test.000", dataset.FilePath);
+    }
+
+    [Fact]
     public void Dataset_ExpectedHash_IsParsedFromHashMrn()
     {
         const string xml = """

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
@@ -90,6 +90,19 @@ public sealed class ExchangeSetDetectionTests : IDisposable
     }
 
     [Fact]
+    public void ResolveFolderCatalogueName_PrefersCanonicalName()
+    {
+        var folder = Path.Combine(_tempRoot, "canon-preferred");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "catalogue.xml"), "<root/>");
+        File.WriteAllText(Path.Combine(folder, "CATALOG.XML"), "<root/>");
+
+        Assert.Equal(
+            "CATALOG.XML",
+            ExchangeSetDetection.ResolveFolderCatalogueName(folder));
+    }
+
+    [Fact]
     public void ResolveFolderCatalogueName_NullWhenAbsent()
     {
         var folder = Path.Combine(_tempRoot, "none");
@@ -149,6 +162,22 @@ public sealed class ExchangeSetDetectionTests : IDisposable
         Assert.True(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
         Assert.Equal(
             "catalogue.xml",
+            ExchangeSetDetection.ResolveZipCatalogueEntry(zip));
+    }
+
+    [Fact]
+    public void ResolveZipCatalogueEntry_PrefersCanonicalName()
+    {
+        var zip = Path.Combine(_tempRoot, "canon-preferred.zip");
+        using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+        {
+            archive.CreateEntry("catalogue.xml");
+            archive.CreateEntry("CATALOG.XML");
+            archive.CreateEntry("data/S411.gml");
+        }
+
+        Assert.Equal(
+            "CATALOG.XML",
             ExchangeSetDetection.ResolveZipCatalogueEntry(zip));
     }
 

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
@@ -62,6 +62,44 @@ public sealed class ExchangeSetDetectionTests : IDisposable
     }
 
     [Fact]
+    public void LooksLikeExchangeSetFolder_AcceptsS411CatalogueSpelling()
+    {
+        // JCOMM/IHO S-411 sample sets name the catalogue "catalogue.xml"
+        // rather than the canonical CATALOG.XML; the folder must still
+        // route to the exchange-set loader.
+        var folder = Path.Combine(_tempRoot, "s411");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "catalogue.xml"), "<root/>");
+
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+        Assert.Equal(
+            "catalogue.xml",
+            ExchangeSetDetection.ResolveFolderCatalogueName(folder));
+    }
+
+    [Fact]
+    public void ResolveFolderCatalogueName_PreservesCanonicalName()
+    {
+        var folder = Path.Combine(_tempRoot, "canon");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "CATALOG.XML"), "<root/>");
+
+        Assert.Equal(
+            "CATALOG.XML",
+            ExchangeSetDetection.ResolveFolderCatalogueName(folder));
+    }
+
+    [Fact]
+    public void ResolveFolderCatalogueName_NullWhenAbsent()
+    {
+        var folder = Path.Combine(_tempRoot, "none");
+        Directory.CreateDirectory(folder);
+        Assert.Null(ExchangeSetDetection.ResolveFolderCatalogueName(folder));
+        Assert.Null(ExchangeSetDetection.ResolveFolderCatalogueName(
+            Path.Combine(_tempRoot, "ghost")));
+    }
+
+    [Fact]
     public void LooksLikeExchangeSetFolder_FalseWhenCatalogOnlyInSubfolder()
     {
         // A nested CATALOG.XML doesn't constitute an exchange set
@@ -96,6 +134,22 @@ public sealed class ExchangeSetDetectionTests : IDisposable
         }
 
         Assert.True(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
+    }
+
+    [Fact]
+    public void LooksLikeExchangeSetZip_AcceptsS411CatalogueSpelling()
+    {
+        var zip = Path.Combine(_tempRoot, "s411.zip");
+        using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+        {
+            archive.CreateEntry("catalogue.xml");
+            archive.CreateEntry("data/S411.gml");
+        }
+
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetZip(zip));
+        Assert.Equal(
+            "catalogue.xml",
+            ExchangeSetDetection.ResolveZipCatalogueEntry(zip));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Dragging an S-411 exchange set directory onto the viewer silently did nothing — no dataset loaded and no error appeared — even though the raw `.gml` opened fine. Two chained defects were responsible, both from S-411 using the JCOMM/IHO conventions:

1. **Catalogue filename** — `ExchangeSetDetection` only matched the canonical `CATALOG.XML`. S-411 sample sets name the catalogue `catalogue.xml`, so the dropped folder was never detected as an exchange set and fell through to the single-file loader (which ignores directories) → silent no-op.
2. **Legacy `S100EC` schema layout** — even once routed, `ExchangeCatalogueReader` only found dataset records nested under a `<datasetDiscoveryMetadata>` wrapper (modern S-100 Part 17). The legacy `S100EC` schema (`http://www.iho.int/S100EC`) used by S-411 places `<S100_DatasetDiscoveryMetadata>` records directly under the catalogue root, so parsing yielded **0 datasets**.

## Changes

- **`ExchangeSetDetection.cs`** — recognises both `CATALOG.XML` and `catalogue.xml` (case-insensitive) for folders and ZIPs; adds `ResolveFolderCatalogueName` / `ResolveZipCatalogueEntry` returning the discovered name (preserving casing).
- **`ExchangeSetService.cs`** — resolves the actual catalogue name and passes it to `ExchangeSet.OpenAsync` instead of hardcoding `"CATALOG.XML"` (falls back to `CATALOG.XML` so the existing "not found" path is unchanged).
- **`ExchangeCatalogueReader.cs`** — new `CollectDiscoveryRecords` helper reads discovery records from the wrapper when present, otherwise scans the catalogue root directly (legacy layout). Applied to both dataset and catalogue discovery.
- READMEs updated (ExchangeSets + Viewer).

## Tests

- `ExchangeSetDetectionTests` — `catalogue.xml` folder + ZIP recognised; `ResolveFolderCatalogueName` / `ResolveZipCatalogueEntry` return the on-disk name; null/canonical cases.
- `ExchangeCatalogueReaderTests` — synthetic legacy `S100EC` catalogue with root-level `S100_DatasetDiscoveryMetadata` parses its dataset.
- Full suites pass: ExchangeSets (114) and Viewer exchange-set tests (59 + 1 skipped). Verified end-to-end against a real S-411 sample: folder opens, dataset found, bytes fetched.

Fixes #423