### PR TITLE
Align headless (Skia) and GUI (Mapsui) render paths for automation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
     <PackageVersion Include="Mapsui.Rendering.Skia" Version="5.1.0" />
     <PackageVersion Include="Mapsui.Tiling" Version="5.1.0" />
     <PackageVersion Include="MoonSharp" Version="2.0.0" />
+    <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="ProjNet" Version="2.1.0" />
     <PackageVersion Include="PureHDF" Version="2.1.2" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-798" />

--- a/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/GmlDatasetProcessorBase.cs
@@ -334,7 +334,8 @@ public abstract class GmlDatasetProcessorBase<TFeature> : IDatasetProcessor, IVe
             areaFillProvider: name => prewarm.ResolveAreaFill(name),
             hiddenCategories: context?.HiddenInstructionCategories
                 ?? DrawingInstructionCategory.None,
-            basemap: context?.Basemap ?? BasemapKind.None);
+            basemap: context?.Basemap ?? BasemapKind.None,
+            viewport: context?.Viewport);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/RenderContext.cs
@@ -88,6 +88,32 @@ public abstract record RenderContext
     /// does not declare the id.
     /// </summary>
     public string? DisplayModeId { get; init; }
+
+    /// <summary>
+    /// An explicit display window (geographic bounds + pixel size + scale
+    /// denominator) to render, or <c>null</c> to auto-fit the viewport to the
+    /// dataset extent (the historical single-dataset headless behaviour).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Supplying a viewport brings the single-dataset headless render path into
+    /// alignment with the composite/GUI paths, which have always accepted an
+    /// explicit viewport (CLI <c>--bbox</c> / <c>--center</c>+<c>--scale</c>).
+    /// It lets a caller frame an exact window — e.g. to reproduce a viewer
+    /// screenshot or capture a fixed scene — instead of the padded auto-fit.
+    /// </para>
+    /// <para>
+    /// Honoured by the vector headless path
+    /// (<c>HeadlessVectorRenderer.Render</c>) for S-101, S-57 and the GML
+    /// products. Because an explicit viewport carries a meaningful
+    /// <see cref="Viewport.ScaleDenominator"/>, the vector path additionally
+    /// enables S-100 Part 9 scale-visibility culling when it is set (the
+    /// auto-fit path leaves culling disabled, as the fitted scale is not a real
+    /// compilation scale). Coverage processors (S-102/S-104/S-111) do not yet
+    /// honour an explicit viewport and ignore this property.
+    /// </para>
+    /// </remarks>
+    public Viewport? Viewport { get; init; }
 }
 
 public sealed record S101RenderContext : RenderContext;

--- a/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S101DatasetProcessor.cs
@@ -627,7 +627,8 @@ public sealed class S101DatasetProcessor : IDatasetProcessor, IVectorPortrayalSo
                 areaFillProvider: name => prewarm.ResolveAreaFill(name),
                 hiddenCategories: context?.HiddenInstructionCategories
                     ?? DrawingInstructionCategory.None,
-                basemap: context?.Basemap ?? BasemapKind.None);
+                basemap: context?.Basemap ?? BasemapKind.None,
+                viewport: context?.Viewport);
         }
         finally
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -486,7 +486,8 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
                 background: background ?? new RgbaColor(255, 255, 255, 255),
                 areaFillProvider: name => prewarm.ResolveAreaFill(name),
                 hiddenCategories: context?.HiddenInstructionCategories
-                    ?? DrawingInstructionCategory.None);
+                    ?? DrawingInstructionCategory.None,
+                viewport: context?.Viewport);
         }
         finally
         {

--- a/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
+++ b/src/EncDotNet.S100.Datasets.Pipelines/S57DatasetProcessor.cs
@@ -497,7 +497,8 @@ public sealed class S57DatasetProcessor : IDatasetProcessor, IVectorPortrayalSou
                 background: background ?? new RgbaColor(255, 255, 255, 255),
                 areaFillProvider: name => prewarm.ResolveAreaFill(name),
                 hiddenCategories: context?.HiddenInstructionCategories
-                    ?? DrawingInstructionCategory.None);
+                    ?? DrawingInstructionCategory.None,
+                viewport: context?.Viewport);
         }
         finally
         {

--- a/src/EncDotNet.S100.Renderers.Mapsui/DiskPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/DiskPatternClipCache.cs
@@ -8,7 +8,7 @@ namespace EncDotNet.S100.Renderers.Mapsui;
 /// <summary>
 /// Disk-backed <see cref="IPatternClipCache"/>: persists each computed S-101
 /// pattern-fill priority clip result (see <see cref="MapsuiDisplayListRenderer"/>'s
-/// <c>ClipPatternsByPriority</c>) as a WKB sidecar file so that the
+/// <see cref="EncDotNet.S100.Rendering.Scene.PatternPriorityClipper"/>) as a WKB sidecar file so that the
 /// <em>cold</em> first open of a previously-seen cell — including after a
 /// process restart — skips the multi-second NetTopologySuite overlay.
 /// </summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/IPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/IPatternClipCache.cs
@@ -5,7 +5,7 @@ namespace EncDotNet.S100.Renderers.Mapsui;
 /// <summary>
 /// Caches the result of the S-101 pattern-fill priority clip
 /// (<see cref="MapsuiDisplayListRenderer"/>'s
-/// <c>ClipPatternsByPriority</c>) so that re-renders which do not change the
+/// <see cref="EncDotNet.S100.Rendering.Scene.PatternPriorityClipper"/>) so that re-renders which do not change the
 /// clip inputs — most importantly Day/Dusk/Night palette switches — skip the
 /// expensive NetTopologySuite overlay work.
 /// </summary>

--- a/src/EncDotNet.S100.Renderers.Mapsui/IPatternClipCache.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/IPatternClipCache.cs
@@ -30,6 +30,16 @@ namespace EncDotNet.S100.Renderers.Mapsui;
 /// switch reuse the previously computed geometry verbatim.
 /// </para>
 /// <para>
+/// Both render arms consult this cache. The Mapsui feature ("A") arm wraps its
+/// own clip directly; the default TiledScene ("B") arm — which clips inside the
+/// shared <see cref="EncDotNet.S100.Rendering.Scene.VectorSceneBuilder"/> when
+/// lowering the <see cref="EncDotNet.S100.Rendering.Scene.VectorScene"/> IR —
+/// reaches it through a <see cref="EncDotNet.S100.Rendering.Scene.PatternClipMemoizer"/>
+/// adapter (<see cref="MapsuiDisplayListRenderer"/>). Because both arms produce
+/// identical clip topology and share this key, the expensive overlay is computed
+/// at most once per build regardless of which arm is active.
+/// </para>
+/// <para>
 /// The abstraction is intentionally minimal so that the single-slot in-memory
 /// implementation (<see cref="InMemoryPatternClipCache"/>) and the disk-backed
 /// (WKB sidecar) implementation (<see cref="DiskPatternClipCache"/>) — which

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDatasetRenderer.cs
@@ -361,8 +361,8 @@ public sealed class MapsuiDatasetRenderer
     {
         var c = CultureInfo.InvariantCulture;
         return identityKey
-            + "|tol:" + MapsuiDisplayListRenderer.PatternClipSimplifyToleranceMetres.ToString("R", c)
-            + "|gate:" + MapsuiDisplayListRenderer.MinPointsToSimplifyForClip.ToString(c)
+            + "|tol:" + EncDotNet.S100.Rendering.Scene.PatternPriorityClipper.SimplifyToleranceMetres.ToString("R", c)
+            + "|gate:" + EncDotNet.S100.Rendering.Scene.PatternPriorityClipper.MinPointsToSimplify.ToString(c)
             + "|fmt:" + DiskPatternClipCache.FormatVersion.ToString(c);
     }
 

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -423,6 +423,7 @@ public sealed class MapsuiDisplayListRenderer
                 SymbolResolver = ResolveSymbolAsset,
                 LineStyleProvider = LineStyleProvider,
                 PatternResolver = GetPatternTilePng,
+                PatternClipCache = BuildPatternClipMemoizer(),
                 SymbolScale = SymbolScale,
                 TextScale = TextScale,
                 OutOfBandMinDisplayScale = OutOfBandMinDisplayScale,
@@ -1124,6 +1125,35 @@ public sealed class MapsuiDisplayListRenderer
     /// </summary>
     /// <remarks>Entries must be sorted by ascending priority before calling;
     /// results are returned in the same order.</remarks>
+    /// <summary>
+    /// Adapts this renderer's <see cref="PatternClipCache"/> (an
+    /// <see cref="IPatternClipCache"/> keyed by <see cref="PatternClipCacheKey"/>)
+    /// into the <see cref="Scene.PatternClipMemoizer"/> consumed by
+    /// <see cref="Scene.VectorSceneBuilder"/>, so the default TiledScene ("B") arm
+    /// memoizes its pattern priority-clip exactly like the Mapsui feature ("A")
+    /// arm. Returns <see langword="null"/> when no cache or key is configured, in
+    /// which case the builder clips on every build. The clip result is
+    /// palette-independent, so a Day/Dusk/Night switch (which recolours the
+    /// pattern tiles applied after clipping) reuses the cached geometry.
+    /// </summary>
+    private Scene.PatternClipMemoizer? BuildPatternClipMemoizer()
+    {
+        if (PatternClipCache is not { } cache || PatternClipCacheKey is not { } key)
+            return null;
+
+        return compute => cache
+            .GetOrCompute(key, () =>
+            {
+                var clipped = compute();
+                var tuples = new List<(string PatternRef, int Priority, Geometry Geometry)>(clipped.Count);
+                foreach (var c in clipped)
+                    tuples.Add((c.PatternRef, c.Priority, c.Geometry));
+                return tuples;
+            })
+            .Select(t => new Scene.PatternPriorityClipper.ClippedPattern(t.PatternRef, t.Priority, t.Geometry))
+            .ToList();
+    }
+
     private static List<(string PatternRef, int Priority, Geometry Geometry)> ClipPatternsByPriority(
         List<(string PatternRef, int Priority, List<Polygon> Polygons)> entries,
         List<Polygon> nonPatternedColorFills)

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -327,9 +327,16 @@ public sealed class MapsuiDisplayListRenderer
                     continue;
                 }
 
-                // Track non-patterned color fills (e.g. land areas) for pattern clipping
+                // Track fully-opaque non-patterned colour fills (e.g. land areas)
+                // as pattern occluders. Translucent fills (Transparency > 0) do
+                // not fully hide underlying patterns, and PatternPriorityClipper
+                // treats every supplied polygon as a full occluder, so they are
+                // excluded here — matching the IR path's alpha == 255 gate (area
+                // fills are otherwise opaque; Transparency is their only source of
+                // translucency).
                 if (instruction is AreaInstruction { FillColor: not null } colorFill
                     && geom is not null
+                    && colorFill.Transparency is null or <= 0
                     && !featuresWithPatterns.Contains(colorFill.FeatureReference))
                 {
                     var polygon = CreatePolygonFromGeometry(geom);

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -13,9 +13,6 @@ using Mapsui.Nts;
 using Mapsui.Projections;
 using Mapsui.Styles;
 using NetTopologySuite.Geometries;
-using NetTopologySuite.Operation.Overlay;
-using NetTopologySuite.Operation.OverlayNG;
-using NetTopologySuite.Simplify;
 using MapsuiColor = Mapsui.Styles.Color;
 using S100Diag = EncDotNet.S100.Renderers.Mapsui.Diagnostics;
 using Scene = EncDotNet.S100.Rendering.Scene;
@@ -1115,263 +1112,32 @@ public sealed class MapsuiDisplayListRenderer
 
         return null;
     }
-    /// 1. Lower-priority patterns are clipped by higher-priority pattern areas
-    ///    (e.g. DIAMOND1 at priority 9 is clipped by DQUAL at priority 12).
-    /// 2. All patterns are clipped to exclude non-patterned color fill areas
-    ///    (e.g. land areas) where patterns should not be visible.
+
+    /// <summary>
+    /// Clips lower-priority pattern groups by higher-priority pattern areas and by
+    /// the opaque non-patterned colour fills (e.g. land), so a lower-priority
+    /// pattern does not show through a higher-priority zone and no pattern bleeds
+    /// over land. Delegates to the shared, backend-neutral
+    /// <see cref="Scene.PatternPriorityClipper"/> so the Mapsui feature path and
+    /// the <see cref="Scene.VectorScene"/> IR path (headless Skia + TiledScene)
+    /// clip identically.
     /// </summary>
-    /// <remarks>
-    /// Entries must be sorted by ascending priority before calling.
-    /// Returns (tilePng, clippedGeometry) pairs in ascending priority order.
-    /// <para>
-    /// Pattern geometries are generalized with <see cref="TopologyPreservingSimplifier"/>
-    /// at <see cref="PatternClipSimplifyToleranceMetres"/> before the NetTopologySuite
-    /// overlay operations. S-101 quality/coverage areas (e.g. M_QUAL) can follow the
-    /// coastline with tens of thousands of vertices, the bulk of which are sub-pixel at
-    /// chart display scales. Because the clipped boundary only bounds a tiled raster
-    /// pattern fill, this generalization is visually negligible yet reduces the
-    /// <c>Difference</c>/<c>Union</c> cost on pathological geometries by an order of
-    /// magnitude. Topology-preserving simplification keeps the inputs valid for overlay.
-    /// </para>
-    /// <para>
-    /// The <c>Difference</c>/<c>Union</c> overlays are evaluated with
-    /// NetTopologySuite's <see cref="OverlayNGRobust"/> (OverlayNG) rather than the
-    /// library default legacy overlay. OverlayNG is markedly faster on dense inputs
-    /// and avoids the legacy robustness-snapping retry path (profiling on a ~64,000
-    /// vertex M_QUAL coverage area: the clip frame dropped from ~3.5&#160;s to
-    /// ~1.5&#160;s, with overlay <c>Difference</c> falling from ~2.45&#160;s to
-    /// ~0.45&#160;s). OverlayNG is also robust to the (occasionally invalid) output of
-    /// topology-preserving simplification, so no pre-overlay geometry repair is needed.
-    /// </para>
-    /// </remarks>
+    /// <remarks>Entries must be sorted by ascending priority before calling;
+    /// results are returned in the same order.</remarks>
     private static List<(string PatternRef, int Priority, Geometry Geometry)> ClipPatternsByPriority(
         List<(string PatternRef, int Priority, List<Polygon> Polygons)> entries,
         List<Polygon> nonPatternedColorFills)
     {
-        if (entries.Count == 0)
-            return [];
+        var groups = new List<Scene.PatternPriorityClipper.PatternGroup>(entries.Count);
+        foreach (var entry in entries)
+            groups.Add(new Scene.PatternPriorityClipper.PatternGroup(
+                entry.PatternRef, entry.Priority, entry.Polygons));
 
-        // Build a union of non-patterned color fill areas (e.g. land) that
-        // should occlude all pattern fills.
-        Geometry? excludeAreas = null;
-        if (nonPatternedColorFills.Count > 0)
-        {
-            try
-            {
-                Geometry nonPatterned = nonPatternedColorFills.Count == 1
-                    ? nonPatternedColorFills[0]
-                    : new MultiPolygon(nonPatternedColorFills.ToArray());
-                // Reduce to polygonal-only so this never becomes a mixed-dimension
-                // overlay clip (see ExtractPolygonal): OverlayNG rejects such inputs.
-                excludeAreas = ExtractPolygonal(SimplifyForClip(OverlayNGRobust.Union(nonPatterned)));
-            }
-            catch (TopologyException)
-            {
-                // If union fails, skip land clipping
-            }
-            catch (ArgumentException)
-            {
-                // Mixed-dimension union input rejected by OverlayNG; skip land clipping.
-            }
-        }
+        var clipped = Scene.PatternPriorityClipper.Clip(groups, nonPatternedColorFills);
 
-        // Build merged, generalized geometry for each entry. Simplifying once up
-        // front means the (potentially huge) geometry is cheap to use both as a
-        // Difference subject and when accumulated into the higher-priority union.
-        var merged = entries.Select(e =>
-        {
-            Geometry g = e.Polygons.Count == 1
-                ? e.Polygons[0]
-                : new MultiPolygon(e.Polygons.ToArray());
-            return (e.PatternRef, e.Priority, Geometry: SimplifyForClip(g));
-        }).ToList();
-
-        // Walk from highest priority down, accumulating a union of
-        // higher-priority areas that will clip lower-priority patterns.
-        Geometry? higherPriorityAreas = null;
-        var result = new (string PatternRef, int Priority, Geometry Geometry)[merged.Count];
-
-        for (int i = merged.Count - 1; i >= 0; i--)
-        {
-            var (patternRef, priority, geometry) = merged[i];
-
-            // Start with the original geometry, then subtract exclusion areas
-            var clipped = geometry;
-
-            // Subtract higher-priority pattern areas (only when they actually
-            // overlap this entry's extent — an envelope test avoids a costly
-            // overlay when the areas are disjoint).
-            if (higherPriorityAreas is not null &&
-                higherPriorityAreas.EnvelopeInternal.Intersects(geometry.EnvelopeInternal))
-            {
-                try
-                {
-                    clipped = OverlayNGRobust.Overlay(
-                        clipped, higherPriorityAreas, SpatialFunction.Difference);
-                }
-                catch (TopologyException)
-                {
-                    // Fall back to unclipped geometry
-                }
-                catch (ArgumentException)
-                {
-                    // NTS Difference rejects GeometryCollection arguments;
-                    // accumulated unions can degenerate to that shape.
-                    // Fall back to unclipped geometry.
-                }
-            }
-
-            // Subtract non-patterned color fill areas (e.g. land)
-            if (excludeAreas is not null &&
-                excludeAreas.EnvelopeInternal.Intersects(clipped.EnvelopeInternal))
-            {
-                try
-                {
-                    clipped = OverlayNGRobust.Overlay(
-                        clipped, excludeAreas, SpatialFunction.Difference);
-                }
-                catch (TopologyException)
-                {
-                    // Fall back to current clipped geometry
-                }
-                catch (ArgumentException)
-                {
-                    // GeometryCollection rejected by NTS Difference; keep current geometry.
-                }
-            }
-
-            result[i] = (patternRef, priority, clipped);
-
-            // Add this entry's (generalized) area to the higher-priority union
-            // for use by the next, lower-priority entries. The union is reduced
-            // to polygonal-only so it can never become a mixed-dimension
-            // GeometryCollection that the next iteration's Difference overlay
-            // (and OverlayNG) would reject.
-            try
-            {
-                Geometry accumulated = higherPriorityAreas is null
-                    ? geometry
-                    : OverlayNGRobust.Overlay(higherPriorityAreas, geometry, SpatialFunction.Union);
-                higherPriorityAreas = ExtractPolygonal(accumulated) ?? higherPriorityAreas;
-            }
-            catch (TopologyException)
-            {
-                // If union fails, keep the existing accumulated area
-            }
-            catch (ArgumentException)
-            {
-                // NTS Union rejects GeometryCollection LHS;
-                // keep existing accumulated area.
-            }
-        }
-
-        return [.. result];
-    }
-
-    /// <summary>
-    /// Tolerance, in EPSG:3857 (Web Mercator) metres, used to generalize pattern
-    /// and exclusion geometries before clipping. Web Mercator inflates distances by
-    /// 1/cos(latitude), so this projected tolerance is conservative (smaller in
-    /// ground metres) away from the equator. The clipped boundary only bounds a
-    /// tiled raster pattern fill, so this generalization is not visually significant.
-    /// </summary>
-    public const double PatternClipSimplifyToleranceMetres = 1.0;
-
-    /// <summary>
-    /// Minimum vertex count at which <see cref="SimplifyForClip"/> generalizes a
-    /// geometry before the clip overlay. Below this, the NetTopologySuite
-    /// <c>Difference</c>/<c>Union</c> cost is already small (profiling: a
-    /// ~2,600-vertex pattern area clips in ~50&#160;ms) and the simplifier's own
-    /// fixed setup cost would be net overhead. The cost the optimization targets is
-    /// super-linear and only becomes significant for very dense areas (profiling: a
-    /// ~64,000-vertex M_QUAL coverage area took ~7.7&#160;s), so gating on vertex
-    /// count applies the generalization only where it provides a clear net win and
-    /// leaves the common case (small/moderate areas) byte-identical to no
-    /// generalization at all.
-    /// </summary>
-    public const int MinPointsToSimplifyForClip = 2000;
-
-    /// <summary>
-    /// Generalizes a polygonal geometry for use as a clip subject/mask, preserving
-    /// topological validity so the result is safe for subsequent NetTopologySuite
-    /// overlay operations. Geometries below <see cref="MinPointsToSimplifyForClip"/>
-    /// vertices are returned unchanged (the overlay is already inexpensive at that
-    /// size). Returns the original geometry if simplification fails or degenerates
-    /// to empty.
-    /// </summary>
-    private static Geometry SimplifyForClip(Geometry geometry)
-    {
-        if (geometry.NumPoints < MinPointsToSimplifyForClip)
-            return geometry;
-
-        try
-        {
-            var simplified = TopologyPreservingSimplifier.Simplify(
-                geometry, PatternClipSimplifyToleranceMetres);
-
-            if (simplified is null || simplified.IsEmpty)
-                return geometry;
-
-            if (!simplified.IsValid)
-            {
-                var fixedGeometry = simplified.Buffer(0);
-                simplified = fixedGeometry.IsEmpty ? geometry : fixedGeometry;
-            }
-
-            // Topology-preserving simplification (and the Buffer(0) repair above)
-            // can collapse thin polygons to linestrings, producing a
-            // mixed-dimension GeometryCollection. OverlayNG rejects such inputs
-            // with "Overlay input is mixed-dimension", which previously failed the
-            // entire pattern-clip for a cell. Keep only the polygonal components
-            // so the result is always a valid overlay subject/clip area.
-            var polygonal = ExtractPolygonal(simplified);
-            return polygonal is null || polygonal.IsEmpty ? geometry : polygonal;
-        }
-        catch (TopologyException)
-        {
-            return geometry;
-        }
-    }
-
-    /// <summary>
-    /// Reduces an arbitrary geometry to its polygonal components, returning a
-    /// <see cref="Polygon"/> or <see cref="MultiPolygon"/> (or <see langword="null"/>
-    /// when no polygonal component exists). This guards the pattern-clip overlays
-    /// against the mixed-dimension <see cref="GeometryCollection"/> that
-    /// topology-preserving simplification can emit, which OverlayNG rejects.
-    /// </summary>
-    /// <param name="geometry">The geometry to reduce; may be any dimension.</param>
-    /// <returns>
-    /// The polygonal-only geometry, or <see langword="null"/> when the input
-    /// contains no polygon.
-    /// </returns>
-    internal static Geometry? ExtractPolygonal(Geometry geometry)
-    {
-        if (geometry is Polygon or MultiPolygon)
-            return geometry;
-
-        var polygons = new List<Polygon>();
-        CollectPolygons(geometry, polygons);
-
-        if (polygons.Count == 0)
-            return null;
-        if (polygons.Count == 1)
-            return polygons[0];
-
-        return geometry.Factory.CreateMultiPolygon(polygons.ToArray());
-    }
-
-    private static void CollectPolygons(Geometry geometry, List<Polygon> sink)
-    {
-        switch (geometry)
-        {
-            case Polygon polygon:
-                sink.Add(polygon);
-                break;
-            case GeometryCollection collection:
-                for (int i = 0; i < collection.NumGeometries; i++)
-                    CollectPolygons(collection.GetGeometryN(i), sink);
-                break;
-        }
+        var result = new List<(string PatternRef, int Priority, Geometry Geometry)>(clipped.Count);
+        foreach (var c in clipped)
+            result.Add((c.PatternRef, c.Priority, c.Geometry));
+        return result;
     }
 }

