### PR TITLE
Idle cross-band (±1) pre-warm for faster zoom transitions (#428)

### DIFF
--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -513,6 +513,32 @@ tiles flow through the existing prediction telemetry
 reads time-to-fill at the new band from the cold-latency histogram and the
 prediction-hit counter.
 
+**A/B result (reference cell `101GB00510210.000`, UKHO S-101 trial set, Apple
+Silicon).** Scripted per-transition harness: fresh dataset load (hot cache
+empty, warm disk cache disabled to remove the cross-run confound), settle at the
+source band, dwell idle ~6 s so the pre-warm workers can drain, then zoom one
+band and measure time-to-idle (`await_render_idle` `waitedMs`, 150 ms quiet
+period) at the new band. `S100_VECTOR_TILE_XBAND=0` (OFF) vs `=1` (ON):
+
+| Zoom transition | OFF `waitedMs` | ON `waitedMs` | Δ |
+|---|---|---|---|
+| 15 → 16 | 729 | 345 | **−53 %** |
+| 15 → 16 (repeat) | 716 | 370 | **−48 %** |
+| 16 → 17 | 641 | 611 | −5 % |
+| 16 → 17 (repeat) | 638 | 601 | −6 % |
+| 17 → 18 | 766 | 749 | −2 % |
+| 17 → 18 (repeat) | 754 | 427 | **−43 %** |
+| **Total** | **4245** | **3102** | **−27 %** |
+
+The largest, most reliable win is the fully-warmed transition (15 → 16: ~52 %
+faster time-to-fill, reproducible). Heavier band + 1 footprints (17 → 18) need a
+longer idle dwell to fully warm under the 24-tile cap + lowest-priority drain —
+the first 17 → 18 trial had only started warming (−2 %), the repeat with more
+accrued idle time reached −43 %. **No transition regressed** in either arm
+(every Δ ≤ 0), confirming the idle gate keeps pre-warm off the on-screen fill
+path. Pre-warm cannot alter draw output — it only pre-rasterises tiles that a
+later zoom would draw identically — so visual parity is exact.
+
 ### D.6 Open follow-ups (Phase 4+)
 
 - The Phase-1 B-side polish items (line dashes, label glyphs) still apply.

--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -416,22 +416,28 @@ hysteresis comes from the velocity EMA, not from retaining stale predictions.
 
 ### D.2 Scheduling
 
-Pending work is split into two queues: `PendingVisible` (on-screen exact-band
-misses, high priority) and `PendingPredicted` (the warm set, low priority). The
-pool of coalescing workers drains visible-first, so prediction always yields to
-tiles the user is actually looking at and never delays an on-screen fill. Within
-each tier a worker dequeues **centre-first** (`TakeNearest`): the pending tile
-whose world centre is nearest the current viewport centre rasterises before the
-perimeter, cutting time-to-centre-fill on a cold pan/zoom. Equal-distance ties
-break deterministically on `(band, y, x)`, so the drain order never depends on
-the pending set's hash iteration order. The pool size is
-`RenderingOptimizations.TileWorkerCount` (tier-sized); a per-layer
+Pending work is split into three queues drained in strict priority order:
+`PendingVisible` (on-screen exact-band misses, high priority), `PendingPredicted`
+(the same-band warm set, low priority), and `PendingCrossBand` (the idle
+cross-band ±1 pre-warm set, lowest priority — see D.5). The pool of coalescing
+workers drains visible-first, so prediction always yields to tiles the user is
+actually looking at and never delays an on-screen fill; same-band prediction in
+turn drains before cross-band pre-warm, so warming an adjacent band never delays
+either higher tier. Within each tier a worker dequeues **centre-first**
+(`TakeNearest`): the pending tile whose world centre is nearest the current
+viewport centre rasterises before the perimeter, cutting time-to-centre-fill on a
+cold pan/zoom. Equal-distance ties break deterministically on `(band, y, x)`, so
+the drain order never depends on the pending set's hash iteration order. The pool
+size is `RenderingOptimizations.TileWorkerCount` (tier-sized); a per-layer
 `ActiveWorkers` count plus a process-wide `s_activeWorkerTotal` cap (core count)
 bound how many run at once.
 
-Speculatively-rasterised keys are tracked in `PredictedInCache`; when a later
-frame finds such a key in the visible set it counts a **prediction hit** and
-drops it from the set (bounded-pruned against the cache to stay small).
+Speculatively-rasterised keys (both same-band predicted and cross-band pre-warm)
+are tracked in `PredictedInCache`; when a later frame finds such a key in the
+visible set it counts a **prediction hit** and drops it from the set
+(bounded-pruned against the cache to stay small). Because `TileKey` carries the
+band, a cross-band pre-warm tile scores its hit when a zoom later makes that band
+visible.
 
 ### D.3 Telemetry
 
@@ -470,7 +476,44 @@ zero-cold, meeting the exit criterion. Pan frame time stays well within budget
 in both arms — the extra ~4 ms p90 with prediction on is the low-priority
 warm-set rasterisation, which never blocks an on-screen fill.
 
-### D.5 Open follow-ups (Phase 4+)
+### D.5 Idle cross-band pre-warm (issue #428)
+
+Same-band prediction (D.1) biases only the two band ± 1 **centre** tiles, so a
+zoom that crosses a band boundary still pays near-full cold latency at the new
+band. Cross-band pre-warm closes that gap: when a layer is otherwise idle the
+renderer warms the whole viewport footprint of both adjacent bands, so a
+subsequent zoom-in or zoom-out starts warm.
+
+- **Warm set** — `TileGrid.CrossBandPrewarmTiles` returns the band ± 1 tiles
+  covering the current viewport (selected against the same world viewport at the
+  same live resolution; only the tile size differs by band). Out-of-range
+  neighbour bands are skipped. The set is **centre-first** and truncated to
+  `CrossBandPrewarmMaxTiles` (24), so the most-central — most-likely-next-zoom —
+  tiles win under the cap (the band + 1 footprint alone is ~4× the visible tile
+  count).
+- **Idle gate** — populated only on a frame with **no cold visible misses**
+  (`PendingVisible` empty), so it never competes with an on-screen fill, and only
+  when the hot cache is below `CrossBandPrewarmHeadroomFraction` (0.75) of its
+  byte budget, so its speculative inserts cannot evict the current working set.
+  Visible target-band tiles are additionally pinned (`TileCache.Protect`) so they
+  are never evicted regardless; the headroom guard protects the same-band
+  predicted and fallback tiles.
+- **Priority** — drained at the lowest worker tier, strictly behind
+  `PendingVisible` and `PendingPredicted` (D.2). Even though it is enqueued in the
+  same frame as the same-band warm set, it only rasterises once that has drained.
+- **Redraw-safe** — its tiles are treated as predictions: they never trigger a
+  redraw (so a published adjacent-band tile cannot start a repaint loop) and are
+  cancelled (rebuilt) every frame. A later zoom that makes one visible scores an
+  ordinary prediction hit.
+
+Cross-band pre-warm is a first-class A/B knob (`S100_VECTOR_TILE_XBAND`,
+`CrossBandPrewarmEnabled`), default on except a no-op on the `LowEnd` tier. Its
+tiles flow through the existing prediction telemetry
+(`s100.render.tile.prediction.rasterized` / `.hits`), so a zoom-transition A/B
+reads time-to-fill at the new band from the cold-latency histogram and the
+prediction-hit counter.
+
+### D.6 Open follow-ups (Phase 4+)
 
 - The Phase-1 B-side polish items (line dashes, label glyphs) still apply.
 - A disk-backed tile cache + `styleStateHash` invalidation (palette/settings)

--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -521,12 +521,16 @@ subsequent zoom-in or zoom-out starts warm.
   tiles win under the cap (the band + 1 footprint alone is ~4× the visible tile
   count).
 - **Idle gate** — populated only on a frame with **no cold visible misses**
-  (`PendingVisible` empty), so it never competes with an on-screen fill, and only
-  when the hot cache is below `CrossBandPrewarmHeadroomFraction` (0.75) of its
-  byte budget, so its speculative inserts cannot evict the current working set.
-  Visible target-band tiles are additionally pinned (`TileCache.Protect`) so they
-  are never evicted regardless; the headroom guard protects the same-band
-  predicted and fallback tiles.
+  (`coldExposure == 0` — no cold visible tile this frame, whether still pending
+  *or* already handed to a worker), so it never competes with an on-screen fill.
+  This is deliberately stricter than a `PendingVisible` empty test: `PendingVisible`
+  excludes cold tiles already in flight, so gating on it would let pre-warm start
+  while the viewport still had cold holes mid-raster and steal a worker from the
+  fill. Also gated on the hot cache being below `CrossBandPrewarmHeadroomFraction`
+  (0.75) of its byte budget, so its speculative inserts cannot evict the current
+  working set. Visible target-band tiles are additionally pinned
+  (`TileCache.Protect`) so they are never evicted regardless; the headroom guard
+  protects the same-band predicted and fallback tiles.
 - **Priority** — drained at the lowest worker tier, strictly behind
   `PendingVisible` and `PendingPredicted` (D.2). Even though it is enqueued in the
   same frame as the same-band warm set, it only rasterises once that has drained.

--- a/docs/design/S100-Render-Subsystem-Design.md
+++ b/docs/design/S100-Render-Subsystem-Design.md
@@ -540,7 +540,8 @@ subsequent zoom-in or zoom-out starts warm.
   ordinary prediction hit.
 
 Cross-band pre-warm is a first-class A/B knob (`S100_VECTOR_TILE_XBAND`,
-`CrossBandPrewarmEnabled`), default on except a no-op on the `LowEnd` tier. Its
+`CrossBandPrewarmEnabled`), default on except off by default on the `LowEnd` tier
+(an explicit opt-in is still honoured there). Its
 tiles flow through the existing prediction telemetry
 (`s100.render.tile.prediction.rasterized` / `.hits`), so a zoom-transition A/B
 reads time-to-fill at the new band from the cold-latency histogram and the

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -750,8 +750,9 @@ tiles. Like same-band prediction its tiles never request a repaint and are
 rebuilt (cancelled) every frame; a later zoom that reveals one scores an ordinary
 prediction hit (`TileKey` carries the band).
 
