### PR TITLE
Link feature/attribute rows to the S-100 Feature Catalogue eXaminer (deep links)

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -227,6 +227,16 @@ public partial class App : Application
                     LogCrash("McpServerHost", t.Exception.GetBaseException().ToString());
             }, TaskScheduler.Default);
         };
+
+        // Live-refresh the examiner affordances in the FC and pick panels when
+        // the user toggles the integration or edits the base URL (issue #442),
+        // so the buttons appear/disappear without a catalogue reload or a new
+        // pick.
+        settingsVm.ExaminerSettingsChanged += () =>
+        {
+            s_services.GetService<FeatureCataloguesViewModel>()?.RefreshExaminerAvailability();
+            s_services.GetService<PickReportViewModel>()?.RefreshExaminerAvailability();
+        };
         _ = mcpHost.Apply().ContinueWith(t =>
         {
             if (t.Exception is not null)

--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -549,6 +549,9 @@ public partial class App : Application
         // About dialog + GitHub-release update check (issue #379).
         services.AddSingleton<IUrlOpener>(sp =>
             new ProcessUrlOpener(sp.GetService<ILogger<ProcessUrlOpener>>()));
+        // S-100 Feature Catalogue eXaminer deep-links (issue #442).
+        services.AddSingleton<IS100ExaminerLinkBuilder>(
+            sp => new S100ExaminerLinkBuilder(sp.GetRequiredService<ViewerSettings>()));
         services.AddSingleton<EncDotNet.S100.Viewer.Services.Updates.IAppVersionProvider>(
             _ => new EncDotNet.S100.Viewer.Services.Updates.AssemblyAppVersionProvider());
         services.AddSingleton<EncDotNet.S100.Viewer.Services.Updates.IGitHubReleaseClient>(sp =>
@@ -705,7 +708,10 @@ public partial class App : Application
             sp.GetRequiredService<IGeographicPickPresenter>()));
 
         // View models
-        services.AddSingleton<FeatureCataloguesViewModel>();
+        services.AddSingleton<FeatureCataloguesViewModel>(sp => new FeatureCataloguesViewModel(
+            sp.GetRequiredService<ViewerSettings>(),
+            sp.GetService<IS100ExaminerLinkBuilder>(),
+            sp.GetService<IUrlOpener>()));
         services.AddSingleton<PortrayalCataloguesViewModel>();
         services.AddSingleton<DatasetsViewModel>();
         services.AddSingleton<CatalogPanelViewModel>();
@@ -719,7 +725,11 @@ public partial class App : Application
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<IMarinerSettingsProvider, MarinerSettingsProvider>();
         services.AddSingleton<ITimeFormatProvider, TimeFormatProvider>();
-        services.AddSingleton<PickReportViewModel>();
+        services.AddSingleton<PickReportViewModel>(sp => new PickReportViewModel(
+            sp.GetService<ITimeFormatProvider>(),
+            sp.GetService<IMarinerSettingsProvider>(),
+            sp.GetService<IUrlOpener>(),
+            sp.GetService<IS100ExaminerLinkBuilder>()));
         services.AddSingleton<TimelineViewModel>();
         services.AddSingleton<DisplayToolbarViewModel>();
         services.AddSingleton<TextGroupToolbarViewModel>();

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -232,6 +232,14 @@ shows:
   `CATPLE`) are shown as friendly names ("Category of pile") and
   enumerated values are shown with their FC labels. Complex
   attribute groups can be collapsed.