--- a/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Mapsui/MapsuiDisplayListRenderer.cs
@@ -145,6 +145,16 @@ public sealed class MapsuiDisplayListRenderer
     public string? PatternClipCacheKey { get; init; }
 
     /// <summary>
+    /// Optional per-render override of the active base-plane render subsystem
+    /// (see <see cref="RenderingOptimizations.RenderSubsystem"/>). When set, this
+    /// render uses the specified arm regardless of the process-wide default,
+    /// without mutating global state — making arm-specific behaviour
+    /// deterministic and parallel-safe for tests and harnesses. When
+    /// <see langword="null"/> (the default) the process-wide subsystem applies.
+    /// </summary>
+    public RenderSubsystemKind? RenderSubsystemOverride { get; init; }
+
+    /// <summary>
     /// A cached SVG symbol: its Mapsui <c>svg-content://</c> source URI plus
     /// the pivot-to-bounds-centre offset recovered from the raw SVG before
     /// <see cref="SvgProcessor"/> stripped its layout elements.  The relative
@@ -242,79 +252,93 @@ public sealed class MapsuiDisplayListRenderer
         // symbology emits exactly one rectangle per anchor (see the build loop).
         var pointHitRectKeys = new HashSet<(string FeatureReference, double X, double Y)>();
         var patternEntries = new List<(string PatternRef, int Priority, List<Polygon> Polygons)>();
+        var nonPatternedColorFillPolygons = new List<Polygon>();
         int lastColorFillIndex = -1;
 
-        // 3a. Pattern bookkeeping (unchanged): collect pattern polygons grouped
+        // Select the base-plane render subsystem up front (design §4/§5). The
+        // pattern bookkeeping, priority clip, and pattern-fill feature insertion
+        // below feed the Mapsui feature ("A") arm exclusively: those features are
+        // never rendered by the TiledScene ("B") arm (which paints patterns from
+        // the IR scene bound to the layer) and carry no pick identity, so they are
+        // pure dead weight there. Compute the arm now so the whole pattern phase
+        // can be skipped when the B arm is active.
+        var useTiledScene =
+            (RenderSubsystemOverride ?? RenderingOptimizations.RenderSubsystem)
+                == RenderSubsystemKind.TiledScene;
+
+        // 3a. Pattern bookkeeping (A arm only): collect pattern polygons grouped
         //     by (pattern, priority), plus the non-patterned colour fills (e.g.
         //     land) that clip them. Pattern fills are merged per unique pattern so
         //     overlapping polygons with the same globally-anchored pattern are
         //     drawn exactly once. This mirrors the legacy single-pass collection
         //     and is kept separate from the IR for this slice.
