### PR TITLE
Content-sniff S-411 exchange-set datasets lacking a product identifier

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -630,14 +630,41 @@ public sealed class DatasetPipelineFactory
     /// <c>name</c> (e.g. "Ice Information Product Specification (JCOMM S-411)")
     /// with no identifier or number, so the declared spec cannot be mapped and
     /// the dataset must be recognized from its GML root element / namespaces.
-    /// Only <c>.gml</c>/<c>.xml</c> datasets are sniffed; returns <c>null</c>
-    /// when the file cannot be read or is unrecognized. Returns the canonical
-    /// spec string (e.g. <c>"S-411"</c>) understood by
-    /// <see cref="CreateProcessor(IAssetSource, string, string?, IReadOnlyDictionary{string, string}?)"/>.
+    /// This synchronous wrapper exists for synchronous processor creation; async
+    /// callers should use <see cref="DetectProductSpecFromSourceAsync"/>.
     /// </summary>
     /// <param name="source">The asset source (folder or ZIP) hosting the dataset.</param>
     /// <param name="relativePath">Path to the dataset, relative to <paramref name="source"/>.</param>
     public static string? DetectProductSpecFromSource(IAssetSource source, string relativePath)
+    {
+        return DetectProductSpecFromSourceAsync(source, relativePath)
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    /// Asynchronously content-sniffs a GML dataset stored inside
+    /// <paramref name="source"/> to determine its S-100 product specification
+    /// when the exchange-set catalogue omits a machine-readable
+    /// <c>productIdentifier</c>. Real-world JCOMM S-411 exchange sets declare
+    /// only a human-readable product-specification <c>name</c> (e.g. "Ice
+    /// Information Product Specification (JCOMM S-411)") with no identifier or
+    /// number, so the declared spec cannot be mapped and the dataset must be
+    /// recognized from its GML root element / namespaces. Only
+    /// <c>.gml</c>/<c>.xml</c> datasets are sniffed; returns <c>null</c> when
+    /// the file cannot be read or is unrecognized. Returns the canonical spec
+    /// string (e.g. <c>"S-411"</c>) understood by
+    /// <see cref="CreateProcessor(IAssetSource, string, string?, IReadOnlyDictionary{string, string}?)"/>.
+    /// </summary>
+    /// <param name="source">The asset source (folder or ZIP) hosting the dataset.</param>
+    /// <param name="relativePath">Path to the dataset, relative to <paramref name="source"/>.</param>
+    /// <param name="cancellationToken">Cancellation token for reading dataset bytes.</param>
+    /// <returns>The canonical product-specification string, or <c>null</c> when not recognized.</returns>
+    public static async Task<string?> DetectProductSpecFromSourceAsync(
+        IAssetSource source,
+        string relativePath,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentException.ThrowIfNullOrEmpty(relativePath);
@@ -651,9 +678,14 @@ public sealed class DatasetPipelineFactory
 
         try
         {
-            AssetBytes bytes = source.ReadAllBytesAsync(relativePath).GetAwaiter().GetResult();
+            AssetBytes bytes = await source.ReadAllBytesAsync(relativePath, cancellationToken)
+                .ConfigureAwait(false);
             var xml = System.Text.Encoding.UTF8.GetString(bytes.Bytes.Span).TrimStart();
             return DetectGmlProductSpecFromXml(xml);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -142,6 +142,28 @@ public sealed class DatasetPipelineFactory
             // Some GML files have leading whitespace before the XML declaration;
             // read as text, trim, and parse via a StringReader to tolerate this.
             var xml = File.ReadAllText(path).TrimStart();
+            return DetectGmlProductSpecFromXml(xml);
+        }
+        catch
+        {
+            // Unable to parse – unknown
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Inspects the root element / declared namespaces / <c>productIdentifier</c>
+    /// of an already-loaded GML document body to determine its S-100 product
+    /// specification (e.g. <c>"S-411"</c>). Shared by the file-path and
+    /// asset-source detection paths so exchange-set datasets whose catalogue
+    /// omits a machine-readable <c>productIdentifier</c> (common for JCOMM S-411
+    /// sets) are still routed correctly. Returns <c>null</c> when unrecognized.
+    /// </summary>
+    private static string? DetectGmlProductSpecFromXml(string xml)
+    {
+        try
+        {
             using var stringReader = new StringReader(xml);
             using var reader = System.Xml.XmlReader.Create(stringReader, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit });
             while (reader.Read())
@@ -411,6 +433,7 @@ public sealed class DatasetPipelineFactory
 
         var spec = MapProductIdentifierToSpec(declaredProductSpec)
             ?? DetectProductSpecByExtension(relativePath)
+            ?? DetectProductSpecFromSource(source, relativePath)
             ?? throw new NotSupportedException(
                 $"Unable to determine product specification for '{relativePath}' " +
                 $"(declared='{declaredProductSpec ?? "<none>"}').");
@@ -597,5 +620,44 @@ public sealed class DatasetPipelineFactory
             return null;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Content-sniffs a GML dataset stored inside <paramref name="source"/> to
+    /// determine its S-100 product specification when the exchange-set catalogue
+    /// omits a machine-readable <c>productIdentifier</c>. Real-world JCOMM S-411
+    /// exchange sets declare only a human-readable product-specification
+    /// <c>name</c> (e.g. "Ice Information Product Specification (JCOMM S-411)")
+    /// with no identifier or number, so the declared spec cannot be mapped and
+    /// the dataset must be recognized from its GML root element / namespaces.
+    /// Only <c>.gml</c>/<c>.xml</c> datasets are sniffed; returns <c>null</c>
+    /// when the file cannot be read or is unrecognized. Returns the canonical
+    /// spec string (e.g. <c>"S-411"</c>) understood by
+    /// <see cref="CreateProcessor(IAssetSource, string, string?, IReadOnlyDictionary{string, string}?)"/>.
+    /// </summary>
+    /// <param name="source">The asset source (folder or ZIP) hosting the dataset.</param>
+    /// <param name="relativePath">Path to the dataset, relative to <paramref name="source"/>.</param>
+    public static string? DetectProductSpecFromSource(IAssetSource source, string relativePath)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        var ext = Path.GetExtension(relativePath);
+        if (!string.Equals(ext, ".gml", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ext, ".xml", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        try
+        {
+            AssetBytes bytes = source.ReadAllBytesAsync(relativePath).GetAwaiter().GetResult();
+            var xml = System.Text.Encoding.UTF8.GetString(bytes.Bytes.Span).TrimStart();
+            return DetectGmlProductSpecFromXml(xml);
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -165,7 +165,7 @@ public sealed class DatasetPipelineFactory
         try
         {
             using var stringReader = new StringReader(xml);
-            using var reader = System.Xml.XmlReader.Create(stringReader, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit });
+            using var reader = System.Xml.XmlReader.Create(stringReader, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
             while (reader.Read())
             {
                 if (reader.NodeType == System.Xml.XmlNodeType.Element)
@@ -651,10 +651,11 @@ public sealed class DatasetPipelineFactory
     /// only a human-readable product-specification <c>name</c> (e.g. "Ice
     /// Information Product Specification (JCOMM S-411)") with no identifier or
     /// number, so the declared spec cannot be mapped and the dataset must be
-    /// recognized from its GML root element / namespaces. Only
-    /// <c>.gml</c>/<c>.xml</c> datasets are sniffed; returns <c>null</c> when
-    /// the file cannot be read or is unrecognized. Returns the canonical spec
-    /// string (e.g. <c>"S-411"</c>) understood by
+    /// recognized from its GML root element / namespaces. Reads only a bounded,
+    /// BOM-aware prefix of the dataset. Only <c>.gml</c>/<c>.xml</c> datasets
+    /// are sniffed; returns <c>null</c> when the file cannot be read or is
+    /// unrecognized. Returns the canonical spec string (e.g. <c>"S-411"</c>)
+    /// understood by
     /// <see cref="CreateProcessor(IAssetSource, string, string?, IReadOnlyDictionary{string, string}?)"/>.
     /// </summary>
     /// <param name="source">The asset source (folder or ZIP) hosting the dataset.</param>
@@ -678,9 +679,19 @@ public sealed class DatasetPipelineFactory
 
         try
         {
-            AssetBytes bytes = await source.ReadAllBytesAsync(relativePath, cancellationToken)
+            await using var stream = await source.OpenAsync(relativePath, cancellationToken)
                 .ConfigureAwait(false);
-            var xml = System.Text.Encoding.UTF8.GetString(bytes.Bytes.Span).TrimStart();
+            using var streamReader = new StreamReader(
+                stream,
+                System.Text.Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true);
+            const int MaxSniffPrefixChars = 64 * 1024;
+            var buffer = new char[MaxSniffPrefixChars];
+            int read = await streamReader.ReadBlockAsync(
+                    buffer.AsMemory(0, MaxSniffPrefixChars),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var xml = new string(buffer, 0, read).TrimStart();
             return DetectGmlProductSpecFromXml(xml);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/EncDotNet.S100.Datasets.Pipelines/README.md
+++ b/src/EncDotNet.S100.Datasets.Pipelines/README.md
@@ -39,7 +39,10 @@ enumerating features, and validating:
 
 `DatasetPipelineFactory` discriminates an input file by extension,
 HDF5 signature, or GML application namespace and returns the matching
-processor wrapped in an `IDatasetProcessor`. `ExchangeSetLoader`
+processor wrapped in an `IDatasetProcessor`. Its source-based GML sniff
+is also available through `DetectProductSpecFromSourceAsync(...)` for
+exchange-set callers whose catalogue metadata omits a machine-readable
+product identifier (notably JCOMM S-411 catalogues). `ExchangeSetLoader`
 walks an S-100 exchange-set catalogue and yields one processor per
 dataset entry.
 

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -231,7 +231,9 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 }
 
                 var spec = DatasetPipelineFactory.MapProductSpecificationToSpec(
-                    metadata.ProductSpecification);
+                    metadata.ProductSpecification)
+                    ?? DatasetPipelineFactory.DetectProductSpecFromSource(
+                        tracked.Source, relativePath);
                 if (spec is null)
                 {
                     var msg = string.Format(

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -232,8 +232,9 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 
                 var spec = DatasetPipelineFactory.MapProductSpecificationToSpec(
                     metadata.ProductSpecification)
-                    ?? DatasetPipelineFactory.DetectProductSpecFromSource(
-                        tracked.Source, relativePath);
+                    ?? await DatasetPipelineFactory.DetectProductSpecFromSourceAsync(
+                        tracked.Source, relativePath, cancellationToken)
+                        .ConfigureAwait(true);
                 if (spec is null)
                 {
                     var msg = string.Format(

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactorySourceSniffingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactorySourceSniffingTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Crs.ProjNet;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that the source-based
+/// <see cref="DatasetPipelineFactory.CreateProcessor(IAssetSource, string, string?, System.Collections.Generic.IReadOnlyDictionary{string, string}?)"/>
+/// overload content-sniffs a GML dataset when the exchange-set catalogue
+/// omits a machine-readable product identifier. Real-world JCOMM S-411
+/// exchange sets (e.g. Canadian Ice Service Hudson Bay sets) declare only a
+/// human-readable product-specification name — "Ice Information Product
+/// Specification (JCOMM S-411)" — with no <c>productIdentifier</c> or
+/// <c>number</c>, so the dataset must be recognized from its GML root element.
+/// </summary>
+public class DatasetPipelineFactorySourceSniffingTests
+{
+    private const string JcommIceGml =
+        "<?xml version='1.0' encoding='utf-8'?>\n" +
+        "<ice:IceDataSet xmlns:gml=\"http://www.opengis.net/gml/3.2\" " +
+        "xmlns:ice=\"http://www.jcomm.info/ice\">" +
+        "<ice:IceFeatureMember><ice:seaice gml:id=\"seaice.None\">" +
+        "<ice:iceact>50</ice:iceact>" +
+        "<gml:Polygon srsName=\"http://www.opengis.net/def/crs/EPSG/0/4326\" gml:id=\"seaice.Noneg\">" +
+        "<gml:exterior><gml:LinearRing><gml:posList>61.60 -66.84 61.55 -66.92 61.46 -66.96 61.60 -66.84</gml:posList>" +
+        "</gml:LinearRing></gml:exterior></gml:Polygon>" +
+        "</ice:seaice></ice:IceFeatureMember></ice:IceDataSet>";
+
+    private static DatasetPipelineFactory CreateFactory()
+    {
+        var pcManager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                pcManager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+
+        return new DatasetPipelineFactory(
+            pcManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            new FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue),
+            new DisplayPlaneAuthorityProvider());
+    }
+
+    [Fact]
+    public void CreateProcessor_SniffsJcommIceGml_WhenCatalogueDeclaresNoProductIdentifier()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "s411-sniff-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ice.gml"), JcommIceGml);
+            using var source = FileSystemAssetSource.Create(dir);
+            var factory = CreateFactory();
+
+            // declaredProductSpec is null, mirroring a JCOMM S-411 catalogue
+            // that omits productIdentifier/number.
+            var processor = factory.CreateProcessor(source, "ice.gml", declaredProductSpec: null);
+
+            Assert.IsType<S411DatasetProcessor>(processor);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateProcessor_PrefersDeclaredSpec_OverContentSniffing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "s411-sniff-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ice.gml"), JcommIceGml);
+            using var source = FileSystemAssetSource.Create(dir);
+            var factory = CreateFactory();
+
+            // A declared, recognized spec short-circuits content sniffing.
+            var processor = factory.CreateProcessor(source, "ice.gml", declaredProductSpec: "S-411");
+
+            Assert.IsType<S411DatasetProcessor>(processor);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactorySourceSniffingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactorySourceSniffingTests.cs
@@ -51,11 +51,17 @@ public class DatasetPipelineFactorySourceSniffingTests
             new DisplayPlaneAuthorityProvider());
     }
 
+    private static string CreateScratchDirectory()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "s411-sniff-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
     [Fact]
     public void CreateProcessor_SniffsJcommIceGml_WhenCatalogueDeclaresNoProductIdentifier()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "s411-sniff-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
+        var dir = CreateScratchDirectory();
         try
         {
             File.WriteAllText(Path.Combine(dir, "ice.gml"), JcommIceGml);
@@ -77,8 +83,7 @@ public class DatasetPipelineFactorySourceSniffingTests
     [Fact]
     public void CreateProcessor_PrefersDeclaredSpec_OverContentSniffing()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "s411-sniff-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
+        var dir = CreateScratchDirectory();
         try
         {
             File.WriteAllText(Path.Combine(dir, "ice.gml"), JcommIceGml);
@@ -89,6 +94,46 @@ public class DatasetPipelineFactorySourceSniffingTests
             var processor = factory.CreateProcessor(source, "ice.gml", declaredProductSpec: "S-411");
 
             Assert.IsType<S411DatasetProcessor>(processor);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DetectProductSpecFromSourceAsync_SniffsJcommIceGml()
+    {
+        var dir = CreateScratchDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ice.gml"), JcommIceGml);
+            using var source = FileSystemAssetSource.Create(dir);
+
+            var spec = await DatasetPipelineFactory
+                .DetectProductSpecFromSourceAsync(source, "ice.gml");
+
+            Assert.Equal("S-411", spec);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DetectProductSpecFromSourceAsync_ReturnsNull_ForNonGmlExtension()
+    {
+        var dir = CreateScratchDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ice.txt"), JcommIceGml);
+            using var source = FileSystemAssetSource.Create(dir);
+
+            var spec = await DatasetPipelineFactory
+                .DetectProductSpecFromSourceAsync(source, "ice.txt");
+
+            Assert.Null(spec);
         }
         finally
         {

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactorySourceSniffingTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactorySourceSniffingTests.cs
@@ -122,6 +122,29 @@ public class DatasetPipelineFactorySourceSniffingTests
     }
 
     [Fact]
+    public async Task DetectProductSpecFromSourceAsync_SniffsUtf16BomJcommIceGml()
+    {
+        var dir = CreateScratchDirectory();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, "ice.gml"),
+                JcommIceGml,
+                new System.Text.UnicodeEncoding(bigEndian: false, byteOrderMark: true));
+            using var source = FileSystemAssetSource.Create(dir);
+
+            var spec = await DatasetPipelineFactory
+                .DetectProductSpecFromSourceAsync(source, "ice.gml");
+
+            Assert.Equal("S-411", spec);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task DetectProductSpecFromSourceAsync_ReturnsNull_ForNonGmlExtension()
     {
         var dir = CreateScratchDirectory();

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -45,6 +45,9 @@ public class ExchangeSetServiceLoaderTests
     private static string S101OrphanFixture() =>
         Path.Combine(FixturesRoot(), "Synthetic-S101Orphan");
 
+    private static string S411NoProductIdFixture() =>
+        Path.Combine(FixturesRoot(), "Synthetic-S411NoProductId");
+
     private sealed class NoopLoader : IDatasetLoaderService
     {
         public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
@@ -170,6 +173,34 @@ public class ExchangeSetServiceLoaderTests
         // the underlying file handle is released right away.
         Assert.Empty(datasets.Entries);
         Assert.Empty(datasets.ExchangeSetHeaders);
+    }
+
+    /// <summary>
+    /// Reproduces the real-world JCOMM S-411 (Canadian Ice Service) exchange
+    /// set whose <c>productSpecification</c> declares only a human-readable
+    /// <c>name</c> ("Ice Information Product Specification (JCOMM S-411)") with
+    /// no <c>productIdentifier</c> or number. The declared spec cannot be
+    /// mapped, so the loader must content-sniff the GML root element
+    /// (<c>ice:IceDataSet</c>) and still dispatch the dataset as S-411 rather
+    /// than skipping it as unsupported.
+    /// </summary>
+    [Fact]
+    public async Task OpenAsync_S411NoProductId_ContentSniffsAndLoadsAsS411()
+    {
+        var (datasets, service) = CreateSystem();
+        using var _ = service;
+
+        var result = await service.OpenAsync(S411NoProductIdFixture());
+
+        Assert.Equal(1, result.Total);
+        Assert.Equal(1, result.Loaded);
+        Assert.Equal(0, result.SkippedUnsupported);
+        Assert.False(result.Cancelled);
+        Assert.Empty(result.SkipMessages);
+
+        var entry = Assert.Single(datasets.Entries);
+        Assert.Equal("S-411", entry.ProductSpec);
+        Assert.Equal("S-411/ice.gml", entry.RelativePath);
     }
 
     private sealed class SynchronousProgress<T> : IProgress<T>

--- a/tests/datasets/ExchangeSets/Synthetic-S411NoProductId/CATALOG.XML
+++ b/tests/datasets/ExchangeSets/Synthetic-S411NoProductId/CATALOG.XML
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic exchange-set catalogue reproducing the real-world JCOMM S-411
+  (Canadian Ice Service) shape: the dataset's <productSpecification> carries
+  only a human-readable <name> ("Ice Information Product Specification
+  (JCOMM S-411)") with NO <productIdentifier> and NO number. Consequently
+  DatasetPipelineFactory.MapProductSpecificationToSpec cannot resolve the
+  spec, and the loader must fall back to content-sniffing the GML root
+  element (<ice:IceDataSet>) to recognise it as S-411.
+
+  Unlike the other fixtures in this folder, the referenced dataset file
+  (S-411/ice.gml) IS shipped, because the content-sniff fallback reads its
+  bytes during dispatch (independent of the NoopLoader used by the tests).
+-->
+<S100XC:S100_ExchangeCatalogue
+    xmlns:S100XC="http://www.iho.int/s100/xc/5.0"
+    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
+  <S100XC:identifier>
+    <S100XC:identifier>SYNTH_S411_NOPRODUCTID_v1</S100XC:identifier>
+    <S100XC:dateTime>2026-06-29T18:00:00Z</S100XC:dateTime>
+  </S100XC:identifier>
+  <S100XC:contact>
+    <S100XC:organization>
+      <gco:CharacterString>Synthetic Ice Service</gco:CharacterString>
+    </S100XC:organization>
+  </S100XC:contact>
+  <S100XC:datasetDiscoveryMetadata>
+    <S100XC:S100_DatasetDiscoveryMetadata>
+      <S100XC:fileName>S-411/ice.gml</S100XC:fileName>
+      <S100XC:compressionFlag>false</S100XC:compressionFlag>
+      <S100XC:dataProtection>false</S100XC:dataProtection>
+      <S100XC:copyright>false</S100XC:copyright>
+      <S100XC:purpose>newDataset</S100XC:purpose>
+      <S100XC:notForNavigation>true</S100XC:notForNavigation>
+      <S100XC:editionNumber>1</S100XC:editionNumber>
+      <S100XC:updateNumber>0</S100XC:updateNumber>
+      <S100XC:issueDate>2026-06-29</S100XC:issueDate>
+      <S100XC:productSpecification>
+        <S100XC:name><gco:CharacterString>Ice Information Product Specification (JCOMM S-411)</gco:CharacterString></S100XC:name>
+        <S100XC:version><gco:CharacterString>1.1.0</gco:CharacterString></S100XC:version>
+      </S100XC:productSpecification>
+    </S100XC:S100_DatasetDiscoveryMetadata>
+  </S100XC:datasetDiscoveryMetadata>
+</S100XC:S100_ExchangeCatalogue>

--- a/tests/datasets/ExchangeSets/Synthetic-S411NoProductId/S-411/ice.gml
+++ b/tests/datasets/ExchangeSets/Synthetic-S411NoProductId/S-411/ice.gml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ice:IceDataSet xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ice="http://www.jcomm.info/ice">
+  <ice:IceFeatureMember>
+    <ice:seaice gml:id="seaice.None">
+      <ice:iceact>50</ice:iceact>
+      <ice:iceapc>[10, 40]</ice:iceapc>
+      <ice:icesod>[95, 93]</ice:icesod>
+      <ice:iceflz>[6, 6]</ice:iceflz>
+      <gml:Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/4326" gml:id="seaice.Noneg">
+        <gml:exterior>
+          <gml:LinearRing>
+            <gml:posList>61.60 -66.84 61.55 -66.92 61.46 -66.96 61.30 -67.10 61.60 -66.84</gml:posList>
+          </gml:LinearRing>
+        </gml:exterior>
+      </gml:Polygon>
+    </ice:seaice>
+  </ice:IceFeatureMember>
+</ice:IceDataSet>


### PR DESCRIPTION
## Summary

Follow-up to #423 / #424. Dragging a real JCOMM S-411 (Canadian Ice Service) exchange-set folder into the viewer got as far as reading the catalogue, but then loaded no datasets. These catalogues declare their product specification with only a human-readable `name` -- e.g. `Ice Information Product Specification (JCOMM S-411)` -- and no `productIdentifier` or number. The viewer's `ExchangeSetService` resolved each dataset's spec purely from that declared metadata (`MapProductSpecificationToSpec`), got `null`, and skipped every dataset as "unsupported", so nothing rendered.

The fix adds a GML content-sniff fallback so the exchange-set path recognizes datasets the same way the single-file drag-drop path already does: when the declared spec cannot be mapped, inspect the GML root element (`<ice:IceDataSet>` -> S-411) before giving up. The shared sniffing logic is factored out in `DatasetPipelineFactory` and exposed as `DetectProductSpecFromSource(IAssetSource, string)`, which the source-based `CreateProcessor` and `ExchangeSetService` both use. Verified end-to-end against the Hudson Bay sample: it now loads as one S-411 dataset and renders the full ice-concentration egg-code portrayal.

Related to #423

## Spec alignment

- [ ] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [x] N/A -- change is dataset-routing/detection infrastructure (S-411 recognition), no spec-semantic changes

**Spec section references cited in code/docs:**

N/A -- recognition is by GML root element / namespace, no new spec-derived constants.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (existing real-data tests unchanged; new tests use synthetic fixtures)
- [x] `dotnet test --configuration Release` passes locally (Pipelines 877 passed; Viewer exchange-set suite 10 passed)

New coverage:
- `DatasetPipelineFactorySourceSniffingTests` -- source-based routing of JCOMM ice GML with no declared identifier.
- `ExchangeSetServiceLoaderTests.OpenAsync_S411NoProductId_ContentSniffsAndLoadsAsS411` plus a `Synthetic-S411NoProductId` fixture reproducing the exact catalogue shape.

## Documentation

- [ ] Updated the affected project's `src/<project>/README.md`
- [ ] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments (`DetectProductSpecFromSource`)

## Dependencies

- [x] No new NuGet dependencies
- [x] `gh-advisory-database` security check run for any new dependency (N/A -- none added)

## Breaking changes

None.