+- An **open-in-eXaminer** link on the feature heading and on each
+  attribute row that opens the matching entry on the
+  [S-100 Feature Catalogue eXaminer](https://s100examiner.com/) in
+  your browser, so you can read the full FC definition. The links
+  appear only for product specs the eXaminer hosts; they can be turned
+  off (or pointed at a mirror) under **Settings → S-100 Feature
+  Catalogue eXaminer**. The **Feature Catalogues** panel offers the
+  same catalogue-level link per built-in/loaded catalogue.
 - A **References** section listing every `xlink:href` the feature
   carries. Clicking a row resolves the reference through the same
   processor and re-targets the pick report — particularly useful

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -137,6 +137,9 @@ internal static class Strings
     public static string Tooltip_AddPortrayalCatalogue => Get(nameof(Tooltip_AddPortrayalCatalogue));
     public static string Tooltip_OpenDataset => Get(nameof(Tooltip_OpenDataset));
     public static string Tooltip_RemoveCatalogue => Get(nameof(Tooltip_RemoveCatalogue));
+    public static string Tooltip_OpenCatalogueInExaminer => Get(nameof(Tooltip_OpenCatalogueInExaminer));
+    public static string Tooltip_OpenFeatureInExaminer => Get(nameof(Tooltip_OpenFeatureInExaminer));
+    public static string Tooltip_OpenAttributeInExaminer => Get(nameof(Tooltip_OpenAttributeInExaminer));
     public static string Tooltip_RemoveDataset => Get(nameof(Tooltip_RemoveDataset));
     public static string Tooltip_ToggleDatasetVisibility => Get(nameof(Tooltip_ToggleDatasetVisibility));
     public static string Tooltip_DatasetOpacity => Get(nameof(Tooltip_DatasetOpacity));
@@ -658,6 +661,16 @@ internal static class Strings
     public static string Toast_McpPortFindAnother => Get(nameof(Toast_McpPortFindAnother));
     public static string Toast_McpPortReassignedTitle => Get(nameof(Toast_McpPortReassignedTitle));
     public static string Toast_McpPortReassignedBody => Get(nameof(Toast_McpPortReassignedBody));
+
+    // S-100 Feature Catalogue eXaminer links (issue #442)
+    public static string Settings_ExaminerSection => Get(nameof(Settings_ExaminerSection));
+    public static string Settings_ExaminerSection_Help => Get(nameof(Settings_ExaminerSection_Help));
+    public static string Settings_ExaminerEnabled => Get(nameof(Settings_ExaminerEnabled));
+    public static string Settings_ExaminerEnabledTooltip => Get(nameof(Settings_ExaminerEnabledTooltip));
+    public static string Settings_ExaminerBaseUrl => Get(nameof(Settings_ExaminerBaseUrl));
+    public static string Settings_ExaminerBaseUrlTooltip => Get(nameof(Settings_ExaminerBaseUrlTooltip));
+    public static string Settings_ExaminerBaseUrl_Reset => Get(nameof(Settings_ExaminerBaseUrl_Reset));
+    public static string Settings_ExaminerBaseUrl_ResetTooltip => Get(nameof(Settings_ExaminerBaseUrl_ResetTooltip));
 
     // Load-failure toast
     public static string Toast_DatasetErrorTitle => Get(nameof(Toast_DatasetErrorTitle));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -186,6 +186,15 @@
   <data name="Tooltip_RemoveCatalogue" xml:space="preserve">
     <value>Remove this catalogue</value>
   </data>
+  <data name="Tooltip_OpenCatalogueInExaminer" xml:space="preserve">
+    <value>View this catalogue in the S-100 Feature Catalogue eXaminer (opens in browser)</value>
+  </data>
+  <data name="Tooltip_OpenFeatureInExaminer" xml:space="preserve">
+    <value>View this feature in the S-100 Feature Catalogue eXaminer (opens in browser)</value>
+  </data>
+  <data name="Tooltip_OpenAttributeInExaminer" xml:space="preserve">
+    <value>View this attribute in the S-100 Feature Catalogue eXaminer (opens in browser)</value>
+  </data>
   <data name="Tooltip_RemoveDataset" xml:space="preserve">
     <value>Remove this dataset</value>
   </data>
@@ -1736,6 +1745,32 @@
   <data name="Toast_McpPortReassignedBody" xml:space="preserve">
     <value>MCP server is now on port {0}. Update your MCP client configuration.</value>
     <comment>{0} = newly-assigned port.</comment>
+  </data>
+
+  <!-- S-100 Feature Catalogue eXaminer links (issue #442) -->
+  <data name="Settings_ExaminerSection" xml:space="preserve">
+    <value>S-100 Feature Catalogue eXaminer</value>
+  </data>
+  <data name="Settings_ExaminerSection_Help" xml:space="preserve">
+    <value>Show links from the Feature Catalogues and Object Information panels that open the picked feature or attribute in the S-100 Feature Catalogue eXaminer website.</value>
+  </data>
+  <data name="Settings_ExaminerEnabled" xml:space="preserve">
+    <value>Show eXaminer links</value>
+  </data>
+  <data name="Settings_ExaminerEnabledTooltip" xml:space="preserve">
+    <value>When on, feature and attribute rows offer a link that opens their definition in the S-100 Feature Catalogue eXaminer. Turn off for offline or restricted deployments.</value>
+  </data>
+  <data name="Settings_ExaminerBaseUrl" xml:space="preserve">
+    <value>eXaminer base URL</value>
+  </data>
+  <data name="Settings_ExaminerBaseUrlTooltip" xml:space="preserve">
+    <value>Base URL of the S-100 Feature Catalogue eXaminer. Change it to point the links at a self-hosted mirror.</value>
+  </data>
+  <data name="Settings_ExaminerBaseUrl_Reset" xml:space="preserve">
+    <value>Reset to default</value>
+  </data>
+  <data name="Settings_ExaminerBaseUrl_ResetTooltip" xml:space="preserve">
+    <value>Restore the default S-100 Feature Catalogue eXaminer URL</value>
   </data>
 
   <!-- Load-failure toast -->

--- a/src/EncDotNet.S100.Viewer/Services/S100ExaminerLinkBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/S100ExaminerLinkBuilder.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Builds deep-links into the S-100 Feature Catalogue eXaminer
+/// (https://s100examiner.com/) for a product specification, feature type,
+/// and attribute (issue #442). Abstracted so view-models can be unit-tested
+/// without a live URL.
+/// </summary>
+/// <remarks>
+/// The examiner resolves its query parameters as follows (reverse-engineered
+/// from the live site):
+/// <list type="bullet">
+///   <item><c>?catalog=</c> matches the Feature Catalogue <c>productId</c>
+///   (e.g. <c>S-101</c>) case-insensitively, so the viewer's product-spec
+///   string maps directly.</item>
+///   <item><c>?feature=</c> / <c>?attribute=</c> are resolved tolerantly
+///   (exact code → case-insensitive code → name → S-57 alias), so passing
+///   the Feature Catalogue camel-case <c>code</c> — which is exactly what
+///   <c>FeatureType</c> and <c>PickAttribute.Code</c> already carry — is the
+///   canonical form.</item>
+/// </list>
+/// Only the product specifications the examiner actually hosts (see
+/// <see cref="SupportsSpec"/>) produce a link; everything else returns
+/// <c>null</c> so the UI can hide the affordance rather than link to a
+/// "not found" page.
+/// </remarks>
+internal interface IS100ExaminerLinkBuilder
+{
+    /// <summary>
+    /// True when examiner links are enabled and the base URL is usable.
+    /// When false, every <c>Build…Url</c> method returns <c>null</c>.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// True when the examiner hosts a Feature Catalogue for
+    /// <paramref name="productSpec"/> (e.g. <c>"S-101"</c>) and links are
+    /// enabled.
+    /// </summary>
+    bool SupportsSpec(string? productSpec);
+
+    /// <summary>
+    /// Builds a catalogue-level deep-link (<c>?catalog=</c>), or <c>null</c>
+    /// when links are disabled or the spec is unsupported.
+    /// </summary>
+    string? BuildCatalogueUrl(string? productSpec);
+
+    /// <summary>
+    /// Builds a feature-level deep-link (<c>?catalog=&amp;feature=</c>), or
+    /// <c>null</c> when links are disabled, the spec is unsupported, or the
+    /// feature code is empty.
+    /// </summary>
+    string? BuildFeatureUrl(string? productSpec, string? featureCode);
+
+    /// <summary>
+    /// Builds an attribute-level deep-link
+    /// (<c>?catalog=&amp;feature=&amp;attribute=</c>). The feature code is
+    /// optional — the examiner can resolve an attribute without it. Returns
+    /// <c>null</c> when links are disabled, the spec is unsupported, or the
+    /// attribute code is empty.
+    /// </summary>
+    string? BuildAttributeUrl(string? productSpec, string? featureCode, string? attributeCode);
+}
+
+/// <summary>
+/// Default <see cref="IS100ExaminerLinkBuilder"/> that reads its enabled
+/// state and base URL from <see cref="ViewerSettings"/> on each call, so a
+/// change in the Settings panel takes effect without re-wiring.
+/// </summary>
+internal sealed class S100ExaminerLinkBuilder : IS100ExaminerLinkBuilder
+{
+    private readonly ViewerSettings _settings;
+
+    /// <summary>
+    /// Product specifications hosted by the examiner, from its
+    /// <c>uploads/catalogs.json</c> manifest (checked 2026-07). Compared
+    /// case-insensitively against the viewer's product-spec string.
+    /// S-411 and S-421 are intentionally absent because the examiner does
+    /// not host their Feature Catalogues.
+    /// </summary>
+    private static readonly IReadOnlySet<string> SupportedSpecs =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "S-101", "S-102", "S-104", "S-111", "S-121", "S-122", "S-123",
+            "S-124", "S-125", "S-127", "S-128", "S-129", "S-131", "S-201",
+            "S-401",
+        };
+
+    public S100ExaminerLinkBuilder(ViewerSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => _settings.S100ExaminerLinksEnabled && TryGetBaseUri(out _);
+
+    /// <inheritdoc />
+    public bool SupportsSpec(string? productSpec) =>
+        IsEnabled && !string.IsNullOrWhiteSpace(productSpec) && SupportedSpecs.Contains(productSpec);
+
+    /// <inheritdoc />
+    public string? BuildCatalogueUrl(string? productSpec) =>
+        Build(productSpec, featureCode: null, attributeCode: null);
+
+    /// <inheritdoc />
+    public string? BuildFeatureUrl(string? productSpec, string? featureCode) =>
+        string.IsNullOrWhiteSpace(featureCode)
+            ? null
+            : Build(productSpec, featureCode, attributeCode: null);
+
+    /// <inheritdoc />
+    public string? BuildAttributeUrl(string? productSpec, string? featureCode, string? attributeCode) =>
+        string.IsNullOrWhiteSpace(attributeCode)
+            ? null
+            : Build(productSpec, featureCode, attributeCode);
+
+    private string? Build(string? productSpec, string? featureCode, string? attributeCode)
+    {
+        if (!SupportsSpec(productSpec) || !TryGetBaseUri(out var baseUri))
+            return null;
+
+        var query = new List<string>(3)
+        {
+            "catalog=" + Uri.EscapeDataString(productSpec!),
+        };
+        if (!string.IsNullOrWhiteSpace(featureCode))
+            query.Add("feature=" + Uri.EscapeDataString(featureCode));
+        if (!string.IsNullOrWhiteSpace(attributeCode))
+            query.Add("attribute=" + Uri.EscapeDataString(attributeCode));
+
+        // Build the URL directly rather than via UriBuilder.Query, which
+        // round-trips (and thereby unescapes) the percent-encoded query.
+        // Preserve any base path (e.g. a self-hosted mirror under a subpath)
+        // while discarding any query/fragment the configured value carried.
+        var basePart = baseUri.GetLeftPart(UriPartial.Path);
+        return basePart + "?" + string.Join("&", query);
+    }
+
+    private bool TryGetBaseUri(out Uri baseUri)
+    {
+        baseUri = null!;
+        var value = _settings.S100ExaminerBaseUrl;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+        if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri))
+            return false;
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            return false;
+        baseUri = uri;
+        return true;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/S100ExaminerLinkBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/S100ExaminerLinkBuilder.cs
@@ -128,7 +128,14 @@ internal sealed class S100ExaminerLinkBuilder : IS100ExaminerLinkBuilder
 
     private string? Build(string? productSpec, string? featureCode, string? attributeCode)
     {
-        if (!SupportsSpec(productSpec) || !TryGetBaseUri(out var baseUri))
+        // Validate spec eligibility and parse the base URI in a single pass.
+        // Calling SupportsSpec here would re-parse the base URI (via IsEnabled)
+        // on top of the TryGetBaseUri call below — wasteful since Build can run
+        // per attribute row.
+        if (!_settings.S100ExaminerLinksEnabled
+            || string.IsNullOrWhiteSpace(productSpec)
+            || !SupportedSpecs.Contains(productSpec)
+            || !TryGetBaseUri(out var baseUri))
             return null;
 
         var query = new List<string>(3)

--- a/src/EncDotNet.S100.Viewer/Services/S100ExaminerLinkBuilder.cs
+++ b/src/EncDotNet.S100.Viewer/Services/S100ExaminerLinkBuilder.cs
@@ -17,10 +17,18 @@ namespace EncDotNet.S100.Viewer.Services;
 ///   (e.g. <c>S-101</c>) case-insensitively, so the viewer's product-spec
 ///   string maps directly.</item>
 ///   <item><c>?feature=</c> / <c>?attribute=</c> are resolved tolerantly
-///   (exact code → case-insensitive code → name → S-57 alias), so passing
-///   the Feature Catalogue camel-case <c>code</c> — which is exactly what
-///   <c>FeatureType</c> and <c>PickAttribute.Code</c> already carry — is the
-///   canonical form.</item>
+///   (exact code → case-insensitive code → name → S-57 alias). For the
+///   products the examiner hosts, both <c>FeatureType</c> and
+///   <c>PickAttribute.Code</c> already carry the Feature Catalogue
+///   camel-case <c>code</c>: S-101 (ISO 8211) datasets key attributes by
+///   the ATCS code (e.g. <c>categoryOfSpecialPurposeMark</c>,
+///   <c>colour</c>), and GML-encoded products (S-102/104/111/122/124/125/
+///   127/128/129/131/201) use the GML element name, which is the same
+///   camel-case code. The legacy S-57 six-character acronyms
+///   (e.g. <c>OBJNAM</c>, <c>CATPIB</c>) are only ever seen on true S-57
+///   datasets — which the examiner does not host and this builder never
+///   links — and even those resolve via the alias fallback, so the link is
+///   robust regardless of which form reaches it.</item>
 /// </list>
 /// Only the product specifications the examiner actually hosts (see
 /// <see cref="SupportsSpec"/>) produce a link; everything else returns

--- a/src/EncDotNet.S100.Viewer/ViewModels/CatalogueViewModels.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/CatalogueViewModels.cs
@@ -98,6 +98,23 @@ internal sealed class FeatureCataloguesViewModel : ViewModelBase
     private bool ExaminerSupports(string spec) =>
         _examinerLinks?.SupportsSpec(spec) ?? false;
 
+    /// <summary>
+    /// Re-evaluates <see cref="CatalogueEntry.CanOpenInExaminer"/> for every
+    /// loaded entry against the current examiner settings. Called when the
+    /// user toggles the integration or changes the base URL so the per-row
+    /// "open in eXaminer" buttons appear/disappear without reloading the list
+    /// (issue #442).
+    /// </summary>
+    public void RefreshExaminerAvailability()
+    {
+        // Every entry in this view model is a feature catalogue, so
+        // eligibility reduces to whether the examiner currently hosts the spec.
+        foreach (var entry in Entries)
+        {
+            entry.CanOpenInExaminer = ExaminerSupports(entry.ProductSpec);
+        }
+    }
+
     private CatalogueEntry CreateEntry(string spec, string path, bool isBuiltIn)
     {
         var (name, version, date) = ReadFeatureCatalogueInfo(path);
@@ -233,7 +250,7 @@ internal sealed class PortrayalCataloguesViewModel : ViewModelBase
     }
 }
 
-internal sealed class CatalogueEntry
+internal sealed class CatalogueEntry : ViewModelBase
 {
     public string ProductSpec { get; }
 
@@ -289,9 +306,17 @@ internal sealed class CatalogueEntry
     /// eXaminer (issue #442): the examiner integration is enabled and it
     /// hosts a Feature Catalogue for <see cref="ProductSpec"/>. Gates the
     /// per-row "open in eXaminer" button. Always <c>false</c> for portrayal
-    /// catalogue entries.
+    /// catalogue entries. Live-refreshed by
+    /// <see cref="FeatureCataloguesViewModel.RefreshExaminerAvailability"/>
+    /// when the examiner settings change.
     /// </summary>
-    public bool CanOpenInExaminer { get; }
+    public bool CanOpenInExaminer
+    {
+        get => _canOpenInExaminer;
+        internal set => SetProperty(ref _canOpenInExaminer, value);
+    }
+
+    private bool _canOpenInExaminer;
 
     public CatalogueEntry(
         string productSpec,

--- a/src/EncDotNet.S100.Viewer/ViewModels/CatalogueViewModels.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/CatalogueViewModels.cs
@@ -14,18 +14,46 @@ namespace EncDotNet.S100.Viewer.ViewModels;
 internal sealed class FeatureCataloguesViewModel : ViewModelBase
 {
     private readonly ViewerSettings _settings;
+    private readonly Services.IS100ExaminerLinkBuilder? _examinerLinks;
+    private readonly Services.IUrlOpener? _urlOpener;
 
     public ObservableCollection<CatalogueEntry> Entries { get; } = new();
 
     public ICommand AddCommand { get; }
     public ICommand RemoveCommand { get; }
 
+    /// <summary>
+    /// Opens the row's catalogue in the S-100 Feature Catalogue eXaminer
+    /// (issue #442). No-op when the examiner integration is unavailable.
+    /// </summary>
+    public ICommand OpenInExaminerCommand { get; }
+
     public FeatureCataloguesViewModel(ViewerSettings settings)
+        : this(settings, examinerLinks: null, urlOpener: null)
+    {
+    }
+
+    public FeatureCataloguesViewModel(
+        ViewerSettings settings,
+        Services.IS100ExaminerLinkBuilder? examinerLinks,
+        Services.IUrlOpener? urlOpener)
     {
         _settings = settings;
+        _examinerLinks = examinerLinks;
+        _urlOpener = urlOpener;
         AddCommand = new RelayCommand<string?>(_ => { }); // wired up from view
         RemoveCommand = new RelayCommand<CatalogueEntry>(Remove);
+        OpenInExaminerCommand = new RelayCommand<CatalogueEntry>(OpenInExaminer);
         Reload();
+    }
+
+    private void OpenInExaminer(CatalogueEntry? entry)
+    {
+        if (entry is null || _examinerLinks is null || _urlOpener is null)
+            return;
+        var url = _examinerLinks.BuildCatalogueUrl(entry.ProductSpec);
+        if (!string.IsNullOrEmpty(url))
+            _urlOpener.Open(url);
     }
 
     public void Reload()
@@ -63,17 +91,20 @@ internal sealed class FeatureCataloguesViewModel : ViewModelBase
             // Built-in specs are always covered by the curated title map, so the
             // parsed-name fallback never fires here.
             var title = ComposeTitle(spec, Strings.SpecDisplayName(spec));
-            Entries.Add(new CatalogueEntry(spec, title, displayPath, isBuiltIn: true, version: version, versionDate: versionDate));
+            Entries.Add(new CatalogueEntry(spec, title, displayPath, isBuiltIn: true, version: version, versionDate: versionDate, canOpenInExaminer: ExaminerSupports(spec)));
         }
     }
 
-    private static CatalogueEntry CreateEntry(string spec, string path, bool isBuiltIn)
+    private bool ExaminerSupports(string spec) =>
+        _examinerLinks?.SupportsSpec(spec) ?? false;
+
+    private CatalogueEntry CreateEntry(string spec, string path, bool isBuiltIn)
     {
         var (name, version, date) = ReadFeatureCatalogueInfo(path);
         // Curated name first; fall back to the catalogue's own declared name
         // (for custom specs outside the bundled set).
         var name2 = Strings.SpecDisplayName(spec) ?? (string.IsNullOrWhiteSpace(name) ? null : name);
-        return new CatalogueEntry(spec, ComposeTitle(spec, name2), path, isBuiltIn: isBuiltIn, version: version, versionDate: date);
+        return new CatalogueEntry(spec, ComposeTitle(spec, name2), path, isBuiltIn: isBuiltIn, version: version, versionDate: date, canOpenInExaminer: ExaminerSupports(spec));
     }
 
     /// <summary>
@@ -253,13 +284,23 @@ internal sealed class CatalogueEntry
     /// </summary>
     public bool ShowPath => !IsBuiltIn && !string.IsNullOrEmpty(Path);
 
+    /// <summary>
+    /// True when this catalogue can be opened in the S-100 Feature Catalogue
+    /// eXaminer (issue #442): the examiner integration is enabled and it
+    /// hosts a Feature Catalogue for <see cref="ProductSpec"/>. Gates the
+    /// per-row "open in eXaminer" button. Always <c>false</c> for portrayal
+    /// catalogue entries.
+    /// </summary>
+    public bool CanOpenInExaminer { get; }
+
     public CatalogueEntry(
         string productSpec,
         string displayTitle,
         string path,
         bool isBuiltIn = false,
         string? version = null,
-        string? versionDate = null)
+        string? versionDate = null,
+        bool canOpenInExaminer = false)
     {
         ProductSpec = productSpec;
         DisplayTitle = displayTitle;
@@ -267,5 +308,6 @@ internal sealed class CatalogueEntry
         IsBuiltIn = isBuiltIn;
         Version = version;
         VersionDate = versionDate;
+        CanOpenInExaminer = canOpenInExaminer;
     }
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -547,7 +547,19 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     }
 
     /// <summary>
-    /// Attempts to extract a numeric MMSI from a dynamic hit that
+    /// Re-evaluates the examiner affordances against the current settings.
+    /// Called when the user toggles the integration or changes the base URL
+    /// so the feature- and attribute-level "open in eXaminer" buttons
+    /// appear/disappear immediately, without waiting for the next pick
+    /// (issue #442).
+    /// </summary>
+    public void RefreshExaminerAvailability()
+    {
+        OnPropertyChanged(nameof(IsExaminerAvailable));
+        (OpenFeatureInExaminerCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        (OpenAttributeInExaminerCommand as RelayCommand<PickAttribute>)?.NotifyCanExecuteChanged();
+    }
+
     /// represents an AIS target. AIS feature ids follow the
     /// <c>"ais:{mmsi}"</c> convention defined by
     /// <c>AisDynamicFeatureSource.FeatureIdForMmsi</c>.

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -27,6 +27,8 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
 {
     private readonly ITimeFormatProvider? _timeFormat;
     private readonly IMarinerSettingsProvider? _marinerSettings;
+    private readonly IUrlOpener? _urlOpener;
+    private readonly IS100ExaminerLinkBuilder? _examinerLinks;
     private string? _featureType;
     private string? _featureTypeName;
     private string? _featureRef;
@@ -50,9 +52,20 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     public PickReportViewModel(
         ITimeFormatProvider? timeFormat,
         IMarinerSettingsProvider? marinerSettings)
+        : this(timeFormat, marinerSettings, urlOpener: null, examinerLinks: null)
+    {
+    }
+
+    public PickReportViewModel(
+        ITimeFormatProvider? timeFormat,
+        IMarinerSettingsProvider? marinerSettings,
+        IUrlOpener? urlOpener,
+        IS100ExaminerLinkBuilder? examinerLinks)
     {
         _timeFormat = timeFormat;
         _marinerSettings = marinerSettings;
+        _urlOpener = urlOpener;
+        _examinerLinks = examinerLinks;
         ClearCommand = new RelayCommand(Clear);
         CopyLocationCommand = new RelayCommand(
             () => { if (_location is { } loc) CopyLocationRequested?.Invoke(this, LatLonFormatter.FormatDecimal(loc.Latitude, loc.Longitude)); },
@@ -69,6 +82,12 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         TakeHelmCommand = new RelayCommand<DynamicPickHit>(
             hit => { if (hit is not null && TryGetAisMmsi(hit, out var mmsi)) TakeHelmRequested?.Invoke(this, mmsi); },
             hit => hit is not null && TryGetAisMmsi(hit, out _));
+        OpenFeatureInExaminerCommand = new RelayCommand(
+            OpenFeatureInExaminer,
+            () => IsExaminerAvailable && !string.IsNullOrEmpty(FeatureType));
+        OpenAttributeInExaminerCommand = new RelayCommand<PickAttribute>(
+            OpenAttributeInExaminer,
+            a => IsExaminerAvailable && a is not null && !string.IsNullOrEmpty(a.Code));
 
         if (_timeFormat is not null)
             _timeFormat.TimeFormatChanged += OnTimeFormatChanged;
@@ -489,6 +508,45 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
     public event EventHandler<uint>? TakeHelmRequested;
 
     /// <summary>
+    /// Opens the selected hit's feature in the S-100 Feature Catalogue
+    /// eXaminer (issue #442). Enabled only when the examiner hosts the
+    /// hit's product spec and a feature type is known.
+    /// </summary>
+    public ICommand OpenFeatureInExaminerCommand { get; }
+
+    /// <summary>
+    /// Opens a specific attribute (parameter) of the selected hit's feature
+    /// in the S-100 Feature Catalogue eXaminer (issue #442). Enabled only
+    /// when the examiner hosts the hit's product spec.
+    /// </summary>
+    public ICommand OpenAttributeInExaminerCommand { get; }
+
+    /// <summary>
+    /// True when the S-100 Feature Catalogue eXaminer integration is enabled
+    /// and hosts a catalogue for the selected hit's product spec. Gates the
+    /// feature- and attribute-level "open in eXaminer" affordances.
+    /// </summary>
+    public bool IsExaminerAvailable => _examinerLinks?.SupportsSpec(ProductSpec) ?? false;
+
+    private void OpenFeatureInExaminer()
+    {
+        if (_urlOpener is null || _examinerLinks is null)
+            return;
+        var url = _examinerLinks.BuildFeatureUrl(ProductSpec, FeatureType);
+        if (!string.IsNullOrEmpty(url))
+            _urlOpener.Open(url);
+    }
+
+    private void OpenAttributeInExaminer(PickAttribute? attribute)
+    {
+        if (_urlOpener is null || _examinerLinks is null || attribute is null)
+            return;
+        var url = _examinerLinks.BuildAttributeUrl(ProductSpec, FeatureType, attribute.Code);
+        if (!string.IsNullOrEmpty(url))
+            _urlOpener.Open(url);
+    }
+
+    /// <summary>
     /// Attempts to extract a numeric MMSI from a dynamic hit that
     /// represents an AIS target. AIS feature ids follow the
     /// <c>"ais:{mmsi}"</c> convention defined by
@@ -711,7 +769,10 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
         OnPropertyChanged(nameof(HasSecondaryLabel));
         OnPropertyChanged(nameof(Glyph));
         OnPropertyChanged(nameof(IdentityCaption));
+        OnPropertyChanged(nameof(IsExaminerAvailable));
         (CopyIdentityCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        (OpenFeatureInExaminerCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        (OpenAttributeInExaminerCommand as RelayCommand<PickAttribute>)?.NotifyCanExecuteChanged();
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/PickReportViewModel.cs
@@ -84,10 +84,10 @@ internal sealed class PickReportViewModel : ViewModelBase, EncDotNet.S100.Viewer
             hit => hit is not null && TryGetAisMmsi(hit, out _));
         OpenFeatureInExaminerCommand = new RelayCommand(
             OpenFeatureInExaminer,
-            () => IsExaminerAvailable && !string.IsNullOrEmpty(FeatureType));
+            () => IsExaminerAvailable && !string.IsNullOrWhiteSpace(FeatureType));
         OpenAttributeInExaminerCommand = new RelayCommand<PickAttribute>(
             OpenAttributeInExaminer,
-            a => IsExaminerAvailable && a is not null && !string.IsNullOrEmpty(a.Code));
+            a => IsExaminerAvailable && a is not null && !string.IsNullOrWhiteSpace(a.Code));
 
         if (_timeFormat is not null)
             _timeFormat.TimeFormatChanged += OnTimeFormatChanged;

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -1099,6 +1099,11 @@ internal sealed class SettingsViewModel : ViewModelBase
         _mcpPort = settings.McpPort;
         ResetMcpPortCommand = new RelayCommand(() => McpPort = 0);
 
+        _examinerLinksEnabled = settings.S100ExaminerLinksEnabled;
+        _examinerBaseUrl = settings.S100ExaminerBaseUrl ?? ViewerSettings.DefaultS100ExaminerBaseUrl;
+        ResetExaminerBaseUrlCommand = new RelayCommand(
+            () => ExaminerBaseUrl = ViewerSettings.DefaultS100ExaminerBaseUrl);
+
         var own = settings.OwnShip ?? new OwnShipSettings();
         _ownShipOverlayEnabled = settings.OwnShipOverlayEnabled;
         _ownShipLength = own.LengthMetres;
@@ -1229,6 +1234,58 @@ internal sealed class SettingsViewModel : ViewModelBase
             }
         }
     }
+
+    // ---------------------------------------------------------------
+    // S-100 Feature Catalogue eXaminer deep-links (issue #442).
+    // ---------------------------------------------------------------
+
+    private bool _examinerLinksEnabled;
+    /// <summary>
+    /// Whether feature/attribute rows offer "open in S-100 Feature Catalogue
+    /// eXaminer" deep-links. Persisted to
+    /// <see cref="ViewerSettings.S100ExaminerLinksEnabled"/>.
+    /// </summary>
+    public bool ExaminerLinksEnabled
+    {
+        get => _examinerLinksEnabled;
+        set
+        {
+            if (SetProperty(ref _examinerLinksEnabled, value))
+            {
+                _settings.S100ExaminerLinksEnabled = value;
+                _settings.Save();
+            }
+        }
+    }
+
+    private string _examinerBaseUrl;
+    /// <summary>
+    /// Base URL of the S-100 Feature Catalogue eXaminer used to build
+    /// deep-links. Persisted to
+    /// <see cref="ViewerSettings.S100ExaminerBaseUrl"/>.
+    /// </summary>
+    public string ExaminerBaseUrl
+    {
+        get => _examinerBaseUrl;
+        set
+        {
+            var normalized = string.IsNullOrWhiteSpace(value)
+                ? ViewerSettings.DefaultS100ExaminerBaseUrl
+                : value.Trim();
+            if (SetProperty(ref _examinerBaseUrl, normalized))
+            {
+                _settings.S100ExaminerBaseUrl = normalized;
+                _settings.Save();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Command bound to the "Reset to default" button next to the eXaminer
+    /// base-URL field. Restores
+    /// <see cref="ViewerSettings.DefaultS100ExaminerBaseUrl"/>.
+    /// </summary>
+    public ICommand ResetExaminerBaseUrlCommand { get; }
 
     // ---------------------------------------------------------------
     // Own-vessel dimensions (own-ship symbology PR).

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -1254,6 +1254,7 @@ internal sealed class SettingsViewModel : ViewModelBase
             {
                 _settings.S100ExaminerLinksEnabled = value;
                 _settings.Save();
+                ExaminerSettingsChanged?.Invoke();
             }
         }
     }
@@ -1276,6 +1277,7 @@ internal sealed class SettingsViewModel : ViewModelBase
             {
                 _settings.S100ExaminerBaseUrl = normalized;
                 _settings.Save();
+                ExaminerSettingsChanged?.Invoke();
             }
         }
     }