-        var featuresWithPatterns = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var instruction in sorted)
+        if (!useTiledScene)
         {
-            if (instruction is AreaInstruction { AreaFillReference: not null } pa)
-                featuresWithPatterns.Add(pa.FeatureReference);
-        }
-
-        var nonPatternedColorFillPolygons = new List<Polygon>();
-
-        foreach (var instruction in sorted)
-        {
-            var geom = geometryProvider.GetGeometry(instruction.FeatureReference);
-
-            // LineInstructions with CoordinatesOverride carry their own
-            // synthetic geometry (from augmented rays/arcs) and don't need
-            // the feature's natural geometry to have coordinates.
-            bool hasAugmentedLine = instruction is LineInstruction { CoordinatesOverride: not null };
-            if (!hasAugmentedLine && (geom is null || geom.Coordinates.Count == 0))
-                continue;
-
-            // Defer pattern fills for merging
-            if (instruction is AreaInstruction { AreaFillReference: { } patternRef } areaPattern && geom is not null)
+            var featuresWithPatterns = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var instruction in sorted)
             {
-                // Inclusion gate: only collect the entry when the pattern
-                // resolves to a tile under the current palette (patterns with
-                // no resolvable asset are dropped, exactly as before). The
-                // resolved tile is discarded here; grouping/merging keys on the
-                // palette-independent pattern reference so the clip result is
-                // palette-independent and cacheable. The tile is re-resolved
-                // under the active palette after clipping.
-                if (GetPatternTilePng(patternRef) is not null)
+                if (instruction is AreaInstruction { AreaFillReference: not null } pa)
+                    featuresWithPatterns.Add(pa.FeatureReference);
+            }
+
+            foreach (var instruction in sorted)
+            {
+                var geom = geometryProvider.GetGeometry(instruction.FeatureReference);
+
+                // LineInstructions with CoordinatesOverride carry their own
+                // synthetic geometry (from augmented rays/arcs) and don't need
+                // the feature's natural geometry to have coordinates.
+                bool hasAugmentedLine = instruction is LineInstruction { CoordinatesOverride: not null };
+                if (!hasAugmentedLine && (geom is null || geom.Coordinates.Count == 0))
+                    continue;
+
+                // Defer pattern fills for merging
+                if (instruction is AreaInstruction { AreaFillReference: { } patternRef } areaPattern && geom is not null)
+                {
+                    // Inclusion gate: only collect the entry when the pattern
+                    // resolves to a tile under the current palette (patterns with
+                    // no resolvable asset are dropped, exactly as before). The
+                    // resolved tile is discarded here; grouping/merging keys on the
+                    // palette-independent pattern reference so the clip result is
+                    // palette-independent and cacheable. The tile is re-resolved
+                    // under the active palette after clipping.
+                    if (GetPatternTilePng(patternRef) is not null)
+                    {
+                        var polygon = CreatePolygonFromGeometry(geom);
+                        if (polygon is not null)
+                        {
+                            // Find existing entry with the same pattern reference and priority, or create a new one.
+                            // OrdinalIgnoreCase matches MapsuiRenderAssetCache's tile-resolution
+                            // comparer, so this grouping is exactly equivalent to the previous
+                            // ReferenceEquals(TilePng) grouping (same fillName -> same byte[] ref).
+                            var existing = patternEntries.Find(e =>
+                                string.Equals(e.PatternRef, patternRef, StringComparison.OrdinalIgnoreCase)
+                                && e.Priority == areaPattern.DrawingPriority);
+                            if (existing.PatternRef is not null)
+                            {
+                                existing.Polygons.Add(polygon);
+                            }
+                            else
+                            {
+                                patternEntries.Add((patternRef, areaPattern.DrawingPriority, new List<Polygon> { polygon }));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                // Track non-patterned color fills (e.g. land areas) for pattern clipping
+                if (instruction is AreaInstruction { FillColor: not null } colorFill
+                    && geom is not null
+                    && !featuresWithPatterns.Contains(colorFill.FeatureReference))
                 {
                     var polygon = CreatePolygonFromGeometry(geom);
                     if (polygon is not null)
-                    {
-                        // Find existing entry with the same pattern reference and priority, or create a new one.
-                        // OrdinalIgnoreCase matches MapsuiRenderAssetCache's tile-resolution
-                        // comparer, so this grouping is exactly equivalent to the previous
-                        // ReferenceEquals(TilePng) grouping (same fillName -> same byte[] ref).
-                        var existing = patternEntries.Find(e =>
-                            string.Equals(e.PatternRef, patternRef, StringComparison.OrdinalIgnoreCase)
-                            && e.Priority == areaPattern.DrawingPriority);
-                        if (existing.PatternRef is not null)
-                        {
-                            existing.Polygons.Add(polygon);
-                        }
-                        else
-                        {
-                            patternEntries.Add((patternRef, areaPattern.DrawingPriority, new List<Polygon> { polygon }));
-                        }
-                    }
+                        nonPatternedColorFillPolygons.Add(polygon);
                 }
-                continue;
-            }
-
-            // Track non-patterned color fills (e.g. land areas) for pattern clipping
-            if (instruction is AreaInstruction { FillColor: not null } colorFill
-                && geom is not null
-                && !featuresWithPatterns.Contains(colorFill.FeatureReference))
-            {
-                var polygon = CreatePolygonFromGeometry(geom);
-                if (polygon is not null)
-                    nonPatternedColorFillPolygons.Add(polygon);
             }
         }
+
 
         // 3b. Build Mapsui features from the IR, in Part 9 draw order. Solid-area
         //     ops mark the colour-fill boundary so merged patterns are inserted
@@ -347,48 +371,51 @@ public sealed class MapsuiDisplayListRenderer
         // higher-priority patterns so that, e.g., DIAMOND1 (priority 9)
         // diamonds do not show through DQUAL (priority 12) pattern zones.
         // Also clips all patterns against non-patterned color fill areas
-        // (e.g. land) so patterns don't bleed over land.
-        patternEntries.Sort((a, b) => a.Priority.CompareTo(b.Priority));
-        var clippedPatterns = PatternClipCache is not null && PatternClipCacheKey is not null
-            ? PatternClipCache.GetOrCompute(
-                PatternClipCacheKey,
-                () => ClipPatternsByPriority(patternEntries, nonPatternedColorFillPolygons))
-            : ClipPatternsByPriority(patternEntries, nonPatternedColorFillPolygons);
-
-        // Insert merged pattern fill features after all color fills but before
-        // lines/points/text. This ensures no solid fill can occlude a pattern.
-        // The tile is re-resolved here under the active palette (the clip
-        // geometry is palette-independent and may have come from the cache,
-        // which is shared across palettes).
-        int insertAt = lastColorFillIndex >= 0 ? lastColorFillIndex : 0;
-        foreach (var (patternRef, _, geometry) in clippedPatterns)
+        // (e.g. land) so patterns don't bleed over land. A-arm only: the B arm
+        // renders patterns from the IR scene and skips this phase entirely.
+        if (!useTiledScene)
         {
-            var tile = GetPatternTilePicture(patternRef);
-            if (tile is null)
-                continue;
+            patternEntries.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+            var clippedPatterns = PatternClipCache is not null && PatternClipCacheKey is not null
+                ? PatternClipCache.GetOrCompute(
+                    PatternClipCacheKey,
+                    () => ClipPatternsByPriority(patternEntries, nonPatternedColorFillPolygons))
+                : ClipPatternsByPriority(patternEntries, nonPatternedColorFillPolygons);
 
-            var feature = new GeometryFeature(geometry);
-            feature.Styles.Add(new AnchoredPatternFillStyle
+            // Insert merged pattern fill features after all color fills but before
+            // lines/points/text. This ensures no solid fill can occlude a pattern.
+            // The tile is re-resolved here under the active palette (the clip
+            // geometry is palette-independent and may have come from the cache,
+            // which is shared across palettes).
+            int insertAt = lastColorFillIndex >= 0 ? lastColorFillIndex : 0;
+            foreach (var (patternRef, _, geometry) in clippedPatterns)
             {
-                Tile = tile.Value.Picture,
-                TileRect = tile.Value.Rect,
-            });
-            mapFeatures.Insert(insertAt, feature);
-            insertAt++;
+                var tile = GetPatternTilePicture(patternRef);
+                if (tile is null)
+                    continue;
+
+                var feature = new GeometryFeature(geometry);
+                feature.Styles.Add(new AnchoredPatternFillStyle
+                {
+                    Tile = tile.Value.Picture,
+                    TileRect = tile.Value.Rect,
+                });
+                mapFeatures.Insert(insertAt, feature);
+                insertAt++;
+            }
         }
 
         S100Diag.Telemetry.StylesApplied.Add(mapFeatures.Sum(f => f.Styles.Count));
         S100Diag.Telemetry.FrameDuration.Record(
             (Stopwatch.GetTimestamp() - renderStart) * 1000.0 / Stopwatch.Frequency);
 
-        // Select the base-plane render subsystem (design §4/§5). When the
-        // TiledScene ("B") arm is active, the layer is portrayed by
+        // When the TiledScene ("B") arm is active, the layer is portrayed by
         // S100VectorSceneRenderer rasterising the VectorScene IR directly on a
         // worker — so build a *pattern-complete* scene (the Mapsui lowering above
         // deliberately omits patterns; the B arm renders them from the IR) and
         // bind it to the layer. Otherwise the snapshot ("A") arm (or the plain
-        // per-feature path) renders the Mapsui features built above.
-        var useTiledScene = RenderingOptimizations.RenderSubsystem == RenderSubsystemKind.TiledScene;
+        // per-feature path) renders the Mapsui features built above (including the
+        // clipped pattern fills inserted in the A-arm-only phase).
 
         // Within the TiledScene subsystem, the Phase-2 tiled renderer is the
         // default; S100_VECTOR_SCENE_MODE=single selects the Phase-1

--- a/src/EncDotNet.S100.Renderers.Skia/README.md
+++ b/src/EncDotNet.S100.Renderers.Skia/README.md
@@ -64,10 +64,15 @@ exactly one place:
 - **`ScaleVisibility`** (in `Rendering.Scene`) — shared S-100 Part 9 §11.1 scale-visibility rule.
 - **`ColorResolver`** — S-100 colour-token resolution (palette + inline hex).
 
-**Scope (spike):** the IR currently covers point, line, solid-area, and text
-ops. Pattern fills and Web-Mercator pole limits are not yet represented in the
-IR — pattern fills remain handled by the Mapsui renderer's dedicated pattern
-collection / priority-clip / insert phase. Antimeridian (±180°) crossing **is**
+**Scope:** the IR covers point, line, solid-area, text, and tiled **pattern**
+area-fill ops. Pattern fills are lowered into the IR as `PatternAreaPaintOp`
+when a pattern resolver is supplied (the headless Skia path and the Mapsui
+TiledScene subsystem) and are priority-clipped by the shared
+`PatternPriorityClipper` — the same NetTopologySuite clip the Mapsui feature
+path applies — so a lower-priority pattern does not bleed through a
+higher-priority pattern or an opaque solid fill. The Mapsui feature path leaves
+the resolver unset and drives its own pattern collection / insert phase (still
+sharing the clipper). Antimeridian (±180°) crossing **is**
 handled for the headless auto-fit: `SeamAwareBoundsAccumulator` (in
 `Rendering.Scene`) frames dateline-spanning datasets on their true extent and
 `WorldToScreen` wraps ops into the shifted window at draw time (issue #413).

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -26,8 +26,10 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 /// text within a plane) — the same ordering each Mapsui layer applies —
 /// but a single headless bitmap does not reproduce the S-101 processor's
 /// two-layer area/non-area split (that split exists only to interleave
-/// S-102), nor the Mapsui pattern phase's NetTopologySuite priority-clipping
-/// against higher-priority patterns and opaque solid fills.
+/// S-102). Pattern area-fills <b>are</b> priority-clipped against
+/// higher-priority patterns and opaque solid fills: the shared
+/// <c>VectorSceneBuilder</c> applies <c>PatternPriorityClipper</c> when
+/// lowering the scene, so headless output matches the Mapsui pattern phase.
 /// </remarks>
 public static class HeadlessVectorRenderer
 {

--- a/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
+++ b/src/EncDotNet.S100.Renderers.Skia/Scene/HeadlessVectorRenderer.cs
@@ -11,7 +11,8 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 /// S-100 Part 9 display list (point/line/solid-area/pattern-area/text) through
 /// the shared <see cref="VectorSceneBuilder"/> and rasterises it with
 /// <see cref="SkiaDisplayListRenderer"/>, auto-fitting the viewport to the
-/// resolved scene's EPSG:3857 extent. Works for any vector product (S-101
+/// resolved scene's EPSG:3857 extent unless an explicit viewport is supplied.
+/// Works for any vector product (S-101
 /// ISO 8211, S-12x / S-201 / S-421 GML, …) because it depends only on the
 /// encoding-agnostic <see cref="DrawingInstruction"/> /
 /// <see cref="IFeatureGeometryProvider"/> contract — not on Mapsui.
@@ -31,9 +32,11 @@ namespace EncDotNet.S100.Renderers.Skia.Scene;
 public static class HeadlessVectorRenderer
 {
     /// <summary>
-    /// Renders a display list to a standalone bitmap, auto-fitting the viewport
-    /// to the scene extent. Scale-visibility culling is disabled (the fitted
-    /// scale is not a meaningful compilation scale); all resolved ops are drawn.
+    /// Renders a display list to a standalone bitmap. By default the viewport is
+    /// auto-fitted to the scene extent and scale-visibility culling is disabled
+    /// (the fitted scale is not a meaningful compilation scale), so all resolved
+    /// ops are drawn; pass an explicit <paramref name="viewport"/> to frame an
+    /// exact window and enable scale-visibility culling.
     /// </summary>
     /// <param name="instructions">The Part 9 display list to render.</param>
     /// <param name="geometryProvider">Resolves feature geometry referenced by the instructions.</param>
@@ -68,6 +71,15 @@ public static class HeadlessVectorRenderer
     /// the same auto-fitted viewport, so it registers exactly with the chart.
     /// Defaults to <see cref="BasemapKind.None"/> (no basemap; output unchanged).
     /// </param>
+    /// <param name="viewport">
+    /// Optional explicit display window. When <c>null</c> (the default) the
+    /// viewport is auto-fitted to the scene extent (padded 10%, aspect-matched)
+    /// and scale-visibility culling is disabled. When supplied, that exact
+    /// window is rendered <em>and</em> S-100 Part 9 scale-visibility culling is
+    /// enabled — because an explicit viewport carries a meaningful
+    /// <see cref="Viewport.ScaleDenominator"/> — bringing this path into
+    /// alignment with the composite/GUI render paths.
+    /// </param>
     /// <returns>A newly allocated bitmap owned by the caller.</returns>
     public static SKBitmap Render(
         IReadOnlyList<DrawingInstruction> instructions,
@@ -82,7 +94,8 @@ public static class HeadlessVectorRenderer
         RgbaColor background,
         Func<string, AreaFill?>? areaFillProvider = null,
         DrawingInstructionCategory hiddenCategories = DrawingInstructionCategory.None,
-        BasemapKind basemap = BasemapKind.None)
+        BasemapKind basemap = BasemapKind.None,
+        Viewport? viewport = null)
     {
         ArgumentNullException.ThrowIfNull(instructions);
         ArgumentNullException.ThrowIfNull(geometryProvider);
@@ -101,28 +114,33 @@ public static class HeadlessVectorRenderer
             symbolScale,
             textScale,
             areaFillProvider);
-        var viewport = FitViewport(scene, widthPixels, heightPixels);
+
+        // An explicit viewport frames an exact window and carries a real scale
+        // denominator, so honour scale-visibility; the auto-fit fallback uses a
+        // synthetic scale, so culling stays disabled (draw every resolved op).
+        bool honorScaleVisibility = viewport is not null;
+        var resolvedViewport = viewport ?? FitViewport(scene, widthPixels, heightPixels);
 
         if (basemap == BasemapKind.Offline)
         {
-            // Paint the land basemap under the dataset against the SAME fitted
+            // Paint the land basemap under the dataset against the SAME
             // viewport so the two register exactly. The compositor clears the
             // background once, then draws each transparent layer bottom-first.
             var compositeRenderer = new HeadlessCompositeRenderer { Background = background };
             var layers = new CompositeLayer[]
             {
                 new VectorCompositeLayer(NaturalEarthBasemap.LandScene, honorScaleVisibility: false),
-                new VectorCompositeLayer(scene, honorScaleVisibility: false),
+                new VectorCompositeLayer(scene, honorScaleVisibility),
             };
-            return compositeRenderer.Render(viewport, layers);
+            return compositeRenderer.Render(resolvedViewport, layers);
         }
 
         var renderer = new SkiaDisplayListRenderer
         {
             Background = background,
-            HonorScaleVisibility = false,
+            HonorScaleVisibility = honorScaleVisibility,
         };
-        return renderer.Render(scene, viewport);
+        return renderer.Render(scene, resolvedViewport);
     }
 
     /// <summary>

--- a/src/EncDotNet.S100.Rendering.Scene/EncDotNet.S100.Rendering.Scene.csproj
+++ b/src/EncDotNet.S100.Rendering.Scene/EncDotNet.S100.Rendering.Scene.csproj
@@ -4,9 +4,13 @@
     <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <Description>Backend-neutral vector scene intermediate representation (IR) for the IHO S-100 portrayal pipeline: VectorScene and the PaintOp hierarchy (point/line/area/pattern/text), VectorSceneBuilder, ColorResolver, ScaleVisibility, and WebMercator projection. Depends only on EncDotNet.S100.Core and EncDotNet.S100.Portrayals — no SkiaSharp, Mapsui, or GUI framework — so any rendering backend can consume the same resolved scene. Pairs with EncDotNet.S100.Renderers.Skia for headless rasterisation without the EncDotNet.S100 facade.</Description>
+    <Description>Backend-neutral vector scene intermediate representation (IR) for the IHO S-100 portrayal pipeline: VectorScene and the PaintOp hierarchy (point/line/area/pattern/text), VectorSceneBuilder, ColorResolver, ScaleVisibility, WebMercator projection, and PatternPriorityClipper (NetTopologySuite priority-clipping of pattern area fills). Depends only on EncDotNet.S100.Core, EncDotNet.S100.Portrayals, and NetTopologySuite — no SkiaSharp, Mapsui, or GUI framework — so any rendering backend can consume the same resolved scene. Pairs with EncDotNet.S100.Renderers.Skia for headless rasterisation without the EncDotNet.S100 facade.</Description>
     <PackageTags>S-100;portrayal;rendering;IR;VectorScene;headless;IHO;hydrography;ECDIS</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NetTopologySuite" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EncDotNet.S100.Core\EncDotNet.S100.Core.csproj" />

--- a/src/EncDotNet.S100.Rendering.Scene/PaintOp.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/PaintOp.cs
@@ -183,13 +183,17 @@ public sealed class AreaPaintOp : PaintOp
 /// <c>SKShader</c> anchored at world (0,0) projected to screen space, matching
 /// the Mapsui <c>AnchoredPatternFillStyle</c> contract so the pattern is
 /// seamless across overlapping polygons that share a global tile grid.</para>
-/// <para><b>Known limitation.</b> Unlike the Mapsui pattern phase, the
-/// headless lowering does not perform NetTopologySuite priority-clipping:
-/// lower-priority pattern ops are simply drawn before higher-priority ones and
-/// are not clipped by non-patterned solid colour fills (e.g. land). Patterns
-/// may therefore visibly bleed across opaque overlay areas in headless
-/// renders. Acceptance per issue #192 is "as closely as practical"; tighter
-/// clipping is a separate refinement.</para>
+/// <para><b>Priority clipping.</b> When <see cref="VectorSceneBuilder"/> lowers
+/// pattern fills it priority-clips them via the shared
+/// <see cref="PatternPriorityClipper"/> (S-100 Part 9 §11.3): a lower-priority
+/// pattern op is clipped where a higher-priority pattern op — or an opaque
+/// non-patterned solid colour fill (e.g. land) — covers it, so the geometry
+/// carried here is already the visible portion. This is the identical clip the
+/// Mapsui feature path applies, so the headless Skia backend and the Mapsui
+/// TiledScene subsystem no longer bleed patterns across opaque overlay areas
+/// (resolves the issue #192 "as closely as practical" caveat). A clipped group
+/// can be a multi-polygon, so it is emitted as several ops (one shell + holes
+/// each).</para>
 /// </remarks>
 public sealed class PatternAreaPaintOp : PaintOp
 {

--- a/src/EncDotNet.S100.Rendering.Scene/PatternClipMemoizer.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/PatternClipMemoizer.cs
@@ -1,0 +1,27 @@
+namespace EncDotNet.S100.Rendering.Scene;
+
+/// <summary>
+/// Memoizes the (palette-independent) result of the pattern priority-clip
+/// (<see cref="PatternPriorityClipper.Clip"/>) so a <see cref="VectorSceneBuilder"/>
+/// re-build that does not change the clip inputs — most importantly a
+/// Day/Dusk/Night palette switch — reuses the previously computed clip geometry
+/// instead of repeating the expensive NetTopologySuite overlay.
+/// </summary>
+/// <param name="compute">
+/// Runs the clip on a cache miss. The delegate invokes it only when it has no
+/// cached result to return; on a hit it returns the cached geometry and
+/// <paramref name="compute"/> is not called.
+/// </param>
+/// <returns>The clipped pattern geometry, cached or freshly computed.</returns>
+/// <remarks>
+/// The clipped boundary geometry is fully determined by the fixed dataset
+/// geometry plus the mariner/ECDIS display state and is independent of the
+/// palette (which only recolours the pattern tiles applied <em>after</em>
+/// clipping), so a single cached result is valid across palette switches. The
+/// Mapsui renderer wires this to its <c>IPatternClipCache</c> (bound to the
+/// current portrayal cache key) for the default TiledScene ("B") arm — bringing
+/// it to parity with the Mapsui feature ("A") arm. The headless Skia path leaves
+/// it unset, since a headless render performs the clip exactly once.
+/// </remarks>
+public delegate IReadOnlyList<PatternPriorityClipper.ClippedPattern> PatternClipMemoizer(
+    Func<IReadOnlyList<PatternPriorityClipper.ClippedPattern>> compute);

--- a/src/EncDotNet.S100.Rendering.Scene/PatternPriorityClipper.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/PatternPriorityClipper.cs
@@ -1,0 +1,321 @@
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Overlay;
+using NetTopologySuite.Operation.OverlayNG;
+using NetTopologySuite.Simplify;
+
+namespace EncDotNet.S100.Rendering.Scene;
+
+/// <summary>
+/// Backend-neutral priority-clipping of S-100 Part 9 §11.3 tiled pattern area
+/// fills. Given the pattern areas grouped by (pattern reference, drawing
+/// priority) and the opaque non-patterned colour fills, this computes the
+/// visible portion of each pattern group by subtracting every higher-priority
+/// pattern area and every opaque colour fill (e.g. land) from it, so that a
+/// lower-priority pattern does not show through a higher-priority pattern zone
+/// and no pattern bleeds over an opaque area.
+/// </summary>
+/// <remarks>
+/// <para>This is the single, shared implementation used by both render paths:
+/// the Mapsui feature path (<c>MapsuiDisplayListRenderer</c>) invokes it
+/// directly, and the <see cref="VectorScene"/> IR path
+/// (<see cref="VectorSceneBuilder"/>, consumed by the headless Skia backend and
+/// the Mapsui TiledScene subsystem) applies it when lowering pattern ops. Both
+/// therefore clip identically.</para>
+/// <para>All geometry is expressed in EPSG:3857 (Web-Mercator) metres, matching
+/// the <see cref="PaintOp"/> unit contract. The algorithm uses NetTopologySuite
+/// <see cref="OverlayNGRobust"/> (OverlayNG) for full-precision, robust overlay
+/// and generalizes dense areas via <see cref="TopologyPreservingSimplifier"/>
+/// (gated by <see cref="MinPointsToSimplify"/>) to keep the overlay cost bounded
+/// on very dense coverage cells. The clip geometry is palette-independent, so
+/// results are cacheable keyed on the palette-independent portrayal key.</para>
+/// </remarks>
+public static class PatternPriorityClipper
+{
+    /// <summary>
+    /// A group of same-pattern, same-priority area fills to be clipped as one
+    /// unit. Grouping mirrors the Mapsui feature path so both render arms
+    /// produce identical clip topology.
+    /// </summary>
+    /// <param name="PatternRef">The portrayal-catalogue area-fill name.</param>
+    /// <param name="Priority">The S-100 Part 9 drawing priority shared by the group.</param>
+    /// <param name="Polygons">The pattern-area polygons in EPSG:3857 metres.</param>
+    public readonly record struct PatternGroup(
+        string PatternRef, int Priority, IReadOnlyList<Polygon> Polygons);
+
+    /// <summary>
+    /// The clipped, still-visible geometry for one <see cref="PatternGroup"/>.
+    /// </summary>
+    /// <param name="PatternRef">The portrayal-catalogue area-fill name.</param>
+    /// <param name="Priority">The group's drawing priority.</param>
+    /// <param name="Geometry">
+    /// The visible portion after clipping; may be an empty geometry, a
+    /// <see cref="Polygon"/>, or a <see cref="MultiPolygon"/>.
+    /// </param>
+    public readonly record struct ClippedPattern(
+        string PatternRef, int Priority, Geometry Geometry);
+
+    /// <summary>
+    /// Tolerance, in EPSG:3857 (Web Mercator) metres, used to generalize pattern
+    /// and exclusion geometries before clipping. Web Mercator inflates distances by
+    /// 1/cos(latitude), so this projected tolerance is conservative (smaller in
+    /// ground metres) away from the equator. The clipped boundary only bounds a
+    /// tiled raster pattern fill, so this generalization is not visually significant.
+    /// </summary>
+    public const double SimplifyToleranceMetres = 1.0;
+
+    /// <summary>
+    /// Minimum vertex count at which <see cref="SimplifyForClip"/> generalizes a
+    /// geometry before the clip overlay. Below this, the NetTopologySuite
+    /// <c>Difference</c>/<c>Union</c> cost is already small (profiling: a
+    /// ~2,600-vertex pattern area clips in ~50&#160;ms) and the simplifier's own
+    /// fixed setup cost would be net overhead. The cost the optimization targets is
+    /// super-linear and only becomes significant for very dense areas (profiling: a
+    /// ~64,000-vertex M_QUAL coverage area took ~7.7&#160;s), so gating on vertex
+    /// count applies the generalization only where it provides a clear net win and
+    /// leaves the common case (small/moderate areas) byte-identical to no
+    /// generalization at all.
+    /// </summary>
+    public const int MinPointsToSimplify = 2000;
+
+    /// <summary>
+    /// Clips each pattern group against all higher-priority pattern areas and the
+    /// supplied opaque non-patterned colour fills.
+    /// </summary>
+    /// <param name="entries">
+    /// The pattern groups, <b>pre-sorted ascending by priority</b>. The returned
+    /// list is in the same order as this input.
+    /// </param>
+    /// <param name="nonPatternedColorFills">
+    /// Opaque non-patterned colour-fill polygons (e.g. land) that occlude every
+    /// pattern fill. May be empty.
+    /// </param>
+    /// <returns>
+    /// The clipped geometry for each input group, in input order. A group whose
+    /// area is fully occluded yields an empty geometry.
+    /// </returns>
+    /// <remarks>
+    /// The overlay favours robustness: when an individual <c>Difference</c> or
+    /// <c>Union</c> throws (<see cref="TopologyException"/> on degenerate input,
+    /// or <see cref="ArgumentException"/> when an accumulated union degenerates to
+    /// a <see cref="GeometryCollection"/> that NTS overlay rejects), the algorithm
+    /// falls back to the unclipped geometry for that step rather than failing the
+    /// whole clip. This keeps a pattern visible (un-clipped) in preference to
+    /// dropping it, matching the historical Mapsui behaviour.
+    /// </remarks>
+    public static IReadOnlyList<ClippedPattern> Clip(
+        IReadOnlyList<PatternGroup> entries,
+        IReadOnlyList<Polygon> nonPatternedColorFills)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(nonPatternedColorFills);
+
+        if (entries.Count == 0)
+            return [];
+
+        // Build a union of non-patterned color fill areas (e.g. land) that
+        // should occlude all pattern fills.
+        Geometry? excludeAreas = null;
+        if (nonPatternedColorFills.Count > 0)
+        {
+            try
+            {
+                Geometry nonPatterned = nonPatternedColorFills.Count == 1
+                    ? nonPatternedColorFills[0]
+                    : new MultiPolygon([.. nonPatternedColorFills]);
+                // Reduce to polygonal-only so this never becomes a mixed-dimension
+                // overlay clip (see ExtractPolygonal): OverlayNG rejects such inputs.
+                excludeAreas = ExtractPolygonal(SimplifyForClip(OverlayNGRobust.Union(nonPatterned)));
+            }
+            catch (TopologyException)
+            {
+                // If union fails, skip land clipping
+            }
+            catch (ArgumentException)
+            {
+                // Mixed-dimension union input rejected by OverlayNG; skip land clipping.
+            }
+        }
+
+        // Build merged, generalized geometry for each entry. Simplifying once up
+        // front means the (potentially huge) geometry is cheap to use both as a
+        // Difference subject and when accumulated into the higher-priority union.
+        var merged = entries.Select(e =>
+        {
+            Geometry g = e.Polygons.Count == 1
+                ? e.Polygons[0]
+                : new MultiPolygon([.. e.Polygons]);
+            return (e.PatternRef, e.Priority, Geometry: SimplifyForClip(g));
+        }).ToList();
+
+        // Walk from highest priority down, accumulating a union of
+        // higher-priority areas that will clip lower-priority patterns.
+        Geometry? higherPriorityAreas = null;
+        var result = new ClippedPattern[merged.Count];
+
+        for (int i = merged.Count - 1; i >= 0; i--)
+        {
+            var (patternRef, priority, geometry) = merged[i];
+
+            // Start with the original geometry, then subtract exclusion areas
+            var clipped = geometry;
+
+            // Subtract higher-priority pattern areas (only when they actually
+            // overlap this entry's extent — an envelope test avoids a costly
+            // overlay when the areas are disjoint).
+            if (higherPriorityAreas is not null &&
+                higherPriorityAreas.EnvelopeInternal.Intersects(geometry.EnvelopeInternal))
+            {
+                try
+                {
+                    clipped = OverlayNGRobust.Overlay(
+                        clipped, higherPriorityAreas, SpatialFunction.Difference);
+                }
+                catch (TopologyException)
+                {
+                    // Fall back to unclipped geometry
+                }
+                catch (ArgumentException)
+                {
+                    // NTS Difference rejects GeometryCollection arguments;
+                    // accumulated unions can degenerate to that shape.
+                    // Fall back to unclipped geometry.
+                }
+            }
+
+            // Subtract non-patterned color fill areas (e.g. land)
+            if (excludeAreas is not null &&
+                excludeAreas.EnvelopeInternal.Intersects(clipped.EnvelopeInternal))
+            {
+                try
+                {
+                    clipped = OverlayNGRobust.Overlay(
+                        clipped, excludeAreas, SpatialFunction.Difference);
+                }
+                catch (TopologyException)
+                {
+                    // Fall back to current clipped geometry
+                }
+                catch (ArgumentException)
+                {
+                    // GeometryCollection rejected by NTS Difference; keep current geometry.
+                }
+            }
+
+            result[i] = new ClippedPattern(patternRef, priority, clipped);
+
+            // Add this entry's (generalized) area to the higher-priority union
+            // for use by the next, lower-priority entries. The union is reduced
+            // to polygonal-only so it can never become a mixed-dimension
+            // GeometryCollection that the next iteration's Difference overlay
+            // (and OverlayNG) would reject.
+            try
+            {
+                Geometry accumulated = higherPriorityAreas is null
+                    ? geometry
+                    : OverlayNGRobust.Overlay(higherPriorityAreas, geometry, SpatialFunction.Union);
+                higherPriorityAreas = ExtractPolygonal(accumulated) ?? higherPriorityAreas;
+            }
+            catch (TopologyException)
+            {
+                // If union fails, keep the existing accumulated area
+            }
+            catch (ArgumentException)
+            {
+                // NTS Union rejects GeometryCollection LHS;
+                // keep existing accumulated area.
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Generalizes a polygonal geometry for use as a clip subject/mask, preserving
+    /// topological validity so the result is safe for subsequent NetTopologySuite
+    /// overlay operations. Geometries below <see cref="MinPointsToSimplify"/>
+    /// vertices are returned unchanged (the overlay is already inexpensive at that
+    /// size). Returns the original geometry if simplification fails or degenerates
+    /// to empty.
+    /// </summary>
+    /// <param name="geometry">The geometry to generalize.</param>
+    /// <returns>The generalized (or original) geometry.</returns>
+    public static Geometry SimplifyForClip(Geometry geometry)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+
+        if (geometry.NumPoints < MinPointsToSimplify)
+            return geometry;
+
+        try
+        {
+            var simplified = TopologyPreservingSimplifier.Simplify(
+                geometry, SimplifyToleranceMetres);
+
+            if (simplified is null || simplified.IsEmpty)
+                return geometry;
+
+            if (!simplified.IsValid)
+            {
+                var fixedGeometry = simplified.Buffer(0);
+                simplified = fixedGeometry.IsEmpty ? geometry : fixedGeometry;
+            }
+
+            // Topology-preserving simplification (and the Buffer(0) repair above)
+            // can collapse thin polygons to linestrings, producing a
+            // mixed-dimension GeometryCollection. OverlayNG rejects such inputs
+            // with "Overlay input is mixed-dimension", which previously failed the
+            // entire pattern-clip for a cell. Keep only the polygonal components
+            // so the result is always a valid overlay subject/clip area.
+            var polygonal = ExtractPolygonal(simplified);
+            return polygonal is null || polygonal.IsEmpty ? geometry : polygonal;
+        }
+        catch (TopologyException)
+        {
+            return geometry;
+        }
+    }
+
+    /// <summary>
+    /// Reduces an arbitrary geometry to its polygonal components, returning a
+    /// <see cref="Polygon"/> or <see cref="MultiPolygon"/> (or <see langword="null"/>
+    /// when no polygonal component exists). This guards the pattern-clip overlays
+    /// against the mixed-dimension <see cref="GeometryCollection"/> that
+    /// topology-preserving simplification can emit, which OverlayNG rejects.
+    /// </summary>
+    /// <param name="geometry">The geometry to reduce; may be any dimension.</param>
+    /// <returns>
+    /// The polygonal-only geometry, or <see langword="null"/> when the input
+    /// contains no polygon.
+    /// </returns>
+    public static Geometry? ExtractPolygonal(Geometry geometry)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+
+        if (geometry is Polygon or MultiPolygon)
+            return geometry;
+
+        var polygons = new List<Polygon>();
+        CollectPolygons(geometry, polygons);
+
+        if (polygons.Count == 0)
+            return null;
+        if (polygons.Count == 1)
+            return polygons[0];
+
+        return geometry.Factory.CreateMultiPolygon([.. polygons]);
+    }
+
+    private static void CollectPolygons(Geometry geometry, List<Polygon> sink)
+    {
+        switch (geometry)
+        {
+            case Polygon polygon:
+                sink.Add(polygon);
+                break;
+            case GeometryCollection collection:
+                for (int i = 0; i < collection.NumGeometries; i++)
+                    CollectPolygons(collection.GetGeometryN(i), sink);
+                break;
+        }
+    }
+}

--- a/src/EncDotNet.S100.Rendering.Scene/PatternPriorityClipper.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/PatternPriorityClipper.cs
@@ -79,15 +79,17 @@ public static class PatternPriorityClipper
 
     /// <summary>
     /// Clips each pattern group against all higher-priority pattern areas and the
-    /// supplied opaque non-patterned colour fills.
+    /// supplied non-patterned colour fills.
     /// </summary>
     /// <param name="entries">
     /// The pattern groups, <b>pre-sorted ascending by priority</b>. The returned
     /// list is in the same order as this input.
     /// </param>
     /// <param name="nonPatternedColorFills">
-    /// Opaque non-patterned colour-fill polygons (e.g. land) that occlude every
-    /// pattern fill. May be empty.
+    /// Non-patterned colour-fill polygons (e.g. land) that should occlude every
+    /// pattern fill. The clipper treats each polygon as a full occluder; the
+    /// caller is responsible for supplying only fills that are actually opaque.
+    /// May be empty.
     /// </param>
     /// <returns>
     /// The clipped geometry for each input group, in input order. A group whose

--- a/src/EncDotNet.S100.Rendering.Scene/README.md
+++ b/src/EncDotNet.S100.Rendering.Scene/README.md
@@ -17,6 +17,7 @@ Mapsui, or any GUI framework.
 | `ResolvedSymbol`, `SymbolAsset` | Resolved point-symbol content + pivot (S-100 Part 9 §11.5). |
 | `VectorSceneBuilder` | Lowers a `DrawingInstruction` display list into a `VectorScene`. Pattern tiles are supplied as PNG bytes through an injected `Func<string, byte[]?>` delegate, so the builder stays rasteriser-free. When it lowers pattern fills it priority-clips them via `PatternPriorityClipper`. |
 | `PatternPriorityClipper` | Backend-neutral NetTopologySuite priority-clipping of tiled pattern area fills (S-100 Part 9 §11.3): subtracts higher-priority pattern areas and opaque non-patterned solid fills (e.g. land) from each lower-priority pattern. Shared by both render paths (the Mapsui feature renderer delegates to it) so headless Skia, the Mapsui TiledScene subsystem, and the Mapsui feature path clip identically. |
+| `PatternClipMemoizer` | Optional delegate a caller injects into `VectorSceneBuilder` to memoize the (palette-independent) pattern-clip result, so a re-build that only changes the palette reuses the geometry instead of repeating the overlay. The Mapsui renderer wires it to its pattern-clip cache for the default TiledScene subsystem. |
 | `ColorResolver` | S-100 colour-token → `RgbaColor` resolution. |
 | `ScaleVisibility` | S-100 Part 9 §11.1 scale-visibility semantics (SCAMIN inclusion). |
 | `WebMercator` | Spherical EPSG:3857 forward projection (the `lat/lon → 3857` half of the S-100 Part 9 projection). |
@@ -59,9 +60,10 @@ guide for the end-to-end path.
 The **stable, supported surface** of this package is the set of types documented
 in [What lives here](#what-lives-here): `VectorScene`, the `PaintOp` hierarchy
 (`PointPaintOp`, `LinePaintOp`, `AreaPaintOp`, `PatternAreaPaintOp`,
-`TextPaintOp`), `VectorSceneBuilder`, `PatternPriorityClipper`, `ColorResolver`,
-`ScaleVisibility`, and `WebMercator`. Types that are `internal` or undocumented
-are implementation detail and may change at any time.
+`TextPaintOp`), `VectorSceneBuilder`, `PatternPriorityClipper`,
+`PatternClipMemoizer`, `ColorResolver`, `ScaleVisibility`, and `WebMercator`.
+Types that are `internal` or undocumented are implementation detail and may
+change at any time.
 
 All `EncDotNet.S100.*` packages share **one version**, derived from the release
 git tag (there is no per-package version). Versioning follows

--- a/src/EncDotNet.S100.Rendering.Scene/README.md
+++ b/src/EncDotNet.S100.Rendering.Scene/README.md
@@ -15,7 +15,8 @@ Mapsui, or any GUI framework.
 | `WorldToScreen` | Backend-neutral EPSG:3857 world → pixel affine derived from a `Viewport` (the `EPSG:3857 → pixels` half of the Part 9 projection). Lets a Skia-free backend project the IR's world coordinates. Wraps ops across the ±180° antimeridian when the viewport is a seam-shifted frame (issue #413). |
 | `SeamAwareBoundsAccumulator` | Computes a seam-aware EPSG:3857 auto-fit extent: detects geometry straddling the ±180° antimeridian (via a longitude-occupancy histogram + largest-empty-arc heuristic) and shifts the western cluster into a contiguous world-X window so dateline-spanning datasets are framed on their true extent (issue #413). |
 | `ResolvedSymbol`, `SymbolAsset` | Resolved point-symbol content + pivot (S-100 Part 9 §11.5). |
-| `VectorSceneBuilder` | Lowers a `DrawingInstruction` display list into a `VectorScene`. Pattern tiles are supplied as PNG bytes through an injected `Func<string, byte[]?>` delegate, so the builder stays rasteriser-free. |
+| `VectorSceneBuilder` | Lowers a `DrawingInstruction` display list into a `VectorScene`. Pattern tiles are supplied as PNG bytes through an injected `Func<string, byte[]?>` delegate, so the builder stays rasteriser-free. When it lowers pattern fills it priority-clips them via `PatternPriorityClipper`. |
+| `PatternPriorityClipper` | Backend-neutral NetTopologySuite priority-clipping of tiled pattern area fills (S-100 Part 9 §11.3): subtracts higher-priority pattern areas and opaque non-patterned solid fills (e.g. land) from each lower-priority pattern. Shared by both render paths (the Mapsui feature renderer delegates to it) so headless Skia, the Mapsui TiledScene subsystem, and the Mapsui feature path clip identically. |
 | `ColorResolver` | S-100 colour-token → `RgbaColor` resolution. |
 | `ScaleVisibility` | S-100 Part 9 §11.1 scale-visibility semantics (SCAMIN inclusion). |
 | `WebMercator` | Spherical EPSG:3857 forward projection (the `lat/lon → 3857` half of the S-100 Part 9 projection). |
@@ -58,9 +59,9 @@ guide for the end-to-end path.
 The **stable, supported surface** of this package is the set of types documented
 in [What lives here](#what-lives-here): `VectorScene`, the `PaintOp` hierarchy
 (`PointPaintOp`, `LinePaintOp`, `AreaPaintOp`, `PatternAreaPaintOp`,
-`TextPaintOp`), `VectorSceneBuilder`, `ColorResolver`, `ScaleVisibility`, and
-`WebMercator`. Types that are `internal` or undocumented are implementation
-detail and may change at any time.
+`TextPaintOp`), `VectorSceneBuilder`, `PatternPriorityClipper`, `ColorResolver`,
+`ScaleVisibility`, and `WebMercator`. Types that are `internal` or undocumented
+are implementation detail and may change at any time.
 
 All `EncDotNet.S100.*` packages share **one version**, derived from the release
 git tag (there is no per-package version). Versioning follows

--- a/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
@@ -262,10 +262,13 @@ public sealed class VectorSceneBuilder
         }
 
         // Group pattern ops by (pattern reference, priority), building NTS polygons
-        // and a merged template (tile + union scale band) per group.
+        // and a merged template (tile + union scale band) per group. Pattern
+        // references are compared case-insensitively (OrdinalIgnoreCase) to match
+        // the Mapsui feature path's tile-resolution comparer, so mixed-case
+        // references group identically across both render arms.
         var groupOrder = new List<(string PatternRef, int Priority)>();
-        var groupPolygons = new Dictionary<(string, int), List<Polygon>>();
-        var groupTemplates = new Dictionary<(string, int), PatternGroupTemplate>();
+        var groupPolygons = new Dictionary<(string, int), List<Polygon>>(PatternGroupKeyComparer);
+        var groupTemplates = new Dictionary<(string, int), PatternGroupTemplate>(PatternGroupKeyComparer);
         var unclippable = new List<PatternAreaPaintOp>();
 
         foreach (var (op, priority) in patternPriorities)
@@ -347,6 +350,27 @@ public sealed class VectorSceneBuilder
             insertAt = ops.Count;
         ops.RemoveAll(o => o is PatternAreaPaintOp);
         ops.InsertRange(insertAt, rebuilt);
+    }
+
+    /// <summary>
+    /// Groups pattern-clip keys by drawing priority and case-insensitive pattern
+    /// reference (<see cref="StringComparison.OrdinalIgnoreCase"/>), mirroring the
+    /// Mapsui feature path's tile-resolution comparer so both render arms produce
+    /// identical clip topology for mixed-case pattern references.
+    /// </summary>
+    private static readonly IEqualityComparer<(string, int)> PatternGroupKeyComparer =
+        new PatternGroupKeyEqualityComparer();
+
+    private sealed class PatternGroupKeyEqualityComparer : IEqualityComparer<(string, int)>
+    {
+        public bool Equals((string, int) x, (string, int) y)
+            => x.Item2 == y.Item2
+                && string.Equals(x.Item1, y.Item1, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string, int) obj)
+            => HashCode.Combine(
+                obj.Item1 is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item1),
+                obj.Item2);
     }
 
     /// <summary>Per-group attributes carried through the pattern clip.</summary>

--- a/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
@@ -2,6 +2,7 @@ using EncDotNet.S100.DataModel;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
 using EncDotNet.S100.Portrayals;
+using NetTopologySuite.Geometries;
 
 namespace EncDotNet.S100.Rendering.Scene;
 
@@ -32,9 +33,12 @@ public readonly record struct SymbolAsset(
 /// <b>Scope.</b> Both solid-colour and tiled-symbol pattern area fills are
 /// lowered into the IR. Pattern fills are emitted as
 /// <see cref="PatternAreaPaintOp"/> only when a <see cref="PatternResolver"/>
-/// is supplied (the headless Skia path); the Mapsui renderer leaves the
-/// resolver unset and continues to drive its own pattern collection /
-/// priority-clip / insert phase, so its output is unchanged.
+/// is supplied (the headless Skia path and the Mapsui TiledScene subsystem);
+/// the Mapsui feature path leaves the resolver unset and continues to drive its
+/// own pattern collection / insert phase, so its output is unchanged. When
+/// pattern ops are emitted they are priority-clipped via the shared
+/// <see cref="PatternPriorityClipper"/> — the same algorithm the Mapsui feature
+/// path uses — so all three paths clip identically.
 /// </remarks>
 public sealed class VectorSceneBuilder
 {
@@ -153,9 +157,18 @@ public sealed class VectorSceneBuilder
             .ToList();
 
         var ops = new List<PaintOp>(sorted.Count);
+        var patternPriorities = new List<(PatternAreaPaintOp Op, int Priority)>();
+        HashSet<string>? featuresWithPatterns = null;
 
         foreach (var instruction in sorted)
         {
+            // Track every feature carrying a pattern fill (even when its geometry
+            // is missing or its tile does not resolve), mirroring the Mapsui
+            // feature path: such a feature's own solid colour fill is not used as
+            // a pattern exclusion area.
+            if (instruction is AreaInstruction { AreaFillReference: not null })
+                (featuresWithPatterns ??= new(StringComparer.Ordinal)).Add(instruction.FeatureReference);
+
             var geom = geometryProvider.GetGeometry(instruction.FeatureReference);
 
             bool hasAugmentedLine = instruction is LineInstruction { CoordinatesOverride: not null };
@@ -177,10 +190,249 @@ public sealed class VectorSceneBuilder
             };
 
             if (op is not null)
+            {
                 ops.Add(op);
+                if (op is PatternAreaPaintOp patternOp)
+                    patternPriorities.Add((patternOp, instruction.DrawingPriority));
+            }
         }
 
+        // Priority-clip pattern ops in the IR (shared with the Mapsui feature
+        // path via PatternPriorityClipper) so the headless Skia backend and the
+        // Mapsui TiledScene subsystem clip identically to the Mapsui feature arm.
+        if (patternPriorities.Count > 0)
+            ClipPatternAreas(ops, patternPriorities, featuresWithPatterns);
+
         return new VectorScene(ops);
+    }
+
+    private static readonly GeometryFactory ClipGeometryFactory = new();
+
+    /// <summary>
+    /// Applies S-100 Part 9 §11.3 pattern priority-clipping to the pattern ops in
+    /// <paramref name="ops"/> using the shared <see cref="PatternPriorityClipper"/>,
+    /// then rewrites the pattern-op block in place with the clipped result. Pattern
+    /// ops are grouped by (pattern reference, drawing priority) — matching the
+    /// Mapsui feature path — so both render arms produce identical clip topology.
+    /// </summary>
+    /// <remarks>
+    /// A clipped group can become a <see cref="MultiPolygon"/>, so one input op may
+    /// expand into several output ops (one per polygon). Because clipping merges the
+    /// ops of a group into a single geometry, the resulting op(s) carry the group's
+    /// <em>union</em> scale-visibility band (the widest visible range across the
+    /// merged ops); this is a superset, so a merged region is never over-culled. In
+    /// practice ops sharing a pattern reference and priority also share their scale
+    /// rules, so the band is unchanged in the common case.
+    /// </remarks>
+    private void ClipPatternAreas(
+        List<PaintOp> ops,
+        List<(PatternAreaPaintOp Op, int Priority)> patternPriorities,
+        HashSet<string>? featuresWithPatterns)
+    {
+        // Opaque non-patterned solid colour fills (e.g. land) occlude patterns.
+        // A feature that itself carries a pattern does not contribute its solid
+        // fill as an exclusion area (mirrors the Mapsui feature path).
+        var excludes = new List<Polygon>();
+        foreach (var op in ops)
+        {
+            if (op is AreaPaintOp area
+                && (featuresWithPatterns is null || !featuresWithPatterns.Contains(area.FeatureReference)))
+            {
+                var polygon = CreatePolygon(area.WorldShell, area.WorldHoles);
+                if (polygon is not null)
+                    excludes.Add(polygon);
+            }
+        }
+
+        // Group pattern ops by (pattern reference, priority), building NTS polygons
+        // and a merged template (tile + union scale band) per group.
+        var groupOrder = new List<(string PatternRef, int Priority)>();
+        var groupPolygons = new Dictionary<(string, int), List<Polygon>>();
+        var groupTemplates = new Dictionary<(string, int), PatternGroupTemplate>();
+        var unclippable = new List<PatternAreaPaintOp>();
+
+        foreach (var (op, priority) in patternPriorities)
+        {
+            var polygon = CreatePolygon(op.WorldShell, op.WorldHoles);
+            if (polygon is null)
+            {
+                // Degenerate ring: keep the op visible rather than dropping it.
+                unclippable.Add(op);
+                continue;
+            }
+
+            var key = (op.PatternReference, priority);
+            if (groupPolygons.TryGetValue(key, out var list))
+            {
+                groupTemplates[key] = groupTemplates[key].MergeBand(op.ScaleMinimum, op.ScaleMaximum);
+            }
+            else
+            {
+                list = [];
+                groupPolygons[key] = list;
+                groupOrder.Add(key);
+                groupTemplates[key] = new PatternGroupTemplate(
+                    op.FeatureReference, op.TilePng, op.ScaleMinimum, op.ScaleMaximum);
+            }
+
+            list.Add(polygon);
+        }
+
+        // The shared clipper requires entries pre-sorted ascending by priority.
+        groupOrder.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+
+        var entries = new List<PatternPriorityClipper.PatternGroup>(groupOrder.Count);
+        foreach (var key in groupOrder)
+            entries.Add(new PatternPriorityClipper.PatternGroup(key.PatternRef, key.Priority, groupPolygons[key]));
+
+        var clipped = PatternPriorityClipper.Clip(entries, excludes);
+
+        // Rebuild pattern ops from the clipped geometry, expanding a MultiPolygon
+        // result into one op per polygon.
+        var rebuilt = new List<PaintOp>();
+        foreach (var (patternRef, priority, geometry) in clipped)
+        {
+            if (geometry.IsEmpty)
+                continue;
+
+            var template = groupTemplates[(patternRef, priority)];
+            foreach (var (shell, holes) in EnumeratePolygonRings(geometry))
+            {
+                rebuilt.Add(new PatternAreaPaintOp
+                {
+                    FeatureReference = template.FeatureReference,
+                    ScaleMinimum = template.ScaleMinimum,
+                    ScaleMaximum = template.ScaleMaximum,
+                    PatternReference = patternRef,
+                    WorldShell = shell,
+                    WorldHoles = holes,
+                    TilePng = template.TilePng,
+                });
+            }
+        }
+
+        rebuilt.AddRange(unclippable);
+
+        // Replace the (contiguous, draw-order rank-1) pattern-op block in place:
+        // patterns sit after solid area fills and before lines/points/text.
+        int insertAt = ops.FindIndex(o => o is PatternAreaPaintOp);
+        if (insertAt < 0)
+            insertAt = ops.Count;
+        ops.RemoveAll(o => o is PatternAreaPaintOp);
+        ops.InsertRange(insertAt, rebuilt);
+    }
+
+    /// <summary>Per-group attributes carried through the pattern clip.</summary>
+    private readonly record struct PatternGroupTemplate(
+        string FeatureReference, byte[] TilePng, double? ScaleMinimum, double? ScaleMaximum)
+    {
+        /// <summary>
+        /// Widens this template's scale-visibility band to the union of it and the
+        /// supplied band (a null bound means "unbounded", which dominates the union).
+        /// </summary>
+        public PatternGroupTemplate MergeBand(double? scaleMinimum, double? scaleMaximum)
+        {
+            double? mergedMinimum = ScaleMinimum is null || scaleMinimum is null
+                ? null
+                : Math.Max(ScaleMinimum.Value, scaleMinimum.Value);
+            double? mergedMaximum = ScaleMaximum is null || scaleMaximum is null
+                ? null
+                : Math.Min(ScaleMaximum.Value, scaleMaximum.Value);
+            return this with { ScaleMinimum = mergedMinimum, ScaleMaximum = mergedMaximum };
+        }
+    }
+
+    /// <summary>
+    /// Builds an NTS polygon from already-projected EPSG:3857 ring coordinates,
+    /// closing rings and dropping degenerate ones (fewer than three distinct
+    /// vertices) exactly as the Mapsui feature path does, so both paths clip the
+    /// same set of areas.
+    /// </summary>
+    private static Polygon? CreatePolygon(
+        IReadOnlyList<(double X, double Y)> shell,
+        IReadOnlyList<IReadOnlyList<(double X, double Y)>> holes)
+    {
+        var shellRing = BuildLinearRing(shell);
+        if (shellRing is null)
+            return null;
+
+        if (holes.Count == 0)
+            return ClipGeometryFactory.CreatePolygon(shellRing);
+
+        var holeRings = new List<LinearRing>(holes.Count);
+        foreach (var hole in holes)
+        {
+            var ring = BuildLinearRing(hole);
+            if (ring is not null)
+                holeRings.Add(ring);
+        }
+
+        return holeRings.Count == 0
+            ? ClipGeometryFactory.CreatePolygon(shellRing)
+            : ClipGeometryFactory.CreatePolygon(shellRing, [.. holeRings]);
+    }
+
+    private static LinearRing? BuildLinearRing(IReadOnlyList<(double X, double Y)> coords)
+    {
+        if (coords.Count < 3)
+            return null;
+
+        var ring = new List<Coordinate>(coords.Count + 1);
+        foreach (var (x, y) in coords)
+            ring.Add(new Coordinate(x, y));
+
+        // Close the ring if not already closed.
+        if (ring.Count > 0 && !ring[0].Equals2D(ring[^1]))
+            ring.Add(new Coordinate(ring[0].X, ring[0].Y));
+
+        if (ring.Count < 4)
+            return null;
+
+        return ClipGeometryFactory.CreateLinearRing([.. ring]);
+    }
+
+    /// <summary>
+    /// Enumerates the exterior + interior rings of every polygon in a clipped
+    /// geometry (a <see cref="Polygon"/> or <see cref="MultiPolygon"/>) as
+    /// EPSG:3857 coordinate tuples, dropping each ring's closing duplicate vertex
+    /// to match the open-ring convention of <see cref="PatternAreaPaintOp"/>.
+    /// </summary>
+    private static IEnumerable<(IReadOnlyList<(double X, double Y)> Shell,
+        IReadOnlyList<IReadOnlyList<(double X, double Y)>> Holes)> EnumeratePolygonRings(Geometry geometry)
+    {
+        for (int i = 0; i < geometry.NumGeometries; i++)
+        {
+            if (geometry.GetGeometryN(i) is not Polygon polygon || polygon.IsEmpty)
+                continue;
+
+            var shell = RingToTuples(polygon.ExteriorRing);
+            if (shell.Count < 3)
+                continue;
+
+            var holes = new List<IReadOnlyList<(double X, double Y)>>(polygon.NumInteriorRings);
+            for (int h = 0; h < polygon.NumInteriorRings; h++)
+            {
+                var hole = RingToTuples(polygon.GetInteriorRingN(h));
+                if (hole.Count >= 3)
+                    holes.Add(hole);
+            }
+
+            yield return (shell, holes);
+        }
+    }
+
+    private static List<(double X, double Y)> RingToTuples(LineString ring)
+    {
+        var coords = ring.Coordinates;
+        int count = coords.Length;
+        // Drop the closing duplicate vertex (NTS rings are explicitly closed).
+        if (count >= 2 && coords[0].Equals2D(coords[count - 1]))
+            count--;
+
+        var result = new List<(double X, double Y)>(count);
+        for (int i = 0; i < count; i++)
+            result.Add((coords[i].X, coords[i].Y));
+        return result;
     }
 
     private PatternAreaPaintOp? BuildPatternArea(

--- a/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
@@ -38,7 +38,9 @@ public readonly record struct SymbolAsset(
 /// own pattern collection / insert phase, so its output is unchanged. When
 /// pattern ops are emitted they are priority-clipped via the shared
 /// <see cref="PatternPriorityClipper"/> — the same algorithm the Mapsui feature
-/// path uses — so all three paths clip identically.
+/// path uses — so all three paths clip identically. The (palette-independent)
+/// clip result can be memoized via <see cref="PatternClipCache"/> so re-builds
+/// that only change the palette skip the expensive overlay.
 /// </remarks>
 public sealed class VectorSceneBuilder
 {
@@ -71,6 +73,21 @@ public sealed class VectorSceneBuilder
     /// for a given name silently drops just that instruction.
     /// </summary>
     public Func<string, byte[]?>? PatternResolver { get; init; }
+
+    /// <summary>
+    /// Optional memoizer for the pattern priority-clip result. When set, the
+    /// builder routes the shared <see cref="PatternPriorityClipper.Clip"/> call
+    /// through this delegate, so a re-build whose clip inputs are unchanged — most
+    /// importantly a Day/Dusk/Night palette switch — reuses the previously
+    /// computed (palette-independent) clip geometry instead of repeating the
+    /// expensive NetTopologySuite overlay. The Mapsui renderer wires this to its
+    /// pattern-clip cache for the default TiledScene render subsystem, matching
+    /// the caching the Mapsui feature path already enjoys; the headless Skia path
+    /// leaves it unset (a headless render clips once). Only consulted when a
+    /// <see cref="PatternResolver"/> is also set (otherwise no pattern ops are
+    /// emitted and there is nothing to clip).
+    /// </summary>
+    public PatternClipMemoizer? PatternClipCache { get; init; }
 
     /// <summary>Global scale factor applied to all point symbols (default 1.0).</summary>
     public double SymbolScale { get; init; } = 1.0;
@@ -285,7 +302,9 @@ public sealed class VectorSceneBuilder
         foreach (var key in groupOrder)
             entries.Add(new PatternPriorityClipper.PatternGroup(key.PatternRef, key.Priority, groupPolygons[key]));
 
-        var clipped = PatternPriorityClipper.Clip(entries, excludes);
+        var clipped = PatternClipCache is null
+            ? PatternPriorityClipper.Clip(entries, excludes)
+            : PatternClipCache(() => PatternPriorityClipper.Clip(entries, excludes));
 
         // Rebuild pattern ops from the clipped geometry, expanding a MultiPolygon
         // result into one op per polygon.
@@ -295,18 +314,26 @@ public sealed class VectorSceneBuilder
             if (geometry.IsEmpty)
                 continue;
 
-            var template = groupTemplates[(patternRef, priority)];
+            var template = groupTemplates.TryGetValue((patternRef, priority), out var found)
+                ? found
+                // A memoized clip result (shared with the Mapsui feature arm via
+                // PatternClipCache) can, in a pathological case, carry a group key
+                // absent from this build's templates; skip it rather than throw.
+                : (PatternGroupTemplate?)null;
+            if (template is null)
+                continue;
+
             foreach (var (shell, holes) in EnumeratePolygonRings(geometry))
             {
                 rebuilt.Add(new PatternAreaPaintOp
                 {
-                    FeatureReference = template.FeatureReference,
-                    ScaleMinimum = template.ScaleMinimum,
-                    ScaleMaximum = template.ScaleMaximum,
+                    FeatureReference = template.Value.FeatureReference,
+                    ScaleMinimum = template.Value.ScaleMinimum,
+                    ScaleMaximum = template.Value.ScaleMaximum,
                     PatternReference = patternRef,
                     WorldShell = shell,
                     WorldHoles = holes,
-                    TilePng = template.TilePng,
+                    TilePng = template.Value.TilePng,
                 });
             }
         }

--- a/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
+++ b/src/EncDotNet.S100.Rendering.Scene/VectorSceneBuilder.cs
@@ -246,13 +246,18 @@ public sealed class VectorSceneBuilder
         List<(PatternAreaPaintOp Op, int Priority)> patternPriorities,
         HashSet<string>? featuresWithPatterns)
     {
-        // Opaque non-patterned solid colour fills (e.g. land) occlude patterns.
-        // A feature that itself carries a pattern does not contribute its solid
-        // fill as an exclusion area (mirrors the Mapsui feature path).
+        // Fully-opaque non-patterned solid colour fills (e.g. land) occlude
+        // patterns. Translucent fills (alpha < 255 — an AreaInstruction's
+        // Transparency is folded into the fill alpha) do not fully hide what lies
+        // under them, and PatternPriorityClipper treats every supplied polygon as
+        // a full occluder, so they must not clip patterns. A feature that itself
+        // carries a pattern does not contribute its solid fill as an exclusion
+        // area (mirrors the Mapsui feature path).
         var excludes = new List<Polygon>();
         foreach (var op in ops)
         {
             if (op is AreaPaintOp area
+                && area.Fill.A == 255
                 && (featuresWithPatterns is null || !featuresWithPatterns.Contains(area.FeatureReference)))
             {
                 var polygon = CreatePolygon(area.WorldShell, area.WorldHoles);

--- a/tests/EncDotNet.S100.Cli.Tests/DisplayListJsonWriterTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/DisplayListJsonWriterTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using EncDotNet.S100.Cli.Infrastructure;
+using EncDotNet.S100.Core;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.Pipelines.Portrayal;
+using EncDotNet.S100.Interoperability;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Cli.Tests;
+
+public class DisplayListJsonWriterTests
+{
+    // A geometry provider that has no natural geometry for the feature — the
+    // situation for a Part 9A augmented line whose parent feature is, e.g., a
+    // point Light. The line is still drawn from its CoordinatesOverride.
+    private sealed class NullGeometryProvider : IFeatureGeometryProvider
+    {
+        public FeatureGeometry? GetGeometry(string featureReference) => null;
+    }
+
+    private static VectorPortrayalResult ResultFor(DrawingInstruction instruction) =>
+        new()
+        {
+            SubLayers =
+            [
+                new VectorSubLayer
+                {
+                    LayerKey = "s101.linework",
+                    LayerName = "Linework",
+                    Instructions = [instruction],
+                    Plane = S98DisplayPlane.BaseChartUnder,
+                },
+            ],
+            Palette = new ColorPalette("test", new Dictionary<string, string>()),
+            GeometryProvider = new NullGeometryProvider(),
+            Product = "S-101",
+            Spec = new SpecRef("S-101", default),
+            SourceDatasetId = "ds",
+            Info = "test",
+        };
+
+    private static JsonElement FirstInstruction(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("instructions")[0].Clone();
+    }
+
+    [Fact]
+    public void AugmentedLine_SummarisesCoordinatesOverride_NotNullFeatureGeometry()
+    {
+        var line = new LineInstruction
+        {
+            FeatureReference = "light-1",
+            LineStyleReference = "SECTR1",
+            CoordinatesOverride =
+            [
+                new GeoPosition(10.0, 20.0),
+                new GeoPosition(11.0, 21.0),
+                new GeoPosition(12.0, 22.0),
+            ],
+        };
+
+        var geometry = FirstInstruction(DisplayListJsonWriter.Serialize(ResultFor(line), "ds", "Day"))
+            .GetProperty("geometry");
+
+        // Without the fix the feature geometry is null, so the summary would be
+        // null; the override must be reflected instead.
+        Assert.Equal(JsonValueKind.Object, geometry.ValueKind);
+        Assert.Equal("Curve", geometry.GetProperty("type").GetString());
+        Assert.Equal(3, geometry.GetProperty("vertexCount").GetInt32());
+        var anchor = geometry.GetProperty("anchor");
+        Assert.Equal(10.0, anchor[0].GetDouble());
+        Assert.Equal(20.0, anchor[1].GetDouble());
+    }
+
+    [Fact]
+    public void Line_WithoutCoordinatesOverride_AndNoFeatureGeometry_HasNullGeometry()
+    {
+        var line = new LineInstruction
+        {
+            FeatureReference = "coastline-1",
+            LineStyleReference = "CSTLN",
+        };
+
+        // A null geometry summary is omitted from the JSON (WhenWritingNull), so
+        // the instruction carries no "geometry" property at all.
+        var instruction = FirstInstruction(DisplayListJsonWriter.Serialize(ResultFor(line), "ds", "Day"));
+
+        Assert.False(instruction.TryGetProperty("geometry", out _));
+    }
+}

--- a/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
+++ b/tests/EncDotNet.S100.Cli.Tests/EncDotNet.S100.Cli.Tests.csproj
@@ -33,6 +33,7 @@
     <Content Include="..\datasets\S57\US5MA1BO\US5MA1BO.000" CopyToOutputDirectory="PreserveNewest" Link="TestData\US5MA1BO.000" />
     <Content Include="..\datasets\S124\navwarn_surface.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S124\navwarn_surface.gml" />
     <Content Include="..\datasets\S125\aton_point.gml" CopyToOutputDirectory="PreserveNewest" Link="TestData\S125\aton_point.gml" />
+    <Content Include="..\datasets\S102\102US004MI1CI262227.h5" CopyToOutputDirectory="PreserveNewest" Link="TestData\S102\102US004MI1CI262227.h5" />
     <Content Include="..\datasets\ExchangeSets\Synthetic-Renderable\**\*" CopyToOutputDirectory="PreserveNewest" Link="TestData\ExchangeSet\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 

--- a/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/OptionParsingTests.cs
@@ -1,6 +1,7 @@
 using EncDotNet.S100.Cli.Commands;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
+using SkiaSharp;
 
 namespace EncDotNet.S100.Cli.Tests;
 
@@ -188,5 +189,44 @@ public sealed class OptionParsingTests
         Assert.True(ValidateCommand.IsSuppressed("S101-R-1.2", patterns));
         Assert.True(ValidateCommand.IsSuppressed("S102-R-9.9", patterns));
         Assert.False(ValidateCommand.IsSuppressed("S104-R-1.1", patterns));
+    }
+
+    [Theory]
+    [InlineData(null, "chart.png", SKEncodedImageFormat.Png)]
+    [InlineData(null, "chart.jpg", SKEncodedImageFormat.Jpeg)]
+    [InlineData(null, "chart.webp", SKEncodedImageFormat.Webp)]
+    [InlineData("webp", "chart", SKEncodedImageFormat.Webp)]
+    public void TryResolveOutput_resolves_image_kinds(
+        string? format, string output, SKEncodedImageFormat expected)
+    {
+        Assert.True(RenderCommand.TryResolveOutput(format, output, out var kind, out var image, out _));
+        Assert.Equal(RenderCommand.RenderOutputKind.Image, kind);
+        Assert.Equal(expected, image);
+    }
+
+    [Theory]
+    [InlineData(null, "chart.json")]   // inferred from extension
+    [InlineData("json", "chart.txt")]  // explicit, non-image extension
+    [InlineData("json", "chart")]      // explicit, no extension
+    public void TryResolveOutput_resolves_display_list_kind(string? format, string output)
+    {
+        Assert.True(RenderCommand.TryResolveOutput(format, output, out var kind, out _, out _));
+        Assert.Equal(RenderCommand.RenderOutputKind.DisplayList, kind);
+    }
+
+    [Fact]
+    public void TryResolveOutput_rejects_format_json_against_image_extension()
+    {
+        Assert.False(
+            RenderCommand.TryResolveOutput("json", "chart.png", out _, out _, out var error));
+        Assert.Contains("json", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryResolveOutput_rejects_unknown_format()
+    {
+        Assert.False(
+            RenderCommand.TryResolveOutput("tiff", "chart.tiff", out _, out _, out var error));
+        Assert.Contains("json", error, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using EncDotNet.S100.Cli.Infrastructure;
 using SkiaSharp;
 
@@ -247,6 +248,192 @@ public sealed class RenderCommandTests
             if (File.Exists(output))
                 File.Delete(output);
         }
+    }
+
+    [Fact]
+    public void Render_writes_a_display_list_json_document()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.json");
+        try
+        {
+            int exit = CliApp.Build().Run(["render", dataset, output]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(output));
+            var root = doc.RootElement;
+            Assert.Equal("S-124", root.GetProperty("product").GetString());
+            Assert.Equal("navwarn_surface.gml", root.GetProperty("dataset").GetString());
+
+            var instructions = root.GetProperty("instructions");
+            Assert.Equal(JsonValueKind.Array, instructions.ValueKind);
+            Assert.Equal(
+                root.GetProperty("instructionCount").GetInt32(), instructions.GetArrayLength());
+            Assert.True(instructions.GetArrayLength() > 0);
+
+            // Every instruction carries the base portrayal fields the format promises.
+            foreach (var instruction in instructions.EnumerateArray())
+            {
+                Assert.False(string.IsNullOrEmpty(instruction.GetProperty("kind").GetString()));
+                Assert.False(string.IsNullOrEmpty(instruction.GetProperty("feature").GetString()));
+                Assert.True(instruction.TryGetProperty("plane", out _));
+                Assert.True(instruction.TryGetProperty("drawingPriority", out _));
+            }
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_display_list_json_is_deterministic()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var first = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.json");
+        var second = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.json");
+        try
+        {
+            Assert.Equal(0, CliApp.Build().Run(["render", dataset, first]));
+            Assert.Equal(0, CliApp.Build().Run(["render", dataset, second]));
+
+            // Pure portrayal output: two runs over the same dataset and render
+            // context must be byte-identical so the document is snapshot-testable.
+            Assert.Equal(File.ReadAllBytes(first), File.ReadAllBytes(second));
+        }
+        finally
+        {
+            if (File.Exists(first)) File.Delete(first);
+            if (File.Exists(second)) File.Delete(second);
+        }
+    }
+
+    [Fact]
+    public void Render_json_via_explicit_format_over_non_image_extension()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.txt");
+        try
+        {
+            int exit = CliApp.Build().Run(["render", dataset, output, "--format", "json"]);
+
+            Assert.Equal(0, exit);
+            using var doc = JsonDocument.Parse(File.ReadAllText(output));
+            Assert.Equal("S-124", doc.RootElement.GetProperty("product").GetString());
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_format_json_conflicting_with_image_extension_returns_nonzero()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(["render", dataset, output, "--format", "json"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Render_json_rejected_for_composite_form_returns_nonzero()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.json");
+        int exit = CliApp.Build().Run(["render", "--layer", dataset, output]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Render_single_dataset_with_bbox_writes_png()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--bbox", "-80,30,-60,45", "--width", "400", "--height", "300"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+
+            using var bitmap = SKBitmap.Decode(output);
+            Assert.NotNull(bitmap);
+            Assert.Equal(400, bitmap!.Width);
+            Assert.Equal(300, bitmap.Height);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_single_dataset_with_center_scale_writes_png()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--center", "-70,38", "--scale", "20000000",
+                 "--width", "400", "--height", "300"]);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Render_viewport_flags_rejected_with_format_json_returns_nonzero()
+    {
+        var dataset = FixturePath(Path.Combine("S124", "navwarn_surface.gml"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.json");
+        int exit = CliApp.Build().Run(["render", dataset, output, "--bbox", "-80,30,-60,45"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void Render_viewport_flags_rejected_for_coverage_product_returns_nonzero()
+    {
+        var dataset = FixturePath(Path.Combine("S102", "102US004MI1CI262227.h5"));
+        Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
+
+        var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
+        int exit = CliApp.Build().Run(
+            ["render", dataset, output, "--bbox", "-76,38,-75,39", "--width", "200", "--height", "200"]);
+        Assert.NotEqual(0, exit);
+        Assert.False(File.Exists(output));
     }
 
     /// <summary>

--- a/tests/EncDotNet.S100.Cli.Tests/RenderCompositeCommandTests.cs
+++ b/tests/EncDotNet.S100.Cli.Tests/RenderCompositeCommandTests.cs
@@ -173,16 +173,26 @@ public sealed class RenderCompositeCommandTests
     }
 
     [Fact]
-    public void Bbox_in_single_dataset_form_returns_nonzero()
+    public void Bbox_in_single_dataset_vector_form_writes_png()
     {
+        // Alignment: a single vector dataset now honours an explicit viewport
+        // (previously composite-only). marine_curve.gml is S-127 (vector).
         var dataset = Path.Combine(AppContext.BaseDirectory, "TestData", "marine_curve.gml");
         Skip.IfNot(File.Exists(dataset), $"Fixture not found: {dataset}");
 
         var output = Path.Combine(Path.GetTempPath(), $"s100-cli-{Guid.NewGuid():N}.png");
-        int exit = CliApp.Build().Run(
-            ["render", dataset, output, "--bbox", "-1.5,50.0,-1.0,50.5"]);
-        Assert.NotEqual(0, exit);
-        Assert.False(File.Exists(output));
+        try
+        {
+            int exit = CliApp.Build().Run(
+                ["render", dataset, output, "--bbox", "-1.5,50.0,-1.0,50.5"]);
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(output));
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Pipelines.Tests/PatternClipCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PatternClipCacheTests.cs
@@ -132,8 +132,10 @@ public class PatternClipCacheTests
                 $"Clipped geometry {i} differs between cached and uncached paths.");
         }
 
+        // The expensive clip overlay is computed exactly once (a single miss);
+        // the number of cache reads (hits) depends on how many render arms consult
+        // the shared cache and is not asserted here.
         Assert.Equal(1, cache.Misses);
-        Assert.Equal(0, cache.Hits);
     }
 
     [Fact]
@@ -150,8 +152,10 @@ public class PatternClipCacheTests
             NewRenderer(palette, cache, cacheKey: "k1")
                 .Render(BuildInstructions(), provider));
 
+        // A second render with the same key adds no further compute (the miss
+        // count stays at one) and is served from the cache (at least one hit).
         Assert.Equal(1, cache.Misses);
-        Assert.Equal(1, cache.Hits);
+        Assert.True(cache.Hits >= 1);
 
         Assert.Equal(first.Count, second.Count);
         Assert.NotEmpty(first);
@@ -182,8 +186,10 @@ public class PatternClipCacheTests
             NewRenderer(night, cache, cacheKey: "k1")
                 .Render(BuildInstructions(), provider));
 
+        // A palette-only change reuses the cached (palette-independent) geometry:
+        // no further compute (miss count stays at one), served from the cache.
         Assert.Equal(1, cache.Misses);
-        Assert.Equal(1, cache.Hits);
+        Assert.True(cache.Hits >= 1);
 
         Assert.Equal(dayGeom.Count, nightGeom.Count);
         Assert.NotEmpty(dayGeom);

--- a/tests/EncDotNet.S100.Pipelines.Tests/PatternClipCacheTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PatternClipCacheTests.cs
@@ -82,13 +82,19 @@ public class PatternClipCacheTests
     private static MapsuiDisplayListRenderer NewRenderer(
         ColorPalette palette,
         IPatternClipCache? cache,
-        string? cacheKey) => new()
+        string? cacheKey,
+        RenderSubsystemKind subsystem = RenderSubsystemKind.Mapsui) => new()
         {
             Palette = palette,
             AreaFillProvider = AreaFills(),
             SymbolProvider = Symbols(),
             PatternClipCache = cache,
             PatternClipCacheKey = cacheKey,
+            // Pin the Mapsui feature ("A") arm: these tests inspect the clipped
+            // pattern-fill Mapsui features, which only the A arm builds. The
+            // TiledScene ("B") arm renders patterns from the IR and skips the
+            // feature-path pattern phase, so it produces no pattern features.
+            RenderSubsystemOverride = subsystem,
         };
 
     private static List<Geometry> PatternGeometries(Mapsui.Layers.ILayer layer)
@@ -132,10 +138,11 @@ public class PatternClipCacheTests
                 $"Clipped geometry {i} differs between cached and uncached paths.");
         }
 
-        // The expensive clip overlay is computed exactly once (a single miss);
-        // the number of cache reads (hits) depends on how many render arms consult
-        // the shared cache and is not asserted here.
+        // The expensive clip overlay is computed exactly once (a single miss).
+        // These tests pin the A arm, so the feature-path clip at the renderer's
+        // GetOrCompute site is the sole cache consumer.
         Assert.Equal(1, cache.Misses);
+        Assert.Equal(0, cache.Hits);
     }
 
     [Fact]
@@ -197,6 +204,44 @@ public class PatternClipCacheTests
         {
             Assert.Same(dayGeom[i], nightGeom[i]);
         }
+    }
+
+    [Fact]
+    public void TiledSceneArm_SkipsPatternFeatureBuilding()
+    {
+        var palette = ColorPalette.Default;
+        var provider = new StubGeometryProvider();
+
+        // The A arm builds clipped pattern-fill Mapsui features; the B arm
+        // (TiledScene) renders patterns from the IR scene and must skip that
+        // feature-path work entirely (the features are neither drawn nor
+        // pickable there), so no AnchoredPatternFillStyle features are emitted.
+        var aArm = PatternGeometries(
+            NewRenderer(palette, cache: null, cacheKey: null, RenderSubsystemKind.Mapsui)
+                .Render(BuildInstructions(), provider));
+        var bArm = PatternGeometries(
+            NewRenderer(palette, cache: null, cacheKey: null, RenderSubsystemKind.TiledScene)
+                .Render(BuildInstructions(), provider));
+
+        Assert.NotEmpty(aArm);
+        Assert.Empty(bArm);
+    }
+
+    [Fact]
+    public void TiledSceneArm_WarmsSharedClipCacheOnceViaMemoizer()
+    {
+        var palette = ColorPalette.Default;
+        var provider = new StubGeometryProvider();
+        var cache = new InMemoryPatternClipCache();
+
+        // On the B arm the feature-path clip (and its cache read) is skipped, but
+        // the VectorSceneBuilder memoizer still routes the IR clip through the
+        // same shared cache — so the expensive overlay is computed exactly once
+        // (a single miss), not twice.
+        NewRenderer(palette, cache, cacheKey: "k1", RenderSubsystemKind.TiledScene)
+            .Render(BuildInstructions(), provider);
+
+        Assert.Equal(1, cache.Misses);
     }
 
     [Fact]

--- a/tests/EncDotNet.S100.Pipelines.Tests/PatternClipPolygonalTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/PatternClipPolygonalTests.cs
@@ -1,4 +1,4 @@
-using EncDotNet.S100.Renderers.Mapsui;
+using EncDotNet.S100.Rendering.Scene;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Operation.Overlay;
 using NetTopologySuite.Operation.OverlayNG;
@@ -34,7 +34,7 @@ public class PatternClipPolygonalTests
     public void ExtractPolygonal_PolygonInput_ReturnedUnchanged()
     {
         var polygon = Square(0, 0, 10);
-        Assert.Same(polygon, MapsuiDisplayListRenderer.ExtractPolygonal(polygon));
+        Assert.Same(polygon, PatternPriorityClipper.ExtractPolygonal(polygon));
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class PatternClipPolygonalTests
 
         var mixed = Factory.CreateGeometryCollection([polygon, line, point]);
 
-        var result = MapsuiDisplayListRenderer.ExtractPolygonal(mixed);
+        var result = PatternPriorityClipper.ExtractPolygonal(mixed);
 
         Assert.NotNull(result);
         Assert.Equal(Dimension.Surface, result!.Dimension);
@@ -71,7 +71,7 @@ public class PatternClipPolygonalTests
 
         var mixed = Factory.CreateGeometryCollection([a, line, b]);
 
-        var result = MapsuiDisplayListRenderer.ExtractPolygonal(mixed);
+        var result = PatternPriorityClipper.ExtractPolygonal(mixed);
 
         var multi = Assert.IsType<MultiPolygon>(result);
         Assert.Equal(2, multi.NumGeometries);
@@ -87,7 +87,7 @@ public class PatternClipPolygonalTests
         ]);
         var collection = Factory.CreateGeometryCollection([line]);
 
-        Assert.Null(MapsuiDisplayListRenderer.ExtractPolygonal(collection));
+        Assert.Null(PatternPriorityClipper.ExtractPolygonal(collection));
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class PatternClipPolygonalTests
         ]);
         var mixed = Factory.CreateGeometryCollection([polygon, line]);
 
