### PR TITLE
Add s100 s57 convert command and S101DocumentWriter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <!-- EncDotNet -->
-    <PackageVersion Include="EncDotNet.Iso8211" Version="0.5.1" />
+    <PackageVersion Include="EncDotNet.Iso8211" Version="0.6.0" />
     <PackageVersion Include="EncDotNet.S57" Version="0.5.1" />
     <!-- Mapping / rendering -->
     <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.330" />

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -174,8 +174,8 @@ the feature/attribute/information/association code catalogues), the spatial
 records (`PRID`, `MRID`, `CRID`, `CCID`, `SRID`), the feature records (`FRID`,
 `FOID`, `ATTR`, `SPAS`, `INAS`), and the information records (`IRID`, `ATTR`).
 A document read from a real `.000` and written back is equivalent when read
-again. Feature-to-feature associations (`FASC`) are not emitted — the S-57
-translator produces none and the reader does not surface them.
+again. Feature-to-feature associations (`FASC`) are not emitted: the S-57
+translator produces none, so there are none to encode.
 
 This is the encoder behind the `s100 s57 convert` CLI command, which translates
 an S-57 base cell to `S101Document` and writes it as a base S-101 cell

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -172,10 +172,11 @@ emits (field tags, subfield names, and binary formats matching the canonical
 S-101 encoding), followed by a DSID record (identification, structure info, and
 the feature/attribute/information/association code catalogues), the spatial
 records (`PRID`, `MRID`, `CRID`, `CCID`, `SRID`), the feature records (`FRID`,
-`FOID`, `ATTR`, `SPAS`, `INAS`), and the information records (`IRID`, `ATTR`).
-A document read from a real `.000` and written back is equivalent when read
-again. Feature-to-feature associations (`FACS`) are not emitted: the S-57
-translator produces none, so there are none to encode.
+`FOID`, `ATTR`, `SPAS`, `FACS`, `INAS`), and the information records (`IRID`,
+`ATTR`). A document read from a real `.000` and written back is equivalent when
+read again. Feature-to-feature associations (`FACS`) are serialized and
+round-trip when present, although the S-57 translator does not currently produce
+any.
 
 This is the encoder behind the `s100 s57 convert` CLI command, which translates
 an S-57 base cell to `S101Document` and writes it as a base S-101 cell

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -174,7 +174,7 @@ the feature/attribute/information/association code catalogues), the spatial
 records (`PRID`, `MRID`, `CRID`, `CCID`, `SRID`), the feature records (`FRID`,
 `FOID`, `ATTR`, `SPAS`, `INAS`), and the information records (`IRID`, `ATTR`).
 A document read from a real `.000` and written back is equivalent when read
-again. Feature-to-feature associations (`FASC`) are not emitted: the S-57
+again. Feature-to-feature associations (`FACS`) are not emitted: the S-57
 translator produces none, so there are none to encode.
 
 This is the encoder behind the `s100 s57 convert` CLI command, which translates

--- a/src/EncDotNet.S100.Datasets.S101/README.md
+++ b/src/EncDotNet.S100.Datasets.S101/README.md
@@ -8,6 +8,7 @@ This library reads S-101 datasets encoded in ISO 8211 format and executes the S-
 
 - **`S101Dataset`** — parsed ENC dataset containing features from ISO 8211 records.
 - **`S101Document`**, **`S101DocumentReader`** — low-level ISO 8211 record parsing.
+- **`S101DocumentWriter`** — the symmetric inverse of `S101DocumentReader`: encodes an `S101Document` back to an ISO/IEC 8211 S-101 dataset (`byte[]` / stream / file). Used by the S-57 → S-101 conversion path (`s100 s57 convert`). It emits a Data Descriptive Record (DDR) plus one data record per dataset / spatial / feature / information object; a document read from a `.000` and written back round-trips through the reader. See below.
 - **`S101LuaRuleExecutor`** — `ILuaVectorRuleExecutor` implementation that wraps the product-agnostic `LuaRuleExecutor` from `EncDotNet.S100.Core`, supplying the S-101 seams: the `S101LuaDataProvider` host bridge, the mariner→context-parameter bindings, a feature-anchor provider for augmented line tessellation, and the SAFCON contour-label transform.
 - **`S101PortrayalCatalogue`** — `IVectorPortrayalCatalogue` implementation that loads XSLT/Lua rules, symbols, line styles, area fills, and color palettes.
 - **`S101VectorSource`** — `IVectorSource` implementation for the vector pipeline. Surface geometry resolves both the exterior ring (`Feature.Coordinates`) and any interior rings / holes (`Feature.InteriorRings`) from the RIAS field (USAG = 2), so a sea/depth area encoded around islands (S-100 Part 10a surface topology) renders with the land cut out instead of painting solidly over every `LandArea`.
@@ -154,6 +155,32 @@ Every record-id field also carries `RVER` (record version) and `RUIN`
 attribute fields carry their inline per-element update instructions
 (`SAUI` / `FAUI` / `IUIN` / `ATIN`). These are read into the model to
 drive sequential update application.