@@ -1286,6 +1288,14 @@ internal sealed class SettingsViewModel : ViewModelBase
     /// <see cref="ViewerSettings.DefaultS100ExaminerBaseUrl"/>.
     /// </summary>
     public ICommand ResetExaminerBaseUrlCommand { get; }
+
+    /// <summary>
+    /// Raised when an examiner setting (<see cref="ExaminerLinksEnabled"/> or
+    /// <see cref="ExaminerBaseUrl"/>) changes, so panels that surface
+    /// "open in eXaminer" affordances can refresh their availability without
+    /// waiting for a reload or the next pick (issue #442).
+    /// </summary>
+    public event Action? ExaminerSettingsChanged;
 
     // ---------------------------------------------------------------
     // Own-vessel dimensions (own-ship symbology PR).

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -499,6 +499,27 @@ internal sealed class ViewerSettings
     /// </summary>
     public string McpBindAddress { get; set; } = "127.0.0.1";
 
+    /// <summary>
+    /// Whether "open in S-100 Feature Catalogue eXaminer" deep-links are
+    /// surfaced from the Feature Catalogues and Object Information panels
+    /// (issue #442). Enabled by default; can be turned off for air-gapped
+    /// or otherwise restricted deployments where opening a third-party
+    /// site is undesirable.
+    /// </summary>
+    public bool S100ExaminerLinksEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Base URL of the S-100 Feature Catalogue eXaminer used to build the
+    /// deep-links (issue #442). Configurable so an operator can point the
+    /// links at a self-hosted mirror. The builder appends
+    /// <c>?catalog=&amp;feature=&amp;attribute=</c> query parameters; an
+    /// empty or malformed value disables the links.
+    /// </summary>
+    public string S100ExaminerBaseUrl { get; set; } = DefaultS100ExaminerBaseUrl;
+
+    /// <summary>Default S-100 Examiner base URL.</summary>
+    public const string DefaultS100ExaminerBaseUrl = "https://s100examiner.com/";
+
     /// <summary>Maximum number of dataset paths kept in <see cref="RecentDatasetPaths"/>.</summary>
     public const int MaxRecentDatasets = 10;
 