-        var subject = MapsuiDisplayListRenderer.ExtractPolygonal(mixed)!;
+        var subject = PatternPriorityClipper.ExtractPolygonal(mixed)!;
         var clip = Square(5, 0, 10);
 
         var difference = OverlayNGRobust.Overlay(

--- a/tests/EncDotNet.S100.Pipelines.Tests/S101DiskPatternClipCacheProcessorTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/S101DiskPatternClipCacheProcessorTests.cs
@@ -63,10 +63,10 @@ public class S101DiskPatternClipCacheProcessorTests
             var renderer = new MapsuiDatasetRenderer(new ProjNetCrsTransformFactory(), sharedCache);
 
             // First cold open: the disk cache is empty, so the clip is computed
-            // (a miss) and persisted. No clip-cache hits yet.
+            // (a miss) and persisted.
             var first = (S101DatasetProcessor)factory.CreateProcessor(DenseCellPath);
             await renderer.RenderAsync(first);
-            Assert.Equal(0, sharedCache.Hits);
+            Assert.True(sharedCache.Misses >= 1);
 
             // Second cold open (simulates reopening the cell, even after a
             // restart): a brand-new processor over the same shared disk cache.

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
@@ -142,6 +142,36 @@ public sealed class VectorSceneBuilderPatternClipTests
     }
 
     [Fact]
