### PR TITLE
Keep out-of-scale datasets discoverable when zoomed out

### DIFF
--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -45,6 +45,7 @@ public partial class MainWindow : ShadUI.Window
     private EventHandler? _renderActivityRefreshHandler;
     private EncDotNet.S100.Viewer.Services.DynamicSources.DynamicSourceOverlayHost? _dynamicSourceOverlayHost;
     private EncDotNet.S100.Viewer.Services.PickHighlightController? _pickHighlightController;
+    private EncDotNet.S100.Viewer.Services.DatasetExtentIndicatorController? _extentIndicatorController;
     private ILayer? _basemapLayer;
     private Mapsui.Layers.MemoryLayer? _routeOverlayLayer;
     private EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider? _routeAppearance;
@@ -194,6 +195,8 @@ public partial class MainWindow : ShadUI.Window
             _dynamicSourceOverlayHost = null;
             _pickHighlightController?.Dispose();
             _pickHighlightController = null;
+            _extentIndicatorController?.Dispose();
+            _extentIndicatorController = null;
             // Clear the late-bound accessors this window owns so panel /
             // screenshot MCP tools observe the torn-down state (UiNotReady /
             // WindowNotReady) rather than a stale controller, and so the
@@ -396,7 +399,15 @@ public partial class MainWindow : ShadUI.Window
                 EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider>(),
             App.Services.GetRequiredService<SettingsViewModel>());
 
-        // Disable Mapsui's built-in LoggingWidget — it can throw "minX > maxX" on
+        // Out-of-scale extent indicators: outline the extents of loaded
+        // datasets that have zoomed out past their display-scale minimum, so a
+        // wide-spread exchange set still shows where its members are (#446).
+        _extentIndicatorController = new EncDotNet.S100.Viewer.Services.DatasetExtentIndicatorController(
+            mapHost,
+            _viewModel.Datasets,
+            App.Services.GetRequiredService<
+                EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider>(),
+            App.Services.GetRequiredService<SettingsViewModel>());
         // narrow viewports during resize, and the exception is raised on the
         // render thread where we cannot intercept it.
         Mapsui.Widgets.InfoWidgets.LoggingWidget.ShowLoggingInMap = Mapsui.Widgets.ActiveMode.No;

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -408,6 +408,7 @@ public partial class MainWindow : ShadUI.Window
             App.Services.GetRequiredService<
                 EncDotNet.S100.Viewer.Tools.IMeasureOverlayAppearanceProvider>(),
             App.Services.GetRequiredService<SettingsViewModel>());
+        // Disable Mapsui's built-in LoggingWidget — it can throw "minX > maxX" on
         // narrow viewports during resize, and the exception is raised on the
         // render thread where we cannot intercept it.
         Mapsui.Widgets.InfoWidgets.LoggingWidget.ShowLoggingInMap = Mapsui.Widgets.ActiveMode.No;

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -135,6 +135,12 @@ is draggable and persisted. The panel opens on the Exchange sets tab,
 unless only loose datasets are loaded, in which case it opens on the
 Datasets tab.
 
+**Double-click a dataset row to reveal it** — the viewer ensures the
+dataset is loaded and then flies the map to that dataset's extent. This
+is the quickest way to locate a member of a wide-spread exchange set,
+especially one that has zoomed out of scale (see *Out-of-scale extent
+indicators* below).
+
 ## The map view
 
 A Mapsui-backed map fills the centre of the window with a basemap
@@ -149,6 +155,24 @@ The viewer renders directly in WGS-84 latitude/longitude internally
 and projects to EPSG:3857 (Web Mercator) for display. Coverage
 grids tagged with UTM-band CRSs (typical for S-102) are reprojected
 on the fly via ProjNet.
+
+### Out-of-scale extent indicators
+
+S-101 datasets stop drawing once the map is zoomed out past their
+coarsest intended display scale. When an exchange set spans far-apart
+areas, framing its union extent can zoom out far enough that *every*
+member disappears — leaving an empty map with nothing to aim at. To keep
+those datasets discoverable, the viewer draws a thin dashed accent-colour
+border around the extent of any loaded, visible dataset **exactly when
+its content has zoomed out of scale**. The border marks where the
+dataset is so you have a target to zoom in on (or double-click its row in
+the Datasets panel to fly straight to it). Zooming back in past the
+dataset's display-scale limit hides the border and restores its content.
+
+The indicators can be turned off via **Settings → Map → Out-of-scale
+dataset outlines** (on by default). They have no effect when "ignore
+scale minima" is enabled, since datasets then never drop out on
+zoom-out.
 
 ## Routes
 

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -162,7 +162,7 @@ S-101 datasets stop drawing once the map is zoomed out past their
 coarsest intended display scale. When an exchange set spans far-apart
 areas, framing its union extent can zoom out far enough that *every*
 member disappears — leaving an empty map with nothing to aim at. To keep
