### PR TITLE
Defer cell loads for large S-57 exchange sets (issue #458)

### DIFF
--- a/src/EncDotNet.S100.Viewer/App.axaml.cs
+++ b/src/EncDotNet.S100.Viewer/App.axaml.cs
@@ -589,6 +589,22 @@ public partial class App : Application
         services.AddSingleton<IFileDialogService, FileDialogService>();
         services.AddSingleton<IExchangeSetService, ExchangeSetService>();
 
+        // Viewport-driven lazy loading of large exchange sets (issue #458):
+        // registers cells without loading them and loads only what is in view.
+        services.AddSingleton<EncDotNet.S100.Viewer.Services.LazyLoading.ExchangeSetLazyLoadCoordinator>(sp =>
+        {
+            var datasets = sp.GetRequiredService<DatasetsViewModel>();
+            var loader = sp.GetRequiredService<IDatasetLoaderService>();
+            var notifier = sp.GetRequiredService<
+                EncDotNet.S100.Viewer.Services.IMapViewportNotifier>();
+            return new EncDotNet.S100.Viewer.Services.LazyLoading.ExchangeSetLazyLoadCoordinator(
+                notifier,
+                (entry, _) => datasets.RequestLoadAsync(entry),
+                loader.UnloadEntry,
+                logger: sp.GetService<ILogger<
+                    EncDotNet.S100.Viewer.Services.LazyLoading.ExchangeSetLazyLoadCoordinator>>());
+        });
+
         // Own-ship dynamic source. The steerable driver dead-reckons a
         // moving point seeded at Solent (50.8°N 1.3°W) tracking due east
         // at 5 m/s (~9.7 kn) and exposes IOwnShipHelm so map gestures,

--- a/src/EncDotNet.S100.Viewer/README.md
+++ b/src/EncDotNet.S100.Viewer/README.md
@@ -117,6 +117,25 @@ and translated to the in-memory S-101 model so they render through
 the S-101 portrayal pipeline. This is best-effort, not an S-52
 implementation.
 
+### Lazy loading of very large exchange sets
+
+Opening a large S-57 exchange set (thousands of cells) no longer loads
+every cell up front. Above a threshold (default 50 cells) the viewer
+**registers** every cell — the Datasets panel lists them immediately
+(dimmed) and their footprints are drawn as extent outlines — but
+**defers** reading and portraying a cell's bytes until it actually
+enters the viewport at a relevant scale. Cells are selected by
+viewport intersection plus a usage-band → scale gate, loaded through a
+bounded-concurrency gate, and evicted (LRU, beyond a retention budget)
+when they leave the view. This keeps the open non-blocking and bounds
+peak memory regardless of set size (issue #458). The relevant types
+live under `Services/LazyLoading/`
+(`ExchangeSetLazyLoadCoordinator`, `LazyCellGate`, `LruEvictionPolicy`,
+`CellUsageBand`). Cells are registered in a single batch via
+`DatasetsViewModel.AddRangeFromExchangeSet(IReadOnlyList<ExchangeSetCellRegistration>)`
+(backed by `BulkObservableCollection`) so a set of thousands of cells
+registers with one collection notification rather than one per cell.
+
 ## The Datasets panel
 
 Loaded data is organised in the **Datasets** activity panel as two

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.cs
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.cs
@@ -473,6 +473,7 @@ internal static class Strings
     public static string Status_FileNoLongerExists => Get(nameof(Status_FileNoLongerExists));
     public static string Status_ExchangeSetLoaded => Get(nameof(Status_ExchangeSetLoaded));
     public static string Status_ExchangeSetLoadedWithErrors => Get(nameof(Status_ExchangeSetLoadedWithErrors));
+    public static string Status_ExchangeSetRegistered => Get(nameof(Status_ExchangeSetRegistered));
     public static string Status_ExchangeSetFailed => Get(nameof(Status_ExchangeSetFailed));
     public static string Status_ExchangeSetCatalogNotFound => Get(nameof(Status_ExchangeSetCatalogNotFound));
     public static string Status_S57ExchangeSetNoCells => Get(nameof(Status_S57ExchangeSetNoCells));
@@ -623,6 +624,7 @@ internal static class Strings
     public static string Toast_Success => Get(nameof(Toast_Success));
     public static string Toast_Info => Get(nameof(Toast_Info));
     public static string Toast_ExchangeSetLoaded => Get(nameof(Toast_ExchangeSetLoaded));
+    public static string Toast_ExchangeSetRegistered => Get(nameof(Toast_ExchangeSetRegistered));
     public static string Toast_ExchangeSetFailed => Get(nameof(Toast_ExchangeSetFailed));
     public static string Toast_DatasetError => Get(nameof(Toast_DatasetError));
     public static string Toast_Loading => Get(nameof(Toast_Loading));

--- a/src/EncDotNet.S100.Viewer/Resources/Strings.resx
+++ b/src/EncDotNet.S100.Viewer/Resources/Strings.resx
@@ -1199,6 +1199,10 @@
     <value>Loaded {0} of {1} dataset(s) from {2} ({3} skipped).</value>
     <comment>{0} = dispatched, {1} = total, {2} = source path, {3} = skipped count.</comment>
   </data>
+  <data name="Status_ExchangeSetRegistered" xml:space="preserve">
+    <value>Registered {0} cell(s) from {1}; loading on demand as you navigate.</value>
+    <comment>{0} = registered (deferred) cell count, {1} = source path. Used for large exchange sets whose cells load lazily.</comment>
+  </data>
   <data name="Status_ExchangeSetFailed" xml:space="preserve">
     <value>Failed to open exchange set {0}: {1}</value>
   </data>
@@ -1673,6 +1677,9 @@
   </data>
   <data name="Toast_ExchangeSetLoaded" xml:space="preserve">
     <value>Exchange Set Loaded</value>
+  </data>
+  <data name="Toast_ExchangeSetRegistered" xml:space="preserve">
+    <value>Exchange Set Ready</value>
   </data>
   <data name="Toast_ExchangeSetFailed" xml:space="preserve">
     <value>Exchange Set Failed</value>

--- a/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
@@ -157,11 +157,16 @@ internal sealed class DatasetExtentIndicatorController : IDisposable
                 // A cell registered for lazy loading but not yet loaded (issue
                 // #458): outline its catalogue footprint at every zoom
                 // (MinVisible 0) so the mariner sees where unloaded data lies
-                // and that panning/zooming there will pull it in.
-                if (entry.IsDeferred && entry.GeographicBounds is { } bounds)
+                // and that panning/zooming there will pull it in. Honour the
+                // visibility toggle here too — a hidden deferred cell shows no
+                // outline, consistent with a hidden loaded dataset.
+                if (entry.IsDeferred)
                 {
-                    foreach (var deferredExtent in ToMercatorExtents(bounds))
-                        indicators.Add(new DatasetExtentIndicator(deferredExtent, 0.0));
+                    if (entry.IsVisible && entry.GeographicBounds is { } bounds)
+                    {
+                        foreach (var deferredExtent in ToMercatorExtents(bounds))
+                            indicators.Add(new DatasetExtentIndicator(deferredExtent, 0.0));
+                    }
                     continue;
                 }
 

--- a/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
@@ -133,6 +133,7 @@ internal sealed class DatasetExtentIndicatorController : IDisposable
         if (e.PropertyName is nameof(DatasetEntry.MercatorExtent)
             or nameof(DatasetEntry.ContentMaxVisibleResolution)
             or nameof(DatasetEntry.IsLoaded)
+            or nameof(DatasetEntry.IsDeferred)
             or nameof(DatasetEntry.IsVisible))
         {
             _marshal(Rebuild);
@@ -153,6 +154,17 @@ internal sealed class DatasetExtentIndicatorController : IDisposable
         {
             foreach (var entry in _datasets.Entries)
             {
+                // A cell registered for lazy loading but not yet loaded (issue
+                // #458): outline its catalogue footprint at every zoom
+                // (MinVisible 0) so the mariner sees where unloaded data lies
+                // and that panning/zooming there will pull it in.
+                if (entry.IsDeferred && entry.GeographicBounds is { } bounds)
+                {
+                    if (ToMercatorExtent(bounds) is { } deferredExtent)
+                        indicators.Add(new DatasetExtentIndicator(deferredExtent, 0.0));
+                    continue;
+                }
+
                 if (!entry.IsLoaded || !entry.IsVisible)
                     continue;
                 if (entry.MercatorExtent is not { } extent)
@@ -165,6 +177,35 @@ internal sealed class DatasetExtentIndicatorController : IDisposable
         }
 
         DatasetExtentIndicatorOverlayLayer.Update(_layer, indicators, _appearance.Current.Accent);
+    }
+
+    /// <summary>
+    /// Projects an EPSG:4326 catalogue footprint to an EPSG:3857 (web-mercator)
+    /// rectangle for the overlay. Returns <see langword="null"/> for a degenerate
+    /// or unprojectable box.
+    /// </summary>
+    private static Mapsui.MRect? ToMercatorExtent(ExchangeSets.BoundingBox bounds)
+    {
+        var west = bounds.WestBoundLongitude;
+        var east = bounds.EastBoundLongitude;
+        var south = bounds.SouthBoundLatitude;
+        var north = bounds.NorthBoundLatitude;
+        if (double.IsNaN(west) || double.IsNaN(east)
+            || double.IsNaN(south) || double.IsNaN(north))
+        {
+            return null;
+        }
+
+        // Mercator is undefined at the poles; clamp to the projection's limit.
+        south = Math.Clamp(south, -85.05112878, 85.05112878);
+        north = Math.Clamp(north, -85.05112878, 85.05112878);
+
+        var (minX, minY) = Mapsui.Projections.SphericalMercator.FromLonLat(west, south);
+        var (maxX, maxY) = Mapsui.Projections.SphericalMercator.FromLonLat(east, north);
+        if (maxX <= minX || maxY <= minY)
+            return null;
+
+        return new Mapsui.MRect(minX, minY, maxX, maxY);
     }
 
     private static void DispatcherMarshal(Action action)

--- a/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetExtentIndicatorController.cs
@@ -160,7 +160,7 @@ internal sealed class DatasetExtentIndicatorController : IDisposable
                 // and that panning/zooming there will pull it in.
                 if (entry.IsDeferred && entry.GeographicBounds is { } bounds)
                 {
-                    if (ToMercatorExtent(bounds) is { } deferredExtent)
+                    foreach (var deferredExtent in ToMercatorExtents(bounds))
                         indicators.Add(new DatasetExtentIndicator(deferredExtent, 0.0));
                     continue;
                 }
@@ -180,16 +180,41 @@ internal sealed class DatasetExtentIndicatorController : IDisposable
     }
 
     /// <summary>
-    /// Projects an EPSG:4326 catalogue footprint to an EPSG:3857 (web-mercator)
-    /// rectangle for the overlay. Returns <see langword="null"/> for a degenerate
-    /// or unprojectable box.
+    /// Projects an EPSG:4326 catalogue footprint to one or two EPSG:3857
+    /// (web-mercator) rectangles for the overlay. A footprint that crosses the
+    /// ±180° antimeridian seam (west &gt; east) is split into two non-wrapping
+    /// boxes — <c>[west, +180]</c> and <c>[-180, east]</c> — so seam-crossing
+    /// deferred cells still show an outline. Yields nothing for a degenerate or
+    /// unprojectable box.
     /// </summary>
-    private static Mapsui.MRect? ToMercatorExtent(ExchangeSets.BoundingBox bounds)
+    private static IEnumerable<Mapsui.MRect> ToMercatorExtents(ExchangeSets.BoundingBox bounds)
     {
         var west = bounds.WestBoundLongitude;
         var east = bounds.EastBoundLongitude;
         var south = bounds.SouthBoundLatitude;
         var north = bounds.NorthBoundLatitude;
+
+        if (!double.IsNaN(west) && !double.IsNaN(east) && west > east)
+        {
+            if (ToMercatorExtent(west, 180.0, south, north) is { } eastSegment)
+                yield return eastSegment;
+            if (ToMercatorExtent(-180.0, east, south, north) is { } westSegment)
+                yield return westSegment;
+            yield break;
+        }
+
+        if (ToMercatorExtent(west, east, south, north) is { } extent)
+            yield return extent;
+    }
+
+    /// <summary>
+    /// Projects a single non-wrapping EPSG:4326 rectangle to an EPSG:3857
+    /// (web-mercator) rectangle for the overlay. Returns <see langword="null"/>
+    /// for a degenerate or unprojectable box.
+    /// </summary>
+    private static Mapsui.MRect? ToMercatorExtent(
+        double west, double east, double south, double north)
+    {
         if (double.IsNaN(west) || double.IsNaN(east)
             || double.IsNaN(south) || double.IsNaN(north))
         {

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -871,7 +871,11 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
             disposableProcessor.Dispose();
         }
         _entryOrder.Remove(entry);
-        _activeFlags.Remove(EntryId(entry));
+        // NB: unlike RemoveEntry, do NOT clear _activeFlags here. Eviction
+        // keeps the DatasetEntry registered, so its user-set active/inactive
+        // state must survive the unload → reload cycle; dropping the flag would
+        // silently reset an inactive cell back to active (the GetActive
+        // default) when it next loads. See issue #458.
         _globalTime.Unregister(entry);
         entry.IsDeferred = true;
         if (_mapHost is not null)

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -842,6 +842,42 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         DatasetRemoved?.Invoke(entry);
     }
 
+    /// <summary>
+    /// Unloads a lazily-loaded exchange-set cell's <em>bytes</em> (layers,
+    /// sub-layers, and processor) while leaving the <see cref="DatasetEntry"/>
+    /// registered in the Datasets panel, and marks it
+    /// <see cref="DatasetEntry.IsDeferred"/> again so it reverts to an extent
+    /// outline that can be reloaded when it next enters the viewport. This is
+    /// the LRU-eviction counterpart to <see cref="LoadAsync"/>; unlike
+    /// <see cref="RemoveEntry"/> it does not fire <see cref="DatasetRemoved"/>
+    /// or drop the entry from the collection. No-op for an entry that owns no
+    /// layers. See issue #458.
+    /// </summary>
+    /// <param name="entry">The exchange-set cell entry to unload.</param>
+    public void UnloadEntry(DatasetEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        RemoveEntryLayers(entry);
+        UnsubscribeSubLayers(entry);
+        entry.SubLayers.Clear();
+        _entryLayerKeys.Remove(entry);
+        _entryStackEntries.Remove(entry);
+        if (_subscribedEntries.Remove(entry))
+            entry.PropertyChanged -= OnEntryPropertyChanged;
+        if (_processors.Remove(entry, out var removedProcessor)
+            && removedProcessor is IDisposable disposableProcessor)
+        {
+            disposableProcessor.Dispose();
+        }
+        _entryOrder.Remove(entry);
+        _activeFlags.Remove(EntryId(entry));
+        _globalTime.Unregister(entry);
+        entry.IsDeferred = true;
+        if (_mapHost is not null)
+            _mapHost.ReorderDatasetLayers(FlattenLayerOrder());
+    }
+
     public void SetEntryOrder(IReadOnlyList<DatasetEntry> orderedEntries)
     {
         ArgumentNullException.ThrowIfNull(orderedEntries);

--- a/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/DatasetLoaderService.cs
@@ -870,7 +870,13 @@ internal sealed class DatasetLoaderService : IDatasetLoaderService
         {
             disposableProcessor.Dispose();
         }
-        _entryOrder.Remove(entry);
+        // NB: unlike RemoveEntry, do NOT drop the entry from _entryOrder here.
+        // Eviction keeps the DatasetEntry registered; FlattenLayerOrder already
+        // skips entries with no layers (RemoveEntryLayers cleared _entryLayers
+        // above), so its slot is inert while unloaded but preserved. Removing it
+        // would make the next reload look like a first load and re-insert it at
+        // index 0, reshuffling cross-dataset paint order on every evict/reload
+        // cycle. See issue #458.
         // NB: unlike RemoveEntry, do NOT clear _activeFlags here. Eviction
         // keeps the DatasetEntry registered, so its user-set active/inactive
         // state must survive the unload → reload cycle; dropping the flag would

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -38,16 +38,21 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
 {
     private readonly DatasetsViewModel _datasets;
     private readonly INotificationService _notifications;
+    private readonly LazyLoading.ExchangeSetLazyLoadCoordinator? _lazyCoordinator;
     private readonly List<TrackedExchangeSet> _tracked = new();
     private bool _subscribed;
     private bool _disposed;
 
-    public ExchangeSetService(DatasetsViewModel datasets, INotificationService notifications)
+    public ExchangeSetService(
+        DatasetsViewModel datasets,
+        INotificationService notifications,
+        LazyLoading.ExchangeSetLazyLoadCoordinator? lazyCoordinator = null)
     {
         ArgumentNullException.ThrowIfNull(datasets);
         ArgumentNullException.ThrowIfNull(notifications);
         _datasets = datasets;
         _notifications = notifications;
+        _lazyCoordinator = lazyCoordinator;
     }
 
     /// <summary>
@@ -523,9 +528,80 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 cells.Count,
                 closeAction: CloseExchangeSetFromHeader);
 
+            // Above the lazy-load threshold, register every cell without
+            // loading its bytes and hand them to the viewport-driven
+            // coordinator, which loads only the cells that are actually in view
+            // at a relevant scale. This keeps a 7,000-cell set from freezing the
+            // UI thread and exhausting memory (issue #458). Small sets still load
+            // eagerly for immediacy.
+            var deferLoads = _lazyCoordinator is not null
+                && cells.Count > _lazyCoordinator.Options.CellThreshold;
+
             var dispatched = 0;
             var completedLoads = 0;
             var loadTasks = new List<Task>();
+
+            if (deferLoads)
+            {
+                // Build every cell's registration descriptor and add them in a
+                // single batch so the grouping / extent-overlay subscribers
+                // rebuild once, not once per cell (O(N) instead of O(N²)).
+                var specs = new List<ViewModels.ExchangeSetCellRegistration>(cells.Count);
+                foreach (var cell in cells)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    IReadOnlyList<string> updates = cell.UpdateRelativePaths.Count == 0
+                        ? Array.Empty<string>()
+                        : cell.UpdateRelativePaths;
+                    specs.Add(new ViewModels.ExchangeSetCellRegistration(
+                        Source: tracked.Source,
+                        RelativePath: cell.RelativePath,
+                        ProductSpec: "S-57",
+                        DisplayName: cell.CellName,
+                        UpdateRelativePaths: updates,
+                        GeographicBounds: cell.BoundingBox));
+                }
+
+                var entries = _datasets.AddRangeFromExchangeSet(specs);
+                tracked.Entries.AddRange(entries);
+                dispatched = entries.Count;
+
+                // The registered entries appear immediately (dimmed, with extent
+                // outlines); the coordinator loads the in-view ones on the next
+                // viewport tick. Nothing to await, so the open completes at once
+                // and the UI stays responsive.
+                _lazyCoordinator!.Register(entries);
+
+                var registeredMsg = string.Format(
+                    Strings.Status_ExchangeSetLoaded, dispatched,
+                    Notifications.NotificationFormat.ShortenPath(folderOrCataloguePath));
+                var deferredTerminal = new ExchangeSetTerminalInfo(
+                    NotificationSeverity.Success, Strings.Toast_ExchangeSetLoaded, registeredMsg);
+
+                if (tracked.Header is { } deferredHeader)
+                {
+                    deferredHeader.LoadedCount = dispatched;
+                    deferredHeader.UnsupportedCount = 0;
+                }
+
+                _ = VerifySignaturesAsync(tracked);
+                activity?.SetTag("s57.exchangeset.dataset.deferred", dispatched);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
+                return new ExchangeSetOpenResult
+                {
+                    SourcePath = folderOrCataloguePath,
+                    Total = cells.Count,
+                    Loaded = dispatched,
+                    SkippedUnsupported = 0,
+                    Cancelled = false,
+                    SkipMessages = Array.Empty<string>(),
+                    UnionBoundingBox = unionBoundingBox,
+                    PendingTerminal = deferredTerminal,
+                };
+            }
+
+            // Eager path: build every cell entry and queue its byte load.
             foreach (var cell in cells)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -539,7 +615,8 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                     cell.RelativePath,
                     "S-57",
                     displayName: cell.CellName,
-                    updateRelativePaths: updateRelativePaths);
+                    updateRelativePaths: updateRelativePaths,
+                    geographicBounds: cell.BoundingBox);
                 tracked.Entries.Add(entry);
                 loadTasks.Add(_datasets.RequestLoadAsync(entry));
                 dispatched++;