+    public void MixedCasePatternReferences_GroupCaseInsensitively()
+    {
+        // The Mapsui feature path groups pattern references with OrdinalIgnoreCase
+        // (matching its tile-resolution comparer). The IR path must do the same, so
+        // two overlapping same-priority ops whose references differ only in case
+        // merge into ONE group (a single unioned op) rather than two separate ops.
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("a", Rectangle(0, 0, 10, 10));
+        geometry.Add("b", Rectangle(0, 0, 10, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "a", AreaFillReference = "PATTERN", DrawingPriority = 5 },
+            new AreaInstruction { FeatureReference = "b", AreaFillReference = "pattern", DrawingPriority = 5 },
+        ];
+
+        var scene = NewBuilder().Build(instructions, geometry);
+
+        // Case-insensitive grouping unifies both ops under the first-seen key, so
+        // every emitted pattern op carries the same reference. Under the previous
+        // case-sensitive grouping they landed in two distinct groups ("PATTERN" and
+        // "pattern"), yielding two different reference values.
+        var references = scene.Ops.OfType<PatternAreaPaintOp>()
+            .Select(o => o.PatternReference)
+            .Distinct()
+            .ToList();
+        Assert.Equal(["PATTERN"], references);
+    }
+
+    [Fact]
     public void NoPatternResolver_EmitsNoPatternOps()
     {
         var geometry = new DictionaryGeometryProvider();

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
@@ -122,6 +122,30 @@ public sealed class VectorSceneBuilderPatternClipTests
     }
 
     [Fact]
