### PR TITLE
Add cheap S-57 ReadMetadata peek + wire loose-folder probe (closes #460)

### DIFF
--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -38,6 +38,7 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
     private bool _decoderLoaded;
     private ValidationReport? _validationReport;
     private bool _validationCached;
+    private DatasetMetadata? _metadata;
 
     // ECDIS settings that hide nothing — used when a render context carries no
     // explicit display state, so a standalone/headless render draws everything
@@ -47,6 +48,16 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
         new() { Category = EcdisDisplayCategory.All };
 
     public SpecRef Spec => new("S-57", default);
+
+    /// <summary>
+    /// The lightweight <see cref="DatasetMetadata"/> for this cell — canonical
+    /// <c>S-57</c> specification, WGS-84 extent, and compilation-scale display
+    /// window — derived from the already-parsed (update-folded) document without
+    /// a second read, and memoized (issue #460 / #467 WS1). The extent folds the
+    /// raw spatial coordinates directly rather than going through the S-101
+    /// translation, so it is a cheap byproduct.
+    /// </summary>
+    public DatasetMetadata Metadata => _metadata ??= S57Dataset.ReadMetadata(_rawS57Document);
 
     public S57DatasetProcessor(
         string path,

--- a/src/EncDotNet.S100.Datasets.S57/README.md
+++ b/src/EncDotNet.S100.Datasets.S57/README.md
@@ -19,7 +19,12 @@ Key types:
 - **`S57Dataset`** — entry point; opens a `.000` file and exposes the parsed
   `EncDotNet.S57.S57Document` from the upstream package, plus a static
   `IsS57File(path)` discriminator used by `EncDotNet.S100.Datasets.Pipelines`
-  to disambiguate `.000` files that could otherwise be S-101.
+  to disambiguate `.000` files that could otherwise be S-101. Also exposes a
+  cheap `ReadMetadata` "peek" path (issue #460) that folds the WGS-84 extent
+  from the raw spatial coordinates (via the DSPM coordinate multiplication
+  factor) and the compilation-scale (CSCL) display window **without** the
+  S-57 → S-101 translation or any portrayal — so a host can frame a viewport
+  over a loose folder of S-57 cells before deciding to load each in full.
 - **`S57ToS101Translator`** — translates an `S57Document` (package type) into
   an `S101Document` by remapping object/attribute codes, exploding multi-point
   soundings, synthesising the `information` complex attribute from textual

--- a/src/EncDotNet.S100.Datasets.S57/S57Dataset.cs
+++ b/src/EncDotNet.S100.Datasets.S57/S57Dataset.cs
@@ -1,3 +1,6 @@
+using EncDotNet.S100.Core;
+using EncDotNet.S100.Pipelines;
+
 namespace EncDotNet.S100.Datasets.S57;
 
 /// <summary>
@@ -22,6 +25,144 @@ public sealed class S57Dataset
 
     /// <summary>Number of feature records in the dataset.</summary>
     public int FeatureCount => Document.FeatureRecords.Count;
+
+    /// <summary>
+    /// Reads only the lightweight <see cref="DatasetMetadata"/> for an S-57
+    /// base cell at <paramref name="path"/> — its (canonical) specification,
+    /// geographic extent, and intended display-scale window — for phased /
+    /// deferred loading (issue #460). See <see cref="ReadMetadata()"/> for the
+    /// rationale and the cheap-scan strategy.
+    /// </summary>
+    /// <param name="path">Absolute path to the S-57 base cell (<c>.000</c>).</param>
+    /// <returns>The cell's lightweight metadata.</returns>
+    public static DatasetMetadata ReadMetadata(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        return Open(path).ReadMetadata();
+    }
+
+    /// <summary>
+    /// Reads only the lightweight <see cref="DatasetMetadata"/> for an S-57
+    /// base cell from <paramref name="stream"/>. See
+    /// <see cref="ReadMetadata()"/> for the phased-loading rationale.
+    /// </summary>
+    /// <param name="stream">The S-57 base cell (<c>.000</c>) stream.</param>
+    /// <returns>The cell's lightweight metadata.</returns>
+    public static DatasetMetadata ReadMetadata(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        return Open(stream).ReadMetadata();
+    }
+
+    /// <summary>
+    /// Produces the lightweight <see cref="DatasetMetadata"/> for this already
+    /// parsed dataset: the canonical <c>S-57</c> specification, the geographic
+    /// extent, and the compilation-scale display window (issue #460).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The phased win over a full load is that the S-57 → S-101 translation and
+    /// the portrayal catalogue are never touched: the extent is folded directly
+    /// from the raw spatial records' coordinates (2-D vertices and sounding
+    /// nodes), divided by the coordinate multiplication factor (COMF) from the
+    /// <c>DSPM</c> field to yield WGS-84 decimal degrees. This mirrors the
+    /// extent the full render ultimately fits, but skips feature/attribute
+    /// materialisation.
+    /// </para>
+    /// <para>
+    /// The display-scale window carries only a coarsest bound, sourced from the
+    /// compilation scale (CSCL, S-57 Appendix B.1 §7.3.1.1) — the same value the
+    /// full processor applies as the whole-cell minimum display scale. The
+    /// canonical spec name is <c>S-57</c> with a <c>default</c> edition, matching
+    /// <c>S57DatasetProcessor.Spec</c>.
+    /// </para>
+    /// </remarks>
+    /// <returns>The cell's lightweight metadata.</returns>
+    public DatasetMetadata ReadMetadata() => ReadMetadata(Document);
+
+    /// <summary>
+    /// Produces the lightweight <see cref="DatasetMetadata"/> for an
+    /// already-parsed (and, where applicable, update-folded)
+    /// <see cref="EncDotNet.S57.S57Document"/>. Exposed so the render pipeline's
+    /// <c>S57DatasetProcessor</c> can surface the same metadata from the merged
+    /// document it already holds, without re-opening the cell.
+    /// </summary>
+    /// <param name="document">The parsed S-57 document.</param>
+    /// <returns>The document's lightweight metadata.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="document"/> is null.</exception>
+    public static DatasetMetadata ReadMetadata(EncDotNet.S57.S57Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return new DatasetMetadata
+        {
+            Spec = new SpecRef("S-57", default),
+            Extent = ComputeExtent(document),
+            HorizontalCrsEpsg = null,
+            DisplayScale = ResolveDisplayScale(document),
+        };
+    }
+
+    /// <summary>
+    /// Folds the WGS-84 extent from every 2-D vertex and sounding node in the
+    /// document's spatial records, converting raw integer coordinates to decimal
+    /// degrees via the coordinate multiplication factor (COMF, S-57 Appendix
+    /// B.1 §7.3.1.1). Returns <see langword="null"/> when the document declares
+    /// no usable COMF or carries no coordinate-bearing spatial record.
+    /// </summary>
+    private static BoundingBox? ComputeExtent(EncDotNet.S57.S57Document document)
+    {
+        var comf = document.CoordinateMultiplicationFactor;
+        if (comf <= 0)
+            return null;
+
+        long minX = long.MaxValue, maxX = long.MinValue;
+        long minY = long.MaxValue, maxY = long.MinValue;
+        var any = false;
+
+        foreach (var vector in document.VectorRecords)
+        {
+            foreach (var c in vector.Coordinates2D)
+            {
+                if (c.X < minX) minX = c.X;
+                if (c.X > maxX) maxX = c.X;
+                if (c.Y < minY) minY = c.Y;
+                if (c.Y > maxY) maxY = c.Y;
+                any = true;
+            }
+
+            foreach (var s in vector.Soundings)
+            {
+                if (s.X < minX) minX = s.X;
+                if (s.X > maxX) maxX = s.X;
+                if (s.Y < minY) minY = s.Y;
+                if (s.Y > maxY) maxY = s.Y;
+                any = true;
+            }
+        }
+
+        if (!any)
+            return null;
+
+        double divisor = comf;
+        return new BoundingBox(
+            southLatitude: minY / divisor,
+            westLongitude: minX / divisor,
+            northLatitude: maxY / divisor,
+            eastLongitude: maxX / divisor);
+    }
+
+    /// <summary>
+    /// Resolves the display-scale window from the compilation scale (CSCL) in
+    /// the <c>DSPM</c> field. Only the coarsest bound is modelled — S-57 has no
+    /// finest-scale analogue — matching the whole-cell minimum display scale the
+    /// full processor applies. Returns <see langword="null"/> when the cell
+    /// declares no usable compilation scale.
+    /// </summary>
+    private static DisplayScaleRange? ResolveDisplayScale(EncDotNet.S57.S57Document document)
+    {
+        var compilationScale = document.DataSetParameters?.CompilationScale ?? 0;
+        return compilationScale > 0 ? new DisplayScaleRange(compilationScale, null) : null;
+    }
 
     /// <summary>Opens an S-57 base cell from a file path.</summary>
     public static S57Dataset Open(string path)

--- a/src/EncDotNet.S100.Viewer/Services/CachingDatasetMetadataReader.cs
+++ b/src/EncDotNet.S100.Viewer/Services/CachingDatasetMetadataReader.cs
@@ -2,6 +2,7 @@ using EncDotNet.S100.Core;
 using EncDotNet.S100.Core.Metadata;
 using EncDotNet.S100.Datasets.Pipelines;
 using EncDotNet.S100.Datasets.S101;
+using EncDotNet.S100.Datasets.S57;
 
 namespace EncDotNet.S100.Viewer.Services;
 
@@ -23,7 +24,7 @@ namespace EncDotNet.S100.Viewer.Services;
 /// <para>
 /// Only products with a cheap path-based metadata reader are supported;
 /// the current caller (loose-cell folder framing) sees S-101 / S-57 ENC
-/// cells, and S-101 is wired here. An unrecognised or unsupported product,
+/// cells, and both are wired here. An unrecognised or unsupported product,
 /// or any parse failure, yields <see langword="null"/> and is not cached
 /// (there is no negative caching), so a transient error simply retries next
 /// time and never blocks loading.
@@ -74,6 +75,7 @@ internal sealed class CachingDatasetMetadataReader : IDatasetMetadataReader
     private static Func<string, DatasetMetadata>? ResolveProducer(string? spec) => spec switch
     {
         "S-101" => S101Dataset.ReadMetadata,
+        "S-57" => S57Dataset.ReadMetadata,
         _ => null,
     };
 }

--- a/tests/EncDotNet.S100.Datasets.S57.Tests/S57DatasetMetadataTests.cs
+++ b/tests/EncDotNet.S100.Datasets.S57.Tests/S57DatasetMetadataTests.cs
@@ -1,0 +1,199 @@
+using EncDotNet.S100.Datasets.S101;
+
+namespace EncDotNet.S100.Datasets.S57.Tests;
+
+/// <summary>
+/// Tests for <see cref="S57Dataset.ReadMetadata(EncDotNet.S57.S57Document)"/> —
+/// the cheap "peek" path added for phased / deferred loading (issue #460). The
+/// extent must fold the raw spatial coordinates (2-D vertices and sounding
+/// nodes) through the coordinate multiplication factor (COMF), and the
+/// display-scale window must carry the compilation scale (CSCL) as its coarsest
+/// bound, all without the S-57 → S-101 translation or any portrayal.
+/// </summary>
+public class S57DatasetMetadataTests
+{
+    private const uint Comf = 10_000_000;
+
+    private static int Raw(double degrees) => (int)Math.Round(degrees * Comf);
+
+    private static EncDotNet.S57.S57RecordName Name(byte rcnm, uint id)
+        => new() { RecordNameCode = rcnm, RecordId = (int)id };
+
+    private static EncDotNet.S57.S57VectorRecord Node(uint id, double lat, double lon)
+        => new()
+        {
+            RecordName = Name(120, id), // ConnectedNode
+            VectorPointers = [],
+            Coordinates2D = [new EncDotNet.S57.S57Coordinate2D { X = Raw(lon), Y = Raw(lat) }],
+            Soundings = [],
+            Attributes = [],
+        };
+
+    private static EncDotNet.S57.S57VectorRecord SoundingNode(uint id, double lat, double lon, int depth)
+        => new()
+        {
+            RecordName = Name(110, id), // IsolatedNode
+            VectorPointers = [],
+            Coordinates2D = [],
+            Soundings = [new EncDotNet.S57.S57Sounding { X = Raw(lon), Y = Raw(lat), Depth = depth }],
+            Attributes = [],
+        };
+
+    private static EncDotNet.S57.S57Document Document(
+        IEnumerable<EncDotNet.S57.S57VectorRecord>? vectorRecords = null,
+        int compilationScale = 50_000,
+        uint comf = Comf)
+        => new()
+        {
+            DataSetIdentification = new EncDotNet.S57.S57DataSetIdentification
+            {
+                DataSetName = "TEST.000",
+                EditionNumber = "1",
+                UpdateNumber = "0",
+                IssueDate = "20240101",
+            },
+            DataSetParameters = new EncDotNet.S57.S57DataSetParameters
+            {
+                CompilationScale = compilationScale,
+                CoordinateMultiplicationFactor = (int)comf,
+                SoundingMultiplicationFactor = 10,
+            },
+            VectorRecords = (vectorRecords ?? Array.Empty<EncDotNet.S57.S57VectorRecord>()).ToArray(),
+            FeatureRecords = Array.Empty<EncDotNet.S57.S57FeatureRecord>(),
+        };
+
+    [Fact]
+    public void ReadMetadata_declares_canonical_S57_spec()
+    {
+        var metadata = S57Dataset.ReadMetadata(Document());
+
+        Assert.Equal("S-57", metadata.Spec.Name);
+        Assert.Equal(default, metadata.Spec.Edition);
+        Assert.Null(metadata.HorizontalCrsEpsg);
+    }
+
+    [Fact]
+    public void ReadMetadata_folds_extent_over_vertices()
+    {
+        var document = Document(
+        [
+            Node(1, lat: 42.1, lon: -71.5),
+            Node(2, lat: 42.9, lon: -70.5),
+        ]);
+
+        var extent = S57Dataset.ReadMetadata(document).Extent;
+
+        Assert.NotNull(extent);
+        Assert.Equal(-71.5, extent!.WestLongitude, 6);
+        Assert.Equal(-70.5, extent.EastLongitude, 6);
+        Assert.Equal(42.1, extent.SouthLatitude, 6);
+        Assert.Equal(42.9, extent.NorthLatitude, 6);
+    }
+
+    [Fact]
+    public void ReadMetadata_includes_sounding_nodes_in_extent()
+    {
+        var document = Document(
+        [
+            Node(1, lat: 42.5, lon: -71.0),
+            SoundingNode(2, lat: 43.2, lon: -69.8, depth: 120),
+        ]);
+
+        var extent = S57Dataset.ReadMetadata(document).Extent;
+
+        Assert.NotNull(extent);
+        Assert.Equal(-71.0, extent!.WestLongitude, 6);
+        Assert.Equal(-69.8, extent.EastLongitude, 6);
+        Assert.Equal(42.5, extent.SouthLatitude, 6);
+        Assert.Equal(43.2, extent.NorthLatitude, 6);
+    }
+
+    [Fact]
+    public void ReadMetadata_returns_null_extent_when_no_coordinates()
+    {
+        var metadata = S57Dataset.ReadMetadata(Document());
+
+        Assert.Null(metadata.Extent);
+    }
+
+    [Fact]
+    public void ReadMetadata_returns_null_extent_when_comf_is_zero()
+    {
+        var document = Document([Node(1, lat: 42.0, lon: -71.0)], comf: 0);
+
+        Assert.Null(S57Dataset.ReadMetadata(document).Extent);
+    }
+
+    [Fact]
+    public void ReadMetadata_surfaces_compilation_scale_as_coarsest_bound()
+    {
+        var metadata = S57Dataset.ReadMetadata(Document(compilationScale: 45_000));
+
+        Assert.NotNull(metadata.DisplayScale);
+        Assert.Equal(45_000, metadata.DisplayScale!.Value.Minimum);
+        Assert.Null(metadata.DisplayScale.Value.Maximum);
+    }
+
+    [Fact]
+    public void ReadMetadata_returns_null_display_scale_when_compilation_scale_absent()
+    {
+        var metadata = S57Dataset.ReadMetadata(Document(compilationScale: 0));
+
+        Assert.Null(metadata.DisplayScale);
+    }
+
+    [Fact]
+    public void ReadMetadata_rejects_null_document()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => S57Dataset.ReadMetadata((EncDotNet.S57.S57Document)null!));
+    }
+
+    private static string ResolveFixturePath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "tests", "datasets", "S57", "US5MA1BO", fileName);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return Path.Combine("tests", "datasets", "S57", "US5MA1BO", fileName);
+    }
+
+    [SkippableFact]
+    public void ReadMetadata_real_cell_overloads_agree_and_extent_matches_full_translation()
+    {
+        var path = ResolveFixturePath("US5MA1BO.000");
+        Skip.IfNot(File.Exists(path), $"S-57 test cell not present: {path}");
+
+        var pathExtent = S57Dataset.ReadMetadata(path).Extent;
+        Assert.NotNull(pathExtent);
+
+        // The static path overload and the instance overload must agree.
+        var dataset = S57Dataset.Open(path);
+        Assert.Equal(pathExtent, dataset.ReadMetadata().Extent);
+
+        // Plausible WGS-84 window (US5MA1BO is a US east-coast harbour cell).
+        var extent = pathExtent!;
+        Assert.True(extent.WestLongitude < extent.EastLongitude);
+        Assert.True(extent.SouthLatitude < extent.NorthLatitude);
+        Assert.InRange(extent.WestLongitude, -180.0, 180.0);
+        Assert.InRange(extent.NorthLatitude, -90.0, 90.0);
+
+        // The cheap raw-coordinate scan covers every vertex; the full S-57 →
+        // S-101 translation only materialises the coordinates referenced by
+        // features, so the authoritative translated extent must sit inside the
+        // probe estimate (never larger). Both derive from the same integer
+        // coordinates and COMF, so they should also be close.
+        var translated = S101Dataset.FromDocument(new S57ToS101Translator().Translate(dataset));
+        var full = translated.ReadMetadata().Extent;
+        Assert.NotNull(full);
+
+        const double tolerance = 1e-6;
+        Assert.True(extent.WestLongitude <= full!.WestLongitude + tolerance);
+        Assert.True(extent.EastLongitude >= full.EastLongitude - tolerance);
+        Assert.True(extent.SouthLatitude <= full.SouthLatitude + tolerance);
+        Assert.True(extent.NorthLatitude >= full.NorthLatitude - tolerance);
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/S57DatasetProcessorScaleBandTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S57DatasetProcessorScaleBandTests.cs
@@ -86,6 +86,33 @@ public class S57DatasetProcessorScaleBandTests
         Assert.True(result.CellMinimumDisplayScale > 0);
     }
 