--- a/src/EncDotNet.S100.Viewer/Views/FeatureCataloguesView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/FeatureCataloguesView.axaml
@@ -41,15 +41,25 @@
                                        IsVisible="{Binding ShowPath}"
                                        TextTrimming="CharacterEllipsis" />
                         </StackPanel>
-                        <Button Grid.Column="1"
-                                Classes="Icon"
-                                Command="{Binding $parent[ItemsControl].((vm:FeatureCataloguesViewModel)DataContext).RemoveCommand}"
-                                CommandParameter="{Binding}"
-                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_RemoveCatalogue}"
-                                IsVisible="{Binding !IsBuiltIn}"
-                                VerticalAlignment="Center">
-                            <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
-                        </Button>
+                        <StackPanel Grid.Column="1"
+                                    Orientation="Horizontal"
+                                    Spacing="2"
+                                    VerticalAlignment="Center">
+                            <Button Classes="Icon"
+                                    Command="{Binding $parent[ItemsControl].((vm:FeatureCataloguesViewModel)DataContext).OpenInExaminerCommand}"
+                                    CommandParameter="{Binding}"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenCatalogueInExaminer}"
+                                    IsVisible="{Binding CanOpenInExaminer}">
+                                <ic:FluentIcon Icon="Open" IconVariant="Regular" FontSize="16" />
+                            </Button>
+                            <Button Classes="Icon"
+                                    Command="{Binding $parent[ItemsControl].((vm:FeatureCataloguesViewModel)DataContext).RemoveCommand}"
+                                    CommandParameter="{Binding}"
+                                    ToolTip.Tip="{x:Static loc:Strings.Tooltip_RemoveCatalogue}"
+                                    IsVisible="{Binding !IsBuiltIn}">
+                                <ic:FluentIcon Icon="Delete" IconVariant="Regular" FontSize="16" />
+                            </Button>
+                        </StackPanel>
                     </Grid>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -45,7 +45,7 @@
                         </ToolTip.Tip>
                     </TextBlock>
                     <Grid Grid.Column="2"