-those datasets discoverable, the viewer draws a thin dashed accent-colour
+those datasets discoverable, the viewer draws a thin dotted accent-colour
 border around the extent of any loaded, visible dataset **exactly when
 its content has zoomed out of scale**. The border marks where the
 dataset is so you have a target to zoom in on (or double-click its row in

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -440,6 +440,8 @@ internal static class Strings
     public static string Settings_Cancel => Get(nameof(Settings_Cancel));
     public static string Settings_BasemapEnabled => Get(nameof(Settings_BasemapEnabled));
     public static string Tooltip_BasemapEnabled => Get(nameof(Tooltip_BasemapEnabled));
+    public static string Settings_ShowOutOfScaleExtentIndicators => Get(nameof(Settings_ShowOutOfScaleExtentIndicators));
+    public static string Tooltip_ShowOutOfScaleExtentIndicators => Get(nameof(Tooltip_ShowOutOfScaleExtentIndicators));
     public static string Settings_NationalLanguage => Get(nameof(Settings_NationalLanguage));
     public static string Tooltip_NationalLanguage => Get(nameof(Tooltip_NationalLanguage));
     public static string Settings_NationalLanguage_Default => Get(nameof(Settings_NationalLanguage_Default));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1107,6 +1107,12 @@
   <data name="Tooltip_BasemapEnabled" xml:space="preserve">
     <value>Choose the basemap drawn beneath the chart: None (water-coloured background), Offline (bundled Natural Earth land, no network), or Online (OpenStreetMap tiles). Offline and None work with zero network access.</value>
   </data>
+  <data name="Settings_ShowOutOfScaleExtentIndicators" xml:space="preserve">
+    <value>Out-of-scale dataset outlines</value>
+  </data>
+  <data name="Tooltip_ShowOutOfScaleExtentIndicators" xml:space="preserve">
+    <value>When zoomed out past a dataset's display-scale minimum (so it draws nothing), outline its extent with an accent border so you can still see where the data is and zoom toward it. Has no effect when "ignore scale minima" is enabled, since datasets then never drop out on zoom-out.</value>
+  </data>
   <data name="Basemap_None" xml:space="preserve">
     <value>None</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Avalonia.Threading;
+using EncDotNet.S100.Viewer.Tools;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+
+namespace EncDotNet.S100.Viewer.Services;
+
+/// <summary>
+/// Keeps a map overlay outlining the extents of loaded datasets that have
+/// zoomed out past their display-scale minimum — and therefore render no
+/// content — so a mariner who frames a wide-spread exchange set still sees
+/// where the member datasets are and has a target to zoom toward (issue #446).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The controller observes the <see cref="DatasetsViewModel"/>'s entries: it
+/// rebuilds the overlay whenever a dataset is added, removed, (re)loaded,
+/// hidden/shown, or its captured extent / scale cutoff changes. Each qualifying
+/// entry contributes one dashed accent rectangle whose border style is gated by
+/// <c>MinVisible</c> = the entry's
+/// <see cref="DatasetEntry.ContentMaxVisibleResolution"/>, so Mapsui reveals it
+/// exactly when the dataset's own content drops out on zoom-out (no navigator
+/// subscription required).
+/// </para>
+/// <para>
+/// An entry qualifies only when it is loaded, visible, carries a captured
+/// <see cref="DatasetEntry.MercatorExtent"/>, and has a non-null content cutoff
+/// (i.e. a display-scale minimum that actually suppresses it). Datasets that
+/// never disappear on zoom-out contribute nothing. The whole overlay is
+/// suppressed when the mariner disables
+/// <see cref="SettingsViewModel.ShowOutOfScaleExtentIndicators"/>.
+/// </para>
+/// </remarks>
+internal sealed class DatasetExtentIndicatorController : IDisposable
+{
+    private readonly IMapHost _mapHost;
+    private readonly DatasetsViewModel _datasets;
+    private readonly IMeasureOverlayAppearanceProvider _appearance;
+    private readonly SettingsViewModel _settings;
+    private readonly Action<Action> _marshal;
+    private readonly MemoryLayer _layer;
+    private readonly HashSet<DatasetEntry> _subscribed = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates and attaches the controller. The map host must already be
+    /// initialised (basemap added) so the overlay lands above the basemap.
+    /// </summary>
+    /// <param name="mapHost">Target map host.</param>
+    /// <param name="datasets">The datasets view-model to observe.</param>
+    /// <param name="appearance">Accent/theme provider for the border colour.</param>
+    /// <param name="settings">Settings view-model supplying the on/off toggle.</param>
+    /// <param name="marshal">
+    /// Optional UI-thread marshalling override. Defaults to
+    /// <see cref="Dispatcher.UIThread"/>; tests inject a synchronous
+    /// implementation.
+    /// </param>
+    public DatasetExtentIndicatorController(
+        IMapHost mapHost,
+        DatasetsViewModel datasets,
+        IMeasureOverlayAppearanceProvider appearance,
+        SettingsViewModel settings,
+        Action<Action>? marshal = null)
+    {
+        ArgumentNullException.ThrowIfNull(mapHost);
+        ArgumentNullException.ThrowIfNull(datasets);
+        ArgumentNullException.ThrowIfNull(appearance);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        _mapHost = mapHost;
+        _datasets = datasets;
+        _appearance = appearance;
+        _settings = settings;
+        _marshal = marshal ?? DispatcherMarshal;
+
+        _layer = DatasetExtentIndicatorOverlayLayer.Create();
+
+        _datasets.Entries.CollectionChanged += OnEntriesChanged;
+        foreach (var entry in _datasets.Entries)
+            Subscribe(entry);
+
+        _appearance.Changed += OnAppearanceChanged;
+        _settings.ExtentIndicatorsChanged += OnToggleChanged;
+
+        _marshal(() =>
+        {
+            _mapHost.AddOverlayLayer(_layer);
+            Rebuild();
+        });
+    }
+
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+            foreach (DatasetEntry entry in e.OldItems)
+                Unsubscribe(entry);
+
+        if (e.NewItems is not null)
+            foreach (DatasetEntry entry in e.NewItems)
+                Subscribe(entry);
+
+        // A reset clears OldItems/NewItems; resync from scratch.
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            foreach (var entry in _subscribed)
+                entry.PropertyChanged -= OnEntryChanged;
+            _subscribed.Clear();
+            foreach (var entry in _datasets.Entries)
+                Subscribe(entry);
+        }
+
+        _marshal(Rebuild);
+    }
+
+    private void Subscribe(DatasetEntry entry)
+    {
+        if (_subscribed.Add(entry))
+            entry.PropertyChanged += OnEntryChanged;
+    }
+
+    private void Unsubscribe(DatasetEntry entry)
+    {
+        if (_subscribed.Remove(entry))
+            entry.PropertyChanged -= OnEntryChanged;
+    }
+
+    private void OnEntryChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(DatasetEntry.MercatorExtent)
+            or nameof(DatasetEntry.ContentMaxVisibleResolution)
+            or nameof(DatasetEntry.IsLoaded)
+            or nameof(DatasetEntry.IsVisible))
+        {
+            _marshal(Rebuild);
+        }
+    }
+
+    private void OnAppearanceChanged(object? sender, EventArgs e) => _marshal(Rebuild);
+
+    private void OnToggleChanged() => _marshal(Rebuild);
+
+    private void Rebuild()
+    {
+        if (_disposed) return;
+
+        var indicators = new List<DatasetExtentIndicator>();
+
+        if (_settings.ShowOutOfScaleExtentIndicators)
+        {
+            foreach (var entry in _datasets.Entries)
+            {
+                if (!entry.IsLoaded || !entry.IsVisible)
+                    continue;
+                if (entry.MercatorExtent is not { } extent)
+                    continue;
+                if (entry.ContentMaxVisibleResolution is not { } cutoff)
+                    continue;
+
+                indicators.Add(new DatasetExtentIndicator(extent, cutoff));
+            }
+        }
+
+        DatasetExtentIndicatorOverlayLayer.Update(_layer, indicators, _appearance.Current.Accent);
+    }
+
+    private static void DispatcherMarshal(Action action)
+    {
+        if (Dispatcher.UIThread.CheckAccess()) action();
+        else Dispatcher.UIThread.Post(action);
+    }
+
+    /// <summary>Detaches the overlay layer and unsubscribes. Idempotent.</summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _datasets.Entries.CollectionChanged -= OnEntriesChanged;
+        foreach (var entry in _subscribed)
+            entry.PropertyChanged -= OnEntryChanged;
+        _subscribed.Clear();
+
+        _appearance.Changed -= OnAppearanceChanged;
+        _settings.ExtentIndicatorsChanged -= OnToggleChanged;
+
+        _marshal(() => _mapHost.RemoveOverlayLayer(_layer));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -461,6 +461,11 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
 
                 token.ThrowIfCancellationRequested();
                 ReplaceLayers(entry, result.Layers.ToList(), result.LayerNames, result.StackEntries);