-Cross-band pre-warm is on by default (a no-op on the `LowEnd` performance tier)
-and is a first-class A/B knob: `S100_VECTOR_TILE_XBAND=0`
+Cross-band pre-warm is on by default (off by default on the `LowEnd` performance
+tier, though an explicit opt-in via the env var or settings toggle is still
+honoured) and is a first-class A/B knob: `S100_VECTOR_TILE_XBAND=0`
 (`CrossBandPrewarmEnabled`) disables it, leaving the same-band warm set intact.
 Its tiles flow through the existing prediction telemetry, so a zoom-transition
 A/B reads time-to-fill at the new band from `s100.render.tile.cold.latency` and

--- a/src/EncDotNet.S100.Renderers.Mapsui/README.md
+++ b/src/EncDotNet.S100.Renderers.Mapsui/README.md
@@ -721,6 +721,34 @@ Prediction is on by default and is a first-class A/B knob:
 fell from **58 % → 16 %** (the residual is the cold start, not the pan), at a
 ~32 % prediction hit-rate; the steady-pan window itself was entirely zero-cold.
 
+### Idle cross-band pre-warm (issue #428)
+
+Same-band prediction warms only the two z±1 *centre* tiles, so a zoom that
+crosses a band boundary still pays near-full cold latency at the new band. Idle
+cross-band pre-warm closes that gap: when a layer is otherwise idle the renderer
+warms the whole viewport footprint of both adjacent bands
+(`TileGrid.CrossBandPrewarmTiles`), so a subsequent zoom-in or zoom-out starts
+warm.
+
+It runs as a **third, lowest-priority queue** (`PendingCrossBand`), drained
+strictly behind `PendingVisible` and `PendingPredicted`, so warming an adjacent
+band never delays visible or same-band work. It is enqueued only on a frame with
+**no cold visible misses** and only while the hot cache is below 75 % of its byte
+budget, so its speculative inserts never evict the current working set (visible
+target-band tiles are additionally pinned via `TileCache.Protect`). The set is
+centre-first and capped at 24 tiles per frame — the band+1 footprint alone is
+~4× the visible count — so the cap keeps the most-central, most-likely-next-zoom
+tiles. Like same-band prediction its tiles never request a repaint and are
+rebuilt (cancelled) every frame; a later zoom that reveals one scores an ordinary
+prediction hit (`TileKey` carries the band).
+
+Cross-band pre-warm is on by default (a no-op on the `LowEnd` performance tier)
+and is a first-class A/B knob: `S100_VECTOR_TILE_XBAND=0`
+(`CrossBandPrewarmEnabled`) disables it, leaving the same-band warm set intact.
+Its tiles flow through the existing prediction telemetry, so a zoom-transition
+A/B reads time-to-fill at the new band from `s100.render.tile.cold.latency` and
+the `s100.render.tile.prediction.hits` counter.
+
 ### Persistent warm disk cache + `styleStateHash` (Phase 4)
 
 Below the in-memory hot cache sits a **persistent, on-disk warm tier**

--- a/src/EncDotNet.S100.Renderers.Mapsui/RenderingOptimizations.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/RenderingOptimizations.cs
@@ -85,6 +85,7 @@ public static class RenderingOptimizations
     private static double s_tileGutterDip;
     private static double s_tileBudgetMb;
     private static bool s_tilePredictionEnabled;
+    private static bool s_tileCrossBandPrewarmEnabled;
     private static bool s_tileDiskCacheEnabled;
     private static double s_tileDiskMb;
     private static bool s_tileGpuResidencyEnabled;
@@ -124,6 +125,11 @@ public static class RenderingOptimizations
             SeedDouble("S100_VECTOR_TILE_BUDGET_MB", MachineProfile.TileBudgetMb(tier), MinTileBudgetMb, MaxTileBudgetMb);
         (s_tilePredictionEnabled, TilePredictionEnvExplicit) =
             SeedBool("S100_VECTOR_TILE_PREDICT", defaultValue: true);
+        // Idle cross-band (±1) pre-warm (issue #428): default on except on the
+        // LowEnd tier, where the extra speculative raster/cache pressure is not
+        // worth it on a constrained host (a no-op there unless env-pinned).
+        (s_tileCrossBandPrewarmEnabled, TileCrossBandPrewarmEnvExplicit) =
+            SeedBool("S100_VECTOR_TILE_XBAND", defaultValue: tier != PerformanceProfile.LowEnd);
         (s_tileDiskCacheEnabled, TileDiskCacheEnvExplicit) =
             SeedBool("S100_VECTOR_TILE_DISK", defaultValue: true);
         (s_tileDiskMb, TileDiskMbEnvExplicit) =
@@ -283,6 +289,26 @@ public static class RenderingOptimizations
     public static bool TilePredictionEnvExplicit { get; }
 
     /// <summary>
+    /// Whether idle cross-band pre-warm (issue&#160;#428) is enabled: when the
+    /// tiled base plane is otherwise idle (no cold visible misses and cache
+    /// headroom to spare) the renderer speculatively rasterises the
+    /// band&#160;±&#160;1 tiles covering the current viewport, so a subsequent
+    /// zoom starts warm. Seeded from <c>S100_VECTOR_TILE_XBAND</c> (default on,
+    /// except a no-op on the <see cref="PerformanceProfile.LowEnd"/> tier). Read
+    /// every frame, so a change takes effect live. Independent of
+    /// <see cref="TilePredictionEnabled"/> (same-band halo/fan warm set), but
+    /// drained at a strictly lower worker priority than it.
+    /// </summary>
+    public static bool TileCrossBandPrewarmEnabled
+    {
+        get => s_tileCrossBandPrewarmEnabled;
+        set { if (!TileCrossBandPrewarmEnvExplicit) s_tileCrossBandPrewarmEnabled = value; }
+    }
+
+    /// <summary>True when <see cref="TileCrossBandPrewarmEnabled"/> is pinned by an explicit environment variable.</summary>
+    public static bool TileCrossBandPrewarmEnvExplicit { get; }
+
+    /// <summary>
     /// Whether the persistent warm disk tile cache (Phase&#160;4) is enabled.
     /// Seeded from <c>S100_VECTOR_TILE_DISK</c> (default on). The shared disk
     /// cache is created once per process, so a change applies on restart.
@@ -404,6 +430,7 @@ public static class RenderingOptimizations
         if (!TileGpuBudgetMbEnvExplicit) s_tileGpuBudgetMb = MachineProfile.TileGpuBudgetMb(tier);
         if (!TileDiskMbEnvExplicit) s_tileDiskMb = MachineProfile.TileDiskMb(tier);
         if (!TileWorkerCountEnvExplicit) s_tileWorkerCount = MachineProfile.TileWorkers(tier);
+        if (!TileCrossBandPrewarmEnvExplicit) s_tileCrossBandPrewarmEnabled = tier != PerformanceProfile.LowEnd;
     }
 
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/RenderingOptimizations.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/RenderingOptimizations.cs
@@ -125,9 +125,11 @@ public static class RenderingOptimizations
             SeedDouble("S100_VECTOR_TILE_BUDGET_MB", MachineProfile.TileBudgetMb(tier), MinTileBudgetMb, MaxTileBudgetMb);
         (s_tilePredictionEnabled, TilePredictionEnvExplicit) =
             SeedBool("S100_VECTOR_TILE_PREDICT", defaultValue: true);