+
+## Writing datasets
+
+`S101DocumentWriter` is the inverse of `S101DocumentReader`: it serializes an
+`S101Document` to an ISO/IEC 8211 S-101 dataset.
+
+```csharp
+byte[] bytes = S101DocumentWriter.Write(document);
+S101DocumentWriter.WriteToFile("cell.000", document);
+await S101DocumentWriter.WriteToFileAsync("cell.000", document);
+```
+
+The writer authors a Data Descriptive Record (DDR) covering every field it
+emits (field tags, subfield names, and binary formats matching the canonical
+S-101 encoding), followed by a DSID record (identification, structure info, and
+the feature/attribute/information/association code catalogues), the spatial
+records (`PRID`, `MRID`, `CRID`, `CCID`, `SRID`), the feature records (`FRID`,
+`FOID`, `ATTR`, `SPAS`, `INAS`), and the information records (`IRID`, `ATTR`).
+A document read from a real `.000` and written back is equivalent when read
+again. Feature-to-feature associations (`FASC`) are not emitted — the S-57
+translator produces none and the reader does not surface them.
+
+This is the encoder behind the `s100 s57 convert` CLI command, which translates
+an S-57 base cell to `S101Document` and writes it as a base S-101 cell
+(application profile `1`).
+
 
 ## Sequential updates
 

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
@@ -1,0 +1,439 @@
+using EncDotNet.Iso8211;
+
+namespace EncDotNet.S100.Datasets.S101;
+
+/// <summary>
+/// Serializes an <see cref="S101Document"/> to an S-101 ISO/IEC 8211 encoded
+/// dataset (a <c>.000</c> cell), the symmetric inverse of
+/// <see cref="S101DocumentReader"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The writer emits a Data Descriptive Record (DDR) describing every field it
+/// uses, followed by one data record per dataset / spatial / feature /
+/// information object, using the field and subfield structure defined by S-101
+/// (S-100 Part 10a). Field tags, subfield names, and binary formats mirror the
+/// canonical S-101 encoding so the output round-trips through
+/// <see cref="S101DocumentReader"/>.
+/// </para>
+/// <para>
+/// This is the encoder consumed by the S-57 → S-101 conversion pipeline: an
+/// <see cref="S101Document"/> produced by the translator is serialized here to a
+/// standalone base cell (application profile <c>1</c>). Feature-to-feature
+/// associations (<c>FASC</c>) are not emitted; the translator produces none and
+/// <see cref="S101DocumentReader"/> does not surface them.
+/// </para>
+/// </remarks>
+public static class S101DocumentWriter
+{
+    // Record names (RCNM) per S-101 / S-100 Part 10a.
+    private const byte RcnmDataset = 10;
+    private const byte RcnmFeature = 100;
+    private const byte RcnmPoint = 110;
+    private const byte RcnmMultiPoint = 115;
+    private const byte RcnmCurve = 120;
+    private const byte RcnmCompositeCurve = 125;
+    private const byte RcnmSurface = 130;
+    private const byte RcnmInformation = 150;
+
+    private static readonly Iso8211WriterOptions Options = Iso8211WriterOptions.Default;
+    private static readonly IReadOnlyDictionary<string, Iso8211FieldDefinition> FieldDefs = BuildFieldDefinitions();
+
+    /// <summary>
+    /// Serializes the supplied document to an in-memory ISO 8211 byte buffer.
+    /// </summary>
+    /// <param name="document">The document to serialize.</param>
+    /// <returns>The encoded ISO 8211 dataset bytes.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="document"/> is <see langword="null"/>.</exception>
+    public static byte[] Write(S101Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return Iso8211DocumentWriter.Write(BuildDocument(document), Options);
+    }
+
+    /// <summary>
+    /// Serializes the supplied document to a stream.
+    /// </summary>
+    /// <param name="stream">The destination stream.</param>
+    /// <param name="document">The document to serialize.</param>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    public static void Write(Stream stream, S101Document document)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(document);
+        Iso8211DocumentWriter.Write(stream, BuildDocument(document), Options);
+    }
+
+    /// <summary>
+    /// Asynchronously serializes the supplied document to a stream.
+    /// </summary>
+    /// <param name="stream">The destination stream.</param>
+    /// <param name="document">The document to serialize.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that completes when the document has been written.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    public static Task WriteAsync(Stream stream, S101Document document, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(document);
+        return Iso8211DocumentWriter.WriteAsync(stream, BuildDocument(document), Options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Serializes the supplied document to a file, overwriting any existing file.
+    /// </summary>
+    /// <param name="path">The destination file path.</param>
+    /// <param name="document">The document to serialize.</param>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    public static void WriteToFile(string path, S101Document document)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(document);
+        Iso8211DocumentWriter.WriteToFile(path, BuildDocument(document), Options);
+    }
+
+    /// <summary>
+    /// Asynchronously serializes the supplied document to a file, overwriting any existing file.
+    /// </summary>
+    /// <param name="path">The destination file path.</param>
+    /// <param name="document">The document to serialize.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that completes when the file has been written.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    public static Task WriteToFileAsync(string path, S101Document document, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(document);
+        return Iso8211DocumentWriter.WriteToFileAsync(path, BuildDocument(document), Options, cancellationToken);
+    }
+
+    private static Iso8211Document BuildDocument(S101Document doc)
+    {
+        var builder = new Iso8211DocumentBuilder();
+
+        // The DDR carries only the field definitions actually used below.
+        builder.AddRecord(Iso8211DataDescriptiveRecordWriter.BuildDdr(FieldDefs.Values, options: Options));
+
+        builder.AddRecord(BuildDatasetRecord(doc));
+
+        foreach (var p in doc.Points.Values)
+            builder.AddRecord(BuildPointRecord(p));
+        foreach (var m in doc.MultiPoints.Values)
+            builder.AddRecord(BuildMultiPointRecord(m));
+        foreach (var c in doc.CurveSegments.Values)
+            builder.AddRecord(BuildCurveRecord(c));
+        foreach (var cc in doc.CompositeCurves.Values)
+            builder.AddRecord(BuildCompositeCurveRecord(cc));
+        foreach (var s in doc.Surfaces.Values)
+            builder.AddRecord(BuildSurfaceRecord(s));
+        foreach (var info in doc.InformationTypes.Values)
+            builder.AddRecord(BuildInformationRecord(info));
+        foreach (var f in doc.Features)
+            builder.AddRecord(BuildFeatureRecord(f));
+
+        return builder.Build();
+    }
+
+    // ── Record builders ─────────────────────────────────────────────────
+
+    private static Iso8211Record BuildDatasetRecord(S101Document doc)
+    {
+        var id = doc.Identification;
+        var si = doc.StructureInfo;
+
+        var dsid = Field("DSID")
+            .AddSubfields(
+                (int)(id.RecordName == 0 ? RcnmDataset : id.RecordName),
+                id.RecordId,
+                id.EncodingSpecification,
+                id.EncodingSpecificationEdition,
+                id.ProductSpecification,
+                id.ProductSpecificationEdition,
+                id.ApplicationProfile,
+                id.DatasetName,
+                id.DatasetTitle,
+                id.DatasetReferenceDate,
+                id.DatasetLanguage,
+                id.DatasetAbstract,
+                id.DatasetEdition,
+                0 /* DSTC */);
+
+        var dssi = Field("DSSI")
+            .AddSubfields(
+                0d, 0d, 0d, // DCOX/DCOY/DCOZ
+                si.CoordinateMultiplicationFactorX,
+                si.CoordinateMultiplicationFactorY,
+                si.CoordinateMultiplicationFactorZ,
+                doc.InformationTypes.Count, // NOIR
+                doc.Points.Count,           // NOPN
+                doc.MultiPoints.Count,      // NOMN
+                doc.CurveSegments.Count,    // NOCN
+                doc.CompositeCurves.Count,  // NOXN
+                doc.Surfaces.Count,         // NOSN
+                doc.Features.Count);        // NOFR
+
+        var record = new Iso8211RecordBuilder(Options)
+            .AddField(dsid)
+            .AddField(dssi);
+
+        AddCatalogue(record, "FTCS", doc.FeatureTypeCatalogue);
+        AddCatalogue(record, "ATCS", doc.AttributeTypeCatalogue);
+        AddCatalogue(record, "ITCS", doc.InformationTypeCatalogue);
+        AddCatalogue(record, "IACS", doc.InformationAssociationCatalogue);
+        AddCatalogue(record, "FACS", doc.FeatureAssociationCatalogue);
+        AddCatalogue(record, "ARCS", doc.RoleCatalogue);
+
+        return record.Build();
+    }
+
+    private static void AddCatalogue(Iso8211RecordBuilder record, string tag, IReadOnlyDictionary<ushort, string> entries)
+    {
+        if (entries.Count == 0)
+            return;
+
+        var field = Field(tag);
+        foreach (var (code, acronym) in entries)
+            field.AddSubfields(acronym, (int)code);
+        record.AddField(field);
+    }
+
+    private static Iso8211Record BuildPointRecord(S101PointRecord p)
+    {
+        var prid = Field("PRID").AddSubfields(
+            (int)RcnmPoint, p.RecordId, (int)p.RecordVersion, (int)p.UpdateInstruction);
+        var c2it = Field("C2IT").AddSubfields(p.Y, p.X);
+        return new Iso8211RecordBuilder(Options).AddField(prid).AddField(c2it).Build();
+    }
+
+    private static Iso8211Record BuildMultiPointRecord(S101MultiPointRecord m)
+    {
+        var mrid = Field("MRID").AddSubfields(
+            (int)RcnmMultiPoint, m.RecordId, (int)m.RecordVersion, (int)m.UpdateInstruction);
+
+        var c3il = Field("C3IL");
+        // Leading VCID (b11) followed by repeating Y/X/Z triples (rep@1).
+        c3il.AddSubfield(0);
+        foreach (var (y, x, z) in m.Points)
+            c3il.AddSubfields(y, x, z);
+
+        return new Iso8211RecordBuilder(Options).AddField(mrid).AddField(c3il).Build();
+    }
+
+    private static Iso8211Record BuildCurveRecord(S101CurveSegmentRecord c)
+    {
+        var record = new Iso8211RecordBuilder(Options)
+            .AddField(Field("CRID").AddSubfields(
+                (int)RcnmCurve, c.RecordId, (int)c.RecordVersion, (int)c.UpdateInstruction));
+
+        if (c.PointAssociations.Count > 0)
+        {
+            var ptas = Field("PTAS");
+            foreach (var a in c.PointAssociations)
+                ptas.AddSubfields((int)a.RecordName, a.RecordId, (int)a.Topology);
+            record.AddField(ptas);
+        }
+
+        if (c.IntermediateCoordinates.Count > 0)
+        {
+            var c2il = Field("C2IL");
+            foreach (var (y, x) in c.IntermediateCoordinates)
+                c2il.AddSubfields(y, x);
+            record.AddField(c2il);
+        }
+
+        return record.Build();
+    }
+
+    private static Iso8211Record BuildCompositeCurveRecord(S101CompositeCurveRecord cc)
+    {
+        var record = new Iso8211RecordBuilder(Options)
+            .AddField(Field("CCID").AddSubfields(
+                (int)RcnmCompositeCurve, cc.RecordId, (int)cc.RecordVersion, (int)cc.UpdateInstruction));
+
+        if (cc.CurveComponents.Count > 0)
+        {
+            var cuco = Field("CUCO");
+            foreach (var u in cc.CurveComponents)
+                cuco.AddSubfields((int)u.RecordName, u.RecordId, (int)u.Orientation);
+            record.AddField(cuco);
+        }
+
+        return record.Build();
+    }
+
+    private static Iso8211Record BuildSurfaceRecord(S101SurfaceRecord s)
+    {
+        var record = new Iso8211RecordBuilder(Options)
+            .AddField(Field("SRID").AddSubfields(
+                (int)RcnmSurface, s.RecordId, (int)s.RecordVersion, (int)s.UpdateInstruction));
+
+        if (s.RingAssociations.Count > 0)
+        {
+            var rias = Field("RIAS");
+            foreach (var r in s.RingAssociations)
+                rias.AddSubfields((int)r.RecordName, r.RecordId, (int)r.Orientation, (int)r.Usage, 0 /* RAUI */);
+            record.AddField(rias);
+        }
+
+        return record.Build();
+    }
+
+    private static Iso8211Record BuildFeatureRecord(S101FeatureRecord f)
+    {
+        var record = new Iso8211RecordBuilder(Options)
+            .AddField(Field("FRID").AddSubfields(
+                (int)RcnmFeature, f.RecordId, (int)f.FeatureTypeCode, (int)f.RecordVersion, (int)f.UpdateInstruction))
+            .AddField(Field("FOID").AddSubfields(
+                (int)f.ProducingAgency, f.FeatureIdentificationNumber, (int)f.FeatureIdentificationSubdivision));
+
+        AddAttributes(record, f.Attributes);
+
+        if (f.SpatialAssociations.Count > 0)
+        {
+            var spas = Field("SPAS");
+            foreach (var a in f.SpatialAssociations)
+                spas.AddSubfields((int)a.RecordName, a.RecordId, (int)a.Orientation, 0 /* SMIN */, 0 /* SMAX */, (int)a.UpdateInstruction);
+            record.AddField(spas);
+        }
+
+        if (f.InformationAssociations.Count > 0)
+        {
+            foreach (var a in f.InformationAssociations)
+            {
+                record.AddField(Field("INAS").AddSubfields(
+                    (int)RcnmInformation, a.RecordId, (int)a.NumericCode, (int)a.RoleCode, (int)a.UpdateInstruction));
+            }
+        }
+
+        return record.Build();
+    }
+
+    private static Iso8211Record BuildInformationRecord(S101InformationRecord info)
+    {
+        var record = new Iso8211RecordBuilder(Options)
+            .AddField(Field("IRID").AddSubfields(
+                (int)RcnmInformation, info.RecordId, (int)info.InformationTypeCode, (int)info.RecordVersion, (int)info.UpdateInstruction));
+
+        AddAttributes(record, info.Attributes);
+        return record.Build();
+    }
+
+    private static void AddAttributes(Iso8211RecordBuilder record, IReadOnlyList<S101Attribute> attributes)
+    {
+        if (attributes.Count == 0)
+            return;
+
+        var attr = Field("ATTR");
+        foreach (var a in attributes)
+            attr.AddSubfields((int)a.NumericCode, (int)a.Index, (int)a.ParentIndex, (int)a.UpdateInstruction, a.Value);
+        record.AddField(attr);
+    }
+
+    private static Iso8211FieldBuilder Field(string tag) => new(FieldDefs[tag], Options);
+
+    // ── Field definitions (the DDR) ─────────────────────────────────────
+
+    private static Iso8211SubfieldFormat U1 => new() { FormatType = Iso8211SubfieldFormatType.UnsignedInteger, Width = 1 };
+    private static Iso8211SubfieldFormat U2 => new() { FormatType = Iso8211SubfieldFormatType.UnsignedInteger, Width = 2 };
+    private static Iso8211SubfieldFormat U4 => new() { FormatType = Iso8211SubfieldFormatType.UnsignedInteger, Width = 4 };
+    private static Iso8211SubfieldFormat S4 => new() { FormatType = Iso8211SubfieldFormatType.SignedInteger, Width = 4 };
+    private static Iso8211SubfieldFormat F8 => new() { FormatType = Iso8211SubfieldFormatType.FloatingPoint, Width = 8 };
+    private static Iso8211SubfieldFormat A => new() { FormatType = Iso8211SubfieldFormatType.CharacterData, Width = 0 };
+
+    private static IReadOnlyDictionary<string, Iso8211FieldDefinition> BuildFieldDefinitions()
+    {
+        var defs = new List<Iso8211FieldDefinition>
+        {
+            Def("DSID", "Data Set Identification", Iso8211DataStructureCode.ConcatenatedArray, Iso8211DataTypeCode.MixedDataTypes, -1,
+                ("RCNM", U1), ("RCID", U4), ("ENSP", A), ("ENED", A), ("PRSP", A), ("PRED", A), ("PROF", A),
+                ("DSNM", A), ("DSTL", A), ("DSRD", A), ("DSLG", A), ("DSAB", A), ("DSED", A), ("DSTC", U1)),
+            Def("DSSI", "Data Set Structure Information", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.MixedDataTypes, -1,
+                ("DCOX", F8), ("DCOY", F8), ("DCOZ", F8), ("CMFX", U4), ("CMFY", U4), ("CMFZ", U4),
+                ("NOIR", U4), ("NOPN", U4), ("NOMN", U4), ("NOCN", U4), ("NOXN", U4), ("NOSN", U4), ("NOFR", U4)),
+
+            Def("FTCS", "Feature Type Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("FTCD", A), ("FTNC", U2)),
+            Def("ATCS", "Attribute Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("ATCD", A), ("ANCD", U2)),
+            Def("ITCS", "Information Type Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("ITCD", A), ("ITNC", U2)),
+            Def("IACS", "Information Association Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("IACD", A), ("IANC", U2)),
+            Def("FACS", "Feature Association Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("FACD", A), ("FANC", U2)),
+            Def("ARCS", "Association Role Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("ARCD", A), ("ARNC", U2)),
+
+            Def("PRID", "Point Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("RVER", U2), ("RUIN", U1)),
+            Def("C2IT", "2-D Integer Coordinate Tuple", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("YCOO", S4), ("XCOO", S4)),
+
+            Def("MRID", "Multi Point Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("RVER", U2), ("RUIN", U1)),
+            Def("C3IL", "3-D Integer Coordinate List", Iso8211DataStructureCode.ConcatenatedArray, Iso8211DataTypeCode.ImplicitPoint, 1,
+                ("VCID", U1), ("YCOO", S4), ("XCOO", S4), ("ZCOO", S4)),
+
+            Def("CRID", "Curve Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("RVER", U2), ("RUIN", U1)),
+            Def("PTAS", "Point Association", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.ImplicitPoint, 0,
+                ("RRNM", U1), ("RRID", U4), ("TOPI", U1)),
+            Def("C2IL", "2-D Integer Coordinate List", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.ImplicitPoint, 0,
+                ("YCOO", S4), ("XCOO", S4)),
+
+            Def("CCID", "Composite Curve Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("RVER", U2), ("RUIN", U1)),
+            Def("CUCO", "Curve Component", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.ImplicitPoint, 0,
+                ("RRNM", U1), ("RRID", U4), ("ORNT", U1)),
+
+            Def("SRID", "Surface Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("RVER", U2), ("RUIN", U1)),
+            Def("RIAS", "Ring Association", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.ImplicitPoint, 0,
+                ("RRNM", U1), ("RRID", U4), ("ORNT", U1), ("USAG", U1), ("RAUI", U1)),
+
+            Def("FRID", "Feature Type Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("NFTC", U2), ("RVER", U2), ("RUIN", U1)),
+            Def("FOID", "Feature Object Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("AGEN", U2), ("FIDN", U4), ("FIDS", U2)),
+            Def("ATTR", "Attribute", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0,
+                ("NATC", U2), ("ATIX", U2), ("PAIX", U2), ("ATIN", U1), ("ATVL", A)),
+            Def("SPAS", "Spatial Association", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.ImplicitPoint, 0,
+                ("RRNM", U1), ("RRID", U4), ("ORNT", U1), ("SMIN", U4), ("SMAX", U4), ("SAUI", U1)),
+            Def("INAS", "Information Association", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.MixedDataTypes, -1,
+                ("RRNM", U1), ("RRID", U4), ("NIAC", U2), ("NARC", U2), ("IUIN", U1)),
+
+            Def("IRID", "Information Type Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,
+                ("RCNM", U1), ("RCID", U4), ("NITC", U2), ("RVER", U2), ("RUIN", U1)),
+        };
+
+        return defs.ToDictionary(d => d.Tag, d => d);
+    }
+
+    private static Iso8211FieldDefinition Def(
+        string tag,
+        string name,
+        Iso8211DataStructureCode structureCode,
+        Iso8211DataTypeCode typeCode,
+        int repeatingStartIndex,
+        params (string Name, Iso8211SubfieldFormat Format)[] subfields)
+    {
+        var subfieldDefs = new List<Iso8211SubfieldDefinition>(subfields.Length);
+        for (int i = 0; i < subfields.Length; i++)
+        {
+            subfieldDefs.Add(new Iso8211SubfieldDefinition
+            {
+                Name = subfields[i].Name,
+                Format = subfields[i].Format,
+                Index = i,
+                IsRepeating = repeatingStartIndex >= 0 && i >= repeatingStartIndex,
+            });
+        }
+
+        var formatControls = "(" + string.Join(",", subfields.Select(s => s.Format.ToString())) + ")";
+
+        return new Iso8211FieldDefinition
+        {
+            Tag = tag,
+            FieldName = name,
+            DataStructureCode = structureCode,
+            DataTypeCode = typeCode,
+            RepeatingSubfieldStartIndex = repeatingStartIndex,
+            SubfieldDefinitions = subfieldDefs,
+            FormatControls = formatControls,
+        };
+    }
+}

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
@@ -20,7 +20,7 @@ namespace EncDotNet.S100.Datasets.S101;
 /// This is the encoder consumed by the S-57 → S-101 conversion pipeline: an
 /// <see cref="S101Document"/> produced by the translator is serialized here to a
 /// standalone base cell (application profile <c>1</c>). Feature-to-feature
-/// associations (<c>FASC</c>) are not emitted: the S-57 translator produces none,
+/// associations (<c>FACS</c>) are not emitted: the S-57 translator produces none,
 /// so there are none to encode.
 /// </para>
 /// </remarks>
@@ -84,10 +84,11 @@ public static class S101DocumentWriter
     /// </summary>
     /// <param name="path">The destination file path.</param>
     /// <param name="document">The document to serialize.</param>
-    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="document"/> is <see langword="null"/>.</exception>
     public static void WriteToFile(string path, S101Document document)
     {
-        ArgumentNullException.ThrowIfNull(path);
+        ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(document);
         Iso8211DocumentWriter.WriteToFile(path, BuildDocument(document), Options);
     }
@@ -99,10 +100,11 @@ public static class S101DocumentWriter
     /// <param name="document">The document to serialize.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that completes when the file has been written.</returns>
-    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="document"/> is <see langword="null"/>.</exception>
     public static Task WriteToFileAsync(string path, S101Document document, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(path);
+        ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(document);
         return Iso8211DocumentWriter.WriteToFileAsync(path, BuildDocument(document), Options, cancellationToken);
     }

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
@@ -20,8 +20,8 @@ namespace EncDotNet.S100.Datasets.S101;
 /// This is the encoder consumed by the S-57 → S-101 conversion pipeline: an
 /// <see cref="S101Document"/> produced by the translator is serialized here to a
 /// standalone base cell (application profile <c>1</c>). Feature-to-feature
-/// associations (<c>FACS</c>) are not emitted: the S-57 translator produces none,
-/// so there are none to encode.
+/// associations (<c>FACS</c>) are serialized when present, although the S-57
+/// translator does not currently produce any.
 /// </para>
 /// </remarks>
 public static class S101DocumentWriter
@@ -37,14 +37,13 @@ public static class S101DocumentWriter
     private const byte RcnmInformation = 150;
 
     private static readonly Iso8211WriterOptions Options = Iso8211WriterOptions.Default;
-    private static readonly IReadOnlyDictionary<string, Iso8211FieldDefinition> FieldDefs = BuildFieldDefinitions();
-
     /// <summary>
     /// Serializes the supplied document to an in-memory ISO 8211 byte buffer.
     /// </summary>
     /// <param name="document">The document to serialize.</param>
     /// <returns>The encoded ISO 8211 dataset bytes.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="document"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The document requires incompatible uses of the <c>FACS</c> field tag.</exception>
     public static byte[] Write(S101Document document)
     {
         ArgumentNullException.ThrowIfNull(document);
@@ -57,6 +56,7 @@ public static class S101DocumentWriter
     /// <param name="stream">The destination stream.</param>
     /// <param name="document">The document to serialize.</param>
     /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The document requires incompatible uses of the <c>FACS</c> field tag.</exception>
     public static void Write(Stream stream, S101Document document)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -72,6 +72,7 @@ public static class S101DocumentWriter
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that completes when the document has been written.</returns>
     /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The document requires incompatible uses of the <c>FACS</c> field tag.</exception>
     public static Task WriteAsync(Stream stream, S101Document document, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -86,6 +87,7 @@ public static class S101DocumentWriter
     /// <param name="document">The document to serialize.</param>
     /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or empty.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="document"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The document requires incompatible uses of the <c>FACS</c> field tag.</exception>
     public static void WriteToFile(string path, S101Document document)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
@@ -102,6 +104,7 @@ public static class S101DocumentWriter
     /// <returns>A task that completes when the file has been written.</returns>
     /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or empty.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="document"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The document requires incompatible uses of the <c>FACS</c> field tag.</exception>
     public static Task WriteToFileAsync(string path, S101Document document, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
@@ -112,38 +115,49 @@ public static class S101DocumentWriter
     private static Iso8211Document BuildDocument(S101Document doc)
     {
         var builder = new Iso8211DocumentBuilder();
+        var hasFeatureAssociations = doc.Features.Any(f => f.FeatureAssociations.Count > 0);
+        if (hasFeatureAssociations && doc.FeatureAssociationCatalogue.Count > 0)
+        {
+            throw new NotSupportedException(
+                "S101DocumentWriter cannot emit both the feature association code catalogue and feature association pointers because both use ISO 8211 field tag FACS.");
+        }
+
+        var fieldDefs = BuildFieldDefinitions(hasFeatureAssociations);
 
         // The DDR carries the full canonical field definition set, including definitions not emitted in this document.
-        builder.AddRecord(Iso8211DataDescriptiveRecordWriter.BuildDdr(FieldDefs.Values, options: Options));
+        builder.AddRecord(Iso8211DataDescriptiveRecordWriter.BuildDdr(fieldDefs.Values, options: Options));
 
-        builder.AddRecord(BuildDatasetRecord(doc));
+        builder.AddRecord(BuildDatasetRecord(doc, fieldDefs, hasFeatureAssociations));
 
         foreach (var p in doc.Points.Values)
-            builder.AddRecord(BuildPointRecord(p));
+            builder.AddRecord(BuildPointRecord(p, fieldDefs));
         foreach (var m in doc.MultiPoints.Values)
-            builder.AddRecord(BuildMultiPointRecord(m));
+            builder.AddRecord(BuildMultiPointRecord(m, fieldDefs));
         foreach (var c in doc.CurveSegments.Values)
-            builder.AddRecord(BuildCurveRecord(c));
+            builder.AddRecord(BuildCurveRecord(c, fieldDefs));
         foreach (var cc in doc.CompositeCurves.Values)
-            builder.AddRecord(BuildCompositeCurveRecord(cc));
+            builder.AddRecord(BuildCompositeCurveRecord(cc, fieldDefs));
         foreach (var s in doc.Surfaces.Values)
-            builder.AddRecord(BuildSurfaceRecord(s));
+            builder.AddRecord(BuildSurfaceRecord(s, fieldDefs));
         foreach (var info in doc.InformationTypes.Values)
-            builder.AddRecord(BuildInformationRecord(info));
+            builder.AddRecord(BuildInformationRecord(info, fieldDefs));
         foreach (var f in doc.Features)
-            builder.AddRecord(BuildFeatureRecord(f));
+            builder.AddRecord(BuildFeatureRecord(f, fieldDefs));
 
         return builder.Build();
     }
 
     // ── Record builders ─────────────────────────────────────────────────
 
-    private static Iso8211Record BuildDatasetRecord(S101Document doc)
+    private static Iso8211Record BuildDatasetRecord(
+        S101Document doc,
+        IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs,
+        bool featureAssociationFieldsUseFacs)
     {
         var id = doc.Identification;
         var si = doc.StructureInfo;
 
-        var dsid = Field("DSID")
+        var dsid = Field("DSID", fieldDefs)
             .AddSubfields(
                 (int)(id.RecordName == 0 ? RcnmDataset : id.RecordName),
                 id.RecordId,
@@ -160,7 +174,7 @@ public static class S101DocumentWriter
                 id.DatasetEdition,
                 0 /* DSTC */);
 
-        var dssi = Field("DSSI")
+        var dssi = Field("DSSI", fieldDefs)
             .AddSubfields(
                 0d, 0d, 0d, // DCOX/DCOY/DCOZ
                 si.CoordinateMultiplicationFactorX,
@@ -178,41 +192,45 @@ public static class S101DocumentWriter
             .AddField(dsid)
             .AddField(dssi);
 
-        AddCatalogue(record, "FTCS", doc.FeatureTypeCatalogue);
-        AddCatalogue(record, "ATCS", doc.AttributeTypeCatalogue);
-        AddCatalogue(record, "ITCS", doc.InformationTypeCatalogue);
-        AddCatalogue(record, "IACS", doc.InformationAssociationCatalogue);
-        AddCatalogue(record, "FACS", doc.FeatureAssociationCatalogue);
-        AddCatalogue(record, "ARCS", doc.RoleCatalogue);
+        AddCatalogue(record, "FTCS", doc.FeatureTypeCatalogue, fieldDefs);
+        AddCatalogue(record, "ATCS", doc.AttributeTypeCatalogue, fieldDefs);
+        AddCatalogue(record, "ITCS", doc.InformationTypeCatalogue, fieldDefs);
+        AddCatalogue(record, "IACS", doc.InformationAssociationCatalogue, fieldDefs);
+        if (!featureAssociationFieldsUseFacs)
+            AddCatalogue(record, "FACS", doc.FeatureAssociationCatalogue, fieldDefs);
+        AddCatalogue(record, "ARCS", doc.RoleCatalogue, fieldDefs);
 
         return record.Build();
     }
 
-    private static void AddCatalogue(Iso8211RecordBuilder record, string tag, IReadOnlyDictionary<ushort, string> entries)
+    private static void AddCatalogue(
+        Iso8211RecordBuilder record,
+        string tag,
+        IReadOnlyDictionary<ushort, string> entries,
+        IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         if (entries.Count == 0)
             return;
 
-        var field = Field(tag);
+        var field = Field(tag, fieldDefs);
         foreach (var (code, acronym) in entries)
             field.AddSubfields(acronym, (int)code);
         record.AddField(field);
     }
 
-    private static Iso8211Record BuildPointRecord(S101PointRecord p)
+    private static Iso8211Record BuildPointRecord(S101PointRecord p, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
-        var prid = Field("PRID").AddSubfields(
+        var prid = Field("PRID", fieldDefs).AddSubfields(
             (int)RcnmPoint, p.RecordId, (int)p.RecordVersion, (int)p.UpdateInstruction);
-        var c2it = Field("C2IT").AddSubfields(p.Y, p.X);
+        var c2it = Field("C2IT", fieldDefs).AddSubfields(p.Y, p.X);
         return new Iso8211RecordBuilder(Options).AddField(prid).AddField(c2it).Build();
     }
 
-    private static Iso8211Record BuildMultiPointRecord(S101MultiPointRecord m)
+    private static Iso8211Record BuildMultiPointRecord(S101MultiPointRecord m, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
-        var mrid = Field("MRID").AddSubfields(
+        var mrid = Field("MRID", fieldDefs).AddSubfields(
             (int)RcnmMultiPoint, m.RecordId, (int)m.RecordVersion, (int)m.UpdateInstruction);
-
-        var c3il = Field("C3IL");
+        var c3il = Field("C3IL", fieldDefs);
         // Leading VCID (b11) followed by repeating Y/X/Z triples (rep@1).
         c3il.AddSubfield(0);
         foreach (var (y, x, z) in m.Points)
@@ -221,15 +239,15 @@ public static class S101DocumentWriter
         return new Iso8211RecordBuilder(Options).AddField(mrid).AddField(c3il).Build();
     }
 
-    private static Iso8211Record BuildCurveRecord(S101CurveSegmentRecord c)
+    private static Iso8211Record BuildCurveRecord(S101CurveSegmentRecord c, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         var record = new Iso8211RecordBuilder(Options)
-            .AddField(Field("CRID").AddSubfields(
+            .AddField(Field("CRID", fieldDefs).AddSubfields(
                 (int)RcnmCurve, c.RecordId, (int)c.RecordVersion, (int)c.UpdateInstruction));
 
         if (c.PointAssociations.Count > 0)
         {
-            var ptas = Field("PTAS");
+            var ptas = Field("PTAS", fieldDefs);
             foreach (var a in c.PointAssociations)
                 ptas.AddSubfields((int)a.RecordName, a.RecordId, (int)a.Topology);
             record.AddField(ptas);
@@ -237,7 +255,7 @@ public static class S101DocumentWriter
 
         if (c.IntermediateCoordinates.Count > 0)
         {
-            var c2il = Field("C2IL");
+            var c2il = Field("C2IL", fieldDefs);
             foreach (var (y, x) in c.IntermediateCoordinates)
                 c2il.AddSubfields(y, x);
             record.AddField(c2il);
@@ -246,15 +264,15 @@ public static class S101DocumentWriter
         return record.Build();
     }
 
-    private static Iso8211Record BuildCompositeCurveRecord(S101CompositeCurveRecord cc)
+    private static Iso8211Record BuildCompositeCurveRecord(S101CompositeCurveRecord cc, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         var record = new Iso8211RecordBuilder(Options)
-            .AddField(Field("CCID").AddSubfields(
+            .AddField(Field("CCID", fieldDefs).AddSubfields(
                 (int)RcnmCompositeCurve, cc.RecordId, (int)cc.RecordVersion, (int)cc.UpdateInstruction));
 
         if (cc.CurveComponents.Count > 0)
         {
-            var cuco = Field("CUCO");
+            var cuco = Field("CUCO", fieldDefs);
             foreach (var u in cc.CurveComponents)
                 cuco.AddSubfields((int)u.RecordName, u.RecordId, (int)u.Orientation);
             record.AddField(cuco);
@@ -263,15 +281,15 @@ public static class S101DocumentWriter
         return record.Build();
     }
 
-    private static Iso8211Record BuildSurfaceRecord(S101SurfaceRecord s)
+    private static Iso8211Record BuildSurfaceRecord(S101SurfaceRecord s, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         var record = new Iso8211RecordBuilder(Options)
-            .AddField(Field("SRID").AddSubfields(
+            .AddField(Field("SRID", fieldDefs).AddSubfields(
                 (int)RcnmSurface, s.RecordId, (int)s.RecordVersion, (int)s.UpdateInstruction));
 
         if (s.RingAssociations.Count > 0)
         {
-            var rias = Field("RIAS");
+            var rias = Field("RIAS", fieldDefs);
             foreach (var r in s.RingAssociations)
                 rias.AddSubfields((int)r.RecordName, r.RecordId, (int)r.Orientation, (int)r.Usage, 0 /* RAUI */);
             record.AddField(rias);
@@ -280,29 +298,38 @@ public static class S101DocumentWriter
         return record.Build();
     }
 
-    private static Iso8211Record BuildFeatureRecord(S101FeatureRecord f)
+    private static Iso8211Record BuildFeatureRecord(S101FeatureRecord f, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         var record = new Iso8211RecordBuilder(Options)
-            .AddField(Field("FRID").AddSubfields(
+            .AddField(Field("FRID", fieldDefs).AddSubfields(
                 (int)RcnmFeature, f.RecordId, (int)f.FeatureTypeCode, (int)f.RecordVersion, (int)f.UpdateInstruction))
-            .AddField(Field("FOID").AddSubfields(
+            .AddField(Field("FOID", fieldDefs).AddSubfields(
                 (int)f.ProducingAgency, f.FeatureIdentificationNumber, (int)f.FeatureIdentificationSubdivision));
 
-        AddAttributes(record, f.Attributes);
+        AddAttributes(record, f.Attributes, fieldDefs);
 
         if (f.SpatialAssociations.Count > 0)
         {
-            var spas = Field("SPAS");
+            var spas = Field("SPAS", fieldDefs);
             foreach (var a in f.SpatialAssociations)
                 spas.AddSubfields((int)a.RecordName, a.RecordId, (int)a.Orientation, 0 /* SMIN */, 0 /* SMAX */, (int)a.UpdateInstruction);
             record.AddField(spas);
+        }
+
+        if (f.FeatureAssociations.Count > 0)
+        {
+            foreach (var a in f.FeatureAssociations)
+            {
+                record.AddField(Field("FACS", fieldDefs).AddSubfields(
+                    (int)RcnmFeature, a.RecordId, (int)a.NumericCode, (int)a.RoleCode, (int)a.UpdateInstruction));
+            }
         }
 
         if (f.InformationAssociations.Count > 0)
         {
             foreach (var a in f.InformationAssociations)
             {
-                record.AddField(Field("INAS").AddSubfields(
+                record.AddField(Field("INAS", fieldDefs).AddSubfields(
                     (int)RcnmInformation, a.RecordId, (int)a.NumericCode, (int)a.RoleCode, (int)a.UpdateInstruction));
             }
         }
@@ -310,28 +337,31 @@ public static class S101DocumentWriter
         return record.Build();
     }
 
-    private static Iso8211Record BuildInformationRecord(S101InformationRecord info)
+    private static Iso8211Record BuildInformationRecord(S101InformationRecord info, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         var record = new Iso8211RecordBuilder(Options)
-            .AddField(Field("IRID").AddSubfields(
+            .AddField(Field("IRID", fieldDefs).AddSubfields(
                 (int)RcnmInformation, info.RecordId, (int)info.InformationTypeCode, (int)info.RecordVersion, (int)info.UpdateInstruction));
 
-        AddAttributes(record, info.Attributes);
+        AddAttributes(record, info.Attributes, fieldDefs);
         return record.Build();
     }
 
-    private static void AddAttributes(Iso8211RecordBuilder record, IReadOnlyList<S101Attribute> attributes)
+    private static void AddAttributes(
+        Iso8211RecordBuilder record,
+        IReadOnlyList<S101Attribute> attributes,
+        IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs)
     {
         if (attributes.Count == 0)
             return;
 
-        var attr = Field("ATTR");
+        var attr = Field("ATTR", fieldDefs);
         foreach (var a in attributes)
             attr.AddSubfields((int)a.NumericCode, (int)a.Index, (int)a.ParentIndex, (int)a.UpdateInstruction, a.Value);
         record.AddField(attr);
     }
 
-    private static Iso8211FieldBuilder Field(string tag) => new(FieldDefs[tag], Options);
+    private static Iso8211FieldBuilder Field(string tag, IReadOnlyDictionary<string, Iso8211FieldDefinition> fieldDefs) => new(fieldDefs[tag], Options);
 
     // ── Field definitions (the DDR) ─────────────────────────────────────
 
@@ -342,7 +372,7 @@ public static class S101DocumentWriter
     private static Iso8211SubfieldFormat F8 => new() { FormatType = Iso8211SubfieldFormatType.FloatingPoint, Width = 8 };
     private static Iso8211SubfieldFormat A => new() { FormatType = Iso8211SubfieldFormatType.CharacterData, Width = 0 };
 
-    private static IReadOnlyDictionary<string, Iso8211FieldDefinition> BuildFieldDefinitions()
+    private static IReadOnlyDictionary<string, Iso8211FieldDefinition> BuildFieldDefinitions(bool featureAssociationFieldsUseFacs)
     {
         var defs = new List<Iso8211FieldDefinition>
         {
@@ -357,7 +387,10 @@ public static class S101DocumentWriter
             Def("ATCS", "Attribute Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("ATCD", A), ("ANCD", U2)),
             Def("ITCS", "Information Type Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("ITCD", A), ("ITNC", U2)),
             Def("IACS", "Information Association Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("IACD", A), ("IANC", U2)),
-            Def("FACS", "Feature Association Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("FACD", A), ("FANC", U2)),
+            featureAssociationFieldsUseFacs
+                ? Def("FACS", "Feature Association", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.MixedDataTypes, -1,
+                    ("RRNM", U1), ("RRID", U4), ("NFAC", U2), ("NARC", U2), ("FAUI", U1))
+                : Def("FACS", "Feature Association Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("FACD", A), ("FANC", U2)),
             Def("ARCS", "Association Role Codes", Iso8211DataStructureCode.Array, Iso8211DataTypeCode.MixedDataTypes, 0, ("ARCD", A), ("ARNC", U2)),
 
             Def("PRID", "Point Record Identifier", Iso8211DataStructureCode.Vector, Iso8211DataTypeCode.ImplicitPoint, -1,

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
@@ -20,8 +20,8 @@ namespace EncDotNet.S100.Datasets.S101;
 /// This is the encoder consumed by the S-57 → S-101 conversion pipeline: an
 /// <see cref="S101Document"/> produced by the translator is serialized here to a
 /// standalone base cell (application profile <c>1</c>). Feature-to-feature
-/// associations (<c>FASC</c>) are not emitted; the translator produces none and
-/// <see cref="S101DocumentReader"/> does not surface them.
+/// associations (<c>FASC</c>) are not emitted: the S-57 translator produces none,
+/// so there are none to encode.
 /// </para>
 /// </remarks>
 public static class S101DocumentWriter

--- a/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
+++ b/src/EncDotNet.S100.Datasets.S101/S101DocumentWriter.cs
@@ -111,7 +111,7 @@ public static class S101DocumentWriter
     {
         var builder = new Iso8211DocumentBuilder();
 
-        // The DDR carries only the field definitions actually used below.
+        // The DDR carries the full canonical field definition set, including definitions not emitted in this document.
         builder.AddRecord(Iso8211DataDescriptiveRecordWriter.BuildDdr(FieldDefs.Values, options: Options));
 
         builder.AddRecord(BuildDatasetRecord(doc));

--- a/tests/EncDotNet.S100.Cli.Tests/S57ConvertCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/S57ConvertCommandTests.cs
@@ -1,0 +1,59 @@
+using EncDotNet.S100.Cli.Infrastructure;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+/// <summary>
+/// Tests for <c>s100 s57 convert</c>: converting an S-57 base cell to an S-101
+/// dataset via the CLI.
+/// </summary>
+public sealed class S57ConvertCommandTests : IDisposable
+{
+    private readonly string _outputDir = Directory.CreateTempSubdirectory("s57-convert-").FullName;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_outputDir, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private static string FixturePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", fileName);
+
+    [SkippableFact]
+    public void Convert_writes_a_readable_s101_dataset()
+    {
+        var source = FixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(source), $"Fixture not found: {source}");
+
+        var output = Path.Combine(_outputDir, "converted.000");
+
+        int exit = CliApp.Build().Run(["s57", "convert", "-o", output, source]);
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(output), "Expected the converted S-101 dataset to be written.");
+        Assert.True(new FileInfo(output).Length > 0, "Converted dataset should not be empty.");
+    }
+
+    [Fact]
+    public void Convert_missing_source_returns_validation_error()
+    {
+        var output = Path.Combine(_outputDir, "converted.000");
+
+        int exit = CliApp.Build().Run(["s57", "convert", "-o", output, "does-not-exist.000"]);
+
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [SkippableFact]
+    public void Convert_missing_output_option_returns_validation_error()
+    {
+        var source = FixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(source), $"Fixture not found: {source}");
+
+        int exit = CliApp.Build().Run(["s57", "convert", source]);
+
+        Assert.NotEqual(0, exit);
+    }
+}

--- a/tests/EncDotNet.S100.Cli.Tests/S57ConvertCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/S57ConvertCommandTests.cs
@@ -56,4 +56,20 @@ public sealed class S57ConvertCommandTests : IDisposable
 
         Assert.NotEqual(0, exit);
     }
+
+    [SkippableFact]
+    public void Convert_missing_output_directory_returns_validation_error()
+    {
+        var source = FixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(source), $"Fixture not found: {source}");
+
+        var missingDir = Path.Combine(_outputDir, "missing");
+        var output = Path.Combine(missingDir, "converted.000");
+
+        int exit = CliApp.Build().Run(["s57", "convert", "-o", output, source]);
+
+        Assert.NotEqual(0, exit);
+        Assert.False(Directory.Exists(missingDir));
+        Assert.False(File.Exists(output));
+    }
 }

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/EncDotNet.S100.Datasets.S101.Tests.csproj
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/EncDotNet.S100.Datasets.S101.Tests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S101\EncDotNet.S100.Datasets.S101.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S57\EncDotNet.S100.Datasets.S57.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
@@ -1,0 +1,296 @@
+using System.Collections.ObjectModel;
+using EncDotNet.S100.Datasets.S57;
+
+namespace EncDotNet.S100.Datasets.S101.Tests;
+
+/// <summary>
+/// Round-trip tests for <see cref="S101DocumentWriter"/>: a document written to
+/// ISO 8211 bytes and read back with <see cref="S101DocumentReader"/> must be
+/// equivalent to the original.
+/// </summary>
+public class S101DocumentWriterTests
+{
+    [Fact]
+    public void WriteThenRead_PreservesAllRecordKinds()
+    {
+        var original = BuildSampleDocument();
+
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var roundTripped = S101DocumentReader.ReadFromStream(stream);
+
+        // Identification
+        Assert.Equal(original.Identification.RecordName, roundTripped.Identification.RecordName);
+        Assert.Equal(original.Identification.RecordId, roundTripped.Identification.RecordId);
+        Assert.Equal(original.Identification.ProductSpecification, roundTripped.Identification.ProductSpecification);
+        Assert.Equal(original.Identification.DatasetName, roundTripped.Identification.DatasetName);
+        Assert.Equal(original.Identification.DatasetTitle, roundTripped.Identification.DatasetTitle);
+        Assert.Equal(original.Identification.DatasetReferenceDate, roundTripped.Identification.DatasetReferenceDate);
+        Assert.Equal(original.Identification.ApplicationProfile, roundTripped.Identification.ApplicationProfile);
+
+        // Structure info (coordinate scale factors)
+        Assert.Equal(original.StructureInfo.CoordinateMultiplicationFactorX, roundTripped.StructureInfo.CoordinateMultiplicationFactorX);
+        Assert.Equal(original.StructureInfo.CoordinateMultiplicationFactorY, roundTripped.StructureInfo.CoordinateMultiplicationFactorY);
+        Assert.Equal(original.StructureInfo.CoordinateMultiplicationFactorZ, roundTripped.StructureInfo.CoordinateMultiplicationFactorZ);
+
+        // Catalogues
+        Assert.Equal(original.FeatureTypeCatalogue, roundTripped.FeatureTypeCatalogue);
+        Assert.Equal(original.AttributeTypeCatalogue, roundTripped.AttributeTypeCatalogue);
+        Assert.Equal(original.InformationTypeCatalogue, roundTripped.InformationTypeCatalogue);
+
+        // Record counts
+        Assert.Equal(original.Points.Count, roundTripped.Points.Count);
+        Assert.Equal(original.MultiPoints.Count, roundTripped.MultiPoints.Count);
+        Assert.Equal(original.CurveSegments.Count, roundTripped.CurveSegments.Count);
+        Assert.Equal(original.CompositeCurves.Count, roundTripped.CompositeCurves.Count);
+        Assert.Equal(original.Surfaces.Count, roundTripped.Surfaces.Count);
+        Assert.Equal(original.Features.Count, roundTripped.Features.Count);
+        Assert.Equal(original.InformationTypes.Count, roundTripped.InformationTypes.Count);
+    }
+
+    [Fact]
+    public void WriteThenRead_PreservesPointCoordinates()
+    {
+        var original = BuildSampleDocument();
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var rt = S101DocumentReader.ReadFromStream(stream);
+
+        var op = original.Points[1];
+        var rp = rt.Points[1];
+        Assert.Equal(op.X, rp.X);
+        Assert.Equal(op.Y, rp.Y);
+        Assert.Equal(op.RecordVersion, rp.RecordVersion);
+    }
+
+    [Fact]
+    public void WriteThenRead_PreservesMultiPointSoundings()
+    {
+        var original = BuildSampleDocument();
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var rt = S101DocumentReader.ReadFromStream(stream);
+
+        Assert.Equal(original.MultiPoints[10].Points, rt.MultiPoints[10].Points);
+    }
+
+    [Fact]
+    public void WriteThenRead_PreservesCurveGeometryAndTopology()
+    {
+        var original = BuildSampleDocument();
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var rt = S101DocumentReader.ReadFromStream(stream);
+
+        var oc = original.CurveSegments[20];
+        var rc = rt.CurveSegments[20];
+        Assert.Equal(oc.IntermediateCoordinates, rc.IntermediateCoordinates);
+        Assert.Equal(oc.PointAssociations, rc.PointAssociations);
+    }
+
+    [Fact]
+    public void WriteThenRead_PreservesSurfaceRings()
+    {
+        var original = BuildSampleDocument();
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var rt = S101DocumentReader.ReadFromStream(stream);
+
+        Assert.Equal(original.Surfaces[40].RingAssociations, rt.Surfaces[40].RingAssociations);
+    }
+
+    [Fact]
+    public void WriteThenRead_PreservesFeatureAttributesAndSpatialAssociations()
+    {
+        var original = BuildSampleDocument();
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var rt = S101DocumentReader.ReadFromStream(stream);
+
+        var of = original.Features[0];
+        var rf = rt.Features.Single(f => f.RecordId == of.RecordId);
+        Assert.Equal(of.FeatureTypeCode, rf.FeatureTypeCode);
+        Assert.Equal(of.ProducingAgency, rf.ProducingAgency);
+        Assert.Equal(of.FeatureIdentificationNumber, rf.FeatureIdentificationNumber);
+        Assert.Equal(of.FeatureIdentificationSubdivision, rf.FeatureIdentificationSubdivision);
+
+        Assert.Equal(of.Attributes.Count, rf.Attributes.Count);
+        for (int i = 0; i < of.Attributes.Count; i++)
+        {
+            Assert.Equal(of.Attributes[i].NumericCode, rf.Attributes[i].NumericCode);
+            Assert.Equal(of.Attributes[i].Value, rf.Attributes[i].Value);
+        }
+
+        Assert.Equal(of.SpatialAssociations.Count, rf.SpatialAssociations.Count);
+        for (int i = 0; i < of.SpatialAssociations.Count; i++)
+        {
+            Assert.Equal(of.SpatialAssociations[i].RecordName, rf.SpatialAssociations[i].RecordName);
+            Assert.Equal(of.SpatialAssociations[i].RecordId, rf.SpatialAssociations[i].RecordId);
+            Assert.Equal(of.SpatialAssociations[i].Orientation, rf.SpatialAssociations[i].Orientation);
+        }
+    }
+
+    [SkippableFact]
+    public void ConvertRealS57Fixture_Translate_Write_Read_RoundTrips()
+    {
+        var fixture = LocateFixture(Path.Combine("S57", "US5MA1BO", "US5MA1BO.000"));
+        Skip.If(fixture is null, "S-57 fixture US5MA1BO.000 not found.");
+
+        var dataset = S57Dataset.Open(fixture!);
+        var translator = new S57ToS101Translator(S57S101Mapping.Default, allowedEnumValues: null);
+        var docA = translator.Translate(dataset);
+
+        var bytes = S101DocumentWriter.Write(docA);
+        Assert.NotEmpty(bytes);
+
+        using var stream = new MemoryStream(bytes);
+        var docB = S101DocumentReader.ReadFromStream(stream);
+
+        Assert.Equal(docA.Points.Count, docB.Points.Count);
+        Assert.Equal(docA.MultiPoints.Count, docB.MultiPoints.Count);
+        Assert.Equal(docA.CurveSegments.Count, docB.CurveSegments.Count);
+        Assert.Equal(docA.CompositeCurves.Count, docB.CompositeCurves.Count);
+        Assert.Equal(docA.Surfaces.Count, docB.Surfaces.Count);
+        Assert.Equal(docA.Features.Count, docB.Features.Count);
+        Assert.Equal(docA.FeatureTypeCatalogue, docB.FeatureTypeCatalogue);
+        Assert.Equal(docA.AttributeTypeCatalogue, docB.AttributeTypeCatalogue);
+
+        // Spot-check that per-feature attribute values survive the round-trip.
+        var fa = docA.Features.First(f => f.Attributes.Count > 0);
+        var fb = docB.Features.Single(f => f.RecordId == fa.RecordId);
+        Assert.Equal(
+            fa.Attributes.Select(a => (a.NumericCode, a.Value)),
+            fb.Attributes.Select(a => (a.NumericCode, a.Value)));
+    }
+
+    private static S101Document BuildSampleDocument()
+    {
+        return new S101Document
+        {
+            Identification = new S101DatasetIdentification
+            {
+                RecordName = 10,
+                RecordId = 1,
+                EncodingSpecification = "S-100 Part 10a",
+                EncodingSpecificationEdition = "5.2.0",
+                ProductSpecification = "INT.IHO.S-101.1.0",
+                ProductSpecificationEdition = "1.0.0",
+                ApplicationProfile = "1",
+                DatasetName = "US5MA1BO.000",
+                DatasetTitle = "Sample Cell",
+                DatasetReferenceDate = "20240101",
+                DatasetLanguage = "eng",
+                DatasetAbstract = "abstract",
+                DatasetEdition = "1",
+            },
+            StructureInfo = new S101DatasetStructureInfo
+            {
+                CoordinateMultiplicationFactorX = 10_000_000,
+                CoordinateMultiplicationFactorY = 10_000_000,
+                CoordinateMultiplicationFactorZ = 10,
+            },
+            FeatureTypeCatalogue = new Dictionary<ushort, string> { [42] = "DepthArea", [7] = "Sounding" },
+            AttributeTypeCatalogue = new Dictionary<ushort, string> { [100] = "valdco", [200] = "objnam" },
+            InformationTypeCatalogue = new Dictionary<ushort, string> { [5] = "SpatialQuality" },
+            InformationAssociationCatalogue = new Dictionary<ushort, string>(),
+            FeatureAssociationCatalogue = new Dictionary<ushort, string>(),
+            RoleCatalogue = new Dictionary<ushort, string>(),
+            Points = new Dictionary<uint, S101PointRecord>
+            {
+                [1] = new S101PointRecord { RecordId = 1, X = -710_000_000, Y = 420_000_000, RecordVersion = 1, UpdateInstruction = S101UpdateInstruction.Insert },
+            },
+            MultiPoints = new Dictionary<uint, S101MultiPointRecord>
+            {
+                [10] = new S101MultiPointRecord
+                {
+                    RecordId = 10,
+                    Points = [(420_000_100, -710_000_100, 53), (420_000_200, -710_000_200, 128)],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+            },
+            CurveSegments = new Dictionary<uint, S101CurveSegmentRecord>
+            {
+                [20] = new S101CurveSegmentRecord
+                {
+                    RecordId = 20,
+                    PointAssociations =
+                    [
+                        new S101PointAssociation(110, 1, 1),
+                        new S101PointAssociation(110, 2, 2),
+                    ],
+                    IntermediateCoordinates = [(420_000_050, -710_000_050), (420_000_060, -710_000_070)],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+            },
+            CompositeCurves = new Dictionary<uint, S101CompositeCurveRecord>
+            {
+                [30] = new S101CompositeCurveRecord
+                {
+                    RecordId = 30,
+                    CurveComponents = [new S101CurveUsage(120, 20, 1)],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+            },
+            Surfaces = new Dictionary<uint, S101SurfaceRecord>
+            {
+                [40] = new S101SurfaceRecord
+                {
+                    RecordId = 40,
+                    RingAssociations =
+                    [
+                        new S101RingAssociation(125, 30, 1, 1),
+                        new S101RingAssociation(125, 31, 1, 2),
+                    ],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+            },
+            Features =
+            [
+                new S101FeatureRecord
+                {
+                    RecordId = 50,
+                    FeatureTypeCode = 42,
+                    ProducingAgency = 550,
+                    FeatureIdentificationNumber = 123_456,
+                    FeatureIdentificationSubdivision = 1,
+                    Attributes =
+                    [
+                        new S101Attribute(200, 1, "Boston Harbor"),
+                        new S101Attribute(100, 1, "10.5"),
+                    ],
+                    SpatialAssociations = [new S101SpatialAssociation(130, 40, 1)],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+            ],
+            InformationTypes = new Dictionary<uint, S101InformationRecord>
+            {
+                [60] = new S101InformationRecord
+                {
+                    RecordId = 60,
+                    InformationTypeCode = 5,
+                    Attributes = [new S101Attribute(200, 1, "quality note")],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+            },
+        };
+    }
+
+    private static string? LocateFixture(string relativeUnderDatasets)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "tests", "datasets", relativeUnderDatasets);
+            if (File.Exists(candidate))
+                return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
@@ -130,6 +130,27 @@ public class S101DocumentWriterTests
     }
 
     [Fact]
+    public void WriteThenRead_PreservesFeatureAssociations()
+    {
+        var original = BuildSampleDocument();
+        var bytes = S101DocumentWriter.Write(original);
+        using var stream = new MemoryStream(bytes);
+        var rt = S101DocumentReader.ReadFromStream(stream);
+
+        var of = original.Features[0];
+        var rf = rt.Features.Single(f => f.RecordId == of.RecordId);
+
+        Assert.Equal(of.FeatureAssociations.Count, rf.FeatureAssociations.Count);
+        for (int i = 0; i < of.FeatureAssociations.Count; i++)
+        {
+            Assert.Equal(of.FeatureAssociations[i].NumericCode, rf.FeatureAssociations[i].NumericCode);
+            Assert.Equal(of.FeatureAssociations[i].RecordId, rf.FeatureAssociations[i].RecordId);
+            Assert.Equal(of.FeatureAssociations[i].RoleCode, rf.FeatureAssociations[i].RoleCode);
+            Assert.Equal(of.FeatureAssociations[i].UpdateInstruction, rf.FeatureAssociations[i].UpdateInstruction);
+        }
+    }
+
+    [Fact]
     public void WriteToFile_WithEmptyPath_ThrowsArgumentException()
     {
         var document = BuildSampleDocument();
@@ -278,6 +299,31 @@ public class S101DocumentWriterTests
                         new S101Attribute(100, 1, "10.5"),
                     ],
                     SpatialAssociations = [new S101SpatialAssociation(130, 40, 1)],
+                    FeatureAssociations =
+                    [
+                        new S101FeatureAssociation(8, 51, 3, S101UpdateInstruction.Insert),
+                        new S101FeatureAssociation(9, 52, 4, S101UpdateInstruction.Modify),
+                    ],
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+                new S101FeatureRecord
+                {
+                    RecordId = 51,
+                    FeatureTypeCode = 42,
+                    ProducingAgency = 550,
+                    FeatureIdentificationNumber = 123_457,
+                    FeatureIdentificationSubdivision = 1,
+                    RecordVersion = 1,
+                    UpdateInstruction = S101UpdateInstruction.Insert,
+                },
+                new S101FeatureRecord
+                {
+                    RecordId = 52,
+                    FeatureTypeCode = 42,
+                    ProducingAgency = 550,
+                    FeatureIdentificationNumber = 123_458,
+                    FeatureIdentificationSubdivision = 1,
                     RecordVersion = 1,
                     UpdateInstruction = S101UpdateInstruction.Insert,
                 },

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using EncDotNet.S100.Datasets.S57;
 
 namespace EncDotNet.S100.Datasets.S101.Tests;

--- a/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S101.Tests/S101DocumentWriterTests.cs
@@ -129,6 +129,22 @@ public class S101DocumentWriterTests
         }
     }
 
+    [Fact]
+    public void WriteToFile_WithEmptyPath_ThrowsArgumentException()
+    {
+        var document = BuildSampleDocument();
+
+        Assert.Throws<ArgumentException>(() => S101DocumentWriter.WriteToFile("", document));
+    }
+
+    [Fact]
+    public async Task WriteToFileAsync_WithEmptyPath_ThrowsArgumentException()
+    {
+        var document = BuildSampleDocument();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => S101DocumentWriter.WriteToFileAsync("", document));
+    }
+
     [SkippableFact]
     public void ConvertRealS57Fixture_Translate_Write_Read_RoundTrips()
     {

--- a/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommand.cs
@@ -26,10 +26,6 @@ internal sealed class S57ConvertCommand : Command<S57ConvertCommandSettings>
             var translator = new S57ToS101Translator();
             var document = translator.Translate(dataset);
 
-            var outputDirectory = Path.GetDirectoryName(Path.GetFullPath(settings.OutputPath));
-            if (!string.IsNullOrEmpty(outputDirectory))
-                Directory.CreateDirectory(outputDirectory);
-
             S101DocumentWriter.WriteToFile(settings.OutputPath, document);
 
             AnsiConsole.MarkupLineInterpolated(

--- a/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommand.cs
@@ -1,0 +1,54 @@
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S57;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// <c>s100 s57 convert -o &lt;output&gt; &lt;source&gt;</c> — converts an S-57 base
+/// cell to an S-101 dataset by translating it with
+/// <see cref="S57ToS101Translator"/> and encoding the result with
+/// <see cref="S101DocumentWriter"/> (ISO/IEC 8211; S-100 Part 10a).
+/// </summary>
+/// <remarks>
+/// This command is a thin driver over the existing translation and encoding
+/// libraries; it deliberately does not alter conversion semantics, which are
+/// owned by <see cref="S57ToS101Translator"/>.
+/// </remarks>
+internal sealed class S57ConvertCommand : Command<S57ConvertCommandSettings>
+{
+    public override int Execute(CommandContext context, S57ConvertCommandSettings settings)
+    {
+        try
+        {
+            var dataset = S57Dataset.Open(settings.SourcePath);
+            var translator = new S57ToS101Translator();
+            var document = translator.Translate(dataset);
+
+            var outputDirectory = Path.GetDirectoryName(Path.GetFullPath(settings.OutputPath));
+            if (!string.IsNullOrEmpty(outputDirectory))
+                Directory.CreateDirectory(outputDirectory);
+
+            S101DocumentWriter.WriteToFile(settings.OutputPath, document);
+
+            AnsiConsole.MarkupLineInterpolated(
+                $"[green]Converted[/] {settings.SourcePath} [green]→[/] {settings.OutputPath} ({document.Features.Count} features).");
+            return 0;
+        }
+        catch (NotSupportedException ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Not supported:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 4;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error:[/] {ex.Message}");
+            if (settings.Debug)
+                AnsiConsole.WriteException(ex);
+            return 1;
+        }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommandSettings.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommandSettings.cs
@@ -32,6 +32,10 @@ internal sealed class S57ConvertCommandSettings : CommandSettings
         if (string.IsNullOrWhiteSpace(OutputPath))
             return Spectre.Console.ValidationResult.Error("An output path is required (-o|--output).");
 
+        var dir = Path.GetDirectoryName(Path.GetFullPath(OutputPath));
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            return Spectre.Console.ValidationResult.Error($"Output directory does not exist: {dir}");
+
         return Spectre.Console.ValidationResult.Success();
     }
 }

--- a/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommandSettings.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/S57ConvertCommandSettings.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace EncDotNet.S100.Cli.Commands;
+
+/// <summary>
+/// Settings for <c>s100 s57 convert</c>: the S-57 source cell to read and the
+/// S-101 dataset file to write.
+/// </summary>
+internal sealed class S57ConvertCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<source>")]
+    [Description("Path to the source S-57 base cell (.000).")]
+    public string SourcePath { get; init; } = string.Empty;
+
+    [CommandOption("-o|--output <output>")]
+    [Description("Path of the S-101 dataset file to write (e.g. my-cell.000).")]
+    public string OutputPath { get; init; } = string.Empty;
+
+    [CommandOption("--debug")]
+    [Description("Show full stack traces on error.")]
+    public bool Debug { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        if (string.IsNullOrWhiteSpace(SourcePath))
+            return Spectre.Console.ValidationResult.Error("A source S-57 dataset path is required.");
+
+        if (!File.Exists(SourcePath))
+            return Spectre.Console.ValidationResult.Error($"Source S-57 dataset not found: {SourcePath}");
+
+        if (string.IsNullOrWhiteSpace(OutputPath))
+            return Spectre.Console.ValidationResult.Error("An output path is required (-o|--output).");
+
+        return Spectre.Console.ValidationResult.Success();
+    }
+}

--- a/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
+++ b/tools/EncDotNet.S100.Cli/EncDotNet.S100.Cli.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\src\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Crs.ProjNet\EncDotNet.S100.Crs.ProjNet.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.Pipelines\EncDotNet.S100.Datasets.Pipelines.csproj" />
+    <ProjectReference Include="..\..\src\EncDotNet.S100.Datasets.S57\EncDotNet.S100.Datasets.S57.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Features\EncDotNet.S100.Features.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Portrayals\EncDotNet.S100.Portrayals.csproj" />
     <ProjectReference Include="..\..\src\EncDotNet.S100.Scripting.MoonSharp\EncDotNet.S100.Scripting.MoonSharp.csproj" />

--- a/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/CliApp.cs
@@ -43,6 +43,15 @@ internal static class CliApp
             config.AddCommand<ListSpecsCommand>("list-specs")
                 .WithDescription("List supported product specifications and headless-render capability.")
                 .WithExample("list-specs");
+
+            config.AddBranch("s57", s57 =>
+            {
+                s57.SetDescription("S-57 (IHO S-57 / ENC) specific operations.");
+
+                s57.AddCommand<S57ConvertCommand>("convert")
+                    .WithDescription("Convert an S-57 base cell to an S-101 dataset (ISO/IEC 8211).")
+                    .WithExample("s57", "convert", "-o", "my-s101-dataset.000", "my-s57-dataset.000");
+            });
         });
         return app;
     }

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -5,8 +5,9 @@ primary command renders any supported dataset — or a composite of several,
 via repeated `--layer` or by pointing at an entire exchange set / directory —
 to a PNG, JPEG, or WebP image by
 running the dataset's portrayal pipeline through the Mapsui-free Skia *headless*
-it can also report a dataset's product specification (`info`) and validate a
-dataset against its specification's normative rule pack (`validate`). It is
+it can also report a dataset's product specification (`info`), validate a
+dataset against its specification's normative rule pack (`validate`), and
+convert an S-57 base cell to an S-101 dataset (`s57 convert`). It is
 intended as the basis for batch scripts (for example, generating previews of
 sea-ice or surface-current datasets, or gating a data pipeline on validation).
 
@@ -244,6 +245,27 @@ after suppression (warnings and info are reported but do not fail); pass
 
 Lists the supported product specifications and whether each supports the
 headless render path.
+
+### `s100 s57 convert -o <output> <source>`
+
+Converts an S-57 base cell (`.000`) to an S-101 dataset, writing an ISO/IEC 8211
+encoded `.000` file (S-100 Part 10a). The source is translated to an
+`S101Document` in memory with the same `S57ToS101Translator` the render/validate
+paths use, then encoded with `S101DocumentWriter`.
+
+```
+s100 s57 convert -o my-s101-dataset.000 my-s57-dataset.000
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `-o`, `--output <path>` | _required_ | Path of the S-101 dataset file to write. |
+| `--debug` | off | Show a full stack trace on error. |
+
+The written dataset can be inspected with `s100 info`, validated with
+`s100 validate`, and rendered with `s100 render`. Conversion semantics (feature
+and attribute mapping, allowed-value enforcement) are owned by
+`S57ToS101Translator`; this command only drives it and encodes the result.
 
 ## Supported specifications
 


### PR DESCRIPTION
## Summary

Adds a spec-scoped `s57` CLI branch with a `convert` command that converts an S-57 base cell to an S-101 dataset:

```
s100 s57 convert -o my-s101-dataset.000 my-s57-dataset.000
```

The motivation is to expose S-57 to S-101 conversion as a first-class CLI operation, and to establish the `sXxx` sub-command convention for spec-specific commands. The pipeline is `S57Dataset -> S57ToS101Translator -> S101Document -> S101DocumentWriter -> ISO/IEC 8211 .000`. Conversion semantics remain owned by `S57ToS101Translator` (unchanged), so this stays orthogonal to the parallel conversion-quality work in another session.

The bulk of the work is the new **`S101DocumentWriter`**, the symmetric inverse of `S101DocumentReader`. It authors a Data Descriptive Record (DDR) covering every field it emits, then a DSID record (identification, structure info, and the six code catalogues), the spatial records (`PRID`, `MRID`, `CRID`, `CCID`, `SRID`), the feature records (`FRID`, `FOID`, `ATTR`, `SPAS`, `INAS`), and the information records (`IRID`, `ATTR`). Because the writer authors both the DDR and the data, subfield names and binary formats are internally consistent, so a document read from a real cell round-trips through the reader.

Built on the new `EncDotNet.Iso8211` 0.6.0 writer/builder API (bumped from 0.5.1).

Non-obvious points worth a reviewer's attention:
- `DSID/DSRD` is emitted as a variable-length `A` rather than the canonical fixed `A(8)` so empty or rich date strings round-trip exactly. The writer owns both DDR and data, so internal consistency is what matters for the reader, not byte-for-byte match with a producer's fixed-width layout.
- Feature-to-feature associations (`FASC`) are deliberately not emitted: the translator produces none and `S101DocumentReader` does not surface them, so they cannot round-trip regardless.

### Verification

Beyond the unit tests, I verified end-to-end against real ENCs by rendering each chart two ways and comparing the images: `render(S-57)` versus `render(s57 convert -> S-101)`. The convert path forces the document through the full write/read round-trip before rendering. Across 11 charts spanning every scale band and several regions (166 to 2837 features), the two renders were byte-identical on SHA-256, confirming the writer preserves every rendered field with zero loss.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [ ] N/A

**Spec section references cited in code/docs:** S-100 Part 10a (ISO/IEC 8211 record encoding) for the DDR structure, record names (RCNM), and field/subfield layout; cited in `S101DocumentWriter` XML docs.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New tests: `S101DocumentWriterTests` (round-trips every record kind, plus a real S-57 fixture translate/write/read) and `S57ConvertCommandTests` (CLI success and validation-error paths). No regressions across the S101, CLI, S57, and Pipelines test projects.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

CLI README documents the `s57 convert` command; the S-101 README documents `S101DocumentWriter`.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

`EncDotNet.Iso8211` bumped 0.5.1 -> 0.6.0 in `Directory.Packages.props` (adds the writer/builder API this feature consumes).

## Breaking changes

None. The change is purely additive: a new public `S101DocumentWriter`, a new CLI sub-command, and a package version bump.

Closes #434