@@ -950,6 +1027,7 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
         // Snapshot the entries: removing from `_datasets.Entries`
         // mutates `tracked.Entries` indirectly via OnEntriesChanged.
         var entriesToRemove = tracked.Entries.ToArray();
+        _lazyCoordinator?.Unregister(entriesToRemove);
         foreach (var entry in entriesToRemove)
         {
             _datasets.Entries.Remove(entry);

--- a/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/ExchangeSetService.cs
@@ -573,10 +573,10 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 _lazyCoordinator!.Register(entries);
 
                 var registeredMsg = string.Format(
-                    Strings.Status_ExchangeSetLoaded, dispatched,
+                    Strings.Status_ExchangeSetRegistered, dispatched,
                     Notifications.NotificationFormat.ShortenPath(folderOrCataloguePath));
                 var deferredTerminal = new ExchangeSetTerminalInfo(
-                    NotificationSeverity.Success, Strings.Toast_ExchangeSetLoaded, registeredMsg);
+                    NotificationSeverity.Success, Strings.Toast_ExchangeSetRegistered, registeredMsg);
 
                 if (tracked.Header is { } deferredHeader)
                 {
@@ -592,6 +592,9 @@ internal sealed class ExchangeSetService : IExchangeSetService, IDisposable
                 {
                     SourcePath = folderOrCataloguePath,
                     Total = cells.Count,
+                    // Deferred path: report the registered-cell count so the
+                    // open is treated as a success (no bytes are dispatched
+                    // yet). See ExchangeSetOpenResult.Loaded and issue #458.
                     Loaded = dispatched,
                     SkippedUnsupported = 0,
                     Cancelled = false,

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -90,11 +90,19 @@ internal interface IDatasetLoaderService
     /// <see cref="LoadAsync"/>. See issue #458.
     /// </summary>
     /// <remarks>
-    /// Provided as a default interface member (delegates to
-    /// <see cref="RemoveEntry"/>) so existing test doubles need not
-    /// override it; the production loader keeps the entry registered.
+    /// Provided as a default interface member so existing test doubles need
+    /// not override it. A bare interface cannot preserve collection
+    /// membership, so the fallback re-marks the entry
+    /// <see cref="DatasetEntry.IsDeferred"/> (honouring that half of the
+    /// contract) and then removes its layers via <see cref="RemoveEntry"/>;
+    /// the production loader (<c>DatasetLoaderService</c>) overrides this to
+    /// keep the entry registered in the panel.
     /// </remarks>
-    void UnloadEntry(DatasetEntry entry) => RemoveEntry(entry);
+    void UnloadEntry(DatasetEntry entry)
+    {
+        entry.IsDeferred = true;
+        RemoveEntry(entry);
+    }
 
     /// <summary>
     /// Reorders the dataset layers on the map to match the supplied

--- a/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IDatasetLoaderService.cs
@@ -83,6 +83,20 @@ internal interface IDatasetLoaderService
     void RemoveEntry(DatasetEntry entry);
 
     /// <summary>
+    /// Unloads a lazily-loaded exchange-set cell's bytes (layers and
+    /// processor) but keeps the <see cref="DatasetEntry"/> registered and
+    /// re-marks it <see cref="DatasetEntry.IsDeferred"/> so it can reload
+    /// when it next enters the viewport. The LRU-eviction counterpart to
+    /// <see cref="LoadAsync"/>. See issue #458.
+    /// </summary>
+    /// <remarks>
+    /// Provided as a default interface member (delegates to
+    /// <see cref="RemoveEntry"/>) so existing test doubles need not
+    /// override it; the production loader keeps the entry registered.
+    /// </remarks>
+    void UnloadEntry(DatasetEntry entry) => RemoveEntry(entry);
+
+    /// <summary>
     /// Reorders the dataset layers on the map to match the supplied
     /// entry sequence. Lowest-indexed entry paints first (bottom of
     /// the dataset stack). Entries not currently bound to layers are

--- a/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
+++ b/src/EncDotNet.S100.Viewer/Services/IExchangeSetService.cs
@@ -43,7 +43,12 @@ public sealed class ExchangeSetOpenResult
     /// <summary>Total datasets in the catalogue.</summary>
     public int Total { get; init; }
 
-    /// <summary>Datasets successfully dispatched to a processor.</summary>
+    /// <summary>Datasets successfully dispatched to a processor. For a large
+    /// exchange set opened on the lazy (deferred) path, no cell bytes are
+    /// dispatched during the open, so this instead reports the number of cells
+    /// <em>registered</em> for on-demand loading — a non-zero success count the
+    /// open flow (e.g. the MCP <c>open_dataset</c> tool) treats as "opened".
+    /// See issue #458.</summary>
     public int Loaded { get; init; }
 
     /// <summary>Datasets skipped because their product identifier is not

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/CellUsageBand.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/CellUsageBand.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace EncDotNet.S100.Viewer.Services.LazyLoading;
+
+/// <summary>
+/// Parses the ENC <em>navigational purpose</em> (usage band) from a cell name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both S-57 (S-57 Ed 3.1 Appendix B.1 §B.1.1) and S-101 (S-100 Part 10a /
+/// S-101 §5.5) name a base cell as a two-character producer/country code
+/// followed by a single navigational-purpose digit and up to eight further
+/// characters of cell identifier — e.g. <c>US<b>1</b>EEZ1M</c> is band&#160;1
+/// (Overview). The digit therefore lives at index&#160;2 (0-based) of the
+/// cell name.
+/// </para>
+/// <para>
+/// The band is a cheap, load-free proxy for a cell's intended scale range,
+/// which lets the viewer decide whether a cell is relevant at the current
+/// zoom <em>before</em> parsing it (viewport-driven lazy loading). A cell
+/// whose band cannot be parsed returns <see langword="null"/>; callers treat
+/// an unknown band as "always eligible" so nothing is hidden by an
+/// unrecognised name.
+/// </para>
+/// </remarks>
+internal static class CellUsageBand
+{
+    /// <summary>Lowest valid navigational-purpose band (Overview).</summary>
+    public const int MinBand = 1;
+
+    /// <summary>Highest valid navigational-purpose band (Berthing).</summary>
+    public const int MaxBand = 6;
+
+    /// <summary>
+    /// Extracts the navigational-purpose band (<see cref="MinBand"/>..
+    /// <see cref="MaxBand"/>) from <paramref name="cellName"/>, or
+    /// <see langword="null"/> when the name is too short or the band
+    /// character is not a valid digit in range.
+    /// </summary>
+    /// <param name="cellName">
+    /// The cell name, with or without a file extension (e.g. <c>US1EEZ1M</c>
+    /// or <c>US1EEZ1M.000</c>). Leading directory separators are ignored.
+    /// </param>
+    public static int? TryParse(string? cellName)
+    {
+        if (string.IsNullOrEmpty(cellName))
+            return null;
+
+        // Strip any directory prefix and extension so a relative path such as
+        // "US1EEZ1M/US1EEZ1M.000" resolves to the bare cell name.
+        var name = cellName;
+        var lastSep = name.LastIndexOfAny(['/', '\\']);
+        if (lastSep >= 0)
+            name = name[(lastSep + 1)..];
+
+        var dot = name.IndexOf('.');
+        if (dot >= 0)
+            name = name[..dot];
+
+        if (name.Length < 3)
+            return null;
+
+        var c = name[2];
+        if (c < '0' || c > '9')
+            return null;
+
+        var band = c - '0';
+        return band is >= MinBand and <= MaxBand ? band : null;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -192,6 +192,13 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
             return;
         }
 
+        // The viewport notifier fires on the UI thread; capture its
+        // synchronisation context so the debounced Evaluate() — which mutates
+        // Mapsui layers, the loader, and DatasetEntry properties (all
+        // UI-thread-affine) — is marshalled back to the UI thread rather than
+        // running on the thread-pool continuation. See issue #458.
+        var uiContext = SynchronizationContext.Current;
+
         CancellationTokenSource newCts;
         lock (_lock)
         {
@@ -210,7 +217,10 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
                 if (ReferenceEquals(_debounceCts, newCts))
                     _debounceCts = null;
             }
-            Evaluate(snapshot);
+            if (uiContext is not null)
+                uiContext.Post(_ => { if (!_disposed) Evaluate(snapshot); }, null);
+            else
+                Evaluate(snapshot);
         }, TaskScheduler.Default);
     }
 