+                // Record the dataset's mercator extent so the panel can zoom to
+                // it (double-click reveal) and the out-of-scale extent indicator
+                // can outline it, even for exchange-set entries that opt out of
+                // the auto-zoom below (issue #446).
+                entry.MercatorExtent = result.Extent;
                 // Exchange-set entries opt out of the per-dataset auto-zoom so
                 // the union-extent zoom from `IExchangeSetService` (or the
                 // user's manual Zoom-to-Extent toolbar action) wins. Without
@@ -1168,6 +1173,9 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
     /// </summary>
     private void ApplyCellScaleWindow(DatasetEntry entry, IReadOnlyList<ILayer> layers)
     {
+        // Default to "never disappears" until we confirm a window was applied.
+        entry.ContentMaxVisibleResolution = null;
+
         if (layers.Count == 0)
             return;
         if (entry.MinimumDisplayScale is not int minimumDisplayScale)
@@ -1176,6 +1184,20 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             return;
 
         MapsuiDatasetRenderer.ApplyCellScaleWindow(layers, minimumDisplayScale);
+
+        // Record the whole-cell zoom-out cutoff so the out-of-scale extent
+        // indicator (issue #446) knows the resolution at which this dataset
+        // fully drops out. A dataset is visible while at least one layer draws
+        // (resolution <= its MaxVisible), so the cutoff is the largest finite
+        // MaxVisible across the clamped layers — the last layer to vanish.
+        double cutoff = 0.0;
+        foreach (var layer in layers)
+        {
+            if (layer is BaseLayer baseLayer && baseLayer.MaxVisible < double.MaxValue)
+                cutoff = Math.Max(cutoff, baseLayer.MaxVisible);
+        }
+
+        entry.ContentMaxVisibleResolution = cutoff > 0.0 ? cutoff : null;
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
+using Mapsui.Styles;
+using NetTopologySuite.Geometries;
+using MapsuiColor = Mapsui.Styles.Color;
+
+namespace EncDotNet.S100.Viewer.Tools;
+
+/// <summary>
+/// One out-of-scale extent indicator: the EPSG:3857 extent of a loaded dataset
+/// together with the coarsest resolution at which that dataset's content still
+/// draws. The indicator's accent border is shown only when the viewport is
+/// zoomed out past <see cref="MinVisibleResolution"/> — i.e. exactly when the
+/// dataset itself has dropped out — giving the mariner a target to zoom toward
+/// (issue #446).
+/// </summary>
+/// <param name="Extent">The dataset's EPSG:3857 (web-mercator) extent.</param>
+/// <param name="MinVisibleResolution">
+/// The dataset's whole-cell zoom-out cutoff (metres per pixel), i.e.
+/// <see cref="ViewModels.DatasetEntry.ContentMaxVisibleResolution"/>. Beyond
+/// this resolution the dataset renders nothing, so the border is drawn from
+/// here outward (used as the border style's <c>MinVisible</c>).
+/// </param>
+internal readonly record struct DatasetExtentIndicator(
+    MRect Extent,
+    double MinVisibleResolution);
+
+/// <summary>
+/// Builds the Mapsui <see cref="MemoryLayer"/> overlay that outlines the
+/// extents of loaded datasets which have zoomed out of scale (issue #446).
+/// </summary>
+/// <remarks>
+/// Each indicator is a dashed accent rectangle tracing the dataset extent, with
+/// its border <see cref="VectorStyle"/> gated by <c>MinVisible</c> set to the
+/// dataset's content cutoff. Mapsui therefore reveals the border precisely when
+/// the viewport zooms out past the point where the dataset's content stops
+/// drawing, and hides it again once the mariner zooms back in — so the overlay
+/// is viewport-agnostic and needs no navigator subscription. The outline is
+/// deliberately thin, dashed, and unfilled so it reads as a "here be data"
+/// hint rather than chart content (see the <c>chart-cartography</c> guidance on
+/// subtle, non-competing decoration).
+/// </remarks>
+internal static class DatasetExtentIndicatorOverlayLayer
+{
+    /// <summary>Stable layer name; reused so the host can find/remove it.</summary>
+    public const string LayerName = "Dataset Extent Indicators";
+
+    /// <summary>
+    /// Default accent (matches <c>ViewerSettings.AccentColor</c> default of
+    /// <c>#007ACC</c>). Used when no accent has been pushed to the overlay yet.
+    /// </summary>
+    public static readonly (byte R, byte G, byte B) DefaultAccent = (0x00, 0x7A, 0xCC);
+
+    // Screen-independent dashed hairline. Kept thin so a border around a whole
+    // cell never dominates the (otherwise empty) zoomed-out view.
+    private const double OutlineWidth = 2.0;
+    private const float OutlineOpacity = 0.9f;
+    private static readonly float[] DashArray = { 6.0f, 4.0f };
+
+    /// <summary>Creates a fresh, empty overlay layer.</summary>
+    public static MemoryLayer Create() => new()
+    {
+        Name = LayerName,
+        Style = null,
+        Features = new List<IFeature>(),
+    };
+
+    /// <summary>
+    /// Replaces <paramref name="layer"/>'s features with one dashed accent
+    /// rectangle per indicator in <paramref name="indicators"/>, coloured with
+    /// <paramref name="accent"/>. An empty list clears the overlay.
+    /// </summary>
+    /// <param name="layer">The overlay layer to update.</param>
+    /// <param name="indicators">The out-of-scale dataset extents to outline.</param>
+    /// <param name="accent">Accent colour (RGB bytes) for the borders.</param>
+    public static void Update(
+        MemoryLayer layer,
+        IReadOnlyList<DatasetExtentIndicator> indicators,
+        (byte R, byte G, byte B) accent)
+    {
+        var features = new List<IFeature>(indicators.Count);
+        var color = new MapsuiColor(accent.R, accent.G, accent.B);
+
+        foreach (var indicator in indicators)
+        {
+            var extent = indicator.Extent;
+            var shell = new LinearRing(new[]
+            {
+                new Coordinate(extent.MinX, extent.MinY),
+                new Coordinate(extent.MaxX, extent.MinY),
+                new Coordinate(extent.MaxX, extent.MaxY),
+                new Coordinate(extent.MinX, extent.MaxY),
+                new Coordinate(extent.MinX, extent.MinY),
+            });
+
+            var feature = new GeometryFeature(new Polygon(shell));
+            feature.Styles.Add(new VectorStyle
+            {
+                Fill = null,
+                Line = null,
+                Outline = new Pen
+                {
+                    Color = color,
+                    Width = OutlineWidth,
+                    PenStyle = PenStyle.Dash,
+                    DashArray = DashArray,
+                },
+                Opacity = OutlineOpacity,
+                // Show the border only when zoomed out past the dataset's
+                // content cutoff — the moment the dataset itself vanishes.
+                MinVisible = indicator.MinVisibleResolution,
+            });
+            features.Add(feature);
+        }
+
+        layer.Features = features;
+        layer.DataHasChanged();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
@@ -54,10 +54,12 @@ internal static class DatasetExtentIndicatorOverlayLayer
     public static readonly (byte R, byte G, byte B) DefaultAccent = (0x00, 0x7A, 0xCC);
 
     // Screen-independent dashed hairline. Kept thin so a border around a whole
-    // cell never dominates the (otherwise empty) zoomed-out view.
+    // cell never dominates the (otherwise empty) zoomed-out view. Short dashes
+    // and gaps keep the rectangle legible even at coarse zoom, where long
+    // dashes fragment the outline and make the extent hard to read.
     private const double OutlineWidth = 2.0;
     private const float OutlineOpacity = 0.9f;
-    private static readonly float[] DashArray = { 6.0f, 4.0f };
+    private static readonly float[] DashArray = { 2.0f, 2.0f };
 
     /// <summary>Creates a fresh, empty overlay layer.</summary>
     public static MemoryLayer Create() => new()

--- a/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
@@ -53,15 +53,17 @@ internal static class DatasetExtentIndicatorOverlayLayer
     /// </summary>
     public static readonly (byte R, byte G, byte B) DefaultAccent = (0x00, 0x7A, 0xCC);
 
-    // Screen-independent dashed hairline. Kept thin so a border around a whole
-    // cell never dominates the (otherwise empty) zoomed-out view. Short dashes
-    // and gaps keep the rectangle legible even at coarse zoom, where long
-    // dashes fragment the outline and make the extent hard to read. The stroke
-    // is drawn semi-transparent so the indicator stays muted when it overlaps
-    // another dataset's content.
+    // Screen-independent dotted hairline. Kept thin so a border around a whole
+    // cell never dominates the (otherwise empty) zoomed-out view. A round stroke
+    // cap combined with a near-zero on-segment renders each dash as a round dot,
+    // which reads more cleanly than dashes at coarse zoom. Values are multiplied
+    // by the pen width by the renderer, so the gap here is ~3x the width. This
+    // only takes effect with PenStyle.UserDefined; the preset PenStyle.Dash
+    // ignores DashArray. The stroke is drawn semi-transparent so the indicator
+    // stays muted when it overlaps another dataset's content.
     private const double OutlineWidth = 2.0;
     private const float OutlineOpacity = 0.5f;
-    private static readonly float[] DashArray = { 1.0f, 1.5f };
+    private static readonly float[] DashArray = { 0.01f, 3.0f };
 
     /// <summary>Creates a fresh, empty overlay layer.</summary>
     public static MemoryLayer Create() => new()
@@ -108,7 +110,8 @@ internal static class DatasetExtentIndicatorOverlayLayer
                 {
                     Color = color,
                     Width = OutlineWidth,
-                    PenStyle = PenStyle.Dash,
+                    PenStyle = PenStyle.UserDefined,
+                    PenStrokeCap = PenStrokeCap.Round,
                     DashArray = DashArray,
                 },
                 Opacity = OutlineOpacity,

--- a/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
+++ b/src/EncDotNet.S100.Viewer/Tools/DatasetExtentIndicatorOverlayLayer.cs
@@ -56,10 +56,12 @@ internal static class DatasetExtentIndicatorOverlayLayer
     // Screen-independent dashed hairline. Kept thin so a border around a whole
     // cell never dominates the (otherwise empty) zoomed-out view. Short dashes
     // and gaps keep the rectangle legible even at coarse zoom, where long
-    // dashes fragment the outline and make the extent hard to read.
+    // dashes fragment the outline and make the extent hard to read. The stroke
+    // is drawn semi-transparent so the indicator stays muted when it overlaps
+    // another dataset's content.
     private const double OutlineWidth = 2.0;
-    private const float OutlineOpacity = 0.9f;
-    private static readonly float[] DashArray = { 2.0f, 2.0f };
+    private const float OutlineOpacity = 0.5f;
+    private static readonly float[] DashArray = { 1.0f, 1.5f };
 
     /// <summary>Creates a fresh, empty overlay layer.</summary>
     public static MemoryLayer Create() => new()

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -1023,9 +1023,10 @@ internal sealed class DatasetsViewModel : ViewModelBase
     /// <see cref="RequestLoad"/>, this also re-centres an <em>already-loaded</em>
     /// dataset — including exchange-set members, which opt out of the loader's
     /// per-dataset auto-zoom — so the user can jump to a far-away cell that has
-    /// zoomed out of view. Fire-and-forget; load failures are surfaced by the
-    /// loader's own notifications. No-op framing when the dataset produced no
-    /// geometry (e.g. an out-of-range time-gated entry). See issue #446.
+    /// zoomed out of view. Load failures are surfaced by the loader's own
+    /// notifications rather than thrown to the caller; callers may await the
+    /// returned task to observe completion. No-op framing when the dataset
+    /// produced no geometry (e.g. an out-of-range time-gated entry). See issue #446.
     /// </summary>
     /// <param name="entry">The dataset entry to reveal.</param>
     /// <returns>A task that completes once the reveal (load + zoom) is done.</returns>

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -87,6 +87,40 @@ internal sealed class DatasetEntry : ViewModelBase
     /// </remarks>
     public int? MaximumDisplayScale { get; }
 
+    private Mapsui.MRect? _mercatorExtent;
+    /// <summary>
+    /// The dataset's EPSG:3857 (web-mercator) extent, captured from the
+    /// renderer's <c>DatasetResult.Extent</c> the first time the dataset is
+    /// rendered. <see langword="null"/> until the dataset has been loaded (and
+    /// for out-of-range time-gated entries that produced no layers). Used to
+    /// zoom/pan the map to this dataset (double-click reveal) and to draw the
+    /// out-of-scale extent indicator (issue #446).
+    /// </summary>
+    public Mapsui.MRect? MercatorExtent
+    {
+        get => _mercatorExtent;
+        set => SetProperty(ref _mercatorExtent, value);
+    }
+
+    private double? _contentMaxVisibleResolution;
+    /// <summary>
+    /// The coarsest EPSG:3857 resolution (metres per pixel) at which this
+    /// dataset's content still draws, i.e. the whole-cell zoom-out cutoff that
+    /// <see cref="EncDotNet.S100.Renderers.Mapsui.MapsuiDatasetRenderer.ApplyCellScaleWindow"/>
+    /// imposed from <see cref="MinimumDisplayScale"/> (issue #438 Phase 1).
+    /// Once the viewport resolution exceeds this value the dataset renders
+    /// nothing; the out-of-scale extent indicator (issue #446) uses it as its
+    /// <c>MinVisible</c> so the accent border appears exactly when the content
+    /// drops out. <see langword="null"/> when no scale window was applied (no
+    /// <see cref="MinimumDisplayScale"/>, or the mariner opted to ignore scale
+    /// minima), meaning the dataset never disappears on zoom-out.
+    /// </summary>
+    public double? ContentMaxVisibleResolution
+    {
+        get => _contentMaxVisibleResolution;
+        set => SetProperty(ref _contentMaxVisibleResolution, value);
+    }
+
     private bool _isLoaded;
     public bool IsLoaded
     {
@@ -980,6 +1014,30 @@ internal sealed class DatasetsViewModel : ViewModelBase
     {
         ArgumentNullException.ThrowIfNull(entry);
         return _loader.LoadAsync(entry);
+    }
+
+    /// <summary>
+    /// "Reveals" a dataset in response to an explicit user gesture
+    /// (double-clicking its row): ensures the dataset is loaded, then frames
+    /// the map on its extent via <see cref="ZoomDispatcher"/>. Unlike a plain
+    /// <see cref="RequestLoad"/>, this also re-centres an <em>already-loaded</em>
+    /// dataset — including exchange-set members, which opt out of the loader's
+    /// per-dataset auto-zoom — so the user can jump to a far-away cell that has
+    /// zoomed out of view. Fire-and-forget; load failures are surfaced by the
+    /// loader's own notifications. No-op framing when the dataset produced no
+    /// geometry (e.g. an out-of-range time-gated entry). See issue #446.
+    /// </summary>
+    /// <param name="entry">The dataset entry to reveal.</param>
+    /// <returns>A task that completes once the reveal (load + zoom) is done.</returns>
+    public async Task RevealDatasetAsync(DatasetEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (!entry.IsLoaded)
+            await RequestLoadAsync(entry).ConfigureAwait(true);
+
+        if (entry.MercatorExtent is { } extent)
+            _zoomDispatcher?.Invoke(extent);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/SettingsViewModel.cs
@@ -897,6 +897,33 @@ internal sealed class SettingsViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Raised when <see cref="ShowOutOfScaleExtentIndicators"/> changes so the
+    /// extent-indicator overlay can be rebuilt without a relaunch.
+    /// </summary>
+    public event Action? ExtentIndicatorsChanged;
+
+    private bool _showOutOfScaleExtentIndicators;
+    /// <summary>
+    /// Whether an accent border is drawn around the extent of a loaded dataset
+    /// that has zoomed out past its display-scale minimum (issue #446).
+    /// Persisted to <see cref="ViewerSettings.ShowOutOfScaleExtentIndicators"/>;
+    /// changing it raises <see cref="ExtentIndicatorsChanged"/>.
+    /// </summary>
+    public bool ShowOutOfScaleExtentIndicators
+    {
+        get => _showOutOfScaleExtentIndicators;
+        set
+        {
+            if (SetProperty(ref _showOutOfScaleExtentIndicators, value))
+            {
+                _settings.ShowOutOfScaleExtentIndicators = value;
+                _settings.Save();
+                ExtentIndicatorsChanged?.Invoke();
+            }
+        }
+    }
+
     private string _nationalLanguage = "";
     public string NationalLanguage
     {
@@ -1093,6 +1120,7 @@ internal sealed class SettingsViewModel : ViewModelBase
         _tileWorkerCount = RenderingOptimizations.TileWorkerCount;
 
         _basemapMode = settings.BasemapMode;
+        _showOutOfScaleExtentIndicators = settings.ShowOutOfScaleExtentIndicators;
         _nationalLanguage = settings.NationalLanguage ?? def.NationalLanguage;
 
         _mcpEnabled = settings.McpEnabled;

--- a/src/EncDotNet.S100.Viewer/ViewerSettings.cs
+++ b/src/EncDotNet.S100.Viewer/ViewerSettings.cs
@@ -370,6 +370,17 @@ internal sealed class ViewerSettings
     public bool IsStatusBarVisible { get; set; } = true;
 
     /// <summary>
+    /// Whether an accent-coloured border is drawn around the extent of a loaded
+    /// dataset that has zoomed out past its display-scale minimum (and therefore
+    /// renders no content). Enabled by default so a mariner who frames a
+    /// wide-spread exchange set still sees where the member datasets are and has
+    /// a target to zoom toward (issue #446). No effect when the
+    /// <see cref="IgnoreScaleMinimum"/> mariner override is set, since datasets
+    /// then never drop out on zoom-out.
+    /// </summary>
+    public bool ShowOutOfScaleExtentIndicators { get; set; } = true;
+
+    /// <summary>
     /// Whether the online OpenStreetMap basemap tile layer is shown
     /// beneath the chart data. Enabled by default. Disabling it removes
     /// the remote tile fetch entirely — useful for offline operation

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
@@ -37,7 +37,7 @@ public partial class DatasetsView : UserControl
         vm.RequestLoad(entry);
     }
 
-    private void OnDatasetDoubleTapped(object? sender, TappedEventArgs e)
+    private async void OnDatasetDoubleTapped(object? sender, TappedEventArgs e)
     {
         if (DataContext is not DatasetsViewModel vm) return;
 
@@ -51,8 +51,10 @@ public partial class DatasetsView : UserControl
                 {
                     // Reveal: ensure the dataset is loaded, then fly the map to
                     // its extent — including exchange-set cells that have zoomed
-                    // out of view (issue #446).
-                    _ = vm.RevealDatasetAsync(entry);
+                    // out of view (issue #446). Awaited (async void, like the
+                    // other event handlers here) so a fault surfaces on the UI
+                    // thread instead of becoming an unobserved task exception.
+                    await vm.RevealDatasetAsync(entry);
                     return;
                 }
                 current = current.Parent as Control;

--- a/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/Views/DatasetsView.axaml.cs
@@ -49,7 +49,10 @@ public partial class DatasetsView : UserControl
             {
                 if (current.DataContext is DatasetEntry entry)
                 {
-                    vm.RequestLoad(entry);
+                    // Reveal: ensure the dataset is loaded, then fly the map to
+                    // its extent — including exchange-set cells that have zoomed
+                    // out of view (issue #446).
+                    _ = vm.RevealDatasetAsync(entry);
                     return;
                 }
                 current = current.Parent as Control;

--- a/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
+++ b/src/EncDotNet.S100.Viewer/Views/SettingsView.axaml
@@ -186,6 +186,12 @@
                 </ComboBox>
             </Grid>
 
+            <Grid Classes="settingRow" ColumnDefinitions="*,Auto"
+                  ToolTip.Tip="{x:Static loc:Strings.Tooltip_ShowOutOfScaleExtentIndicators}">
+                <TextBlock Grid.Column="0" Text="{x:Static loc:Strings.Settings_ShowOutOfScaleExtentIndicators}" />
+                <ToggleSwitch Grid.Column="1" Classes="setting" IsChecked="{Binding ShowOutOfScaleExtentIndicators}" />
+            </Grid>
+
             <!-- Render subsystem A/B + tiled knobs (issue #331) -->
             <TextBlock Text="{x:Static loc:Strings.Settings_RenderSubsystemSubsection}"
                        FontSize="12"

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetExtentIndicatorControllerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetExtentIndicatorControllerTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Viewer;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Tests.DynamicSources;
+using EncDotNet.S100.Viewer.Tools;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="DatasetExtentIndicatorController"/>, which
+/// keeps the out-of-scale extent-indicator overlay in sync with the dataset
+/// entries (issue #446). Uses a synchronous marshal and a fake map host so no
+/// Avalonia dispatcher is required.
+/// </summary>
+public class DatasetExtentIndicatorControllerTests
+{
+    private sealed class NoopLoader : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
+    }
+
+    private static SettingsViewModel NewSettings(bool indicatorsOn = true)
+    {
+        var path = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"settings-{Guid.NewGuid():N}.json");
+        var settings = new ViewerSettings
+        {
+            SettingsFilePath = path,
+            ShowOutOfScaleExtentIndicators = indicatorsOn,
+        };
+        return new SettingsViewModel(settings);
+    }
+
+    private static DatasetEntry LoadedOutOfScaleEntry(DatasetsViewModel vm)
+    {
+        var entry = vm.Add("/a.000", "S-101");
+        entry.IsLoaded = true;
+        entry.IsVisible = true;
+        entry.MercatorExtent = new MRect(0, 0, 100, 100);
+        entry.ContentMaxVisibleResolution = 50.0;
+        return entry;
+    }
+
+    private static int FeatureCount(FakeMapHost host)
+    {
+        var layer = host.OverlayLayers.OfType<MemoryLayer>()
+            .Single(l => l.Name == DatasetExtentIndicatorOverlayLayer.LayerName);
+        return layer.Features.Count();
+    }
+
+    [Fact]
+    public void Construction_AddsOverlayLayer()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        Assert.Contains(host.OverlayLayers, l => l.Name == DatasetExtentIndicatorOverlayLayer.LayerName);
+    }
+
+    [Fact]
+    public void QualifyingEntry_ProducesOneIndicator()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        LoadedOutOfScaleEntry(vm);
+
+        Assert.Equal(1, FeatureCount(host));
+    }
+
+    [Fact]
+    public void EntryWithoutContentCutoff_ProducesNoIndicator()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        var entry = vm.Add("/a.000", "S-101");
+        entry.IsLoaded = true;
+        entry.MercatorExtent = new MRect(0, 0, 100, 100);
+        // ContentMaxVisibleResolution left null → never disappears → no border.
+
+        Assert.Equal(0, FeatureCount(host));
+    }
+
+    [Fact]
+    public void HiddenEntry_ProducesNoIndicator()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        var entry = LoadedOutOfScaleEntry(vm);
+        entry.IsVisible = false;
+
+        Assert.Equal(0, FeatureCount(host));
+    }
+
+    [Fact]
+    public void TogglingSettingOff_ClearsIndicators()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        var settings = NewSettings(indicatorsOn: true);
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), settings,
+            marshal: a => a());
+
+        LoadedOutOfScaleEntry(vm);
+        Assert.Equal(1, FeatureCount(host));
+
+        settings.ShowOutOfScaleExtentIndicators = false;
+        Assert.Equal(0, FeatureCount(host));
+    }
+
+    [Fact]
+    public void Dispose_RemovesOverlayLayer()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        controller.Dispose();
+
+        Assert.DoesNotContain(host.OverlayLayers, l => l.Name == DatasetExtentIndicatorOverlayLayer.LayerName);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetExtentIndicatorOverlayLayerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetExtentIndicatorOverlayLayerTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using EncDotNet.S100.Viewer.Tools;
+using Mapsui;
+using Mapsui.Styles;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DatasetExtentIndicatorOverlayLayer"/>, the pure
+/// Mapsui overlay builder for the out-of-scale dataset extent borders
+/// (issue #446). No Avalonia / UI thread is involved.
+/// </summary>
+public class DatasetExtentIndicatorOverlayLayerTests
+{
+    private static VectorStyle? StyleOf(IFeature feature) =>
+        feature.Styles.OfType<VectorStyle>().FirstOrDefault();
+
+    [Fact]
+    public void Update_WithNoIndicators_ClearsFeatures()
+    {
+        var layer = DatasetExtentIndicatorOverlayLayer.Create();
+
+        DatasetExtentIndicatorOverlayLayer.Update(
+            layer,
+            new List<DatasetExtentIndicator>(),
+            DatasetExtentIndicatorOverlayLayer.DefaultAccent);
+
+        Assert.Empty(layer.Features);
+    }
+
+    [Fact]
+    public void Update_ProducesOneOutlineFeaturePerIndicator()
+    {
+        var layer = DatasetExtentIndicatorOverlayLayer.Create();
+        var indicators = new List<DatasetExtentIndicator>
+        {
+            new(new MRect(0, 0, 100, 100), MinVisibleResolution: 10.0),
+            new(new MRect(200, 200, 300, 300), MinVisibleResolution: 25.0),
+        };
+
+        DatasetExtentIndicatorOverlayLayer.Update(
+            layer, indicators, DatasetExtentIndicatorOverlayLayer.DefaultAccent);
+
+        Assert.Equal(2, layer.Features.Count());
+    }
+
+    [Fact]
+    public void Update_SetsBorderMinVisibleToTheContentCutoff()
+    {
+        var layer = DatasetExtentIndicatorOverlayLayer.Create();
+        var indicators = new List<DatasetExtentIndicator>
+        {
+            new(new MRect(0, 0, 100, 100), MinVisibleResolution: 42.5),
+        };
+
+        DatasetExtentIndicatorOverlayLayer.Update(
+            layer, indicators, DatasetExtentIndicatorOverlayLayer.DefaultAccent);
+
+        var style = StyleOf(layer.Features.Single());
+        Assert.NotNull(style);
+        // The border must only appear once zoomed out past the dataset's
+        // content cutoff, i.e. MinVisible == the indicator's cutoff resolution.
+        Assert.Equal(42.5, style!.MinVisible);
+    }
+
+    [Fact]
+    public void Update_DrawsAnUnfilledAccentOutline()
+    {
+        var layer = DatasetExtentIndicatorOverlayLayer.Create();
+        var accent = ((byte)0x12, (byte)0x34, (byte)0x56);
+        var indicators = new List<DatasetExtentIndicator>
+        {
+            new(new MRect(0, 0, 10, 10), MinVisibleResolution: 1.0),
+        };
+
+        DatasetExtentIndicatorOverlayLayer.Update(layer, indicators, accent);
+
+        var style = StyleOf(layer.Features.Single());
+        Assert.NotNull(style);
+        Assert.Null(style!.Fill);
+        Assert.NotNull(style.Outline);
+        Assert.Equal(0x12, style.Outline!.Color.R);
+        Assert.Equal(0x34, style.Outline.Color.G);
+        Assert.Equal(0x56, style.Outline.Color.B);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelTests.cs
@@ -233,4 +233,92 @@ public class DatasetsViewModelTests
         Assert.Equal(1.0, a.Opacity);
         Assert.Equal(1.0, sub.Opacity);
     }
+
+    // ----- RevealDatasetAsync (issue #446) -----
+
+    /// <summary>Loader that marks an entry loaded and stamps an extent on load.</summary>
+    private sealed class LoadingLoader : IDatasetLoaderService
+    {
+        private readonly Mapsui.MRect _extent;
+        public List<DatasetEntry> LoadCalls { get; } = new();
+        public LoadingLoader(Mapsui.MRect extent) => _extent = extent;
+
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default)
+        {
+            LoadCalls.Add(entry);
+            entry.IsLoaded = true;
+            entry.MercatorExtent = _extent;
+            return Task.CompletedTask;
+        }
+        public Task ReRenderAtTimeAsync(System.DateTime t, System.Threading.CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
+    }
+
+    [Fact]
+    public async Task RevealDatasetAsync_AlreadyLoaded_ZoomsToExtent_WithoutReloading()
+    {
+        var loader = new RecordingLoader();
+        var vm = new DatasetsViewModel(loader);
+        var entry = vm.Add("/a.000", "S-101");
+        entry.IsLoaded = true;
+        var extent = new Mapsui.MRect(1, 2, 3, 4);
+        entry.MercatorExtent = extent;
+
+        Mapsui.MRect? zoomed = null;
+        vm.ZoomDispatcher = r => zoomed = r;
+
+        await vm.RevealDatasetAsync(entry);
+
+        Assert.Same(extent, zoomed);
+        Assert.Empty(loader.LoadCalls); // already loaded → no reload
+    }
+
+    [Fact]
+    public async Task RevealDatasetAsync_NotLoaded_LoadsThenZoomsToStampedExtent()
+    {
+        var extent = new Mapsui.MRect(10, 20, 30, 40);
+        var loader = new LoadingLoader(extent);
+        var vm = new DatasetsViewModel(loader);
+        var entry = vm.Add("/a.000", "S-101");
+
+        Mapsui.MRect? zoomed = null;
+        vm.ZoomDispatcher = r => zoomed = r;
+
+        await vm.RevealDatasetAsync(entry);
+
+        Assert.Single(loader.LoadCalls);
+        Assert.Same(extent, zoomed);
+    }
+
+    [Fact]
+    public async Task RevealDatasetAsync_LoadedButNoExtent_DoesNotZoom()
+    {
+        var loader = new RecordingLoader();
+        var vm = new DatasetsViewModel(loader);
+        var entry = vm.Add("/a.000", "S-101");
+        entry.IsLoaded = true; // loaded but produced no geometry (e.g. time-gated)
+
+        var zoomCount = 0;
+        vm.ZoomDispatcher = _ => zoomCount++;
+
+        await vm.RevealDatasetAsync(entry);
+
+        Assert.Equal(0, zoomCount);
+        Assert.Empty(loader.LoadCalls);
+    }
 }


