### PR TITLE
Load catalogue-less folders of loose ENC cells on drop (#449)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/DatasetPipelineFactory.cs
@@ -558,6 +558,46 @@ public sealed class DatasetPipelineFactory
     }
 
     /// <summary>
+    /// Creates a processor for the base cell file at
+    /// <paramref name="baseFilePath"/>, discovering and applying any sibling
+    /// sequential update files (<c>….001</c>, <c>….002</c>, …) that live in the
+    /// same directory. This gives a single dropped <c>.000</c> cell the same
+    /// up-to-date rendering as one loaded from an exchange set. S-57 and S-101
+    /// cells (told apart by the <c>DSPM</c> content sniff in
+    /// <see cref="DetectProductSpec"/>) both apply updates via their respective
+    /// <c>*WithUpdates</c> path; any other product, or a base cell with no
+    /// updates on disk, falls back to <see cref="CreateProcessor(string)"/>.
+    /// S-57 Ed 3.1 App B.1 / S-100 Part 10a.
+    /// </summary>
+    /// <param name="baseFilePath">Path to the base cell file (<c>….000</c>).</param>
+    public IDatasetProcessor CreateProcessorWithFilesystemUpdates(string baseFilePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(baseFilePath);
+
+        var updates = S101FilesystemUpdateDiscovery.FindSequentialUpdates(baseFilePath);
+        if (updates.Count == 0)
+            return CreateProcessor(baseFilePath);
+
+        var spec = DetectProductSpec(baseFilePath);
+        switch (spec)
+        {
+            case "S-101":
+                return CreateS101ProcessorWithUpdates(baseFilePath, updates);
+            case "S-57":
+                var directory = Path.GetDirectoryName(Path.GetFullPath(baseFilePath))
+                    ?? throw new ArgumentException(
+                        "Base cell path must include a directory.", nameof(baseFilePath));
+                var source = FileSystemAssetSource.Create(directory);
+                var updateNames = updates.Select(Path.GetFileName).OfType<string>().ToList();
+                return CreateS57ProcessorWithUpdates(
+                    source, Path.GetFileName(baseFilePath), updateNames);
+            default:
+                // Non-ENC products never carry .000 sequential updates.
+                return CreateProcessor(baseFilePath);
+        }
+    }
+
+    /// <summary>
     /// Normalizes an exchange-set product identifier (e.g. <c>"S-101"</c>,
     /// <c>"S101"</c>, <c>"s-101"</c>) to the canonical spec strings used
     /// by <see cref="CreateProcessor(string)"/>'s switch (<c>"S-101"</c>, etc.).

--- a/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/MainWindow.axaml.cs
@@ -1381,14 +1381,25 @@ public partial class MainWindow : ShadUI.Window
                 continue;
 
             // Folder drop: treat as an exchange set when CATALOG.XML
-            // (S-100) or CATALOG.031 (S-57) is at the root, otherwise
-            // ignore (the dataset loader is single-file).
+            // (S-100) or CATALOG.031 (S-57) is at the root. Otherwise, a
+            // catalogue-less folder of loose ENC cells (a base ….000 plus
+            // its updates) is scanned and loaded; anything else raises a
+            // notification rather than being silently ignored.
             if (Directory.Exists(path))
             {
                 if (ExchangeSetDetection.LooksLikeExchangeSetFolder(path)
-                    || ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(path))
+                    || ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(path)
+                    || ExchangeSetDetection.LooksLikeLooseCellFolder(path))
                 {
                     await RunExchangeSetAsync(path);
+                }
+                else
+                {
+                    App.Services.GetRequiredService<INotificationService>()
+                        .Create(Strings.Toast_Warning)
+                        .WithSeverity(NotificationSeverity.Warning)
+                        .WithContent(string.Format(Strings.Status_FolderNoDatasets, path))
+                        .Show();
                 }
                 continue;
             }

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -98,9 +98,17 @@ The viewer accepts:
   as S-100 sets, driven by the S-57 verifier. (Directory/`CATALOG.031`
   only — zipped S-57 sets are not supported, matching the
   directory-rooted S-57 verifier used by the `s100 validate` CLI.)
