### PR TITLE
Optimize S-100 Skia vector line renderer hotspot (DrawLine)

### DIFF
--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -36,8 +36,12 @@ exactly one place:
   (`EPSG:3857 → screen`) via a `Viewport`-derived affine. Parsed symbol pictures
   are cached process-wide (keyed by the resolved SVG), point/text ops whose
   anchor falls outside the viewport (plus `PointCullMarginPx`) are culled before
-  any per-op work, and text drawing pools its `SKFont`/`SKPaint` per render —
-  all three matter for the tiled subsystem's per-frame overlay, which replays
+  any per-op work, line ops whose projected bounding box (padded by the stroke
+  half-width) misses the cull rectangle are likewise skipped before the native
+  `DrawPath`, and both text and line drawing pool their Skia resources per
+  render (text pools `SKFont`/`SKPaint`; lines reuse one `SKPath`/`SKPaint`, a
+  batched `AddPoly` point buffer, and a per-pattern dash-effect cache) —
+  all of which matter for the tiled subsystem's per-frame overlay, which replays
   this renderer live every frame. `RenderOnto` takes an optional cull rectangle
   so a caller that rotates the canvas can expand it to the rotated viewport's
   bounding box, plus an `OverlayDrawOptions` overload that adds the live

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -330,6 +330,10 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
         // share a size), disposed once when the render completes.
         TextDrawScratch? textScratch = null;
 
+        // Per-render reusable line resources; see LineDrawScratch. Lazily
+        // created because text/point-only overlay passes draw no lines.
+        LineDrawScratch? lineScratch = null;
+
         try
         {
             foreach (var op in scene.Ops)
@@ -347,7 +351,8 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
                         DrawPatternArea(canvas, pattern, transform, patternImages);
                         break;
                     case LinePaintOp line:
-                        DrawLine(canvas, line, transform);
+                        lineScratch ??= new LineDrawScratch();
+                        DrawLine(canvas, line, transform, cullBounds, lineScratch);
                         break;
                     case PointPaintOp point when options.DrawPoints:
                         DrawPoint(canvas, point, transform, cullBounds,
@@ -371,6 +376,7 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
                     img?.Dispose();
             }
             textScratch?.Dispose();
+            lineScratch?.Dispose();
         }
     }
 
@@ -457,42 +463,70 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
         canvas.Restore();
     }
 