@@ -296,16 +306,33 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
     private async Task PumpLoadAsync(DatasetEntry entry)
     {
         await _gate.WaitAsync().ConfigureAwait(true);
+        var aborted = false;
         try
         {
             await _loadAsync(entry, CancellationToken.None).ConfigureAwait(true);
             lock (_lock)
             {
-                _deferred.Remove(entry);
-                _loading.Remove(entry);
-                _loaded.Touch(entry);
-                _loadedEntries.Add(entry);
-                entry.IsDeferred = false;
+                // If Unregister()/Dispose() ran while this cell was loading, the
+                // entry is no longer tracked in _loading; treat the finished
+                // load as stale rather than re-adding layers for a closed
+                // exchange set (zombie layers) or resurrecting an entry the UI
+                // has already dropped. See issue #458.
+                aborted = _disposed || !_loading.Remove(entry);
+                if (!aborted)
+                {
+                    _deferred.Remove(entry);
+                    _loaded.Touch(entry);
+                    _loadedEntries.Add(entry);
+                    entry.IsDeferred = false;
+                }
+            }
+
+            if (aborted)
+            {
+                // Unwind the just-completed load so its bytes/layers do not
+                // linger after the exchange set was closed.
+                try { _unload(entry); }
+                catch (Exception ex) { _logger.LogWarning(ex, "Lazy-load abort unload threw."); }
             }
         }
         catch (Exception ex)

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -305,8 +305,21 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
 
     private async Task PumpLoadAsync(DatasetEntry entry)
     {
-        await _gate.WaitAsync().ConfigureAwait(true);
+        try
+        {
+            await _gate.WaitAsync().ConfigureAwait(true);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Dispose() disposed the gate while this load was queued. Tracking
+            // is already cleared, so there is nothing to unwind — just abandon
+            // the fire-and-forget task rather than surface an unobserved
+            // exception. See issue #458.
+            return;
+        }
+
         var aborted = false;
+        var disposed = false;
         try
         {
             await _loadAsync(entry, CancellationToken.None).ConfigureAwait(true);
@@ -317,7 +330,8 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
                 // load as stale rather than re-adding layers for a closed
                 // exchange set (zombie layers) or resurrecting an entry the UI
                 // has already dropped. See issue #458.
-                aborted = _disposed || !_loading.Remove(entry);
+                disposed = _disposed;
+                aborted = disposed || !_loading.Remove(entry);
                 if (!aborted)
                 {
                     _deferred.Remove(entry);
@@ -327,10 +341,12 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
                 }
             }
 
-            if (aborted)
+            // Unwind a load the viewport still wanted but whose exchange set was
+            // closed mid-flight. When the whole coordinator is disposing, skip
+            // the unload — teardown removes the layers wholesale and we must not
+            // touch the map during shutdown.
+            if (aborted && !disposed)
             {
-                // Unwind the just-completed load so its bytes/layers do not
-                // linger after the exchange set was closed.
                 try { _unload(entry); }
                 catch (Exception ex) { _logger.LogWarning(ex, "Lazy-load abort unload threw."); }
             }
@@ -342,7 +358,11 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
         }
         finally
         {
-            _gate.Release();
+            // The gate may have been disposed by Dispose() while the load ran;
+            // a fire-and-forget Release() must not surface an unobserved
+            // ObjectDisposedException during teardown.
+            try { _gate.Release(); }
+            catch (ObjectDisposedException) { }
         }
     }
 

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -336,6 +336,18 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
         var disposed = false;
         try
         {
+            // Abandon a load that was queued on the gate but whose exchange set
+            // was closed (Unregister) or whose coordinator was disposed while it
+            // waited: the expensive parse/portray must not run for an entry the
+            // UI has already dropped, and must not touch the map during
+            // shutdown. Nothing to unwind — no layers were added. The gate is
+            // released in the finally. See issue #458.
+            lock (_lock)
+            {
+                if (_disposed || !_loading.Contains(entry))
+                    return;
+            }
+
             await _loadAsync(entry, CancellationToken.None).ConfigureAwait(true);
             lock (_lock)
             {

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Viewer.ViewModels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EncDotNet.S100.Viewer.Services.LazyLoading;
+
+/// <summary>
+/// Tunable parameters for <see cref="ExchangeSetLazyLoadCoordinator"/>.
+/// Centralised so the whole lazy-loading heuristic can be adjusted in one
+/// place. See issue #458.
+/// </summary>
+internal sealed record LazyLoadOptions
+{
+    /// <summary>
+    /// Cell-count above which an opened exchange set switches from eager
+    /// (load-every-cell) to lazy (register-then-load-on-demand) behaviour.
+    /// A rough proxy: small sets load eagerly for simplicity, large ones defer.
+    /// </summary>
+    public int CellThreshold { get; init; } = 50;
+
+    /// <summary>
+    /// Maximum number of cell loads allowed to run concurrently. Defaults to
+    /// half the logical processor count (min&#160;2) to leave head-room for the
+    /// render subsystem, which rasterises tiles on worker threads — saturating
+    /// every core with parse/translate work starves rendering and re-freezes
+    /// the UI the feature set out to keep responsive.
+    /// </summary>
+    public int MaxConcurrency { get; init; } = Math.Max(2, Environment.ProcessorCount / 2);
+
+    /// <summary>
+    /// Maximum number of loaded cells to retain in memory. When the loaded set
+    /// exceeds this budget the coldest off-screen cells are evicted (their
+    /// bytes unloaded, their extent outline kept). Generous by default so
+    /// normal panning never thrashes; the eviction is a safety valve against
+    /// the unbounded-memory growth that motivated the feature.
+    /// </summary>
+    public int RetentionBudget { get; init; } = 400;
+
+    /// <summary>
+    /// Trailing-edge debounce applied to viewport changes before re-evaluating
+    /// which cells to load, so a single pan/zoom gesture coalesces into one
+    /// pass. <see cref="TimeSpan.Zero"/> disables debouncing (used by tests).
+    /// </summary>
+    public TimeSpan ViewportDebounce { get; init; } = TimeSpan.FromMilliseconds(200);
+}
+
+/// <summary>
+/// Coordinates viewport-driven lazy loading of exchange-set cells. Large
+/// exchange sets register every cell up front as a lightweight
+/// <see cref="DatasetEntry"/> (footprint&#160;+&#160;usage band, no bytes) and
+/// hand them here; this coordinator watches the map viewport and loads only the
+/// cells that are both in view and appropriate for the current scale, capping
+/// concurrency and evicting the coldest off-screen cells when the retention
+/// budget is exceeded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The decision logic lives in the pure, unit-tested
+/// <see cref="LazyCellGate"/> and <see cref="LruEvictionPolicy{TKey}"/>; this
+/// class is the stateful glue: viewport subscription, debounce, a
+/// bounded-concurrency load pump, and eviction. Load / unload are injected as
+/// delegates so the coordinator is testable without the full loader stack.
+/// </para>
+/// <para>
+/// The coordinator assumes it is driven on the UI thread (the map viewport
+/// notifier fires there and the injected load delegate dispatches its own
+/// off-thread work), but guards its shared registries with a lock for safety.
+/// See issue #458.
+/// </para>
+/// </remarks>
+internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
+{
+    private readonly IMapViewportNotifier _notifier;
+    private readonly Func<DatasetEntry, CancellationToken, Task> _loadAsync;
+    private readonly Action<DatasetEntry> _unload;
+    private readonly LazyLoadOptions _options;
+    private readonly ILogger _logger;
+
+    private readonly object _lock = new();
+    private readonly HashSet<DatasetEntry> _deferred = new();
+    private readonly HashSet<DatasetEntry> _loading = new();
+    private readonly LruEvictionPolicy<DatasetEntry> _loaded = new();
+    private readonly SemaphoreSlim _gate;
+
+    private CancellationTokenSource? _debounceCts;
+    private bool _disposed;
+
+    /// <summary>
+    /// Constructs a coordinator bound to <paramref name="notifier"/>.
+    /// </summary>
+    /// <param name="notifier">Map-viewport change publisher.</param>
+    /// <param name="loadAsync">
+    /// Loads a single registered cell (typically
+    /// <c>DatasetsViewModel.RequestLoadAsync</c>). Must not throw for a normal
+    /// per-cell failure — the loader surfaces those itself.
+    /// </param>
+    /// <param name="unload">
+    /// Unloads a loaded cell's bytes while keeping it registered (typically
+    /// <c>IDatasetLoaderService.UnloadEntry</c>), used for LRU eviction.
+    /// </param>
+    /// <param name="options">Tunables; defaults when <see langword="null"/>.</param>
+    /// <param name="logger">Optional logger.</param>
+    public ExchangeSetLazyLoadCoordinator(
+        IMapViewportNotifier notifier,
+        Func<DatasetEntry, CancellationToken, Task> loadAsync,
+        Action<DatasetEntry> unload,
+        LazyLoadOptions? options = null,
+        ILogger<ExchangeSetLazyLoadCoordinator>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(notifier);
+        ArgumentNullException.ThrowIfNull(loadAsync);
+        ArgumentNullException.ThrowIfNull(unload);
+
+        _notifier = notifier;
+        _loadAsync = loadAsync;
+        _unload = unload;
+        _options = options ?? new LazyLoadOptions();
+        _logger = logger ?? NullLogger<ExchangeSetLazyLoadCoordinator>.Instance;
+        _gate = new SemaphoreSlim(Math.Max(1, _options.MaxConcurrency));
+
+        _notifier.ViewportChanged += OnViewportChanged;
+    }
+
+    /// <summary>The active tunables.</summary>
+    public LazyLoadOptions Options => _options;
+
+    /// <summary>Test hook: the number of cells currently registered as deferred.</summary>
+    internal int DeferredCount { get { lock (_lock) return _deferred.Count; } }
+
+    /// <summary>Test hook: the number of cells currently held loaded.</summary>
+    internal int LoadedCount { get { lock (_lock) return _loaded.Count; } }
+
+    /// <summary>
+    /// Registers <paramref name="entries"/> as deferred (not-yet-loaded) cells
+    /// and immediately evaluates the current viewport so any that are already in
+    /// view begin loading. Each entry is marked
+    /// <see cref="DatasetEntry.IsDeferred"/>. Safe to call repeatedly; entries
+    /// already registered are ignored.
+    /// </summary>
+    /// <param name="entries">The registered-not-loaded cell entries.</param>
+    public void Register(IEnumerable<DatasetEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        lock (_lock)
+        {
+            if (_disposed) return;
+            foreach (var entry in entries)
+            {
+                if (entry is null) continue;
+                entry.IsDeferred = true;
+                _deferred.Add(entry);
+            }
+        }
+
+        if (_notifier.Current is { } seed)
+            Evaluate(seed);
+    }
+
+    /// <summary>
+    /// Drops <paramref name="entries"/> from all coordinator tracking (e.g. when
+    /// their exchange set is closed). Does not unload — the caller owns removal
+    /// from the map.
+    /// </summary>
+    /// <param name="entries">The entries to forget.</param>
+    public void Unregister(IEnumerable<DatasetEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        lock (_lock)
+        {
+            foreach (var entry in entries)
+            {
+                if (entry is null) continue;
+                _deferred.Remove(entry);
+                _loading.Remove(entry);
+                _loaded.Remove(entry);
+            }
+        }
+    }
+
+    private void OnViewportChanged(object? sender, MapViewportSnapshot snapshot)
+    {
+        if (_disposed) return;
+
+        if (_options.ViewportDebounce <= TimeSpan.Zero)
+        {
+            Evaluate(snapshot);
+            return;
+        }
+
+        CancellationTokenSource newCts;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            newCts = new CancellationTokenSource();
+            _debounceCts = newCts;
+        }
+
+        _ = Task.Delay(_options.ViewportDebounce, newCts.Token).ContinueWith(t =>
+        {
+            if (t.IsCanceled || _disposed) return;
+            lock (_lock)
+            {
+                if (ReferenceEquals(_debounceCts, newCts))
+                    _debounceCts = null;
+            }
+            Evaluate(snapshot);
+        }, TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// Evaluates <paramref name="snapshot"/> against every registered cell:
+    /// starts gated loads for in-view, scale-eligible deferred cells; touches
+    /// the LRU for in-view loaded cells; then evicts the coldest off-screen
+    /// cells beyond the retention budget. Exposed to tests via the zero-debounce
+    /// path.
+    /// </summary>
+    internal void Evaluate(MapViewportSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var centreLat = (snapshot.MinLatitude + snapshot.MaxLatitude) / 2.0;
+        var scaleDenominator = LazyCellGate.ScaleDenominator(
+            snapshot.MercatorResolution, centreLat);
+
+        List<DatasetEntry> toLoad = new();
+        List<DatasetEntry> victims = new();
+        lock (_lock)
+        {
+            if (_disposed) return;
+
+            foreach (var entry in _deferred)
+            {
+                if (_loading.Contains(entry)) continue;
+                if (LazyCellGate.ShouldBeLoaded(
+                        entry.GeographicBounds, entry.UsageBand, scaleDenominator,
+                        snapshot.MinLatitude, snapshot.MinLongitude,
+                        snapshot.MaxLatitude, snapshot.MaxLongitude))
+                {
+                    toLoad.Add(entry);
+                }
+            }
+
+            // Warm the LRU for cells that remain in view so eviction favours
+            // off-screen cells.
+            var protectedKeys = new HashSet<DatasetEntry>();
+            foreach (var loadedEntry in _loadedEntries)
+            {
+                if (LazyCellGate.IntersectsViewport(
+                        loadedEntry.GeographicBounds,
+                        snapshot.MinLatitude, snapshot.MinLongitude,
+                        snapshot.MaxLatitude, snapshot.MaxLongitude))
+                {
+                    _loaded.Touch(loadedEntry);
+                    protectedKeys.Add(loadedEntry);
+                }
+            }
+
+            foreach (var entry in toLoad)
+                _loading.Add(entry);
+
+            victims = _loaded
+                .SelectEvictions(_options.RetentionBudget, protectedKeys)
+                .ToList();
+            foreach (var victim in victims)
+            {
+                _loaded.Remove(victim);
+                _loadedEntries.Remove(victim);
+                // Return the evicted cell to the deferred pool so it reloads
+                // (from scratch) the next time it enters the viewport.
+                _deferred.Add(victim);
+            }
+        }
+
+        foreach (var victim in victims)
+        {
+            try { _unload(victim); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Lazy-load eviction unload threw."); }
+        }
+
+        foreach (var entry in toLoad)
+            _ = PumpLoadAsync(entry);
+    }
+
+    // Mirror of the LRU membership for enumeration: the LRU is the authority for
+    // ordering / eviction; this set answers "is this entry currently loaded?"
+    // and is kept in lockstep with the LRU under _lock.
+    private readonly HashSet<DatasetEntry> _loadedEntries = new();
+
+    private async Task PumpLoadAsync(DatasetEntry entry)
+    {
+        await _gate.WaitAsync().ConfigureAwait(true);
+        try
+        {
+            await _loadAsync(entry, CancellationToken.None).ConfigureAwait(true);
+            lock (_lock)
+            {
+                _deferred.Remove(entry);
+                _loading.Remove(entry);
+                _loaded.Touch(entry);
+                _loadedEntries.Add(entry);
+                entry.IsDeferred = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Lazy-load cell load threw.");
+            lock (_lock) _loading.Remove(entry);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _notifier.ViewportChanged -= OnViewportChanged;
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            _debounceCts = null;
+            _deferred.Clear();
+            _loading.Clear();
+            _loaded.Clear();
+            _loadedEntries.Clear();
+        }
+        _gate.Dispose();
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -215,12 +215,22 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
 
         _ = Task.Delay(_options.ViewportDebounce, newCts.Token).ContinueWith(t =>
         {
-            if (t.IsCanceled || _disposed) return;
+            // Only the most-recent debounce may fire. If a newer viewport
+            // change superseded this one, OnViewportChanged already replaced
+            // (and disposed) _debounceCts, so this stale continuation must
+            // no-op — including when Task.Delay completed before the newer
+            // change could cancel it. When still current, dispose the
+            // completed CTS here so it does not leak (nothing else will).
             lock (_lock)
             {
-                if (ReferenceEquals(_debounceCts, newCts))
-                    _debounceCts = null;
+                if (!ReferenceEquals(_debounceCts, newCts))
+                    return;
+                _debounceCts = null;
+                newCts.Dispose();
             }
+
+            if (t.IsCanceled || _disposed) return;
+
             if (uiContext is not null)
                 uiContext.Post(_ => { if (!_disposed) Evaluate(snapshot); }, null);
             else

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -152,6 +152,16 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
             foreach (var entry in entries)
             {
                 if (entry is null) continue;
+                // Idempotent: skip an entry already tracked in any state
+                // (deferred, loading, or loaded). Re-marking a since-loaded cell
+                // IsDeferred would dim it and show a deferred outline while its
+                // layers are still on the map. See issue #458.
+                if (_deferred.Contains(entry)
+                    || _loading.Contains(entry)
+                    || _loadedEntries.Contains(entry))
+                {
+                    continue;
+                }
                 entry.IsDeferred = true;
                 _deferred.Add(entry);
             }

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/ExchangeSetLazyLoadCoordinator.cs
@@ -178,6 +178,10 @@ internal sealed class ExchangeSetLazyLoadCoordinator : IDisposable
                 _deferred.Remove(entry);
                 _loading.Remove(entry);
                 _loaded.Remove(entry);
+                // Keep the LRU mirror in lockstep: leaving the entry in
+                // _loadedEntries would let Evaluate() re-Touch() it back into
+                // the LRU and keep acting on a closed cell. See issue #458.
+                _loadedEntries.Remove(entry);
             }
         }
     }

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/LazyCellGate.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/LazyCellGate.cs
@@ -67,7 +67,10 @@ internal static class LazyCellGate
     /// (all values in EPSG:4326 decimal degrees). A touching edge counts as
     /// an overlap. A <see langword="null"/> footprint (container-style cells
     /// with no coverage) is treated as always intersecting so it is never
-    /// culled by geography.
+    /// culled by geography. Either box may cross the ±180° antimeridian seam
+    /// (west &gt; east); such ranges are split into two non-wrapping segments
+    /// (<c>[west, +180]</c> ∪ <c>[-180, east]</c>) before the longitude test
+    /// so seam-crossing cells and viewports still match near the dateline.
     /// </summary>
     public static bool IntersectsViewport(
         BoundingBox? cell,
@@ -79,14 +82,54 @@ internal static class LazyCellGate
         if (cell is null)
             return true;
 
-        // Standard axis-aligned overlap test; disjoint when one box is wholly
-        // to one side of the other.
+        // Latitude never wraps: disjoint when one box is wholly north or
+        // south of the other.
         if (cell.NorthBoundLatitude < viewSouth || cell.SouthBoundLatitude > viewNorth)
             return false;
-        if (cell.EastBoundLongitude < viewWest || cell.WestBoundLongitude > viewEast)
-            return false;
 
-        return true;
+        // Longitude can wrap the ±180° seam, so overlap is tested per
+        // non-wrapping segment pair rather than with a single interval test.
+        return LongitudesOverlap(
+            cell.WestBoundLongitude, cell.EastBoundLongitude, viewWest, viewEast);
+    }
+
+    /// <summary>
+    /// True when two longitude ranges overlap, treating a range whose
+    /// <paramref name="aWest"/> exceeds its <paramref name="aEast"/> (likewise
+    /// for <paramref name="bWest"/>/<paramref name="bEast"/>) as crossing the
+    /// ±180° antimeridian seam. Each range is decomposed into up to two
+    /// non-wrapping segments and every segment pair is tested for a touching
+    /// or overlapping interval.
+    /// </summary>
+    private static bool LongitudesOverlap(
+        double aWest, double aEast, double bWest, double bEast)
+    {
+        foreach (var (aLo, aHi) in SplitLongitude(aWest, aEast))
+            foreach (var (bLo, bHi) in SplitLongitude(bWest, bEast))
+                if (aLo <= bHi && bLo <= aHi)
+                    return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Splits a possibly seam-crossing longitude range into one or two
+    /// non-wrapping <c>[low, high]</c> segments. A range with
+    /// <paramref name="west"/> &gt; <paramref name="east"/> yields
+    /// <c>[west, +180]</c> and <c>[-180, east]</c>.
+    /// </summary>
+    private static IEnumerable<(double Low, double High)> SplitLongitude(
+        double west, double east)
+    {
+        if (west <= east)
+        {
+            yield return (west, east);
+        }
+        else
+        {
+            yield return (west, 180.0);
+            yield return (-180.0, east);
+        }
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/LazyCellGate.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/LazyCellGate.cs
@@ -1,0 +1,127 @@
+using System;
+using EncDotNet.S100.ExchangeSets;
+
+namespace EncDotNet.S100.Viewer.Services.LazyLoading;
+
+/// <summary>
+/// Pure decision logic for viewport-driven lazy loading of exchange-set cells:
+/// given a cell's geographic footprint and navigational-purpose band, decides
+/// whether the cell is relevant at the current viewport and scale. Kept free
+/// of Mapsui / view-model types so it is exhaustively unit-testable.
+/// </summary>
+/// <remarks>
+/// A cell should be loaded when it BOTH intersects the visible viewport AND
+/// its usage band is appropriate for the current display scale. The band
+/// gate is what prevents the pathological case that motivated this feature:
+/// loading thousands of large-scale (harbour / berthing) cells while zoomed
+/// out over an entire region. Band-to-scale thresholds are heuristic (ECDIS
+/// navigational-purpose scale ranges, widened slightly so cells appear just
+/// before they are strictly needed) and centralised here for tuning.
+/// </remarks>
+internal static class LazyCellGate
+{
+    /// <summary>
+    /// Coarsest scale denominator (1:N) at which a cell of each
+    /// navigational-purpose band starts being loaded. A band is eligible when
+    /// the current scale denominator is at or below its threshold — i.e. the
+    /// view is zoomed in at least far enough for that band to be relevant.
+    /// Index by band (1..6). Overview (band&#160;1) is always eligible.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the conventional ENC navigational-purpose scale bands
+    /// (Overview / General / Coastal / Approach / Harbour / Berthing),
+    /// widened ~2× so cells load slightly ahead of the strict boundary and the
+    /// chart never shows a blank band mid-zoom. Heuristic and tunable.
+    /// </remarks>
+    private static readonly double[] BandMaxScaleDenominator =
+    {
+        double.PositiveInfinity, // index 0 unused / unknown-band fallback
+        double.PositiveInfinity, // 1 Overview  — always eligible
+        3_000_000,               // 2 General
+        700_000,                 // 3 Coastal
+        180_000,                 // 4 Approach
+        45_000,                  // 5 Harbour
+        10_000,                  // 6 Berthing
+    };
+
+    /// <summary>
+    /// True when a cell of navigational-purpose <paramref name="band"/> is
+    /// appropriate to load at the given <paramref name="scaleDenominator"/>
+    /// (1:N). An unknown band (<see langword="null"/>) or an unavailable scale
+    /// (non-finite or ≤ 0) fails <em>open</em> (eligible) so no cell is hidden
+    /// by an unparseable name or a not-yet-laid-out viewport; the bounded load
+    /// gate and LRU budget still cap the working set.
+    /// </summary>
+    public static bool IsBandEligible(int? band, double scaleDenominator)
+    {
+        if (band is not { } b || b < CellUsageBand.MinBand || b > CellUsageBand.MaxBand)
+            return true;
+        if (double.IsNaN(scaleDenominator) || scaleDenominator <= 0)
+            return true;
+
+        return scaleDenominator <= BandMaxScaleDenominator[b];
+    }
+
+    /// <summary>
+    /// True when <paramref name="cell"/> overlaps the viewport rectangle
+    /// (all values in EPSG:4326 decimal degrees). A touching edge counts as
+    /// an overlap. A <see langword="null"/> footprint (container-style cells
+    /// with no coverage) is treated as always intersecting so it is never
+    /// culled by geography.
+    /// </summary>
+    public static bool IntersectsViewport(
+        BoundingBox? cell,
+        double viewSouth,
+        double viewWest,
+        double viewNorth,
+        double viewEast)
+    {
+        if (cell is null)
+            return true;
+
+        // Standard axis-aligned overlap test; disjoint when one box is wholly
+        // to one side of the other.
+        if (cell.NorthBoundLatitude < viewSouth || cell.SouthBoundLatitude > viewNorth)
+            return false;
+        if (cell.EastBoundLongitude < viewWest || cell.WestBoundLongitude > viewEast)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when a cell with the given footprint and band should be loaded for
+    /// a viewport whose bounds and scale are supplied — the conjunction of
+    /// <see cref="IntersectsViewport"/> and <see cref="IsBandEligible"/>.
+    /// </summary>
+    public static bool ShouldBeLoaded(
+        BoundingBox? cell,
+        int? band,
+        double scaleDenominator,
+        double viewSouth,
+        double viewWest,
+        double viewNorth,
+        double viewEast) =>
+        IntersectsViewport(cell, viewSouth, viewWest, viewNorth, viewEast)
+        && IsBandEligible(band, scaleDenominator);
+
+    /// <summary>
+    /// Converts an EPSG:3857 (web-mercator) resolution in metres/pixel to an
+    /// approximate map-scale denominator (1:N) at the given latitude, applying
+    /// the web-mercator cosine distortion correction and the OGC 0.28&#160;mm
+    /// standardized pixel size (mirrors <see cref="MapScaleFormatter"/>).
+    /// Returns <see cref="double.NaN"/> for a non-positive resolution.
+    /// </summary>
+    public static double ScaleDenominator(double mercatorResolution, double latitudeDegrees)
+    {
+        if (double.IsNaN(mercatorResolution) || mercatorResolution <= 0)
+            return double.NaN;
+
+        var groundMetersPerPixel =
+            mercatorResolution * Math.Cos(latitudeDegrees * Math.PI / 180.0);
+        if (groundMetersPerPixel <= 0 || double.IsNaN(groundMetersPerPixel))
+            return double.NaN;
+
+        return groundMetersPerPixel / MapScaleFormatter.PixelSizeMeters;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/LruEvictionPolicy.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/LruEvictionPolicy.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace EncDotNet.S100.Viewer.Services.LazyLoading;
 
@@ -14,8 +13,8 @@ namespace EncDotNet.S100.Viewer.Services.LazyLoading;
 /// <remarks>
 /// <para>
 /// Kept deliberately free of view-model / Mapsui types (keys are opaque) so the
-/// eviction contract is exhaustively unit-testable. The coordinator supplies
-/// <see cref="DatasetEntry"/> instances as keys at runtime. See issue #458.
+/// eviction contract is exhaustively unit-testable. The coordinator supplies its
+/// cell entries as keys at runtime. See issue #458.
 /// </para>
 /// <para>
 /// "Recently used" means "most recently confirmed in-view or loaded". A cell is

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/LruEvictionPolicy.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/LruEvictionPolicy.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EncDotNet.S100.Viewer.Services.LazyLoading;
+
+/// <summary>
+/// Pure least-recently-used bookkeeping for the set of exchange-set cells the
+/// lazy-load coordinator currently holds in memory. Tracks the order in which
+/// loaded cells were last touched and, when the retention budget is exceeded,
+/// nominates the coldest cells for eviction — never evicting a cell that is
+/// still relevant to the current viewport.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Kept deliberately free of view-model / Mapsui types (keys are opaque) so the
+/// eviction contract is exhaustively unit-testable. The coordinator supplies
+/// <see cref="DatasetEntry"/> instances as keys at runtime. See issue #458.
+/// </para>
+/// <para>
+/// "Recently used" means "most recently confirmed in-view or loaded". A cell is
+/// <see cref="Touch"/>ed each time it is loaded or re-confirmed inside the
+/// viewport, moving it to the warm end of the list; eviction always takes from
+/// the cold end.
+/// </para>
+/// </remarks>
+/// <typeparam name="TKey">The loaded-cell key type (reference equality).</typeparam>
+internal sealed class LruEvictionPolicy<TKey> where TKey : notnull
+{
+    // Head (index 0) = coldest (least-recently used); tail = warmest.
+    private readonly LinkedList<TKey> _order = new();
+    private readonly Dictionary<TKey, LinkedListNode<TKey>> _nodes = new();
+
+    /// <summary>The number of loaded keys currently tracked.</summary>
+    public int Count => _nodes.Count;
+
+    /// <summary>
+    /// Records that <paramref name="key"/> is loaded and was just used, moving
+    /// it to the warm (most-recently-used) end. Idempotent: touching an already
+    /// tracked key only re-orders it. Returns <see langword="true"/> when the
+    /// key was newly added (i.e. not previously tracked).
+    /// </summary>
+    public bool Touch(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (_nodes.TryGetValue(key, out var existing))
+        {
+            _order.Remove(existing);
+            _order.AddLast(existing);
+            return false;
+        }
+
+        _nodes[key] = _order.AddLast(key);
+        return true;
+    }
+
+    /// <summary>
+    /// Stops tracking <paramref name="key"/> (e.g. after it is evicted or the
+    /// exchange set is closed). No-op when the key is not tracked.
+    /// </summary>
+    public void Remove(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (_nodes.Remove(key, out var node))
+            _order.Remove(node);
+    }
+
+    /// <summary>Removes every tracked key.</summary>
+    public void Clear()
+    {
+        _order.Clear();
+        _nodes.Clear();
+    }
+
+    /// <summary><see langword="true"/> when <paramref name="key"/> is tracked.</summary>
+    public bool Contains(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return _nodes.ContainsKey(key);
+    }
+
+    /// <summary>
+    /// Nominates the coldest tracked keys to evict so that no more than
+    /// <paramref name="retentionBudget"/> keys remain loaded, skipping any key
+    /// in <paramref name="protectedKeys"/> (typically the cells still visible in
+    /// the current viewport — evicting those would immediately reload them).
+    /// The returned keys are <em>not</em> removed from tracking; the caller
+    /// unloads each and then calls <see cref="Remove"/>.
+    /// </summary>
+    /// <param name="retentionBudget">
+    /// Maximum number of loaded keys to keep. Values &lt; 0 are treated as 0.
+    /// </param>
+    /// <param name="protectedKeys">
+    /// Keys that must never be evicted regardless of age; may be
+    /// <see langword="null"/> or empty.
+    /// </param>
+    /// <returns>
+    /// The keys to evict, coldest first. Empty when the budget is satisfied or
+    /// every over-budget key is protected.
+    /// </returns>
+    public IReadOnlyList<TKey> SelectEvictions(
+        int retentionBudget,
+        IReadOnlySet<TKey>? protectedKeys = null)
+    {
+        if (retentionBudget < 0)
+            retentionBudget = 0;
+
+        var overBy = _nodes.Count - retentionBudget;
+        if (overBy <= 0)
+            return Array.Empty<TKey>();
+
+        var victims = new List<TKey>(overBy);
+        foreach (var key in _order) // coldest first
+        {
+            if (victims.Count >= overBy)
+                break;
+            if (protectedKeys is not null && protectedKeys.Contains(key))
+                continue;
+            victims.Add(key);
+        }
+
+        return victims;
+    }
+}

--- a/src/EncDotNet.S100.Viewer/Services/LazyLoading/LruEvictionPolicy.cs
+++ b/src/EncDotNet.S100.Viewer/Services/LazyLoading/LruEvictionPolicy.cs
@@ -24,12 +24,18 @@ namespace EncDotNet.S100.Viewer.Services.LazyLoading;
 /// the cold end.
 /// </para>
 /// </remarks>
-/// <typeparam name="TKey">The loaded-cell key type (reference equality).</typeparam>
-internal sealed class LruEvictionPolicy<TKey> where TKey : notnull
+/// <typeparam name="TKey">
+/// The loaded-cell key type. Constrained to a reference type and keyed by
+/// <see cref="ReferenceEqualityComparer"/> so tracking is by object identity
+/// regardless of whether <typeparamref name="TKey"/> overrides equality — the
+/// coordinator distinguishes cells by reference, never by value.
+/// </typeparam>
+internal sealed class LruEvictionPolicy<TKey> where TKey : class
 {
     // Head (index 0) = coldest (least-recently used); tail = warmest.
     private readonly LinkedList<TKey> _order = new();
-    private readonly Dictionary<TKey, LinkedListNode<TKey>> _nodes = new();
+    private readonly Dictionary<TKey, LinkedListNode<TKey>> _nodes =
+        new(ReferenceEqualityComparer.Instance);
 
     /// <summary>The number of loaded keys currently tracked.</summary>
     public int Count => _nodes.Count;

--- a/src/EncDotNet.S100.Viewer/Services/MapViewportNotifier.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapViewportNotifier.cs
@@ -104,6 +104,7 @@ internal sealed class MapViewportNotifier : IMapViewportNotifier, IDisposable
             MinLongitude = minLon,
             MaxLatitude = maxLat,
             MaxLongitude = maxLon,
+            MercatorResolution = viewport.Resolution,
         };
     }
 

--- a/src/EncDotNet.S100.Viewer/Services/MapViewportSnapshot.cs
+++ b/src/EncDotNet.S100.Viewer/Services/MapViewportSnapshot.cs
@@ -38,4 +38,15 @@ internal sealed record MapViewportSnapshot
 
     /// <summary>Longitude span (east - west) in degrees.</summary>
     public double LongitudeSpanDegrees => MaxLongitude - MinLongitude;
+
+    /// <summary>
+    /// The map's EPSG:3857 (Web Mercator) resolution in metres-per-pixel
+    /// at the moment of the snapshot, taken from Mapsui's
+    /// <c>Viewport.Resolution</c>. Combined with the viewport-centre
+    /// latitude this yields the on-screen scale denominator used to pick
+    /// which usage-band cells are relevant (see
+    /// <see cref="LazyLoading.LazyCellGate"/>). <c>0</c> when the
+    /// resolution was unavailable.
+    /// </summary>
+    public double MercatorResolution { get; init; }
 }

--- a/src/EncDotNet.S100.Viewer/ViewModels/BulkObservableCollection.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/BulkObservableCollection.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// An <see cref="ObservableCollection{T}"/> that adds a bulk-insert operation
+/// raising a single <see cref="NotifyCollectionChangedAction.Reset"/> instead of
+/// one <see cref="NotifyCollectionChangedAction.Add"/> per item. This keeps
+/// registering a very large exchange set (thousands of cells) from triggering
+/// O(N²) work in every collection subscriber (grouping rebuilds, extent-overlay
+/// rebuilds, etc.) — the pathology that froze the UI when opening a 7,000-cell
+/// S-57 set. See issue #458.
+/// </summary>
+/// <typeparam name="T">The element type.</typeparam>
+internal sealed class BulkObservableCollection<T> : ObservableCollection<T>
+{
+    /// <summary>
+    /// Inserts every item in <paramref name="items"/> at
+    /// <paramref name="index"/> (preserving their order), then raises a single
+    /// collection-changed <see cref="NotifyCollectionChangedAction.Reset"/> plus
+    /// the <c>Count</c>/indexer property notifications. Subscribers that handle
+    /// Reset by resynchronising therefore run once for the whole batch rather
+    /// than once per item. No event is raised for an empty batch.
+    /// </summary>
+    /// <param name="index">Zero-based insert position.</param>
+    /// <param name="items">The items to insert.</param>
+    public void InsertRange(int index, IEnumerable<T> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        var list = items as IReadOnlyList<T> ?? items.ToList();
+        if (list.Count == 0)
+            return;
+
+        CheckReentrancy();
+
+        for (var i = 0; i < list.Count; i++)
+            Items.Insert(index + i, list[i]);
+
+        OnPropertyChanged(new System.ComponentModel.PropertyChangedEventArgs(nameof(Count)));
+        OnPropertyChanged(new System.ComponentModel.PropertyChangedEventArgs("Item[]"));
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+}

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -87,6 +87,42 @@ internal sealed class DatasetEntry : ViewModelBase
     /// </remarks>
     public int? MaximumDisplayScale { get; }
 
+    /// <summary>
+    /// The cell's geographic (EPSG:4326) footprint as declared in the
+    /// exchange-set catalogue, known <em>before</em> the dataset is parsed.
+    /// <see langword="null"/> for plain file loads and catalogues that omit
+    /// coverage (e.g. container-style features). Drives viewport-driven lazy
+    /// loading: the coordinator culls out-of-view cells by this box without
+    /// touching their bytes. See issue #458.
+    /// </summary>
+    public ExchangeSets.BoundingBox? GeographicBounds { get; }
+
+    /// <summary>
+    /// The ENC navigational-purpose band (1&#160;Overview .. 6&#160;Berthing)
+    /// parsed from the cell name (S-57 Ed 3.1 App&#160;B.1 / S-101 §5.5), or
+    /// <see langword="null"/> when the name is not a recognised ENC cell.
+    /// Used as a load-free scale proxy for lazy loading (issue #458).
+    /// </summary>
+    public int? UsageBand { get; }
+
+    private bool _isDeferred;
+    /// <summary>
+    /// True when this entry has been <em>registered</em> from a large exchange
+    /// set but its bytes have not yet been loaded — it appears in the Datasets
+    /// panel (dimmed) and as a map extent outline, and is loaded on demand when
+    /// it enters the viewport at a relevant scale. Cleared once the cell loads.
+    /// See issue #458.
+    /// </summary>
+    public bool IsDeferred
+    {
+        get => _isDeferred;
+        set
+        {
+            if (SetProperty(ref _isDeferred, value))
+                OnPropertyChanged(nameof(RowOpacity));
+        }
+    }
+
     private Mapsui.MRect? _mercatorExtent;
     /// <summary>
     /// The dataset's EPSG:3857 (web-mercator) extent, captured from the
@@ -209,9 +245,10 @@ internal sealed class DatasetEntry : ViewModelBase
     }
 
     /// <summary>
-    /// UI helper: dims the row text when the dataset is hidden.
+    /// UI helper: dims the row text when the dataset is hidden or still
+    /// deferred (registered from a large exchange set but not yet loaded).
     /// </summary>
-    public double RowOpacity => _isVisible ? 1.0 : 0.5;
+    public double RowOpacity => (!_isVisible || _isDeferred) ? 0.5 : 1.0;
 
     /// <summary>
     /// Flips <see cref="IsVisible"/>. Bound to the eye-icon button in
@@ -460,7 +497,8 @@ internal sealed class DatasetEntry : ViewModelBase
         string? displayName,
         IReadOnlyList<string>? updateRelativePaths = null,
         int? minimumDisplayScale = null,
-        int? maximumDisplayScale = null)
+        int? maximumDisplayScale = null,
+        ExchangeSets.BoundingBox? geographicBounds = null)
     {
         FilePath = filePath;
         ProductSpec = productSpec;
@@ -469,8 +507,11 @@ internal sealed class DatasetEntry : ViewModelBase
         UpdateRelativePaths = updateRelativePaths ?? Array.Empty<string>();
         MinimumDisplayScale = minimumDisplayScale;
         MaximumDisplayScale = maximumDisplayScale;
+        GeographicBounds = geographicBounds;
         DisplayName = displayName ?? System.IO.Path.GetFileName(
             relativePath is { Length: > 0 } ? relativePath : filePath);
+        UsageBand = Services.LazyLoading.CellUsageBand.TryParse(DisplayName)
+            ?? Services.LazyLoading.CellUsageBand.TryParse(relativePath);
         ToggleVisibilityCommand = new RelayCommand(() => IsVisible = !IsVisible);
 
         _subLayers.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasSubLayers));
@@ -533,7 +574,7 @@ internal sealed class DatasetsViewModel : ViewModelBase
 {
     private readonly IDatasetLoaderService _loader;
 
-    public ObservableCollection<DatasetEntry> Entries { get; } = new();
+    public BulkObservableCollection<DatasetEntry> Entries { get; } = new();
 
     /// <summary>
     /// Header rows surfaced above <see cref="Entries"/> in the Datasets
@@ -897,7 +938,8 @@ internal sealed class DatasetsViewModel : ViewModelBase
         string? displayName = null,
         IReadOnlyList<string>? updateRelativePaths = null,
         int? minimumDisplayScale = null,
-        int? maximumDisplayScale = null)
+        int? maximumDisplayScale = null,
+        ExchangeSets.BoundingBox? geographicBounds = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentException.ThrowIfNullOrEmpty(relativePath);
@@ -915,13 +957,66 @@ internal sealed class DatasetsViewModel : ViewModelBase
             displayName: displayName,
             updateRelativePaths: updateRelativePaths,
             minimumDisplayScale: minimumDisplayScale,
-            maximumDisplayScale: maximumDisplayScale);
+            maximumDisplayScale: maximumDisplayScale,
+            geographicBounds: geographicBounds);
         Entries.Insert(0, entry);
         return entry;
     }
 
     /// <summary>
-    /// Registers a header row for a freshly-opened exchange set. The
+    /// Registers many exchange-set cells in a single batch, raising one
+    /// collection-changed notification for the whole set rather than one per
+    /// cell. Used by the lazy-loading path (issue #458) so opening a very large
+    /// exchange set does not incur O(N²) rebuild work in the grouping / extent
+    /// overlay subscribers and freeze the UI. Each entry is created deferred
+    /// (bytes unloaded) with its catalogue footprint; the returned list is in
+    /// the same order as <paramref name="registrations"/>.
+    /// </summary>
+    /// <param name="registrations">The per-cell registration descriptors.</param>
+    /// <returns>The created (registered, not-yet-loaded) entries.</returns>
+    public IReadOnlyList<DatasetEntry> AddRangeFromExchangeSet(
+        IReadOnlyList<ExchangeSetCellRegistration> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var created = new List<DatasetEntry>(registrations.Count);
+        foreach (var reg in registrations)
+        {
+            var entry = new DatasetEntry(
+                filePath: reg.RelativePath,
+                productSpec: reg.ProductSpec,
+                source: reg.Source,
+                relativePath: reg.RelativePath,
+                displayName: reg.DisplayName,
+                updateRelativePaths: reg.UpdateRelativePaths,
+                minimumDisplayScale: reg.MinimumDisplayScale,
+                maximumDisplayScale: reg.MaximumDisplayScale,
+                geographicBounds: reg.GeographicBounds);
+
+            // Mark the entry deferred *before* it is inserted (and therefore
+            // before the extent-overlay / grouping subscribers attach to it).
+            // The coordinator's later Register call sets IsDeferred = true again,
+            // but because the value is unchanged that set is a no-op and raises
+            // no PropertyChanged — avoiding an O(N²) rebuild storm when a very
+            // large set (thousands of cells) is registered. See issue #458.
+            entry.IsDeferred = true;
+
+            // The bulk insert raises a Reset (no NewItems), so wire the zoom
+            // dispatcher here rather than relying on the collection handler.
+            if (_zoomDispatcher is not null)
+                entry.ZoomDispatcher = _zoomDispatcher;
+
+            created.Add(entry);
+        }
+
+        // Newest datasets sit at the top of the paint stack (index 0), matching
+        // AddFromExchangeSet's single-item semantics.
+        Entries.InsertRange(0, created);
+        return created;
+    }
+
+    /// <summary>
+    /// Registers a header for an opened exchange set. The
     /// supplied <paramref name="closeAction"/> is invoked when the user
     /// clicks the header's Close button and is responsible for removing
     /// every <see cref="DatasetEntry"/> that came from this set

--- a/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/DatasetsViewModel.cs
@@ -982,6 +982,16 @@ internal sealed class DatasetsViewModel : ViewModelBase
         var created = new List<DatasetEntry>(registrations.Count);
         foreach (var reg in registrations)
         {
+            // Validate each registration up front for parity with
+            // AddFromExchangeSet, so a caller that accidentally supplies a null
+            // source or empty RelativePath/ProductSpec fails fast here rather
+            // than creating a DatasetEntry in an invalid state that surfaces as
+            // a harder-to-diagnose failure later. See issue #458.
+            ArgumentNullException.ThrowIfNull(reg);
+            ArgumentNullException.ThrowIfNull(reg.Source);
+            ArgumentException.ThrowIfNullOrEmpty(reg.RelativePath);
+            ArgumentException.ThrowIfNullOrEmpty(reg.ProductSpec);
+
             var entry = new DatasetEntry(
                 filePath: reg.RelativePath,
                 productSpec: reg.ProductSpec,

--- a/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetCellRegistration.cs
+++ b/src/EncDotNet.S100.Viewer/ViewModels/ExchangeSetCellRegistration.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using EncDotNet.S100.Core;
+
+namespace EncDotNet.S100.Viewer.ViewModels;
+
+/// <summary>
+/// Immutable descriptor for one exchange-set cell to register in bulk via
+/// <see cref="DatasetsViewModel.AddRangeFromExchangeSet"/>. Mirrors the
+/// parameters of <see cref="DatasetsViewModel.AddFromExchangeSet"/> so a large
+/// set can be registered with a single collection notification (issue #458).
+/// </summary>
+/// <param name="Source">The asset source the cell's bytes live in.</param>
+/// <param name="RelativePath">The cell's path relative to the source root.</param>
+/// <param name="ProductSpec">The product specification (e.g. <c>"S-57"</c>).</param>
+/// <param name="DisplayName">The cell's display name, or <see langword="null"/>
+/// to derive it from the path.</param>
+/// <param name="UpdateRelativePaths">In-set sequential update file paths.</param>
+/// <param name="MinimumDisplayScale">Coarsest display scale, if known.</param>
+/// <param name="MaximumDisplayScale">Finest display scale, if known.</param>
+/// <param name="GeographicBounds">The cell's EPSG:4326 footprint from the
+/// catalogue, used for viewport culling.</param>
+internal sealed record ExchangeSetCellRegistration(
+    IAssetSource Source,
+    string RelativePath,
+    string ProductSpec,
+    string? DisplayName = null,
+    IReadOnlyList<string>? UpdateRelativePaths = null,
+    int? MinimumDisplayScale = null,
+    int? MaximumDisplayScale = null,
+    ExchangeSets.BoundingBox? GeographicBounds = null);

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetExtentIndicatorControllerTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetExtentIndicatorControllerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EncDotNet.S100.Core;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Datasets.Pipelines.Interoperability;
 using EncDotNet.S100.Viewer;
@@ -163,5 +164,60 @@ public class DatasetExtentIndicatorControllerTests
         controller.Dispose();
 
         Assert.DoesNotContain(host.OverlayLayers, l => l.Name == DatasetExtentIndicatorOverlayLayer.LayerName);
+    }
+
+    private sealed class StubAssetSource : IAssetSource
+    {
+        public Task<System.IO.Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+            => Task.FromResult<System.IO.Stream>(new System.IO.MemoryStream());
+        public void Dispose() { }
+    }
+
+    private static ExchangeSets.BoundingBox Box(double w, double e, double s, double n) => new()
+    {
+        WestBoundLongitude = w,
+        EastBoundLongitude = e,
+        SouthBoundLatitude = s,
+        NorthBoundLatitude = n,
+    };
+
+    private static DatasetEntry DeferredEntry(DatasetsViewModel vm)
+        => vm.AddRangeFromExchangeSet(new List<ExchangeSetCellRegistration>
+        {
+            new(new StubAssetSource(), "a/US1.000", "S-57", GeographicBounds: Box(-123, -122, 37, 38)),
+        })[0];
+
+    [Fact]
+    public void DeferredVisibleEntry_ProducesOutline()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        var entry = DeferredEntry(vm);
+
+        Assert.True(entry.IsDeferred);
+        Assert.True(entry.IsVisible);
+        Assert.Equal(1, FeatureCount(host));
+    }
+
+    [Fact]
+    public void HiddenDeferredEntry_ProducesNoOutline()
+    {
+        var host = new FakeMapHost();
+        var vm = new DatasetsViewModel(new NoopLoader());
+        using var controller = new DatasetExtentIndicatorController(
+            host, vm, new StubMeasureOverlayAppearanceProvider(), NewSettings(),
+            marshal: a => a());
+
+        var entry = DeferredEntry(vm);
+        Assert.Equal(1, FeatureCount(host));
+
+        // Hiding a deferred cell must remove its outline too, consistent with
+        // hiding a loaded dataset (issue #458).
+        entry.IsVisible = false;
+        Assert.Equal(0, FeatureCount(host));
     }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelAddRangeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelAddRangeTests.cs
@@ -144,4 +144,46 @@ public class DatasetsViewModelAddRangeTests
         Assert.Equal(1, resets);
         Assert.Equal(0, otherActions);
     }
+
+    [Fact]
+    public void AddRangeFromExchangeSet_EmptyRelativePath_Throws()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var regs = new List<ExchangeSetCellRegistration>
+        {
+            new(src, "", "S-57"),
+        };
+
+        Assert.Throws<ArgumentException>(() => vm.AddRangeFromExchangeSet(regs));
+        // A rejected batch must not partially register anything.
+        Assert.Empty(vm.Entries);
+    }
+
+    [Fact]
+    public void AddRangeFromExchangeSet_EmptyProductSpec_Throws()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var regs = new List<ExchangeSetCellRegistration>
+        {
+            new(src, "a/US1.000", ""),
+        };
+
+        Assert.Throws<ArgumentException>(() => vm.AddRangeFromExchangeSet(regs));
+        Assert.Empty(vm.Entries);
+    }
+
+    [Fact]
+    public void AddRangeFromExchangeSet_NullSource_Throws()
+    {
+        var vm = NewVm();
+        var regs = new List<ExchangeSetCellRegistration>
+        {
+            new(null!, "a/US1.000", "S-57"),
+        };
+
+        Assert.Throws<ArgumentNullException>(() => vm.AddRangeFromExchangeSet(regs));
+        Assert.Empty(vm.Entries);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelAddRangeTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/DatasetsViewModelAddRangeTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Interoperability;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.ViewModels;
+using Mapsui.Layers;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Covers the batched exchange-set registration path
+/// (<see cref="DatasetsViewModel.AddRangeFromExchangeSet"/>) added for
+/// lazy loading of very large sets (issue #458). The key contract is that
+/// entries are created <em>already deferred</em> and inserted with a single
+/// collection notification, so the later coordinator <c>Register</c> — which
+/// re-asserts <c>IsDeferred = true</c> — raises no per-entry change events
+/// (avoiding an O(N²) extent/grouping rebuild storm).
+/// </summary>
+public class DatasetsViewModelAddRangeTests
+{
+    private sealed class StubAssetSource : IAssetSource
+    {
+        public Task<Stream> OpenAsync(string relativePath, CancellationToken cancellationToken = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public void Dispose() { }
+    }
+
+    private sealed class NoopLoader : IDatasetLoaderService
+    {
+        public IReadOnlyDictionary<DatasetEntry, IDatasetProcessor> Processors { get; }
+            = new Dictionary<DatasetEntry, IDatasetProcessor>();
+        public IReadOnlyDictionary<DatasetEntry, IReadOnlyList<ILayer>> EntryLayers { get; }
+            = new Dictionary<DatasetEntry, IReadOnlyList<ILayer>>();
+        public event Action<DatasetEntry>? DatasetLoaded { add { } remove { } }
+        public event Action<DatasetEntry>? DatasetRemoved { add { } remove { } }
+        public void Initialize(IMapHost host, ViewerCommandSettings? options) { }
+        public Task LoadAsync(DatasetEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ReRenderAtTimeAsync(DateTime t, CancellationToken ct) => Task.CompletedTask;
+        public Task ReRenderAllAsync() => Task.CompletedTask;
+        public void RemoveEntry(DatasetEntry entry) { }
+        public void SetEntryOrder(IReadOnlyList<DatasetEntry> ordered) { }
+        public IReadOnlyList<ILayer> CurrentStackedLayers => Array.Empty<ILayer>();
+        public IReadOnlyList<LayerStackEntry> CurrentStackEntries => Array.Empty<LayerStackEntry>();
+        public event Action? LayerStackChanged { add { } remove { } }
+        public bool GetActive(string datasetId) => true;
+        public void SetActive(string datasetId, bool active) { }
+        public event Action<string>? ActiveChanged { add { } remove { } }
+    }
+
+    private static DatasetsViewModel NewVm() => new(new NoopLoader());
+
+    private static ExchangeSets.BoundingBox Box(double w, double e, double s, double n) => new()
+    {
+        WestBoundLongitude = w,
+        EastBoundLongitude = e,
+        SouthBoundLatitude = s,
+        NorthBoundLatitude = n,
+    };
+
+    [Fact]
+    public void AddRangeFromExchangeSet_CreatesEntriesAlreadyDeferred_InOrder()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var regs = new List<ExchangeSetCellRegistration>
+        {
+            new(src, "a/US1.000", "S-57", DisplayName: "US1", GeographicBounds: Box(-123, -122, 37, 38)),
+            new(src, "a/US2.000", "S-57", DisplayName: "US2", GeographicBounds: Box(-124, -123, 38, 39)),
+            new(src, "a/US3.000", "S-57", DisplayName: "US3"),
+        };
+
+        var created = vm.AddRangeFromExchangeSet(regs);
+
+        Assert.Equal(3, created.Count);
+        Assert.All(created, e => Assert.True(e.IsDeferred));
+        Assert.Equal("US1", created[0].DisplayName);
+        Assert.Equal("US2", created[1].DisplayName);
+        Assert.Equal("US3", created[2].DisplayName);
+        Assert.Equal(3, vm.Entries.Count);
+        // A deferred entry is dimmed in the panel.
+        Assert.Equal(0.5, created[0].RowOpacity);
+    }
+
+    [Fact]
+    public void ReassertingIsDeferredTrue_OnBornDeferredEntry_RaisesNoPropertyChanged()
+    {
+        // This is the crux of the O(N²) fix (issue #458): entries are born
+        // deferred, so the coordinator's later `IsDeferred = true` is a no-op
+        // that raises no PropertyChanged — hence no per-entry extent rebuild.
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var created = vm.AddRangeFromExchangeSet(new List<ExchangeSetCellRegistration>
+        {
+            new(src, "a/US1.000", "S-57", GeographicBounds: Box(-123, -122, 37, 38)),
+        });
+
+        var entry = created[0];
+        Assert.True(entry.IsDeferred);
+
+        var raised = new List<string?>();
+        PropertyChangedEventHandler handler = (_, e) => raised.Add(e.PropertyName);
+        entry.PropertyChanged += handler;
+        try
+        {
+            entry.IsDeferred = true; // re-assert the unchanged value
+        }
+        finally
+        {
+            entry.PropertyChanged -= handler;
+        }
+
+        Assert.Empty(raised);
+    }
+
+    [Fact]
+    public void AddRangeFromExchangeSet_RaisesSingleResetNotification()
+    {
+        var vm = NewVm();
+        var src = new StubAssetSource();
+        var resets = 0;
+        var otherActions = 0;
+        vm.Entries.CollectionChanged += (_, e) =>
+        {
+            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+                resets++;
+            else
+                otherActions++;
+        };
+
+        vm.AddRangeFromExchangeSet(new List<ExchangeSetCellRegistration>
+        {
+            new(src, "a/US1.000", "S-57"),
+            new(src, "a/US2.000", "S-57"),
+            new(src, "a/US3.000", "S-57"),
+        });
+
+        Assert.Equal(1, resets);
+        Assert.Equal(0, otherActions);
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Concurrent;
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S100.Viewer.Services;
+using EncDotNet.S100.Viewer.Services.LazyLoading;
+using EncDotNet.S100.Viewer.ViewModels;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ExchangeSetLazyLoadCoordinator"/> — the stateful
+/// glue that turns viewport changes into gated cell loads and LRU evictions
+/// (issue #458). Debounce is disabled so <c>Evaluate</c> runs synchronously.
+/// </summary>
+public sealed class ExchangeSetLazyLoadCoordinatorTests
+{
+    private static DatasetEntry Cell(string name, double south, double west, double north, double east)
+        => new(
+            filePath: name + ".000",
+            productSpec: "S-57",
+            source: null,
+            relativePath: name + ".000",
+            displayName: name,
+            geographicBounds: new BoundingBox
+            {
+                WestBoundLongitude = west,
+                EastBoundLongitude = east,
+                SouthBoundLatitude = south,
+                NorthBoundLatitude = north,
+            });
+
+    // A viewport over the US east coast, zoomed in tight (small mercator
+    // resolution → large scale, so all usage bands are eligible).
+    private static MapViewportSnapshot Viewport(
+        double south, double west, double north, double east, double resolution = 5.0)
+        => new()
+        {
+            MinLatitude = south,
+            MinLongitude = west,
+            MaxLatitude = north,
+            MaxLongitude = east,
+            MercatorResolution = resolution,
+        };
+
+    private sealed class FakeNotifier : IMapViewportNotifier
+    {
+        public MapViewportSnapshot? Current { get; private set; }
+        public event EventHandler<MapViewportSnapshot>? ViewportChanged;
+        public void Publish(MapViewportSnapshot snapshot)
+        {
+            Current = snapshot;
+            ViewportChanged?.Invoke(this, snapshot);
+        }
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(10);
+        }
+        return condition();
+    }
+
+    private static ExchangeSetLazyLoadCoordinator Create(
+        FakeNotifier notifier,
+        ConcurrentBag<DatasetEntry> loaded,
+        ConcurrentBag<DatasetEntry> unloaded,
+        LazyLoadOptions? options = null)
+        => new(
+            notifier,
+            (entry, _) => { loaded.Add(entry); return Task.CompletedTask; },
+            entry => unloaded.Add(entry),
+            options ?? new LazyLoadOptions { ViewportDebounce = TimeSpan.Zero });
+
+    [Fact]
+    public async Task InViewCell_IsLoaded()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, unloaded);
+
+        var cell = Cell("US5A", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+        notifier.Publish(Viewport(40, -75, 41, -74));
+
+        Assert.True(await WaitUntilAsync(() => loaded.Contains(cell)));
+        Assert.False(cell.IsDeferred);
+    }
+
+    [Fact]
+    public async Task OutOfViewCell_IsNotLoaded()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, unloaded);
+
+        var farCell = Cell("US5B", 0, 10, 1, 11); // off the coast of Africa
+        coordinator.Register(new[] { farCell });
+        notifier.Publish(Viewport(40, -75, 41, -74));
+
+        await Task.Delay(100);
+        Assert.DoesNotContain(farCell, loaded);
+        Assert.True(farCell.IsDeferred);
+    }
+
+    [Fact]
+    public async Task Register_MarksEntriesDeferred()
+    {
+        var notifier = new FakeNotifier();
+        var coordinator = Create(notifier, new(), new());
+
+        var cell = Cell("US5C", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+
+        Assert.True(cell.IsDeferred);
+        Assert.Equal(1, coordinator.DeferredCount);
+        coordinator.Dispose();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ZoomedOut_LargeScaleBandCells_NotLoaded()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, new());
+
+        // Band 5 (Harbour) cell — only relevant at large scale. A very coarse
+        // resolution (zoomed way out) should keep it deferred even though it
+        // intersects the viewport.
+        var harbourCell = Cell("US5HARBOR", 40, -75, 41, -74);
+        coordinator.Register(new[] { harbourCell });
+        notifier.Publish(Viewport(30, -85, 50, -65, resolution: 3000.0));
+
+        await Task.Delay(100);
+        Assert.DoesNotContain(harbourCell, loaded);
+    }
+
+    [Fact]
+    public async Task RetentionBudget_EvictsOffScreenColdCells()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, unloaded,
+            new LazyLoadOptions { ViewportDebounce = TimeSpan.Zero, RetentionBudget = 1 });
+
+        var a = Cell("US5AA", 40, -75, 41, -74);
+        var b = Cell("US5BB", 40, -74, 41, -73);
+        coordinator.Register(new[] { a, b });
+
+        // Frame both cells so both load.
+        notifier.Publish(Viewport(40, -75, 41, -73));
+        Assert.True(await WaitUntilAsync(() => coordinator.LoadedCount == 2));
+
+        // Pan away entirely; both are now off-screen and over the budget of 1,
+        // so eviction unloads the coldest.
+        notifier.Publish(Viewport(0, 10, 1, 11));
+
+        Assert.True(await WaitUntilAsync(() => unloaded.Count >= 1));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -202,4 +202,47 @@ public sealed class ExchangeSetLazyLoadCoordinatorTests
         Assert.True(await WaitUntilAsync(() => unloaded.Contains(cell)));
         Assert.Equal(0, coordinator.LoadedCount);
     }