-                          ColumnDefinitions="Auto,*"
+                          ColumnDefinitions="Auto,*,Auto"
                           VerticalAlignment="Center">
                         <Border Grid.Column="0"
                                 Width="12" Height="12"
@@ -69,6 +69,17 @@
                                 </MultiBinding>
                             </ToolTip.Tip>
                         </TextBlock>
+                        <Button Grid.Column="2"
+                                Classes="Icon"
+                                Padding="2"
+                                Margin="6,0,0,0"
+                                VerticalAlignment="Center"
+                                Command="{Binding $parent[views:PickReportView].((vm:PickReportViewModel)DataContext).OpenAttributeInExaminerCommand}"
+                                CommandParameter="{Binding}"
+                                ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenAttributeInExaminer}"
+                                IsVisible="{Binding $parent[views:PickReportView].((vm:PickReportViewModel)DataContext).IsExaminerAvailable}">
+                            <ic:FluentIcon Icon="Open" IconVariant="Regular" FontSize="13" />
+                        </Button>
                     </Grid>
                 </Grid>
                 </StackPanel>
@@ -426,14 +437,24 @@
                                          Opacity="0.6"
                                          TextWrapping="Wrap" />
                 </StackPanel>
-                <Button Grid.Column="2"
-                        VerticalAlignment="Top"
-                        Padding="6"
-                        Background="Transparent"
-                        Command="{Binding CopyIdentityCommand}"
-                        ToolTip.Tip="{x:Static loc:Strings.Tooltip_CopyIdentity}">
-                    <ic:FluentIcon Icon="Copy" IconVariant="Regular" FontSize="16" />
-                </Button>
+                <StackPanel Grid.Column="2"
+                            Orientation="Horizontal"
+                            Spacing="2"
+                            VerticalAlignment="Top">
+                    <Button Padding="6"
+                            Background="Transparent"
+                            Command="{Binding OpenFeatureInExaminerCommand}"
+                            IsVisible="{Binding IsExaminerAvailable}"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenFeatureInExaminer}">
+                        <ic:FluentIcon Icon="Open" IconVariant="Regular" FontSize="16" />
+                    </Button>
+                    <Button Padding="6"
+                            Background="Transparent"
+                            Command="{Binding CopyIdentityCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.Tooltip_CopyIdentity}">
+                        <ic:FluentIcon Icon="Copy" IconVariant="Regular" FontSize="16" />
+                    </Button>
+                </StackPanel>
             </Grid>
 
             <!-- References list (xlink:href targets) -->

