### PR TITLE
Add center-priority tile dequeue to S-100 tiled renderer

### DIFF
--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -419,8 +419,13 @@ hysteresis comes from the velocity EMA, not from retaining stale predictions.
 Pending work is split into two queues: `PendingVisible` (on-screen exact-band
 misses, high priority) and `PendingPredicted` (the warm set, low priority). The
 pool of coalescing workers drains visible-first, so prediction always yields to
-tiles the user is actually looking at and never delays an on-screen fill. The
-pool size is `RenderingOptimizations.TileWorkerCount` (tier-sized); a per-layer
+tiles the user is actually looking at and never delays an on-screen fill. Within
+each tier a worker dequeues **centre-first** (`TakeNearest`): the pending tile
+whose world centre is nearest the current viewport centre rasterises before the
+perimeter, cutting time-to-centre-fill on a cold pan/zoom. Equal-distance ties
+break deterministically on `(band, y, x)`, so the drain order never depends on
+the pending set's hash iteration order. The pool size is
+`RenderingOptimizations.TileWorkerCount` (tier-sized); a per-layer
 `ActiveWorkers` count plus a process-wide `s_activeWorkerTotal` cap (core count)
 bound how many run at once.
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -719,6 +719,8 @@ public static class S100VectorTileRenderer
             {
                 state.PendingDeviceScale = deviceScale;
                 state.PendingGeneration = state.Generation;
+                state.PendingCenterX = centerX;
+                state.PendingCenterY = centerY;
                 // Spin up enough workers to cover the pending tiles, capped at the
                 // tier's per-layer pool size, so a cold pan's misses rasterise in
                 // parallel instead of one at a time. A second cap on the total live
@@ -1462,12 +1464,12 @@ public static class S100VectorTileRenderer
 
                     if (state.PendingVisible.Count > 0)
                     {
-                        key = TakeOne(state.PendingVisible);
+                        key = TakeNearest(state.PendingVisible, state.PendingCenterX, state.PendingCenterY);
                         isPrediction = false;
                     }
                     else
                     {
-                        key = TakeOne(state.PendingPredicted);
+                        key = TakeNearest(state.PendingPredicted, state.PendingCenterX, state.PendingCenterY);
                         isPrediction = true;
                     }
 
@@ -1592,15 +1594,66 @@ public static class S100VectorTileRenderer
         }
     }
 