+
+    [Fact]
+    public async Task DisposeDuringInFlightLoad_DoesNotThrow()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+
+        var release = new TaskCompletionSource();
+        var started = new TaskCompletionSource();
+        var coordinator = new ExchangeSetLazyLoadCoordinator(
+            notifier,
+            async (entry, _) =>
+            {
+                started.TrySetResult();
+                await release.Task;
+                loaded.Add(entry);
+            },
+            entry => unloaded.Add(entry),
+            new LazyLoadOptions { ViewportDebounce = TimeSpan.Zero });
+
+        var cell = Cell("US5DD", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+        notifier.Publish(Viewport(40, -75, 41, -74));
+
+        Assert.True(await WaitUntilAsync(() => started.Task.IsCompleted));
+
+        // Dispose (which disposes the internal semaphore) while the load is
+        // in-flight, then let it finish; the fire-and-forget pump must not
+        // surface an unobserved ObjectDisposedException on WaitAsync/Release.
+        coordinator.Dispose();
+        release.SetResult();
+
+        // Give the pump time to run its finally block, then flush finalizers to
+        // surface any unobserved task exception.
+        await Task.Delay(100);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        // A disposed coordinator that swallowed the teardown race must not have
+        // re-marked the closed cell loaded.
+        Assert.Equal(0, coordinator.LoadedCount);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -164,4 +164,42 @@ public sealed class ExchangeSetLazyLoadCoordinatorTests
 
         Assert.True(await WaitUntilAsync(() => unloaded.Count >= 1));
     }