+    public void TranslucentSolidFill_DoesNotClipPattern()
+    {
+        // A translucent solid fill (Transparency > 0 -> alpha < 255) does not fully
+        // hide underlying patterns, so it must NOT be treated as a pattern occluder
+        // (PatternPriorityClipper treats every supplied polygon as a full occluder).
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("pattern", Rectangle(0, 0, 10, 10));
+        geometry.Add("water", Rectangle(0, 0, 5, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "water", FillColor = "DEPVS", Transparency = 0.5, DrawingPriority = 1 },
+            new AreaInstruction { FeatureReference = "pattern", AreaFillReference = "PATTERN", DrawingPriority = 5 },
+        ];
+
+        var scene = NewBuilder().Build(instructions, geometry);
+
+        var patternGeometry = ToGeometry(SinglePatternOp(scene, "PATTERN"));
+        // The pattern is retained across the translucent fill (both halves visible).
+        Assert.True(patternGeometry.Contains(At(2, 5)));
+        Assert.True(patternGeometry.Contains(At(8, 5)));
+    }
+
+    [Fact]
     public void FeatureOwnSolidFill_DoesNotClipItsOwnPattern()
     {
         // A feature carrying both a solid fill and a pattern must not have its own

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
@@ -1,0 +1,161 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Rendering.Scene;
+using NetTopologySuite.Geometries;
+
+namespace EncDotNet.S100.Pipelines.Tests;
+
+/// <summary>
+/// Verifies that <see cref="VectorSceneBuilder"/> priority-clips the pattern
+/// area fills it lowers into the <see cref="VectorScene"/> IR — the same
+/// clipping the Mapsui feature path performs via
+/// <see cref="PatternPriorityClipper"/>, now shared so the headless Skia backend
+/// and the Mapsui TiledScene subsystem clip identically (S-100 Part 9 §11.3).
+/// A lower-priority pattern must be clipped away where a higher-priority pattern
+/// or an opaque non-patterned solid colour fill covers it.
+/// </summary>
+public sealed class VectorSceneBuilderPatternClipTests
+{
+    private static readonly GeometryFactory Factory = new();
+
+    private sealed class DictionaryGeometryProvider : IFeatureGeometryProvider
+    {
+        private readonly Dictionary<string, FeatureGeometry> _geometries = new(StringComparer.Ordinal);
+
+        public void Add(string featureReference, params (double Lon, double Lat)[] ring)
+        {
+            _geometries[featureReference] = new FeatureGeometry
+            {
+                Type = GeometryType.Surface,
+                Coordinates = [.. ring.Select(p => new GeoPosition(p.Lat, p.Lon))],
+            };
+        }
+
+        public FeatureGeometry? GetGeometry(string featureReference) =>
+            _geometries.TryGetValue(featureReference, out var g) ? g : null;
+    }
+
+    private static (double Lon, double Lat)[] Rectangle(double lon0, double lat0, double lon1, double lat1) =>
+        [(lon0, lat0), (lon1, lat0), (lon1, lat1), (lon0, lat1)];
+
+    private static VectorSceneBuilder NewBuilder() => new()
+    {
+        ResolveColor = static _ => new RgbaColor(200, 200, 200, 255),
+        PatternResolver = static _ => [1, 2, 3, 4],
+    };
+
+    /// <summary>Reconstructs an NTS polygon from a lowered pattern op's world rings.</summary>
+    private static Geometry ToGeometry(PatternAreaPaintOp op)
+    {
+        var shell = Factory.CreateLinearRing(CloseRing(op.WorldShell));
+        if (op.WorldHoles.Count == 0)
+            return Factory.CreatePolygon(shell);
+
+        var holes = op.WorldHoles.Select(h => Factory.CreateLinearRing(CloseRing(h))).ToArray();
+        return Factory.CreatePolygon(shell, holes);
+    }
+
+    private static Coordinate[] CloseRing(IReadOnlyList<(double X, double Y)> ring)
+    {
+        var coords = new List<Coordinate>(ring.Count + 1);
+        foreach (var (x, y) in ring)
+            coords.Add(new Coordinate(x, y));
+        if (coords.Count > 0 && !coords[0].Equals2D(coords[^1]))
+            coords.Add(new Coordinate(coords[0].X, coords[0].Y));
+        return [.. coords];
+    }
+
+    private static Point At(double lon, double lat)
+    {
+        var (x, y) = WebMercator.FromLonLat(lon, lat);
+        return Factory.CreatePoint(new Coordinate(x, y));
+    }
+
+    private static PatternAreaPaintOp SinglePatternOp(VectorScene scene, string patternReference) =>
+        Assert.Single(scene.Ops.OfType<PatternAreaPaintOp>(), o => o.PatternReference == patternReference);
+
+    [Fact]
+    public void HigherPriorityPattern_ClipsLowerPriorityPattern()
+    {
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("low", Rectangle(0, 0, 10, 10));
+        geometry.Add("high", Rectangle(0, 0, 5, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "low", AreaFillReference = "PATTERN_LOW", DrawingPriority = 5 },
+            new AreaInstruction { FeatureReference = "high", AreaFillReference = "PATTERN_HIGH", DrawingPriority = 10 },
+        ];
+
+        var scene = NewBuilder().Build(instructions, geometry);
+
+        var lowGeometry = ToGeometry(SinglePatternOp(scene, "PATTERN_LOW"));
+        // The overlap with the higher-priority pattern (left half) is clipped away…
+        Assert.False(lowGeometry.Contains(At(2, 5)));
+        // …while the non-overlapping right half remains.
+        Assert.True(lowGeometry.Contains(At(8, 5)));
+
+        // The higher-priority pattern is not clipped by anything below it.
+        var highGeometry = ToGeometry(SinglePatternOp(scene, "PATTERN_HIGH"));
+        Assert.True(highGeometry.Contains(At(2, 5)));
+    }
+
+    [Fact]
+    public void OpaqueSolidFill_ClipsPattern()
+    {
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("pattern", Rectangle(0, 0, 10, 10));
+        geometry.Add("land", Rectangle(0, 0, 5, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "land", FillColor = "LANDA", DrawingPriority = 1 },
+            new AreaInstruction { FeatureReference = "pattern", AreaFillReference = "PATTERN", DrawingPriority = 5 },
+        ];
+
+        var scene = NewBuilder().Build(instructions, geometry);
+
+        var patternGeometry = ToGeometry(SinglePatternOp(scene, "PATTERN"));
+        // The pattern must not bleed over the opaque solid (land) fill.
+        Assert.False(patternGeometry.Contains(At(2, 5)));
+        Assert.True(patternGeometry.Contains(At(8, 5)));
+    }
+
+    [Fact]
+    public void FeatureOwnSolidFill_DoesNotClipItsOwnPattern()
+    {
+        // A feature carrying both a solid fill and a pattern must not have its own
+        // solid fill treated as an exclusion area (mirrors the Mapsui feature path).
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("both", Rectangle(0, 0, 10, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "both", FillColor = "DEPMS", DrawingPriority = 5 },
+            new AreaInstruction { FeatureReference = "both", AreaFillReference = "PATTERN", DrawingPriority = 5 },
+        ];
+
+        var scene = NewBuilder().Build(instructions, geometry);
+
+        var patternGeometry = ToGeometry(SinglePatternOp(scene, "PATTERN"));
+        Assert.True(patternGeometry.Contains(At(5, 5)));
+    }
+
+    [Fact]
+    public void NoPatternResolver_EmitsNoPatternOps()
+    {
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("area", Rectangle(0, 0, 10, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "area", AreaFillReference = "PATTERN", DrawingPriority = 5 },
+        ];
+
+        // No PatternResolver: the Mapsui feature path drives its own pattern phase.
+        var builder = new VectorSceneBuilder { ResolveColor = static _ => new RgbaColor(0, 0, 0, 255) };
+        var scene = builder.Build(instructions, geometry);
+
+        Assert.Empty(scene.Ops.OfType<PatternAreaPaintOp>());
+    }
+}

--- a/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
+++ b/tests/EncDotNet.S100.Pipelines.Tests/VectorSceneBuilderPatternClipTests.cs
@@ -158,4 +158,89 @@ public sealed class VectorSceneBuilderPatternClipTests
 
         Assert.Empty(scene.Ops.OfType<PatternAreaPaintOp>());
     }
+
+    [Fact]
+    public void PatternClipCache_ResultIsUsedInsteadOfRecomputing()
+    {
+        // The builder must build its pattern ops from the memoizer's returned
+        // geometry, not from a fresh clip. A memoizer that returns an empty clip
+        // result therefore yields a scene with no pattern ops.
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("pattern", Rectangle(0, 0, 10, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "pattern", AreaFillReference = "PATTERN", DrawingPriority = 5 },
+        ];
+
+        int computeCount = 0;
+        var builder = new VectorSceneBuilder
+        {
+            ResolveColor = static _ => new RgbaColor(200, 200, 200, 255),
+            PatternResolver = static _ => [1, 2, 3, 4],
+            PatternClipCache = compute =>
+            {
+                computeCount++;
+                _ = compute();
+                return [];
+            },
+        };
+
+        var scene = builder.Build(instructions, geometry);
+
+        Assert.Equal(1, computeCount);
+        Assert.Empty(scene.Ops.OfType<PatternAreaPaintOp>());
+    }
+
+    [Fact]
+    public void PatternClipCache_MemoizesClipAcrossRebuilds()
+    {
+        // Simulates the palette-switch case: two consecutive layer builds sharing
+        // one cache must run the expensive clip only once, and the second build
+        // must still produce the correctly clipped geometry from the cache.
+        var geometry = new DictionaryGeometryProvider();
+        geometry.Add("low", Rectangle(0, 0, 10, 10));
+        geometry.Add("high", Rectangle(0, 0, 5, 10));
+
+        DrawingInstruction[] instructions =
+        [
+            new AreaInstruction { FeatureReference = "low", AreaFillReference = "PATTERN_LOW", DrawingPriority = 5 },
+            new AreaInstruction { FeatureReference = "high", AreaFillReference = "PATTERN_HIGH", DrawingPriority = 10 },
+        ];
+
+        IReadOnlyList<PatternPriorityClipper.ClippedPattern>? cached = null;
+        int computeCount = 0;
+        PatternClipMemoizer memoizer = compute =>
+        {
+            if (cached is null)
+            {
+                computeCount++;
+                cached = compute();
+            }
+
+            return cached;
+        };
+
+        VectorScene Build() => new VectorSceneBuilder
+        {
+            ResolveColor = static _ => new RgbaColor(200, 200, 200, 255),
+            PatternResolver = static _ => [1, 2, 3, 4],
+            PatternClipCache = memoizer,
+        }.Build(instructions, geometry);
+
+        var first = Build();
+        var second = Build();
+
+        // The clip overlay ran exactly once despite two builds.
+        Assert.Equal(1, computeCount);
+
+        // Both builds produce the same clipped low-priority pattern: the left half
+        // (under the higher-priority pattern) is removed, the right half remains.
+        foreach (var scene in new[] { first, second })
+        {
+            var lowGeometry = ToGeometry(SinglePatternOp(scene, "PATTERN_LOW"));
+            Assert.False(lowGeometry.Contains(At(2, 5)));
+            Assert.True(lowGeometry.Contains(At(8, 5)));
+        }
+    }
 }

