### PR TITLE
Order overlapping ENC cells by scale band, not load order (#464)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
@@ -239,7 +239,8 @@ public sealed class HeadlessCompositor
                     sub.Plane,
                     sub.WithinPlanePriority,
                     vector.SourceDatasetId,
-                    sub.SourceFeatureType));
+                    sub.SourceFeatureType,
+                    SourceScaleDenominator: vector.CellMinimumDisplayScale));
             }
             return (items, vector.Spec.Name, vector.SourceDatasetId);
         }

--- a/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/HeadlessCompositor.cs
@@ -239,8 +239,10 @@ public sealed class HeadlessCompositor
                     sub.Plane,
                     sub.WithinPlanePriority,
                     vector.SourceDatasetId,
-                    sub.SourceFeatureType,
-                    SourceScaleDenominator: vector.CellMinimumDisplayScale));
+                    sub.SourceFeatureType)
+                {
+                    SourceScaleDenominator = vector.CellMinimumDisplayScale,
+                });
             }
             return (items, vector.Spec.Name, vector.SourceDatasetId);
         }

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
@@ -70,9 +70,12 @@ public sealed class InteroperabilityAuthority : IInteroperabilityAuthority
         // denominator is a larger-scale (finer) cell, which must paint on top,
         // so we sort by denominator DESCENDING (coarse first / bottom, fine
         // last / top). Items with no known scale (null) are treated as coarsest
-        // (int.MaxValue) so they sit at the bottom of their plane and preserve
-        // their relative load order among themselves — leaving the prior
-        // behaviour unchanged for products that carry no cell-wide scale.
+        // (int.MaxValue): they keep their relative load order AMONG THEMSELVES,
+        // but a known-scale (finer) item in the same plane/priority now sorts
+        // ABOVE them where previously the two would have been decided purely by
+        // load order. Products that carry no cell-wide scale at all (all GML and
+        // coverage items are null) are therefore unaffected relative to each
+        // other; only mixed null/known groups shift.
         return entries
             .OrderBy(e => (int)e.Plane)
             .ThenBy(e => e.WithinPlanePriority)

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/InteroperabilityAuthority.cs
@@ -7,7 +7,7 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// Resolves the per-product default plane from a hardcoded table
 /// derived from S-98 Main §9.2.1 / MSC.530(106)/Rev.1 §Appendix 2
 /// "priority of information"; sorts entries by
-/// <c>(Plane, WithinPlanePriority, input order)</c>.
+/// <c>(Plane, WithinPlanePriority, scale denominator descending, input order)</c>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -61,12 +61,22 @@ public sealed class InteroperabilityAuthority : IInteroperabilityAuthority
         ArgumentNullException.ThrowIfNull(entries);
 
         // OrderBy is documented as a stable sort in LINQ-to-Objects,
-        // so entries that share (Plane, WithinPlanePriority) retain
+        // so entries that share (Plane, WithinPlanePriority, scale) retain
         // their input order — that's the dataset-load-order tiebreaker
         // required by §4.3.2 of the design note.
+        //
+        // The scale tiebreaker (issue #464) orders overlapping cells of
+        // different navigational-purpose bands deterministically: a smaller
+        // denominator is a larger-scale (finer) cell, which must paint on top,
+        // so we sort by denominator DESCENDING (coarse first / bottom, fine
+        // last / top). Items with no known scale (null) are treated as coarsest
+        // (int.MaxValue) so they sit at the bottom of their plane and preserve
+        // their relative load order among themselves — leaving the prior
+        // behaviour unchanged for products that carry no cell-wide scale.
         return entries
             .OrderBy(e => (int)e.Plane)
             .ThenBy(e => e.WithinPlanePriority)
+            .ThenByDescending(e => e.SourceScaleDenominator ?? int.MaxValue)
             .ToList();
     }
 

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/SubLayerStackItem.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/SubLayerStackItem.cs
@@ -39,10 +39,26 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// When set, the authority slots the item by the catalogue's <c>order</c>
 /// rather than by <paramref name="Plane"/>. Always null for PR-L1.
 /// </param>