+
+    [Fact]
+    public async Task LoadCompletingAfterUnregister_IsUnwound()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+
+        // A load delegate that blocks until released, so we can Unregister the
+        // cell mid-flight and prove the finished load is unwound rather than
+        // marked loaded (no zombie layers). See issue #458.
+        var release = new TaskCompletionSource();
+        var started = new TaskCompletionSource();
+        using var coordinator = new ExchangeSetLazyLoadCoordinator(
+            notifier,
+            async (entry, _) =>
+            {
+                started.TrySetResult();
+                await release.Task;
+                loaded.Add(entry);
+            },
+            entry => unloaded.Add(entry),
+            new LazyLoadOptions { ViewportDebounce = TimeSpan.Zero });
+
+        var cell = Cell("US5ZZ", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+        notifier.Publish(Viewport(40, -75, 41, -74));
+
+        // Wait until the load is in-flight, then close the exchange set.
+        Assert.True(await WaitUntilAsync(() => started.Task.IsCompleted));
+        coordinator.Unregister(new[] { cell });
+
+        // Let the (now-stale) load finish.
+        release.SetResult();
+
+        Assert.True(await WaitUntilAsync(() => unloaded.Contains(cell)));
+        Assert.Equal(0, coordinator.LoadedCount);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -302,6 +302,28 @@ public sealed class ExchangeSetLazyLoadCoordinatorTests
     }
 
     [Fact]