### PR DESCRIPTION
## Summary

Since the #438 layer-declutter work clamps each S-101 dataset layer's `MaxVisible` to its coarsest intended display scale, datasets now vanish when the map is zoomed out past that scale. For a wide-spread exchange set, framing the union extent can zoom out far enough that *every* member disappears, leaving an empty map with nothing to aim at. This is a regression from the original "always show the dataset" behaviour.

This PR restores discoverability with two affordances:

- **Double-click to reveal.** Double-clicking a dataset row in the Datasets panel ensures the dataset is loaded, then flies the map to its extent (`DatasetsViewModel.RevealDatasetAsync`).
- **Out-of-scale extent indicators.** A thin, muted, dotted accent-colour rectangle is drawn around the extent of any loaded, visible dataset *exactly when its content has zoomed out of scale*, giving the user a target to zoom toward. Toggle via **Settings > Map > Out-of-scale dataset outlines** (on by default).

The key design decision: the indicator's `VectorStyle.MinVisible` is set to the dataset's computed content-cutoff resolution (read from the clamped layers), so Mapsui shows the outline precisely when the content stops drawing. This is viewport-agnostic and needs no navigator subscription. Extents (`DatasetResult.Extent`) and the cutoff resolution are plumbed onto `DatasetEntry` in the loader.