-        // Idle cross-band (±1) pre-warm (issue #428): default on except on the
-        // LowEnd tier, where the extra speculative raster/cache pressure is not
-        // worth it on a constrained host (a no-op there unless env-pinned).
+        // Idle cross-band (±1) pre-warm (issue #428): seed default on except on
+        // the LowEnd tier, where the extra speculative raster/cache pressure is not
+        // worth it on a constrained host. This governs only the default seed (and
+        // the profile-switch default in ApplyProfile); an explicit opt-in via
+        // env var or the setter is still honoured on any tier.
         (s_tileCrossBandPrewarmEnabled, TileCrossBandPrewarmEnvExplicit) =
             SeedBool("S100_VECTOR_TILE_XBAND", defaultValue: tier != PerformanceProfile.LowEnd);
         (s_tileDiskCacheEnabled, TileDiskCacheEnvExplicit) =
@@ -293,11 +295,16 @@ public static class RenderingOptimizations
     /// tiled base plane is otherwise idle (no cold visible misses and cache
     /// headroom to spare) the renderer speculatively rasterises the
     /// band&#160;±&#160;1 tiles covering the current viewport, so a subsequent
-    /// zoom starts warm. Seeded from <c>S100_VECTOR_TILE_XBAND</c> (default on,
-    /// except a no-op on the <see cref="PerformanceProfile.LowEnd"/> tier). Read
-    /// every frame, so a change takes effect live. Independent of
-    /// <see cref="TilePredictionEnabled"/> (same-band halo/fan warm set), but
-    /// drained at a strictly lower worker priority than it.
+    /// zoom starts warm. Seeded from <c>S100_VECTOR_TILE_XBAND</c>; the seed
+    /// <b>default</b> is on, except off on the <see cref="PerformanceProfile.LowEnd"/>
+    /// tier (and re-forced off whenever the profile switches to LowEnd — see
+    /// <see cref="ApplyProfile"/>), where the extra speculative raster/cache
+    /// pressure is not worth it on a constrained host. That LowEnd rule governs the
+    /// <i>default</i> only: an explicit opt-in — env var or this setter (e.g. the
+    /// viewer toggle) — is still honoured on any tier, exactly like
+    /// <see cref="TilePredictionEnabled"/>. Read every frame, so a change takes
+    /// effect live. Independent of <see cref="TilePredictionEnabled"/> (same-band
+    /// halo/fan warm set), but drained at a strictly lower worker priority than it.
     /// </summary>
     public static bool TileCrossBandPrewarmEnabled
     {

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -851,7 +851,16 @@ public static class S100VectorTileRenderer
                     CrossBandPrewarmMaxTiles);
                 foreach (var key in crossBand)
                 {
-                    if (!state.Cache.Contains(key) && !state.InFlight.Contains(key))
+                    // Also exclude keys already queued in a higher tier this frame:
+                    // the band ± 1 centre tiles overlap TileGrid.PredictedTiles, so
+                    // without this guard the same key would sit in both PendingPredicted
+                    // and PendingCrossBand and be rasterised twice (predicted tier first,
+                    // then cross-band), double-counting TilePredictionRasterized and
+                    // wasting CPU / disk writes (issue #428 review follow-up).
+                    if (!state.Cache.Contains(key)
+                        && !state.InFlight.Contains(key)
+                        && !state.PendingVisible.Contains(key)
+                        && !state.PendingPredicted.Contains(key))
                     {
                         state.PendingCrossBand.Add(key);
                     }

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -1846,10 +1846,10 @@ public static class S100VectorTileRenderer
                     // all read the pre-decrement count and over-shed below baseline.
                     if (ShouldWorkerExit(
                             sceneNull: currentScene is null,
-                            hasVisible,
-                            hasPredicted || hasCrossBand,
-                            state.ActiveWorkers,
-                            RenderingOptimizations.TileWorkerCount))
+                            hasVisible: hasVisible,
+                            hasPredicted: hasPredicted || hasCrossBand,
+                            layerActiveWorkers: state.ActiveWorkers,
+                            baseline: RenderingOptimizations.TileWorkerCount))
                     {
                         state.ActiveWorkers--;
                         Interlocked.Decrement(ref s_activeWorkerTotal);

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -123,6 +123,44 @@ public static class S100VectorTileRenderer
     public static bool PredictionEnabled => RenderingOptimizations.TilePredictionEnabled;
 
     /// <summary>
+    /// Whether idle <b>cross-band pre-warm</b> (issue&#160;#428) is enabled. When
+    /// on, and the tiled base plane is otherwise idle for a layer (no cold
+    /// visible misses this frame and cache headroom to spare), the renderer
+    /// speculatively rasterises the band&#160;±&#160;1 tiles covering the current
+    /// viewport at the <em>lowest</em> worker priority (behind visible and
+    /// same-band predicted work), so a subsequent zoom-in or zoom-out starts warm
+    /// instead of paying full cold-tile latency at the new band. Sourced from
+    /// <see cref="RenderingOptimizations.TileCrossBandPrewarmEnabled"/> (seeded
+    /// from <c>S100_VECTOR_TILE_XBAND</c>, default on except a no-op on the
+    /// LowEnd tier); read every frame so a change takes effect live. Like the
+    /// same-band prediction warm set, its tiles never trigger a redraw and are
+    /// cancelled (rebuilt) every frame.
+    /// </summary>
+    public static bool CrossBandPrewarmEnabled => RenderingOptimizations.TileCrossBandPrewarmEnabled;
+
+    /// <summary>
+    /// The maximum number of adjacent-band tiles enqueued per frame for idle
+    /// cross-band pre-warm (issue&#160;#428). Bounds the speculative warm budget
+    /// so pre-warm cannot churn the hot cache: the band&#160;+&#160;1 footprint
+    /// alone is ~4× the visible tile count, so an uncapped warm set could evict a
+    /// large share of the working set. The centre-first ordering
+    /// (<see cref="TileGrid.CrossBandPrewarmTiles"/>) keeps the most-central tiles
+    /// under this cap.
+    /// </summary>
+    private const int CrossBandPrewarmMaxTiles = 24;
+
+    /// <summary>
+    /// The fraction of the hot-cache byte budget below which idle cross-band
+    /// pre-warm may run (issue&#160;#428). When the resident set already exceeds
+    /// this, pre-warm is skipped for the frame so its speculative inserts never
+    /// force eviction of the current working set — the "LRU/hot-cache aware"
+    /// bound the feature calls for. Visible target-band tiles are additionally
+    /// pinned via <see cref="TileCache.Protect"/>, so they are never evicted
+    /// regardless; this guard protects the same-band predicted and fallback tiles.
+    /// </summary>
+    private const double CrossBandPrewarmHeadroomFraction = 0.75;
+
+    /// <summary>
     /// Whether the persistent <b>disk tile cache</b> (Phase&#160;4) is enabled.
     /// When on, a tile missing from the in-memory cache is looked up on disk
     /// before being re-rasterised, and freshly rasterised tiles are persisted —
@@ -476,6 +514,7 @@ public static class S100VectorTileRenderer
             state.InFlight.Clear();
             state.PendingVisible.Clear();
             state.PendingPredicted.Clear();
+            state.PendingCrossBand.Clear();
             state.PredictedInCache.Clear();
             state.VisibleEnqueueTicks.Clear();
             // A new scene is a teleport for prediction: drop the stale velocity
@@ -723,7 +762,35 @@ public static class S100VectorTileRenderer
                 }
             }
 
-            if (state.PendingVisible.Count > 0 || state.PendingPredicted.Count > 0)
+            // Enqueue the idle cross-band (±1) pre-warm set at the lowest priority
+            // (issue #428). Only when the layer is otherwise idle — no cold
+            // visible misses this frame — so pre-warm never competes with an
+            // on-screen fill; and only with cache headroom to spare so its
+            // speculative inserts cannot evict the current working set. The warm
+            // set covers the whole viewport footprint of band ± 1 (centre-first,
+            // capped), so a subsequent zoom starts warm. Drained strictly behind
+            // PendingVisible and PendingPredicted in the worker, so even though it
+            // is enqueued in the same frame as the same-band predicted set it only
+            // rasterises once that has drained. Excludes cached / in-flight tiles.
+            state.PendingCrossBand.Clear();
+            if (CrossBandPrewarmEnabled
+                && state.PendingVisible.Count == 0
+                && state.Cache.ResidentBytes < (long)(state.Cache.BudgetBytes * CrossBandPrewarmHeadroomFraction))
+            {
+                var crossBand = TileGrid.CrossBandPrewarmTiles(
+                    centerX, centerY, coverWidth, coverHeight, resolution, band,
+                    CrossBandPrewarmMaxTiles);
+                foreach (var key in crossBand)
+                {
+                    if (!state.Cache.Contains(key) && !state.InFlight.Contains(key))
+                    {
+                        state.PendingCrossBand.Add(key);
+                    }
+                }
+            }
+
+            if (state.PendingVisible.Count > 0 || state.PendingPredicted.Count > 0
+                || state.PendingCrossBand.Count > 0)
             {
                 state.PendingDeviceScale = deviceScale;
                 state.PendingGeneration = state.Generation;
@@ -737,7 +804,7 @@ public static class S100VectorTileRenderer
                 // big exchange set). Never start more than there is work for.
                 var perLayer = Math.Min(
                     RenderingOptimizations.TileWorkerCount,
-                    state.PendingVisible.Count + state.PendingPredicted.Count);
+                    state.PendingVisible.Count + state.PendingPredicted.Count + state.PendingCrossBand.Count);
                 var globalRoom = s_maxTotalWorkers - Volatile.Read(ref s_activeWorkerTotal);
                 workersToStart = Math.Min(perLayer - state.ActiveWorkers, globalRoom);
                 if (workersToStart > 0)