+    public async Task Register_AlreadyLoadedCell_IsNotReMarkedDeferred()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, unloaded);
+
+        var cell = Cell("US5HH", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+        notifier.Publish(Viewport(40, -75, 41, -74));
+        Assert.True(await WaitUntilAsync(() => coordinator.LoadedCount == 1));
+        Assert.False(cell.IsDeferred);
+
+        // Re-registering the same (now-loaded) cell must be idempotent: it must
+        // not re-mark the cell deferred (which would dim it and show a deferred
+        // outline) or disturb its loaded state. See issue #458.
+        coordinator.Register(new[] { cell });
+        Assert.False(cell.IsDeferred);
+        Assert.Equal(1, coordinator.LoadedCount);
+    }
+
+    [Fact]
     public async Task QueuedLoad_AbandonedWhenUnregisteredBeforeGate()
     {
         var notifier = new FakeNotifier();

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -300,4 +300,62 @@ public sealed class ExchangeSetLazyLoadCoordinatorTests
         await Task.Delay(80);
         Assert.Single(loaded);
     }
+
+    [Fact]
+    public async Task QueuedLoad_AbandonedWhenUnregisteredBeforeGate()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+
+        var firstStarted = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        var gate = new object();
+        DatasetEntry? blocker = null;
+
+        // MaxConcurrency = 1: the first cell to acquire the gate blocks it while
+        // the second waits queued behind it. See issue #458.
+        using var coordinator = new ExchangeSetLazyLoadCoordinator(
+            notifier,
+            async (entry, _) =>
+            {
+                bool isBlocker;
+                lock (gate)
+                {
+                    isBlocker = blocker is null;
+                    if (isBlocker) blocker = entry;
+                }
+                if (isBlocker)
+                {
+                    firstStarted.TrySetResult();
+                    await release.Task;
+                }
+                loaded.Add(entry);
+            },
+            entry => unloaded.Add(entry),
+            new LazyLoadOptions { ViewportDebounce = TimeSpan.Zero, MaxConcurrency = 1 });
+
+        var cellA = Cell("US5GA", 40, -75, 41, -74);
+        var cellB = Cell("US5GB", 40, -75, 41, -74);
+        coordinator.Register(new[] { cellA, cellB });
+        notifier.Publish(Viewport(40, -75, 41, -74));
+
+        Assert.True(await WaitUntilAsync(() => firstStarted.Task.IsCompleted));
+
+        // Close the cell still queued on the gate (whichever did not win it).
+        var queued = ReferenceEquals(blocker, cellA) ? cellB : cellA;
+        coordinator.Unregister(new[] { queued });
+
+        // Release the blocker; the queued load now acquires the gate and must
+        // abandon before running the expensive _loadAsync.
+        release.SetResult();
+
+        Assert.True(await WaitUntilAsync(() => loaded.Contains(blocker!)));
+        await Task.Delay(50);
+
+        // The queued cell's load never ran (not added to loaded), and since no
+        // layers were built it is not unwound either.
+        Assert.DoesNotContain(queued, loaded);
+        Assert.DoesNotContain(queued, unloaded);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -245,4 +245,30 @@ public sealed class ExchangeSetLazyLoadCoordinatorTests
         // re-marked the closed cell loaded.
         Assert.Equal(0, coordinator.LoadedCount);
     }