+/// <param name="SourceScaleDenominator">
+/// The source cell's coarsest intended display-scale denominator — a proxy
+/// for its navigational-purpose (usage) band, used to break ties between
+/// overlapping cells of different scales within the same
+/// <paramref name="Plane"/> and <paramref name="WithinPlanePriority"/>. A
+/// <em>smaller</em> denominator means a larger-scale (finer) cell, which must
+/// paint <em>on top of</em> a smaller-scale (coarser) cell of the same feature
+/// content (S-101 FC §3.1.1 <c>DataCoverage.minimumDisplayScale</c>; S-57
+/// DSPM compilation scale CSCL, S-57 Appendix B.1 §7.3.1.1). Without this the
+/// tie falls through to dataset load order, which is non-deterministic under
+/// viewport-driven lazy loading (issue #464). <see langword="null"/> when the
+/// producing dataset carries no usable cell-wide scale (e.g. GML and coverage
+/// products); such items are treated as coarsest and keep their relative load
+/// order.
+/// </param>
 public sealed record SubLayerStackItem(
     StackPayload Payload,
     S98DisplayPlane Plane,
     int WithinPlanePriority,
     string SourceDatasetId,
     string? SourceFeatureType = null,
-    string? ExtensionId = null);
+    string? ExtensionId = null,
+    int? SourceScaleDenominator = null);

--- a/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/SubLayerStackItem.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/Interoperability/SubLayerStackItem.cs
@@ -39,26 +39,34 @@ namespace EncDotNet.S100.Datasets.Pipelines.Interoperability;
 /// When set, the authority slots the item by the catalogue's <c>order</c>
 /// rather than by <paramref name="Plane"/>. Always null for PR-L1.
 /// </param>
-/// <param name="SourceScaleDenominator">
-/// The source cell's coarsest intended display-scale denominator — a proxy
-/// for its navigational-purpose (usage) band, used to break ties between
-/// overlapping cells of different scales within the same
-/// <paramref name="Plane"/> and <paramref name="WithinPlanePriority"/>. A
-/// <em>smaller</em> denominator means a larger-scale (finer) cell, which must
-/// paint <em>on top of</em> a smaller-scale (coarser) cell of the same feature
-/// content (S-101 FC §3.1.1 <c>DataCoverage.minimumDisplayScale</c>; S-57
-/// DSPM compilation scale CSCL, S-57 Appendix B.1 §7.3.1.1). Without this the
-/// tie falls through to dataset load order, which is non-deterministic under
-/// viewport-driven lazy loading (issue #464). <see langword="null"/> when the
-/// producing dataset carries no usable cell-wide scale (e.g. GML and coverage
-/// products); such items are treated as coarsest and keep their relative load
-/// order.
-/// </param>
 public sealed record SubLayerStackItem(
     StackPayload Payload,
     S98DisplayPlane Plane,
     int WithinPlanePriority,
     string SourceDatasetId,
     string? SourceFeatureType = null,
-    string? ExtensionId = null,
-    int? SourceScaleDenominator = null);
+    string? ExtensionId = null)
+{
+    /// <summary>
+    /// The source cell's coarsest intended display-scale denominator — a proxy
+    /// for its navigational-purpose (usage) band, used to break ties between
+    /// overlapping cells of different scales within the same
+    /// <see cref="Plane"/> and <see cref="WithinPlanePriority"/>. A
+    /// <em>smaller</em> denominator means a larger-scale (finer) cell, which
+    /// must paint <em>on top of</em> a smaller-scale (coarser) cell of the same
+    /// feature content (S-101 FC §3.1.1 <c>DataCoverage.minimumDisplayScale</c>;
+    /// S-57 DSPM compilation scale CSCL, S-57 Appendix B.1 §7.3.1.1). Without
+    /// this the tie falls through to dataset load order, which is
+    /// non-deterministic under viewport-driven lazy loading (issue #464).
+    /// <see langword="null"/> when the producing dataset carries no usable
+    /// cell-wide scale (e.g. GML and coverage products); such items are treated
+    /// as coarsest and preserve their relative load order among themselves.
+    /// </summary>
+    /// <remarks>
+    /// Kept as an init-only property rather than a primary-constructor
+    /// parameter so appending it does not change the generated constructor
+    /// signature — that keeps the public record binary-compatible with callers
+    /// compiled against the earlier six-parameter constructor.
+    /// </remarks>
+    public int? SourceScaleDenominator { get; init; }
+}