@@ -1459,9 +1526,14 @@ public static class S100VectorTileRenderer
                 lock (state.Sync)
                 {
                     // Visible tiles always drain before speculative ones, so
-                    // prediction work yields to anything actually on screen.
+                    // prediction work yields to anything actually on screen; and
+                    // the same-band predicted warm set drains before the
+                    // lowest-priority idle cross-band (±1) pre-warm (issue #428),
+                    // so cross-band never delays either.
                     if (state.Scene is null
-                        || (state.PendingVisible.Count == 0 && state.PendingPredicted.Count == 0))
+                        || (state.PendingVisible.Count == 0
+                            && state.PendingPredicted.Count == 0
+                            && state.PendingCrossBand.Count == 0))
                     {
                         // Drained: leave the loop and let the finally decrement
                         // ActiveWorkers. Decrementing here as well would open a race
@@ -1475,9 +1547,19 @@ public static class S100VectorTileRenderer
                         key = TakeNearest(state.PendingVisible, state.PendingCenterX, state.PendingCenterY);
                         isPrediction = false;
                     }
-                    else
+                    else if (state.PendingPredicted.Count > 0)
                     {
                         key = TakeNearest(state.PendingPredicted, state.PendingCenterX, state.PendingCenterY);
+                        isPrediction = true;
+                    }
+                    else
+                    {
+                        // Lowest tier: idle cross-band pre-warm. Treated as a
+                        // prediction (tracked in PredictedInCache, never triggers a
+                        // redraw) so a published adjacent-band tile cannot start a
+                        // repaint loop; it is picked up when a later zoom makes it
+                        // visible.
+                        key = TakeNearest(state.PendingCrossBand, state.PendingCenterX, state.PendingCenterY);
                         isPrediction = true;
                     }
 
@@ -2007,6 +2089,12 @@ public static class S100VectorTileRenderer
         // Visible misses drain before speculative (predicted) tiles.
         public readonly HashSet<TileKey> PendingVisible = new();
         public readonly HashSet<TileKey> PendingPredicted = new();
+
+        // Idle cross-band (±1) pre-warm tiles (issue #428): the lowest-priority
+        // tier, drained only after PendingVisible and PendingPredicted are empty.
+        // Populated only when the layer is otherwise idle (no cold visible misses
+        // this frame, cache headroom to spare); rebuilt (cancelled) every frame.
+        public readonly HashSet<TileKey> PendingCrossBand = new();
 
         // First-enqueue Stopwatch ticks for each cold visible tile still awaiting
         // publish, so the worker can record end-to-end cold latency (queue wait +

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -131,10 +131,10 @@ public static class S100VectorTileRenderer
     /// same-band predicted work), so a subsequent zoom-in or zoom-out starts warm
     /// instead of paying full cold-tile latency at the new band. Sourced from
     /// <see cref="RenderingOptimizations.TileCrossBandPrewarmEnabled"/> (seeded
-    /// from <c>S100_VECTOR_TILE_XBAND</c>, default on except a no-op on the
-    /// LowEnd tier); read every frame so a change takes effect live. Like the
-    /// same-band prediction warm set, its tiles never trigger a redraw and are
-    /// cancelled (rebuilt) every frame.
+    /// from <c>S100_VECTOR_TILE_XBAND</c>, default on except off by default on the
+    /// LowEnd tier — an explicit opt-in is still honoured there); read every frame
+    /// so a change takes effect live. Like the same-band prediction warm set, its
+    /// tiles never trigger a redraw and are cancelled (rebuilt) every frame.
     /// </summary>
     public static bool CrossBandPrewarmEnabled => RenderingOptimizations.TileCrossBandPrewarmEnabled;
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/S100VectorTileRenderer.cs
@@ -841,9 +841,16 @@ public static class S100VectorTileRenderer
             // PendingVisible and PendingPredicted in the worker, so even though it
             // is enqueued in the same frame as the same-band predicted set it only
             // rasterises once that has drained. Excludes cached / in-flight tiles.