One non-obvious gotcha worth flagging for reviewers: Mapsui's `PenStyle.Dash` uses a fixed preset dash pattern and ignores a custom `DashArray`; only `PenStyle.UserDefined` honours it. The dotted look is therefore achieved with `UserDefined` + a near-zero on-segment + `PenStrokeCap.Round`.

![Out-of-scale dotted extent indicators over two clustered S-101 cells](https://github.com/user-attachments/assets/f2130ec8-e17f-453a-8136-b74f45acb2da)

Closes #446

## Spec alignment

- [x] N/A - change is purely viewer UX (portrayal-adjacent overlay, no spec-encoding semantics)

The indicators only apply to datasets whose layers were scale-clamped (S-101 via the #438 window); no feature-catalogue, encoding, or portrayal-catalogue rules are touched.

**Spec section references cited in code/docs:**

N/A

## Tests

- [x] Added/updated xunit tests under `tests/` (overlay builder, controller gating across all visibility conditions, reveal command)
- [x] Tests requiring real data files use `SkippableFact` (no new real-data tests needed; fixtures are synthetic/in-memory)
- [x] `dotnet test --configuration Release` passes locally (full viewer suite: 1462 passed, 3 skipped)

Also verified end to end via the headless viewer MCP loop on real UKHO trial cells: content renders with no border when zoomed in, and the dotted extent outline appears exactly when the content drops out on zoom-out.

## Documentation

- [x] Updated the affected project's `src/<project>/README.md` (Datasets panel reveal gesture + new "Out-of-scale extent indicators" section)
- [x] Updated conceptual docs under `docs/` if user-facing behaviour changed (viewer README is the user-facing doc for this feature)
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies, OR versions added to `Directory.Packages.props` (not in the `.csproj`)
- [x] `gh-advisory-database` security check run for any new dependency (N/A - no new dependencies)

## Breaking changes

None. New behaviour is additive and the extent indicators can be turned off in Settings; the toggle defaults on.