--- a/src/EncDotNet.S100.Renderers.Mapsui/Interoperability/LayerStackEntry.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/Interoperability/LayerStackEntry.cs
@@ -38,4 +38,12 @@ public sealed record LayerStackEntry(ILayer Layer, SubLayerStackItem Item)
 
     /// <summary>Optional IC-declared custom plane identifier (S-98 Annex A §A-3.2.1.1).</summary>
     public string? ExtensionId => Item.ExtensionId;
+
+    /// <summary>
+    /// The source cell's coarsest intended display-scale denominator (a proxy
+    /// for its navigational-purpose band), or <see langword="null"/> when the
+    /// dataset carries no cell-wide scale. Smaller means a finer cell that
+    /// paints on top of coarser overlapping cells (issue #464).
+    /// </summary>
+    public int? SourceScaleDenominator => Item.SourceScaleDenominator;
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
@@ -183,8 +183,10 @@ public sealed class MapsuiDatasetRenderer
                     sub.Plane,
                     sub.WithinPlanePriority,
                     result.SourceDatasetId,
-                    sub.SourceFeatureType,
-                    SourceScaleDenominator: result.CellMinimumDisplayScale)));
+                    sub.SourceFeatureType)
+                {
+                    SourceScaleDenominator = result.CellMinimumDisplayScale,
+                }));
 
             union = Union(union, layer.Extent);
         }

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
@@ -183,7 +183,8 @@ public sealed class MapsuiDatasetRenderer
                     sub.Plane,
                     sub.WithinPlanePriority,
                     result.SourceDatasetId,
-                    sub.SourceFeatureType)));
+                    sub.SourceFeatureType,
+                    SourceScaleDenominator: result.CellMinimumDisplayScale)));
 
             union = Union(union, layer.Extent);
         }

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
@@ -201,5 +201,5 @@ public class InteroperabilityAuthorityTests
         => new(new SyntheticStackPayload(id), plane, priority, id);
 
     private static SubLayerStackItem Entry(string id, S98DisplayPlane plane, int? scale, int priority = 0)
-        => new(new SyntheticStackPayload(id), plane, priority, id, SourceScaleDenominator: scale);
+        => new(new SyntheticStackPayload(id), plane, priority, id) { SourceScaleDenominator = scale };
 }

--- a/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/InteroperabilityAuthorityTests.cs
@@ -142,6 +142,64 @@ public class InteroperabilityAuthorityTests
         Assert.Equal(S98DisplayPlane.BaseChartUnder, lo.GetDefaultPlane("S-101", "area"));
     }
 