+            //
+            // The idle gate keys on coldExposure (every cold visible tile this
+            // frame, pending OR already in flight), not PendingVisible.Count:
+            // PendingVisible excludes cold tiles already handed to a worker, so a
+            // PendingVisible.Count == 0 test would let pre-warm start while the
+            // viewport still had cold holes mid-raster and steal a worker from
+            // finishing the on-screen fill — breaking the guarantee above.
             state.PendingCrossBand.Clear();
             if (CrossBandPrewarmEnabled
-                && state.PendingVisible.Count == 0
+                && coldExposure == 0
                 && state.Cache.ResidentBytes < (long)(state.Cache.BudgetBytes * CrossBandPrewarmHeadroomFraction))
             {
                 var crossBand = TileGrid.CrossBandPrewarmTiles(

--- a/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
@@ -369,6 +369,118 @@ internal static class TileGrid
     }
 
     /// <summary>
+    /// The <b>idle cross-band pre-warm set</b> (design §3.6, issue&#160;#428): the
+    /// tiles of the immediately adjacent bands (<paramref name="band"/>&#160;±&#160;1)
+    /// that cover the <em>current</em> viewport, so a subsequent zoom-in or
+    /// zoom-out starts warm instead of paying full cold-tile latency at the new
+    /// band. Unlike <see cref="PredictedTiles"/> (which biases only the two
+    /// band&#160;±&#160;1 <i>centre</i> tiles), this warms the whole viewport
+    /// footprint of each adjacent band.
+    /// </summary>
+    /// <remarks>
+    /// The result is ordered <b>centre-first</b> (nearest tile-centre to the
+    /// viewport centre first, ties broken deterministically on
+    /// <c>(Band, Y, X)</c>) and truncated to <paramref name="maxTiles"/>, so a
+    /// bounded warm budget keeps the most-central — most-likely-next-zoom-target —
+    /// tiles. Out-of-range neighbour bands (<c>&lt; MinBand</c> or
+    /// <c>&gt; MaxBand</c>) are skipped. The band&#160;±&#160;1 tiles are selected
+    /// against the same world viewport at the same live <paramref name="resolution"/>;
+    /// only the tile size differs by band (band+1 yields ~4× the tiles, band-1
+    /// ~¼×), which is exactly why the centre-first cap matters for the finer band.
+    /// Callers run this only when otherwise idle and drain it at the lowest
+    /// worker priority, so it never competes with visible or same-band predicted
+    /// work.
+    /// </remarks>
+    /// <param name="centerX">Viewport centre X (EPSG:3857 metres).</param>
+    /// <param name="centerY">Viewport centre Y (EPSG:3857 metres).</param>
+    /// <param name="widthDip">Viewport width in DIP.</param>
+    /// <param name="heightDip">Viewport height in DIP.</param>
+    /// <param name="resolution">Live resolution in metres/DIP.</param>
+    /// <param name="band">The current (live-fit) band; neighbours are <paramref name="band"/>&#160;±&#160;1.</param>
+    /// <param name="maxTiles">The maximum number of tiles to return (bounds the warm budget). Values ≤ 0 yield an empty set.</param>
+    /// <returns>The centre-first, capped adjacent-band warm set (may be empty).</returns>
+    public static IReadOnlyList<TileKey> CrossBandPrewarmTiles(
+        double centerX, double centerY, double widthDip, double heightDip, double resolution, int band,
+        int maxTiles)
+    {
+        if (maxTiles <= 0)
+        {
+            return Array.Empty<TileKey>();
+        }
+
+        var candidates = new List<TileKey>();
+        for (var neighbour = band - 1; neighbour <= band + 1; neighbour += 2)
+        {
+            if (neighbour < MinBand || neighbour > MaxBand)
+            {
+                continue;
+            }
+
+            var range = VisibleTileRange(centerX, centerY, widthDip, heightDip, resolution, neighbour);
+            if (range.IsEmpty)
+            {
+                continue;
+            }
+
+            for (var y = range.YStart; y <= range.YEnd; y++)
+            {
+                for (var x = range.XStart; x <= range.XEnd; x++)
+                {
+                    candidates.Add(new TileKey(neighbour, x, y));
+                }
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return Array.Empty<TileKey>();
+        }
+
+        // Centre-first: order by squared distance of each tile's world centre to
+        // the viewport centre so the cap keeps the tiles most likely to sit under
+        // the next zoom. Ties break on (Band, Y, X) — the same deterministic
+        // order S100VectorTileRenderer.TakeNearest uses — so the truncation never
+        // depends on enumeration order.
+        candidates.Sort((a, b) =>
+        {
+            var byDist = CenterDistanceSquared(a, centerX, centerY)
+                .CompareTo(CenterDistanceSquared(b, centerX, centerY));
+            if (byDist != 0)
+            {
+                return byDist;
+            }
+
+            if (a.Band != b.Band)
+            {
+                return a.Band.CompareTo(b.Band);
+            }
+
+            if (a.Y != b.Y)
+            {
+                return a.Y.CompareTo(b.Y);
+            }
+
+            return a.X.CompareTo(b.X);
+        });
+
+        if (candidates.Count > maxTiles)
+        {
+            candidates.RemoveRange(maxTiles, candidates.Count - maxTiles);
+        }
+
+        return candidates;
+    }
+
+    /// <summary>The squared EPSG:3857 distance from a tile's world centre to a point.</summary>
+    private static double CenterDistanceSquared(TileKey key, double centerX, double centerY)
+    {
+        var (minX, minY, maxX, maxY) = TileWorldBounds(key);
+        var dx = (minX + maxX) * 0.5 - centerX;
+        var dy = (minY + maxY) * 0.5 - centerY;
+        return dx * dx + dy * dy;
+    }
+
+    /// <summary>
     /// Projects EPSG:3857 world bounds to the north-up viewport's DIP screen
     /// rectangle (top-left origin, +Y down). Used both to place a tile's core
     /// and to place its guttered image.

--- a/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
@@ -408,7 +408,7 @@ internal static class TileGrid
             return Array.Empty<TileKey>();
         }
 
-        var candidates = new List<TileKey>();
+        var candidates = new List<(TileKey Key, double Dist)>();
         for (var neighbour = band - 1; neighbour <= band + 1; neighbour += 2)
         {
             if (neighbour < MinBand || neighbour > MaxBand)
@@ -426,7 +426,8 @@ internal static class TileGrid
             {
                 for (var x = range.XStart; x <= range.XEnd; x++)
                 {
-                    candidates.Add(new TileKey(neighbour, x, y));
+                    var key = new TileKey(neighbour, x, y);
+                    candidates.Add((key, CenterDistanceSquared(key, centerX, centerY)));
                 }
             }
         }
@@ -438,37 +439,41 @@ internal static class TileGrid
 
         // Centre-first: order by squared distance of each tile's world centre to
         // the viewport centre so the cap keeps the tiles most likely to sit under
-        // the next zoom. Ties break on (Band, Y, X) — the same deterministic
-        // order S100VectorTileRenderer.TakeNearest uses — so the truncation never
+        // the next zoom. The distance is precomputed once per tile above (one
+        // TileWorldBounds call each) rather than recomputed inside the O(n log n)
+        // comparator, so this idle-frame sort stays cheap. Ties break on
+        // (Band, Y, X) — the same deterministic order
+        // S100VectorTileRenderer.TakeNearest uses — so the truncation never
         // depends on enumeration order.
         candidates.Sort((a, b) =>
         {
-            var byDist = CenterDistanceSquared(a, centerX, centerY)
-                .CompareTo(CenterDistanceSquared(b, centerX, centerY));
+            var byDist = a.Dist.CompareTo(b.Dist);
             if (byDist != 0)
             {
                 return byDist;
             }
 
-            if (a.Band != b.Band)
+            if (a.Key.Band != b.Key.Band)
             {
-                return a.Band.CompareTo(b.Band);
+                return a.Key.Band.CompareTo(b.Key.Band);
             }
 
-            if (a.Y != b.Y)
+            if (a.Key.Y != b.Key.Y)
             {
-                return a.Y.CompareTo(b.Y);
+                return a.Key.Y.CompareTo(b.Key.Y);
             }
 
-            return a.X.CompareTo(b.X);
+            return a.Key.X.CompareTo(b.Key.X);
         });
 
-        if (candidates.Count > maxTiles)
+        var count = Math.Min(candidates.Count, maxTiles);
+        var result = new TileKey[count];
+        for (var i = 0; i < count; i++)
         {
-            candidates.RemoveRange(maxTiles, candidates.Count - maxTiles);
+            result[i] = candidates[i].Key;
         }
 
-        return candidates;
+        return result;
     }
 
     /// <summary>The squared EPSG:3857 distance from a tile's world centre to a point.</summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/TileGrid.cs
@@ -408,7 +408,16 @@ internal static class TileGrid
             return Array.Empty<TileKey>();
         }
 
-        var candidates = new List<(TileKey Key, double Dist)>();
+        var found = false;
+
+        // Keep only the maxTiles nearest candidates via a bounded max-heap
+        // (worst-first) rather than materialising and sorting every adjacent-band
+        // tile: VisibleTileRange can enumerate thousands of cells for band + 1, so a
+        // full O(n log n) sort plus O(n) allocation on an idle frame is wasteful when
+        // the renderer only ever keeps the top maxTiles (24). This is O(n log K) time
+        // and O(K) space; the drained order is identical to the previous full sort.
+        var heap = new PriorityQueue<TileKey, (double Dist, int Band, int Y, int X)>(
+            CrossBandWorstFirstComparer);
         for (var neighbour = band - 1; neighbour <= band + 1; neighbour += 2)
         {
             if (neighbour < MinBand || neighbour > MaxBand)
@@ -427,54 +436,72 @@ internal static class TileGrid
                 for (var x = range.XStart; x <= range.XEnd; x++)
                 {
                     var key = new TileKey(neighbour, x, y);
-                    candidates.Add((key, CenterDistanceSquared(key, centerX, centerY)));
+                    var priority = (CenterDistanceSquared(key, centerX, centerY), neighbour, y, x);
+                    found = true;
+                    if (heap.Count < maxTiles)
+                    {
+                        heap.Enqueue(key, priority);
+                    }
+                    else
+                    {
+                        // Heap is full: push the candidate then evict the current
+                        // worst (farthest) of the K + 1, so the heap always retains
+                        // the K nearest tiles seen so far. If the candidate is itself
+                        // the worst, EnqueueDequeue drops it straight back out.
+                        heap.EnqueueDequeue(key, priority);
+                    }
                 }
             }
         }
 
-        if (candidates.Count == 0)
+        if (!found)
         {
             return Array.Empty<TileKey>();
         }
 