+    [SkippableFact]
+    public void Metadata_MatchesReaderPeek_AndIsMemoized()
+    {
+        var fixturePath = ResolveFixturePath(FixtureFile);
+        Skip.IfNot(File.Exists(fixturePath),
+            $"S-57 fixture not found at expected path: {fixturePath}");
+
+        var processor = CreateProcessor(fixturePath);
+
+        var metadata = processor.Metadata;
+
+        // The processor surfaces the same cheap metadata the reader's peek path
+        // produces (issue #460): canonical S-57 spec, WGS-84 extent folded from
+        // the raw coordinates, and the CSCL display window.
+        Assert.Equal("S-57", metadata.Spec.Name);
+        Assert.NotNull(metadata.Extent);
+        Assert.NotNull(metadata.DisplayScale);
+        Assert.NotNull(metadata.DisplayScale!.Value.Minimum);
+
+        var peek = EncDotNet.S100.Datasets.S57.S57Dataset.ReadMetadata(fixturePath);
+        Assert.Equal(peek.Extent, metadata.Extent);
+        Assert.Equal(peek.DisplayScale, metadata.DisplayScale);
+
+        // Metadata is memoized: repeat access returns the same instance.
+        Assert.Same(metadata, processor.Metadata);
+    }
+
     private static string ResolveFixturePath(string fileName)
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/EncDotNet.S100.Viewer.Tests/CachingDatasetMetadataReaderTests.cs
+++ b/tests/EncDotNet.S100.Viewer.Tests/CachingDatasetMetadataReaderTests.cs
@@ -29,6 +29,19 @@ public class CachingDatasetMetadataReaderTests : IDisposable
     private static string S101Cell() =>
         System.IO.Path.Combine("TestData", "S101", "DATASET_FILES", "101AA00DS0003.000");
 