+- **Catalogue-less ENC cell folders** — point it at a directory that
+  holds loose base cells (`.000`) with no `CATALOG.031`/`CATALOG.XML`
+  and it loads every base cell, sniffing S-57 vs S-101 per cell and
+  applying each cell's sibling filesystem updates (`.001`, `.002`, …).
+  A dropped folder that yields no renderable cells raises a
+  notification instead of being silently ignored.
 - **Loose datasets** — drop an individual `.h5` (S-102 / S-104 /
   S-111), `.gml` (any of the GML-encoded products), `.000` S-101
-  ENC cell, or `.000` S-57 ENC cell onto the window.
+  ENC cell, or `.000` S-57 ENC cell onto the window. A dropped `.000`
+  base cell also picks up any sibling `.001`/`.002`… updates that sit
+  next to it on disk.
 - **Recent files** — the **File → Recent** submenu replays previous
   loads in order; entries that no longer exist on disk are skipped.
 

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -476,6 +476,8 @@ internal static class Strings
     public static string Status_ExchangeSetFailed => Get(nameof(Status_ExchangeSetFailed));
     public static string Status_ExchangeSetCatalogNotFound => Get(nameof(Status_ExchangeSetCatalogNotFound));
     public static string Status_S57ExchangeSetNoCells => Get(nameof(Status_S57ExchangeSetNoCells));
+    public static string Status_LooseCellFolderNoCells => Get(nameof(Status_LooseCellFolderNoCells));
+    public static string Status_FolderNoDatasets => Get(nameof(Status_FolderNoDatasets));
     public static string Status_ExchangeSetUnsupportedSpec => Get(nameof(Status_ExchangeSetUnsupportedSpec));
     public static string Status_ExchangeSetCancelled => Get(nameof(Status_ExchangeSetCancelled));
     public static string Status_ExchangeSetOrphanUpdate => Get(nameof(Status_ExchangeSetOrphanUpdate));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1208,6 +1208,14 @@
   <data name="Status_S57ExchangeSetNoCells" xml:space="preserve">
     <value>No renderable cells found in the S-57 exchange set {0}.</value>
   </data>
+  <data name="Status_LooseCellFolderNoCells" xml:space="preserve">
+    <value>No renderable ENC cells found in {0}.</value>
+    <comment>{0} = folder path. Shown when a catalogue-less folder of loose cells yields nothing loadable.</comment>
+  </data>
+  <data name="Status_FolderNoDatasets" xml:space="preserve">
+    <value>No S-100 exchange set or ENC cells found in {0}.</value>
+    <comment>{0} = dropped folder path. Shown when a dropped folder has no catalogue and no loose base cells.</comment>
+  </data>
   <data name="Status_ExchangeSetUnsupportedSpec" xml:space="preserve">
     <value>Skipped {0}: unsupported product specification '{1}'.</value>
   </data>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoadGateway.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoadGateway.cs