-        // Centre-first: order by squared distance of each tile's world centre to
-        // the viewport centre so the cap keeps the tiles most likely to sit under
-        // the next zoom. The distance is precomputed once per tile above (one
-        // TileWorldBounds call each) rather than recomputed inside the O(n log n)
-        // comparator, so this idle-frame sort stays cheap. Ties break on
-        // (Band, Y, X) — the same deterministic order
-        // S100VectorTileRenderer.TakeNearest uses — so the truncation never
-        // depends on enumeration order.
-        candidates.Sort((a, b) =>
+        // Drain worst-first (the comparer puts the farthest tile on top) and fill the
+        // result back-to-front, producing the centre-first order — identical to the
+        // previous Sort's (Dist, Band, Y, X) ordering. Ties are impossible because
+        // each TileKey is unique, so the order is fully deterministic and matches the
+        // (Band, Y, X) tie-break S100VectorTileRenderer.TakeNearest also uses.
+        var result = new TileKey[heap.Count];
+        for (var i = result.Length - 1; i >= 0; i--)
         {
-            var byDist = a.Dist.CompareTo(b.Dist);
+            result[i] = heap.Dequeue();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Worst-first ordering (farthest tile-centre, then largest <c>(Band, Y, X)</c>)
+    /// for the bounded top-K max-heap in <see cref="CrossBandPrewarmTiles"/>: a
+    /// <see cref="PriorityQueue{TElement,TPriority}"/> is a min-heap, so inverting the
+    /// nearest-first order surfaces the most-evictable tile on top and lets
+    /// <see cref="PriorityQueue{TElement,TPriority}.EnqueueDequeue"/> retain the K
+    /// nearest. The drained result is the exact inverse — centre-first.
+    /// </summary>
+    private static readonly IComparer<(double Dist, int Band, int Y, int X)> CrossBandWorstFirstComparer =
+        Comparer<(double Dist, int Band, int Y, int X)>.Create(static (a, b) =>
+        {
+            var byDist = b.Dist.CompareTo(a.Dist);
             if (byDist != 0)
             {
                 return byDist;
             }
 
-            if (a.Key.Band != b.Key.Band)
+            if (a.Band != b.Band)
             {
-                return a.Key.Band.CompareTo(b.Key.Band);
+                return b.Band.CompareTo(a.Band);
             }
 
-            if (a.Key.Y != b.Key.Y)
+            if (a.Y != b.Y)
             {
-                return a.Key.Y.CompareTo(b.Key.Y);
+                return b.Y.CompareTo(a.Y);
             }
 
-            return a.Key.X.CompareTo(b.Key.X);
+            return b.X.CompareTo(a.X);
         });
-
-        var count = Math.Min(candidates.Count, maxTiles);
-        var result = new TileKey[count];
-        for (var i = 0; i < count; i++)
-        {
-            result[i] = candidates[i].Key;
-        }
-
-        return result;
-    }
 
     /// <summary>The squared EPSG:3857 distance from a tile's world centre to a point.</summary>
     private static double CenterDistanceSquared(TileKey key, double centerX, double centerY)

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -405,6 +405,8 @@ internal static class Strings
     public static string Tooltip_TileGutterDip => Get(nameof(Tooltip_TileGutterDip));
     public static string Settings_TilePredictionEnabled => Get(nameof(Settings_TilePredictionEnabled));
     public static string Tooltip_TilePredictionEnabled => Get(nameof(Tooltip_TilePredictionEnabled));
+    public static string Settings_TileCrossBandPrewarmEnabled => Get(nameof(Settings_TileCrossBandPrewarmEnabled));
+    public static string Tooltip_TileCrossBandPrewarmEnabled => Get(nameof(Tooltip_TileCrossBandPrewarmEnabled));
     public static string Settings_TileBudgetMb => Get(nameof(Settings_TileBudgetMb));
     public static string Tooltip_TileBudgetMb => Get(nameof(Tooltip_TileBudgetMb));
     public static string Settings_PerformanceProfile => Get(nameof(Settings_PerformanceProfile));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1002,6 +1002,12 @@
   <data name="Tooltip_TilePredictionEnabled" xml:space="preserve">
     <value>Speculatively rasterize tiles a pan or zoom is about to reveal, so newly exposed edges are already cached. Takes effect immediately. Recommended on.</value>
   </data>
+  <data name="Settings_TileCrossBandPrewarmEnabled" xml:space="preserve">
+    <value>Cross-band pre-warm</value>
+  </data>
+  <data name="Tooltip_TileCrossBandPrewarmEnabled" xml:space="preserve">
+    <value>When idle, speculatively rasterize the adjacent zoom levels (±1 band) covering the current view, so a subsequent zoom starts warm. Runs at the lowest priority behind on-screen work. Takes effect immediately. Recommended on.</value>
+  </data>
   <data name="Settings_TileBudgetMb" xml:space="preserve">
     <value>In-memory cache (MB)</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -678,8 +678,9 @@ internal sealed class SettingsViewModel : ViewModelBase
     private bool _tileCrossBandPrewarmEnabled;
     /// <summary>
     /// Whether idle cross-band (±1) pre-warm is enabled (issue&#160;#428). Read
-    /// every frame, so the change takes effect live. Disabled when pinned by
-    /// <c>S100_VECTOR_TILE_XBAND</c>.
+    /// every frame, so the change takes effect live. Not user-editable (see
+    /// <see cref="TileCrossBandPrewarmEditable"/>) when pinned by
+    /// <c>S100_VECTOR_TILE_XBAND</c> — env pinning can force it either on or off.
     /// </summary>
     public bool TileCrossBandPrewarmEnabled
     {

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -675,6 +675,29 @@ internal sealed class SettingsViewModel : ViewModelBase
     /// <summary>Whether the prediction knob is user-editable (not env-pinned).</summary>
     public bool TilePredictionEditable => !RenderingOptimizations.TilePredictionEnvExplicit;
 
+    private bool _tileCrossBandPrewarmEnabled;
+    /// <summary>
+    /// Whether idle cross-band (±1) pre-warm is enabled (issue&#160;#428). Read
+    /// every frame, so the change takes effect live. Disabled when pinned by
+    /// <c>S100_VECTOR_TILE_XBAND</c>.
+    /// </summary>
+    public bool TileCrossBandPrewarmEnabled
+    {
+        get => _tileCrossBandPrewarmEnabled;
+        set
+        {
+            if (SetProperty(ref _tileCrossBandPrewarmEnabled, value))
+            {
+                RenderingOptimizations.TileCrossBandPrewarmEnabled = value;
+                _settings.TileCrossBandPrewarmEnabled = value;
+                RaiseMarinerChanged();
+            }
+        }
+    }
+
+    /// <summary>Whether the cross-band pre-warm knob is user-editable (not env-pinned).</summary>
+    public bool TileCrossBandPrewarmEditable => !RenderingOptimizations.TileCrossBandPrewarmEnvExplicit;
+
     private bool _tileDiskCacheEnabled;
     /// <summary>
     /// Whether the warm disk tile cache is enabled. The shared cache is created
@@ -1019,6 +1042,13 @@ internal sealed class SettingsViewModel : ViewModelBase
         }
 
         _tilePredictionEnabled = RenderingOptimizations.TilePredictionEnabled;
+
+        if (settings.TileCrossBandPrewarmEnabled is { } tileXBand)
+        {
+            RenderingOptimizations.TileCrossBandPrewarmEnabled = tileXBand;
+        }
+
+        _tileCrossBandPrewarmEnabled = RenderingOptimizations.TileCrossBandPrewarmEnabled;
 
         if (settings.TileDiskCacheEnabled is { } tileDisk)
         {

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -686,10 +686,11 @@ internal sealed class SettingsViewModel : ViewModelBase
         get => _tileCrossBandPrewarmEnabled;
         set
         {
-            if (SetProperty(ref _tileCrossBandPrewarmEnabled, value))
+            RenderingOptimizations.TileCrossBandPrewarmEnabled = value;
+            var effective = RenderingOptimizations.TileCrossBandPrewarmEnabled;
+            if (SetProperty(ref _tileCrossBandPrewarmEnabled, effective))
             {
-                RenderingOptimizations.TileCrossBandPrewarmEnabled = value;
-                _settings.TileCrossBandPrewarmEnabled = value;
+                _settings.TileCrossBandPrewarmEnabled = effective;
                 RaiseMarinerChanged();
             }
         }
@@ -841,10 +842,15 @@ internal sealed class SettingsViewModel : ViewModelBase
                 _tileGpuBudgetMb = RenderingOptimizations.TileGpuBudgetMb;
                 _tileDiskMb = RenderingOptimizations.TileDiskMb;
                 _tileWorkerCount = RenderingOptimizations.TileWorkerCount;
+                // ApplyProfile re-derives the cross-band pre-warm default from the
+                // new tier (off on LowEnd), so mirror it back or the toggle would
+                // drift from the renderer after a profile switch (issue #428).
+                _tileCrossBandPrewarmEnabled = RenderingOptimizations.TileCrossBandPrewarmEnabled;
                 OnPropertyChanged(nameof(TileBudgetMb));
                 OnPropertyChanged(nameof(TileGpuBudgetMb));
                 OnPropertyChanged(nameof(TileDiskMb));
                 OnPropertyChanged(nameof(TileWorkerCount));
+                OnPropertyChanged(nameof(TileCrossBandPrewarmEnabled));
                 OnPropertyChanged(nameof(ResolvedProfileLabel));
                 RaiseMarinerChanged();
             }

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -272,6 +272,14 @@ internal sealed class ViewerSettings
     public bool? TilePredictionEnabled { get; set; }
 
     /// <summary>
+    /// Whether idle cross-band (±1) pre-warm is enabled (issue&#160;#428).
+    /// <see langword="null"/> → best default (on, except a no-op on the LowEnd
+    /// tier). Mirrors <c>RenderingOptimizations.TileCrossBandPrewarmEnabled</c> /
+    /// <c>S100_VECTOR_TILE_XBAND</c>.
+    /// </summary>
+    public bool? TileCrossBandPrewarmEnabled { get; set; }
+
+    /// <summary>
     /// Whether the warm disk tile cache is enabled (issue #331).
     /// <see langword="null"/> → best default (on). Mirrors
     /// <c>RenderingOptimizations.TileDiskCacheEnabled</c> /

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -273,8 +273,9 @@ internal sealed class ViewerSettings
 
     /// <summary>
     /// Whether idle cross-band (±1) pre-warm is enabled (issue&#160;#428).
-    /// <see langword="null"/> → best default (on, except a no-op on the LowEnd
-    /// tier). Mirrors <c>RenderingOptimizations.TileCrossBandPrewarmEnabled</c> /
+    /// <see langword="null"/> → best default (on, except off by default on the
+    /// LowEnd tier; an explicit opt-in is still honoured there). Mirrors
+    /// <c>RenderingOptimizations.TileCrossBandPrewarmEnabled</c> /
     /// <c>S100_VECTOR_TILE_XBAND</c>.
     /// </summary>
     public bool? TileCrossBandPrewarmEnabled { get; set; }

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -294,6 +294,13 @@
                     </Grid>
 
                     <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                          IsEnabled="{Binding TileCrossBandPrewarmEditable}"
+                          ToolTip.Tip="{x:Static loc:Strings.Tooltip_TileCrossBandPrewarmEnabled}">
+                        <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_TileCrossBandPrewarmEnabled}" />
+                        <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding TileCrossBandPrewarmEnabled}" />
+                    </Grid>
+
+                    <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
                           IsEnabled="{Binding TileGpuResidencyEditable}"
                           ToolTip.Tip="{x:Static loc:Strings.Tooltip_TileGpuResidencyEnabled}">
                         <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_TileGpuResidencyEnabled}" />