--- a/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/PickReportView.axaml
@@ -60,6 +60,7 @@
                                    Text="{Binding DisplayText}"
                                    FontSize="12"
                                    FontWeight="Medium"
+                                   VerticalAlignment="Center"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis">
                             <ToolTip.Tip>
@@ -70,15 +71,20 @@
                             </ToolTip.Tip>
                         </TextBlock>
                         <Button Grid.Column="2"
-                                Classes="Icon"
-                                Padding="2"
+                                Width="22" Height="22"
+                                MinWidth="0" MinHeight="0"
+                                Padding="0"
                                 Margin="6,0,0,0"
+                                Background="Transparent"
+                                BorderThickness="0"
                                 VerticalAlignment="Center"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
                                 Command="{Binding $parent[views:PickReportView].((vm:PickReportViewModel)DataContext).OpenAttributeInExaminerCommand}"
                                 CommandParameter="{Binding}"
                                 ToolTip.Tip="{x:Static loc:Strings.Tooltip_OpenAttributeInExaminer}"
                                 IsVisible="{Binding $parent[views:PickReportView].((vm:PickReportViewModel)DataContext).IsExaminerAvailable}">
-                            <ic:FluentIcon Icon="Open" IconVariant="Regular" FontSize="13" />
+                            <ic:FluentIcon Icon="Open" IconVariant="Regular" FontSize="14" Opacity="0.7" />
                         </Button>
                     </Grid>
                 </Grid>

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -594,6 +594,37 @@
                 </StackPanel>
             </StackPanel>
 
+            <!-- S-100 Feature Catalogue eXaminer links (issue #442) -->
+            <Separator Margin="0,8,0,0" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_ExaminerSection}"
+                       FontSize="14"
+                       FontWeight="SemiBold"
+                       Opacity="0.7" />
+            <TextBlock Text="{x:Static loc:Strings.Settings_ExaminerSection_Help}"
+                       FontSize="11"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Settings_ExaminerEnabledTooltip}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_ExaminerEnabled}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding ExaminerLinksEnabled}" />
+            </Grid>
+            <StackPanel Spacing="6">
+                <TextBlock Text="{x:Static loc:Strings.Settings_ExaminerBaseUrl}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBox Text="{Binding ExaminerBaseUrl}"
+                             ToolTip.Tip="{x:Static loc:Strings.Settings_ExaminerBaseUrlTooltip}"
+                             MinWidth="280"
+                             VerticalAlignment="Center" />
+                    <Button Content="{x:Static loc:Strings.Settings_ExaminerBaseUrl_Reset}"
+                            Command="{Binding ResetExaminerBaseUrlCommand}"
+                            ToolTip.Tip="{x:Static loc:Strings.Settings_ExaminerBaseUrl_ResetTooltip}"
+                            VerticalAlignment="Center" />
+                </StackPanel>
+            </StackPanel>
+
             <!-- AIS overlay (PR-D3) -->
             <Separator Margin="0,8,0,0" />
             <TextBlock Text="{x:Static loc:Strings.Settings_AisSection}"

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -613,16 +613,19 @@
                 <TextBlock Text="{x:Static loc:Strings.Settings_ExaminerBaseUrl}"
                            FontSize="12"
                            FontWeight="SemiBold" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBox Text="{Binding ExaminerBaseUrl}"
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox Grid.Column="0"
+                             Text="{Binding ExaminerBaseUrl}"
                              ToolTip.Tip="{x:Static loc:Strings.Settings_ExaminerBaseUrlTooltip}"
-                             MinWidth="280"
+                             MinWidth="120"
+                             Margin="0,0,8,0"
                              VerticalAlignment="Center" />
-                    <Button Content="{x:Static loc:Strings.Settings_ExaminerBaseUrl_Reset}"
+                    <Button Grid.Column="1"
+                            Content="{x:Static loc:Strings.Settings_ExaminerBaseUrl_Reset}"
                             Command="{Binding ResetExaminerBaseUrlCommand}"
                             ToolTip.Tip="{x:Static loc:Strings.Settings_ExaminerBaseUrl_ResetTooltip}"
                             VerticalAlignment="Center" />
-                </StackPanel>
+                </Grid>
             </StackPanel>
 
             <!-- AIS overlay (PR-D3) -->

--- a/tests/EncDotNet.S100.Viewer.Tests/ExaminerViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExaminerViewModelTests.cs
@@ -80,14 +80,59 @@ public class ExaminerViewModelTests
     }
 
     [Fact]