+
+    [Fact]
+    public async Task UnregisterLoadedCell_IsNotReTouchedByLaterEvaluate()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, unloaded);
+
+        var cell = Cell("US5EE", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+
+        // Frame it so it loads and enters the LRU mirror.
+        notifier.Publish(Viewport(40, -75, 41, -74));
+        Assert.True(await WaitUntilAsync(() => coordinator.LoadedCount == 1));
+
+        // Close the exchange set: the entry must be forgotten completely.
+        coordinator.Unregister(new[] { cell });
+        Assert.Equal(0, coordinator.LoadedCount);
+
+        // A later viewport tick that still intersects the (now-unregistered)
+        // footprint must not resurrect it into the LRU.
+        notifier.Publish(Viewport(40, -75, 41, -74));
+        await Task.Delay(50);
+        Assert.Equal(0, coordinator.LoadedCount);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/ExchangeSetLazyLoadCoordinatorTests.cs
@@ -271,4 +271,33 @@ public sealed class ExchangeSetLazyLoadCoordinatorTests
         await Task.Delay(50);
         Assert.Equal(0, coordinator.LoadedCount);
     }
+
+    [Fact]
+    public async Task DebouncedRapidViewportChanges_EvaluateOnlyLatestSnapshot()
+    {
+        var notifier = new FakeNotifier();
+        var loaded = new ConcurrentBag<DatasetEntry>();
+        var unloaded = new ConcurrentBag<DatasetEntry>();
+        using var coordinator = Create(notifier, loaded, unloaded,
+            new LazyLoadOptions { ViewportDebounce = TimeSpan.FromMilliseconds(60) });
+
+        var cell = Cell("US5FF", 40, -75, 41, -74);
+        coordinator.Register(new[] { cell });
+
+        // Rapidly publish several viewports away from the cell, then finally
+        // one that frames it. On the debounced path only the latest snapshot
+        // must drive Evaluate(), so the cell loads exactly once and the
+        // superseded snapshots never fire.
+        notifier.Publish(Viewport(0, 10, 1, 11));
+        notifier.Publish(Viewport(0, 20, 1, 21));
+        notifier.Publish(Viewport(40, -75, 41, -74));
+
+        Assert.True(await WaitUntilAsync(() => loaded.Contains(cell)));
+        Assert.Equal(1, coordinator.LoadedCount);
+        Assert.False(cell.IsDeferred);
+
+        // Give any stale continuation the chance to (incorrectly) re-run.
+        await Task.Delay(80);
+        Assert.Single(loaded);
+    }
 }

