### PR TITLE
Elastic per-layer tile worker pools (#432)

### DIFF
--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -386,7 +386,10 @@ the exact band lands. Accepted.
   drains the visible-miss queue in parallel, with a process-wide cap of the
   logical-core count so multi-cell exchange sets don't oversubscribe; measured to
   cut single-cell cold-tile latency ≈3× on a 16-core host. `LowEnd` keeps one
-  worker.
+  worker. The per-layer size is a floor, not a ceiling: a busy layer borrows idle
+  global capacity toward the process-wide cap for visible work, with a fairness
+  floor reserving each other active-visible layer its share (issue #432; design
+  §D.2).
 - The Phase-1 B-side polish items (line dashes, label glyphs) still apply and
   are unchanged by tiling.
 
@@ -424,10 +427,32 @@ each tier a worker dequeues **centre-first** (`TakeNearest`): the pending tile
 whose world centre is nearest the current viewport centre rasterises before the
 perimeter, cutting time-to-centre-fill on a cold pan/zoom. Equal-distance ties
 break deterministically on `(band, y, x)`, so the drain order never depends on
-the pending set's hash iteration order. The pool size is
+the pending set's hash iteration order. The pool size floor is
 `RenderingOptimizations.TileWorkerCount` (tier-sized); a per-layer
 `ActiveWorkers` count plus a process-wide `s_activeWorkerTotal` cap (core count)
 bound how many run at once.
+
+**Elastic borrowing (issue #432).** The per-layer count is a *floor*
+(reservation), not a hard ceiling. When a layer has a visible cold backlog and
+global room exists, it may start workers above its floor toward `s_maxTotalWorkers`
+so idle cores drain a single busy layer's cold-miss queue instead of sitting
+unused (the common one-busy-layer / idle-siblings shape of a cold pan). Three
+invariants keep this safe. **(1) Visible-only:** the elastic ceiling is gated to
+the *visible* pending count — predicted/speculative tiles never justify borrowing,
+so a busy layer's off-screen prewarm can't occupy borrowed cores a sibling wants
+for on-screen work. `ComputeWorkersToStart` encodes the cap arithmetic. **(2)
+Prompt give-back:** a borrowed (above-floor) worker sheds itself at the
+visible→predicted boundary — `ShouldWorkerExit` returns true once no visible work
+remains and `ActiveWorkers > TileWorkerCount` — releasing its slot under
+`state.Sync` so a cascade of sheds converges on the floor without over-shedding.
+Tile rasters are short and non-preemptible, so capacity returns within roughly one
+tile's raster time; no preemption machinery is needed. **(3) Fairness floor:**
+before lending, each *other* layer that currently has visible cold work (tracked in
+a time-windowed active-visible-layer registry, keyed by `TileState`) keeps its
+`TileWorkerCount` reservation, so a dense bottom-of-z-order layer painting first
+cannot borrow the whole budget and starve later-painting siblings — it can only
+lend *leftover* room. On a `LowEnd` (single-worker) host the elastic ceiling
+collapses to the floor and the whole path no-ops.
 
 Speculatively-rasterised keys are tracked in `PredictedInCache`; when a later
 frame finds such a key in the visible set it counts a **prediction hit** and

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -599,11 +599,19 @@ native memory; visible tiles are kept most-recently-used so they are never
 evicted mid-frame. A tier-sized pool of coalescing workers per layer drains the
 visible-miss set (replaced every frame), and all cache access is serialised
 through the layer lock so a worker cannot dispose an image the compositor is
-blitting. The pool size is `S100_VECTOR_TILE_WORKERS` (default sized by the
+blitting. The pool size floor is `S100_VECTOR_TILE_WORKERS` (default sized by the
 performance profile — one on low-end hosts, scaling with cores on high-end), so a
 cold pan's visible misses rasterise in parallel instead of one at a time; a
 process-wide cap (logical-core count) stops *N* layers × *N* workers from
-oversubscribing the cores and starving the UI thread on a big exchange set.
+oversubscribing the cores and starving the UI thread on a big exchange set. That
+per-layer size is a **floor, not a ceiling**: a layer with a visible cold backlog
+may borrow idle global capacity toward the process-wide cap (issue #432), but only
+for *visible* work — speculative prewarm never borrows, and a borrowed worker sheds
+itself the moment visible work drains (returning capacity within ~one tile raster)
+rather than falling through to prediction. Before lending, each other layer that
+also has visible work keeps its own floor reserved, so a dense bottom-of-z-order
+layer cannot starve later-painting siblings; on a `LowEnd` (single-worker) host the
+elastic ceiling collapses to the floor and the behaviour is unchanged.
 Telemetry histograms `TileRasterizeDuration` (worker) and `TileCompositeDuration`
 (UI composite pass) attribute the two halves, while `TileColdLatency` measures the
 end-to-end queue-wait-plus-rasterise a cold tile takes to appear. A rotated

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -1662,7 +1662,7 @@ public static class S100VectorTileRenderer
                 }
                 else
                 {
-                    s_visibleLayerStamps.AddOrUpdate(state, new ActiveVisibleEntry(nowTicks, layerActiveWorkers));
+                    s_visibleLayerStamps.Add(state, new ActiveVisibleEntry(nowTicks, layerActiveWorkers));
                 }
             }
             else
@@ -1728,8 +1728,9 @@ public static class S100VectorTileRenderer
             {
                 // Stop before touching Skia once the process is shutting down,
                 // so ShutdownAndDrain's wait completes and no tile is rasterised
-                // into a half-torn-down Skia. The finally releases the slot and
-                // completes the drain-gate registration.
+                // into a half-torn-down Skia. slotReleased is still false on this
+                // path, so the finally below releases the slot and completes the
+                // drain-gate registration.
                 if (s_drainGate.IsDraining)
                 {
                     return;

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -1729,9 +1729,8 @@ public static class S100VectorTileRenderer
                     // global capacity returns to the pool within ~one tile raster.
                     // Release the slot under this same lock so concurrent sheds can't
                     // all read the pre-decrement count and over-shed below baseline.
-                    if (currentScene is null
-                        || ShouldWorkerExit(
-                            sceneNull: false,
+                    if (ShouldWorkerExit(
+                            sceneNull: currentScene is null,
                             hasVisible,
                             hasPredicted,
                             state.ActiveWorkers,
@@ -1758,7 +1757,12 @@ public static class S100VectorTileRenderer
 
                     deviceScale = state.PendingDeviceScale;
                     generation = state.PendingGeneration;
-                    scene = currentScene;
+                    // ShouldWorkerExit returns true for a null scene, so reaching
+                    // here means the scene is live; the null-coalescing throw is
+                    // unreachable but gives the compiler its non-null narrowing
+                    // (no scene can vanish while we hold state.Sync).
+                    scene = currentScene ?? throw new InvalidOperationException(
+                        "Scene became null after ShouldWorkerExit returned false.");
                     baseIndex = state.BaseIndex;
                     diskNamespace = state.DiskNamespace;
                     state.InFlight.Add(key);

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -257,6 +257,49 @@ public static class S100VectorTileRenderer
 
     private static int s_activeWorkerTotal;
 
+    /// <summary>
+    /// Sliding window, in seconds, over which a layer that had visible cold work
+    /// is still counted as an active competitor for the fairness reservation used
+    /// by elastic borrowing (issue #432). A layer that stops painting (culled,
+    /// resolution-hidden, torn down) or that fully caches its visible tiles ages
+    /// out of the <see cref="s_visibleLayerStamps"/> registry within this window,
+    /// so the "active visible layers" divisor never inflates with dead layers.
+    /// A couple of frames' worth is enough to bridge the serialized per-layer
+    /// paint of one frame without over-holding.
+    /// </summary>
+    private const double ElasticFairnessWindowSeconds = 0.5;
+
+    /// <summary>
+    /// Guards <see cref="s_visibleLayerStamps"/> and <see cref="s_visibleLayerPruneScratch"/>.
+    /// Only ever taken on the render/UI thread (layer paint is serialized there),
+    /// so it is effectively uncontended; tile workers never touch it. Always
+    /// acquired <em>after</em> a layer's <c>state.Sync</c> and never the reverse,
+    /// and workers never take it, so it introduces no lock-order cycle.
+    /// </summary>
+    private static readonly object s_visibleLayerSync = new();
+
+    /// <summary>
+    /// Registry of layers that recently had visible cold work, keyed by their
+    /// <see cref="TileState"/>. Each entry records the <see cref="Stopwatch"/> tick
+    /// of the layer's last such paint and the worker count it held at that point,
+    /// so elastic borrowing can reserve each <em>other</em> active-visible layer
+    /// only its <em>shortfall</em> to the <see cref="RenderingOptimizations.TileWorkerCount"/>
+    /// floor before lending idle capacity (issue #432 fairness floor). Counting a
+    /// competitor's own workers — rather than all other layers' workers — stops an
+    /// unrelated predicted-only layer's workers from wrongly satisfying an
+    /// active-visible sibling's reservation.
+    /// </summary>
+    private static readonly Dictionary<TileState, ActiveVisibleEntry> s_visibleLayerStamps = new();
+
+    /// <summary>Reusable scratch for pruning <see cref="s_visibleLayerStamps"/> without per-call allocation.</summary>
+    private static readonly List<TileState> s_visibleLayerPruneScratch = new();
+
+    /// <summary>
+    /// A layer's active-visible registry entry: the <see cref="Stopwatch"/> tick of
+    /// its last paint with visible cold work, and the workers it held then.
+    /// </summary>
+    private readonly record struct ActiveVisibleEntry(long StampTicks, int ActiveWorkers);
+
 
     /// <summary>
     /// Signals every tile worker to stop and blocks until in-flight tile
@@ -684,6 +727,16 @@ public static class S100VectorTileRenderer
 
             visibleQueueDepth = state.PendingVisible.Count;
 
+            // Refresh this layer's active-visible-layer registry entry and read the
+            // worker reservation owed to OTHER layers that currently have visible
+            // cold work, so the worker-start block below lends only leftover global
+            // capacity to this layer (issue #432 fairness floor). A layer counts as
+            // active-visible whenever it has visible cold tiles (pending OR already
+            // in flight), so a layer mid-raster of its visible burst still keeps its
+            // reservation; the reservation is each sibling's shortfall to its floor,
+            // so siblings already running their share owe nothing.
+            var reservedForOtherLayers = RefreshActiveVisibleLayers(state, coldExposure > 0, state.ActiveWorkers, frameTicks);
+
             // Drop enqueue stamps for tiles no longer visible (panned away before
             // they landed) so the dictionary stays bounded by the visible set.
             if (state.VisibleEnqueueTicks.Count > visibleSet.Count)
@@ -729,21 +782,46 @@ public static class S100VectorTileRenderer
                 state.PendingGeneration = state.Generation;
                 state.PendingCenterX = centerX;
                 state.PendingCenterY = centerY;
-                // Spin up enough workers to cover the pending tiles, capped at the
-                // tier's per-layer pool size, so a cold pan's misses rasterise in
-                // parallel instead of one at a time. A second cap on the total live
-                // workers across every layer keeps N layers × N workers from
-                // oversubscribing the cores (which would starve the UI thread on a
-                // big exchange set). Never start more than there is work for.
-                var perLayer = Math.Min(
-                    RenderingOptimizations.TileWorkerCount,
-                    state.PendingVisible.Count + state.PendingPredicted.Count);
-                var globalRoom = s_maxTotalWorkers - Volatile.Read(ref s_activeWorkerTotal);
-                workersToStart = Math.Min(perLayer - state.ActiveWorkers, globalRoom);
+
+                // Spin up workers to cover the pending tiles. The per-layer
+                // TileWorkerCount is a *floor* (reservation), not a hard ceiling:
+                // a layer with a visible backlog may borrow idle global capacity
+                // toward s_maxTotalWorkers (issue #432), but only for *visible*
+                // work — predicted/speculative tiles never justify borrowing, so a
+                // busy layer's prewarm can't occupy cores a sibling wants for
+                // on-screen tiles. On a LowEnd (single-worker) host there is nothing
+                // to borrow, so the elastic ceiling collapses to the floor and this
+                // reduces to the pre-elastic behaviour. A per-layer floor is
+                // reserved for every other active-visible layer before any elastic
+                // extra is granted, so a dense bottom-of-z-order layer can't starve
+                // siblings that paint later in the frame.
+                var baseline = RenderingOptimizations.TileWorkerCount;
+                var elasticCeiling = RenderingOptimizations.ResolvedProfile == PerformanceProfile.LowEnd
+                    ? baseline
+                    : s_maxTotalWorkers;
+
+                workersToStart = ComputeWorkersToStart(
+                    baseline,
+                    elasticCeiling,
+                    s_maxTotalWorkers,
+                    Volatile.Read(ref s_activeWorkerTotal),
+                    state.ActiveWorkers,
+                    state.PendingVisible.Count,
+                    state.PendingPredicted.Count,
+                    reservedForOtherLayers);
+
                 if (workersToStart > 0)
                 {
                     state.ActiveWorkers += workersToStart;
                     Interlocked.Add(ref s_activeWorkerTotal, workersToStart);
+
+                    // Publish the post-grant worker count so a sibling painting later
+                    // in this same frame sees this layer's true share and reserves
+                    // only its own shortfall against it.
+                    if (coldExposure > 0)
+                    {
+                        RecordActiveVisibleLayerWorkers(state, state.ActiveWorkers, frameTicks);
+                    }
                 }
             }
 
@@ -1433,16 +1511,198 @@ public static class S100VectorTileRenderer
         canvas.Restore();
     }
 
+    /// <summary>
+    /// Computes how many new tile workers a layer may start this paint, turning
+    /// the per-layer <paramref name="baseline"/> from a hard ceiling into a floor
+    /// that a busy layer may exceed by borrowing idle global capacity for
+    /// <em>visible</em> work (issue #432). Pure and deterministic given its inputs
+    /// so the borrow policy is unit-testable without a live render.
+    /// </summary>
+    /// <param name="baseline">
+    /// The per-layer worker reservation (<see cref="RenderingOptimizations.TileWorkerCount"/>).
+    /// Always reachable (subject to <paramref name="maxTotalWorkers"/>); predicted
+    /// work is never served above this count.
+    /// </param>
+    /// <param name="elasticCeiling">
+    /// The maximum workers a single layer may reach when borrowing for visible
+    /// work. Equal to <paramref name="baseline"/> on a LowEnd host (no borrowing),
+    /// otherwise <paramref name="maxTotalWorkers"/>.
+    /// </param>
+    /// <param name="maxTotalWorkers">The process-wide worker cap (<see cref="s_maxTotalWorkers"/>).</param>
+    /// <param name="activeWorkerTotal">Current total live workers across all layers.</param>
+    /// <param name="layerActiveWorkers">This layer's current live workers.</param>
+    /// <param name="pendingVisible">This layer's pending visible (on-screen) cold tiles.</param>
+    /// <param name="pendingPredicted">This layer's pending predicted (speculative) tiles.</param>
+    /// <param name="reservedForOthers">
+    /// Total workers reserved for <em>other</em> active-visible layers — each such
+    /// layer's shortfall to its <paramref name="baseline"/> floor — which this
+    /// layer may not borrow. The fairness floor that stops a dense low-z layer
+    /// starving later-painting siblings.
+    /// </param>
+    /// <returns>The number of new workers to start (never negative).</returns>
+    internal static int ComputeWorkersToStart(
+        int baseline,
+        int elasticCeiling,
+        int maxTotalWorkers,
+        int activeWorkerTotal,
+        int layerActiveWorkers,
+        int pendingVisible,
+        int pendingPredicted,
+        int reservedForOthers)
+    {
+        var totalPending = pendingVisible + pendingPredicted;
+        if (totalPending <= 0)
+        {
+            return 0;
+        }
+
+        var globalRoom = maxTotalWorkers - activeWorkerTotal;
+        if (globalRoom <= 0)
+        {
+            return 0;
+        }
+
+        // Floor grant: reach the per-layer reservation regardless of siblings,
+        // bounded only by global room (the pre-elastic behaviour). Serves visible
+        // and predicted work alike.
+        var desiredBaseline = Math.Min(baseline, totalPending);
+        var baselineStart = Math.Clamp(desiredBaseline - layerActiveWorkers, 0, globalRoom);
+
+        // Elastic grant: borrow toward the elastic ceiling for VISIBLE work only,
+        // from whatever room remains after this layer's own floor and the floor
+        // reservation owed to every other active-visible layer.
+        var elasticStart = 0;
+        var layerCeiling = Math.Max(desiredBaseline, Math.Min(elasticCeiling, pendingVisible));
+        if (layerCeiling > desiredBaseline)
+        {
+            var elasticRoom = globalRoom - baselineStart - Math.Max(0, reservedForOthers);
+            var elasticWant = layerCeiling - Math.Max(layerActiveWorkers, desiredBaseline);
+            if (elasticWant > 0 && elasticRoom > 0)
+            {
+                elasticStart = Math.Min(elasticWant, elasticRoom);
+            }
+        }
+
+        return baselineStart + elasticStart;
+    }
+
+    /// <summary>
+    /// Decides whether a tile worker should leave its drain loop this iteration.
+    /// A worker exits when its layer's scene is gone or all pending work has
+    /// drained, and — the elastic addition (issue #432) — when it is an
+    /// above-<paramref name="baseline"/> ("borrowed") worker that has reached the
+    /// visible→predicted boundary: with no visible work left it sheds instead of
+    /// falling through to speculative work, so borrowed global capacity returns to
+    /// the pool within roughly one tile's raster time rather than leaking into
+    /// prewarm. Pure so the shed policy is unit-testable.
+    /// </summary>
+    /// <param name="sceneNull">True when the layer's scene has been cleared.</param>
+    /// <param name="hasVisible">True when the layer has pending visible tiles.</param>
+    /// <param name="hasPredicted">True when the layer has pending predicted tiles.</param>
+    /// <param name="layerActiveWorkers">This layer's current live workers.</param>
+    /// <param name="baseline">The per-layer floor (<see cref="RenderingOptimizations.TileWorkerCount"/>).</param>
+    /// <returns>True when the worker should exit its loop.</returns>
+    internal static bool ShouldWorkerExit(
+        bool sceneNull,
+        bool hasVisible,
+        bool hasPredicted,
+        int layerActiveWorkers,
+        int baseline) =>
+        sceneNull
+        || (!hasVisible && !hasPredicted)
+        || (!hasVisible && layerActiveWorkers > baseline);
+
+    /// <summary>
+    /// Refreshes <paramref name="state"/>'s entry in the active-visible-layer
+    /// registry and returns the worker reservation owed to <em>other</em> layers
+    /// that have had visible cold work within <see cref="ElasticFairnessWindowSeconds"/>
+    /// — the sum over those layers of their shortfall to the per-layer floor
+    /// (<see cref="RenderingOptimizations.TileWorkerCount"/>). Counting each
+    /// competitor's own workers, rather than all other layers', keeps an unrelated
+    /// predicted-only layer's workers from wrongly satisfying an active-visible
+    /// sibling's reservation. Stamps (or removes) this layer, then prunes stale
+    /// entries so layers that stopped painting — culled, resolution-hidden, or torn
+    /// down — age out of the reservation. Called only on the render thread under
+    /// the layer's <c>state.Sync</c>; takes <see cref="s_visibleLayerSync"/> second,
+    /// never the reverse.
+    /// </summary>
+    /// <param name="state">The painting layer's tile state.</param>
+    /// <param name="hasVisibleWork">True when the layer has visible cold tiles (pending or in flight) this paint.</param>
+    /// <param name="layerActiveWorkers">This layer's current live workers (its own entry excludes itself from the reservation).</param>
+    /// <param name="nowTicks">The current <see cref="Stopwatch"/> tick.</param>
+    /// <returns>The total worker reservation owed to other active-visible layers.</returns>
+    private static int RefreshActiveVisibleLayers(TileState state, bool hasVisibleWork, int layerActiveWorkers, long nowTicks)
+    {
+        var windowTicks = (long)(Stopwatch.Frequency * ElasticFairnessWindowSeconds);
+        var baseline = RenderingOptimizations.TileWorkerCount;
+        lock (s_visibleLayerSync)
+        {
+            if (hasVisibleWork)
+            {
+                s_visibleLayerStamps[state] = new ActiveVisibleEntry(nowTicks, layerActiveWorkers);
+            }
+            else
+            {
+                s_visibleLayerStamps.Remove(state);
+            }
+
+            var reserved = 0;
+            s_visibleLayerPruneScratch.Clear();
+            foreach (var entry in s_visibleLayerStamps)
+            {
+                if (nowTicks - entry.Value.StampTicks > windowTicks)
+                {
+                    s_visibleLayerPruneScratch.Add(entry.Key);
+                }
+                else if (!ReferenceEquals(entry.Key, state))
+                {
+                    reserved += Math.Max(0, baseline - entry.Value.ActiveWorkers);
+                }
+            }
+
+            foreach (var stale in s_visibleLayerPruneScratch)
+            {
+                s_visibleLayerStamps.Remove(stale);
+            }
+
+            return reserved;
+        }
+    }
+
+    /// <summary>
+    /// Updates <paramref name="state"/>'s registry entry with its post-grant worker
+    /// count, so a sibling painting later in the same frame sees this layer's true
+    /// share and reserves only its own shortfall against it. No-op if the layer is
+    /// not currently registered as active-visible.
+    /// </summary>
+    private static void RecordActiveVisibleLayerWorkers(TileState state, int layerActiveWorkers, long nowTicks)
+    {
+        lock (s_visibleLayerSync)
+        {
+            if (s_visibleLayerStamps.ContainsKey(state))
+            {
+                s_visibleLayerStamps[state] = new ActiveVisibleEntry(nowTicks, layerActiveWorkers);
+            }
+        }
+    }
+
     private static void Worker(TileState state)
     {
+        // Set true when this worker releases its pool slot under state.Sync at the
+        // exit decision below, so the finally does not decrement a second time.
+        // Guarding the decrement under the same lock that reads ActiveWorkers is
+        // what lets a cascade of shedding elastic workers converge on the baseline
+        // instead of every one observing the pre-decrement count and over-shedding
+        // (which would stall the predicted drain and thrash the pool).
+        var slotReleased = false;
         try
         {
             while (true)
             {
                 // Stop before touching Skia once the process is shutting down,
                 // so ShutdownAndDrain's wait completes and no tile is rasterised
-                // into a half-torn-down Skia. The single finally clears the
-                // rendering flag and completes the drain-gate registration.
+                // into a half-torn-down Skia. The finally releases the slot and
+                // completes the drain-gate registration.
                 if (s_drainGate.IsDraining)
                 {
                     return;
@@ -1458,19 +1718,34 @@ public static class S100VectorTileRenderer
 
                 lock (state.Sync)
                 {
-                    // Visible tiles always drain before speculative ones, so
-                    // prediction work yields to anything actually on screen.
-                    if (state.Scene is null
-                        || (state.PendingVisible.Count == 0 && state.PendingPredicted.Count == 0))
+                    var currentScene = state.Scene;
+                    var hasVisible = state.PendingVisible.Count > 0;
+                    var hasPredicted = state.PendingPredicted.Count > 0;
+
+                    // Exit when the scene is gone or all work has drained, and — the
+                    // elastic addition (issue #432) — shed an above-baseline
+                    // ("borrowed") worker the moment visible work runs out rather
+                    // than letting it fall through to speculative work, so borrowed
+                    // global capacity returns to the pool within ~one tile raster.
+                    // Release the slot under this same lock so concurrent sheds can't
+                    // all read the pre-decrement count and over-shed below baseline.
+                    if (currentScene is null
+                        || ShouldWorkerExit(
+                            sceneNull: false,
+                            hasVisible,
+                            hasPredicted,
+                            state.ActiveWorkers,
+                            RenderingOptimizations.TileWorkerCount))
                     {
-                        // Drained: leave the loop and let the finally decrement
-                        // ActiveWorkers. Decrementing here as well would open a race
-                        // where a frame restarts a worker between this point and the
-                        // finally, over-counting the pool.
+                        state.ActiveWorkers--;
+                        Interlocked.Decrement(ref s_activeWorkerTotal);
+                        slotReleased = true;
                         return;
                     }
 
-                    if (state.PendingVisible.Count > 0)
+                    // Visible tiles always drain before speculative ones, so
+                    // prediction work yields to anything actually on screen.
+                    if (hasVisible)
                     {
                         key = TakeNearest(state.PendingVisible, state.PendingCenterX, state.PendingCenterY);
                         isPrediction = false;
@@ -1483,7 +1758,7 @@ public static class S100VectorTileRenderer
 
                     deviceScale = state.PendingDeviceScale;
                     generation = state.PendingGeneration;
-                    scene = state.Scene;
+                    scene = currentScene;
                     baseIndex = state.BaseIndex;
                     diskNamespace = state.DiskNamespace;
                     state.InFlight.Add(key);
@@ -1586,15 +1861,20 @@ public static class S100VectorTileRenderer
         finally
         {
             // Release this worker's pool slot so the next frame can spin up a fresh
-            // worker for any still-pending tiles. Both normal drain-exit and the
-            // abnormal-exit path land here. Mirror the per-layer slot in the
-            // process-wide total so other layers can reclaim the headroom.
-            lock (state.Sync)
+            // worker for any still-pending tiles, unless the shed/drain path above
+            // already released it under state.Sync. Both the normal drain-exit and
+            // the abnormal-exit (shutdown / exception) paths land here. Mirror the
+            // per-layer slot in the process-wide total so other layers can reclaim
+            // the headroom.
+            if (!slotReleased)
             {
-                state.ActiveWorkers--;
-            }
+                lock (state.Sync)
+                {
+                    state.ActiveWorkers--;
+                }
 
-            Interlocked.Decrement(ref s_activeWorkerTotal);
+                Interlocked.Decrement(ref s_activeWorkerTotal);
+            }
 
             // Pair the TryRegister at the worker-start site. When the last
             // worker completes, this signals ShutdownAndDrain that Skia is idle.

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -288,17 +288,33 @@ public static class S100VectorTileRenderer
     /// competitor's own workers — rather than all other layers' workers — stops an
     /// unrelated predicted-only layer's workers from wrongly satisfying an
     /// active-visible sibling's reservation.
+    /// <para>
+    /// Keyed <b>weakly</b> via <see cref="ConditionalWeakTable{TKey,TValue}"/> so it
+    /// never roots a <see cref="TileState"/>. <see cref="TileState"/> is otherwise
+    /// held only weakly (in <see cref="s_states"/>, keyed by <see cref="ILayer"/>);
+    /// a plain <see cref="Dictionary{TKey,TValue}"/> here would keep a removed
+    /// layer's tiling state — including its rasterised tile cache and scenes — alive
+    /// for the process lifetime if the layer disappeared while still registered and
+    /// no later paint pruned it. With a weak key the GC reclaims a dead layer's
+    /// entry even when no further paint occurs.
+    /// </para>
     /// </summary>
-    private static readonly Dictionary<TileState, ActiveVisibleEntry> s_visibleLayerStamps = new();
+    private static readonly ConditionalWeakTable<TileState, ActiveVisibleEntry> s_visibleLayerStamps = new();
 
-    /// <summary>Reusable scratch for pruning <see cref="s_visibleLayerStamps"/> without per-call allocation.</summary>
+    /// <summary>Reusable scratch for time-pruning <see cref="s_visibleLayerStamps"/> without per-call allocation.</summary>
     private static readonly List<TileState> s_visibleLayerPruneScratch = new();
 
     /// <summary>
     /// A layer's active-visible registry entry: the <see cref="Stopwatch"/> tick of
-    /// its last paint with visible cold work, and the workers it held then.
+    /// its last paint with visible cold work, and the workers it held then. A mutable
+    /// reference type because <see cref="ConditionalWeakTable{TKey,TValue}"/> requires
+    /// a reference value; it is only ever read/written under <see cref="s_visibleLayerSync"/>.
     /// </summary>
-    private readonly record struct ActiveVisibleEntry(long StampTicks, int ActiveWorkers);
+    private sealed class ActiveVisibleEntry(long stampTicks, int activeWorkers)
+    {
+        public long StampTicks = stampTicks;
+        public int ActiveWorkers = activeWorkers;
+    }
 
 
     /// <summary>
@@ -1639,7 +1655,15 @@ public static class S100VectorTileRenderer
         {
             if (hasVisibleWork)
             {
-                s_visibleLayerStamps[state] = new ActiveVisibleEntry(nowTicks, layerActiveWorkers);
+                if (s_visibleLayerStamps.TryGetValue(state, out var box))
+                {
+                    box.StampTicks = nowTicks;
+                    box.ActiveWorkers = layerActiveWorkers;
+                }
+                else
+                {
+                    s_visibleLayerStamps.AddOrUpdate(state, new ActiveVisibleEntry(nowTicks, layerActiveWorkers));
+                }
             }
             else
             {
@@ -1648,6 +1672,8 @@ public static class S100VectorTileRenderer
 
             var reserved = 0;
             s_visibleLayerPruneScratch.Clear();
+            // A dead layer's weak key drops out of the table on its own; this pass
+            // only evicts still-live layers whose last visible paint aged out.
             foreach (var entry in s_visibleLayerStamps)
             {
                 if (nowTicks - entry.Value.StampTicks > windowTicks)
@@ -1679,9 +1705,10 @@ public static class S100VectorTileRenderer
     {
         lock (s_visibleLayerSync)
         {
-            if (s_visibleLayerStamps.ContainsKey(state))
+            if (s_visibleLayerStamps.TryGetValue(state, out var box))
             {
-                s_visibleLayerStamps[state] = new ActiveVisibleEntry(nowTicks, layerActiveWorkers);
+                box.StampTicks = nowTicks;
+                box.ActiveWorkers = layerActiveWorkers;
             }
         }
     }

--- a/tests/EncDotNet.S100.Pipelines.Tests/ElasticTileWorkerPoolTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/ElasticTileWorkerPoolTests.cs
@@ -1,0 +1,195 @@
+using EncDotNet.S100.Renderers.Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for the elastic per-layer tile worker-pool policy (issue #432):
+/// <see cref="S100VectorTileRenderer.ComputeWorkersToStart"/> (how many workers a
+/// layer may start, turning the per-layer floor into a reservation that a busy
+/// layer may exceed by borrowing idle global capacity for visible work) and
+/// <see cref="S100VectorTileRenderer.ShouldWorkerExit"/> (shedding a borrowed
+/// worker at the visible→predicted boundary). Both helpers are pure, so the
+/// borrow/shed policy is pinned without a live render.
+/// </summary>
+public class ElasticTileWorkerPoolTests
+{
+    // Representative asymmetric multi-core host: per-layer floor 4, global cap 16.
+    private const int Baseline = 4;
+    private const int MaxTotal = 16;
+
+    private static int Compute(
+        int activeTotal,
+        int layerActive,
+        int pendingVisible,
+        int pendingPredicted,
+        int reservedForOthers,
+        int? elasticCeiling = null) =>
+        S100VectorTileRenderer.ComputeWorkersToStart(
+            Baseline,
+            elasticCeiling ?? MaxTotal,
+            MaxTotal,
+            activeTotal,
+            layerActive,
+            pendingVisible,
+            pendingPredicted,
+            reservedForOthers);
+
+    [Fact]
+    public void NoPendingWork_StartsNothing()
+    {
+        Assert.Equal(0, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 0, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void GlobalPoolExhausted_StartsNothing()
+    {
+        // Every core is already busy on other layers: no room to grant.
+        Assert.Equal(0, Compute(activeTotal: MaxTotal, layerActive: 0, pendingVisible: 20, pendingPredicted: 0, reservedForOthers: 8));
+    }
+
+    [Fact]
+    public void SmallVisibleBacklog_StaysWithinFloor_NoBorrow()
+    {
+        // Two visible misses: covered by the floor, no reason to borrow.
+        Assert.Equal(2, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 2, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void OneBusyLayer_IdleSiblings_BorrowsFullGlobalPool()
+    {
+        // The headline case: one layer with a large visible cold backlog and every
+        // sibling idle borrows the whole global pool instead of capping at the floor.
+        Assert.Equal(MaxTotal, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void Borrowing_IsGatedToVisibleWork_PredictedNeverBorrows()
+    {
+        // A huge predicted backlog with no visible misses stays capped at the floor:
+        // speculative work must never occupy borrowed cores.
+        Assert.Equal(Baseline, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 0, pendingPredicted: 40, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void Borrowing_ClampsElasticToVisibleCount()
+    {
+        // Visible backlog (6) exceeds the floor but is far below the global cap, so
+        // the layer borrows exactly up to the visible count, not the whole pool.
+        Assert.Equal(6, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 6, pendingPredicted: 30, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void FairnessFloor_ReservesBaselineForOtherActiveVisibleLayer()
+    {
+        // A dense bottom-of-z-order layer paints first with a huge visible backlog
+        // while a sibling is also active-visible and running nothing yet (its whole
+        // baseline is owed). This layer must leave the sibling its baseline (4)
+        // reservation: 16 - 4 = 12 workers, not the whole pool.
+        Assert.Equal(12, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: Baseline));
+    }
+
+    [Fact]
+    public void FairnessFloor_LaterPaintingLayerStillReachesItsBaseline()
+    {
+        // After the first layer borrowed 12 (previous test), the sibling paints with
+        // 12 workers already live and the first layer over its floor (owes nothing).
+        // Its own floor (4) is still reachable — it is not starved — and the pool now
+        // sits exactly at the cap.
+        Assert.Equal(Baseline, Compute(activeTotal: 12, layerActive: 0, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void FairnessFloor_ReservesOnlySiblingShortfall_NotUnrelatedWorkers()
+    {
+        // A sibling active-visible and already running its whole baseline owes no
+        // reservation (shortfall 0), so this layer may borrow the room an unrelated
+        // predicted-only layer's 4 workers leave free: 16 - 4 = 12.
+        Assert.Equal(12, Compute(activeTotal: 4, layerActive: 0, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void FairnessFloor_ReservesSummedShortfallOfManySiblings()
+    {
+        // Three other active-visible siblings each owed their full baseline (4) =>
+        // 12 reserved. This bottom layer may take only 16 - 12 = 4 (its own floor),
+        // leaving each sibling room to reach its floor.
+        Assert.Equal(Baseline, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 3 * Baseline));
+    }
+
+    [Fact]
+    public void AlreadyAtFloor_GrantsOnlyTheElasticTopUp()
+    {
+        // The layer already runs its baseline (4) and has a big visible backlog with
+        // no active siblings: it tops up to the global cap, i.e. 16 - 4 = 12 more.
+        Assert.Equal(12, Compute(activeTotal: 4, layerActive: 4, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void AlreadyAtCeiling_GrantsNothing()
+    {
+        // The layer already holds the whole pool; nothing more to grant.
+        Assert.Equal(0, Compute(activeTotal: MaxTotal, layerActive: MaxTotal, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 0));
+    }
+
+    [Fact]
+    public void LowEndCeiling_CollapsesToFloor_NoBorrow()
+    {
+        // On a LowEnd host the elastic ceiling equals the floor: the change no-ops
+        // and a busy layer is capped at the baseline exactly as before.
+        Assert.Equal(Baseline, Compute(activeTotal: 0, layerActive: 0, pendingVisible: 40, pendingPredicted: 0, reservedForOthers: 0, elasticCeiling: Baseline));
+    }
+
+    [Fact]
+    public void LowEndProfile_SingleWorkerFloor_NeverExceedsOne()
+    {
+        // The genuine LowEnd shape: baseline 1, ceiling collapsed to 1. A single
+        // layer never runs more than one worker regardless of backlog.
+        var started = S100VectorTileRenderer.ComputeWorkersToStart(
+            baseline: 1,
+            elasticCeiling: 1,
+            maxTotalWorkers: 4,
+            activeWorkerTotal: 0,
+            layerActiveWorkers: 0,
+            pendingVisible: 40,
+            pendingPredicted: 10,
+            reservedForOthers: 0);
+
+        Assert.Equal(1, started);
+    }
+
+    [Theory]
+    [InlineData(true, true, 8, "an elastic worker keeps serving while visible work remains")]
+    [InlineData(false, false, 8, "shed a borrowed worker at the visible->predicted boundary")]
+    [InlineData(false, true, 4, "a floor worker keeps serving predicted work")]
+    public void ShouldWorkerExit_ElasticShedPolicy(bool hasVisible, bool expectContinue, int activeWorkers, string _)
+    {
+        var exit = S100VectorTileRenderer.ShouldWorkerExit(
+            sceneNull: false,
+            hasVisible: hasVisible,
+            hasPredicted: true,
+            layerActiveWorkers: activeWorkers,
+            baseline: Baseline);
+
+        Assert.Equal(expectContinue, !exit);
+    }
+
+    [Fact]
+    public void ShouldWorkerExit_SceneGone_Exits()
+    {
+        Assert.True(S100VectorTileRenderer.ShouldWorkerExit(sceneNull: true, hasVisible: true, hasPredicted: true, layerActiveWorkers: 1, baseline: Baseline));
+    }
+
+    [Fact]
+    public void ShouldWorkerExit_FullyDrained_Exits()
+    {
+        Assert.True(S100VectorTileRenderer.ShouldWorkerExit(sceneNull: false, hasVisible: false, hasPredicted: false, layerActiveWorkers: 1, baseline: Baseline));
+    }
+
+    [Fact]
+    public void ShouldWorkerExit_FloorWorker_ServesPredicted()
+    {
+        // At or below the floor, a worker drains predicted work rather than shedding.
+        Assert.False(S100VectorTileRenderer.ShouldWorkerExit(sceneNull: false, hasVisible: false, hasPredicted: true, layerActiveWorkers: Baseline, baseline: Baseline));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to EncDotNet.S100! -->

## Summary

Turns the per-layer `TileWorkerCount` in the Mapsui vector tile renderer from a hard ceiling into a floor (a reservation). Previously each layer was independently capped at `TileWorkerCount`, so a single busy layer could not use spare cores even when the rest of the global tile-worker pool sat idle. Now a layer with dense **visible** cold work can borrow idle global capacity toward `max(TileWorkerCount, ProcessorCount)`, while a fairness floor reserves every other active-visible layer its own share so a bottom-of-z-order layer cannot starve later-painting siblings.

Key design points:

- **Pure helpers** `ComputeWorkersToStart` and `ShouldWorkerExit` isolate the cap arithmetic and the shed decision so the policy is deterministically unit-testable.
- **Elastic borrowing is visible-only.** Predicted/speculative (prewarm) tiles never justify borrowing, so a busy layer's prewarm cannot occupy cores a sibling needs for visible work.
- **Prompt give-back.** Borrowed ("elastic") workers shed at the visible->predicted boundary, so capacity returns to the pool within roughly one tile's raster time instead of leaking into prewarm.
- **Fairness by shortfall.** A short time-windowed registry tracks each active-visible layer's live worker count; the reservation owed to others is the summed per-sibling shortfall to the floor, so unrelated predicted-only workers never wrongly satisfy a sibling's reservation.
- **Race-safe shed.** The exit/shed decision decrements the layer and global worker counters under `state.Sync` so a cascade of shedding workers converges on the baseline instead of every worker reading the pre-decrement count and over-shedding.
- **LowEnd is a no-op.** On the LowEnd performance profile the elastic ceiling collapses to the baseline.

Validated end-to-end in the viewer against real UKHO S-101 trial data: output is pixel-identical between this branch and its parent (same SHA256, zero diff), and a deterministic cold time-to-idle A/B (prewarm and disk cache disabled) over a dense multi-layer scene showed no regression (baseline median 461ms vs elastic 481ms, within ~1%). On these sparse trial cells the visible rasterization is light enough that neither the floor nor the elastic ceiling is ever the bottleneck, so the borrowing simply does no harm; its win materializes when a single layer is genuinely visible-tile-raster-bound.

## Spec alignment

- [x] N/A — change is purely infrastructural (build, CI, docs, tooling)

**Spec section references cited in code/docs:** N/A — renderer concurrency change, no spec semantics touched.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact` (N/A here; the new tests are pure and need no external data)
- [x] `dotnet test --configuration Release` passes locally (20 new tests; full Pipelines suite 900 passing / 1 skipped)

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (Mapsui renderer worker-pool paragraph)
- [x] Updated conceptual docs under `docs/` (render subsystem design doc, elastic borrowing section)
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies
- [x] `gh-advisory-database` security check run for any new dependency (N/A — no new dependency)

## Breaking changes

None. Visual output is unchanged (verified pixel-identical); this is an internal tile-worker scheduling change.

Closes #432