-    public void Fc_builtin_entry_unsupported_spec_cannot_open()
+    public void Fc_refresh_updates_can_open_when_links_disabled()
     {
         var settings = NewSettings();
         var links = new S100ExaminerLinkBuilder(settings);
         var vm = new FeatureCataloguesViewModel(settings, links, new StubUrlOpener());
 
-        vm.AddBuiltIn("S-421", "(built-in)");
-        var entry = vm.Entries.Single(e => e.ProductSpec == "S-421");
+        vm.AddBuiltIn("S-101", "(built-in)");
+        var entry = vm.Entries.Single(e => e.ProductSpec == "S-101");
+        Assert.True(entry.CanOpenInExaminer);
+
+        // Simulate the user disabling the integration in Settings.
+        settings.S100ExaminerLinksEnabled = false;
+        vm.RefreshExaminerAvailability();
         Assert.False(entry.CanOpenInExaminer);
+
+        // ...and re-enabling it.
+        settings.S100ExaminerLinksEnabled = true;
+        vm.RefreshExaminerAvailability();
+        Assert.True(entry.CanOpenInExaminer);
+    }
+
+    [Fact]
+    public void Settings_change_raises_examiner_settings_changed()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s);
+        var count = 0;
+        vm.ExaminerSettingsChanged += () => count++;
+
+        vm.ExaminerLinksEnabled = false;
+        vm.ExaminerBaseUrl = "https://mirror.example.org/";
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void Fc_refresh_raises_property_changed_on_entry()
+    {
+        var settings = NewSettings();
+        var links = new S100ExaminerLinkBuilder(settings);
+        var vm = new FeatureCataloguesViewModel(settings, links, new StubUrlOpener());
+
+        vm.AddBuiltIn("S-101", "(built-in)");
+        var entry = vm.Entries.Single(e => e.ProductSpec == "S-101");
+        var raised = false;
+        entry.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(CatalogueEntry.CanOpenInExaminer))
+                raised = true;
+        };
+
+        settings.S100ExaminerLinksEnabled = false;
+        vm.RefreshExaminerAvailability();
+        Assert.True(raised);
     }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExaminerViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExaminerViewModelTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Tests for the S-100 Feature Catalogue eXaminer wiring in the Settings
+/// and Feature Catalogue view-models (issue #442).
+/// </summary>
+public class ExaminerViewModelTests
+{
+    private sealed class StubUrlOpener : IUrlOpener
+    {
+        public string? LastUrl { get; private set; }
+        public void Open(string url) => LastUrl = url;
+    }
+
+    private static ViewerSettings NewSettings()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        return new ViewerSettings { SettingsFilePath = path };
+    }
+
+    [Fact]
+    public void Settings_default_examiner_links_enabled()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s);
+        Assert.True(vm.ExaminerLinksEnabled);
+        Assert.Equal(ViewerSettings.DefaultS100ExaminerBaseUrl, vm.ExaminerBaseUrl);
+    }
+
+    [Fact]
+    public void Settings_toggle_persists()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s) { ExaminerLinksEnabled = false };
+        Assert.False(s.S100ExaminerLinksEnabled);
+    }
+
+    [Fact]
+    public void Settings_base_url_persists_and_resets()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s) { ExaminerBaseUrl = "https://mirror.example.org/" };
+        Assert.Equal("https://mirror.example.org/", s.S100ExaminerBaseUrl);
+
+        vm.ResetExaminerBaseUrlCommand.Execute(null);
+        Assert.Equal(ViewerSettings.DefaultS100ExaminerBaseUrl, vm.ExaminerBaseUrl);
+        Assert.Equal(ViewerSettings.DefaultS100ExaminerBaseUrl, s.S100ExaminerBaseUrl);
+    }
+
+    [Fact]
+    public void Settings_blank_base_url_falls_back_to_default()
+    {
+        var s = NewSettings();
+        var vm = new SettingsViewModel(s) { ExaminerBaseUrl = "   " };
+        Assert.Equal(ViewerSettings.DefaultS100ExaminerBaseUrl, vm.ExaminerBaseUrl);
+    }
+
+    [Fact]
+    public void Fc_builtin_entry_supported_spec_can_open_and_links()
+    {
+        var settings = NewSettings();
+        var opener = new StubUrlOpener();
+        var links = new S100ExaminerLinkBuilder(settings);
+        var vm = new FeatureCataloguesViewModel(settings, links, opener);
+
+        vm.AddBuiltIn("S-101", "(built-in)");
+        var entry = vm.Entries.Single(e => e.ProductSpec == "S-101");
+        Assert.True(entry.CanOpenInExaminer);
+
+        vm.OpenInExaminerCommand.Execute(entry);
+        Assert.Equal("https://s100examiner.com/?catalog=S-101", opener.LastUrl);
+    }
+
+    [Fact]
+    public void Fc_builtin_entry_unsupported_spec_cannot_open()
+    {
+        var settings = NewSettings();
+        var links = new S100ExaminerLinkBuilder(settings);
+        var vm = new FeatureCataloguesViewModel(settings, links, new StubUrlOpener());
+
+        vm.AddBuiltIn("S-421", "(built-in)");
+        var entry = vm.Entries.Single(e => e.ProductSpec == "S-421");
+        Assert.False(entry.CanOpenInExaminer);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -926,4 +926,31 @@ public class PickReportViewModelTests
         Assert.False(vm.IsExaminerAvailable);
         Assert.False(vm.OpenFeatureInExaminerCommand.CanExecute(null));
     }
+
+    [Fact]
+    public void Examiner_Refresh_UpdatesAvailability_WhenSettingToggled()
+    {
+        var settings = ExaminerSettings();
+        var links = new S100ExaminerLinkBuilder(settings);
+        var vm = new PickReportViewModel(null, null, new StubUrlOpener(), links);
+        vm.SetPick("Building", "Building", "1", "f.000", "S-101",
+            new[] { Leaf("colour", "1") });
+        Assert.True(vm.IsExaminerAvailable);
+
+        var raised = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(PickReportViewModel.IsExaminerAvailable))
+                raised = true;
+        };
+
+        // User disables the integration; the pick panel must react without a
+        // fresh pick.
+        settings.S100ExaminerLinksEnabled = false;
+        vm.RefreshExaminerAvailability();
+
+        Assert.True(raised);
+        Assert.False(vm.IsExaminerAvailable);
+        Assert.False(vm.OpenFeatureInExaminerCommand.CanExecute(null));
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/PickReportViewModelTests.cs
@@ -836,4 +836,94 @@ public class PickReportViewModelTests
         Assert.Null(vm.IdentityCaption);
         Assert.False(vm.CopyIdentityCommand.CanExecute(null));
     }