+    private static string S57Cell()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = System.IO.Path.Combine(
+                dir.FullName, "tests", "datasets", "S57", "US5MA1BO", "US5MA1BO.000");
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return System.IO.Path.Combine("tests", "datasets", "S57", "US5MA1BO", "US5MA1BO.000");
+    }
+
     [Fact]
     public void Returns_null_for_empty_path()
     {
@@ -61,6 +74,28 @@ public class CachingDatasetMetadataReaderTests : IDisposable
         var first = reader.TryRead(cell);
         Assert.NotNull(first);
         Assert.Equal("S-101", first!.Spec.Name);
+        Assert.NotNull(first.Extent);
+        Assert.Equal(1, cache.Misses);
+
+        var second = reader.TryRead(cell);
+        Assert.NotNull(second);
+        Assert.Equal(first.Extent, second!.Extent);
+        Assert.Equal(1, cache.Hits);
+        Assert.Equal(1, cache.Misses);
+    }
+
+    [SkippableFact]
+    public void Reads_s57_extent_then_serves_a_hit()
+    {
+        var cell = S57Cell();
+        Skip.IfNot(File.Exists(cell), $"S-57 test cell not present: {cell}");
+
+        var cache = new DiskDatasetMetadataCache(_cacheDir, 1_000_000);
+        var reader = new CachingDatasetMetadataReader(cache);
+
+        var first = reader.TryRead(cell);
+        Assert.NotNull(first);
+        Assert.Equal("S-57", first!.Spec.Name);
         Assert.NotNull(first.Extent);
         Assert.Equal(1, cache.Misses);
 


### PR DESCRIPTION
## Summary

Closes the final S-57 gap in **phased dataset loading (#460)**.

Phases 1–3 of #460 (Core `DatasetMetadata` types, `ReadMetadata` on every reader, `IDatasetProcessor.Metadata`, the cross-session metadata cache) and most of phase 4 (loose-folder union framing via `ExchangeSetService.ComputeLooseCellUnion` + `onFramingReady`) already landed in #462 and #467/#468. The one remaining gap — surfaced by the recent S-57 / loose-dataset work — was that **S-57 loose cells had no cheap metadata path**:

- `CachingDatasetMetadataReader.ResolveProducer` wired only `"S-101"`, so a loose folder of S-57 cells got a `null` probe → the cheap union-framing degraded to the eager legacy fallback (the exact scenario #460 set out to eliminate).
- `S57DatasetProcessor.Metadata` returned the empty `IDatasetProcessor.Metadata` default (null extent), unlike every other processor.

## Changes

- **`S57Dataset.ReadMetadata`** (instance + `string` / `Stream` / `S57Document` overloads): folds the WGS-84 extent from the raw spatial coordinates (2-D vertices + sounding nodes) via the DSPM coordinate multiplication factor, and surfaces the CSCL compilation scale as the coarsest display-scale bound — **without** the S-57 → S-101 translation or any portrayal.
- **`S57DatasetProcessor.Metadata`** overridden (memoized, derived from the already update-folded document).
- **`CachingDatasetMetadataReader`** now dispatches `"S-57"` to `S57Dataset.ReadMetadata`, so loose S-57 folders get cheap union framing like S-101.
- S-57 README updated.

## Tests

- `S57DatasetMetadataTests` — synthetic-builder unit tests (extent folding over vertices + soundings, COMF/CSCL edge cases, spec, null guards) plus a real-fixture test asserting overload parity and containment/closeness against the full S-57→S-101 translation extent.
- `CachingDatasetMetadataReaderTests` — S-57 dispatch + cache hit/miss.
- `S57DatasetProcessorScaleBandTests` — processor `Metadata` matches the reader peek and is memoized.

`dotnet format whitespace` and `dotnet format style --diagnostics IDE0005` both verify clean on the changed files.

## Out of scope

`ViewerDatasetCatalog.TryProject` routes `"S-57"` through `ProjectS101` (opening an S-57 file as S-101 for the MCP projection) — a separate pre-existing concern, left untouched.