+    [Fact]
+    public void Sort_finer_cell_paints_on_top_within_same_plane_and_priority()
+    {
+        // Two overlapping ENC cells of different navigational-purpose bands on
+        // the same plane/priority: the finer (smaller-denominator) harbour cell
+        // must paint LAST (on top), regardless of input (load) order.
+        var general = Entry("general", S98DisplayPlane.BaseChartOver, scale: 150_000);
+        var harbour = Entry("harbour", S98DisplayPlane.BaseChartOver, scale: 12_000);
+
+        var coarseFirst = _auth.Sort(new[] { general, harbour });
+        var fineFirst = _auth.Sort(new[] { harbour, general });
+
+        Assert.Equal(new[] { "general", "harbour" }, coarseFirst.Select(e => e.SourceDatasetId).ToArray());
+        Assert.Equal(new[] { "general", "harbour" }, fineFirst.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Sort_unknown_scale_is_treated_as_coarsest()
+    {
+        // An item with no known scale (null) is treated as coarsest, so a known
+        // finer cell in the same plane/priority paints above it.
+        var unknown = Entry("unknown", S98DisplayPlane.BaseChartOver, scale: null);
+        var fine = Entry("fine", S98DisplayPlane.BaseChartOver, scale: 12_000);
+
+        var sorted = _auth.Sort(new[] { fine, unknown });
+
+        Assert.Equal(new[] { "unknown", "fine" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Sort_preserves_load_order_when_scale_unknown()
+    {
+        // Two items that both lack a scale keep their input (load) order — the
+        // scale tiebreaker must not disturb products with no cell-wide scale.
+        var a = Entry("a", S98DisplayPlane.OtherChartOverlays, scale: null);
+        var b = Entry("b", S98DisplayPlane.OtherChartOverlays, scale: null);
+
+        var sorted = _auth.Sort(new[] { a, b });
+
+        Assert.Equal(new[] { "a", "b" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
+    [Fact]
+    public void Sort_scale_tiebreaker_yields_to_plane_and_priority()
+    {
+        // Scale only breaks ties WITHIN a plane/priority: a finer cell on a
+        // lower plane still paints below a coarser cell on a higher plane.
+        var fineUnder = Entry("fineUnder", S98DisplayPlane.BaseChartUnder, scale: 12_000);
+        var coarseOver = Entry("coarseOver", S98DisplayPlane.BaseChartOver, scale: 150_000);
+
+        var sorted = _auth.Sort(new[] { coarseOver, fineUnder });
+
+        Assert.Equal(new[] { "fineUnder", "coarseOver" }, sorted.Select(e => e.SourceDatasetId).ToArray());
+    }
+
     private static SubLayerStackItem Entry(string id, S98DisplayPlane plane, int priority = 0)
         => new(new SyntheticStackPayload(id), plane, priority, id);
+
+    private static SubLayerStackItem Entry(string id, S98DisplayPlane plane, int? scale, int priority = 0)
+        => new(new SyntheticStackPayload(id), plane, priority, id, SourceScaleDenominator: scale);
 }


### PR DESCRIPTION
## Summary

Fixes #464. Overlapping S-57/S-101 ENC cells covering the same area at different navigational-purpose (usage) bands were layered purely by dataset **load order**, which is non-deterministic under viewport-driven lazy loading. As you zoomed/panned, a coarser cell could paint its area fills over a finer cell's features (e.g. a marina would vanish at the most zoomed-in level).

The cross-dataset paint order (`InteroperabilityAuthority.Sort`) previously keyed only on `(Plane, WithinPlanePriority, load-order)` — there was no scale term, so overlapping cells of different bands tied and fell through to load order.

## Change (option 1 — decision stays in the S-98 authority)

- **`SubLayerStackItem`** gains a `SourceScaleDenominator` field: the cell's coarsest intended display-scale denominator (S-101 `DataCoverage.minimumDisplayScale` per FC §3.1.1; S-57 DSPM compilation scale CSCL per Appendix B.1 §7.3.1.1), a monotonic proxy for the cell's band.
- **`InteroperabilityAuthority.Sort`** adds a deterministic scale tiebreaker after plane and within-plane priority: `.ThenByDescending(SourceScaleDenominator ?? int.MaxValue)`. A smaller denominator (larger scale / finer) paints last, i.e. on top. Items with no cell-wide scale (GML and coverage products) are treated as coarsest and keep their relative load order, so their behaviour is unchanged.
- Wired the value from the already-computed `CellMinimumDisplayScale` through the two builders of vector stack items: `MapsuiDatasetRenderer.ConvertVector` and `HeadlessCompositor.BuildItems`.
- Exposed a delegating `SourceScaleDenominator` on `LayerStackEntry` for consistency.

`LoadOrderInteroperabilityAuthority` is intentionally left unchanged — its contract is "ignore S-98, pure load order".

## Tests

Added 4 cases to `InteroperabilityAuthorityTests`:
- finer cell paints on top within the same plane/priority regardless of input (load) order;
- unknown scale is treated as coarsest;
- null scale preserves load order;
- scale only breaks ties within a plane/priority (yields to plane and priority).

Pipelines suite: 943 passed / 3 skipped. Viewer suite: 1537 passed / 3 skipped. Both `dotnet format` checks (whitespace + IDE0005) clean.

## Scope note

This fixes paint **ordering** so overlapping cells stack deterministically (finer on top). Full **suppression/culling** of the coarser cell underneath the finer one is a separate multi-dataset rendering concern tracked in its own issue.