-    private static TileKey TakeOne(HashSet<TileKey> pending)
+    /// <summary>
+    /// Removes and returns the pending tile whose world centre is nearest the
+    /// viewport centre (<paramref name="centerX"/>, <paramref name="centerY"/> in
+    /// EPSG:3857 metres), so central tiles rasterise before the perimeter within
+    /// a priority tier — cutting time-to-centre-fill on a cold pan/zoom without
+    /// disturbing the visible-before-predicted ordering (that is the caller's
+    /// two-tier drain). Ties are broken deterministically on
+    /// (<c>Band</c>, <c>Y</c>, <c>X</c>) so the drain order never depends on the
+    /// set's hash iteration order. Returns <see langword="default"/> for an empty
+    /// set. O(n) per call over a viewport-sized set (tens of tiles).
+    /// </summary>
+    /// <param name="pending">The pending tile set to draw from; mutated in place.</param>
+    /// <param name="centerX">Viewport centre X in EPSG:3857 metres.</param>
+    /// <param name="centerY">Viewport centre Y in EPSG:3857 metres.</param>
+    /// <returns>The removed nearest-to-centre tile, or <see langword="default"/> when empty.</returns>
+    internal static TileKey TakeNearest(HashSet<TileKey> pending, double centerX, double centerY)
     {
+        var found = false;
+        var best = default(TileKey);
+        var bestScore = double.PositiveInfinity;
         foreach (var k in pending)
         {
-            pending.Remove(k);
-            return k;
+            var (minX, minY, maxX, maxY) = TileGrid.TileWorldBounds(k);
+            var dx = (minX + maxX) * 0.5 - centerX;
+            var dy = (minY + maxY) * 0.5 - centerY;
+            var score = dx * dx + dy * dy;
+            if (!found || score < bestScore || (score == bestScore && TileOrderLess(k, best)))
+            {
+                found = true;
+                best = k;
+                bestScore = score;
+            }
         }
 
-        return default;
+        if (found)
+        {
+            pending.Remove(best);
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Deterministic total order on tiles by (<c>Band</c>, <c>Y</c>, <c>X</c>),
+    /// used only to break equal centre-distance ties in <see cref="TakeNearest"/>
+    /// so the drain order is stable across runs.
+    /// </summary>
+    private static bool TileOrderLess(TileKey a, TileKey b)
+    {
+        if (a.Band != b.Band)
+        {
+            return a.Band < b.Band;
+        }
+
+        if (a.Y != b.Y)
+        {
+            return a.Y < b.Y;
+        }
+
+        return a.X < b.X;
     }
 
     /// <summary>
@@ -1940,6 +1993,15 @@ public static class S100VectorTileRenderer
         public int ActiveWorkers;
         public float PendingDeviceScale = 1f;
         public long PendingGeneration;
+
+        // Viewport centre (EPSG:3857 metres) of the frame that produced the
+        // current pending sets, so the worker can dequeue centre-first within
+        // each priority tier (nearest pending tile to the viewport centre
+        // rasterises before the perimeter). Refreshed every frame that enqueues
+        // work, in lockstep with the pending sets, so it always matches the
+        // centre the visible/predicted tiles were selected for.
+        public double PendingCenterX;
+        public double PendingCenterY;
 
         // Off-screen north-up composite for the current rotated frame (null on
         // north-up frames). DrawImage is deferred, so these must outlive the frame

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -1620,9 +1620,24 @@ public static class S100VectorTileRenderer
             var dx = (minX + maxX) * 0.5 - centerX;
             var dy = (minY + maxY) * 0.5 - centerY;
             var score = dx * dx + dy * dy;
-            if (!found || score < bestScore || (score == bestScore && TileOrderLess(k, best)))
+            if (!found)
             {
                 found = true;
+                best = k;
+                bestScore = score;
+                continue;
+            }
+
+            // Squared distances in EPSG:3857 metres are large and involve π and
+            // division, so exact equality is unreliable for detecting a tie.
+            // Distinct tiles differ by at least ~a tile edge, which dwarfs this
+            // relative tolerance, so genuine ties (including mirror-image tiles)
+            // fall through to the deterministic (Band, Y, X) order while nearer
+            // tiles still win outright.
+            var tolerance = 1e-9 * Math.Max(Math.Abs(score), Math.Abs(bestScore));
+            var isTie = Math.Abs(score - bestScore) <= tolerance;
+            if (isTie ? TileOrderLess(k, best) : score < bestScore)
+            {
                 best = k;
                 bestScore = score;
             }

--- a/tests/EncDotNet.S100.Pipelines.Tests/CatalogueResolutionDiagnosticsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/CatalogueResolutionDiagnosticsTests.cs
@@ -10,7 +10,7 @@ public class CatalogueResolutionDiagnosticsTests
 {
     private sealed record Measurement(long Value, IReadOnlyDictionary<string, object?> Tags);
 
-    private static MeterListener StartCapture(List<Measurement> sink)
+    private static MeterListener StartCapture(List<Measurement> sink, string catalogueKind)
     {
         var listener = new MeterListener
         {
@@ -27,7 +27,15 @@ public class CatalogueResolutionDiagnosticsTests
         {
             var dict = new Dictionary<string, object?>(tags.Length);
             for (int i = 0; i < tags.Length; i++) dict[tags[i].Key] = tags[i].Value;
-            sink.Add(new Measurement(value, dict));
+
+            // The counter is process-wide, so measurements emitted by other
+            // test classes running in parallel (e.g. real dataset processors)
+            // also reach this listener. Filter to this test's unique catalogue
+            // kind so the assertions only see measurements this test provoked.
+            if (dict.TryGetValue("s100.catalogue.kind", out var kind) && Equals(kind, catalogueKind))
+            {
+                sink.Add(new Measurement(value, dict));
+            }
         });
         listener.Start();
         return listener;
@@ -36,12 +44,12 @@ public class CatalogueResolutionDiagnosticsTests
     [Fact]
     public void Report_NullCatalogueRef_DoesNothing()
     {
-
+        var kind = UniqueKind();
         var measurements = new List<Measurement>();
-        using var listener = StartCapture(measurements);
+        using var listener = StartCapture(measurements, kind);
 
         CatalogueResolutionDiagnostics.Report(this, new SpecRef("S-101", new SpecVersion(1, 2, 0)),
-            null, "portrayal");
+            null, kind);
 
         Assert.Empty(measurements);
     }
@@ -49,37 +57,37 @@ public class CatalogueResolutionDiagnosticsTests
     [Fact]
     public void Report_ExactMatch_EmitsCounterWithExactTag()
     {
-
+        var kind = UniqueKind();
         var scope = new object();
         var measurements = new List<Measurement>();
-        using var listener = StartCapture(measurements);
+        using var listener = StartCapture(measurements, kind);
 
         CatalogueResolutionDiagnostics.Report(scope,
             new SpecRef("S-101", new SpecVersion(1, 2, 0)),
             new CatalogueRef("S-101", new SpecVersion(1, 2, 0)),
-            "portrayal");
+            kind);
 
         var m = Assert.Single(measurements);
         Assert.Equal(1L, m.Value);
         Assert.Equal("S-101", m.Tags["s100.spec.name"]);
         Assert.Equal("1.2.0", m.Tags["s100.spec.edition"]);
         Assert.Equal("1.2.0", m.Tags["s100.catalogue.version"]);
-        Assert.Equal("portrayal", m.Tags["s100.catalogue.kind"]);
+        Assert.Equal(kind, m.Tags["s100.catalogue.kind"]);
         Assert.Equal("Exact", m.Tags["s100.catalogue.match"]);
     }
 
     [Fact]
     public void Report_MajorDivergence_TagsAccordingly()
     {
-
+        var kind = UniqueKind();
         var scope = new object();
         var measurements = new List<Measurement>();
-        using var listener = StartCapture(measurements);
+        using var listener = StartCapture(measurements, kind);
 
         CatalogueResolutionDiagnostics.Report(scope,
             new SpecRef("S-101", new SpecVersion(1, 2, 0)),
             new CatalogueRef("S-101", new SpecVersion(2, 0, 0)),
-            "portrayal");
+            kind);
 
         var m = Assert.Single(measurements);
         Assert.Equal("MajorDivergence", m.Tags["s100.catalogue.match"]);
@@ -88,16 +96,16 @@ public class CatalogueResolutionDiagnosticsTests
     [Fact]
     public void Report_RepeatedSamePair_EmitsOnlyOnce()
     {
-
+        var kind = UniqueKind();
         var scope = new object();
         var measurements = new List<Measurement>();
-        using var listener = StartCapture(measurements);
+        using var listener = StartCapture(measurements, kind);
 
         var spec = new SpecRef("S-101", new SpecVersion(1, 2, 0));
         var cat = new CatalogueRef("S-101", new SpecVersion(2, 0, 0));
-        CatalogueResolutionDiagnostics.Report(scope, spec, cat, "portrayal");
-        CatalogueResolutionDiagnostics.Report(scope, spec, cat, "portrayal");
-        CatalogueResolutionDiagnostics.Report(scope, spec, cat, "portrayal");
+        CatalogueResolutionDiagnostics.Report(scope, spec, cat, kind);
+        CatalogueResolutionDiagnostics.Report(scope, spec, cat, kind);
+        CatalogueResolutionDiagnostics.Report(scope, spec, cat, kind);
 
         Assert.Single(measurements);
     }
@@ -105,17 +113,19 @@ public class CatalogueResolutionDiagnosticsTests
     [Fact]
     public void Report_DistinctScopes_EmitIndependently()
     {
-
+        var kind = UniqueKind();
         var scopeA = new object();
         var scopeB = new object();
         var measurements = new List<Measurement>();
-        using var listener = StartCapture(measurements);
+        using var listener = StartCapture(measurements, kind);
 
         var spec = new SpecRef("S-101", new SpecVersion(1, 2, 0));
         var cat = new CatalogueRef("S-101", new SpecVersion(2, 0, 0));
-        CatalogueResolutionDiagnostics.Report(scopeA, spec, cat, "portrayal");
-        CatalogueResolutionDiagnostics.Report(scopeB, spec, cat, "portrayal");
+        CatalogueResolutionDiagnostics.Report(scopeA, spec, cat, kind);
+        CatalogueResolutionDiagnostics.Report(scopeB, spec, cat, kind);
 
         Assert.Equal(2, measurements.Count);
     }
+
+    private static string UniqueKind() => "portrayal-" + Guid.NewGuid().ToString("N");
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileCenterPriorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileCenterPriorityTests.cs
@@ -114,7 +114,11 @@ public class TileCenterPriorityTests
         {
             var next = S100VectorTileRenderer.TakeNearest(pending, cx, cy);
             var d = DistSq(next);
-            Assert.True(d >= previous, $"drain order must be non-decreasing distance: {previous} -> {d}");
+            // Same-ring tiles are equal-distance ties resolved by (Band, Y, X),
+            // so allow the same sub-ULP relative slack the dequeue treats as a
+            // tie rather than requiring a strict exact-distance ordering.
+            var tolerance = 1e-9 * Math.Max(previous, d);
+            Assert.True(d >= previous - tolerance, $"drain order must be non-decreasing distance: {previous} -> {d}");
             previous = d;
         }
     }

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileCenterPriorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileCenterPriorityTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Renderers.Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for the centre-priority tile dequeue
+/// (<see cref="S100VectorTileRenderer.TakeNearest"/>). These pin the properties
+/// the worker relies on when draining a priority tier: the tile nearest the
+/// viewport centre is picked first, the pick is removed from the pending set,
+/// ties are broken deterministically (independent of hash iteration order), and
+/// draining the whole set yields a centre-out ordering. Visible-before-predicted
+/// tiering is the caller's concern and is unaffected.
+/// </summary>
+public class TileCenterPriorityTests
+{
+    private const int Band = 10;
+
+    /// <summary>The EPSG:3857 centre of a tile, matching TileGrid's bounds math.</summary>
+    private static (double X, double Y) TileCenter(TileKey key)
+    {
+        var (minX, minY, maxX, maxY) = TileGrid.TileWorldBounds(key);
+        return ((minX + maxX) * 0.5, (minY + maxY) * 0.5);
+    }
+
+    [Fact]
+    public void TakeNearest_EmptySetReturnsDefault()
+    {
+        var pending = new HashSet<TileKey>();
+        Assert.Equal(default, S100VectorTileRenderer.TakeNearest(pending, 0, 0));
+        Assert.Empty(pending);
+    }
+
+    [Fact]
+    public void TakeNearest_PicksTileNearestViewportCentre()
+    {
+        var near = new TileKey(Band, 100, 100);
+        var far = new TileKey(Band, 140, 100);
+        var farther = new TileKey(Band, 180, 60);
+        var pending = new HashSet<TileKey> { far, farther, near };
+
+        var (cx, cy) = TileCenter(near);
+        var picked = S100VectorTileRenderer.TakeNearest(pending, cx, cy);
+
+        Assert.Equal(near, picked);
+    }
+
+    [Fact]
+    public void TakeNearest_RemovesReturnedTile()
+    {
+        var a = new TileKey(Band, 10, 10);
+        var b = new TileKey(Band, 11, 10);
+        var pending = new HashSet<TileKey> { a, b };
+
+        var (cx, cy) = TileCenter(a);
+        var picked = S100VectorTileRenderer.TakeNearest(pending, cx, cy);
+
+        Assert.Equal(a, picked);
+        Assert.DoesNotContain(a, pending);
+        Assert.Contains(b, pending);
+        Assert.Single(pending);
+    }
+
+    [Fact]
+    public void TakeNearest_BreaksEqualDistanceTiesDeterministically()
+    {
+        // Two tiles equidistant from a centre exactly between them: the tie-break
+        // is (Band, Y, X), so the lower (Y, X) wins regardless of set order.
+        var left = new TileKey(Band, 50, 50);
+        var right = new TileKey(Band, 51, 50);
+        var size = TileGrid.TileWorldSize(Band);
+        var (lx, _) = TileCenter(left);
+        var (_, ly) = TileCenter(left);
+        var midX = lx + size * 0.5; // exactly on the shared edge → equal distance
+
+        var forward = S100VectorTileRenderer.TakeNearest(
+            new HashSet<TileKey> { left, right }, midX, ly);
+        var reversed = S100VectorTileRenderer.TakeNearest(
+            new HashSet<TileKey> { right, left }, midX, ly);
+
+        Assert.Equal(left, forward);
+        Assert.Equal(left, reversed);
+    }
+
+    [Fact]
+    public void TakeNearest_DrainingYieldsCentreOutOrdering()
+    {
+        // A 5x5 block of tiles centred on (cx, cy); draining one at a time must
+        // produce non-decreasing distance from the centre (centre tile first,
+        // corners last).
+        var centreTile = new TileKey(Band, 200, 200);
+        var (cx, cy) = TileCenter(centreTile);
+        var pending = new HashSet<TileKey>();
+        for (var dy = -2; dy <= 2; dy++)
+        {
+            for (var dx = -2; dx <= 2; dx++)
+            {
+                pending.Add(new TileKey(Band, 200 + dx, 200 + dy));
+            }
+        }
+
+        double DistSq(TileKey k)
+        {
+            var (tx, ty) = TileCenter(k);
+            return (tx - cx) * (tx - cx) + (ty - cy) * (ty - cy);
+        }
+
+        var first = S100VectorTileRenderer.TakeNearest(pending, cx, cy);
+        Assert.Equal(centreTile, first);
+
+        var previous = DistSq(first);
+        while (pending.Count > 0)
+        {
+            var next = S100VectorTileRenderer.TakeNearest(pending, cx, cy);
+            var d = DistSq(next);
+            Assert.True(d >= previous, $"drain order must be non-decreasing distance: {previous} -> {d}");
+            previous = d;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The tiled renderer prioritizes visible tiles over predicted tiles, but within each tier it drained its pending set with an arbitrary hash-order `TakeOne`. Central viewport tiles were therefore not guaranteed to rasterise before the perimeter on a cold pan/zoom, adding perceived latency where the user is actually looking.

This replaces `TakeOne` with `TakeNearest`, which removes the pending tile whose world centre is closest to the viewport centre (EPSG:3857 metres), with a deterministic `(Band, Y, X)` tie-break so drain order never depends on the set's hash iteration order. The viewport centre is captured per frame (`PendingCenterX/Y`) in lockstep with the pending sets. Everything else is preserved: visible-before-predicted two-tier ordering, per-frame cancellation, dedupe guards (cache / in-flight), and style-safe disk namespaces. It is a pure dequeue-ordering change with no correctness impact.

**Measured impact** (A/B against a UKHO S-101 trial exchange set, 28 datasets, 16 pan/zoom jumps at zoom 14, single build gated so dequeue order was the only variable):

| Tile bucket | Metric | Before (unordered) | After (center-first) |
| --- | --- | --: | --: |
| CENTER | median | 165.7 ms | 43.4 ms (-74%) |
| CENTER | p95 | 1205 ms | 521 ms (-57%) |
| NEAR | median | 166.5 ms | 62.6 ms (-62%) |
| FAR | median | 246.6 ms | 306.9 ms (+24%, intended) |
| ALL | median | 188 ms | 206 ms (~flat) |

Perimeter (FAR) tiles are modestly deferred, which is the intended trade-off; overall worker throughput (ALL median) is essentially unchanged. The built-in `cold.latency` counter corroborates (per-interval p95 mean 3354 ms to 505 ms), and rasterize duration was unchanged, confirming the win comes from queue order rather than rasterization cost. Note the baseline arm ran second with a warmer disk cache yet was slower, so the gain is not a cache-ordering artifact.

Follow-up pyramid optimizations from the issue (metatile raster jobs, cross-band prewarm, parent->child synthesis, adaptive tile size) are intentionally left out of scope.

Closes #422

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a rendering-performance architecture change (tile scheduling), not a product-spec semantic change, so no spec skill applied.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/` (`TileCenterPriorityTests`: empty set, nearest pick, removal, deterministic tie-break, center-out drain)
- [x] Tests requiring real data files use `SkippableFact` (N/A — new tests use synthetic tile keys)
- [x] `dotnet test --configuration Release` passes locally (858 passed, 1 skipped)

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (N/A — no README API surface change)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (design doc §D.2 Scheduling)
- [x] New public APIs have XML doc comments (`TakeNearest` documented)

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependency)

## Breaking changes

None. Pure internal dequeue-ordering change.