--- a/tests/EncDotNet.S100.VisualRegression.Tests/HeadlessVectorRendererViewportTests.cs
+++ b/tests/EncDotNet.S100.VisualRegression.Tests/HeadlessVectorRendererViewportTests.cs
@@ -1,0 +1,132 @@
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Pipelines;
+using EncDotNet.S100.Pipelines.Vector;
+using EncDotNet.S100.Renderers.Skia.Scene;
+using SkiaSharp;
+
+namespace EncDotNet.S100.VisualRegression.Tests;
+
+/// <summary>
+/// Tests for the optional explicit <see cref="Viewport"/> honoured by
+/// <see cref="HeadlessVectorRenderer.Render"/>. An explicit viewport frames an
+/// exact window instead of auto-fitting the scene extent, and — because it
+/// carries a meaningful <see cref="Viewport.ScaleDenominator"/> — also enables
+/// S-100 Part 9 scale-visibility culling, bringing the single-dataset headless
+/// path into alignment with the composite/GUI paths.
+/// </summary>
+public sealed class HeadlessVectorRendererViewportTests
+{
+    private static readonly RgbaColor White = new(255, 255, 255, 255);
+
+    // A single red area near the origin (lat/lon 0.001–0.009).
+    private sealed class OriginAreaGeometryProvider : IFeatureGeometryProvider
+    {
+        public FeatureGeometry? GetGeometry(string featureReference) => featureReference == "area"
+            ? new FeatureGeometry
+            {
+                Type = GeometryType.Surface,
+                Coordinates =
+                [
+                    new GeoPosition(0.001, 0.001),
+                    new GeoPosition(0.001, 0.009),
+                    new GeoPosition(0.009, 0.009),
+                    new GeoPosition(0.009, 0.001),
+                ],
+            }
+            : null;
+    }
+
+    private static IReadOnlyList<DrawingInstruction> AreaOnly(double? scaleMinimum = null) =>
+    [
+        new AreaInstruction
+        {
+            FeatureReference = "area",
+            FillColor = "FILL",
+            ScaleMinimum = scaleMinimum,
+        },
+    ];
+
+    private static ColorPalette TestPalette() => new(
+        "Test",
+        new Dictionary<string, string> { ["FILL"] = "#FFA0A0" });
+
+    private static SKBitmap Render(IReadOnlyList<DrawingInstruction> instructions, Viewport? viewport) =>
+        HeadlessVectorRenderer.Render(
+            instructions,
+            new OriginAreaGeometryProvider(),
+            TestPalette(),
+            symbolProvider: null,
+            lineStyleProvider: null,
+            symbolScale: 1.0,
+            textScale: 1.0,
+            widthPixels: 200,
+            heightPixels: 200,
+            background: White,
+            viewport: viewport);
+
+    private static Viewport MakeViewport(
+        double minLon, double minLat, double maxLon, double maxLat, double scaleDenominator) => new()
+        {
+            MinLongitude = minLon,
+            MinLatitude = minLat,
+            MaxLongitude = maxLon,
+            MaxLatitude = maxLat,
+            WidthPixels = 200,
+            HeightPixels = 200,
+            ScaleDenominator = scaleDenominator,
+        };
+
+    [Fact]
+    public void Explicit_Viewport_Frames_The_Requested_Window_Not_The_Auto_Fit()
+    {
+        // Auto-fit (no viewport) frames the area, so its red fill is visible.
+        using var autoFit = Render(AreaOnly(), viewport: null);
+        Assert.True(HasRedPixel(autoFit),
+            "Auto-fit should frame the origin area and draw its fill.");
+
+        // An explicit viewport far from the origin excludes the geometry, so
+        // the output is the untouched background — proving the exact window was
+        // honoured rather than the auto-fitted extent.
+        using var elsewhere = Render(AreaOnly(), MakeViewport(-71.0, 40.0, -70.0, 41.0, 50_000.0));
+        Assert.False(HasRedPixel(elsewhere),
+            "An explicit viewport away from the geometry must not auto-fit back onto it.");
+    }
+
+    [Fact]
+    public void Explicit_Viewport_Enables_Scale_Visibility_Culling()
+    {
+        // A viewport that contains the geometry, at a denominator (5000) more
+        // zoomed-out than the instruction's ScaleMinimum (500 = largest allowed
+        // denominator). Same window, two instruction variants:
+        var viewport = MakeViewport(-0.02, -0.02, 0.02, 0.02, 5_000.0);
+
+        // No scale limits → drawn (confirms the window frames the geometry).
+        using var unlimited = Render(AreaOnly(scaleMinimum: null), viewport);
+        Assert.True(HasRedPixel(unlimited),
+            "The viewport should contain the origin area when it has no scale limits.");
+
+        // ScaleMinimum 500 < viewport denominator 5000 → culled by scale
+        // visibility, which is only active because a viewport was supplied.
+        using var culled = Render(AreaOnly(scaleMinimum: 500.0), viewport);
+        Assert.False(HasRedPixel(culled),
+            "An explicit viewport must honour S-100 scale-visibility culling.");
+
+        // The same scale-limited instruction under auto-fit is still drawn,
+        // because the auto-fit path leaves culling disabled.
+        using var autoFit = Render(AreaOnly(scaleMinimum: 500.0), viewport: null);
+        Assert.True(HasRedPixel(autoFit),
+            "Auto-fit leaves scale-visibility culling disabled, so the area is drawn.");
+    }
+
+    private static bool HasRedPixel(SKBitmap bitmap)
+    {
+        for (int y = 0; y < bitmap.Height; y++)
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                var p = bitmap.GetPixel(x, y);
+                if (p.Red > 200 && p.Green < 200 && p.Blue < 200)
+                    return true;
+            }
+        return false;
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -76,15 +76,15 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         public string? OutputOption { get; init; }
 
         [CommandOption("--bbox <BBOX>")]
-        [Description("Explicit viewport as a WGS-84 bounding box 'minLon,minLat,maxLon,maxLat' (e.g. --bbox -1.5,50.0,-1.0,50.5). Mutually exclusive with --center/--scale. When omitted, the single-dataset form auto-fits the dataset extent and the composite form auto-fits the union of all layers. For a single vector dataset this also enables S-100 Part 9 scale-visibility culling. Not supported for coverage products (S-102/S-104/S-111).")]
+        [Description("Explicit viewport as a WGS-84 bounding box 'minLon,minLat,maxLon,maxLat' (e.g. --bbox -1.5,50.0,-1.0,50.5). Mutually exclusive with --center/--scale. When omitted, the single-dataset form auto-fits the dataset extent and the composite form auto-fits the union of all layers. For a single vector dataset this also enables S-100 Part 9 scale-visibility culling. Not supported for coverage products (S-102/S-104/S-111). Rejected with --format json (a display list has no viewport).")]
         public string? BoundingBox { get; init; }
 
         [CommandOption("--center <CENTER>")]
-        [Description("Explicit viewport centre 'lon,lat' (e.g. --center -1.25,50.25). Must be used with --scale. Not supported for coverage products (S-102/S-104/S-111).")]
+        [Description("Explicit viewport centre 'lon,lat' (e.g. --center -1.25,50.25). Must be used with --scale. Not supported for coverage products (S-102/S-104/S-111). Rejected with --format json (a display list has no viewport).")]
         public string? Center { get; init; }
 
         [CommandOption("--scale <DENOMINATOR>")]
-        [Description("Explicit viewport scale denominator (e.g. --scale 50000 for 1:50000). Must be used with --center. Not supported for coverage products (S-102/S-104/S-111).")]
+        [Description("Explicit viewport scale denominator (e.g. --scale 50000 for 1:50000). Must be used with --center. Not supported for coverage products (S-102/S-104/S-111). Rejected with --format json (a display list has no viewport).")]
         public double? Scale { get; init; }
 
         [CommandOption("--format")]

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using EncDotNet.S100.Cli.Infrastructure;
 using EncDotNet.S100.Datasets.Pipelines;
+using EncDotNet.S100.Datasets.Pipelines.Portrayal;
 using EncDotNet.S100.Hdf5;
 using EncDotNet.S100.Pipelines;
 using EncDotNet.S100.Pipelines.Vector;
@@ -75,19 +76,19 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         public string? OutputOption { get; init; }
 
         [CommandOption("--bbox <BBOX>")]
-        [Description("Composite only: explicit shared viewport as a WGS-84 bounding box 'minLon,minLat,maxLon,maxLat' (e.g. --bbox -1.5,50.0,-1.0,50.5). Mutually exclusive with --center/--scale. When omitted, the compositor auto-fits the union of all layers.")]
+        [Description("Explicit viewport as a WGS-84 bounding box 'minLon,minLat,maxLon,maxLat' (e.g. --bbox -1.5,50.0,-1.0,50.5). Mutually exclusive with --center/--scale. When omitted, the single-dataset form auto-fits the dataset extent and the composite form auto-fits the union of all layers. For a single vector dataset this also enables S-100 Part 9 scale-visibility culling. Not supported for coverage products (S-102/S-104/S-111).")]
         public string? BoundingBox { get; init; }
 
         [CommandOption("--center <CENTER>")]
-        [Description("Composite only: explicit shared viewport centre 'lon,lat' (e.g. --center -1.25,50.25). Must be used with --scale.")]
+        [Description("Explicit viewport centre 'lon,lat' (e.g. --center -1.25,50.25). Must be used with --scale. Not supported for coverage products (S-102/S-104/S-111).")]
         public string? Center { get; init; }
 
         [CommandOption("--scale <DENOMINATOR>")]
-        [Description("Composite only: explicit shared viewport scale denominator (e.g. --scale 50000 for 1:50000). Must be used with --center.")]
+        [Description("Explicit viewport scale denominator (e.g. --scale 50000 for 1:50000). Must be used with --center. Not supported for coverage products (S-102/S-104/S-111).")]
         public double? Scale { get; init; }
 
         [CommandOption("--format")]
-        [Description("Output image format: png, jpeg (jpg), or webp. Default: inferred from the output file extension, falling back to png.")]
+        [Description("Output format: png, jpeg (jpg), webp, or json. json emits the S-100 Part 9 display list (single-dataset form only) instead of an image. Default: inferred from the output file extension, falling back to png.")]
         public string? Format { get; init; }
 
         [CommandOption("--quality")]
@@ -176,9 +177,6 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
 
         /// <summary>Whether this invocation composites an exchange set / directory.</summary>
         public bool IsExchangeSetComposite => IsExplicitExchangeSet || IsPositionalExchangeSet;
-
-        /// <summary>Whether the composite viewport flags (<c>--bbox</c>/<c>--center</c>/<c>--scale</c>) apply.</summary>
-        public bool AllowsViewport => IsComposite || IsExchangeSetComposite;
 
         /// <summary>The exchange-set source path for the exchange-set form.</summary>
         public string? ExchangeSetSource => IsExplicitExchangeSet ? ExchangeSet : Input;
@@ -321,10 +319,14 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                     return ValidationResult.Error("An output path is required.");
             }
 
-            if (!TryResolveFormat(Format, output, out _, out var formatError))
+            if (!TryResolveOutput(Format, output, out var outputKind, out _, out var formatError))
                 return ValidationResult.Error(formatError);
 
-            var viewportResult = ValidateViewport();
+            if (outputKind == RenderOutputKind.DisplayList && (IsComposite || IsExchangeSetComposite))
+                return ValidationResult.Error(
+                    "Display-list (json) output is currently supported only for the single-dataset form.");
+
+            var viewportResult = ValidateViewport(outputKind);
             if (!viewportResult.Successful)
                 return viewportResult;
 
@@ -335,15 +337,15 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
             return ValidationResult.Success();
         }
 
-        private ValidationResult ValidateViewport()
+        private ValidationResult ValidateViewport(RenderOutputKind outputKind)
         {
             bool hasBbox = !string.IsNullOrWhiteSpace(BoundingBox);
             bool hasCenter = !string.IsNullOrWhiteSpace(Center);
             bool hasScale = Scale is not null;
 
-            if ((hasBbox || hasCenter || hasScale) && !AllowsViewport)
+            if ((hasBbox || hasCenter || hasScale) && outputKind == RenderOutputKind.DisplayList)
                 return ValidationResult.Error(
-                    "--bbox, --center, and --scale apply only to the composite forms (--layer or --exchange-set).");
+                    "--bbox, --center, and --scale do not apply to --format json (a display list has no viewport).");
 
             if (hasBbox && (hasCenter || hasScale))
                 return ValidationResult.Error("--bbox cannot be combined with --center/--scale.");
@@ -406,13 +408,6 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 Console.Error.WriteLine(processor.VersionAssessment.BuildMessage());
             }
 
-            if (processor is not IHeadlessImageRenderer headless)
-            {
-                AnsiConsole.MarkupLineInterpolated(
-                    $"[red]Headless image rendering is not supported for {spec}.[/]");
-                return 3;
-            }
-
             TryParsePalette(settings.Palette, out var palette);
             RgbaColor? background = ResolveBackground(settings);
             var hidden = ResolveHiddenCategories(settings);
@@ -423,19 +418,56 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 return 2;
             }
 
+            Viewport? viewport = ResolveViewport(settings);
+            if (viewport is not null && processor is not IVectorPortrayalSource)
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]An explicit viewport (--bbox/--center/--scale) is not yet supported for {spec}; it applies to vector products (their headless render honours the exact window).[/]");
+                return 3;
+            }
+
             var renderContext = RenderContextBuilder.Build(
                 processor, palette, settings.SymbolScale, settings.TextScale, settings.TimeStep, hidden,
-                ResolveBasemap(settings), displayModeId);
+                ResolveBasemap(settings), displayModeId, viewport);
+
+            TryResolveOutput(settings.Format, outputPath, out var outputKind, out var imageFormat, out _);
+
+            if (outputKind == RenderOutputKind.DisplayList)
+            {
+                if (processor is not IVectorPortrayalSource vectorSource)
+                {
+                    AnsiConsole.MarkupLineInterpolated(
+                        $"[red]Display-list (json) output is not supported for {spec} (only vector products emit a Part 9 display list).[/]");
+                    return 3;
+                }
+
+                var portrayal = vectorSource.BuildVectorPortrayalAsync(renderContext)
+                    .GetAwaiter().GetResult();
+                var json = DisplayListJsonWriter.Serialize(
+                    portrayal, Path.GetFileName(datasetPath), settings.Palette.Trim().ToLowerInvariant());
+                File.WriteAllText(outputPath, json);
+
+                int instructionCount = portrayal.SubLayers.Sum(l => l.Instructions.Count);
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[green]Wrote[/] {outputPath} ([grey]{spec}, display-list, {instructionCount} instruction(s)[/])");
+                return 0;
+            }
+
+            if (processor is not IHeadlessImageRenderer headless)
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]Headless image rendering is not supported for {spec}.[/]");
+                return 3;
+            }
 
             using var bitmap = headless
                 .RenderHeadlessAsync(settings.Width, settings.Height, renderContext, background)
                 .GetAwaiter().GetResult();
 
-            TryResolveFormat(settings.Format, outputPath, out var format, out _);
-            WriteImage(bitmap, outputPath, format, settings.Quality);
+            WriteImage(bitmap, outputPath, imageFormat, settings.Quality);
 
             AnsiConsole.MarkupLineInterpolated(
-                $"[green]Wrote[/] {outputPath} ([grey]{spec}, {format}, {bitmap.Width}x{bitmap.Height}[/])");
+                $"[green]Wrote[/] {outputPath} ([grey]{spec}, {imageFormat}, {bitmap.Width}x{bitmap.Height}[/])");
             return 0;
         }
         catch (Exception ex)
@@ -655,6 +687,73 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
     }
 
     /// <summary>
+    /// The kind of artifact <c>render</c> produces: a rasterised image, or the
+    /// S-100 Part 9 display list as JSON.
+    /// </summary>
+    internal enum RenderOutputKind
+    {
+        /// <summary>A rasterised image (png / jpeg / webp).</summary>
+        Image,
+
+        /// <summary>The Part 9 display list serialized as JSON (<c>--format json</c>).</summary>
+        DisplayList,
+    }
+
+    /// <summary>
+    /// Resolves both the output <see cref="RenderOutputKind"/> and, for the image
+    /// kind, the concrete <see cref="SKEncodedImageFormat"/> from an explicit
+    /// <paramref name="format"/> option (when supplied) or the extension of
+    /// <paramref name="outputPath"/>. The <c>json</c> token (explicit or via a
+    /// <c>.json</c> extension) selects <see cref="RenderOutputKind.DisplayList"/>;
+    /// everything else resolves through <see cref="TryResolveFormat"/> to an image
+    /// format. Returns <see langword="false"/> with a populated
+    /// <paramref name="error"/> when <c>--format json</c> conflicts with a
+    /// recognised image extension, or when the image resolution fails.
+    /// </summary>
+    internal static bool TryResolveOutput(
+        string? format, string outputPath,
+        out RenderOutputKind kind, out SKEncodedImageFormat imageFormat, out string error)
+    {
+        kind = RenderOutputKind.Image;
+        imageFormat = SKEncodedImageFormat.Png;
+        error = string.Empty;
+
+        var ext = Path.GetExtension(outputPath).TrimStart('.');
+        bool extIsImage = TryParseFormatToken(ext, out _);
+
+        if (!string.IsNullOrWhiteSpace(format))
+        {
+            if (IsDisplayListToken(format))
+            {
+                if (extIsImage)
+                {
+                    error =
+                        $"--format json conflicts with the output extension " +
+                        $"'{Path.GetExtension(outputPath)}'. Use a non-image extension " +
+                        "(e.g. .json) or omit --format.";
+                    return false;
+                }
+
+                kind = RenderOutputKind.DisplayList;
+                return true;
+            }
+
+            return TryResolveFormat(format, outputPath, out imageFormat, out error);
+        }
+
+        if (IsDisplayListToken(ext))
+        {
+            kind = RenderOutputKind.DisplayList;
+            return true;
+        }
+
+        return TryResolveFormat(format, outputPath, out imageFormat, out error);
+    }
+
+    private static bool IsDisplayListToken(string value) =>
+        value.Trim().ToLowerInvariant() is "json";
+
+    /// <summary>
     /// Resolves the desired <see cref="SKEncodedImageFormat"/> from an explicit
     /// <paramref name="format"/> option when supplied, otherwise infers it from
     /// the extension of <paramref name="outputPath"/>, falling back to PNG when
@@ -676,7 +775,7 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
         {
             if (!TryParseFormatToken(format, out resolved))
             {
-                error = $"Unknown --format '{format}'. Use png, jpeg, or webp.";
+                error = $"Unknown --format '{format}'. Use png, jpeg, webp, or json.";
                 return false;
             }
 

--- a/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
+++ b/tools/EncDotNet.S100.Cli/Commands/RenderCommand.cs
@@ -729,8 +729,9 @@ internal sealed class RenderCommand : Command<RenderCommand.Settings>
                 {
                     error =
                         $"--format json conflicts with the output extension " +
-                        $"'{Path.GetExtension(outputPath)}'. Use a non-image extension " +
-                        "(e.g. .json) or omit --format.";
+                        $"'{Path.GetExtension(outputPath)}'. Use a non-image output " +
+                        "extension (e.g. .json) to write a display list, or drop " +
+                        "--format to render an image to the current extension.";
                     return false;
                 }
 

--- a/tools/EncDotNet.S100.Cli/Infrastructure/DisplayListJsonWriter.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/DisplayListJsonWriter.cs
@@ -129,20 +129,31 @@ internal static class DisplayListJsonWriter
         dto.DrawingPriority = instruction.DrawingPriority;
         dto.ScaleMinimum = instruction.ScaleMinimum;
         dto.ScaleMaximum = instruction.ScaleMaximum;
-        dto.Geometry = SummariseGeometry(geometry.GetGeometry(instruction.FeatureReference));
+        dto.Geometry = instruction is LineInstruction { CoordinatesOverride: { } overrideCoordinates }
+            ? SummariseCoordinates(GeometryType.Curve, overrideCoordinates)
+            : SummariseGeometry(geometry.GetGeometry(instruction.FeatureReference));
         return dto;
     }
 
     private static GeometrySummaryDto? SummariseGeometry(FeatureGeometry? geometry)
     {
-        if (geometry is null || geometry.Coordinates.Count == 0)
+        if (geometry is null)
             return null;
 
-        GeoPosition anchor = geometry.Coordinates[0];
+        return SummariseCoordinates(geometry.Type, geometry.Coordinates);
+    }
+
+    private static GeometrySummaryDto? SummariseCoordinates(
+        GeometryType type, IReadOnlyList<GeoPosition> coordinates)
+    {
+        if (coordinates.Count == 0)
+            return null;
+
+        GeoPosition anchor = coordinates[0];
         return new GeometrySummaryDto
         {
-            Type = geometry.Type.ToString(),
-            VertexCount = geometry.Coordinates.Count,
+            Type = type.ToString(),
+            VertexCount = coordinates.Count,
             Anchor = [Math.Round(anchor.Latitude, 6), Math.Round(anchor.Longitude, 6)],
         };
     }

--- a/tools/EncDotNet.S100.Cli/Infrastructure/DisplayListJsonWriter.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/DisplayListJsonWriter.cs
@@ -41,7 +41,11 @@ internal static class DisplayListJsonWriter
     /// <param name="result">The built vector portrayal (sub-layers + geometry).</param>
     /// <param name="datasetName">The source dataset file name, echoed into the document.</param>
     /// <param name="palette">The active palette token (e.g. <c>day</c>).</param>
-    /// <returns>The serialized JSON document, terminated with a trailing newline.</returns>
+    /// <returns>
+    /// The serialized JSON document, terminated with a single trailing <c>\n</c>.
+    /// A fixed newline (rather than <see cref="Environment.NewLine"/>) keeps the
+    /// output byte-identical across operating systems for stable snapshot/diffing.
+    /// </returns>
     public static string Serialize(VectorPortrayalResult result, string datasetName, string palette)
     {
         ArgumentNullException.ThrowIfNull(result);
@@ -73,7 +77,7 @@ internal static class DisplayListJsonWriter
             Instructions = instructions,
         };
 