@@ -61,6 +61,7 @@ internal sealed class DatasetLoadGateway : IDatasetLoadGateway
         {
             return ExchangeSetDetection.LooksLikeExchangeSetFolder(path)
                     || ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(path)
+                    || ExchangeSetDetection.LooksLikeLooseCellFolder(path)
                 ? DatasetPathKind.ExchangeSet
                 : DatasetPathKind.File;
         }

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -357,7 +357,7 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             var processor = await Task.Run(() =>
             {
                 if (!fromExchangeSet)
-                    return _pipelineFactory.CreateProcessor(entry.FilePath);
+                    return _pipelineFactory.CreateProcessorWithFilesystemUpdates(entry.FilePath);
 
                 // Collapse a base cell and its in-set sequential updates into a
                 // single up-to-date dataset. S-101 / S-57 / S-100 Part 10a;

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetDetection.cs
@@ -43,6 +43,11 @@ internal static class ExchangeSetDetection
     /// case-insensitively.</summary>
     private const string S57CatalogueFileName = "CATALOG.031";
 
+    /// <summary>The base-cell extension shared by S-57 (S-57 Ed 3.1
+    /// Appendix B.1) and S-101 (S-100 Part 10a) ENC datasets. Sequential
+    /// updates use <c>.001</c>, <c>.002</c>, …</summary>
+    private const string BaseCellExtension = ".000";
+
     private static bool IsCatalogueFileName(string fileName) =>
         Array.Exists(
             CatalogueFileNames,
@@ -194,5 +199,57 @@ internal static class ExchangeSetDetection
             return Path.GetDirectoryName(Path.GetFullPath(path))!;
 
         throw new FileNotFoundException($"Not an S-57 exchange set: {path}");
+    }
+
+    /// <summary>
+    /// Enumerates the top-level base cells (<c>….000</c> files) in
+    /// <paramref name="folderPath"/>, returning their full paths in
+    /// case-insensitive ordinal name order. Recognises both S-57
+    /// (S-57 Ed 3.1 Appendix B.1) and S-101 (S-100 Part 10a) cells,
+    /// which share the <c>.000</c> extension — the two are told apart
+    /// later by content (the S-57 DSPM sniff in
+    /// <c>DatasetPipelineFactory.DetectProductSpec</c>). Returns an
+    /// empty list when the folder does not exist, is inaccessible, or
+    /// holds no base cells.
+    /// </summary>
+    public static IReadOnlyList<string> EnumerateLooseBaseCells(string folderPath)
+    {
+        if (string.IsNullOrEmpty(folderPath)) return Array.Empty<string>();
+        try
+        {
+            if (!Directory.Exists(folderPath)) return Array.Empty<string>();
+            return Directory
+                .EnumerateFiles(folderPath, "*", SearchOption.TopDirectoryOnly)
+                .Where(f => string.Equals(
+                    Path.GetExtension(f), BaseCellExtension,
+                    StringComparison.OrdinalIgnoreCase))
+                .OrderBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (UnauthorizedAccessException) { return Array.Empty<string>(); }
+        catch (IOException) { return Array.Empty<string>(); }
+    }
+
+    /// <summary>
+    /// True when <paramref name="folderPath"/> is a catalogue-less folder
+    /// of loose ENC cells — it contains at least one top-level base cell
+    /// (<c>….000</c>) but <em>no</em> exchange-set catalogue (neither
+    /// <c>CATALOG.XML</c>/<c>catalogue.xml</c> nor <c>CATALOG.031</c>).
+    /// Such folders (e.g. a single cell's subfolder extracted from an
+    /// exchange set) are loaded by scanning for base cells and applying
+    /// their sibling sequential updates, rather than by parsing a
+    /// catalogue. Returns <c>false</c> for any folder that already routes
+    /// to an exchange-set loader, and for I/O or permission failures.
+    /// </summary>
+    public static bool LooksLikeLooseCellFolder(string folderPath)
+    {
+        if (string.IsNullOrEmpty(folderPath)) return false;
+
+        // A folder with a catalogue is handled by the exchange-set
+        // loaders; only genuinely catalogue-less folders take this path.
+        if (LooksLikeExchangeSetFolder(folderPath)) return false;
+        if (LooksLikeS57ExchangeSetFolder(folderPath)) return false;
+
+        return EnumerateLooseBaseCells(folderPath).Count > 0;
     }
 }

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -97,6 +97,17 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 .ConfigureAwait(true);
         }
 
+        // A catalogue-less folder of loose ENC cells (a base ….000 plus its
+        // sequential updates, with no CATALOG.XML/CATALOG.031) is not an
+        // exchange set but is still loadable: scan for base cells and apply
+        // their in-folder updates. S-57 Ed 3.1 App B.1 / S-100 Part 10a.
+        if (ExchangeSetDetection.LooksLikeLooseCellFolder(folderOrZipPath))
+        {
+            return await OpenLooseCellFolderAsync(
+                    folderOrZipPath, progress, cancellationToken, notification)
+                .ConfigureAwait(true);
+        }
+
         // s100.exchangeset.open child span sits under whatever
         // s100.viewer.command span the caller (MainWindow) opened.
         using var activity = Telemetry.ActivitySource.StartActivity(
@@ -578,6 +589,194 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
             return new ExchangeSetOpenResult
             {
                 SourcePath = folderOrCataloguePath,
+                FailureMessage = ex.Message,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Opens a catalogue-less folder of loose ENC cells. Each top-level
+    /// base cell (<c>….000</c>) is dispatched with its sibling sequential
+    /// updates (<c>….001</c>, <c>….002</c>, …) applied, mirroring a single
+    /// dropped <c>.000</c> so a folder-of-cells and a lone cell behave
+    /// consistently. Cells are told apart as S-57 vs S-101 by the same
+    /// content sniff the single-file loader uses
+    /// (<see cref="DatasetPipelineFactory.DetectProductSpec"/>); a
+    /// <see cref="FileSystemAssetSource"/> rooted at the folder backs every
+    /// entry and its updates. S-57 Ed 3.1 App B.1 / S-100 Part 10a.
+    /// </summary>
+    private async Task<ExchangeSetOpenResult> OpenLooseCellFolderAsync(
+        string folderPath,
+        IProgress<ExchangeSetProgress>? progress,
+        CancellationToken cancellationToken,
+        INotificationHandle? notification)
+    {
+        using var activity = Telemetry.ActivitySource.StartActivity(
+            "loosecells.folder.open", System.Diagnostics.ActivityKind.Internal);
+        activity?.SetTag("loosecells.source.path", folderPath);
+
+        IAssetSource? source = null;
+        try
+        {
+            var baseCells = ExchangeSetDetection.EnumerateLooseBaseCells(folderPath);
+            activity?.SetTag("loosecells.cell.count", baseCells.Count);
+
+            if (baseCells.Count == 0)
+            {
+                var emptyMsg = string.Format(
+                    Strings.Status_LooseCellFolderNoCells, folderPath);
+                Terminal(notification, NotificationSeverity.Warning, Strings.Toast_ExchangeSetFailed, emptyMsg);
+                activity?.SetStatus(ActivityStatusCode.Error, "no cells");
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderPath,
+                    CatalogueNotFound = true,
+                    FailureMessage = emptyMsg,
+                };
+            }
+
+            progress?.Report(new ExchangeSetProgress(folderPath, baseCells.Count, 0, 0, null));
+
+            source = FileSystemAssetSource.Create(folderPath);
+            var tracked = new TrackedExchangeSet(
+                folderPath,
+                source,
+                owner: source,
+                verifier: null);
+            _tracked.Add(tracked);
+            // Lifetime ownership has transferred to the tracked entry; do not
+            // dispose `source` directly below.
+            source = null;
+
+            tracked.Header = _datasets.RegisterExchangeSetHeader(
+                tracked.Source,
+                folderPath,
+                producer: null,
+                issueDate: null,
+                baseCells.Count,
+                closeAction: CloseExchangeSetFromHeader);
+
+            var dispatched = 0;
+            var completedLoads = 0;
+            var loadTasks = new List<Task>();
+            foreach (var baseCell in baseCells)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var spec = DatasetPipelineFactory.DetectProductSpec(baseCell);
+                if (spec is null) continue;
+
+                // Discover the sibling updates on disk and pass them as
+                // folder-relative names so they resolve through the same
+                // FileSystemAssetSource as the base cell.
+                var updateRelativePaths = S101FilesystemUpdateDiscovery
+                    .FindSequentialUpdates(baseCell)
+                    .Select(Path.GetFileName)
+                    .OfType<string>()
+                    .ToList();
+
+                var entry = _datasets.AddFromExchangeSet(
+                    tracked.Source,
+                    Path.GetFileName(baseCell),
+                    spec,
+                    displayName: Path.GetFileName(baseCell),
+                    updateRelativePaths: updateRelativePaths);
+                tracked.Entries.Add(entry);
+                loadTasks.Add(_datasets.RequestLoadAsync(entry));
+                dispatched++;
+            }
+
+            // Report progress on actual load completions rather than dispatch
+            // (see the S-100 path for rationale).
+            foreach (var loadTask in loadTasks)
+            {
+                _ = loadTask.ContinueWith(
+                    _ =>
+                    {
+                        var done = Interlocked.Increment(ref completedLoads);
+                        progress?.Report(new ExchangeSetProgress(
+                            folderPath, baseCells.Count, done, 0, null));
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            await Task.WhenAll(loadTasks).ConfigureAwait(true);
+
+            // Every base cell failed the content sniff (e.g. not actually an
+            // ENC .000) — release the tracked source so the folder handle is
+            // not leaked, and surface a warning instead of an empty group.
+            if (dispatched == 0)
+            {
+                if (tracked.Header is { } orphanHeader)
+                {
+                    _datasets.RemoveExchangeSetHeader(orphanHeader);
+                    tracked.Header = null;
+                }
+                tracked.Owner.Dispose();
+                _tracked.Remove(tracked);
+
+                var noneMsg = string.Format(
+                    Strings.Status_LooseCellFolderNoCells, folderPath);
+                Terminal(notification, NotificationSeverity.Warning, Strings.Toast_ExchangeSetFailed, noneMsg);
+                activity?.SetStatus(ActivityStatusCode.Error, "no loadable cells");
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderPath,
+                    CatalogueNotFound = true,
+                    FailureMessage = noneMsg,
+                };
+            }
+
+            var loadedMsg = string.Format(
+                Strings.Status_ExchangeSetLoaded, dispatched,
+                Notifications.NotificationFormat.ShortenPath(folderPath));
+            var pendingTerminal = new ExchangeSetTerminalInfo(
+                NotificationSeverity.Success, Strings.Toast_ExchangeSetLoaded, loadedMsg);
+
+            activity?.SetTag("loosecells.dataset.loaded", dispatched);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+
+            if (tracked.Header is { } trackedHeader)
+            {
+                trackedHeader.LoadedCount = dispatched;
+                trackedHeader.UnsupportedCount = 0;
+            }
+
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderPath,
+                Total = baseCells.Count,
+                Loaded = dispatched,
+                SkippedUnsupported = 0,
+                Cancelled = false,
+                SkipMessages = Array.Empty<string>(),
+                // Loose cells carry no catalogue bounding box; the drop
+                // handler frames them by unioning loaded layer extents.
+                UnionBoundingBox = null,
+                PendingTerminal = pendingTerminal,
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            source?.Dispose();
+            activity?.SetStatus(ActivityStatusCode.Error, "cancelled");
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderPath,
+                Cancelled = true,
+            };
+        }
+        catch (Exception ex)
+        {
+            var failedMsg = string.Format(Strings.Status_ExchangeSetFailed, folderPath, ex.Message);
+            Terminal(notification, NotificationSeverity.Error, Strings.Toast_ExchangeSetFailed, failedMsg);
+            source?.Dispose();
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            return new ExchangeSetOpenResult
+            {
+                SourcePath = folderPath,
                 FailureMessage = ex.Message,
             };
         }

--- a/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFilesystemUpdatesTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/DatasetPipelineFactoryFilesystemUpdatesTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using EncDotNet.S100.Crs.ProjNet;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S57;
+using EncDotNet.S100.Features;
+using EncDotNet.S100.Portrayals;
+using EncDotNet.S100.Scripting.MoonSharp;
+using EncDotNet.S100.Specifications;
+using Xunit;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Coverage for
+/// <see cref="DatasetPipelineFactory.CreateProcessorWithFilesystemUpdates(string)"/>,
+/// which gives a single dropped base cell (<c>….000</c>) the same
+/// sequential-update application as an exchange-set load (issue #449).
+/// Because the S-101/S-57 processors parse their base cell eagerly, the
+/// construction paths are exercised against a real cell supplied via the
+/// <c>ENCDOTNET_S101_BASE_CELL</c> / <c>ENCDOTNET_S57_BASE_CELL</c>
+/// environment variables, and skipped otherwise so CI never depends on
+/// (or commits) real ENC data.
+/// </summary>
+public class DatasetPipelineFactoryFilesystemUpdatesTests
+{
+    private static DatasetPipelineFactory CreateFactory()
+    {
+        var pcManager = new PortrayalCatalogueManager();
+        foreach (var spec in Specification.AvailableSpecs)
+        {
+            if (Specification.HasPortrayalCatalogue(spec))
+                pcManager.SetSource(spec, Specification.CreatePortrayalCatalogueSource(spec));
+        }
+
+        return new DatasetPipelineFactory(
+            pcManager,
+            new MoonSharpLuaEngine(),
+            new ProjNetCrsTransformFactory(),
+            new FeatureCatalogueManager(Specification.TryOpenFeatureCatalogue),
+            new DisplayPlaneAuthorityProvider());
+    }
+
+    [Fact]
+    public void CreateProcessorWithFilesystemUpdates_RejectsNullOrEmpty()
+    {
+        var factory = CreateFactory();
+        Assert.Throws<ArgumentException>(
+            () => factory.CreateProcessorWithFilesystemUpdates(""));
+    }
+
+    [SkippableFact]
+    public void CreateProcessorWithFilesystemUpdates_RealS101BaseCell_BuildsS101Processor()
+    {
+        var basePath = Environment.GetEnvironmentVariable("ENCDOTNET_S101_BASE_CELL");
+        Skip.If(string.IsNullOrEmpty(basePath), "ENCDOTNET_S101_BASE_CELL not set.");
+        Skip.IfNot(File.Exists(basePath!), $"Base cell not found: {basePath}.");
+
+        var factory = CreateFactory();
+
+        var processor = factory.CreateProcessorWithFilesystemUpdates(basePath!);
+
+        // Whether or not the cell has sibling updates on disk, an S-101
+        // base cell must produce an S-101 processor.
+        Assert.IsType<S101DatasetProcessor>(processor);
+    }
+
+    [SkippableFact]
+    public void CreateProcessorWithFilesystemUpdates_RealS57BaseCell_BuildsS57Processor()
+    {
+        var basePath = Environment.GetEnvironmentVariable("ENCDOTNET_S57_BASE_CELL");
+        Skip.If(string.IsNullOrEmpty(basePath), "ENCDOTNET_S57_BASE_CELL not set.");
+        Skip.IfNot(File.Exists(basePath!), $"Base cell not found: {basePath}.");
+
+        var factory = CreateFactory();
+
+        var processor = factory.CreateProcessorWithFilesystemUpdates(basePath!);
+
+        Assert.IsType<S57DatasetProcessor>(processor);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetLoadGatewayTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetLoadGatewayTests.cs
@@ -60,6 +60,38 @@ public class DatasetLoadGatewayTests
     }
 
     [Fact]
+    public void Classify_returns_exchange_set_for_catalogue_less_loose_cell_folder()
+    {
+        // A folder of loose cells (base ….000 + updates, no catalogue)
+        // routes to the exchange-set path so its base cells load with
+        // their sequential updates applied (issue #449).
+        var dir = Path.Combine(Path.GetTempPath(), $"gw-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "CELL.000"), "base");
+        File.WriteAllText(Path.Combine(dir, "CELL.001"), "update");
+        try
+        {
+            var gateway = Make(out _, out _);
+            Assert.Equal(DatasetPathKind.ExchangeSet, gateway.Classify(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Classify_returns_file_for_folder_without_cells_or_catalogue()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"gw-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "readme.txt"), "text");
+        try
+        {
+            var gateway = Make(out _, out _);
+            Assert.Equal(DatasetPathKind.File, gateway.Classify(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void IsReady_reflects_loader_initialisation()
     {
         var gateway = Make(out _, out var loader);

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetDetectionTests.cs
@@ -306,4 +306,98 @@ public sealed class ExchangeSetDetectionTests : IDisposable
             () => ExchangeSetDetection.ResolveS57Root(
                 Path.Combine(_tempRoot, "nope.000")));
     }
+
+    // ── Loose-cell folder detection (issue #449) ──────────────────────
+
+    [Fact]
+    public void EnumerateLooseBaseCells_ReturnsTopLevelBaseCells()
+    {
+        var folder = Path.Combine(_tempRoot, "loose");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.000"), "base");
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.001"), "update");
+        File.WriteAllText(Path.Combine(folder, "US5WA02M.000"), "base2");
+        File.WriteAllText(Path.Combine(folder, "notes.txt"), "ignore");
+
+        var cells = ExchangeSetDetection.EnumerateLooseBaseCells(folder);
+
+        Assert.Equal(2, cells.Count);
+        Assert.Contains(cells, c => Path.GetFileName(c) == "US5WA01M.000");
+        Assert.Contains(cells, c => Path.GetFileName(c) == "US5WA02M.000");
+        Assert.DoesNotContain(cells, c => Path.GetFileName(c) == "US5WA01M.001");
+    }
+
+    [Fact]
+    public void EnumerateLooseBaseCells_CaseInsensitiveExtension()
+    {
+        var folder = Path.Combine(_tempRoot, "loose-ci");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "CELL.000"), "base");
+
+        Assert.Single(ExchangeSetDetection.EnumerateLooseBaseCells(folder));
+    }
+
+    [Fact]
+    public void EnumerateLooseBaseCells_EmptyForMissingFolder()
+    {
+        Assert.Empty(ExchangeSetDetection.EnumerateLooseBaseCells(
+            Path.Combine(_tempRoot, "missing")));
+        Assert.Empty(ExchangeSetDetection.EnumerateLooseBaseCells(""));
+    }
+
+    [Fact]
+    public void LooksLikeLooseCellFolder_TrueForCatalogueLessCellFolder()
+    {
+        var folder = Path.Combine(_tempRoot, "cells");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.000"), "base");
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.001"), "update");
+
+        Assert.True(ExchangeSetDetection.LooksLikeLooseCellFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeLooseCellFolder_FalseWhenS100CataloguePresent()
+    {
+        var folder = Path.Combine(_tempRoot, "cells-with-s100");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.000"), "base");
+        File.WriteAllText(Path.Combine(folder, "CATALOG.XML"), "<root/>");
+
+        // A catalogue is present, so this must route to the exchange-set
+        // loader, not the loose-cell path.
+        Assert.False(ExchangeSetDetection.LooksLikeLooseCellFolder(folder));
+        Assert.True(ExchangeSetDetection.LooksLikeExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeLooseCellFolder_FalseWhenS57CataloguePresent()
+    {
+        var folder = Path.Combine(_tempRoot, "cells-with-s57");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.000"), "base");
+        File.WriteAllText(Path.Combine(folder, "CATALOG.031"), "binary");
+
+        Assert.False(ExchangeSetDetection.LooksLikeLooseCellFolder(folder));
+        Assert.True(ExchangeSetDetection.LooksLikeS57ExchangeSetFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeLooseCellFolder_FalseForFolderWithoutBaseCells()
+    {
+        var folder = Path.Combine(_tempRoot, "no-cells");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "readme.txt"), "text");
+        File.WriteAllText(Path.Combine(folder, "US5WA01M.001"), "orphan update");
+
+        Assert.False(ExchangeSetDetection.LooksLikeLooseCellFolder(folder));
+    }
+
+    [Fact]
+    public void LooksLikeLooseCellFolder_FalseForMissingOrEmptyPath()
+    {
+        Assert.False(ExchangeSetDetection.LooksLikeLooseCellFolder(
+            Path.Combine(_tempRoot, "missing")));
+        Assert.False(ExchangeSetDetection.LooksLikeLooseCellFolder(""));
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetServiceLoaderTests.cs
@@ -315,4 +315,109 @@ public class ExchangeSetServiceLoaderTests
         Assert.Equal(ExchangeSetDetection.ResolveS57Root(root!), header.SourcePath);
         Assert.Equal(result.Loaded, header.LoadedCount);
     }
+
+    // ── Catalogue-less loose-cell folders (issue #449) ────────────────
+
+    private static string MakeLooseCellFolder(string name, params string[] files)
+    {
+        var folder = Path.Combine(
+            Path.GetTempPath(), $"loose-{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(folder);
+        foreach (var file in files)
+            File.WriteAllText(Path.Combine(folder, file), "synthetic");
+        return folder;
+    }
+
+    [Fact]
+    public async Task OpenAsync_LooseCellFolder_LoadsBaseWithFilesystemUpdates()
+    {
+        // A catalogue-less folder: a base cell plus its two sequential
+        // updates, no CATALOG.XML / CATALOG.031. The fake ENC bytes fail
+        // the S-57 DSPM sniff, so the cell is dispatched as S-101 (the
+        // NoopLoader never parses it).
+        var folder = MakeLooseCellFolder(
+            "updates", "US5WA01M.000", "US5WA01M.001", "US5WA01M.002");
+        try
+        {
+            var (datasets, service) = CreateSystem();
+            using var _ = service;
+
+            var result = await service.OpenAsync(folder);
+
+            Assert.Equal(1, result.Total);
+            Assert.Equal(1, result.Loaded);
+            Assert.Equal(0, result.SkippedUnsupported);
+            Assert.False(result.Cancelled);
+            Assert.Null(result.UnionBoundingBox);
+
+            var entry = Assert.Single(datasets.Entries);
+            Assert.Equal("S-101", entry.ProductSpec);
+            Assert.Equal("US5WA01M.000", entry.RelativePath);
+            Assert.True(entry.IsFromExchangeSet);
+            Assert.True(entry.HasUpdates);
+            Assert.Equal(
+                new[] { "US5WA01M.001", "US5WA01M.002" },
+                entry.UpdateRelativePaths);
+        }
+        finally
+        {
+            Directory.Delete(folder, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task OpenAsync_LooseCellFolder_LoadsEveryBaseCell()
+    {
+        var folder = MakeLooseCellFolder(
+            "multi", "US5WA01M.000", "US5WA02M.000", "US5WA02M.001");
+        try
+        {
+            var (datasets, service) = CreateSystem();
+            using var _ = service;
+
+            var result = await service.OpenAsync(folder);
+
+            Assert.Equal(2, result.Total);
+            Assert.Equal(2, result.Loaded);
+            Assert.Equal(2, datasets.Entries.Count);
+
+            // The second cell carries its update; the first has none.
+            var cell2 = Assert.Single(
+                datasets.Entries, e => e.RelativePath == "US5WA02M.000");
+            Assert.Equal(new[] { "US5WA02M.001" }, cell2.UpdateRelativePaths);
+            var cell1 = Assert.Single(
+                datasets.Entries, e => e.RelativePath == "US5WA01M.000");
+            Assert.False(cell1.HasUpdates);
+        }
+        finally
+        {
+            Directory.Delete(folder, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task OpenAsync_LooseCellFolder_RegistersHeaderAndClosesCleanly()
+    {
+        var folder = MakeLooseCellFolder("header", "US5WA01M.000");
+        try
+        {
+            var (datasets, service) = CreateSystem();
+            using var _ = service;
+
+            await service.OpenAsync(folder);
+
+            var header = Assert.Single(datasets.ExchangeSetHeaders);
+            Assert.Equal(folder, header.SourcePath);
+            Assert.Equal(1, header.LoadedCount);
+
+            header.CloseCommand.Execute(null);
+
+            Assert.Empty(datasets.Entries);
+            Assert.Empty(datasets.ExchangeSetHeaders);
+        }
+        finally
+        {
+            Directory.Delete(folder, recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Dropping a folder of loose ENC cells (a base `….000` plus its sequential updates `….001`/`….002`/…, with no `CATALOG.031` or `CATALOG.XML`) rendered nothing. The viewer only treated a dropped folder as loadable when a catalogue sat at its root, so a single cell's extracted subfolder fell through the drop handler silently (issue #449).

This teaches the drop path to recognise a catalogue-less folder of loose cells and load it the same way an exchange set is loaded: enumerate the base cells, sniff S-57 vs S-101 per cell, and apply each cell's sibling filesystem updates. It also makes a single dropped `.000` consistent by applying any sibling updates that sit next to it on disk, and surfaces a notification when a dropped folder yields nothing instead of failing silently.

Key pieces and how they fit:

- `ExchangeSetDetection` gains `EnumerateLooseBaseCells` and `LooksLikeLooseCellFolder`, which flag a folder that has at least one top-level `.000` but no catalogue (so it never shadows the existing exchange-set loaders).
- `ExchangeSetService.OpenLooseCellFolderAsync` mirrors the S-57 loader: it builds a `FileSystemAssetSource`, registers a header, and dispatches each base cell as an exchange-set entry so the existing update-applying load path handles it.
- `MainWindow.OnDrop` routes loose-cell folders to that loader and raises a warning toast when a dropped folder has neither a catalogue nor loadable cells.
- `DatasetLoadGateway.Classify` now classifies loose-cell folders as `ExchangeSet`, keeping the MCP/programmatic open path in step with drag-drop.
- `DatasetPipelineFactory.CreateProcessorWithFilesystemUpdates` gives a single dropped `.000` the same up-to-date rendering by discovering and applying sibling updates; `DatasetLoaderService` uses it for non-exchange-set entries.

Worth noting for review: S-57 and S-101 cells share the `.000` extension and are told apart by content (the DSPM sniff in `DetectProductSpec`), so both go through their respective `*WithUpdates` path; other products, or a base cell with no updates on disk, fall back to the plain single-file processor.

## Spec alignment

- [x] S-101 ENC (`s101-enc`)
- [x] N/A — change is largely infrastructural (viewer drop handling, loader plumbing)

**Spec section references cited in code/docs:** S-57 Ed 3.1 Appendix B.1 and S-100 Part 10a for the base cell / sequential update (`.000`/`.001`/…) file convention.

## Tests

- [x] Added/updated xunit tests under `tests/`
- [x] Tests requiring real data files use `SkippableFact`
- [x] `dotnet test --configuration Release` passes locally

Viewer suite: 1475 passed / 3 skipped. Pipelines suite: 921 passed / 3 skipped. Also verified end-to-end via the headless viewer + MCP: a synthetic catalogue-less folder classified as `exchangeSet`, loaded one S-101 cell with real bounds, and rendered (VectorStyle/SymbolStyle draw calls).

## Documentation

- [x] Updated the affected project's `src/<project>/README.md`
- [x] New public APIs have XML doc comments

## Dependencies

- [x] No new NuGet dependencies

## Breaking changes

None.

Closes #449