--- a/tests/EncDotNet.S100.Pipelines.Tests/RenderingOptimizationsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/RenderingOptimizationsTests.cs
@@ -217,9 +217,11 @@ public class RenderingOptimizationsTests
         var originalProfile = RenderingOptimizations.Profile;
         try
         {
-            // LowEnd is a no-op for cross-band prewarm (issue #428): the extra
+            // LowEnd defaults cross-band prewarm off (issue #428): the extra
             // speculative raster/cache pressure is not worth it on a constrained
-            // host. Any other tier defaults it on.
+            // host. This governs the profile-switch *default* only — an explicit
+            // opt-in via env var or setter is still honoured — and any other tier
+            // defaults it on.
             RenderingOptimizations.Profile = PerformanceProfile.LowEnd;
             Assert.False(RenderingOptimizations.TileCrossBandPrewarmEnabled);
 

--- a/tests/EncDotNet.S100.Pipelines.Tests/RenderingOptimizationsTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/RenderingOptimizationsTests.cs
@@ -184,6 +184,55 @@ public class RenderingOptimizationsTests
     }
 
     [Fact]
+    public void TileCrossBandPrewarm_RoundTrips_WhenNotEnvPinned()
+    {
+        if (RenderingOptimizations.TileCrossBandPrewarmEnvExplicit)
+        {
+            return; // pinned by S100_VECTOR_TILE_XBAND; setter is a no-op
+        }
+
+        var original = RenderingOptimizations.TileCrossBandPrewarmEnabled;
+        try
+        {
+            RenderingOptimizations.TileCrossBandPrewarmEnabled = false;
+            Assert.False(RenderingOptimizations.TileCrossBandPrewarmEnabled);
+            RenderingOptimizations.TileCrossBandPrewarmEnabled = true;
+            Assert.True(RenderingOptimizations.TileCrossBandPrewarmEnabled);
+        }
+        finally
+        {
+            RenderingOptimizations.TileCrossBandPrewarmEnabled = original;
+        }
+    }
+
+    [Fact]
+    public void Profile_LowEnd_DisablesCrossBandPrewarm_WhenNotEnvPinned()
+    {
+        if (RenderingOptimizations.ProfileEnvExplicit ||
+            RenderingOptimizations.TileCrossBandPrewarmEnvExplicit)
+        {
+            return; // env-pinned; profile setter / prewarm default are no-ops
+        }
+
+        var originalProfile = RenderingOptimizations.Profile;
+        try
+        {
+            // LowEnd is a no-op for cross-band prewarm (issue #428): the extra
+            // speculative raster/cache pressure is not worth it on a constrained
+            // host. Any other tier defaults it on.
+            RenderingOptimizations.Profile = PerformanceProfile.LowEnd;
+            Assert.False(RenderingOptimizations.TileCrossBandPrewarmEnabled);
+
+            RenderingOptimizations.Profile = PerformanceProfile.HighEnd;
+            Assert.True(RenderingOptimizations.TileCrossBandPrewarmEnabled);
+        }
+        finally
+        {
+            RenderingOptimizations.Profile = originalProfile;
+        }
+    }
+
+    [Fact]
     public void TileGutter_Clamps_AndRoundTrips_WhenNotEnvPinned()
     {
         if (RenderingOptimizations.TileGutterDipEnvExplicit)
@@ -237,6 +286,7 @@ public class RenderingOptimizationsTests
     public void TileRenderer_StaticProperties_Mirror_Config()
     {
         Assert.Equal(RenderingOptimizations.TilePredictionEnabled, S100VectorTileRenderer.PredictionEnabled);
+        Assert.Equal(RenderingOptimizations.TileCrossBandPrewarmEnabled, S100VectorTileRenderer.CrossBandPrewarmEnabled);
         Assert.Equal(RenderingOptimizations.TileGpuResidencyEnabled, S100VectorTileRenderer.GpuResidencyEnabled);
         Assert.Equal(RenderingOptimizations.TileDiskCacheEnabled, S100VectorTileRenderer.DiskCacheEnabled);
         Assert.Equal(RenderingOptimizations.TileGutterDip, S100VectorTileRenderer.GutterDip);

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileCrossBandPrewarmTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileCrossBandPrewarmTests.cs
@@ -24,6 +24,37 @@ public class TileCrossBandPrewarmTests
     }
 
     [Fact]
+    public void CrossBandPrewarmTiles_CappedSequenceMatchesFullOrderedPrefix()
+    {
+        // Pins the exact drain order of the bounded top-K max-heap (issue #428
+        // review): the capped result must be the same ordered sequence as the
+        // uncapped set's (DistSq, Band, Y, X) prefix, not merely the same set.
+        const int band = 9;
+        var res = TileGrid.ResolutionForBand(band);
+        const double cx = 500_000, cy = 300_000;
+
+        var full = TileGrid.CrossBandPrewarmTiles(cx, cy, W, H, res, band, maxTiles: 100_000);
+        const int cap = 8;
+        var capped = TileGrid.CrossBandPrewarmTiles(cx, cy, W, H, res, band, maxTiles: cap);
+
+        Assert.True(full.Count > cap, "test needs an uncapped set larger than the cap");
+
+        double DistSq(TileKey k)
+        {
+            var (tx, ty) = TileCenter(k);
+            return (tx - cx) * (tx - cx) + (ty - cy) * (ty - cy);
+        }
+
+        var expected = full
+            .OrderBy(DistSq)
+            .ThenBy(k => k.Band).ThenBy(k => k.Y).ThenBy(k => k.X)
+            .Take(cap)
+            .ToList();
+
+        Assert.Equal(expected, capped.ToList());
+    }
+
+    [Fact]
     public void CrossBandPrewarmTiles_CoversBothAdjacentBandsOnly()
     {
         const int band = 8;

--- a/tests/EncDotNet.S100.Pipelines.Tests/TileCrossBandPrewarmTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/TileCrossBandPrewarmTests.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using EncDotNet.S100.Renderers.Mapsui;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Unit tests for the idle cross-band pre-warm set
+/// (<see cref="TileGrid.CrossBandPrewarmTiles"/>, issue&#160;#428): the
+/// band&#160;±&#160;1 tiles covering the current viewport that the renderer warms
+/// when otherwise idle so a subsequent zoom starts warm. These pin the
+/// properties the renderer relies on: the set covers only the adjacent bands,
+/// covers their whole viewport footprint when uncapped, is bounded and
+/// centre-first when capped, clamps at the band range ends, and is duplicate-free.
+/// </summary>
+public class TileCrossBandPrewarmTests
+{
+    private const double W = 1024, H = 768;
+
+    private static (double X, double Y) TileCenter(TileKey key)
+    {
+        var (minX, minY, maxX, maxY) = TileGrid.TileWorldBounds(key);
+        return ((minX + maxX) * 0.5, (minY + maxY) * 0.5);
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_CoversBothAdjacentBandsOnly()
+    {
+        const int band = 8;
+        var res = TileGrid.ResolutionForBand(band);
+        var tiles = TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, band, maxTiles: 1000);
+
+        Assert.NotEmpty(tiles);
+        Assert.Contains(tiles, k => k.Band == band - 1);
+        Assert.Contains(tiles, k => k.Band == band + 1);
+        // Never the current band, and never a band more than one away.
+        Assert.All(tiles, k => Assert.InRange(k.Band, band - 1, band + 1));
+        Assert.DoesNotContain(tiles, k => k.Band == band);
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_Uncapped_CoversFullAdjacentBandFootprint()
+    {
+        const int band = 9;
+        var res = TileGrid.ResolutionForBand(band);
+        const double cx = 250_000, cy = -120_000;
+        var tiles = TileGrid.CrossBandPrewarmTiles(cx, cy, W, H, res, band, maxTiles: 100_000).ToHashSet();
+
+        // The whole viewport footprint of each adjacent band (selected against the
+        // same world viewport at the same live resolution) must be present.
+        foreach (var neighbour in new[] { band - 1, band + 1 })
+        {
+            var expected = TileGrid.VisibleTiles(cx, cy, W, H, res, neighbour);
+            Assert.All(expected, k => Assert.Contains(k, tiles));
+        }
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_FinerBandHasMoreTilesThanCoarser()
+    {
+        // band+1 (finer, smaller tiles) covers ~4× the tiles of band-1 (coarser),
+        // which is exactly why the centre-first cap matters for the finer band.
+        const int band = 7;
+        var res = TileGrid.ResolutionForBand(band);
+        var tiles = TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, band, maxTiles: 100_000);
+
+        var finer = tiles.Count(k => k.Band == band + 1);
+        var coarser = tiles.Count(k => k.Band == band - 1);
+        Assert.True(finer > coarser, $"finer band should have more tiles: finer={finer}, coarser={coarser}");
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_CapBoundsCountAndKeepsMostCentral()
+    {
+        const int band = 9;
+        var res = TileGrid.ResolutionForBand(band);
+        const double cx = 500_000, cy = 300_000;
+
+        var full = TileGrid.CrossBandPrewarmTiles(cx, cy, W, H, res, band, maxTiles: 100_000);
+        const int cap = 8;
+        var capped = TileGrid.CrossBandPrewarmTiles(cx, cy, W, H, res, band, maxTiles: cap);
+
+        Assert.True(full.Count > cap, "test needs an uncapped set larger than the cap");
+        Assert.Equal(cap, capped.Count);
+
+        // The capped set is exactly the `cap` tiles nearest the viewport centre.
+        double DistSq(TileKey k)
+        {
+            var (tx, ty) = TileCenter(k);
+            return (tx - cx) * (tx - cx) + (ty - cy) * (ty - cy);
+        }
+
+        var expected = full
+            .OrderBy(DistSq)
+            .ThenBy(k => k.Band).ThenBy(k => k.Y).ThenBy(k => k.X)
+            .Take(cap)
+            .ToHashSet();
+        Assert.Equal(expected, capped.ToHashSet());
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_IsOrderedCentreFirst()
+    {
+        const int band = 10;
+        var res = TileGrid.ResolutionForBand(band);
+        const double cx = 12_345, cy = -67_890;
+        var tiles = TileGrid.CrossBandPrewarmTiles(cx, cy, W, H, res, band, maxTiles: 100_000);
+
+        double DistSq(TileKey k)
+        {
+            var (tx, ty) = TileCenter(k);
+            return (tx - cx) * (tx - cx) + (ty - cy) * (ty - cy);
+        }
+
+        // Non-decreasing distance from the viewport centre across the whole list.
+        for (var i = 1; i < tiles.Count; i++)
+        {
+            Assert.True(DistSq(tiles[i]) >= DistSq(tiles[i - 1]),
+                $"cross-band set must be centre-first: index {i - 1}->{i} distance decreased");
+        }
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_ReturnsNoDuplicates()
+    {
+        const int band = 8;
+        var res = TileGrid.ResolutionForBand(band);
+        var tiles = TileGrid.CrossBandPrewarmTiles(100_000, 100_000, W, H, res, band, maxTiles: 100_000);
+        Assert.Equal(tiles.Count, tiles.Distinct().Count());
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_NonPositiveCapIsEmpty()
+    {
+        var res = TileGrid.ResolutionForBand(8);
+        Assert.Empty(TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, 8, maxTiles: 0));
+        Assert.Empty(TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, 8, maxTiles: -5));
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_DegenerateViewportIsEmpty()
+    {
+        var res = TileGrid.ResolutionForBand(8);
+        Assert.Empty(TileGrid.CrossBandPrewarmTiles(0, 0, 0, H, res, 8, maxTiles: 100));
+        Assert.Empty(TileGrid.CrossBandPrewarmTiles(0, 0, W, 0, res, 8, maxTiles: 100));
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_ClampsAtMinBand_OnlyWarmsBandPlusOne()
+    {
+        // At MinBand there is no band-1, so only band+1 is warmed.
+        var res = TileGrid.ResolutionForBand(TileGrid.MinBand);
+        var tiles = TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, TileGrid.MinBand, maxTiles: 100_000);
+
+        Assert.NotEmpty(tiles);
+        Assert.All(tiles, k => Assert.Equal(TileGrid.MinBand + 1, k.Band));
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_ClampsAtMaxBand_OnlyWarmsBandMinusOne()
+    {
+        // At MaxBand there is no band+1, so only band-1 is warmed.
+        var res = TileGrid.ResolutionForBand(TileGrid.MaxBand);
+        var tiles = TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, TileGrid.MaxBand, maxTiles: 100_000);
+
+        Assert.NotEmpty(tiles);
+        Assert.All(tiles, k => Assert.Equal(TileGrid.MaxBand - 1, k.Band));
+    }
+
+    [Fact]
+    public void CrossBandPrewarmTiles_ExcludesCurrentVisibleBand()
+    {
+        // Regression guard: the cross-band set must never re-warm a current-band
+        // tile (those are the visible/predicted tiers' responsibility).
+        const int band = 8;
+        var res = TileGrid.ResolutionForBand(band);
+        var visible = TileGrid.VisibleTiles(0, 0, W, H, res, band).ToHashSet();
+        var tiles = TileGrid.CrossBandPrewarmTiles(0, 0, W, H, res, band, maxTiles: 100_000);
+
+        Assert.DoesNotContain(tiles, visible.Contains);
+    }
+}


### PR DESCRIPTION
## Summary

Zooming across a scale-band boundary previously paid near-full cold-tile latency at the new band: the existing same-band prediction only biased the two band ±1 *centre* tiles, not the full viewport footprint. This adds an idle cross-band pre-warm so that when a layer is otherwise idle, the renderer speculatively rasterizes the ±1 band tiles covering the current viewport, at the lowest priority behind all visible and same-band-predicted work, so a subsequent zoom-in or zoom-out starts warm.

Key design points:

- **Warm set** — a new pure `TileGrid.CrossBandPrewarmTiles` returns the band ±1 tiles covering the current viewport (same world viewport / live resolution; only the tile size differs by band), selected centre-first and truncated to a 24-tile cap so the most-likely-next-zoom tiles win.
- **Idle gate** — populated only on a frame with no cold visible misses (`PendingVisible` empty) and only while the hot cache is below 0.75 of its byte budget, so it never competes with an on-screen fill and its speculative inserts cannot evict the working set. Drained on a third, lowest worker tier strictly behind `PendingVisible` and `PendingPredicted`.
- **Redraw-safe** — its tiles are treated as predictions: they never trigger a redraw and are rebuilt each frame; a later zoom that makes one visible scores an ordinary prediction hit and reuses the existing prediction telemetry.
- **First-class A/B knob** — `S100_VECTOR_TILE_XBAND` / `CrossBandPrewarmEnabled`, default on except a no-op on the `LowEnd` machine tier, plus a viewer Settings toggle.

The frame-gate is deliberately keyed on `PendingVisible == 0` alone (not also predicted-empty): predicted publishes do not request a redraw, so a "predicted empty" frame would never fire after settling. Instead both predicted misses and cross-band are enqueued on the settling frame and the worker enforces strict tiering.

**Viewer A/B (UKHO S-101 trial cell `101GB00510210.000`, Apple Silicon):** with a sufficient idle dwell, time-to-fill at the new band dropped up to ~52% on a fully-warmed transition and ~27% in aggregate, with no transition regressing in either arm (the idle gate keeps pre-warm off the on-screen fill path). Full table in the design doc D.5.

## Spec alignment

- [x] S-100 framework (`s100-framework`)
- [ ] S-101 ENC (`s101-enc`)
- [ ] S-102 bathymetry (`s102-bathymetry`)
- [ ] S-104 water level (`s104-water-level`)
- [ ] S-111 surface currents (`s111-surface-currents`)
- [ ] S-124 navigational warnings (`s124-nav-warnings`)
- [ ] S-129 under keel clearance (`s129-ukc`)
- [ ] N/A — change is purely infrastructural (build, CI, docs, tooling)

This is a renderer-infrastructure change (Mapsui tiled vector renderer); it does not alter any product's encoding or portrayal semantics. It reuses S-100 Part 9 scale-band conventions already present in the tile grid.

**Spec section references cited in code/docs:** S-100 Part 9 §11.1 scale-visibility (existing band model reused); design record in `docs/design/S100-Render-Subsystem-Design.md` Appendix D.5.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

New `TileCrossBandPrewarmTests` (11 cases: adjacent-band coverage, full footprint, finer>coarser count, centre-first cap/ordering, no duplicates, non-positive cap, degenerate viewport, MinBand/MaxBand clamping, excludes current band) plus `RenderingOptimizationsTests` additions for the flag round-trip and LowEnd no-op. Full Pipelines suite: 893 passed / 1 skipped.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed
- [x] New public APIs have XML doc comments

`Renderers.Mapsui/README.md` gains an "Idle cross-band pre-warm" section; the render-subsystem design doc adds D.5 (design + A/B results) and renumbers the old D.5 to D.6.

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency

No new dependencies.

## Breaking changes

None. Default-on behaviour is additive and gated; the `LowEnd` tier is a no-op, and the feature can be disabled via `S100_VECTOR_TILE_XBAND=0` or the Settings toggle.

Note: expect a merge conflict with #437 (elastic tile worker pools) in the `S100VectorTileRenderer` worker-start arithmetic; both edit the same `perLayer` count and start condition.

Closes #428