+
+    // ---- S-100 Feature Catalogue eXaminer links (issue #442) ----
+
+    private sealed class StubUrlOpener : IUrlOpener
+    {
+        public string? LastUrl { get; private set; }
+        public void Open(string url) => LastUrl = url;
+    }
+
+    private static ViewerSettings ExaminerSettings(bool enabled = true)
+    {
+        var path = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        return new ViewerSettings
+        {
+            SettingsFilePath = path,
+            S100ExaminerLinksEnabled = enabled,
+            S100ExaminerBaseUrl = ViewerSettings.DefaultS100ExaminerBaseUrl,
+        };
+    }
+
+    [Fact]
+    public void Examiner_FeatureCommand_OpensDeepLink()
+    {
+        var opener = new StubUrlOpener();
+        var links = new S100ExaminerLinkBuilder(ExaminerSettings());
+        var vm = new PickReportViewModel(null, null, opener, links);
+        vm.SetPick("Building", "Building", "1", "f.000", "S-101",
+            new[] { Leaf("colour", "1") });
+
+        Assert.True(vm.IsExaminerAvailable);
+        Assert.True(vm.OpenFeatureInExaminerCommand.CanExecute(null));
+        vm.OpenFeatureInExaminerCommand.Execute(null);
+
+        Assert.Equal("https://s100examiner.com/?catalog=S-101&feature=Building", opener.LastUrl);
+    }
+
+    [Fact]
+    public void Examiner_AttributeCommand_OpensDeepLink()
+    {
+        var opener = new StubUrlOpener();
+        var links = new S100ExaminerLinkBuilder(ExaminerSettings());
+        var vm = new PickReportViewModel(null, null, opener, links);
+        var attr = Leaf("colour", "1");
+        vm.SetPick("Building", "Building", "1", "f.000", "S-101", new[] { attr });
+
+        Assert.True(vm.OpenAttributeInExaminerCommand.CanExecute(attr));
+        vm.OpenAttributeInExaminerCommand.Execute(attr);
+
+        Assert.Equal(
+            "https://s100examiner.com/?catalog=S-101&feature=Building&attribute=colour",
+            opener.LastUrl);
+    }
+
+    [Fact]
+    public void Examiner_Unavailable_ForUnsupportedSpec()
+    {
+        var opener = new StubUrlOpener();
+        var links = new S100ExaminerLinkBuilder(ExaminerSettings());
+        var vm = new PickReportViewModel(null, null, opener, links);
+        vm.SetPick("Iceberg", "Iceberg", "1", "f.gml", "S-411",
+            new[] { Leaf("name", "X") });
+
+        Assert.False(vm.IsExaminerAvailable);
+        Assert.False(vm.OpenFeatureInExaminerCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Examiner_Unavailable_WhenDisabled()
+    {
+        var opener = new StubUrlOpener();
+        var links = new S100ExaminerLinkBuilder(ExaminerSettings(enabled: false));
+        var vm = new PickReportViewModel(null, null, opener, links);
+        vm.SetPick("Building", "Building", "1", "f.000", "S-101",
+            new[] { Leaf("colour", "1") });
+
+        Assert.False(vm.IsExaminerAvailable);
+        Assert.False(vm.OpenFeatureInExaminerCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Examiner_Unavailable_WithoutLinkBuilder()
+    {
+        var vm = new PickReportViewModel();
+        vm.SetPick("Building", "Building", "1", "f.000", "S-101",
+            new[] { Leaf("colour", "1") });
+
+        Assert.False(vm.IsExaminerAvailable);
+        Assert.False(vm.OpenFeatureInExaminerCommand.CanExecute(null));
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/S100ExaminerLinkBuilderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/S100ExaminerLinkBuilderTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S100ExaminerLinkBuilder"/> — the deep-link
+/// builder for the S-100 Feature Catalogue eXaminer (issue #442).
+/// </summary>
+public class S100ExaminerLinkBuilderTests
+{
+    private static ViewerSettings NewSettings(
+        bool enabled = true,
+        string? baseUrl = ViewerSettings.DefaultS100ExaminerBaseUrl)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        return new ViewerSettings
+        {
+            SettingsFilePath = path,
+            S100ExaminerLinksEnabled = enabled,
+            S100ExaminerBaseUrl = baseUrl!,
+        };
+    }
+
+    [Fact]
+    public void Catalogue_url_uses_catalog_query()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        var url = builder.BuildCatalogueUrl("S-101");
+        Assert.Equal("https://s100examiner.com/?catalog=S-101", url);
+    }
+
+    [Fact]
+    public void Feature_url_adds_feature_query()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        var url = builder.BuildFeatureUrl("S-101", "Canal");
+        Assert.Equal("https://s100examiner.com/?catalog=S-101&feature=Canal", url);
+    }
+
+    [Fact]
+    public void Attribute_url_adds_feature_and_attribute_queries()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        var url = builder.BuildAttributeUrl("S-101", "Building", "colour");
+        Assert.Equal("https://s100examiner.com/?catalog=S-101&feature=Building&attribute=colour", url);
+    }
+
+    [Fact]
+    public void Attribute_url_without_feature_still_links()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        var url = builder.BuildAttributeUrl("S-101", featureCode: null, "colour");
+        Assert.Equal("https://s100examiner.com/?catalog=S-101&attribute=colour", url);
+    }
+
+    [Fact]
+    public void Values_are_url_encoded()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        var url = builder.BuildFeatureUrl("S-101", "Depth Area");
+        Assert.Equal("https://s100examiner.com/?catalog=S-101&feature=Depth%20Area", url);
+    }
+
+    [Fact]
+    public void Unsupported_spec_returns_null()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        Assert.Null(builder.BuildCatalogueUrl("S-421"));
+        Assert.False(builder.SupportsSpec("S-421"));
+    }
+
+    [Fact]
+    public void Disabled_returns_null()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings(enabled: false));
+        Assert.Null(builder.BuildCatalogueUrl("S-101"));
+        Assert.False(builder.IsEnabled);
+        Assert.False(builder.SupportsSpec("S-101"));
+    }
+
+    [Fact]
+    public void Empty_feature_code_returns_null()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        Assert.Null(builder.BuildFeatureUrl("S-101", "  "));
+    }
+
+    [Fact]
+    public void Empty_attribute_code_returns_null()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        Assert.Null(builder.BuildAttributeUrl("S-101", "Building", ""));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com/")]
+    [InlineData("")]
+    public void Malformed_base_url_returns_null(string baseUrl)
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings(baseUrl: baseUrl));
+        Assert.Null(builder.BuildCatalogueUrl("S-101"));
+        Assert.False(builder.IsEnabled);
+    }
+
+    [Fact]
+    public void Spec_match_is_case_insensitive()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings());
+        Assert.True(builder.SupportsSpec("s-101"));
+    }
+
+    [Fact]
+    public void Custom_base_url_is_honoured()
+    {
+        var builder = new S100ExaminerLinkBuilder(NewSettings(baseUrl: "https://mirror.example.org/examiner/"));
+        var url = builder.BuildFeatureUrl("S-101", "Canal");
+        Assert.Equal("https://mirror.example.org/examiner/?catalog=S-101&feature=Canal", url);
+    }
+}


### PR DESCRIPTION
Closes #442.

Adds deep-links from the viewer into the [S-100 Feature Catalogue eXaminer](https://s100examiner.com/) so users can jump straight to the FC definition of a feature or attribute they're inspecting.

## What
- **New service** `IS100ExaminerLinkBuilder` / `S100ExaminerLinkBuilder` builds `?catalog=` / `?feature=` / `?attribute=` deep-links. It reads its enabled state and base URL from `ViewerSettings` on each call, URL-encodes the (already-canonical FC `<code>`) values, and returns `null` when disabled, when the base URL is malformed, when the code is empty, or when the spec isn't hosted by the eXaminer. The supported-spec set is taken from the eXaminer's `catalogs.json` manifest — **S-411 and S-421 are intentionally excluded** because it doesn't host them.
- **Feature Catalogues panel** — each built-in/loaded catalogue row gets an "open in eXaminer" button (catalogue-level link), gated on `CanOpenInExaminer`.
- **Object Information (pick report) panel** — a feature-level link on the identity block, plus a per-row link on each attribute, both gated on `IsExaminerAvailable` (i.e. the selected hit's product spec is hosted).
- **Settings** — a new "S-100 Feature Catalogue eXaminer" section: on-by-default toggle (`S100ExaminerLinksEnabled`) and a configurable base URL (`S100ExaminerBaseUrl`) with a reset-to-default button, so it can be disabled or pointed at a mirror.
- Localized strings (resx + `Strings.cs`), DI wiring, and a README note.

## Why the codes map directly
`PickHit.FeatureType`, `PickReportViewModel.FeatureType`, and `PickAttribute.Code` already carry the FC camel-case `<code>` (e.g. `colour`, `Building`) for both ISO 8211 (S-101) and GML products, and `CatalogueEntry.ProductSpec` is the `S-10x` id — which is exactly what the eXaminer resolves `?catalog=`/`?feature=`/`?attribute=` against. No mapping layer is required.

## Tests
- `S100ExaminerLinkBuilderTests` — URL building for catalogue/feature/attribute, encoding, case-insensitive spec match, custom base URL, and every `null` path (disabled, unsupported spec, malformed base URL, empty codes).
- `ExaminerViewModelTests` — Settings toggle/base-URL persistence + reset; FC panel `CanOpenInExaminer` and command open behaviour (supported vs unsupported spec).
- `PickReportViewModelTests` — feature/attribute command deep-links via a stub `IUrlOpener`; availability gated off for unsupported spec, when disabled, and when no link builder is injected.

Full viewer suite: **1414 passed, 3 skipped**. Verified end-to-end in the running viewer with an S-125 AtoN dataset.

## Notes
Includes two follow-up layout fixes surfaced during review: the per-attribute button was falling back to the default Button theme (~32px `MinHeight`) and inflating attribute rows (now a compact 22×22 borderless button with centered value text), and the Settings base-URL row now uses a `*,Auto` Grid so the Reset button is never clipped on narrow panels.