-    private static void DrawLine(SKCanvas canvas, LinePaintOp op, WorldToScreen t)
+    private static void DrawLine(
+        SKCanvas canvas, LinePaintOp op, WorldToScreen t, SKRect cullBounds, LineDrawScratch scratch)
     {
-        if (op.World.Count < 2)
+        int count = op.World.Count;
+        if (count < 2)
             return;
 
-        using var path = new SKPath();
-        var (sx, sy) = t.Project(op.World[0]);
-        path.MoveTo(sx, sy);
-        for (int i = 1; i < op.World.Count; i++)
+        // Project every vertex once, into the scratch buffer, tracking the
+        // polyline's screen-space bounding box so an off-view line can be culled
+        // before the (native) DrawPath — matching DrawPoint's cull discipline.
+        var points = scratch.RentPoints(count);
+        float minX = float.MaxValue, minY = float.MaxValue;
+        float maxX = float.MinValue, maxY = float.MinValue;
+        for (int i = 0; i < count; i++)
         {
             var (px, py) = t.Project(op.World[i]);
-            path.LineTo(px, py);
+            points[i] = new SKPoint(px, py);
+            if (px < minX) minX = px;
+            if (px > maxX) maxX = px;
+            if (py < minY) minY = py;
+            if (py > maxY) maxY = py;
         }
 
-        using var paint = new SKPaint
-        {
-            IsAntialias = true,
-            Style = SKPaintStyle.Stroke,
-            Color = op.Color.ToSkia(),
-            StrokeWidth = (float)op.WidthPx,
-            StrokeCap = SKStrokeCap.Round,
-            StrokeJoin = SKStrokeJoin.Round,
-        };
+        float width = (float)op.WidthPx;
 
-        if (op.DashArrayPx is { Count: > 0 })
+        // Pad the bbox by half the stroke width so a wide line whose centreline
+        // sits just outside the cull rectangle (but whose stroke would still
+        // paint inside it) is not wrongly culled. Round joins/caps stay within
+        // half the stroke width of the geometry.
+        float pad = width * 0.5f;
+        if (maxX + pad < cullBounds.Left || minX - pad > cullBounds.Right ||
+            maxY + pad < cullBounds.Top || minY - pad > cullBounds.Bottom)
         {
-            paint.PathEffect = SKPathEffect.CreateDash(op.DashArrayPx.ToArray(), 0f);
+            return;
+        }
+
+        var path = scratch.Path;
+        path.Rewind();
+        path.AddPoly(points.AsSpan(0, count), close: false);
+
+        var paint = scratch.Paint;
+        paint.Color = op.Color.ToSkia();
+        paint.StrokeWidth = width;
+
+        if (op.DashArrayPx is { Count: > 0 } dashArray)
+        {
+            int n = dashArray.Count;
+            Span<float> intervals = n <= 16 ? stackalloc float[n] : new float[n];
+            for (int i = 0; i < n; i++)
+                intervals[i] = dashArray[i];
+            paint.PathEffect = scratch.DashFor(intervals, 0f);
         }
         else if (op.DefaultDash)
         {
             float d = (float)Math.Max(op.WidthPx * 3.0, 3.0);
-            paint.PathEffect = SKPathEffect.CreateDash([d, d], 0f);
+            Span<float> intervals = [d, d];
+            paint.PathEffect = scratch.DashFor(intervals, 0f);
+        }
+        else
+        {
+            paint.PathEffect = null;
         }
 
         canvas.DrawPath(path, paint);
-        paint.PathEffect?.Dispose();
     }
 
     private static void DrawPoint(SKCanvas canvas, PointPaintOp op, WorldToScreen t, SKRect cullBounds,
@@ -880,6 +914,121 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
             foreach (var font in _fonts.Values)
                 font.Dispose();
             _fonts.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Per-render reusable resources for <see cref="DrawLine"/>. A full S-57
+    /// exchange set emits thousands of line ops per tile; allocating a fresh
+    /// <see cref="SKPath"/>, <see cref="SKPaint"/>, and dash
+    /// <see cref="SKPathEffect"/> per op (the previous implementation) churned
+    /// native handles and dominated pan/zoom CPU (finalizer/GC pressure plus the
+    /// per-op interop). This scratch reuses one path (reset via
+    /// <see cref="SKPath.Rewind"/>), one stroke paint (only colour/width/effect
+    /// mutated per op), a growable projection buffer fed to
+    /// <see cref="SKPath.AddPoly(ReadOnlySpan{SKPoint}, bool)"/> in a single
+    /// interop call, and caches dash effects by pattern so shared dashes are
+    /// created once.
+    /// </summary>
+    /// <remarks>
+    /// Instances are per-<c>RenderOnto</c> locals (like
+    /// <see cref="TextDrawScratch"/>), never shared statics or instance fields:
+    /// the tiled subsystem's overlay renderer is a shared instance, and tile
+    /// base-plane workers each rasterise on their own thread, so per-invocation
+    /// scoping keeps the mutable scratch confined to a single thread.
+    /// </remarks>
+    private sealed class LineDrawScratch : IDisposable
+    {
+        private readonly Dictionary<DashKey, SKPathEffect> _dashEffects = new();
+        private SKPoint[] _points = new SKPoint[64];
+
+        /// <summary>The reusable stroke path; call <see cref="SKPath.Rewind"/> before reuse.</summary>
+        public SKPath Path { get; } = new();
+
+        /// <summary>
+        /// The reusable stroke paint. Round cap/join and antialiasing are fixed;
+        /// only <see cref="SKPaint.Color"/>, <see cref="SKPaint.StrokeWidth"/>,
+        /// and <see cref="SKPaint.PathEffect"/> are mutated per op.
+        /// </summary>
+        public SKPaint Paint { get; } = new()
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeCap = SKStrokeCap.Round,
+            StrokeJoin = SKStrokeJoin.Round,
+        };
+
+        /// <summary>Returns a projection buffer with capacity for at least <paramref name="count"/> points.</summary>
+        public SKPoint[] RentPoints(int count)
+        {
+            if (_points.Length < count)
+            {
+                int size = _points.Length;
+                while (size < count)
+                    size *= 2;
+                _points = new SKPoint[size];
+            }
+            return _points;
+        }
+
+        /// <summary>
+        /// Returns a cached dash effect for <paramref name="intervals"/> and
+        /// <paramref name="phase"/>, creating it on first use. The returned
+        /// effect is owned by the scratch and must not be disposed by the caller.
+        /// </summary>
+        public SKPathEffect DashFor(ReadOnlySpan<float> intervals, float phase)
+        {
+            var key = new DashKey(intervals, phase);
+            if (!_dashEffects.TryGetValue(key, out var effect))
+            {
+                effect = SKPathEffect.CreateDash(intervals.ToArray(), phase);
+                _dashEffects[key] = effect;
+            }
+            return effect;
+        }
+
+        public void Dispose()
+        {
+            Path.Dispose();
+            Paint.Dispose();
+            foreach (var effect in _dashEffects.Values)
+                effect.Dispose();
+            _dashEffects.Clear();
+        }
+
+        /// <summary>Value-equal key over a dash interval pattern and phase, so distinct op instances sharing a pattern reuse one effect.</summary>
+        private readonly struct DashKey : IEquatable<DashKey>
+        {
+            private readonly float[] _intervals;
+            private readonly float _phase;
+            private readonly int _hash;
+
+            public DashKey(ReadOnlySpan<float> intervals, float phase)
+            {
+                _intervals = intervals.ToArray();
+                _phase = phase;
+                var hash = new HashCode();
+                foreach (var value in intervals)
+                    hash.Add(value);
+                hash.Add(phase);
+                _hash = hash.ToHashCode();
+            }
+
+            public bool Equals(DashKey other)
+            {
+                if (_phase != other._phase || _intervals.Length != other._intervals.Length)
+                    return false;
+                for (int i = 0; i < _intervals.Length; i++)
+                {
+                    if (_intervals[i] != other._intervals[i])
+                        return false;
+                }
+                return true;
+            }
+
+            public override bool Equals(object? obj) => obj is DashKey other && Equals(other);
+
+            public override int GetHashCode() => _hash;
         }
     }
 

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs
@@ -978,10 +978,14 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
         /// </summary>
         public SKPathEffect DashFor(ReadOnlySpan<float> intervals, float phase)
         {
-            var key = new DashKey(intervals, phase);
+            // Materialize the pattern once and share it between the cache key and
+            // the created effect, so a cache miss allocates a single array rather
+            // than one for the key and another for CreateDash.
+            float[] pattern = intervals.ToArray();
+            var key = new DashKey(pattern, phase);
             if (!_dashEffects.TryGetValue(key, out var effect))
             {
-                effect = SKPathEffect.CreateDash(intervals.ToArray(), phase);
+                effect = SKPathEffect.CreateDash(pattern, phase);
                 _dashEffects[key] = effect;
             }
             return effect;
@@ -1003,9 +1007,9 @@ public sealed class SkiaDisplayListRenderer : IVectorSceneRenderer<SKCanvas>
             private readonly float _phase;
             private readonly int _hash;
 
-            public DashKey(ReadOnlySpan<float> intervals, float phase)
+            public DashKey(float[] intervals, float phase)
             {
-                _intervals = intervals.ToArray();
+                _intervals = intervals;
                 _phase = phase;
                 var hash = new HashCode();
                 foreach (var value in intervals)

--- a/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs
@@ -491,6 +491,127 @@ public sealed class SkiaDisplayListRendererTests
     }
 
 
+    // ── Line screen-bounds culling & path/paint reuse ──────────────────
+
+    [Fact]
+    public void Render_LineFullyOutsideCullBounds_DrawsNothing()
+    {
+        // The cull rectangle is the 200 px viewport inflated by
+        // PointCullMarginPx (256 px), so its right edge is ~456 px. A line at
+        // lon 0.05–0.06 projects to ~x 1000–1200 px — comfortably beyond the
+        // cull rectangle — and must be skipped before DrawPath (matching
+        // DrawPoint's cull discipline).
+        var scene = new VectorScene([
+            new LinePaintOp
+            {
+                FeatureReference = "offscreen",
+                World = [Project(0.05, 0.005), Project(0.06, 0.005)],
+                Color = Black,
+                WidthPx = 3.0,
+            },
+        ]);
+
+        using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+        Assert.True(IsBlank(bitmap, White), "A fully off-bounds line should be culled, not drawn.");
+    }
+
+    [Fact]
+    public void Render_LineWithinBounds_StillDraws()
+    {
+        // The on-screen counterpart of the cull test: a line across the middle
+        // of the viewport must still paint after the cull check.
+        var scene = new VectorScene([
+            new LinePaintOp
+            {
+                FeatureReference = "line",
+                World = [Project(0.001, 0.005), Project(0.009, 0.005)],
+                Color = Black,
+                WidthPx = 3.0,
+            },
+        ]);
+
+        using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+        Assert.False(IsBlank(bitmap, White), "An on-bounds line should still be drawn.");
+    }
+
+    [Fact]
+    public void Render_DashedLine_LeavesGapsVersusSolid()
+    {
+        // Solid vs dashed must still select the right path effect: a solid
+        // stroke fills the centre row continuously, while a dashed stroke of the
+        // same geometry leaves gaps, so materially fewer centre-row pixels paint.
+        int CentreRowPainted(bool dashed)
+        {
+            var scene = new VectorScene([
+                new LinePaintOp
+                {
+                    FeatureReference = "line",
+                    World = [Project(0.001, 0.005), Project(0.009, 0.005)],
+                    Color = Black,
+                    WidthPx = 2.0,
+                    DefaultDash = dashed,
+                },
+            ]);
+
+            using var bitmap = Render(scene, MakeViewport(denom: 25_000));
+            int y = bitmap.Height / 2;
+            int painted = 0;
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                var p = bitmap.GetPixel(x, y);
+                if (p.Red < 200 || p.Green < 200 || p.Blue < 200)
+                    painted++;
+            }
+            return painted;
+        }
+
+        int solid = CentreRowPainted(dashed: false);
+        int dashedCount = CentreRowPainted(dashed: true);
+
+        Assert.True(solid > 0, "Solid line painted nothing on the centre row.");
+        Assert.True(dashedCount > 0, "Dashed line painted nothing on the centre row.");
+        Assert.True(dashedCount < solid * 0.75,
+            $"Dashed line ({dashedCount}px) should leave gaps versus solid ({solid}px).");
+    }
+
+    [Fact]
+    public void Render_ManyLines_ReusesScratchAndMatchesSingleLineOutput()
+    {
+        // Drawing many line ops through the reused per-render path/paint scratch
+        // must produce the same pixels as drawing one — guarding that reuse
+        // (Rewind + mutated paint fields) leaves no state bleeding between ops.
+        LinePaintOp Line(string id) => new()
+        {
+            FeatureReference = id,
+            World = [Project(0.001, 0.005), Project(0.009, 0.005)],
+            Color = Black,
+            WidthPx = 3.0,
+        };
+
+        var single = new VectorScene([Line("a")]);
+        var many = new VectorScene([Line("a"), Line("b"), Line("c"), Line("d")]);
+
+        using var singleBitmap = Render(single, MakeViewport(denom: 25_000));
+        using var manyBitmap = Render(many, MakeViewport(denom: 25_000));
+
+        int Painted(SKBitmap bitmap)
+        {
+            int count = 0;
+            for (int y = 0; y < bitmap.Height; y++)
+                for (int x = 0; x < bitmap.Width; x++)
+                {
+                    var p = bitmap.GetPixel(x, y);
+                    if (p.Red != 255 || p.Green != 255 || p.Blue != 255)
+                        count++;
+                }
+            return count;
+        }
+
+        // Identical coincident lines paint the same coverage as one.
+        Assert.Equal(Painted(singleBitmap), Painted(manyBitmap));
+    }
+
+
     private static Viewport MakeViewport(double denom) => new()
     {
         MinLongitude = 0.0,


### PR DESCRIPTION
Closes #472.

## Summary

CPU profiling of the Avalonia viewer (dotnet-trace, sampled-thread-time) while panning/zooming a full NOAA S-57 exchange set showed `SkiaDisplayListRenderer.DrawLine` as the dominant real-work frame at **20.2% exclusive CPU**. Per line op the old code allocated a fresh `SKPath` (built vertex-by-vertex via `MoveTo`/`LineTo`), a fresh `SKPaint`, a fresh dash `SKPathEffect`, and did **no screen-bounds culling** — all on tile-worker threads during pan/zoom.

This PR makes `DrawLine` a performance-only change (identical visual output):

- **Screen-bounds culling** — vertices are projected once into a pooled buffer while tracking the polyline's screen bbox; padded by the stroke half-width; `DrawPath` is skipped when the bbox misses the cull rectangle (mirroring `DrawPoint`). `cullBounds` is threaded in from `RenderOnto`.
- **Resource pooling** — a new per-invocation `LineDrawScratch` reuses one `SKPath` (`Rewind()`), one stroke `SKPaint` (round cap/join + antialias set once; only colour/width/effect mutated), a growable `SKPoint[]` buffer, and a **per-pattern dash-effect cache**. It's a `RenderOnto` local (mirroring `TextDrawScratch`), so it stays thread-local across tile-worker rasterization — no shared static.
- **Batched path build** — one `AddPoly(ReadOnlySpan<SKPoint>, close:false)` interop call instead of per-vertex `MoveTo`/`LineTo`.

## Files
- `src/EncDotNet.S100.Renderers.Skia/Scene/SkiaDisplayListRenderer.cs` — rewritten `DrawLine` + `LineDrawScratch`; `RenderOnto` wires cull bounds + scratch and disposes it.
- `tests/EncDotNet.S100.VisualRegression.Tests/SkiaDisplayListRendererTests.cs` — 4 new tests.
- `src/EncDotNet.S100.Renderers.Skia/README.md` — documents line cull + pooling.

## Profiling (before → after)

| Frame | Baseline | After |
|---|---|---|
| `DrawLine` **exclusive** | **20.2%** | **0.17%** |
| `SKCanvas.DrawPath` exclusive | (inside DrawLine) | 7.5% (irreducible native stroke rasterization) |
| `DrawLine` inclusive | — | 7.6% |

Re-profiled the Release viewer (osx-arm64) over 306 pan/zoom frames across ~87 dense S-57 harbour cells during a 2-minute trace. The eliminated ~20% was managed/interop overhead (per-vertex P/Invokes + per-op allocations); what remains is genuine native `DrawPath` plus culled-away off-screen lines.

## Tests & checks
- VisualRegression.Tests: **25 passed**, 0 failed (incl. new: off-bounds line culled, on-bounds line draws, dashed-vs-solid gaps, many-lines scratch-reuse pixel-parity — confirming identical output).
- Pipelines.Tests: **968 passed**, 3 skipped, 0 failed.
- `dotnet format whitespace` and `dotnet format style --diagnostics IDE0005` both clean (`--verify-no-changes`).

No datasets, traces, or screenshots committed.