--- a/tests/EncDotNet.S100.Viewer.Tests/LazyCellGateTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LazyCellGateTests.cs
@@ -1,0 +1,132 @@
+using EncDotNet.S100.ExchangeSets;
+using EncDotNet.S100.Viewer.Services.LazyLoading;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+public class CellUsageBandTests
+{
+    [Theory]
+    [InlineData("US1EEZ1M", 1)]
+    [InlineData("US2EEZ2M", 2)]
+    [InlineData("US3GC09M", 3)]
+    [InlineData("US4CA52M", 4)]
+    [InlineData("US5NY1AM", 5)]
+    [InlineData("US6CN01M", 6)]
+    public void TryParse_ValidBand_ReturnsDigit(string name, int expected)
+    {
+        Assert.Equal(expected, CellUsageBand.TryParse(name));
+    }
+
+    [Theory]
+    [InlineData("US1EEZ1M.000", 1)]
+    [InlineData("US5NY1AM.001", 5)]
+    [InlineData("US1EEZ1M/US1EEZ1M.000", 1)]
+    [InlineData("subdir\\US6CN01M.000", 6)]
+    public void TryParse_WithExtensionOrPath_StripsAndParses(string name, int expected)
+    {
+        Assert.Equal(expected, CellUsageBand.TryParse(name));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("US")]           // too short
+    [InlineData("USXEEZ1M")]     // non-digit band
+    [InlineData("US0EEZ1M")]     // band 0 out of range
+    [InlineData("US7EEZ1M")]     // band 7 out of range
+    public void TryParse_Invalid_ReturnsNull(string? name)
+    {
+        Assert.Null(CellUsageBand.TryParse(name));
+    }
+}
+
+public class LazyCellGateTests
+{
+    private static BoundingBox Box(double s, double w, double n, double e) => new()
+    {
+        SouthBoundLatitude = s,
+        WestBoundLongitude = w,
+        NorthBoundLatitude = n,
+        EastBoundLongitude = e,
+    };
+
+    [Fact]
+    public void IntersectsViewport_Overlapping_True()
+    {
+        var cell = Box(40, -74, 41, -73);
+        Assert.True(LazyCellGate.IntersectsViewport(cell, 40.5, -73.5, 42, -72));
+    }
+
+    [Fact]
+    public void IntersectsViewport_Disjoint_False()
+    {
+        var cell = Box(40, -74, 41, -73);
+        Assert.False(LazyCellGate.IntersectsViewport(cell, 10, 10, 20, 20));
+    }
+
+    [Fact]
+    public void IntersectsViewport_TouchingEdge_True()
+    {
+        var cell = Box(40, -74, 41, -73);
+        // Viewport's south edge exactly on the cell's north edge.
+        Assert.True(LazyCellGate.IntersectsViewport(cell, 41, -74, 42, -73));
+    }
+
+    [Fact]
+    public void IntersectsViewport_NullFootprint_TreatedAsIntersecting()
+    {
+        Assert.True(LazyCellGate.IntersectsViewport(null, 10, 10, 20, 20));
+    }
+
+    [Fact]
+    public void IsBandEligible_OverviewAlwaysEligible()
+    {
+        Assert.True(LazyCellGate.IsBandEligible(1, 50_000_000));
+        Assert.True(LazyCellGate.IsBandEligible(1, 1_000));
+    }
+
+    [Fact]
+    public void IsBandEligible_BerthingOnlyWhenZoomedIn()
+    {
+        Assert.False(LazyCellGate.IsBandEligible(6, 2_000_000)); // zoomed out
+        Assert.True(LazyCellGate.IsBandEligible(6, 5_000));      // zoomed in
+    }
+
+    [Fact]
+    public void IsBandEligible_UnknownBandOrScale_FailsOpen()
+    {
+        Assert.True(LazyCellGate.IsBandEligible(null, 2_000_000));
+        Assert.True(LazyCellGate.IsBandEligible(5, double.NaN));
+        Assert.True(LazyCellGate.IsBandEligible(5, 0));
+    }
+
+    [Fact]
+    public void ShouldBeLoaded_RequiresBothIntersectionAndBand()
+    {
+        var cell = Box(40, -74, 41, -73);
+
+        // In view but wrong band (harbour cell, zoomed way out).
+        Assert.False(LazyCellGate.ShouldBeLoaded(cell, 6, 3_000_000, 39, -75, 42, -72));
+
+        // In view and appropriate band.
+        Assert.True(LazyCellGate.ShouldBeLoaded(cell, 6, 5_000, 39, -75, 42, -72));
+
+        // Right band but out of view.
+        Assert.False(LazyCellGate.ShouldBeLoaded(cell, 6, 5_000, 10, 10, 20, 20));
+    }
+
+    [Fact]
+    public void ScaleDenominator_AtEquator_MatchesFormula()
+    {
+        // 50.4 m/px at the equator → 50.4 / 0.00028 = 180 000.
+        var denom = LazyCellGate.ScaleDenominator(50.4, 0.0);
+        Assert.InRange(denom, 179_900, 180_100);
+    }
+
+    [Fact]
+    public void ScaleDenominator_NonPositive_ReturnsNaN()
+    {
+        Assert.True(double.IsNaN(LazyCellGate.ScaleDenominator(0, 0)));
+        Assert.True(double.IsNaN(LazyCellGate.ScaleDenominator(-1, 0)));
+    }
+}

--- a/tests/EncDotNet.S100.Viewer.Tests/LazyCellGateTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LazyCellGateTests.cs
@@ -79,6 +79,39 @@ public class LazyCellGateTests
     }
 
     [Fact]
+    public void IntersectsViewport_SeamCrossingCell_ViewportInEasternSegment_True()
+    {
+        // Cell spans the ±180° seam: west 170°E .. east -170°W (west > east).
+        var cell = Box(-10, 170, 10, -170);
+        // Viewport at 175..179°E lies in the cell's [170, +180] segment.
+        Assert.True(LazyCellGate.IntersectsViewport(cell, -5, 175, 5, 179));
+    }
+
+    [Fact]
+    public void IntersectsViewport_SeamCrossingCell_ViewportInWesternSegment_True()
+    {
+        var cell = Box(-10, 170, 10, -170);
+        // Viewport at -179..-175°W lies in the cell's [-180, -170] segment.
+        Assert.True(LazyCellGate.IntersectsViewport(cell, -5, -179, 5, -175));
+    }
+
+    [Fact]
+    public void IntersectsViewport_SeamCrossingCell_ViewportInGap_False()
+    {
+        var cell = Box(-10, 170, 10, -170);
+        // Viewport at 0..10°E lies in the un-covered gap (-170 .. 170).
+        Assert.False(LazyCellGate.IntersectsViewport(cell, -5, 0, 5, 10));
+    }
+
+    [Fact]
+    public void IntersectsViewport_SeamCrossingViewport_NonWrappingCell_True()
+    {
+        // Non-wrapping cell at 175..179°E; viewport crosses the seam.
+        var cell = Box(-10, 175, 10, 179);
+        Assert.True(LazyCellGate.IntersectsViewport(cell, -5, 170, 5, -170));
+    }
+
+    [Fact]
     public void IsBandEligible_OverviewAlwaysEligible()
     {
         Assert.True(LazyCellGate.IsBandEligible(1, 50_000_000));

--- a/tests/EncDotNet.S100.Viewer.Tests/LruEvictionPolicyTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LruEvictionPolicyTests.cs
@@ -66,7 +66,7 @@ public sealed class LruEvictionPolicyTests
         lru.Touch("c");
 
         var protectedKeys = new HashSet<string> { "a" };
-        var victims = lru.SelectEvictions(retentionBudget: 2, protectedKeys);
+        var victims = lru.SelectEvictions(retentionBudget: 2, protectedKeys: protectedKeys);
 
         // One over budget: the coldest is 'a' but it is protected, so the next
         // coldest unprotected key ('b') is evicted instead.

--- a/tests/EncDotNet.S100.Viewer.Tests/LruEvictionPolicyTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/LruEvictionPolicyTests.cs
@@ -1,0 +1,111 @@
+using EncDotNet.S100.Viewer.Services.LazyLoading;
+using Xunit;
+
+namespace EncDotNet.S100.Viewer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="LruEvictionPolicy{TKey}"/>, the pure
+/// least-recently-used bookkeeping behind lazy-load eviction (issue #458).
+/// </summary>
+public sealed class LruEvictionPolicyTests
+{
+    [Fact]
+    public void Touch_ReportsNewlyAdded()
+    {
+        var lru = new LruEvictionPolicy<string>();
+
+        Assert.True(lru.Touch("a"));
+        Assert.False(lru.Touch("a"));
+        Assert.Equal(1, lru.Count);
+    }
+
+    [Fact]
+    public void SelectEvictions_UnderBudget_ReturnsNothing()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a");
+        lru.Touch("b");
+
+        Assert.Empty(lru.SelectEvictions(retentionBudget: 5));
+    }
+
+    [Fact]
+    public void SelectEvictions_OverBudget_EvictsColdestFirst()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a"); // coldest
+        lru.Touch("b");
+        lru.Touch("c"); // warmest
+
+        var victims = lru.SelectEvictions(retentionBudget: 1);
+
+        // Two over budget: the two coldest, coldest first.
+        Assert.Equal(new[] { "a", "b" }, victims);
+    }
+
+    [Fact]
+    public void Touch_MovesKeyToWarmEnd()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a");
+        lru.Touch("b");
+        lru.Touch("c");
+        lru.Touch("a"); // 'a' is now warmest; 'b' is coldest
+
+        var victims = lru.SelectEvictions(retentionBudget: 2);
+
+        Assert.Equal(new[] { "b" }, victims);
+    }
+
+    [Fact]
+    public void SelectEvictions_NeverEvictsProtectedKeys()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a");
+        lru.Touch("b");
+        lru.Touch("c");
+
+        var protectedKeys = new HashSet<string> { "a" };
+        var victims = lru.SelectEvictions(retentionBudget: 2, protectedKeys);
+
+        // One over budget: the coldest is 'a' but it is protected, so the next
+        // coldest unprotected key ('b') is evicted instead.
+        Assert.DoesNotContain("a", victims);
+        Assert.Equal(new[] { "b" }, victims);
+    }
+
+    [Fact]
+    public void SelectEvictions_DoesNotRemoveFromTracking()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a");
+        lru.Touch("b");
+
+        _ = lru.SelectEvictions(retentionBudget: 0);
+
+        // Selection is advisory; the caller removes explicitly.
+        Assert.Equal(2, lru.Count);
+    }
+
+    [Fact]
+    public void Remove_StopsTracking()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a");
+        lru.Touch("b");
+
+        lru.Remove("a");
+
+        Assert.False(lru.Contains("a"));
+        Assert.Equal(1, lru.Count);
+    }
+
+    [Fact]
+    public void SelectEvictions_NegativeBudget_TreatedAsZero()
+    {
+        var lru = new LruEvictionPolicy<string>();
+        lru.Touch("a");
+
+        Assert.Equal(new[] { "a" }, lru.SelectEvictions(retentionBudget: -5));
+    }
+}


### PR DESCRIPTION
## Problem

Opening a large S-57 exchange set (e.g. the 7,184-cell set) loaded every cell eagerly, **freezing the UI thread** and **exhausting memory** (~33 GB, near-OOM). Fixes #458.

## Approach — viewport-driven lazy loading

Above a threshold (default 50 cells), every cell is **registered** but its bytes are **deferred**:

- The Datasets panel lists all cells immediately (dimmed) with their footprints drawn as extent outlines.
- A coordinator loads only the cells that are in view at a relevant scale (usage-band → scale gate + viewport intersection), through a bounded-concurrency gate, with LRU eviction beyond a retention budget.
- Pure, unit-tested decision core: `CellUsageBand`, `LazyCellGate`, `LruEvictionPolicy`; stateful `ExchangeSetLazyLoadCoordinator` bridges the viewport notifier to gated loads/evictions.
- Registration is batched via `DatasetsViewModel.AddRangeFromExchangeSet` (backed by `BulkObservableCollection`) so thousands of cells register with a **single** collection notification. Entries are **born deferred**, so the coordinator's `IsDeferred` re-assertion is a guarded no-op — this removed a hidden **O(N²)** extent/grouping rebuild that alone cost ~29s on the real set.

## Measured (real 7,184-cell set)

| | before | after |
|---|---|---|
| open time | ~32–139 s (UI blocked) | **~3 s** |
| UI during open | frozen | **responsive** (concurrent `set_viewport` returned in 0.05 s) |
| peak RSS | ~33 GB | **~3.9 GB** |
| cells resident | 7,184 | **~16–27** |

## Tests

- New `AddRangeFromExchangeSet` tests (born-deferred, single Reset, no-op re-assert) plus lazy-core tests (`LazyCellGate`, `LruEvictionPolicy`, coordinator).
- Full viewer suite green: **1522 passed, 3 skipped**.

## Scope / follow-up (deferred — see #458)

Kept intentionally scoped to **S-57** exchange sets (the demonstrated pain). Noted for a follow-up generalization pass:

1. Coalesce the O(N²) layer reorder in `DatasetLoaderService` (no longer a bottleneck now that resident cells are bounded).
2. Extend deferral to the S-100 `CATALOG.XML` open path (`BoundingBox` already available).
3. Extend deferral to the loose-cell-folder path.
4. Generalize the coordinator into a product-agnostic "registered vs. loaded" cell abstraction so any multi-cell opener can feed it — the refactor to do before wiring 2–3.

S-100 sets are typically < 50 cells and stay eager for now.