-        return JsonSerializer.Serialize(document, Options) + Environment.NewLine;
+        return JsonSerializer.Serialize(document, Options) + "\n";
     }
 
     private static InstructionDto ToDto(

--- a/tools/EncDotNet.S100.Cli/Infrastructure/DisplayListJsonWriter.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/DisplayListJsonWriter.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EncDotNet.S100.DataModel;
+using EncDotNet.S100.Datasets.Pipelines.Portrayal;
+using EncDotNet.S100.Pipelines.Vector;
+
+namespace EncDotNet.S100.Cli.Infrastructure;
+
+/// <summary>
+/// Serializes a vector dataset's post-portrayal S-100 Part 9 display list — the
+/// ordered list of <see cref="DrawingInstruction"/> produced by a
+/// <see cref="IVectorPortrayalSource"/> — to a stable, deterministic JSON
+/// document. This is the non-image output format of <c>s100 render</c>
+/// (<c>--format json</c>): it captures <em>what</em> the portrayal pipeline
+/// decided to draw (symbol / line-style / area-fill references, colours,
+/// display planes, priorities, text) rather than the rasterised pixels, so a
+/// portrayal change can be diagnosed and snapshot-tested in text without a
+/// viewer or image diff.
+/// </summary>
+/// <remarks>
+/// The document is pure portrayal output: it contains no timing, no encoder
+/// settings, and no viewport-dependent pixel coordinates, so two runs over the
+/// same dataset and <see cref="RenderContext"/> produce byte-identical JSON.
+/// Geometry is summarised (type, vertex count, and a representative anchor in
+/// latitude/longitude) rather than dumped in full, keeping the output compact
+/// and diffable.
+/// </remarks>
+internal static class DisplayListJsonWriter
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    /// <summary>
+    /// Serializes the display list carried by <paramref name="result"/> to an
+    /// indented JSON string.
+    /// </summary>
+    /// <param name="result">The built vector portrayal (sub-layers + geometry).</param>
+    /// <param name="datasetName">The source dataset file name, echoed into the document.</param>
+    /// <param name="palette">The active palette token (e.g. <c>day</c>).</param>
+    /// <returns>The serialized JSON document, terminated with a trailing newline.</returns>
+    public static string Serialize(VectorPortrayalResult result, string datasetName, string palette)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var instructions = new List<InstructionDto>();
+        for (int subLayer = 0; subLayer < result.SubLayers.Count; subLayer++)
+        {
+            foreach (var instruction in result.SubLayers[subLayer].Instructions)
+                instructions.Add(ToDto(instruction, subLayer, result.GeometryProvider));
+        }
+
+        var document = new DisplayListDto
+        {
+            Dataset = datasetName,
+            Product = result.Product,
+            Spec = result.Spec.ToString(),
+            Palette = palette,
+            SymbolScale = result.SymbolScale,
+            TextScale = result.TextScale,
+            SubLayerCount = result.SubLayers.Count,
+            InstructionCount = instructions.Count,
+            CategoryCounts = new CategoryCountsDto
+            {
+                Areas = instructions.Count(i => i.Kind == "area"),
+                Lines = instructions.Count(i => i.Kind == "line"),
+                Points = instructions.Count(i => i.Kind == "point"),
+                Text = instructions.Count(i => i.Kind == "text"),
+            },
+            Instructions = instructions,
+        };
+
+        return JsonSerializer.Serialize(document, Options) + Environment.NewLine;
+    }
+
+    private static InstructionDto ToDto(
+        DrawingInstruction instruction, int subLayer, IFeatureGeometryProvider geometry)
+    {
+        var dto = instruction switch
+        {
+            PointInstruction p => new InstructionDto
+            {
+                Kind = "point",
+                Symbol = p.SymbolReference,
+                SymbolScale = p.SymbolScale,
+                Rotation = p.Rotation,
+                LocalOffsetX = NonZero(p.LocalOffsetX),
+                LocalOffsetY = NonZero(p.LocalOffsetY),
+                LinePlacementPosition = p.LinePlacementPosition,
+            },
+            LineInstruction l => new InstructionDto
+            {
+                Kind = "line",
+                LineStyle = l.LineStyleReference,
+                LineWidth = NonZero(l.LineWidth),
+                LineColor = l.LineColor,
+                Dashes = l.Dashes?.Select(d => new[] { d.Offset, d.Length }).ToList(),
+            },
+            AreaInstruction a => new InstructionDto
+            {
+                Kind = "area",
+                AreaFill = a.AreaFillReference,
+                FillColor = a.FillColor,
+                Transparency = a.Transparency,
+                OutlineStyle = a.OutlineStyleReference,
+            },
+            TextInstruction t => new InstructionDto
+            {
+                Kind = "text",
+                Text = t.Text,
+                Font = t.FontReference,
+                FontSize = t.FontSize,
+                FontColor = t.FontColor,
+                BackgroundColor = t.BackgroundColor,
+                Rotation = t.Rotation,
+                HorizontalAlignment = t.HorizontalAlignment.ToString(),
+                VerticalAlignment = t.VerticalAlignment.ToString(),
+            },
+            _ => new InstructionDto { Kind = "unknown" },
+        };
+
+        dto.Feature = instruction.FeatureReference;
+        dto.SubLayer = subLayer;
+        dto.Plane = instruction.Plane.ToString();
+        dto.ViewingGroup = instruction.ViewingGroup;
+        dto.DrawingPriority = instruction.DrawingPriority;
+        dto.ScaleMinimum = instruction.ScaleMinimum;
+        dto.ScaleMaximum = instruction.ScaleMaximum;
+        dto.Geometry = SummariseGeometry(geometry.GetGeometry(instruction.FeatureReference));
+        return dto;
+    }
+
+    private static GeometrySummaryDto? SummariseGeometry(FeatureGeometry? geometry)
+    {
+        if (geometry is null || geometry.Coordinates.Count == 0)
+            return null;
+
+        GeoPosition anchor = geometry.Coordinates[0];
+        return new GeometrySummaryDto
+        {
+            Type = geometry.Type.ToString(),
+            VertexCount = geometry.Coordinates.Count,
+            Anchor = [Math.Round(anchor.Latitude, 6), Math.Round(anchor.Longitude, 6)],
+        };
+    }
+
+    private static double? NonZero(double value) => value == 0 ? null : value;
+
+    private sealed class DisplayListDto
+    {
+        public required string Dataset { get; init; }
+        public required string Product { get; init; }
+        public required string Spec { get; init; }
+        public required string Palette { get; init; }
+        public double SymbolScale { get; init; }
+        public double TextScale { get; init; }
+        public int SubLayerCount { get; init; }
+        public int InstructionCount { get; init; }
+        public required CategoryCountsDto CategoryCounts { get; init; }
+        public required IReadOnlyList<InstructionDto> Instructions { get; init; }
+    }
+
+    private sealed class CategoryCountsDto
+    {
+        public int Areas { get; init; }
+        public int Lines { get; init; }
+        public int Points { get; init; }
+        public int Text { get; init; }
+    }
+
+    private sealed class GeometrySummaryDto
+    {
+        public required string Type { get; init; }
+        public int VertexCount { get; init; }
+        public required IReadOnlyList<double> Anchor { get; init; }
+    }
+
+    private sealed class InstructionDto
+    {
+        public required string Kind { get; init; }
+        public string? Feature { get; set; }
+        public int SubLayer { get; set; }
+        public string? Plane { get; set; }
+        public int ViewingGroup { get; set; }
+        public int DrawingPriority { get; set; }
+        public double? ScaleMinimum { get; set; }
+        public double? ScaleMaximum { get; set; }
+
+        // Point
+        public string? Symbol { get; init; }
+        public double? SymbolScale { get; init; }
+        public double? Rotation { get; init; }
+        public double? LocalOffsetX { get; init; }
+        public double? LocalOffsetY { get; init; }
+        public double? LinePlacementPosition { get; init; }
+
+        // Line
+        public string? LineStyle { get; init; }
+        public double? LineWidth { get; init; }
+        public string? LineColor { get; init; }
+        public IReadOnlyList<double[]>? Dashes { get; init; }
+
+        // Area
+        public string? AreaFill { get; init; }
+        public string? FillColor { get; init; }
+        public double? Transparency { get; init; }
+        public string? OutlineStyle { get; init; }
+
+        // Text
+        public string? Text { get; init; }
+        public string? Font { get; init; }
+        public double? FontSize { get; init; }
+        public string? FontColor { get; init; }
+        public string? BackgroundColor { get; init; }
+        public string? HorizontalAlignment { get; init; }
+        public string? VerticalAlignment { get; init; }
+
+        public GeometrySummaryDto? Geometry { get; set; }
+    }
+}

--- a/tools/EncDotNet.S100.Cli/Infrastructure/RenderContextBuilder.cs
+++ b/tools/EncDotNet.S100.Cli/Infrastructure/RenderContextBuilder.cs
@@ -21,7 +21,8 @@ internal static class RenderContextBuilder
         int timeStepIndex,
         DrawingInstructionCategory hiddenCategories = DrawingInstructionCategory.None,
         BasemapKind basemap = BasemapKind.None,
-        string? displayModeId = null)
+        string? displayModeId = null,
+        Viewport? viewport = null)
     {
         DateTime? timeStep = ResolveTimeStep(processor, timeStepIndex);
 
@@ -41,7 +42,7 @@ internal static class RenderContextBuilder
             _ => new GenericRenderContext { Palette = palette, SymbolScale = symbolScale, TextScale = textScale, HiddenInstructionCategories = hiddenCategories },
         };
 
-        return context with { Basemap = basemap, DisplayModeId = displayModeId };
+        return context with { Basemap = basemap, DisplayModeId = displayModeId, Viewport = viewport };
     }
 
     private static DateTime? ResolveTimeStep(IDatasetProcessor processor, int timeStepIndex)

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -338,12 +338,6 @@ and attribute mapping, allowed-value enforcement) are owned by
 
 ## Limitations
 
-- **Vector pattern area-fills are not priority-clipped** on the headless path.
-  Points, lines, solid-area fills, tiled **pattern** area-fills, and text all
-  render, but the headless path does not yet subtract higher-priority patterns
-  and opaque solid fills out of lower-priority semi-transparent patterns the way
-  the Mapsui/viewer path does (via NetTopologySuite), so dense pattern coverages
-  can bleed slightly across such boundaries.
 - **Explicit viewport is vector-only.** `--bbox` / `--center`+`--scale` frame an
   exact window (and enable scale-visibility culling) for a single **vector**
   dataset and for composites, but are **not** yet honoured for a single coverage

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -117,9 +117,9 @@ unless `--format` is given.
 | `--exchange-set`, `--from <path>` | _none_ | Composite an entire exchange set (directory / `CATALOG.XML` / `.zip`). A directory / `CATALOG.XML` / `.zip` passed positionally is also auto-detected. Mutually exclusive with `--layer`. |
 | `--only <specs>` | _all_ | **Exchange-set only.** Restrict compositing to a comma-separated list of product specifications (e.g. `--only S101,S128`; hyphenation and case are ignored). |
 | `-o`, `--output <path>` | _positional_ | Output image path. Required (or given positionally) for the composite forms; an alternative to the positional `<output>` for the single form. |
-| `--bbox <minLon,minLat,maxLon,maxLat>` | union auto-fit | **Composite forms only.** Explicit shared viewport as a WGS-84 bounding box (e.g. `--bbox -1.5,50.0,-1.0,50.5`). Mutually exclusive with `--center`/`--scale`. |
-| `--center <lon,lat>` | union auto-fit | **Composite forms only.** Explicit shared viewport centre. Must be used with `--scale`. |
-| `--scale <denominator>` | union auto-fit | **Composite forms only.** Explicit shared viewport scale denominator (e.g. `--scale 50000` for 1:50 000). Must be used with `--center`. |
+| `--bbox <minLon,minLat,maxLon,maxLat>` | auto-fit | Explicit viewport as a WGS-84 bounding box (e.g. `--bbox -1.5,50.0,-1.0,50.5`). Mutually exclusive with `--center`/`--scale`. Applies to the single-dataset **vector** form and both composite forms; on a single vector dataset it also enables S-100 Part 9 scale-visibility culling. **Not supported for coverage products (S-102/S-104/S-111)**, nor with `--format json`. |
+| `--center <lon,lat>` | auto-fit | Explicit viewport centre. Must be used with `--scale`. Same applicability as `--bbox`. |
+| `--scale <denominator>` | auto-fit | Explicit viewport scale denominator (e.g. `--scale 50000` for 1:50 000). Must be used with `--center`. Same applicability as `--bbox`. |
 | `-w`, `--width` | `1024` | Output image width in pixels. |
 | `-h`, `--height` | `768` | Output image height in pixels. |
 | `--palette` | `day` | Colour palette: `day`, `dusk`, or `night`. |
@@ -127,7 +127,7 @@ unless `--format` is given.
 | `--text-scale` | `1.0` | Text scale factor. |
 | `--time-step <index>` | `0` | Zero-based time-step index for time-series datasets (S-104 / S-111). |
 | `--background <hex>` | opaque white | Background colour, `#RRGGBB` or `#AARRGGBB`. |
-| `--format <fmt>` | inferred from extension, else `png` | Output image format: `png`, `jpeg` (`jpg`), or `webp`. When omitted, the format is inferred from the output file extension; an unrecognised extension falls back to `png`. An explicit `--format` that conflicts with a recognised output extension is rejected. |
+| `--format <fmt>` | inferred from extension, else `png` | Output format: `png`, `jpeg` (`jpg`), `webp`, or `json`. When omitted, the format is inferred from the output file extension; an unrecognised extension falls back to `png`. `json` emits the S-100 Part 9 **display list** (see [Display-list output](#display-list-output-format-json)) instead of an image — **single-dataset form only**. An explicit `--format` that conflicts with a recognised output extension is rejected. |
 | `--quality <1-100>` | `90` | Encoder quality for lossy formats (`jpeg`, `webp`). Ignored for `png`. |
 | `--no-text` | off | Suppress text/label drawing instructions. Shorthand for `--hide text`. In the composite form the suppression is global (applies to every layer). |
 | `--hide <list>` | _none_ | Comma-separated list of drawing-instruction categories to suppress: `text`, `points`, `lines`, `areas` (e.g. `--hide text,points`). Combines additively with `--no-text`. In the composite form the suppression is global. Useful for label-dense products such as S-411 sea-ice, where the egg-code text overlaps fills at preview scales — `--no-text` yields a BSIS-style "clean fill" preview. |
@@ -146,6 +146,10 @@ s100 render NL4NZ110.000 cell.png                          # applies .001/.002/�
 s100 render NL4NZ110.000 base.png --no-updates             # render the base cell only
 s100 render warnings.gml warnings.jpg --quality 85         # JPEG (format inferred from .jpg)
 s100 render warnings.gml preview.webp                      # WebP preview
+s100 render warnings.gml warnings.json                     # display list (not an image)
+s100 render warnings.gml list.txt --format json           # display list, explicit format
+s100 render enc.000 window.png --bbox -1.5,50.0,-1.0,50.5  # exact viewport (vector only)
+s100 render enc.000 window.png --center -1.25,50.25 --scale 50000  # centre + scale
 
 # Composite several products into one chart:
 s100 render --layer enc.000 --layer bathy.h5 --layer warnings.gml chart.png
@@ -158,6 +162,54 @@ s100 render exchange-set/ chart.png                         # auto-detected dire
 s100 render exchange-set/CATALOG.XML chart.png              # auto-detected catalogue
 s100 render --exchange-set exchange-set.zip -o chart.png    # explicit, ZIP archive
 s100 render --from exchange-set/ chart.png --only S101,S102 # restrict to some specs
+```
+
+#### Display-list output (`--format json`)
+
+Instead of rasterising, the single-dataset form can emit the dataset's
+**S-100 Part 9 display list** — the ordered set of drawing instructions the
+portrayal pipeline produced — as JSON. This captures *what* was drawn (symbol,
+line-style and area-fill references, colours, display planes, drawing
+priorities, viewing groups, text) rather than pixels, so a portrayal change can
+be reviewed, diffed, and snapshot-tested in text without a viewer or an image
+comparison. It is available for vector products (S-101, S-57, and the GML
+families S-12x / S-129 / S-131 / S-201 / S-411 / S-421); coverage products
+(S-102 / S-104 / S-111) do not emit a Part 9 display list and report a clear
+error.
+
+The document is **pure portrayal output**: it contains no timing and no encoder
+settings, and geometry is summarised (type, vertex count, and a representative
+latitude/longitude anchor) rather than dumped in full, so two runs over the same
+dataset and render context produce byte-identical JSON. The viewport options
+(`--width` / `--height`) and palette still apply — they influence which
+instructions the pipeline emits — but `--quality` and `--background` are ignored.
+
+```bash
+s100 render warnings.gml warnings.json           # infer json from the .json extension
+s100 render warnings.gml out.txt --format json   # explicit; any non-image extension
+```
+
+```jsonc
+{
+  "dataset": "navwarn_surface.gml",
+  "product": "S-124",
+  "spec": "S-124/1.0.0",
+  "palette": "day",
+  "instructionCount": 3,
+  "categoryCounts": { "areas": 0, "lines": 0, "points": 3, "text": 0 },
+  "instructions": [
+    {
+      "kind": "point",
+      "feature": "f1",
+      "subLayer": 0,
+      "plane": "UnderRadar",
+      "viewingGroup": 31020,
+      "drawingPriority": 15,
+      "symbol": "NavigationalWarningFeaturePart",
+      "geometry": { "type": "Surface", "vertexCount": 5, "anchor": [51.05, 1.2] }
+    }
+  ]
+}
 ```
 
 > **Composite ordering.** The S-98 authority orders layers by display plane,
@@ -286,8 +338,18 @@ and attribute mapping, allowed-value enforcement) are owned by
 
 ## Limitations
 
-- **Vector pattern area-fills are omitted** on the headless path; points,
-  lines, solid-area fills, and text render.
+- **Vector pattern area-fills are not priority-clipped** on the headless path.
+  Points, lines, solid-area fills, tiled **pattern** area-fills, and text all
+  render, but the headless path does not yet subtract higher-priority patterns
+  and opaque solid fills out of lower-priority semi-transparent patterns the way
+  the Mapsui/viewer path does (via NetTopologySuite), so dense pattern coverages
+  can bleed slightly across such boundaries.
+- **Explicit viewport is vector-only.** `--bbox` / `--center`+`--scale` frame an
+  exact window (and enable scale-visibility culling) for a single **vector**
+  dataset and for composites, but are **not** yet honoured for a single coverage
+  dataset (S-102/S-104/S-111); the CLI reports a clear "not supported" error
+  rather than silently ignoring them. Without them, a single dataset auto-fits
+  its extent (padded 10%) with scale-visibility culling disabled.
 - **Coverage fixed-station datasets are not supported.** S-104 / S-111 datasets
   using data coding format 3 or 8 (time series at fixed stations) emit point
   glyphs through the Mapsui path only; the CLI reports a clear "not supported"

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -180,9 +180,12 @@ error.
 The document is **pure portrayal output**: it contains no timing and no encoder
 settings, and geometry is summarised (type, vertex count, and a representative
 latitude/longitude anchor) rather than dumped in full, so two runs over the same
-dataset and render context produce byte-identical JSON. The viewport options
-(`--width` / `--height`) and palette still apply — they influence which
-instructions the pipeline emits — but `--quality` and `--background` are ignored.
+dataset and render context produce byte-identical JSON. The palette and the
+portrayal options (symbol/text scale, display mode, time step, and an explicit
+`--bbox` / `--center` / `--scale` viewport) still influence which instructions
+the pipeline emits, but the raster-only options `--width` / `--height` /
+`--quality` / `--background` are ignored (the JSON path builds the display list
+without rasterizing).
 
 ```bash
 s100 render warnings.gml warnings.json           # infer json from the .json extension

--- a/tools/EncDotNet.S100.Cli/README.md
+++ b/tools/EncDotNet.S100.Cli/README.md
@@ -181,11 +181,12 @@ The document is **pure portrayal output**: it contains no timing and no encoder
 settings, and geometry is summarised (type, vertex count, and a representative
 latitude/longitude anchor) rather than dumped in full, so two runs over the same
 dataset and render context produce byte-identical JSON. The palette and the
-portrayal options (symbol/text scale, display mode, time step, and an explicit
-`--bbox` / `--center` / `--scale` viewport) still influence which instructions
-the pipeline emits, but the raster-only options `--width` / `--height` /
-`--quality` / `--background` are ignored (the JSON path builds the display list
-without rasterizing).
+portrayal options (symbol/text scale, display mode, and time step) still
+influence which instructions the pipeline emits. The raster-only options
+`--width` / `--height` / `--quality` / `--background` are ignored (the JSON path
+builds the display list without rasterizing), and the viewport options `--bbox`
+/ `--center` / `--scale` are rejected for `--format json` (a display list has no
+viewport).
 
 ```bash
 s100 render warnings.gml warnings.json           # infer json from the .json extension


### PR DESCRIPTION
## Summary

Brings the headless (Skia) render path into alignment with the GUI (Mapsui) path so the CLI/library harness can stand in for the single-instance viewer in most diagnosis and regression scenarios. Tracked by #477.

## What's included

- **Display-list JSON output** — `s100 render --format json` emits the drawing-instruction display list for snapshot/diffing (`DisplayListJsonWriter`).
- **Tier 1 — single-dataset headless viewport + scale-visibility.** `s100 render <dataset>` now accepts an explicit viewport (`--bbox` / `--center`+`--scale`) instead of auto-fit only, and honors S-100 Part 9 scale-visibility culling when the scale is caller-specified. Vector products (S-101, S-57, GML via `GmlDatasetProcessorBase`); coverage products return a clear "not supported yet" message. Threaded via `RenderContext.Viewport` → `RenderContextBuilder` → processors → `HeadlessVectorRenderer`.
- **Tier 2 — shared pattern-fill priority-clip.** Lifted the priority clip out of the Mapsui renderer into a single `PatternPriorityClipper` in `Rendering.Scene`, applied inside `VectorSceneBuilder.Build`, so the headless Skia path, the Mapsui TiledScene ("B") arm, and the Mapsui feature ("A") arm all clip identically. `Rendering.Scene` gains a direct `NetTopologySuite` reference.
- **Perf follow-on.** Cache the IR pattern clip on the default TiledScene arm via `PatternClipMemoizer`, and skip the redundant A-arm pattern collection/clip/feature-construction when the B arm is active (that output is neither drawn nor pickable there). Added a per-render `RenderSubsystemOverride` for deterministic, parallel-safe arm selection.

## Testing

- Pipelines.Tests **977 pass** / 3 skip (incl. new `VectorSceneBuilderPatternClipTests`, updated `PatternClipCacheTests`).
- Cli.Tests **157 pass** / 2 skip (new `RenderCommandTests`, `OptionParsingTests`, `HeadlessVectorRendererViewportTests`).
- Viewer.Tests **1555 pass** / 3 skip.
- Full solution build clean; `dotnet format` whitespace + style (IDE0005) both `--verify-no-changes` clean.

## Notes

- Rebased onto latest `main` so the diff contains only this work.
- Left divergent by design (documented): interactive viewport control and online basemap tiles.
- Follow-ups tracked in #477: Tier 3 coverage station glyphs, coverage single-dataset viewport crop, `viewer-emit-render-command`, and `DenseEncCell_PatternClip` baseline regen.